### PR TITLE
Fix ICE on join_v for msv2022 and add msvc2022 workflow

### DIFF
--- a/.github/workflows/msvc_2019.yml
+++ b/.github/workflows/msvc_2019.yml
@@ -1,4 +1,4 @@
-name: msvc
+name: msvc_2019
 
 on:
   push:

--- a/.github/workflows/msvc_2022.yml
+++ b/.github/workflows/msvc_2022.yml
@@ -1,4 +1,4 @@
-name: msvc_cpm
+name: msvc_2022
 
 on:
   push:
@@ -17,14 +17,13 @@ env:
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v3
 
-    # using specific windows SDK to address this issue: https://stackoverflow.com/questions/65402366/c5105-and-other-compiler-warnings-when-building-with-github-actions-winsdk-10
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_SYSTEM_VERSION="10.0.22621.0"
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build
       run: cmake --build build --config ${{env.BUILD_TYPE}} -j 2

--- a/include/glaze/api/name.hpp
+++ b/include/glaze/api/name.hpp
@@ -14,40 +14,48 @@ namespace glz
 {
    namespace detail
    {
-      inline constexpr auto total_length(const auto& strs) noexcept {
+#ifdef _MSC_VER
+      // Workaround for problems with MSVC and passing refrences to stringviews as template params
+      struct string_view_wrapper
+      {
+         const char* start{};
          size_t n{};
-         for_each<std::tuple_size_v<std::decay_t<decltype(strs)>>>([&](auto I) { n += std::get<I>(strs).size(); });
-         return n;
-      }
-
+         constexpr string_view_wrapper(std::string_view sv) : start(sv.data()), n(sv.size()) {}
+         constexpr auto data() const { return start; }
+         constexpr auto begin() const { return data(); }
+         constexpr auto end() const { return data() + n; }
+         constexpr auto size() const { return n; }
+      };
+      template <string_view_wrapper... Strs>
+#else
       template <const std::string_view&... Strs>
+#endif
       struct join
       {
          // Join all strings into a single std::array of chars
          static constexpr auto impl() noexcept
          {
-            // This local copy to a tuple and avoiding of parameter pack expansion is needed to avoid MSVC internal compiler errors
-            constexpr auto strs_tuple = std::make_tuple(Strs...);
-            //constexpr size_t len = (Strs.size() + ... + 0);
-            constexpr size_t len = total_length(strs_tuple);
+            // This local copy to a tuple and avoiding of parameter pack expansion is needed to avoid MSVC internal
+            // compiler errors
+            constexpr size_t len = (Strs.size() + ... + 0);
             std::array<char, len + 1> arr{};
             auto append = [i = 0, &arr](const auto& s) mutable {
                for (auto c : s) arr[i++] = c;
             };
-
-            for_each<sizeof...(Strs)>([&](auto I) { append(std::get<I>(strs_tuple));
-            });
-
-            //(append(Strs), ...);
+            (append(Strs), ...);
             arr[len] = 0;
             return arr;
          }
-         
-         static constexpr auto arr = impl(); // Give the joined string static storage
-         static constexpr std::string_view value {arr.data(), arr.size() - 1};
+
+         static constexpr auto arr = impl();  // Give the joined string static storage
+         static constexpr std::string_view value{arr.data(), arr.size() - 1};
       };
-      // Helper to get the value out
+// Helper to get the value out
+#ifdef _MSC_VER
+      template <string_view_wrapper... Strs>
+#else
       template <const std::string_view&... Strs>
+#endif
       static constexpr auto join_v = join<Strs...>::value;
    }
    

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -260,9 +260,11 @@ namespace glz
          if constexpr (detail::glaze_object_t<std::decay_t<T>>) {
             static constexpr auto key_to_int = detail::make_key_int_map<T>();
             glz::for_each<N>([&](auto I) {
-               static constexpr auto group = [I]() {
-                  return std::get<decltype(I)::value>(groups);
-               }();  // MSVC internal compiler error workaround
+               using index_t = decltype(I);
+               using group_t = std::tuple_element_t<I, decltype(groups)>;
+               static constexpr auto group = [](index_t Index) constexpr -> group_t {
+                  return std::get<Index>(groups);
+               }({}); // MSVC internal compiler error workaround
                static constexpr auto key = std::get<0>(group);
                static constexpr auto sub_partial = std::get<1>(group);
                static constexpr auto frozen_map = detail::make_map<T>();
@@ -274,16 +276,16 @@ namespace glz
 
                detail::dump_int<Opts>(key_to_int.find(key)->second, buffer);
                if constexpr (std::is_member_pointer_v<std::decay_t<decltype(member_ptr)>>) {
-                  write<sub_partial, Opts>(value.*member_ptr, buffer);
+                  //write<sub_partial, Opts>(value.*member_ptr, buffer);
                }
                else {
-                  write<sub_partial, Opts>(member_ptr(value), buffer);
+                  //write<sub_partial, Opts>(member_ptr(value), buffer);
                }
             });
          }
          else if constexpr (detail::map_t<std::decay_t<T>>) {
             glz::for_each<N>([&](auto I) {
-               static constexpr auto group = [I]() {
+               static constexpr auto group = []() {
                   return std::get<decltype(I)::value>(groups);
                }();  // MSVC internal compiler error workaround
                static constexpr auto key_value = std::get<0>(group);

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -276,10 +276,10 @@ namespace glz
 
                detail::dump_int<Opts>(key_to_int.find(key)->second, buffer);
                if constexpr (std::is_member_pointer_v<std::decay_t<decltype(member_ptr)>>) {
-                  //write<sub_partial, Opts>(value.*member_ptr, buffer);
+                  write<sub_partial, Opts>(value.*member_ptr, buffer);
                }
                else {
-                  //write<sub_partial, Opts>(member_ptr(value), buffer);
+                  write<sub_partial, Opts>(member_ptr(value), buffer);
                }
             });
          }

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -260,9 +260,9 @@ namespace glz
          if constexpr (detail::glaze_object_t<std::decay_t<T>>) {
             static constexpr auto key_to_int = detail::make_key_int_map<T>();
             glz::for_each<N>([&](auto I) {
-               static constexpr auto group = [](auto I) {
+               static constexpr auto group = [I]() {
                   return std::get<decltype(I)::value>(groups);
-               }(I);  // MSVC internal compiler error workaround
+               }();  // MSVC internal compiler error workaround
                static constexpr auto key = std::get<0>(group);
                static constexpr auto sub_partial = std::get<1>(group);
                static constexpr auto frozen_map = detail::make_map<T>();
@@ -283,7 +283,7 @@ namespace glz
          }
          else if constexpr (detail::map_t<std::decay_t<T>>) {
             glz::for_each<N>([&](auto I) {
-               static constexpr auto group = []() {
+               static constexpr auto group = [I]() {
                   return std::get<decltype(I)::value>(groups);
                }();  // MSVC internal compiler error workaround
                static constexpr auto key_value = std::get<0>(group);

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -260,8 +260,9 @@ namespace glz
          if constexpr (detail::glaze_object_t<std::decay_t<T>>) {
             static constexpr auto key_to_int = detail::make_key_int_map<T>();
             glz::for_each<N>([&](auto I) {
+               using index_t = decltype(I);
                static constexpr auto group = []() {
-                  return std::get<decltype(I)::value>(groups);
+                  return std::get<index_t::value>(groups);
                }();  // MSVC internal compiler error workaround
                static constexpr auto key = std::get<0>(group);
                static constexpr auto sub_partial = std::get<1>(group);


### PR DESCRIPTION
Other ICEs might pop up for 2022. Added workflow so we can catch them. MSVC seems to have a lot of bugs associated with references in template params.