### PR TITLE
Improve json_t perf and remove lib specific support

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -11,6 +11,7 @@ on:
     branches: [main]
     paths-ignore:
     - '**.md'
+  workflow_dispatch:
 
 env:
   BUILD_TYPE: Release

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -7,6 +7,7 @@ on:
     - feature/*
     paths-ignore:
     - '**.md'
+  workflow_dispatch:
 
 env:
   BUILD_TYPE: Debug

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -11,6 +11,7 @@ on:
     branches: [main]
     paths-ignore:
     - '**.md'
+  workflow_dispatch:
 
 env:
   BUILD_TYPE: Release

--- a/.github/workflows/gcc12.yml
+++ b/.github/workflows/gcc12.yml
@@ -11,6 +11,7 @@ on:
     branches: [main]
     paths-ignore:
     - '**.md'
+  workflow_dispatch:
 
 env:
   BUILD_TYPE: Release

--- a/.github/workflows/msvc_2019.yml
+++ b/.github/workflows/msvc_2019.yml
@@ -11,6 +11,7 @@ on:
     branches: [main]
     paths-ignore:
     - '**.md'
+  workflow_dispatch:
 
 env:
   BUILD_TYPE: Release

--- a/.github/workflows/msvc_2022.yml
+++ b/.github/workflows/msvc_2022.yml
@@ -11,6 +11,7 @@ on:
     branches: [main]
     paths-ignore:
     - '**.md'
+  workflow_dispatch:
 
 env:
   BUILD_TYPE: Release

--- a/include/glaze/json/json_t.hpp
+++ b/include/glaze/json/json_t.hpp
@@ -5,7 +5,7 @@
 
 #include <variant>
 #include <vector>
-#include <map>
+#include <unordered_map>
 #include <stddef.h>
 #include <stdexcept>
 #include <concepts>

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -203,7 +203,8 @@ namespace glz
                      else {
                         using V = std::tuple_element_t<0, nullable_types>;
                         if (!std::holds_alternative<V>(value)) value = V{};
-                        match<"null">(it, end);
+                        ++it;
+                        match<"ull">(it, end);
                      }
                      break;
                   default: {

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -37,7 +37,7 @@ namespace glz
       {
          template <auto Opts, is_context Ctx, class B, class IX>
          static void op(auto&& value, Ctx&& ctx, B&& b, IX&& ix) {
-            using V = decltype(get_member(std::declval<T>(), meta_wrapper_v<T>));
+            using V = std::decay_t<decltype(get_member(std::declval<T>(), meta_wrapper_v<T>))>;
             to_json<V>::template op<Opts>(get_member(value, meta_wrapper_v<T>), std::forward<Ctx>(ctx), std::forward<B>(b), std::forward<IX>(ix));
          }
       };

--- a/include/glaze/util/hash_map.hpp
+++ b/include/glaze/util/hash_map.hpp
@@ -1,3 +1,8 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
 #include <array>
 #include <cassert>
 #include <limits>
@@ -9,6 +14,15 @@
 
 namespace glz
 {
+   // Used for heterogeneous unordered_map lookups
+   struct transparent_string_hash
+   {
+      using is_transparent = void;
+      [[nodiscard]] size_t operator()(const char* txt) const { return std::hash<std::string_view>{}(txt); }
+      [[nodiscard]] size_t operator()(std::string_view txt) const { return std::hash<std::string_view>{}(txt); }
+      [[nodiscard]] size_t operator()(const std::string& txt) const { return std::hash<std::string>{}(txt); }
+   };
+
    namespace detail
    {
       // https://en.wikipedia.org/wiki/Fowler–Noll–Vo_hash_function

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -969,6 +969,7 @@ void bench()
 
       glz::json_t json{};
       glz::read_json(json, buffer);
+      std::string buffer_json_t{};  // Prevent reordering of type key
 
       auto tstart = std::chrono::high_resolution_clock::now();
       for (size_t i{}; i < repeat; ++i) {
@@ -987,13 +988,13 @@ void bench()
 
       tstart = std::chrono::high_resolution_clock::now();
       for (size_t i{}; i < repeat; ++i) {
-         buffer.clear();
-         glz::write_json(json, buffer);
+         buffer_json_t.clear();
+         glz::write_json(json, buffer_json_t);
       }
       tend = std::chrono::high_resolution_clock::now();
       duration = std::chrono::duration_cast<std::chrono::duration<double>>(tend - tstart).count();
-      mbytes_per_sec = repeat * buffer.size() / (duration * 1048576);
-      std::cout << "write_json_t size: " << buffer.size() << " bytes\n";
+      mbytes_per_sec = repeat * buffer_json_t.size() / (duration * 1048576);
+      std::cout << "write_json_t size: " << buffer_json_t.size() << " bytes\n";
       std::cout << "write_json_t: " << duration << " s, " << mbytes_per_sec << " MB/s"
                 << "\n";
 
@@ -1011,11 +1012,11 @@ void bench()
 
       tstart = std::chrono::high_resolution_clock::now();
       for (size_t i{}; i < repeat; ++i) {
-         glz::read_json(json, buffer);
+         glz::read_json(json, buffer_json_t);
       }
       tend = std::chrono::high_resolution_clock::now();
       duration = std::chrono::duration_cast<std::chrono::duration<double>>(tend - tstart).count();
-      mbytes_per_sec = repeat * buffer.size() / (duration * 1048576);
+      mbytes_per_sec = repeat * buffer_json_t.size() / (duration * 1048576);
       std::cout << "read_json_t: " << duration << " s, " << mbytes_per_sec << " MB/s"
                 << "\n";
 


### PR DESCRIPTION
Improve json_t performance by removing unnecessary unwrapping and using an unordered map. Remove json_t specific code in the reader so it could be implemented by a user and doesn't require direct support in the library.