### PR TITLE
Support for lambda members in glaze array types. Support for std::pair in json

### DIFF
--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -246,7 +246,7 @@ namespace glz
          {
             using V = std::decay_t<T>;
             for_each<std::tuple_size_v<meta_t<V>>>([&](auto I) {
-               read<binary>::op<Opts>(value.*glz::tuplet::get<I>(meta_v<V>), ctx, it, end);
+               read<binary>::op<Opts>(get_member(value, glz::tuplet::get<I>(meta_v<V>)), ctx, it, end);
             });
          }
       };

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -223,7 +223,7 @@ namespace glz
          {
             using V = std::decay_t<T>;
             for_each<std::tuple_size_v<meta_t<V>>>([&](auto I) {
-               write<binary>::op<Opts>(value.*glz::tuplet::get<I>(meta_v<V>), ctx, std::forward<Args>(args)...);
+               write<binary>::op<Opts>(get_member(value, glz::tuplet::get<I>(meta_v<V>)), ctx, std::forward<Args>(args)...);
             });
          }
       };

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -430,6 +430,10 @@ namespace glz
       struct tuple_ptr_variant<std::tuple<Ts...>> : unique<std::variant<>, std::add_pointer_t<Ts>...>
       {};
 
+      template <class... Ts>
+      struct tuple_ptr_variant<std::pair<Ts...>> : unique<std::variant<>, std::add_pointer_t<Ts>...>
+      {};
+
       template <class Tuple,
                 class = std::make_index_sequence<std::tuple_size<Tuple>::value>>
       struct value_tuple_variant;

--- a/include/glaze/json/json_ptr.hpp
+++ b/include/glaze/json/json_ptr.hpp
@@ -143,7 +143,7 @@ namespace glz
             if (index >= member_array.size()) return false;
             return std::visit(
                [&](auto&& member_ptr) {
-                  return seek_impl(std::forward<F>(func), value.*member_ptr,
+                  return seek_impl(std::forward<F>(func), get_member(value, member_ptr),
                                    json_ptr);
                },
                member_array[index]);
@@ -446,7 +446,7 @@ namespace glz
             if constexpr (index >= 0 && index < member_array.size()) {
                constexpr auto member = member_array[index];
                constexpr auto member_ptr = std::get<member.index()>(member);
-               using sub_t = decltype(std::declval<V>().*member_ptr);
+               using sub_t = decltype(get_member(std::declval<V>(), member_ptr));
                return valid<sub_t, rem_ptr, Expected_t>();
             }
             else {

--- a/include/glaze/json/json_ptr.hpp
+++ b/include/glaze/json/json_ptr.hpp
@@ -446,7 +446,7 @@ namespace glz
             if constexpr (index >= 0 && index < member_array.size()) {
                constexpr auto member = member_array[index];
                constexpr auto member_ptr = std::get<member.index()>(member);
-               using sub_t = decltype(get_member(std::declval<V>(), member_ptr));
+               using sub_t = decltype(glz::detail::get_member(std::declval<V>(), member_ptr));
                return valid<sub_t, rem_ptr, Expected_t>();
             }
             else {

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -626,7 +626,7 @@ namespace glz
                   read<json>::op<ws_handled<Opts>()>(std::get<I>(value), ctx, it, end);
                }
                else if constexpr (glaze_array_t<T>) {
-                  read<json>::op<ws_handled<Opts>()>(value.*glz::tuplet::get<I>(meta_v<T>), ctx, it, end);
+                  read<json>::op<ws_handled<Opts>()>(get_member(value, glz::tuplet::get<I>(meta_v<T>)), ctx, it, end);
                }
                else {
                   read<json>::op<ws_handled<Opts>()>(glz::tuplet::get<I>(value), ctx, it, end);

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -382,7 +382,7 @@ namespace glz
             using V = std::decay_t<T>;
             for_each<N>([&](auto I) {
                if constexpr (glaze_array_t<V>) {
-                  write<json>::op<Opts>(value.*glz::tuplet::get<I>(meta_v<V>), ctx, std::forward<Args>(args)...);
+                  write<json>::op<Opts>(get_member(value, glz::tuplet::get<I>(meta_v<T>)), ctx, std::forward<Args>(args)...);
                }
                else {
                   write<json>::op<Opts>(glz::tuplet::get<I>(value), ctx, std::forward<Args>(args)...);

--- a/include/glaze/util/tuple.hpp
+++ b/include/glaze/util/tuple.hpp
@@ -12,7 +12,7 @@
 namespace glz
 {
    template <class T>
-   concept is_std_tuple = is_specialization_v<T, std::tuple>;
+   concept is_std_tuple = is_specialization_v<T, std::tuple> || is_specialization_v<T, std::pair>;
    
    inline constexpr auto size_impl(auto&& t) {
        return std::tuple_size_v<std::decay_t<decltype(t)>>;


### PR DESCRIPTION
Should probably add support in binary as well. Also, we will need set support. The only annoying part about sets is you don't know where the element should exist in memory until you read it in and therefore you need a temporary to read into. I dont see a good way around this.