### PR TITLE
Make it able to compile with gcc-10

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -841,51 +841,50 @@ template <>
 struct glz::meta<glz::error_code>
 {
    static constexpr sv name = "glz::error_code";
-   using enum glz::error_code;
-   static constexpr auto value = enumerate("none", none, //
-                                           "no_read_input", no_read_input, //
-                                           "data_must_be_null_terminated", data_must_be_null_terminated, //
-                                           "parse_number_failure", parse_number_failure, //
-                                           "expected_brace", expected_brace, //
-                                           "expected_bracket", expected_bracket, //
-                                           "expected_quote", expected_quote, //
-                                           "exceeded_static_array_size", exceeded_static_array_size, //
-                                           "unexpected_end", unexpected_end, //
-                                           "expected_end_comment", expected_end_comment, //
-                                           "syntax_error", syntax_error, //
-                                           "key_not_found", key_not_found, //
-                                           "unexpected_enum", unexpected_enum, //
-                                           "attempt_member_func_read", attempt_member_func_read, //
-                                           "attempt_read_hidden", attempt_read_hidden, //
-                                           "invalid_nullable_read", invalid_nullable_read, //
-                                           "invalid_variant_object", invalid_variant_object, //
-                                           "invalid_variant_array", invalid_variant_array, //
-                                           "invalid_variant_string", invalid_variant_string, //
-                                           "no_matching_variant_type", no_matching_variant_type, //
-                                           "expected_true_or_false", expected_true_or_false, //
-                                           "unknown_key", unknown_key, //
-                                           "invalid_flag_input", invalid_flag_input, //
-                                           "invalid_escape", invalid_escape, //
-                                           "u_requires_hex_digits", u_requires_hex_digits, //
-                                           "file_extension_not_supported", file_extension_not_supported, //
-                                           "could_not_determine_extension", could_not_determine_extension, //
-                                           "seek_failure", seek_failure, //
-                                           "unicode_escape_conversion_failure", unicode_escape_conversion_failure, //
-                                           "file_open_failure", file_open_failure, //
-                                           "file_include_error", file_include_error, //
-                                           "dump_int_error", dump_int_error, //
-                                           "get_nonexistent_json_ptr", get_nonexistent_json_ptr, //
-                                           "get_wrong_type", get_wrong_type, //
-                                           "cannot_be_referenced", cannot_be_referenced, //
-                                           "invalid_get", invalid_get, //
-                                           "invalid_get_fn", invalid_get_fn, //
-                                           "invalid_call", invalid_call, //
-                                           "invalid_partial_key", invalid_partial_key, //
-                                           "name_mismatch", name_mismatch, //
-                                           "array_element_not_found", array_element_not_found, //
-                                           "elements_not_convertible_to_design", elements_not_convertible_to_design, //
-                                           "unknown_distribution", unknown_distribution, //
-                                           "invalid_distribution_elements", invalid_distribution_elements //
+   static constexpr auto value = enumerate("none", glz::error_code::none, //
+                                           "no_read_input", glz::error_code::no_read_input, //
+                                           "data_must_be_null_terminated", glz::error_code::data_must_be_null_terminated, //
+                                           "parse_number_failure", glz::error_code::parse_number_failure, //
+                                           "expected_brace", glz::error_code::expected_brace, //
+                                           "expected_bracket", glz::error_code::expected_bracket, //
+                                           "expected_quote", glz::error_code::expected_quote, //
+                                           "exceeded_static_array_size", glz::error_code::exceeded_static_array_size, //
+                                           "unexpected_end", glz::error_code::unexpected_end, //
+                                           "expected_end_comment", glz::error_code::expected_end_comment, //
+                                           "syntax_error", glz::error_code::syntax_error, //
+                                           "key_not_found", glz::error_code::key_not_found, //
+                                           "unexpected_enum", glz::error_code::unexpected_enum, //
+                                           "attempt_member_func_read", glz::error_code::attempt_member_func_read, //
+                                           "attempt_read_hidden", glz::error_code::attempt_read_hidden, //
+                                           "invalid_nullable_read", glz::error_code::invalid_nullable_read, //
+                                           "invalid_variant_object", glz::error_code::invalid_variant_object, //
+                                           "invalid_variant_array", glz::error_code::invalid_variant_array, //
+                                           "invalid_variant_string", glz::error_code::invalid_variant_string, //
+                                           "no_matching_variant_type", glz::error_code::no_matching_variant_type, //
+                                           "expected_true_or_false", glz::error_code::expected_true_or_false, //
+                                           "unknown_key", glz::error_code::unknown_key, //
+                                           "invalid_flag_input", glz::error_code::invalid_flag_input, //
+                                           "invalid_escape", glz::error_code::invalid_escape, //
+                                           "u_requires_hex_digits", glz::error_code::u_requires_hex_digits, //
+                                           "file_extension_not_supported", glz::error_code::file_extension_not_supported, //
+                                           "could_not_determine_extension", glz::error_code::could_not_determine_extension, //
+                                           "seek_failure", glz::error_code::seek_failure, //
+                                           "unicode_escape_conversion_failure", glz::error_code::unicode_escape_conversion_failure, //
+                                           "file_open_failure", glz::error_code::file_open_failure, //
+                                           "file_include_error", glz::error_code::file_include_error, //
+                                           "dump_int_error", glz::error_code::dump_int_error, //
+                                           "get_nonexistent_json_ptr", glz::error_code::get_nonexistent_json_ptr, //
+                                           "get_wrong_type", glz::error_code::get_wrong_type, //
+                                           "cannot_be_referenced", glz::error_code::cannot_be_referenced, //
+                                           "invalid_get", glz::error_code::invalid_get, //
+                                           "invalid_get_fn", glz::error_code::invalid_get_fn, //
+                                           "invalid_call", glz::error_code::invalid_call, //
+                                           "invalid_partial_key", glz::error_code::invalid_partial_key, //
+                                           "name_mismatch", glz::error_code::name_mismatch, //
+                                           "array_element_not_found", glz::error_code::array_element_not_found, //
+                                           "elements_not_convertible_to_design", glz::error_code::elements_not_convertible_to_design, //
+                                           "unknown_distribution", glz::error_code::unknown_distribution, //
+                                           "invalid_distribution_elements", glz::error_code::invalid_distribution_elements //
    );
 };
 

--- a/include/glaze/json/json_ptr.hpp
+++ b/include/glaze/json/json_ptr.hpp
@@ -511,7 +511,8 @@ namespace glz
          constexpr auto rem_ptr =
             glz::string_literal_from_view<tokens.second.size()>(tokens.second);
          if constexpr (glz::detail::glaze_object_t<V>) {
-            using G = member_getter<V, glz::string_literal_from_view<key_str.size()>(key_str)>;
+            constexpr auto string_literal_key = glz::string_literal_from_view<key_str.size()>(key_str);
+            using G = member_getter<V, string_literal_key>;
             if constexpr (G::member_it != G::frozen_map.end()) {
                constexpr auto& element = G::member_it->second;
                constexpr auto I = element.index();

--- a/include/glaze/json/prettify.hpp
+++ b/include/glaze/json/prettify.hpp
@@ -74,33 +74,32 @@ namespace glz
 
       inline void prettify_other_states(const char c, general_state& state) noexcept
       {
-         using enum general_state;
          switch (state) {
-         case ESCAPED:
-            state = NORMAL;
+         case general_state::ESCAPED:
+            state = general_state::NORMAL;
             break;
-         case STRING:
+         case general_state::STRING:
             if (c == '"') {
-               state = NORMAL;
+               state = general_state::NORMAL;
             }
             break;
-         case BEFORE_ASTERISK:
-            state = COMMENT;
+         case general_state::BEFORE_ASTERISK:
+            state = general_state::COMMENT;
             break;
-         case COMMENT:
+         case general_state::COMMENT:
             if (c == '*') {
-               state = BEFORE_FSLASH;
+               state = general_state::BEFORE_FSLASH;
             }
             break;
-         case BEFORE_FSLASH:
+         case general_state::BEFORE_FSLASH:
             if (c == '/') {
-               state = NORMAL;
+               state = general_state::NORMAL;
             }
             else {
-               state = COMMENT;
+               state = general_state::COMMENT;
             }
             break;
-         case NORMAL:
+         case general_state::NORMAL:
          default:
             break;
          }
@@ -123,7 +122,7 @@ namespace glz
             out += tabs ? "\t" : " ";
          }
       };
-      
+
       using namespace detail;
       general_state state{general_state::NORMAL};
 
@@ -138,7 +137,7 @@ namespace glz
          }
       }
    }
-   
+
    /// <summary>
    /// allocating version of prettify
    /// </summary>


### PR DESCRIPTION
I used gcc-10 for embedded compilation and saw a few errors.

Using with enums not supported for this version - this is easy part.

But in `include/glaze/json/json_ptr.hpp` gcc has crashed in these line. So I just split it to 2 constexpr and now it compiles.