### PR TITLE
Dragonbox auto switch scientific/decimal notation

### DIFF
--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -16,7 +16,7 @@
 #include "glaze/util/dump.hpp"
 #include "glaze/json/from_ptr.hpp"
 
-#include "dragonbox/dragonbox_to_chars.h"
+#include "glaze/util/to_chars.hpp"
 
 namespace glz
 {
@@ -86,7 +86,10 @@ namespace glz
             using V = std::decay_t<decltype(value)>;
             if constexpr (std::same_as<V, float> || std::same_as<V, double>) {
                auto start = b.data() + ix;
-               const auto end = jkj::dragonbox::to_chars_n(value, start);
+               //TODO: We should be able to improve this
+               const auto end = glz::dragonbox::to_chars(value, start);
+               // Faster but only scientific notation
+               // const auto end = jkj::dragonbox::to_chars_n(value, start);
                ix += std::distance(start, end);
             }
             else {

--- a/include/glaze/util/to_chars.hpp
+++ b/include/glaze/util/to_chars.hpp
@@ -1,0 +1,167 @@
+#include "dragonbox/dragonbox_to_chars.h"
+#include "fmt/format.h"
+
+namespace glz::dragonbox
+{
+   template <class UInt>
+   static constexpr std::uint32_t decimal_length(UInt const v)
+   {
+      if constexpr (std::is_same_v<UInt, std::uint32_t>) {
+         // Function precondition: v is not a 10-digit number.
+         // (f2s: 9 digits are sufficient for round-tripping.)
+         // (d2fixed: We print 9-digit blocks.)
+         assert(v < 1000000000);
+         if (v >= 100000000) {
+            return 9;
+         }
+         if (v >= 10000000) {
+            return 8;
+         }
+         if (v >= 1000000) {
+            return 7;
+         }
+         if (v >= 100000) {
+            return 6;
+         }
+         if (v >= 10000) {
+            return 5;
+         }
+         if (v >= 1000) {
+            return 4;
+         }
+         if (v >= 100) {
+            return 3;
+         }
+         if (v >= 10) {
+            return 2;
+         }
+         return 1;
+      }
+      else {
+         static_assert(std::is_same_v<UInt, std::uint64_t>);
+         // This is slightly faster than a loop.
+         // The average output length is 16.38 digits, so we check high-to-low.
+         // Function precondition: v is not an 18, 19, or 20-digit number.
+         // (17 digits are sufficient for round-tripping.)
+         assert(v < 100000000000000000L);
+         if (v >= 10000000000000000L) {
+            return 17;
+         }
+         if (v >= 1000000000000000L) {
+            return 16;
+         }
+         if (v >= 100000000000000L) {
+            return 15;
+         }
+         if (v >= 10000000000000L) {
+            return 14;
+         }
+         if (v >= 1000000000000L) {
+            return 13;
+         }
+         if (v >= 100000000000L) {
+            return 12;
+         }
+         if (v >= 10000000000L) {
+            return 11;
+         }
+         if (v >= 1000000000L) {
+            return 10;
+         }
+         if (v >= 100000000L) {
+            return 9;
+         }
+         if (v >= 10000000L) {
+            return 8;
+         }
+         if (v >= 1000000L) {
+            return 7;
+         }
+         if (v >= 100000L) {
+            return 6;
+         }
+         if (v >= 10000L) {
+            return 5;
+         }
+         if (v >= 1000L) {
+            return 4;
+         }
+         if (v >= 100L) {
+            return 3;
+         }
+         if (v >= 10L) {
+            return 2;
+         }
+         return 1;
+      }
+   }
+
+   char *to_chars(auto &&val, char *buffer) noexcept
+   {
+      using V = std::decay_t<decltype(val)>;
+
+      auto br = jkj::dragonbox::float_bits<V, jkj::dragonbox::default_float_traits<V>>(val);
+      auto const exponent_bits = br.extract_exponent_bits();
+      auto const s = br.remove_exponent_bits(exponent_bits);
+
+      if (br.is_finite(exponent_bits)) {
+         if (s.is_negative()) {
+            *buffer = '-';
+            ++buffer;
+         }
+         if (br.is_nonzero()) {
+            auto decimal = to_decimal<V, jkj::dragonbox::default_float_traits<V>>(s, exponent_bits,
+                                                                                  jkj::dragonbox::policy::sign::ignore);
+            auto significand = decimal.significand;
+            auto exponent = decimal.exponent;
+
+            if (exponent == 0) {
+               return fmt::detail::format_decimal(buffer, significand, decimal_length(significand)).end;
+            }
+
+            const int s_digits = decimal_length(significand);
+            int output_exp = exponent + s_digits - 1;
+            if (output_exp == 0) {
+               return fmt::detail::write_significand(buffer, significand, s_digits, s_digits + exponent, '.');
+            }
+            else if (output_exp < 0 && output_exp > -4) {
+               const auto fill_to = buffer - output_exp + 1;
+               std::fill(buffer, fill_to, '0');
+               *(buffer + 1) = '.';
+               buffer = fill_to;
+               return fmt::detail::format_decimal(buffer, significand, s_digits).end;
+            }
+            else if (output_exp > 0 && (output_exp - s_digits) < 3) {
+               if (exponent >= 0) {
+                  buffer = fmt::detail::format_decimal(buffer, significand, s_digits).end;
+                  const auto fill_to = buffer + exponent;
+                  std::fill(buffer, fill_to, '0');
+                  return fill_to;
+               }
+               return fmt::detail::write_significand(buffer, significand, s_digits, s_digits + exponent, '.');
+            }
+            using V = std::decay_t<decltype(val)>;
+            return jkj::dragonbox::to_chars_detail::to_chars<V, jkj::dragonbox::default_float_traits<V>>(
+               significand, exponent, buffer);
+         }
+         else {
+            *buffer = '0';
+            return buffer + 1;
+         }
+      }
+      else {
+         if (s.has_all_zero_significand_bits()) {
+            if (s.is_negative()) {
+               *buffer = '-';
+               ++buffer;
+            }
+            std::memcpy(buffer, "Infinity", 8);
+            return buffer + 8;
+         }
+         else {
+            std::memcpy(buffer, "nan", 3);
+            return buffer + 3;
+         }
+      }
+   }
+}

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -539,17 +539,17 @@ void user_types() {
       Thing obj{};
       std::string buffer{};
       glz::write_json(obj, buffer);
-      expect(buffer == R"({"thing":{"a":3.14,"b":"stuff"},"thing2array":[{"a":3.14,"b":"stuff","c":999.342494903,"d":1e-12,"e":203082348402.1,"f":89.089,"g":12380.00000013,"h":1000000.000001}],"vec3":[3.14,2.7,6.5],"list":[6,7,8,2],"deque":[9,6.7,3.1],"vector":[[9,6.7,3.1],[3.14,2.7,6.5]],"i":8,"d":2,"b":false,"c":"W","color":"Green","vb":[true,false,false,true,true,true,true],"sptr":{"a":3.14,"b":"stuff"},"array":["as\"df\\ghjkl","pie","42","foo"],"map":{"a":4,"b":12,"f":7},"mapi":{"2":9.63,"5":3.14,"7":7.42},"thing_ptr":{"a":3.14,"b":"stuff"}})");
+      expect(buffer == R"({"thing":{"a":3.14,"b":"stuff"},"thing2array":[{"a":3.14,"b":"stuff","c":999.342494903,"d":1E-12,"e":203082348402.1,"f":89.089,"g":12380.00000013,"h":1000000.000001}],"vec3":[3.14,2.7,6.5],"list":[6,7,8,2],"deque":[9,6.7,3.1],"vector":[[9,6.7,3.1],[3.14,2.7,6.5]],"i":8,"d":2,"b":false,"c":"W","color":"Green","vb":[true,false,false,true,true,true,true],"sptr":{"a":3.14,"b":"stuff"},"array":["as\"df\\ghjkl","pie","42","foo"],"map":{"a":4,"b":12,"f":7},"mapi":{"2":9.63,"5":3.14,"7":7.42},"thing_ptr":{"a":3.14,"b":"stuff"}})");
 
       buffer.clear();
       glz::write<glz::opts{.skip_null_members=false}>(obj, buffer);
