### PR TITLE
More end check removal

### DIFF
--- a/include/glaze/json/json_t.hpp
+++ b/include/glaze/json/json_t.hpp
@@ -72,6 +72,8 @@ namespace glz
 
       const val_t& operator*() const { return data; }
 
+      void reset() { data = null_t{}; }
+
       json_t() = default;
 
       template <class T>


### PR DESCRIPTION
There are a number of end checks that can be probably avoided due to the json read stuff now assuming null termination. Not 100% sure all of these are safe but it doesn't seem to cause any problems with our early end test when running with asan enabled. But that doesn't mean some untested corner case isn't going to cause a problem. I'll avoid merging this in for now and Ill look back at this Monday or so. It might be good to get a second opinion on this.

