### PR TITLE
Add const methods to json_t. Allow initialization of json_t with non double numeric types.

### DIFF
--- a/include/glaze/json/json_t.hpp
+++ b/include/glaze/json/json_t.hpp
@@ -28,18 +28,32 @@ namespace glz
       }
 
       template <class T>
-      T* get_if()
+      const T& get() const
+      {
+         return std::get<T>(data);
+      }
+
+      template <class T>
+      T* get_if() noexcept
       {
          return std::get_if<T>(data);
       }
 
       template <class T>
-      bool holds()
+      const T* get_if() const noexcept
+      {
+         return std::get_if<T>(&data);
+      }
+
+      template <class T>
+      bool holds() const noexcept
       {
          return std::holds_alternative<T>(data);
       }
 
       json_t& operator[](std::integral auto&& index) { return std::get<array_t>(data)[index]; }
+
+      const json_t& operator[](std::integral auto&& index) const { return std::get<array_t>(data)[index]; }
 
       json_t& operator[](std::convertible_to<std::string_view> auto&& key)
       {
@@ -53,7 +67,18 @@ namespace glz
          return iter->second;
       }
 
-      bool contains(std::convertible_to<std::string_view> auto&& key)
+      const json_t& operator[](std::convertible_to<std::string_view> auto&& key) const
+      {
+         //[] operator for maps does not support heterogeneous lookups yet
+         auto& object = std::get<object_t>(data);
+         auto iter = object.find(key);
+         if (iter == object.end()) {
+            throw std::runtime_error("Key not found.");
+         }
+         return iter->second;
+      }
+
+      bool contains(std::convertible_to<std::string_view> auto&& key) const
       {
          if (!holds<object_t>()) return false;
          auto& object = std::get<object_t>(data);
@@ -66,13 +91,13 @@ namespace glz
 
       operator bool() const { return !std::holds_alternative<null_t>(data); }
 
-      val_t* operator->() { return &data; }
+      val_t* operator->() noexcept { return &data; }
 
-      val_t& operator*() { return data; }
+      val_t& operator*() noexcept { return data; }
 
-      const val_t& operator*() const { return data; }
+      const val_t& operator*() const noexcept { return data; }
 
-      void reset() { data = null_t{}; }
+      void reset() noexcept { data = null_t{}; }
 
       json_t() = default;
 
@@ -81,6 +106,11 @@ namespace glz
       json_t(T&& val)
       {
          data = val;
+      }
+
+      template <class T>
+      requires std::convertible_to<T, double> &&(!std::convertible_to<T, val_t>) json_t(T&& val) {
+         data = static_cast<double>(val);
       }
 
       json_t(std::initializer_list<std::pair<const std::string, json_t>>&& obj) { data = object_t(obj); }

--- a/include/glaze/json/json_t.hpp
+++ b/include/glaze/json/json_t.hpp
@@ -105,12 +105,12 @@ namespace glz
       requires std::convertible_to<T, val_t> && (!std::same_as<json_t, std::decay_t<T>>)
       json_t(T&& val)
       {
-         data = val;
+         data = std::forward<T>(val);
       }
 
       template <class T>
-      requires std::convertible_to<T, double> &&(!std::convertible_to<T, val_t>) json_t(T&& val) {
-         data = static_cast<double>(val);
+      requires std::convertible_to<T, double> && (!std::same_as<json_t, std::decay_t<T>>) &&(!std::convertible_to<T, val_t>) json_t(T&& val) {
+         data = static_cast<double>(std::forward<T>(val));
       }
 
       json_t(std::initializer_list<std::pair<const std::string, json_t>>&& obj) { data = object_t(obj); }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -2293,6 +2293,17 @@ suite generic_json_tests = [] {
       expect(json[1].get<std::string>() == "Hello World");
       expect(json[2]["pi"].get<double>() == 3.14);
    };
+
+   "generic_json_const"_test = [] {
+      auto foo = [](const glz::json_t& json) { return json["s"].get<std::string>(); };
+      glz::json_t json = {{"s", "hello world"}};
+      expect(foo(json) == "hello world");
+   };
+
+   "generic_json_int"_test = [] {
+      glz::json_t json = {{"i", 1}};
+      expect(json["i"].get<double>() == 1);
+   };
 };
 
 struct holder0_t {


### PR DESCRIPTION
This addresses #162.

Additionally, it handles part of #163 by allowing the initialization of json_t with non-double numeric types. double is still the only numeric type stored in json_t since it allows us to use the built-in automatic auto variant type inferencing when there is only one of each fundamental type.

This code is likely to change soon with the removal of exceptions.