### PR TITLE
Fix find_package

### DIFF
--- a/cmake/install-config.cmake
+++ b/cmake/install-config.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/glazeTargets.cmake")


### PR DESCRIPTION
Bring back config file needed for find_package as pointed out by @klemenpeganc

> Something is broken here. Without this command, `glazeConfig.cmake` file will not be generated, which means projects won't be able to call `find_package(glaze REQUIRED)`. However, having this install command will lead to a File doesn't exist error. I have temporarily fixed it on my fork by adding the file `install-config.cmake` and only having `include("${CMAKE_CURRENT_LIST_DIR}/glazeTargets.cmake")` in it. Please take a look.

_Originally posted by @klemenpeganc in https://github.com/stephenberry/glaze/issues/102#issuecomment-1374650273_