### PR TITLE
Json Schema Support

### DIFF
--- a/include/glaze/core/format.hpp
+++ b/include/glaze/core/format.hpp
@@ -8,4 +8,5 @@ namespace glz
    static constexpr uint32_t binary = 0;
    static constexpr uint32_t json = 10;
    static constexpr uint32_t csv = 100;
+   static constexpr uint32_t json_schema = 1000;
 }

--- a/include/glaze/json/includer.hpp
+++ b/include/glaze/json/includer.hpp
@@ -1,0 +1,92 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include "glaze/read.hpp"
+#include "glaze/write.hpp"
+#include "glaze/overwrite.hpp"
+#include "glaze/file_ops.hpp"
+
+#include <filesystem>
+#include <unordered_set>
+#include <vector>
+
+// TODO we need to add a test for this.
+
+namespace glz
+{
+   struct pointer
+   {
+      std::string ptr{};
+      raw_json data{};
+   };
+
+   //TODO this should be templated on datatype instead of using raw_json
+   struct includer_t
+   {
+      std::vector<std::string> includes{};
+      raw_json data{};
+      std::vector<pointer> pointers{};
+
+      void clear() {
+         includes.clear();
+         data.str.clear();
+         pointers.clear();
+      }
+   };
+}
+
+template <>
+struct glz::meta<glaze::includer_t>
+{
+   using T = glaze::includer_t;
+   static constexpr auto value = object("includes", &T::includes, "data", &T::data, "pointers",
+                     &T::pointers);
+};
+
+namespace glz
+{
+   template <class Value>
+   struct includer_t_parser
+   {
+      std::function<void(std::string&, std::filesystem::path const&)> get_buffer = [](std::string& buffer, std::filesystem::path const& path) {
+         file_to_buffer(buffer, path.generic_string());
+      };
+
+      std::unordered_set<std::string> parsing_files{};
+      std::string buffer{};
+      includer_t spec{};
+
+      void parse(Value& data, std::string_view filename,
+                 std::filesystem::path const& working_directory)
+      {
+         const auto path =
+            std::filesystem::canonical(relativize_if_not_absolute(
+            working_directory, std::filesystem::path(filename)));
+         auto path_str = path.string();
+         if (parsing_files.contains(path_str)) {
+            throw std::runtime_error("Circular includes detected");
+         }
+         parsing_files.insert(path_str);
+
+         get_buffer(buffer, path);
+
+         spec.clear();
+         read_json(spec, buffer);
+
+         for (auto&& include : spec.includes) {
+            parse(data, include,
+                  relativize_if_not_absolute(working_directory, include).parent_path());
+         }
+
+         read_json(data, spec.data.str);
+
+         for (auto&& pointer : spec.pointers) {
+            overwrite(data, pointer.ptr, pointer.data);
+         }
+
+         parsing_files.erase(path_str);
+      }
+   };
+}  // namespace glaze

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -1,88 +1,274 @@
-// Glaze Library
-// For the license information refer to glaze.hpp
-
-#pragma once
-
-#include "glaze/read.hpp"
-#include "glaze/write.hpp"
-#include "glaze/overwrite.hpp"
-#include "glaze/file_ops.hpp"
-
-#include <filesystem>
-#include <unordered_set>
-#include <vector>
+#include "glaze/json/write.hpp"
+#include "glaze/api/impl.hpp"
 
 namespace glz
 {
-   struct pointer
+   namespace detail
    {
-      std::string ptr{};
-      raw_json data{};
-   };
+      // TODO switch to using variants when we have write support to get rid of nulls
+      // TODO We should be able to generate the json schema compiletime
+      struct schema_ref
+      {
+         std::string_view ref{};
+         std::optional<std::string_view> description{};
 
-   struct interface_t
-   {
-      std::vector<std::string> includes{};
-      raw_json data{};
-      std::vector<pointer> pointers{};
+         struct glaze
+         {
+            using T = schema_ref;
+            static constexpr auto value = glz::object("$ref", &T::ref,                //
+                                                      "description", &T::description  //
+            );
+         };
+      };
 
-      void clear() {
-         includes.clear();
-         data.str.clear();
-         pointers.clear();
-      }
-   };
+      struct enum_val
+      {
+         std::string_view _const{};
+         std::optional<std::string_view> description{};
+
+         struct glaze
+         {
+            using T = enum_val;
+            static constexpr auto value = glz::object("const", &T::_const,             //
+                                                      "description", &T::description  //
+            );
+         };
+      };
+
+      struct schema
+      {
+         std::vector<std::string_view> type{};
+         std::optional<std::string_view> description{};
+         std::optional<std::map<std::string_view, schema_ref, std::less<>>> properties{};  // glaze_object
+         std::optional<schema_ref> items{};                                        // array
+         std::optional<std::variant<schema_ref, bool>> additionalProperties{};                         // map
+         std::optional<std::map<std::string_view, schema, std::less<>>> defs{};
+         std::optional<std::vector<std::string_view>> _enum{};  // enum
+         std::optional<std::vector<enum_val>> oneOf{};
+      };
+
+   }
 }
 
 template <>
