### PR TITLE
Unescape control and unicode chars when reading. And escape control chars when writing.

### DIFF
--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -81,12 +81,30 @@ namespace glz
             dump<'"'>(b);
             const auto write_char = [&](auto&& c) {
                switch (c) {
-               case '\\':
                case '"':
-                  dump<'\\'>(b);
+                  dump<"\\\"">(b);
                   break;
+               case '\\':
+                  dump<"\\\\">(b);
+                  break;
+               case '\b':
+                  dump<"\\b">(b);
+                  break;
+               case '\f':
+                  dump<"\\f">(b);
+                  break;
+               case '\n':
+                  dump<"\\n">(b);
+                  break;
+               case '\r':
+                  dump<"\\r">(b);
+                  break;
+               case '\t':
+                  dump<"\\t">(b);
+                  break;
+               default:
+                  dump(c, b);
                }
-               dump(c, b);
             };
             if constexpr (char_t<T>) {
                write_char(value);
@@ -106,12 +124,30 @@ namespace glz
             if constexpr (char_t<T>) {
                dump<'"'>(b, ix);
                switch (value) {
-               case '\\':
                case '"':
-                  dump<'\\'>(b, ix);
+                  dump<"\\\"">(b, ix);
                   break;
+               case '\\':
+                  dump<"\\\\">(b, ix);
+                  break;
+               case '\b':
+                  dump<"\\b">(b, ix);
+                  break;
+               case '\f':
+                  dump<"\\f">(b, ix);
+                  break;
+               case '\n':
+                  dump<"\\n">(b, ix);
+                  break;
+               case '\r':
+                  dump<"\\r">(b, ix);
+                  break;
+               case '\t':
+                  dump<"\\t">(b, ix);
+                  break;
+               default:
+                  dump(value, b, ix);
                }
-               dump(value, b, ix);
                dump<'"'>(b, ix);
             }
             else {
@@ -128,14 +164,37 @@ namespace glz
                // now we don't have to check writing
                for (auto&& c : str) {
                   switch (c) {
-                  case '\\':
                   case '"':
-                     b[ix] = '\\';
-                     ++ix;
+                     b[ix++] = '\\';
+                     b[ix++] = '\"';
                      break;
+                  case '\\':
+                     b[ix++] = '\\';
+                     b[ix++] = '\\';
+                     break;
+                  case '\b':
+                     b[ix++] = '\\';
+                     b[ix++] = 'b';
+                     break;
+                  case '\f':
+                     b[ix++] = '\\';
+                     b[ix++] = 'f';
+                     break;
+                  case '\n':
+                     b[ix++] = '\\';
+                     b[ix++] = 'n';
+                     break;
+                  case '\r':
+                     b[ix++] = '\\';
+                     b[ix++] = 'r';
+                     break;
+                  case '\t':
+                     b[ix++] = '\\';
+                     b[ix++] = 't';
+                     break;
+                  default:
+                     b[ix++] = c;
                   }
-                  b[ix] = c;
-                  ++ix;
                }
                dump_unchecked<'"'>(b, ix);
             }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -220,13 +220,77 @@ suite escaping_tests = [] {
       expect(obj.escaped_key2 == "bye");
    };
 
-   "escaped_characters"_test = [] {
-      std::string in = R"({"escape_chars":"\\b\\f\\n\\r\\t\\u11FF"})";
+   "escaped_characters read"_test = [] {
+      std::string in = R"({"escape_chars":"\b\f\n\r\t\u11FF"})";
       Escaped obj{};
 
       glz::read_json(obj, in);
 
-      expect(obj.escape_chars == "\\b\\f\\n\\r\\t\\u11FF");
+      expect(obj.escape_chars == "\b\f\n\r\tᇿ") << obj.escape_chars;
+   };
+
+   "escaped_char read"_test = [] {
+      std::string in = R"("\b")";
+      char c;
+      glz::read_json(c, in);
+      expect(c == '\b');
+
+      in = R"("\f")";
+      glz::read_json(c, in);
+      expect(c == '\f');
+
+      in = R"("\n")";
+      glz::read_json(c, in);
+      expect(c == '\n');
+
+      in = R"("\r")";
+      glz::read_json(c, in);
+      expect(c == '\r');
+
+      in = R"("\t")";
+      glz::read_json(c, in);
+      expect(c == '\t');
+
+      in = R"("\u11FF")";
+      char32_t c32;
+      glz::read_json(c32, in);
+      expect(static_cast<uint32_t>(c32) == 0x11FF);
+
+      in = R"("\u732B")";
+      char16_t c16;
+      glz::read_json(c16, in);
+      char16_t uc = u'\u732b';
+      expect(c16 == uc);
+   };
+
+   "escaped_characters write"_test = [] {
+      std::string str = "\"\\\b\f\n\r\tᇿ";
+      std::string buffer{};
+      glz::write_json(str, buffer);
+      expect(buffer == R"("\"\\\b\f\n\r\tᇿ")");
+   };
+
+   "escaped_char write"_test = [] {
+      std::string out{};
+      char c = '\b';
+      glz::write_json(c, out);
+      expect(out == R"("\b")");
+
+      c = '\f';
+      glz::write_json(c, out);
+      expect(out == R"("\f")");
+
+      c = '\n';
+      glz::write_json(c, out);
+      expect(out == R"("\n")");
+
+      c = '\r';
+      glz::write_json(c, out);
+      expect(out == R"("\r")");
+
+      c = '\t';
+      glz::write_json(c, out);
+      expect(out == R"("\t")");
    };
 };
 
@@ -974,21 +1038,6 @@ void read_tests() {
          glz::read_json(v, s);
          expect(v);
       }
-//*   // TODO add escaped char support for unicode
-      /*{
-         const auto a_num = static_cast<int>('15\u00f8C');
-         std::string s = std::to_string(a_num);
-         char v{};
-         glaze::read_json(v, s);
-         expect(v == a_num);
-      }
-      {
-         const auto a_num = static_cast<int>('15\u00f8C');
-         std::string s = std::to_string(a_num);
-         wchar_t v{};
-         glaze::read_json(v, s);
-         expect(v == a_num);
-      }*/
       {
          std::string s = "1";
          short v;


### PR DESCRIPTION
This deals with issue #55.

Note that the handling of escaped Unicode could be improved quite a bit but I don't expect them that often. Instead, Id expect utf8 encoded strings.