### PR TITLE
Change hashing to operate on 8 bytes at a time. Add page checking to over reads.

### DIFF
--- a/include/glaze/util/string_cmp.hpp
+++ b/include/glaze/util/string_cmp.hpp
@@ -7,33 +7,63 @@
 
 namespace glz
 {
-   // An optimized string comparison algorithm that is typically faster than memcmp
-   inline bool string_cmp(auto&& s0, auto&& s1) noexcept
+   constexpr uint64_t to_uint64(const char* bytes, size_t n = 8) noexcept
    {
-       const auto n = s0.size();
-       if (s1.size() != n) {
-           return false;
-       }
+      // In cases where n < 8 we do overread in the runtime context for perf and special care should be taken:
+      //  * Alignment or page boundary checks should probably be done before calling this function
+      //  * Garbage bits should be handled by caller. Ignore them shift them its up to you.
+      // https://stackoverflow.com/questions/37800739/is-it-safe-to-read-past-the-end-of-a-buffer-within-the-same-page-on-x86-and-x64
+      uint64_t res{};
+      if (std::is_constant_evaluated()) {
+         assert(n <= 8);
+         for (size_t i = 0; i < n; ++i) {
+            res |= static_cast<uint64_t>(bytes[i]) << (8 * i);
+         }
+      }
+      else {
+         // Note: memcpy is way faster with compiletime known length
+         std::memcpy(&res, bytes, 8);
+      }
+      return res;
+   }
 
-       if (n < 8) {
-         const auto* d0 = reinterpret_cast<const uint64_t*>(s0.data());
-          const auto* d1 = reinterpret_cast<const uint64_t*>(s1.data());
-          const auto shift = 64 - 8 * n;
-          return ((*d0) << shift) == ((*d1) << shift);
-         //return std::memcmp(s0.data(), s1.data(), n);
-       }
+   // Note: This relies on undefined behavior but should generally be ok
+   // https://stackoverflow.com/questions/37800739/is-it-safe-to-read-past-the-end-of-a-buffer-within-the-same-page-on-x86-and-x64
+   // Gets better perf then memcmp on small strings like keys but worse perf on longer strings (>40 or so)
+   constexpr bool string_cmp(auto &&s0, auto &&s1) noexcept
+   {
+      const auto n = s0.size();
+      if (s1.size() != n) {
+         return false;
+      }
 
-       const char* d0 = s0.data();
-       const char* d1 = s1.data();
-       const char* end7 = s0.data() + n - 7;
+      if (n < 8) {
+         // TODO add option to skip page checks when we know they are not needed like the compile time known keys or
+         // stringviews in the middle of the buffer
+         if (!std::is_constant_evaluated() && (((reinterpret_cast<std::uintptr_t>(s0.data()) & 4095) > 4088) ||
+                                               ((reinterpret_cast<std::uintptr_t>(s1.data()) & 4095) > 4088)))
+            [[unlikely]] {
+            // Buffer over-read may cross page boundary
+            // There are faster things we could do here but this branch is unlikely
+            return std::memcmp(s0.data(), s1.data(), n);
+         }
+         else {
+            const auto shift = 64 - 8 * n;
+            return (to_uint64(s0.data()) << shift) == (to_uint64(s1.data()) << shift);
+         }
+      }
 
-       for (; d0 < end7; d0 += 8, d1 += 8) {
-         if (*reinterpret_cast<const uint64_t*>(d0) != *reinterpret_cast<const uint64_t*>(d1)) {
-               return false;
-           }
-       }
+      const char *b0 = s0.data();
+      const char *b1 = s1.data();
+      const char *end7 = s0.data() + n - 7;
 
-       const uint64_t nm8 = n - 8;
-       return (*reinterpret_cast<const uint64_t*>(s0.data() + nm8) == *reinterpret_cast<const uint64_t*>(s1.data() + nm8));
+      for (; b0 < end7; b0 += 8, b1 += 8) {
+         if (to_uint64(b0) != to_uint64(b1)) {
+            return false;
+         }
+      }
+
+      const uint64_t nm8 = n - 8;
+      return (to_uint64(s0.data() + nm8) == to_uint64(s1.data() + nm8));
    }
 }


### PR DESCRIPTION
Swapped fnv64 with a method that operates on chunks of 8 bytes rather than 1 byte at a time. Uses a single xor shift multiply for mixing bits since we don't need the best distribution since we can reseed until there are no collisions compile-time so hash speed is more important than quality.
 
Overeads started being used on string processing to improve perf. Page boundary checks were added to prevent segfaults on common architectures where the minimum page size is 4k. Note that all of this is platform dependent and 100% ub but its hard to give up the nearly 2x perf on small strings (and key sizes in json are generally small) processing you can get from using overeads. Even stuff like glibc will tend to use overeads for stuff like strlen though they tend to use alignment checks over page boundary checks since it makes far fewer assumptions.