### PR TITLE
Add warnings flags to test targets and enforce in github workflow with Werror

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_TYPE: Release
+  BUILD_TYPE: Debug
 
 jobs:
   build:

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_TYPE: Release
+  BUILD_TYPE: Debug
 
 jobs:
   build:

--- a/.github/workflows/gcc12.yml
+++ b/.github/workflows/gcc12.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_TYPE: Release
+  BUILD_TYPE: Debug
 
 jobs:
   build:

--- a/.github/workflows/msvc_2019.yml
+++ b/.github/workflows/msvc_2019.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_TYPE: Release
+  BUILD_TYPE: Debug
 
 jobs:
   build:

--- a/.github/workflows/msvc_2022.yml
+++ b/.github/workflows/msvc_2022.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_TYPE: Release
+  BUILD_TYPE: Debug
 
 jobs:
   build:

--- a/include/glaze/api/api.hpp
+++ b/include/glaze/api/api.hpp
@@ -99,11 +99,10 @@ namespace glz
          static constexpr auto N = sizeof...(Args);
          std::array<void*, N> arguments;
 
-         //auto tuple = std::make_tuple(std::forward<Args>(args)...);
-         auto tuple = std::forward_as_tuple(std::forward<Args>(args)...);
+         auto tuple_args = std::forward_as_tuple(std::forward<Args>(args)...);
 
          for_each<N>([&](auto I) {
-            std::get<I>(arguments) = &std::get<I>(tuple);
+            std::get<I>(arguments) = &std::get<I>(tuple_args);
          });
 
          if constexpr (std::is_pointer_v<Ret>) {

--- a/include/glaze/api/impl.hpp
+++ b/include/glaze/api/impl.hpp
@@ -109,7 +109,7 @@ namespace glz
       }
       
       template <class Arg_tuple, class F, class Parent, size_t... Is>
-      decltype(auto) call_args(F&& f, Parent&& parent, std::span<void*> args, std::index_sequence<Is...>)
+      decltype(auto) call_args(F&& f, Parent&& parent, [[maybe_unused]] std::span<void*> args, std::index_sequence<Is...>)
       {
          return f(parent, to_ref<std::tuple_element_t<Is, Arg_tuple>>(args[Is])...);
       }

--- a/include/glaze/api/lib.hpp
+++ b/include/glaze/api/lib.hpp
@@ -111,7 +111,7 @@ namespace glz
 #ifdef GLAZE_API_ON_WINDOWS
             auto* ptr = (create)GetProcAddress(loaded_lib, "glz_iface");
 #else
-            auto* ptr = (create)dlsym(dlopen(path.c_str(), RTLD_NOW), "glz_iface");
+            auto* ptr = reinterpret_cast<create>(dlsym(dlopen(path.c_str(), RTLD_NOW), "glz_iface"));
 #endif
 
             if (ptr) {

--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -229,7 +229,7 @@ namespace glz
                   read<binary>::op<Opts>(value[key], ctx, it, end);
                }
             }
-         };
+         }
       };
 
       template <nullable_t T>

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -245,7 +245,7 @@ namespace glz
          template <auto Opts, class... Args>
          GLZ_ALWAYS_INLINE static auto op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
          {
-            dump_int<Opts>(value.size(), std::forward<Args>(args)...);
+            std::ignore = dump_int<Opts>(value.size(), std::forward<Args>(args)...);
             for (auto&& [k, v] : value) {
                write<binary>::op<Opts>(k, ctx, std::forward<Args>(args)...);
                write<binary>::op<Opts>(v, ctx, std::forward<Args>(args)...);
@@ -374,7 +374,7 @@ namespace glz
                
                static constexpr uint32_t hash = murmur3_32(key);
                detail::dump_type(hash, buffer);
-               write<sub_partial, Opts>(glz::detail::get_member(value, member_ptr), buffer, ctx);
+               std::ignore = write<sub_partial, Opts>(glz::detail::get_member(value, member_ptr), buffer, ctx);
             });
          }
          else if constexpr (detail::map_t<std::decay_t<T>>) {
@@ -389,7 +389,7 @@ namespace glz
                detail::write<binary>::op<Opts>(key, ctx, buffer);
                auto it = value.find(key);
                if (it != value.end()) {
-                  write<sub_partial, Opts>(it->second, buffer, ctx);
+                  std::ignore = write<sub_partial, Opts>(it->second, buffer, ctx);
                }
                else {
                   we.ec = error_code::invalid_partial_key;

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -518,8 +518,7 @@ namespace glz
          auto naive_or_normal_hash = [&]
          {
             // these variables needed for MSVC
-            constexpr bool n_20 = n <= 20;
-            if constexpr (n_20) {
+            if constexpr (n <= 20) {
                return glz::detail::make_naive_map<value_t, n, uint32_t, allow_hash_check>(
                   {std::make_pair<sv, value_t>(
                      sv(glz::tuplet::get<0>(glz::tuplet::get<I>(meta_v<T>))),

--- a/include/glaze/frozen/bits/algorithms.hpp
+++ b/include/glaze/frozen/bits/algorithms.hpp
@@ -55,10 +55,10 @@ namespace glz::frozen
       }
 
       constexpr std::size_t bit_weight(std::size_t n) {
-        return (n <= 8*sizeof(unsigned int))
-          + (n <= 8*sizeof(unsigned long))
-          + (n <= 8*sizeof(unsigned long long))
-          + (n <= 128);
+        return (n <= 8ull*sizeof(unsigned int))
+          + (n <= 8ull*sizeof(unsigned long))
+          + (n <= 8ull*sizeof(unsigned long long))
+          + (n <= 128ull);
       }
 
       unsigned int select_uint_least(std::integral_constant<std::size_t, 4>);

--- a/include/glaze/frozen/bits/pmh.hpp
+++ b/include/glaze/frozen/bits/pmh.hpp
@@ -210,7 +210,7 @@ pmh_tables<M, Hash> constexpr make_pmh_tables(const carray<Item, N> &
       cvector<std::size_t, decltype(step_one)::bucket_max> bucket_slots;
 
       while (bucket_slots.size() < bsize) {
-        auto slot = hash(key(items[bucket[bucket_slots.size()]]), static_cast<size_t>(d.value())) % M;
+        auto slot = hash(key(items[bucket[bucket_slots.size()]]), d.value()) % M;
 
         if (H[slot] != UNUSED || !all_different_from(bucket_slots, slot)) {
           bucket_slots.clear();

--- a/include/glaze/json/json_ptr.hpp
+++ b/include/glaze/json/json_ptr.hpp
@@ -340,10 +340,14 @@ namespace glz
                              std::decay_t<decltype(value)>,
                              std::decay_t<decltype(val)>>) {
                result = true;
+               #if defined(__GNUC__) || defined(__GNUG__)
                #pragma GCC diagnostic push
                #pragma GCC diagnostic ignored "-Waddress"
+               #endif
                val = value;
+               #if defined(__GNUC__) || defined(__GNUG__)
                #pragma GCC diagnostic pop
+               #endif
             }
          },
          std::forward<T>(root_value), json_ptr);

--- a/include/glaze/json/json_ptr.hpp
+++ b/include/glaze/json/json_ptr.hpp
@@ -340,7 +340,10 @@ namespace glz
                              std::decay_t<decltype(value)>,
                              std::decay_t<decltype(val)>>) {
                result = true;
+               #pragma GCC diagnostic push
+               #pragma GCC diagnostic ignored "-Waddress"
                val = value;
+               #pragma GCC diagnostic pop
             }
          },
          std::forward<T>(root_value), json_ptr);

--- a/include/glaze/json/json_ptr.hpp
+++ b/include/glaze/json/json_ptr.hpp
@@ -538,8 +538,13 @@ namespace glz
                   using sub_t = decltype(glz::detail::get_member(std::declval<V>(), member_ptr));
                   return valid<sub_t, rem_ptr, Expected_t>();
                }
+               else {
+                  return false;
+               }
             }
-            return false;
+            else {
+               return false;
+            }
          }
          else if constexpr (glz::detail::array_t<V>) {
             if (glz::detail::stoui(key_str)) {

--- a/include/glaze/json/prettify.hpp
+++ b/include/glaze/json/prettify.hpp
@@ -100,6 +100,7 @@ namespace glz
                state = COMMENT;
             }
             break;
+         case NORMAL:
          default:
             break;
          }

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1149,7 +1149,7 @@ namespace glz
                                         return;
                                      }
                                      else {
-                                        ctx.error = ctx.error = error_code::no_matching_variant_type;
+                                        ctx.error = error_code::no_matching_variant_type;
                                         return;
                                      }
                                   }