-struct glz::meta<glaze::interface_t> {
-   using T = glaze::interface_t;
-   static constexpr auto value = object("includes", &T::includes, "data", &T::data, "pointers",
-                     &T::pointers);
+struct glz::meta<glz::detail::schema>
+{
+   static constexpr std::string_view name = "glz::detail::schema";
+   using T = glz::detail::schema;
+   static constexpr auto value = glz::object("type", &T::type,                                  //
+                                             "description", &T::description,                    //
+                                             "properties", &T::properties,                      //
+                                             "items", &T::items,                                //
+                                             "additionalProperties", &T::additionalProperties,  //
+                                             "$defs", &T::defs,                                 //
+                                             "enum", &T::_enum,                                 //
+                                             "oneOf", &T::oneOf);
 };
 
 namespace glz
 {
-   template <class Value>
-   struct interface_t_parser
+   namespace detail
    {
-      std::function<void(std::string&, std::filesystem::path const&)> get_buffer = [](std::string& buffer, std::filesystem::path const& path) {
-         file_to_buffer(buffer, path.generic_string());
+      template <class T = void>
+      struct to_json_schema
+      {};
+
+      template <>
+      struct write<json_schema>
+      {
+         template <class T, auto Opts, class B>
+         static void op(B&& b)
+         {
+            schema s{};
+            s.defs = std::map<std::string_view, schema, std::less<>>{};
+            to_json_schema<std::decay_t<T>>::template op<Opts>(s, *s.defs);
+            write<opts{}>(s, std::forward<B>(b));
+         }
       };
 
-      std::unordered_set<std::string> parsing_files{};
-      std::string buffer{};
-      interface_t spec{};
-
-      void parse(Value& data, std::string_view filename,
-                 std::filesystem::path const& working_directory)
+      template <class T>
+      requires(std::same_as<T, bool> || std::same_as<T, std::vector<bool>::reference> ||
+               std::same_as<T, std::vector<bool>::const_reference>)
+      struct to_json_schema<T>
       {
-         const auto path =
-            std::filesystem::canonical(relativize_if_not_absolute(
-            working_directory, std::filesystem::path(filename)));
-         auto path_str = path.string();
-         if (parsing_files.contains(path_str)) {
-            throw std::runtime_error("Circular includes detected");
+         template <auto Opts>
+         static void op(auto& s, auto&) noexcept
+         {
+            s.type = {"boolean"};
          }
-         parsing_files.insert(path_str);
+      };
 
-         get_buffer(buffer, path);
-
-         spec.clear();
-         read_json(spec, buffer);
-
-         for (auto&& include : spec.includes) {
-            parse(data, include,
-                  relativize_if_not_absolute(working_directory, include).parent_path());
+      template <num_t T>
+      struct to_json_schema<T>
+      {
+         template <auto Opts>
+         static void op(auto& s, auto&) noexcept
+         {
+            if constexpr (std::integral<T>) {
+               s.type = {"integer"};
+            }
+            else {
+               s.type = {"number"};
+            }
          }
+      };
 
-         read_json(data, spec.data.str);
-
-         for (auto&& pointer : spec.pointers) {
-            overwrite(data, pointer.ptr, pointer.data);
+      template <class T>
+      requires str_t<T> || char_t<T>
+      struct to_json_schema<T>
+      {
+         template <auto Opts>
+         static void op(auto& s, auto&) noexcept
+         {
+            s.type = {"string"};
          }
+      };
 
-         parsing_files.erase(path_str);
-      }
-   };
-}  // namespace glaze
+      template <glaze_enum_t T>
+      struct to_json_schema<T>
+      {
+         template <auto Opts>
+         static void op(auto& s, auto&) noexcept
+         {
+            s.type = {"string"};
+
+            // TODO use oneOf instead of enum to handle doc comments
+            using V = std::decay_t<T>;
+            static constexpr auto N = std::tuple_size_v<meta_t<V>>;
+            //s._enum = std::vector<std::string_view>(N);
+            //for_each<N>([&](auto I) {
+            //   static constexpr auto item = std::get<I>(meta_v<V>);
+            //   (*s._enum)[I.value] = std::get<0>(item);
+            //});
+            s.oneOf = std::vector<enum_val>(N);
+            for_each<N>([&](auto I) {
+               static constexpr auto item = std::get<I>(meta_v<V>);
+               auto& _enum = (*s.oneOf)[I.value];
+               _enum._const = std::get<0>(item);
+               if constexpr (std::tuple_size_v < decltype(item) >> 2) {
+                  _enum.description = std::get<2>(item);
+               }
+            });
+         }
+      };
+
+      template <class T>
+      requires std::same_as<std::decay_t<T>, raw_json>
+      struct to_json_schema<T>
+      {
+         template <auto Opts>
+         static void op(auto& s, auto&) noexcept
+         {
+            s.type = {"number", "string", "boolean", "object", "array", "null"};
+         }
+      };
+
+      template <array_t T>
+      struct to_json_schema<T>
+      {
+         template <auto Opts>
+         static void op(auto& s, auto& defs) noexcept
+         {
+            using V = std::decay_t<nano::ranges::range_value_t<std::decay_t<T>>>;
+            s.type = {"array"};
+            auto& def = defs[name_v<V>];
+            if (def.type.empty()) {
+               to_json_schema<V>::template op<Opts>(def, defs);
+            }
+            s.items = schema_ref{join_v<chars<"#/$defs/">, name_v<V>>};
+         }
+      };
+
+      template <map_t T>
+      struct to_json_schema<T>
+      {
+         template <auto Opts>
+         static void op(auto& s, auto& defs) noexcept
+         {
+            using V = std::decay_t<std::tuple_element_t<1,nano::ranges::range_value_t<std::decay_t<T>>>>;
+            s.type = {"object"};
+            auto& def = defs[name_v<V>];
+            if (def.type.empty()) {
+               to_json_schema<V>::template op<Opts>(def, defs);
+            }
+            s.additionalProperties = schema_ref{join_v<chars<"#/$defs/">, name_v<V>>};
+         }
+      };
+
+      template <nullable_t T>
+      struct to_json_schema<T>
+      {
+         template <auto Opts>
+         static void op(auto& s, auto&) noexcept
+         {
+            using V = decltype(*std::declval<std::decay_t<T>>());
+            to_json_schema<V>::template op<Opts>(s);
+            s.type.emplace_back("null");
+         }
+      };
+
+      template <class T>
+      requires glaze_array_t<std::decay_t<T>> || tuple_t<std::decay_t<T>>
+      struct to_json_schema<T>
+      {
+         template <auto Opts>
+         static void op(auto& s, auto&) noexcept
+         {
+            // TODO: Actually handle this. We can specify a schema per item in items
+            //      We can also do size restrictions on static arrays
+            s.type = {"array"};
+         }
+      };
+
+      template <glaze_object_t T>
+      struct to_json_schema<T>
+      {
+         template <auto Opts>
+         static void op(auto& s, auto& defs) noexcept
+         {
+            s.type = {"object"};
+
+            using V = std::decay_t<T>;
+            static constexpr auto N = std::tuple_size_v<meta_t<V>>;
+            s.properties = std::map<std::string_view, schema_ref, std::less<>>();
+            for_each<N>([&](auto I) {
+               static constexpr auto item = std::get<I>(meta_v<V>);
+               using mptr_t = std::tuple_element_t<1, decltype(item)>;
+               using val_t = std::decay_t<member_check_t<V, mptr_t>>;
+               auto& def = defs[name_v<val_t>];
+               if (def.type.empty()) {
+                  to_json_schema<val_t>::template op<Opts>(def, defs);
+               }
+               auto ref_val = schema_ref{join_v<chars<"#/$defs/">, name_v<val_t>>};
+               if constexpr (std::tuple_size_v < decltype(item) >> 2) {
+                  ref_val.description = std::get<2>(item);
+               }
+               (*s.properties)[std::get<0>(item)] = ref_val;
+            });
+            (*s.properties)["$schema"];
+            s.additionalProperties = false;
+         }
+      };
+
+   }
+
+   template <class T, class Buffer>
+   inline void write_json_schema(Buffer&& buffer)
+   {
+      detail::schema s{};
+      s.defs = std::map<std::string_view, detail::schema, std::less<>>{};
+      detail::to_json_schema<std::decay_t<T>>::template op<opts{}>(s, *s.defs);
+      write<opts{}>(std::move(s), std::forward<Buffer>(buffer));
+   }
+
+   template <class T>
+   inline auto write_json_schema()
+   {
+      std::string buffer{};
+      detail::schema s{};
+      s.defs = std::map<std::string_view, detail::schema, std::less<>>{};
+      detail::to_json_schema<std::decay_t<T>>::template op<opts{}>(s, *s.defs);
+      write<opts{}>(std::move(s), buffer);
+      return buffer;
+   }
+}

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -375,6 +375,7 @@ namespace glz
             using V = std::decay_t<T>;
             static constexpr auto N = std::tuple_size_v<meta_t<V>>;
             dump<'{'>(b);
+            bool first = true;
             for_each<N>([&](auto I) {
                static constexpr auto item = std::get<I>(meta_v<V>);
                using mptr_t = std::tuple_element_t<1, decltype(item)>;
@@ -390,6 +391,15 @@ namespace glz
                      }
                   }();
                   if (is_null) return;
+               }
+
+               if (first) {
+                  first = false;
+               }
+               else {
+                  // Null members may be skipped so we cant just write it out for all but the last member unless
+                  // trailing commas are allowed
+                  dump<','>(b);
                }
 
                using Key = typename std::decay_t<std::tuple_element_t<0, decltype(item)>>;
@@ -416,9 +426,6 @@ namespace glz
                      dump<"*/">(b);
                   }
                }