-      expect(buffer == R"({"thing":{"a":3.14,"b":"stuff"},"thing2array":[{"a":3.14,"b":"stuff","c":999.342494903,"d":1e-12,"e":203082348402.1,"f":89.089,"g":12380.00000013,"h":1000000.000001}],"vec3":[3.14,2.7,6.5],"list":[6,7,8,2],"deque":[9,6.7,3.1],"vector":[[9,6.7,3.1],[3.14,2.7,6.5]],"i":8,"d":2,"b":false,"c":"W","color":"Green","vb":[true,false,false,true,true,true,true],"sptr":{"a":3.14,"b":"stuff"},"optional":null,"array":["as\"df\\ghjkl","pie","42","foo"],"map":{"a":4,"b":12,"f":7},"mapi":{"2":9.63,"5":3.14,"7":7.42},"thing_ptr":{"a":3.14,"b":"stuff"}})");
+      expect(buffer == R"({"thing":{"a":3.14,"b":"stuff"},"thing2array":[{"a":3.14,"b":"stuff","c":999.342494903,"d":1E-12,"e":203082348402.1,"f":89.089,"g":12380.00000013,"h":1000000.000001}],"vec3":[3.14,2.7,6.5],"list":[6,7,8,2],"deque":[9,6.7,3.1],"vector":[[9,6.7,3.1],[3.14,2.7,6.5]],"i":8,"d":2,"b":false,"c":"W","color":"Green","vb":[true,false,false,true,true,true,true],"sptr":{"a":3.14,"b":"stuff"},"optional":null,"array":["as\"df\\ghjkl","pie","42","foo"],"map":{"a":4,"b":12,"f":7},"mapi":{"2":9.63,"5":3.14,"7":7.42},"thing_ptr":{"a":3.14,"b":"stuff"}})");
 
       expect(nothrow([&] { glz::read_json(obj, buffer); }));
 
       buffer.clear();
       glz::write_jsonc(obj, buffer);