@@ -1166,7 +1166,7 @@ namespace glz
 
                             auto matching_types = possible_types.popcount();
                             if (matching_types == 0) {
-                               ctx.error = ctx.error = error_code::no_matching_variant_type;
+                               ctx.error = error_code::no_matching_variant_type;
                                return;
                             }
                             else if (matching_types == 1) {
@@ -1189,14 +1189,14 @@ namespace glz
                             skip_value<Opts>(ctx, it, end);
                             skip_ws<Opts>(ctx, it, end);
                          }
-                         ctx.error = ctx.error = error_code::no_matching_variant_type;
+                         ctx.error = error_code::no_matching_variant_type;
                          return;
                       }
                       break;
                    case '[':
                       using array_types = typename variant_types<T>::array_types;
                       if constexpr (std::tuple_size_v<array_types> < 1) {
-                         ctx.error = ctx.error = error_code::no_matching_variant_type;
+                         ctx.error = error_code::no_matching_variant_type;
                          return;
                       }
                       else {
@@ -1208,7 +1208,7 @@ namespace glz
                    case '"': {
                       using string_types = typename variant_types<T>::string_types;
                       if constexpr (std::tuple_size_v<string_types> < 1) {
-                         ctx.error = ctx.error = error_code::no_matching_variant_type;
+                         ctx.error = error_code::no_matching_variant_type;
                          return;
                       }
                       else {
@@ -1222,7 +1222,7 @@ namespace glz
                    case 'f': {
                       using bool_types = typename variant_types<T>::bool_types;
                       if constexpr (std::tuple_size_v<bool_types> < 1) {
-                         ctx.error = ctx.error = error_code::no_matching_variant_type;
+                         ctx.error = error_code::no_matching_variant_type;
                          return;
                       }
                       else {
@@ -1235,7 +1235,7 @@ namespace glz
                    case 'n':
                       using nullable_types = typename variant_types<T>::nullable_types;
                       if constexpr (std::tuple_size_v<nullable_types> < 1) {
-                         ctx.error = ctx.error = error_code::no_matching_variant_type;
+                         ctx.error = error_code::no_matching_variant_type;
                          return;
                       }
                       else {
@@ -1248,7 +1248,7 @@ namespace glz
                       // Not bool, string, object, or array so must be number or null
                       using number_types = typename variant_types<T>::number_types;
                       if constexpr (std::tuple_size_v<number_types> < 1) {
-                         ctx.error = ctx.error = error_code::no_matching_variant_type;
+                         ctx.error = error_code::no_matching_variant_type;
                          return;
                       }
                       else {

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -78,7 +78,7 @@ namespace glz
          {
             using V = std::decay_t<decltype(value.get())>;
             from_json<V>::template op<Opts>(value.get(), std::forward<Args>(args)...);
-         };
+         }
       };
       
       template <>
@@ -88,7 +88,7 @@ namespace glz
          GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, auto&&...) noexcept
          {
             ctx.error = error_code::attempt_read_hidden;
-         };
+         }
       };
       
       template <>
@@ -98,7 +98,7 @@ namespace glz
          GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, auto&&... args) noexcept
          {
             match<R"("std::monostate")">(args...);
-         };
+         }
       };
       
       template <bool_t T>

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -80,7 +80,7 @@ namespace glz
             dump<'"'>(args...);
             dump("hidden type should not have been written", args...);
             dump<'"'>(args...);
-         };
+         }
       };
       
       template <>
@@ -92,7 +92,7 @@ namespace glz
             dump<'"'>(args...);
             dump("skip type should not have been written", args...);
             dump<'"'>(args...);
-         };
+         }
       };
       
       template <is_member_function_pointer T>
@@ -111,7 +111,7 @@ namespace glz
          {
             using V = std::decay_t<decltype(value.get())>;
             to_json<V>::template op<Opts>(value.get(), std::forward<Args>(args)...);
-         };
+         }
       };
       
       template <boolean_like T>
@@ -442,7 +442,7 @@ namespace glz
          GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, auto&&... args) noexcept
          {
             dump<R"("std::monostate")">(args...);
-         };
+         }
       };
 
       template <is_variant T>

--- a/include/glaze/util/any.hpp
+++ b/include/glaze/util/any.hpp
@@ -65,7 +65,7 @@ namespace glz
      }
 
      any& operator=(any&& rhs) noexcept {
-       any(std::move(rhs)).swap(*this);
+       std::move(rhs).swap(*this);
        return *this;
      }
 

