### PR TITLE
Revert boost ut commit

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ set(BOOST_UT_DISABLE_MODULE ON CACHE INTERNAL "")
 FetchContent_Declare(
   ut
   GIT_REPOSITORY https://github.com/boost-ext/ut.git
-  GIT_TAG c0319c73e954dcd35159e8005dbbd76b33d9eed7
+  GIT_TAG 265199e173b16a75670fae62fc2446b9dffad39e
   FIND_PACKAGE_ARGS
 )
 


### PR DESCRIPTION
Using the the newer boost ut commit was resulting in a memory leak for the code coverage pipeline