-      expect(buffer == R"({"thing":{"a":3.14/*Test comment 1*/,"b":"stuff"/*Test comment 2*/},"thing2array":[{"a":3.14/*Test comment 1*/,"b":"stuff"/*Test comment 2*/,"c":999.342494903,"d":1e-12,"e":203082348402.1,"f":89.089,"g":12380.00000013,"h":1000000.000001}],"vec3":[3.14,2.7,6.5],"list":[6,7,8,2],"deque":[9,6.7,3.1],"vector":[[9,6.7,3.1],[3.14,2.7,6.5]],"i":8,"d":2/*double is the best type*/,"b":false,"c":"W","color":"Green","vb":[true,false,false,true,true,true,true],"sptr":{"a":3.14/*Test comment 1*/,"b":"stuff"/*Test comment 2*/},"array":["as\"df\\ghjkl","pie","42","foo"],"map":{"a":4,"b":12,"f":7},"mapi":{"2":9.63,"5":3.14,"7":7.42},"thing_ptr":{"a":3.14/*Test comment 1*/,"b":"stuff"/*Test comment 2*/}})");
+      expect(buffer == R"({"thing":{"a":3.14/*Test comment 1*/,"b":"stuff"/*Test comment 2*/},"thing2array":[{"a":3.14/*Test comment 1*/,"b":"stuff"/*Test comment 2*/,"c":999.342494903,"d":1E-12,"e":203082348402.1,"f":89.089,"g":12380.00000013,"h":1000000.000001}],"vec3":[3.14,2.7,6.5],"list":[6,7,8,2],"deque":[9,6.7,3.1],"vector":[[9,6.7,3.1],[3.14,2.7,6.5]],"i":8,"d":2/*double is the best type*/,"b":false,"c":"W","color":"Green","vb":[true,false,false,true,true,true,true],"sptr":{"a":3.14/*Test comment 1*/,"b":"stuff"/*Test comment 2*/},"array":["as\"df\\ghjkl","pie","42","foo"],"map":{"a":4,"b":12,"f":7},"mapi":{"2":9.63,"5":3.14,"7":7.42},"thing_ptr":{"a":3.14/*Test comment 1*/,"b":"stuff"/*Test comment 2*/}})");
       expect(nothrow([&] { glz::read_json(obj, buffer); }));
    };
 


### PR DESCRIPTION
I wrapped the dragonbox to_chars stuff to manually handle when we need decimal rather than scientific notation and the tests are now all passing. Perf is better than before with just fmt but not as good as dragonbox::to_chars. It currently uses fmt::detail::format_decimal and fmt::detail::write_significand but those methods are somewhat slow compared to the ones used in the dragonbox ref impl. Integer division in int to string conversion is expensive so dragonbox uses a couple methods to get around this. For one it breaks up the significand for doubles into two 32 bit uints instead of one 64 bit uint. It also uses some pre-computed values to replace divisions with shifts. I'm going to replace fmt::detail::format_decimal and fmt::detail::write_significand with a faster method based on the one used in dragonbox. Hopefully, that will help.