### PR TITLE
Fix includes for vendoring projects

### DIFF
--- a/cmake/install-rules.cmake
+++ b/cmake/install-rules.cmake
@@ -12,7 +12,7 @@ include(GNUInstallDirs)
 set(package glaze)
 
 install(
-    DIRECTORY include/glaze/
+    DIRECTORY include/
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
     COMPONENT glaze_Development
 )


### PR DESCRIPTION
Vendoring projects would previously install glaze directly to `/usr/local/include` if `/usr/local` is their install prefix and wish to install glaze themselves.

Example where this could go wrong:

    set(CMAKE_SKIP_INSTALL_RULES OFF)
    add_subdirectory(third-party/glaze)

And when installing:

    $ cmake -B build -DCMAKE_INSTALL_PREFIX=/foo
    ...
    $ cmake --build build -t install
    ...
    -- Installing: /foo/include/glaze.hpp
    ...

This breaks `#include <glaze/glaze.hpp>` includes!