--- a/include/glaze/util/bit_array.hpp
+++ b/include/glaze/util/bit_array.hpp
@@ -89,7 +89,7 @@ namespace glz::detail {
             }
             else {
                 int res{};
-                for (size_t i = data.size() - 1; i >= 0; --i) {
+                for (int i = static_cast<int>(data.size()) - 1; i > -1; --i) {
                     const auto trailing_zeros = std::countr_zero(data[i]);
                     res += trailing_zeros;
                     if (trailing_zeros < n_chunk_bits) {

--- a/include/glaze/util/dtoa.hpp
+++ b/include/glaze/util/dtoa.hpp
@@ -25,9 +25,9 @@ namespace glz
    inline void u128_mul(uint64_t a, uint64_t b, uint64_t *hi, uint64_t *lo)
    {
    #ifdef __SIZEOF_INT128__
-      unsigned __int128 m = (unsigned __int128)a * b;
-      *hi = (uint64_t)(m >> 64);
-      *lo = (uint64_t)(m);
+      unsigned __int128 m = static_cast<unsigned __int128>(a) * b;
+      *hi = uint64_t(m >> 64);
+      *lo = uint64_t(m);
    #elif defined(_M_X64)
       *lo = _umul128(a, b, hi);
    #elif defined(_M_ARM64)
@@ -52,9 +52,9 @@ namespace glz
    inline void u128_mul_add(uint64_t a, uint64_t b, uint64_t c, uint64_t *hi, uint64_t *lo)
    {
    #ifdef __SIZEOF_INT128__
-      unsigned __int128 m = (unsigned __int128)a * b + c;
-      *hi = (uint64_t)(m >> 64);
-      *lo = (uint64_t)(m);
+      unsigned __int128 m = static_cast<unsigned __int128>(a) * b + c;
+      *hi = uint64_t(m >> 64);
+      *lo = uint64_t(m);
    #else
       uint64_t h, l, t;
       u128_mul(a, b, &h, &l);
@@ -837,7 +837,7 @@ namespace glz
       /*                        : floor(log10(pow(2, exp_bin) * 3.0 / 4.0))     */
       /*   = lower_bound_closer ? floor(exp_bin * log10(2))                     */
       /*                        : floor(exp_bin * log10(2) + log10(3.0 / 4.0))  */
-      k = (int32_t)(exp_bin * 315653 - (lower_bound_closer ? 131237 : 0)) >> 20;
+      k = (exp_bin * 315653 - (lower_bound_closer ? 131237 : 0)) >> 20;
 
       /* k: [-324, 292]                                                         */
       /* h = exp_bin + floor(log2(pow(10, e)))                                  */
@@ -893,17 +893,17 @@ namespace glz
       bool lz;          /* leading zero */
       uint32_t tz1, tz2, tz; /* trailing zero */
 
-      uint32_t abbccddee = (uint32_t)(sig / 100000000);
-      uint32_t ffgghhii = (uint32_t)(sig - (uint64_t)abbccddee * 100000000);
+      uint32_t abbccddee = uint32_t(sig / 100000000);
+      uint32_t ffgghhii = uint32_t(sig - uint64_t(abbccddee) * 100000000);
       uint32_t abbcc = abbccddee / 10000;                /* (abbccddee / 10000) */
       uint32_t ddee = abbccddee - abbcc * 10000;         /* (abbccddee % 10000) */
-      uint32_t abb = (uint32_t)(((uint64_t)abbcc * 167773) >> 24); /* (abbcc / 100) */
+      uint32_t abb = uint32_t((uint64_t(abbcc) * 167773) >> 24); /* (abbcc / 100) */
       uint32_t a = (abb * 41) >> 12;                     /* (abb / 100) */
       uint32_t bb = abb - a * 100;                       /* (abb % 100) */
       uint32_t cc = abbcc - abb * 100;                   /* (abbcc % 100) */
 
       /* write abbcc */
-      buf[0] = (uint8_t)(a + '0');
+      buf[0] = uint8_t(a + '0');
       buf += a > 0;
       lz = bb < 10 && a == 0;
       //((uint16_t *)buf)[0] = *(const uint16_t *)(char_table + (bb * 2 + lz));
@@ -915,7 +915,7 @@ namespace glz
       if (ffgghhii) {
          uint32_t dd = (ddee * 5243) >> 19;                        /* (ddee / 100) */
          uint32_t ee = ddee - dd * 100;                            /* (ddee % 100) */
-         uint32_t ffgg = (uint32_t)(((uint64_t)ffgghhii * 109951163) >> 40); /* (val / 10000) */
+         uint32_t ffgg = uint32_t((uint64_t(ffgghhii) * 109951163) >> 40); /* (val / 10000) */
          uint32_t hhii = ffgghhii - ffgg * 10000;                  /* (val % 10000) */
          uint32_t ff = (ffgg * 5243) >> 19;                        /* (aabb / 100) */
          uint32_t gg = ffgg - ff * 100;                            /* (aabb % 100) */
@@ -1013,9 +1013,9 @@ namespace glz
             exp_bin = 1 - (std::numeric_limits<T>::max_exponent - 1) - (std::numeric_limits<T>::digits - 1);
          }
          else {
-            sig_bin = sig_raw | ((uint64_t)1 << (std::numeric_limits<T>::digits - 1));
+            sig_bin = sig_raw | uint64_t(1ull << (std::numeric_limits<T>::digits - 1));
             exp_bin =
-               (int32_t)exp_raw - (std::numeric_limits<T>::max_exponent - 1) - (std::numeric_limits<T>::digits - 1);
+               int32_t(exp_raw) - (std::numeric_limits<T>::max_exponent - 1) - (std::numeric_limits<T>::digits - 1);
          }
 
          //if constexpr (std::same_as<T, float>) {
@@ -1034,8 +1034,8 @@ namespace glz
          }
 
          int32_t sig_len = 17;
-         sig_len -= (sig_dec < (uint64_t)100000000 * 100000000);
-         sig_len -= (sig_dec < (uint64_t)100000000 * 10000000);
+         sig_len -= (sig_dec < 100000000ull * 100000000ull);
+         sig_len -= (sig_dec < 100000000ull * 10000000ull);
 
          /* the decimal point position relative to the first digit */
          int32_t dot_pos = sig_len + exp_dec;

--- a/include/glaze/util/dtoa.hpp
+++ b/include/glaze/util/dtoa.hpp
@@ -1084,13 +1084,12 @@ namespace glz
                return buffer + 2 - lz;
             }
             else {
-               uint32_t hi = ((uint32_t)exp_dec * 656) >> 16; /* exp / 100 */
-               uint32_t lo = (uint32_t)exp_dec - hi * 100;    /* exp % 100 */
-               buffer[0] = hi + '0';
+               uint32_t hi = (uint32_t(exp_dec) * 656) >> 16; /* exp / 100 */
+               uint32_t lo = uint32_t(exp_dec) - hi * 100;    /* exp % 100 */
+               buffer[0] = uint8_t(hi) + '0';
                *(uint16_t *)&buffer[1] = *(const uint16_t *)(char_table + (lo * 2));
                return buffer + 3;
             }
-            return buffer;
          }
 
       }

--- a/include/glaze/util/dtoa.hpp
+++ b/include/glaze/util/dtoa.hpp
@@ -26,10 +26,14 @@ namespace glz
    inline void u128_mul(uint64_t a, uint64_t b, uint64_t *hi, uint64_t *lo)
    {
    #ifdef __SIZEOF_INT128__
+   #if defined(__GNUC__) || defined(__GNUG__)
    #pragma GCC diagnostic push
    #pragma GCC diagnostic ignored "-Wpedantic"
+   #endif
       unsigned __int128 m = static_cast<unsigned __int128>(a) * b;
+   #if defined(__GNUC__) || defined(__GNUG__)
    #pragma GCC diagnostic pop
+   #endif
       *hi = uint64_t(m >> 64);
       *lo = uint64_t(m);
    #elif defined(_M_X64)
@@ -56,10 +60,14 @@ namespace glz
    inline void u128_mul_add(uint64_t a, uint64_t b, uint64_t c, uint64_t *hi, uint64_t *lo)
    {
    #ifdef __SIZEOF_INT128__
+   #if defined(__GNUC__) || defined(__GNUG__)
    #pragma GCC diagnostic push
    #pragma GCC diagnostic ignored "-Wpedantic"
+   #endif
       unsigned __int128 m = static_cast<unsigned __int128>(a) * b + c;
+   #if defined(__GNUC__) || defined(__GNUG__)
    #pragma GCC diagnostic pop
+   #endif
       *hi = uint64_t(m >> 64);
       *lo = uint64_t(m);
    #else

--- a/include/glaze/util/dtoa.hpp
+++ b/include/glaze/util/dtoa.hpp
@@ -20,12 +20,16 @@ namespace glz
    #pragma intrinsic(__umulh)
    #endif
 
+
    /** Multiplies two 64-bit unsigned integers (a * b),
        returns the 128-bit result as 'hi' and 'lo'. */
    inline void u128_mul(uint64_t a, uint64_t b, uint64_t *hi, uint64_t *lo)
    {
    #ifdef __SIZEOF_INT128__
+   #pragma GCC diagnostic push
+   #pragma GCC diagnostic ignored "-Wpedantic"
       unsigned __int128 m = static_cast<unsigned __int128>(a) * b;
+   #pragma GCC diagnostic pop
       *hi = uint64_t(m >> 64);
       *lo = uint64_t(m);
    #elif defined(_M_X64)
@@ -52,7 +56,10 @@ namespace glz
    inline void u128_mul_add(uint64_t a, uint64_t b, uint64_t c, uint64_t *hi, uint64_t *lo)
    {
    #ifdef __SIZEOF_INT128__
+   #pragma GCC diagnostic push
+   #pragma GCC diagnostic ignored "-Wpedantic"
       unsigned __int128 m = static_cast<unsigned __int128>(a) * b + c;
+   #pragma GCC diagnostic pop
       *hi = uint64_t(m >> 64);
       *lo = uint64_t(m);
    #else
@@ -906,10 +913,8 @@ namespace glz
       buf[0] = uint8_t(a + '0');
       buf += a > 0;
       lz = bb < 10 && a == 0;
-      //((uint16_t *)buf)[0] = *(const uint16_t *)(char_table + (bb * 2 + lz));
       std::memcpy(buf, char_table + (bb * 2 + lz), 2);
       buf -= lz;
-      //((uint16_t *)buf)[1] = ((const uint16_t *)char_table)[cc];
       std::memcpy(buf + 2, char_table + 2*cc, 2);
 
       if (ffgghhii) {
@@ -1087,7 +1092,7 @@ namespace glz
                uint32_t hi = (uint32_t(exp_dec) * 656) >> 16; /* exp / 100 */
                uint32_t lo = uint32_t(exp_dec) - hi * 100;    /* exp % 100 */
                buffer[0] = uint8_t(hi) + '0';
-               *(uint16_t *)&buffer[1] = *(const uint16_t *)(char_table + (lo * 2));
+               std::memcpy(&buffer[1], char_table + (lo * 2), 2);
                return buffer + 3;
             }
          }

--- a/include/glaze/util/hash_map.hpp
+++ b/include/glaze/util/hash_map.hpp
@@ -180,7 +180,7 @@ namespace glz
             glaze_error("Unable to find perfect hash");
          }
 
-         for (size_t i = 0; i < N; ++i) {
+         for (i = 0; i < N; ++i) {
             const auto hash = xsm1<HashType>{}(keys[i], ht.seed);
             if constexpr (allow_hash_check) {
                ht.hashes[i] = hash;
@@ -204,7 +204,7 @@ namespace glz
       template <size_t N, bool IsFrontHash = true>
       inline constexpr single_char_hash_desc single_char_hash(const std::array<std::string_view, N>& v) noexcept
       {
-         if (N > 255) {
+         if constexpr (N > 255) {
             return {};
          }
          

--- a/include/glaze/util/itoa.hpp
+++ b/include/glaze/util/itoa.hpp
@@ -33,6 +33,7 @@
  */
 
 #include <cstdint>
+#include <concepts>
 
 namespace glz
 {
@@ -81,7 +82,7 @@ namespace glz
        
        if (val < 100) { /* 1-2 digits: aa */
            lz = val < 10;
-           ((pair *)buf)[0] = *(pair *)&(char_table[val * 2 + lz]);
+           ((pair *)buf)[0] = *(const pair *)&(char_table[val * 2 + lz]);
            buf -= lz;
            return buf + 2;
            
@@ -89,9 +90,9 @@ namespace glz
            aa = (val * 5243) >> 19; /* (val / 100) */
            bb = val - aa * 100; /* (val % 100) */
            lz = aa < 10;
-           ((pair *)buf)[0] = *(pair *)&(char_table[aa * 2 + lz]);
+           ((pair *)buf)[0] = *(const pair *)&(char_table[aa * 2 + lz]);
            buf -= lz;
-           ((pair *)buf)[1] = ((pair *)char_table)[bb];
+           ((pair *)buf)[1] = ((const pair *)char_table)[bb];
            return buf + 4;
            
        } else if (val < 1000000) { /* 5-6 digits: aabbcc */
@@ -100,10 +101,10 @@ namespace glz
            bb = (bbcc * 5243) >> 19; /* (bbcc / 100) */
            cc = bbcc - bb * 100; /* (bbcc % 100) */
            lz = aa < 10;
-           ((pair *)buf)[0] = *(pair *)&(char_table[aa * 2 + lz]);
+           ((pair *)buf)[0] = *(const pair *)&(char_table[aa * 2 + lz]);
            buf -= lz;
-           ((pair *)buf)[1] = ((pair *)char_table)[bb];
-           ((pair *)buf)[2] = ((pair *)char_table)[cc];
+           ((pair *)buf)[1] = ((const pair *)char_table)[bb];
+           ((pair *)buf)[2] = ((const pair *)char_table)[cc];
            return buf + 6;
            
        } else if (val < 100000000) { /* 7~8 digits: aabbccdd */
@@ -115,11 +116,11 @@ namespace glz
            bb = aabb - aa * 100; /* (aabb % 100) */
            dd = ccdd - cc * 100; /* (ccdd % 100) */
            lz = aa < 10;
-           ((pair *)buf)[0] = *(pair *)&(char_table[aa * 2 + lz]);
+           ((pair *)buf)[0] = *(const pair *)&(char_table[aa * 2 + lz]);
            buf -= lz;
-           ((pair *)buf)[1] = ((pair *)char_table)[bb];
-           ((pair *)buf)[2] = ((pair *)char_table)[cc];
-           ((pair *)buf)[3] = ((pair *)char_table)[dd];
+           ((pair *)buf)[1] = ((const pair *)char_table)[bb];
+           ((pair *)buf)[2] = ((const pair *)char_table)[cc];
+           ((pair *)buf)[3] = ((const pair *)char_table)[dd];
            return buf + 8;
            
        } else { /* 9~10 digits: aabbccddee */
@@ -134,12 +135,12 @@ namespace glz
            cc = bbcc - bb * 100; /* (bbcc % 100) */
            ee = ddee - dd * 100; /* (ddee % 100) */
            lz = aa < 10;
-           ((pair *)buf)[0] = *(pair *)&(char_table[aa * 2 + lz]);
+           ((pair *)buf)[0] = *(const pair *)&(char_table[aa * 2 + lz]);
            buf -= lz;
-           ((pair *)buf)[1] = ((pair *)char_table)[bb];
-           ((pair *)buf)[2] = ((pair *)char_table)[cc];
-           ((pair *)buf)[3] = ((pair *)char_table)[dd];
-           ((pair *)buf)[4] = ((pair *)char_table)[ee];
+           ((pair *)buf)[1] = ((const pair *)char_table)[bb];
+           ((pair *)buf)[2] = ((const pair *)char_table)[cc];
+           ((pair *)buf)[3] = ((const pair *)char_table)[dd];
+           ((pair *)buf)[4] = ((const pair *)char_table)[ee];
            return buf + 10;
        }
    }
@@ -162,10 +163,10 @@ namespace glz
        cc = (ccdd * 5243) >> 19; /* (ccdd / 100) */
        bb = aabb - aa * 100; /* (aabb % 100) */
        dd = ccdd - cc * 100; /* (ccdd % 100) */
-       ((pair *)buf)[0] = ((pair *)char_table)[aa];
-       ((pair *)buf)[1] = ((pair *)char_table)[bb];
-       ((pair *)buf)[2] = ((pair *)char_table)[cc];
-       ((pair *)buf)[3] = ((pair *)char_table)[dd];
+       ((pair *)buf)[0] = ((const pair *)char_table)[aa];
+       ((pair *)buf)[1] = ((const pair *)char_table)[bb];
+       ((pair *)buf)[2] = ((const pair *)char_table)[cc];
+       ((pair *)buf)[3] = ((const pair *)char_table)[dd];
        return buf + 8;
    }
    
@@ -174,8 +175,8 @@ namespace glz
        uint32_t aa, bb;
        aa = (val * 5243) >> 19; /* (val / 100) */
        bb = val - aa * 100; /* (val % 100) */
-       ((pair *)buf)[0] = ((pair *)char_table)[aa];
-       ((pair *)buf)[1] = ((pair *)char_table)[bb];
+       ((pair *)buf)[0] = ((const pair *)char_table)[aa];
+       ((pair *)buf)[1] = ((const pair *)char_table)[bb];
        return buf + 4;
    }
    
@@ -184,7 +185,7 @@ namespace glz
        
        if (val < 100) { /* 1-2 digits: aa */
            lz = val < 10;
-           ((pair *)buf)[0] = *(pair *)&(char_table[val * 2 + lz]);
+           ((pair *)buf)[0] = *(const pair *)&(char_table[val * 2 + lz]);
            buf -= lz;
            return buf + 2;
            
@@ -192,9 +193,9 @@ namespace glz
            aa = (val * 5243) >> 19; /* (val / 100) */
            bb = val - aa * 100; /* (val % 100) */
            lz = aa < 10;
-           ((pair *)buf)[0] = *(pair *)&(char_table[aa * 2 + lz]);
+           ((pair *)buf)[0] = *(const pair *)&(char_table[aa * 2 + lz]);
            buf -= lz;
-           ((pair *)buf)[1] = ((pair *)char_table)[bb];
+           ((pair *)buf)[1] = ((const pair *)char_table)[bb];
            return buf + 4;
            
        } else if (val < 1000000) { /* 5-6 digits: aabbcc */
@@ -203,10 +204,10 @@ namespace glz
            bb = (bbcc * 5243) >> 19; /* (bbcc / 100) */
            cc = bbcc - bb * 100; /* (bbcc % 100) */
            lz = aa < 10;
-           ((pair *)buf)[0] = *(pair *)&(char_table[aa * 2 + lz]);
+           ((pair *)buf)[0] = *(const pair *)&(char_table[aa * 2 + lz]);
            buf -= lz;
-           ((pair *)buf)[1] = ((pair *)char_table)[bb];
-           ((pair *)buf)[2] = ((pair *)char_table)[cc];
+           ((pair *)buf)[1] = ((const pair *)char_table)[bb];
+           ((pair *)buf)[2] = ((const pair *)char_table)[cc];
            return buf + 6;
            
        } else { /* 7-8 digits: aabbccdd */
@@ -218,11 +219,11 @@ namespace glz
            bb = aabb - aa * 100; /* (aabb % 100) */
            dd = ccdd - cc * 100; /* (ccdd % 100) */
            lz = aa < 10;
-           ((pair *)buf)[0] = *(pair *)&(char_table[aa * 2 + lz]);
+           ((pair *)buf)[0] = *(const pair *)&(char_table[aa * 2 + lz]);
            buf -= lz;
-           ((pair *)buf)[1] = ((pair *)char_table)[bb];
-           ((pair *)buf)[2] = ((pair *)char_table)[cc];
-           ((pair *)buf)[3] = ((pair *)char_table)[dd];
+           ((pair *)buf)[1] = ((const pair *)char_table)[bb];
+           ((pair *)buf)[2] = ((const pair *)char_table)[cc];
+           ((pair *)buf)[3] = ((const pair *)char_table)[dd];
            return buf + 8;
        }
    }
@@ -236,10 +237,10 @@ namespace glz
            bb = (bbcc * 5243) >> 19; /* (bbcc / 100) */
            cc = bbcc - bb * 100; /* (bbcc % 100) */
            lz = aa < 10;
-           ((pair *)buf)[0] = *(pair *)&(char_table[aa * 2 + lz]);
+           ((pair *)buf)[0] = *(const pair *)&(char_table[aa * 2 + lz]);
            buf -= lz;
-           ((pair *)buf)[1] = ((pair *)char_table)[bb];
-           ((pair *)buf)[2] = ((pair *)char_table)[cc];
+           ((pair *)buf)[1] = ((const pair *)char_table)[bb];
+           ((pair *)buf)[2] = ((const pair *)char_table)[cc];
            return buf + 6;
            
        } else { /* 7-8 digits: aabbccdd */
@@ -251,11 +252,11 @@ namespace glz
            bb = aabb - aa * 100; /* (aabb % 100) */
            dd = ccdd - cc * 100; /* (ccdd % 100) */
            lz = aa < 10;
-           ((pair *)buf)[0] = *(pair *)&(char_table[aa * 2 + lz]);
+           ((pair *)buf)[0] = *(const pair *)&(char_table[aa * 2 + lz]);
            buf -= lz;
-           ((pair *)buf)[1] = ((pair *)char_table)[bb];
-           ((pair *)buf)[2] = ((pair *)char_table)[cc];
-           ((pair *)buf)[3] = ((pair *)char_table)[dd];
+           ((pair *)buf)[1] = ((const pair *)char_table)[bb];
+           ((pair *)buf)[2] = ((const pair *)char_table)[cc];
+           ((pair *)buf)[3] = ((const pair *)char_table)[dd];
            return buf + 8;
        }
    }

--- a/include/glaze/util/itoa.hpp
+++ b/include/glaze/util/itoa.hpp
@@ -82,7 +82,7 @@ namespace glz
        
        if (val < 100) { /* 1-2 digits: aa */
            lz = val < 10;
-           ((pair *)buf)[0] = *(const pair *)&(char_table[val * 2 + lz]);
+           std::memcpy(&buf[0], &char_table[val * 2 + lz], 2);
            buf -= lz;
            return buf + 2;
            
@@ -90,44 +90,45 @@ namespace glz
            aa = (val * 5243) >> 19; /* (val / 100) */
            bb = val - aa * 100; /* (val % 100) */
            lz = aa < 10;
-           ((pair *)buf)[0] = *(const pair *)&(char_table[aa * 2 + lz]);
+           std::memcpy(&buf[0], &char_table[aa * 2 + lz], 2);
            buf -= lz;
-           ((pair *)buf)[1] = ((const pair *)char_table)[bb];
+           std::memcpy(&buf[2], &char_table[2 * bb], 2);
+
            return buf + 4;
            
        } else if (val < 1000000) { /* 5-6 digits: aabbcc */
-           aa = (uint32_t)(((uint64_t)val * 429497) >> 32); /* (val / 10000) */
+           aa = uint32_t((uint64_t(val) * 429497) >> 32); /* (val / 10000) */
            bbcc = val - aa * 10000; /* (val % 10000) */
            bb = (bbcc * 5243) >> 19; /* (bbcc / 100) */
            cc = bbcc - bb * 100; /* (bbcc % 100) */
            lz = aa < 10;
-           ((pair *)buf)[0] = *(const pair *)&(char_table[aa * 2 + lz]);
+           std::memcpy(buf, char_table + aa * 2 + lz, 2);
            buf -= lz;
-           ((pair *)buf)[1] = ((const pair *)char_table)[bb];
-           ((pair *)buf)[2] = ((const pair *)char_table)[cc];
+           std::memcpy(buf + 2, char_table + bb * 2, 2);
+           std::memcpy(buf + 4, char_table + cc * 2, 2);
            return buf + 6;
            
        } else if (val < 100000000) { /* 7~8 digits: aabbccdd */
            /* (val / 10000) */
-           aabb = (uint32_t)(((uint64_t)val * 109951163) >> 40);
+           aabb = uint32_t((uint64_t(val) * 109951163) >> 40);
            ccdd = val - aabb * 10000; /* (val % 10000) */
            aa = (aabb * 5243) >> 19; /* (aabb / 100) */
            cc = (ccdd * 5243) >> 19; /* (ccdd / 100) */
            bb = aabb - aa * 100; /* (aabb % 100) */
            dd = ccdd - cc * 100; /* (ccdd % 100) */
            lz = aa < 10;
-           ((pair *)buf)[0] = *(const pair *)&(char_table[aa * 2 + lz]);
+           std::memcpy(buf, char_table + aa * 2 + lz, 2);
            buf -= lz;
-           ((pair *)buf)[1] = ((const pair *)char_table)[bb];
-           ((pair *)buf)[2] = ((const pair *)char_table)[cc];
-           ((pair *)buf)[3] = ((const pair *)char_table)[dd];
+           std::memcpy(buf + 2, char_table + bb * 2, 2);
+           std::memcpy(buf + 4, char_table + cc * 2, 2);
+           std::memcpy(buf + 6, char_table + dd * 2, 2);
            return buf + 8;
            
        } else { /* 9~10 digits: aabbccddee */
            /* (val / 10000) */
-           aabbcc = (uint32_t)(((uint64_t)val * 3518437209ul) >> 45);
+           aabbcc = uint32_t((uint64_t(val) * 3518437209ul) >> 45);
            /* (aabbcc / 10000) */
-           aa = (uint32_t)(((uint64_t)aabbcc * 429497) >> 32);
+           aa = uint32_t((uint64_t(aabbcc) * 429497) >> 32);
            ddee = val - aabbcc * 10000; /* (val % 10000) */
            bbcc = aabbcc - aa * 10000; /* (aabbcc % 10000) */
            bb = (bbcc * 5243) >> 19; /* (bbcc / 100) */
@@ -135,12 +136,12 @@ namespace glz
            cc = bbcc - bb * 100; /* (bbcc % 100) */
            ee = ddee - dd * 100; /* (ddee % 100) */
            lz = aa < 10;
-           ((pair *)buf)[0] = *(const pair *)&(char_table[aa * 2 + lz]);
+           std::memcpy(buf, char_table + aa * 2 + lz, 2);
            buf -= lz;
-           ((pair *)buf)[1] = ((const pair *)char_table)[bb];
-           ((pair *)buf)[2] = ((const pair *)char_table)[cc];
-           ((pair *)buf)[3] = ((const pair *)char_table)[dd];
-           ((pair *)buf)[4] = ((const pair *)char_table)[ee];
+           std::memcpy(buf + 2, char_table + bb * 2, 2);
+           std::memcpy(buf + 4, char_table + cc * 2, 2);
+           std::memcpy(buf + 6, char_table + dd * 2, 2);
+           std::memcpy(buf + 8, char_table + ee * 2, 2);
            return buf + 10;
        }
    }
@@ -148,25 +149,25 @@ namespace glz
    template <class T>
    requires std::same_as<T, int32_t>
    inline auto* to_chars(auto *buf, T val) noexcept {
-      uint32_t neg = (uint32_t)-val;
+      uint32_t neg = uint32_t(-val);
       std::size_t sign = val < 0;
       *buf = '-';
-      return to_chars(buf + sign, sign ? (uint32_t)neg : (uint32_t)val);
+      return to_chars(buf + sign, sign ? uint32_t(neg): uint32_t(val));
    }
    
    inline auto* to_chars_u64_len_8(auto *buf, uint32_t val) noexcept {
        /* 8 digits: aabbccdd */
        uint32_t aa, bb, cc, dd, aabb, ccdd;
-       aabb = (uint32_t)(((uint64_t)val * 109951163) >> 40); /* (val / 10000) */
+       aabb = uint32_t((uint64_t(val) * 109951163) >> 40); /* (val / 10000) */
        ccdd = val - aabb * 10000; /* (val % 10000) */
        aa = (aabb * 5243) >> 19; /* (aabb / 100) */
        cc = (ccdd * 5243) >> 19; /* (ccdd / 100) */
        bb = aabb - aa * 100; /* (aabb % 100) */
        dd = ccdd - cc * 100; /* (ccdd % 100) */
-       ((pair *)buf)[0] = ((const pair *)char_table)[aa];
-       ((pair *)buf)[1] = ((const pair *)char_table)[bb];
-       ((pair *)buf)[2] = ((const pair *)char_table)[cc];
-       ((pair *)buf)[3] = ((const pair *)char_table)[dd];
+       std::memcpy(buf, char_table + aa * 2, 2);
+       std::memcpy(buf + 2, char_table + bb * 2, 2);
+       std::memcpy(buf + 4, char_table + cc * 2, 2);
+       std::memcpy(buf + 6, char_table + dd * 2, 2);
        return buf + 8;
    }
    
@@ -175,8 +176,8 @@ namespace glz
        uint32_t aa, bb;
        aa = (val * 5243) >> 19; /* (val / 100) */
        bb = val - aa * 100; /* (val % 100) */
-       ((pair *)buf)[0] = ((const pair *)char_table)[aa];
-       ((pair *)buf)[1] = ((const pair *)char_table)[bb];
+       std::memcpy(buf, char_table + aa * 2, 2);
+       std::memcpy(buf + 2, char_table + bb * 2, 2);
        return buf + 4;
    }
    
@@ -185,7 +186,7 @@ namespace glz
        
        if (val < 100) { /* 1-2 digits: aa */
            lz = val < 10;
-           ((pair *)buf)[0] = *(const pair *)&(char_table[val * 2 + lz]);
+           std::memcpy(buf, char_table + val * 2 + lz, 2);
            buf -= lz;
            return buf + 2;
            
@@ -193,37 +194,37 @@ namespace glz
            aa = (val * 5243) >> 19; /* (val / 100) */
            bb = val - aa * 100; /* (val % 100) */
            lz = aa < 10;
-           ((pair *)buf)[0] = *(const pair *)&(char_table[aa * 2 + lz]);
+           std::memcpy(buf, char_table + aa * 2 + lz, 2);
            buf -= lz;
-           ((pair *)buf)[1] = ((const pair *)char_table)[bb];
+            std::memcpy(buf + 2, char_table + bb * 2, 2);
            return buf + 4;
            
        } else if (val < 1000000) { /* 5-6 digits: aabbcc */
-           aa = (uint32_t)(((uint64_t)val * 429497) >> 32); /* (val / 10000) */
+           aa = uint32_t((uint64_t(val) * 429497) >> 32); /* (val / 10000) */
            bbcc = val - aa * 10000; /* (val % 10000) */
            bb = (bbcc * 5243) >> 19; /* (bbcc / 100) */
            cc = bbcc - bb * 100; /* (bbcc % 100) */
            lz = aa < 10;
-           ((pair *)buf)[0] = *(const pair *)&(char_table[aa * 2 + lz]);
+           std::memcpy(buf, char_table + aa * 2 + lz, 2);
            buf -= lz;
-           ((pair *)buf)[1] = ((const pair *)char_table)[bb];
-           ((pair *)buf)[2] = ((const pair *)char_table)[cc];
+           std::memcpy(buf + 2, char_table + bb * 2, 2);
+           std::memcpy(buf + 4, char_table + cc * 2, 2);
            return buf + 6;
            
        } else { /* 7-8 digits: aabbccdd */
            /* (val / 10000) */
-           aabb = (uint32_t)(((uint64_t)val * 109951163) >> 40);
+           aabb = uint32_t((uint64_t(val) * 109951163) >> 40);
            ccdd = val - aabb * 10000; /* (val % 10000) */
            aa = (aabb * 5243) >> 19; /* (aabb / 100) */
            cc = (ccdd * 5243) >> 19; /* (ccdd / 100) */
            bb = aabb - aa * 100; /* (aabb % 100) */
            dd = ccdd - cc * 100; /* (ccdd % 100) */
            lz = aa < 10;
-           ((pair *)buf)[0] = *(const pair *)&(char_table[aa * 2 + lz]);
+           std::memcpy(buf, char_table + aa * 2 + lz, 2);
            buf -= lz;
-           ((pair *)buf)[1] = ((const pair *)char_table)[bb];
-           ((pair *)buf)[2] = ((const pair *)char_table)[cc];
-           ((pair *)buf)[3] = ((const pair *)char_table)[dd];
+           std::memcpy(buf + 2, char_table + bb * 2, 2);
+           std::memcpy(buf + 4, char_table + cc * 2, 2);
+           std::memcpy(buf + 6, char_table + dd * 2, 2);
            return buf + 8;
        }
    }
@@ -232,31 +233,31 @@ namespace glz
        uint32_t aa, bb, cc, dd, aabb, bbcc, ccdd, lz;
        
        if (val < 1000000) { /* 5-6 digits: aabbcc */
-           aa = (uint32_t)(((uint64_t)val * 429497) >> 32); /* (val / 10000) */
+           aa = uint32_t((uint64_t(val) * 429497) >> 32); /* (val / 10000) */
            bbcc = val - aa * 10000; /* (val % 10000) */
            bb = (bbcc * 5243) >> 19; /* (bbcc / 100) */
            cc = bbcc - bb * 100; /* (bbcc % 100) */
            lz = aa < 10;
-           ((pair *)buf)[0] = *(const pair *)&(char_table[aa * 2 + lz]);
+           std::memcpy(buf, char_table + aa * 2 + lz, 2);
            buf -= lz;
-           ((pair *)buf)[1] = ((const pair *)char_table)[bb];
-           ((pair *)buf)[2] = ((const pair *)char_table)[cc];
+           std::memcpy(buf + 2, char_table + bb * 2, 2);
+           std::memcpy(buf + 4, char_table + cc * 2, 2);
            return buf + 6;
            
        } else { /* 7-8 digits: aabbccdd */
            /* (val / 10000) */
-           aabb = (uint32_t)(((uint64_t)val * 109951163) >> 40);
+           aabb = uint32_t((uint64_t(val) * 109951163) >> 40);
            ccdd = val - aabb * 10000; /* (val % 10000) */
            aa = (aabb * 5243) >> 19; /* (aabb / 100) */
            cc = (ccdd * 5243) >> 19; /* (ccdd / 100) */
            bb = aabb - aa * 100; /* (aabb % 100) */
            dd = ccdd - cc * 100; /* (ccdd % 100) */
            lz = aa < 10;
-           ((pair *)buf)[0] = *(const pair *)&(char_table[aa * 2 + lz]);
+           std::memcpy(buf, char_table + aa * 2 + lz, 2);
            buf -= lz;
-           ((pair *)buf)[1] = ((const pair *)char_table)[bb];
-           ((pair *)buf)[2] = ((const pair *)char_table)[cc];
-           ((pair *)buf)[3] = ((const pair *)char_table)[dd];
+           std::memcpy(buf + 2, char_table + bb * 2, 2);
+           std::memcpy(buf + 4, char_table + cc * 2, 2);
+           std::memcpy(buf + 6, char_table + dd * 2, 2);
            return buf + 8;
        }
    }