-               if constexpr (I < N - 1) {
-                  dump<','>(b);
-               }
             });
             dump<'}'>(b);
          }
@@ -429,6 +436,7 @@ namespace glz
             using V = std::decay_t<T>;
             static constexpr auto N = std::tuple_size_v<meta_t<V>>;
             dump<'{'>(b, ix);
+            bool first = true;
             for_each<N>([&](auto I) {
                static constexpr auto item = std::get<I>(meta_v<V>);
                using mptr_t = std::tuple_element_t<1, decltype(item)>;
@@ -445,6 +453,15 @@ namespace glz
                      }
                   }();
                   if (is_null) return;
+               }
+
+               if (first) {
+                  first = false;
+               }
+               else  {
+                  // Null members may be skipped so we cant just write it out for all but the last member unless
+                  // trailing commas are allowed
+                  dump<','>(b, ix);
                }
 
                using Key = typename std::decay_t<std::tuple_element_t<0, decltype(item)>>;
@@ -484,9 +501,6 @@ namespace glz
                      dump(comment, b, ix);
                      dump<"*/">(b, ix);
                   }
-               }
-               if constexpr (I < N - 1) {
-                  dump<','>(b, ix);
                }
             });
             dump<'}'>(b, ix);


### PR DESCRIPTION
This enables stuff like validation, autocomplete, and linting when editing json files in editors that support it like vscode.

Autocomplete with comments:
![image](https://user-images.githubusercontent.com/9817348/199335067-6e40f1ca-bad5-4bbd-8902-7e921e9e97b1.png)
![image](https://user-images.githubusercontent.com/9817348/199335107-6bb93b1c-c8e2-41b6-a120-22d1320c9d2c.png)
 
Linting:
![image](https://user-images.githubusercontent.com/9817348/199335149-f2a8de52-08a9-415b-b1a5-6f59d0e929c0.png)
![image](https://user-images.githubusercontent.com/9817348/199335176-d2490750-91fe-4e29-bce6-54c0a94db2bc.png)

In some of our internal projects, I plan to generate these schemas post-build and put them in the root of out input directory then we can simply add a $schema property to the top of the root object with a relative path to the schema file to enable linting. and autocomplete.
 
