### PR TITLE
fix: string overflow in get_source_info

### DIFF
--- a/include/glaze/util/validate.hpp
+++ b/include/glaze/util/validate.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <string>
 #include <optional>
 
@@ -29,9 +30,9 @@ namespace glz
          const auto start = std::begin(buffer) + index;
          const auto count = std::count(std::begin(buffer), start, static_cast<V>('\n'));
          const auto rstart = std::rbegin(buffer) + r_index;
-         const auto pnl = std::find(rstart, std::rend(buffer), static_cast<V>('\n'));
+         const auto pnl = std::find(std::min(rstart + 1, std::rend(buffer)), std::rend(buffer), static_cast<V>('\n'));
          const auto dist = std::distance(rstart, pnl);
-         const auto nnl = std::find(start, std::end(buffer), static_cast<V>('\n'));
+         const auto nnl = std::find(std::min(start + 1, std::end(buffer)), std::end(buffer), static_cast<V>('\n'));
          
          if constexpr (std::same_as<V, std::byte>) {
             std::string context{

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -1908,6 +1908,18 @@ suite write_tests = [] {
    };
 };
 
+struct error_comma_obj {
+    struct error_comma_data {
+       std::string instId;
+	   GLZ_LOCAL_META(error_comma_data, instId);
+    };
+
+    std::string code;
+    std::string msg;
+    std::vector<error_comma_data> data;
+    GLZ_LOCAL_META(error_comma_obj, data, code, msg);
+};
+
 suite error_outputs = [] {
    "invalid character"_test = [] {
          std::string s = R"({"Hello":"World"x, "color": "red"})";
@@ -1916,6 +1928,24 @@ suite error_outputs = [] {
       expect(pe != glz::error_code::none);
       auto err = glz::format_error(pe, s);
       expect(err == "1:17: syntax_error\n   {\"Hello\":\"World\"x, \"color\": \"red\"}\n                   ^\n") << err;
+   };
+
+   "extra comma"_test = [] {
+      std::string s = R"({
+      "code": "0",
+      "msg": "",
+      "data": [ {
+          "instId": "USDT"
+        },
+        {
+          "instId": "BTC"
+        },
+     ]
+  })";
+      auto ex = glz::read_json<error_comma_obj>(s);
+      expect(!ex.has_value());
+      auto err = glz::format_error(ex.error(), s);
+      expect(err == "10:7: syntax_error\n        ]\n  }\n         ^\n") << err;
    };
 };
 


### PR DESCRIPTION
when error position point to '\n', `pnl == nnl`, then
```cpp
 std::string context{
               std::begin(buffer) +
                  (pnl == std::rend(buffer) ? 0 : index - dist + 1),
               nnl};
```
the first arg will be `nnl + 1`, the constructor will throw `basic_string::_M_create`.