@@ -268,22 +269,22 @@ namespace glz
        uint32_t mid, low;
        
        if (val < 100000000) { /* 1-8 digits */
-           buf = to_chars_u64_len_1_8(buf, (uint32_t)val);
+           buf = to_chars_u64_len_1_8(buf, uint32_t(val));
            return buf;
            
-       } else if (val < (uint64_t)100000000 * 100000000) { /* 9-16 digits */
+       } else if (val < 100000000ull * 100000000ull) { /* 9-16 digits */
            hgh = val / 100000000;
-           low = (uint32_t)(val - hgh * 100000000); /* (val % 100000000) */
-           buf = to_chars_u64_len_1_8(buf, (uint32_t)hgh);
+           low = uint32_t(val - hgh * 100000000); /* (val % 100000000) */
+           buf = to_chars_u64_len_1_8(buf, uint32_t(hgh));
            buf = to_chars_u64_len_8(buf, low);
            return buf;
            
        } else { /* 17-20 digits */
            tmp = val / 100000000;
-           low = (uint32_t)(val - tmp * 100000000); /* (val % 100000000) */
-           hgh = (uint32_t)(tmp / 10000);
-           mid = (uint32_t)(tmp - hgh * 10000); /* (tmp % 10000) */
-           buf = to_chars_u64_len_5_8(buf, (uint32_t)hgh);
+           low = uint32_t(val - tmp * 100000000); /* (val % 100000000) */
+           hgh = uint32_t(tmp / 10000);
+           mid = uint32_t(tmp - hgh * 10000); /* (tmp % 10000) */
+           buf = to_chars_u64_len_5_8(buf, uint32_t(hgh));
            buf = to_chars_u64_len_4(buf, mid);
            buf = to_chars_u64_len_8(buf, low);
            return buf;
@@ -293,9 +294,9 @@ namespace glz
    template <class T>
    requires std::same_as<T, int64_t>
    inline auto* to_chars(auto *buf, T val) noexcept {
-       uint64_t neg = (uint64_t)-val;
+       uint64_t neg = uint64_t(-val);
        std::size_t sign = val < 0;
        *buf = '-';
-       return to_chars(buf + sign, sign ? (uint64_t)neg : (uint64_t)val);
+       return to_chars(buf + sign, sign ? uint64_t(neg) : uint64_t(val));
    }
 }

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -162,9 +162,9 @@ namespace glz::detail
       for (; it < end_m7; it += 8) {
          uint64_t chunk;
          std::memcpy(&chunk, it, 8);
-         uint64_t test = has_qoute(chunk) | has_escape(chunk);
-         if (test != 0) {
-            it += (std::countr_zero(test) >> 3);
+         uint64_t test_chars = has_qoute(chunk) | has_escape(chunk);
+         if (test_chars != 0) {
+               it += (std::countr_zero(test_chars) >> 3);
             return;
          }
       }
@@ -198,9 +198,9 @@ namespace glz::detail
       for (; it < end_m7; it += 8) {
          uint64_t chunk;
          std::memcpy(&chunk, it, 8);
-         uint64_t test = has_qoute(chunk);
-         if (test != 0) {
-            it += (std::countr_zero(test) >> 3);
+         uint64_t char_test = has_qoute(chunk);
+         if (char_test != 0) {
+            it += (std::countr_zero(char_test) >> 3);
             return;
          }
       }
@@ -238,9 +238,9 @@ namespace glz::detail
       for (; it < end_m7; it += 8) {
          uint64_t chunk;
          std::memcpy(&chunk, it, 8);
-         uint64_t test = has_qoute(chunk);
-         if (test != 0) {
-            it += (std::countr_zero(test) >> 3);
+         uint64_t test_chars = has_qoute(chunk);
+         if (test_chars != 0) {
+            it += (std::countr_zero(test_chars) >> 3);
             
             sv ret{ start, static_cast<size_t>(it - start) };
             ++it;

--- a/include/glaze/util/strod.hpp
+++ b/include/glaze/util/strod.hpp
@@ -51,7 +51,10 @@ namespace glz::detail
 #ifdef __SIZEOF_INT128__
    inline uint64_t mulhi64(uint64_t a, uint64_t b)
    {
+   #pragma GCC diagnostic push
+   #pragma GCC diagnostic ignored "-Wpedantic"
       unsigned __int128 prod = a * static_cast<unsigned __int128>(b);
+   #pragma GCC diagnostic pop
       return prod >> 64;
    }
 #elif defined(_M_X64) || defined(_M_ARM64)

--- a/include/glaze/util/strod.hpp
+++ b/include/glaze/util/strod.hpp
@@ -51,10 +51,12 @@ namespace glz::detail
 #ifdef __SIZEOF_INT128__
    inline uint64_t mulhi64(uint64_t a, uint64_t b)
    {
+   #if defined(__GNUC__) || defined(__GNUG__)
    #pragma GCC diagnostic push
    #pragma GCC diagnostic ignored "-Wpedantic"
       unsigned __int128 prod = a * static_cast<unsigned __int128>(b);
    #pragma GCC diagnostic pop
+   #endif
       return prod >> 64;
    }
 #elif defined(_M_X64) || defined(_M_ARM64)

--- a/include/glaze/util/strod.hpp
+++ b/include/glaze/util/strod.hpp
@@ -417,7 +417,7 @@ namespace glz::detail
       bool sign;
       sign = (*hdr == '-');
       cur += sign;
-      auto apply_sign = [sign](auto&& val) -> T {
+      auto apply_sign = [&](auto&& val) -> T {
          if constexpr (std::is_unsigned_v<T>) {
             return static_cast<T>(val);
          }

--- a/include/glaze/util/strod.hpp
+++ b/include/glaze/util/strod.hpp
@@ -51,7 +51,7 @@ namespace glz::detail
 #ifdef __SIZEOF_INT128__
    inline uint64_t mulhi64(uint64_t a, uint64_t b)
    {
-      unsigned __int128 prod = a * (unsigned __int128)b;
+      unsigned __int128 prod = a * static_cast<unsigned __int128>(b);
       return prod >> 64;
    }
 #elif defined(_M_X64) || defined(_M_ARM64)
@@ -253,11 +253,11 @@ namespace glz::detail
    /** Match a character with specified type. */
    inline bool digi_is_type(uint8_t d, digi_type type) noexcept { return (digi_table[d] & type) != 0; }
    /** Match a floating point indicator: '.', 'e', 'E'. */
-   inline bool digi_is_fp(uint8_t d) noexcept { return digi_is_type(d, (digi_type)(DIGI_TYPE_DOT | DIGI_TYPE_EXP)); }
+   inline bool digi_is_fp(uint8_t d) noexcept { return digi_is_type(d, digi_type(DIGI_TYPE_DOT | DIGI_TYPE_EXP)); }
    /** Match a digit or floating point indicator: [0-9], '.', 'e', 'E'. */
    inline bool digi_is_digit_or_fp(uint8_t d) noexcept
    {
-      return digi_is_type(d, (digi_type)(DIGI_TYPE_ZERO | DIGI_TYPE_NONZERO | DIGI_TYPE_DOT | DIGI_TYPE_EXP));
+      return digi_is_type(d, digi_type(DIGI_TYPE_ZERO | DIGI_TYPE_NONZERO | DIGI_TYPE_DOT | DIGI_TYPE_EXP));
    }
 /* Macros used for loop unrolling and other purpose. */
 #define repeat2(x) \
@@ -317,8 +317,8 @@ namespace glz::detail
 
       bigint_t(uint64_t num)
       {
-         uint32_t lower_word = (uint32_t)num;
-         uint32_t upper_word = (uint32_t)(num >> 32);
+         uint32_t lower_word = uint32_t(num);
+         uint32_t upper_word = uint32_t(num >> 32);
          if (upper_word > 0) {
             data = {lower_word, upper_word};
          }
@@ -331,9 +331,9 @@ namespace glz::detail
       {
          uint32_t carry = 0;
          for (std::size_t i = 0; i < data.size(); i++) {
-            uint64_t res = (uint64_t)data[i] * (uint64_t)num + (uint64_t)carry;
-            uint32_t lower_word = (uint32_t)res;
-            uint32_t upper_word = (uint32_t)(res >> 32);
+            uint64_t res = uint64_t(data[i]) * uint64_t(num) + uint64_t(carry);
+            uint32_t lower_word = uint32_t(res);
+            uint32_t upper_word = uint32_t(res >> 32);
             data[i] = lower_word;
             carry = upper_word;
          }
@@ -423,7 +423,7 @@ namespace glz::detail
          }
       };
       /* begin with non-zero digit */
-      sig = (uint64_t)(*cur - '0');
+      sig = uint64_t(*cur - '0');
       if (sig > 9) {
          if constexpr (std::integral<T>) {
             return false;
@@ -560,7 +560,7 @@ digi_intg_more :
       /* fraction part end */
    digi_frac_end:
       sig_end = cur;
-      exp_sig = -(int32_t)((cur - dot_pos) - 1);
+      exp_sig = -int32_t((cur - dot_pos) - 1);
       if constexpr (force_conformance) {
          if (exp_sig == 0) return false;
       }
@@ -593,7 +593,7 @@ digi_intg_more :
       uint8_t c;
       while (uint8_t(c = *cur - zero) < 10) {
          ++cur;
-         exp_lit = c + (uint32_t)exp_lit * 10;
+         exp_lit = c + uint32_t(exp_lit) * 10;
       }
       // large exponent case
       if ((cur - tmp >= 6)) [[unlikely]] {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,6 @@ int main() {
     std::string buffer{};
     obj_t obj{};
     glz::write_json(obj, buffer);
-    glz::read_json(obj, buffer);
+    std::ignore = glz::read_json(obj, buffer);
     return 0;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ set(BOOST_UT_DISABLE_MODULE ON CACHE INTERNAL "")
 FetchContent_Declare(
   ut
   GIT_REPOSITORY https://github.com/boost-ext/ut.git
-  GIT_TAG 265199e173b16a75670fae62fc2446b9dffad39e
+  GIT_TAG c0319c73e954dcd35159e8005dbbd76b33d9eed7
   FIND_PACKAGE_ARGS
 )
 
@@ -32,7 +32,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
       target_link_options(glz_test_common INTERFACE -fsanitize=address)
     endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    target_compile_options(glz_test_common INTERFACE /GR- /bigobj /fsanitize=address)
+    target_compile_options(glz_test_common INTERFACE /GR- /bigobj) #/fsanitize=address
     target_compile_options(glz_test_common INTERFACE /W4)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,18 +21,19 @@ message(STATUS "...finished fetching dependencies.")
 include(../cmake/code-coverage.cmake)
 add_code_coverage_all_targets()
 
-
 add_library(glz_test_common INTERFACE)
 target_compile_features(glz_test_common INTERFACE cxx_std_20)
 target_link_libraries(glz_test_common INTERFACE Boost::ut glaze::glaze)
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     target_compile_options(glz_test_common INTERFACE -fno-exceptions -fno-rtti)
+    target_compile_options(glz_test_common INTERFACE -Wall -Wextra -pedantic $<$<CONFIG:Debug>:-Werror>)
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       target_compile_options(glz_test_common INTERFACE -fsanitize=address)
       target_link_options(glz_test_common INTERFACE -fsanitize=address)
     endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(glz_test_common INTERFACE /GR- /bigobj) #/fsanitize=address
+    target_compile_options(glz_test_common INTERFACE /W4)
 endif()
 
 add_subdirectory(api_test)

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -595,12 +595,12 @@ void file_include_test()
 {
    includer_struct obj{};
    
-   glz::write_file_binary(obj, "../alabastar.crush");
+   expect(glz::write_file_binary(obj, "../alabastar.crush") == glz::error_code::none);
    
    obj.str = "";
    obj.i = 0;
    
-   glz::read_file_binary(obj, "../alabastar.crush");
+   expect(glz::read_file_binary(obj, "../alabastar.crush") == glz::error_code::none);
    
    expect(obj.str == "Hello") << obj.str;
    expect(obj.i == 55) << obj.i;
@@ -667,57 +667,54 @@ void container_types()
       expect(lis == lis2);
    };
    "map string keys roundtrip"_test = [] {
-      std::map<std::string, int> map;
+      std::map<std::string, int> map1;
       std::string str{"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"};
       std::mt19937 g{};
       for (auto i = 0; i < 20; ++i) {
          std::shuffle(str.begin(), str.end(), g);
-         map[str] = rand();
+         map1[str] = rand();
       }
       std::string buffer{};
       std::map<std::string, int> map2{};
-      glz::write_binary(map, buffer);
+      glz::write_binary(map1, buffer);
       glz::read_binary(map2, buffer);
-      // expect(map == map2);
-      for (auto& it : map) {
+      for (auto& it : map1) {
          expect(map2[it.first] == it.second);
       }
    };
    "map int keys roundtrip"_test = [] {
-      std::map<int, int> map;
+      std::map<int, int> map1;
       for (auto i = 0; i < 20; ++i) {
-         map[rand()] = rand();
+         map1[rand()] = rand();
       }
       std::string buffer{};
       std::map<int, int> map2{};
-      glz::write_binary(map, buffer);
+      glz::write_binary(map1, buffer);
       glz::read_binary(map2, buffer);
-      // expect(map == map2);
-      for (auto& it : map) {
+      for (auto& it : map1) {
          expect(map2[it.first] == it.second);
       }
    };
    "unordered_map int keys roundtrip"_test = [] {
-      std::unordered_map<int, int> map;
+      std::unordered_map<int, int> map1;
       for (auto i = 0; i < 20; ++i) {
-         map[rand()] = rand();
+         map1[rand()] = rand();
       }
       std::string buffer{};
       std::unordered_map<int, int> map2{};
-      glz::write_binary(map, buffer);
+      glz::write_binary(map1, buffer);
       glz::read_binary(map2, buffer);
-      // expect(map == map2);
-      for (auto& it : map) {
+      for (auto& it : map1) {
          expect(map2[it.first] == it.second);
       }
    };
    "tuple roundtrip"_test = [] {
-      auto tuple = std::make_tuple(3, 2.7, std::string("curry"));
-      decltype(tuple) tuple2{};
+      auto tuple1 = std::make_tuple(3, 2.7, std::string("curry"));
+      decltype(tuple1) tuple2{};
       std::string buffer{};
-      glz::write_binary(tuple, buffer);
+      glz::write_binary(tuple1, buffer);
       glz::read_binary(tuple2, buffer);
-      expect(tuple == tuple2);
+      expect(tuple1 == tuple2);
    };
    "pair roundtrip"_test = [] {
       auto pair = std::make_pair(std::string("water"), 5.2);

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -933,7 +933,7 @@ suite early_end = [] {
    "early_end"_test = [] {
       Thing obj{};
       glz::json_t json{};
-      glz::skip skip{};
+      glz::skip skip_json{};
       std::string buffer_data =
          R"({"thing":{"a":3.14/*Test comment 1*/,"b":"stuff"/*Test comment 2*/},"thing2array":[{"a":3.14/*Test comment 1*/,"b":"stuff"/*Test comment 2*/,"c":999.342494903,"d":1e-12,"e":203082348402.1,"f":89.089,"g":12380.00000013,"h":1000000.000001}],"vec3":[3.14,2.7,6.5],"list":[6,7,8,2],"deque":[9,6.7,3.1],"vector":[[9,6.7,3.1],[3.14,2.7,6.5]],"i":8,"d":2/*double is the best type*/,"b":false,"c":"W","vb":[true,false,false,true,true,true,true],"sptr":{"a":3.14/*Test comment 1*/,"b":"stuff"/*Test comment 2*/},"optional":null,"array":["as\"df\\ghjkl","pie","42","foo"],"map":{"a":4,"b":12,"f":7},"mapi":{"2":9.63,"5":3.14,"7":7.42},"thing_ptr":{"a":3.14/*Test comment 1*/,"b":"stuff"/*Test comment 2*/}})";
       std::string_view buffer = buffer_data;
@@ -947,7 +947,7 @@ suite early_end = [] {
          err = glz::read_json(json, buffer);
          expect(err != glz::error_code::none);
          expect(err.location <= buffer.size());
-         err = glz::read_json(skip, buffer);
+         err = glz::read_json(skip_json, buffer);
          expect(err != glz::error_code::none);
          expect(err.location <= buffer.size());
       }
@@ -3856,11 +3856,11 @@ struct Sample
 
 suite invalid_keys = [] {
    "invalid_keys"_test = [] {
-      std::string test = {"{\"a\":1,\"bbbbbb\":\"0\",\"c\":\"Hello World\",\"d\":{\"e\":\"123\"} }"};
+      std::string test_str = {"{\"a\":1,\"bbbbbb\":\"0\",\"c\":\"Hello World\",\"d\":{\"e\":\"123\"} }"};
       auto s = Sample{};
 
-      expect(glz::read<glz::opts{.error_on_unknown_keys = true}>(s, test) != glz::error_code::none);
-      expect(glz::read<glz::opts{.error_on_unknown_keys = false}>(s, test) == glz::error_code::none);
+      expect(glz::read<glz::opts{.error_on_unknown_keys = true}>(s, test_str) != glz::error_code::none);
+      expect(glz::read<glz::opts{.error_on_unknown_keys = false}>(s, test_str) == glz::error_code::none);
    };
 };
 


### PR DESCRIPTION
Addresses #177

Try to handle a bunch of warnings and start enforcing lack of warnings in the tests

Adds the following flags to the test targets
 -Wall -Wextra -pedantic $<$<CONFIG:Debug>:-Werror> on gcc/clang
/W4 on windows