### PR TITLE
Deleted obsolete command in install-rules.cmake

### DIFF
--- a/cmake/install-rules.cmake
+++ b/cmake/install-rules.cmake
@@ -37,13 +37,6 @@ set(
 mark_as_advanced(glaze_INSTALL_CMAKEDIR)
 
 install(
-    FILES cmake/install-config.cmake
-    DESTINATION "${glaze_INSTALL_CMAKEDIR}"
-    RENAME "${package}Config.cmake"
-    COMPONENT glaze_Development
-)
-
-install(
     FILES "${PROJECT_BINARY_DIR}/${package}ConfigVersion.cmake"
     DESTINATION "${glaze_INSTALL_CMAKEDIR}"
     COMPONENT glaze_Development


### PR DESCRIPTION
The file referenced was removed in https://github.com/stephenberry/glaze/commit/ab561f11ae4c17a5b9d9597a611ffd04ff97a42c.