### PR TITLE
hashing binary keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ Glaze requires C++20, using concepts for cleaner code and more helpful errors.
 
 | Library                                                      | Roundtrip Time (s) | Write (MB/s) | Read (MB/s) |
 | ------------------------------------------------------------ | ------------------ | ------------ | ----------- |
-| [**Glaze**](https://github.com/stephenberry/glaze)           | **1.44**           | **999**      | **701**     |
-| [**simdjson (on demand)**](https://github.com/simdjson/simdjson) | **N/A**            | **N/A**      | **1257**    |
-| [**daw_json_link**](https://github.com/beached/daw_json_link) | **2.77**           | **379**      | **484**     |
-| [**RapidJSON**](https://github.com/Tencent/rapidjson)        | **3.75**           | **306**      | **430**     |
-| [**json_struct**](https://github.com/jorgen/json_struct)     | **4.32**           | **232**      | **325**     |
-| [**nlohmann**](https://github.com/nlohmann/json)             | **16.93**          | **87**       | **71**      |
+| [**Glaze**](https://github.com/stephenberry/glaze)           | **1.55**           | **972**      | **637**     |
+| [**simdjson (on demand)**](https://github.com/simdjson/simdjson) | **N/A**            | **N/A**      | **1249**    |
+| [**daw_json_link**](https://github.com/beached/daw_json_link) | **2.86**           | **374**      | **469**     |
+| [**RapidJSON**](https://github.com/Tencent/rapidjson)        | **3.27**           | **303**      | **620**     |
+| [**json_struct**](https://github.com/jorgen/json_struct)     | **4.46**           | **230**      | **315**     |
+| [**nlohmann**](https://github.com/nlohmann/json)             | **17.32**          | **87**       | **71**      |
 
 [Performance test code available here](https://github.com/stephenberry/json_performance)
 

--- a/include/glaze/api/xxh64.hpp
+++ b/include/glaze/api/xxh64.hpp
@@ -25,6 +25,9 @@
 
 #include <cstdint>
 
+// https://github.com/Cyan4973/xxHash
+// http://cyan4973.github.io/xxHash/
+
 struct xxh64 {
     static constexpr uint64_t hash (const char *p, uint64_t len, uint64_t seed) {
         return finalize ((len >= 32 ? h32bytes (p, len, seed) : seed + PRIME5) + len, p + (len & ~0x1F), len & 0x1F);

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -23,6 +23,7 @@
 #include "glaze/util/tuple.hpp"
 #include "glaze/util/type_traits.hpp"
 #include "glaze/util/hash_map.hpp"
+#include "glaze/util/murmur.hpp"
 
 #include <nanorange.hpp>
 
@@ -568,6 +569,26 @@ namespace glz
          constexpr auto indices =
             std::make_index_sequence<std::tuple_size_v<meta_t<T>>>{};
          return make_key_int_map_impl<T>(indices);
+      }
+      
+      template <class T, size_t... I>
+      constexpr auto make_crusher_map_impl(std::index_sequence<I...>)
+      {
+         using value_t = value_tuple_variant_t<meta_t<T>>;
+         constexpr auto n = std::tuple_size_v<meta_t<T>>;
+         
+         return frozen::make_unordered_map<uint32_t, value_t, n>(
+            {std::make_pair<uint32_t, value_t>(
+               murmur3_32(glz::tuplet::get<0>(glz::tuplet::get<I>(meta_v<T>))),
+                                                     glz::tuplet::get<1>(glz::tuplet::get<I>(meta_v<T>)))...});
+      }
+      
+      template <class T>
+      constexpr auto make_crusher_map()
+      {
+         constexpr auto indices =
+            std::make_index_sequence<std::tuple_size_v<meta_t<T>>>{};
+         return make_crusher_map_impl<T>(indices);
       }
 
       template <class T, size_t... I>

--- a/include/glaze/util/murmur.hpp
+++ b/include/glaze/util/murmur.hpp
@@ -1,0 +1,73 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <string_view>
+
+// Modified from: https://en.wikipedia.org/wiki/MurmurHash
+
+namespace glz
+{
+   constexpr uint32_t to_uint32(const char* bytes) noexcept
+   {
+      uint32_t res{};
+      if (std::is_constant_evaluated()) {
+         for (size_t i = 0; i < 4; ++i) {
+            res |= static_cast<uint32_t>(bytes[i]) << (8 * i);
+         }
+      }
+      else {
+         // Note: memcpy is way faster with compiletime known length
+         std::memcpy(&res, bytes, 4);
+      }
+      return res;
+   }
+   
+   inline constexpr uint32_t murmur_32_scramble(uint32_t k) noexcept {
+       k *= 0xcc9e2d51;
+       k = (k << 15) | (k >> 17);
+       k *= 0x1b873593;
+       return k;
+   }
+   
+   inline constexpr uint32_t murmur3_32(auto&& key) noexcept
+   {
+      uint32_t h = 0; // We always use a seed of 0 for Crusher
+       uint32_t k;
+       const auto n = key.size();
+       auto* data = key.data();
+       /* Read in groups of 4. */
+       for (size_t i = n >> 2; i; i--) {
+           // Here is a source of differing results across endiannesses.
+           // A swap here has no effects on hash properties though.
+           k = to_uint32(data);
+
+           data += sizeof(uint32_t);
+           h ^= murmur_32_scramble(k);
+           h = (h << 13) | (h >> 19);
+           h = h * 5 + 0xe6546b64;
+       }
+       /* Read the rest. */
+       k = 0;
+       for (size_t i = n & 3; i; i--) {
+           k <<= 8;
+           k |= key[i - 1];
+       }
+       // A swap is *not* necessary here because the preceding loop already
+       // places the low bytes in the low places according to whatever endianness
+       // we use. Swaps only apply when the memory is copied in a chunk.
+       h ^= murmur_32_scramble(k);
+       /* Finalize. */
+      h ^= n;
+      h ^= h >> 16;
+      h *= 0x85ebca6b;
+      h ^= h >> 13;
+      h *= 0xc2b2ae35;
+      h ^= h >> 16;
+      return h;
+   }
+}

--- a/include/glaze/util/murmur.hpp
+++ b/include/glaze/util/murmur.hpp
@@ -37,32 +37,32 @@ namespace glz
    inline constexpr uint32_t murmur3_32(auto&& key) noexcept
    {
       uint32_t h = 0; // We always use a seed of 0 for Crusher
-       uint32_t k;
-       const auto n = key.size();
-       auto* data = key.data();
-       /* Read in groups of 4. */
-       for (size_t i = n >> 2; i; i--) {
-           // Here is a source of differing results across endiannesses.
-           // A swap here has no effects on hash properties though.
-           k = to_uint32(data);
-
-           data += sizeof(uint32_t);
-           h ^= murmur_32_scramble(k);
-           h = (h << 13) | (h >> 19);
-           h = h * 5 + 0xe6546b64;
-       }
-       /* Read the rest. */
-       k = 0;
-       for (size_t i = n & 3; i; i--) {
-           k <<= 8;
-           k |= key[i - 1];
-       }
-       // A swap is *not* necessary here because the preceding loop already
-       // places the low bytes in the low places according to whatever endianness
-       // we use. Swaps only apply when the memory is copied in a chunk.
-       h ^= murmur_32_scramble(k);
-       /* Finalize. */
-      h ^= n;
+      uint32_t k;
+      const auto n = key.size();
+      auto* data = key.data();
+      /* Read in groups of 4. */
+      for (size_t i = n >> 2; i; i--) {
+         // Here is a source of differing results across endiannesses.
+         // A swap here has no effects on hash properties though.
+         k = to_uint32(data);
+         
+         data += sizeof(uint32_t);
+         h ^= murmur_32_scramble(k);
+         h = (h << 13) | (h >> 19);
+         h = h * 5 + 0xe6546b64;
+      }
+      /* Read the rest. */
+      k = 0;
+      for (size_t i = n & 3; i; i--) {
+         k <<= 8;
+         k |= key[i - 1];
+      }
+      // A swap is *not* necessary here because the preceding loop already
+      // places the low bytes in the low places according to whatever endianness
+      // we use. Swaps only apply when the memory is copied in a chunk.
+      h ^= murmur_32_scramble(k);
+      /* Finalize. */
+      h ^= static_cast<uint32_t>(n); // static_cast needed for MSVC 2019
       h ^= h >> 16;
       h *= 0x85ebca6b;
       h ^= h >> 13;

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -492,6 +492,7 @@ void test_partial()
       std::vector<std::byte> out;
       static constexpr auto partial = glz::json_ptrs("/i",
                                                        "/d",
+                                                       "/hello",
                                                        "/sub/x",
                                                        "/sub/y",
                                                        "/map/fish",
@@ -519,6 +520,12 @@ void test_partial()
       s2.sub.x = 0.0;
       s2.sub.y = 20;
       glz::read_binary(s2, out);
+      
+      expect(s2.i == 2);
+      expect(s2.d == 3.14);
+      expect(s2.hello == "Hello World");
+      expect(s2.sub.x == 400.0);
+      expect(s2.sub.y == 200.0);
    }
    catch (const std::exception& e) {
       std::cout << e.what() << '\n';


### PR DESCRIPTION
This changes to hashing binary keys to support the latest Crusher specification. This hurts performance, but makes the binary specification much more flexible and matches JSON better.