### PR TITLE
Change glz::hash_t to an array

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -1,12 +1,6 @@
 name: code_coverage
 
 on:
-  push:
-    branches:
-    - main
-    - feature/*
-    paths-ignore:
-    - '**.md'
   workflow_dispatch:
 
 env:

--- a/include/glaze/api/api.hpp
+++ b/include/glaze/api/api.hpp
@@ -53,12 +53,12 @@ namespace glz
          }
 
          /// unchecked `void*` access for low level programming (prefer templated get)
-         [[nodiscard]] virtual std::pair<void*, sv> get(const sv path) noexcept = 0;
+         [[nodiscard]] virtual std::pair<void*, glz::hash_t> get(const sv path) noexcept = 0;
       protected:
 
-         virtual bool caller(const sv path, const sv type_hash, void*& ret, std::span<void*> args) noexcept = 0;
+         virtual bool caller(const sv path, const glz::hash_t type_hash, void*& ret, std::span<void*> args) noexcept = 0;
 
-         virtual std::unique_ptr<void, void(*)(void*)> get_fn(const sv path, const sv type_hash) noexcept = 0;
+         virtual std::unique_ptr<void, void (*)(void*)> get_fn(const sv path, const glz::hash_t type_hash) noexcept = 0;
 
          std::string error{};
       };

--- a/include/glaze/api/impl.hpp
+++ b/include/glaze/api/impl.hpp
@@ -35,7 +35,7 @@ namespace glz
    {
       UserType user{};
       
-      std::pair<void*, sv> get(const sv path) noexcept override
+      std::pair<void*, glz::hash_t> get(const sv path) noexcept override
       {
          return get_void(user, path);
       }
@@ -93,7 +93,7 @@ namespace glz
          }
       }
       
-      std::unique_ptr<void, void(*)(void*)> get_fn(const sv path, const sv type_hash) noexcept override
+      std::unique_ptr<void, void (*)(void*)> get_fn(const sv path, const glz::hash_t type_hash) noexcept override
       {
          return get_void_fn(user, path, type_hash);
       }
@@ -114,7 +114,7 @@ namespace glz
          return f(parent, to_ref<std::tuple_element_t<Is, Arg_tuple>>(args[Is])...);
       }
       
-      bool caller(const sv path, const sv type_hash, void*& ret, std::span<void*> args) noexcept override
+      bool caller(const sv path, const glz::hash_t type_hash, void*& ret, std::span<void*> args) noexcept override
       {
          auto p = parent_last_json_ptrs(path);
          const auto parent_ptr = p.first;
@@ -204,11 +204,11 @@ namespace glz
       // Get a pointer to a value at the location of a json_ptr. Will return
       // nullptr if value doesnt exist or is wrong type
       template <class T>
-      std::pair<void*, sv> get_void(T&& root_value, const sv json_ptr)
+      std::pair<void*, hash_t> get_void(T&& root_value, const sv json_ptr)
       {
          void* result{};
          
-         sv type_hash{};
+         glz::hash_t type_hash{};
          
          const auto success = detail::seek_impl(
             [&](auto&& val) {
@@ -225,18 +225,18 @@ namespace glz
             std::forward<T>(root_value), json_ptr);
          
          if (!error.empty()) {
-            return { nullptr, "" };
+            return {nullptr, {}};
          }
          else if (!success) {
             error = "invalid path";
-            return { nullptr, "" };
+            return {nullptr, {}};
          }
          
          return { result, type_hash };
       }
       
       template <class T>
-      auto get_void_fn(T&& root_value, const sv json_ptr, const sv type_hash)
+      auto get_void_fn(T&& root_value, const sv json_ptr, const glz::hash_t type_hash)
       {
          std::unique_ptr<void, void(*)(void*)> result{ nullptr, nullptr };
          

--- a/include/glaze/api/trait.hpp
+++ b/include/glaze/api/trait.hpp
@@ -121,9 +121,27 @@ namespace glz
       
       static constexpr sv hash = hash128_v<to_hash>;
    };
-   
+
+   namespace detail
+   {
+      template <std::unsigned_integral T, size_t N>
+      constexpr std::array<T, N> uint_array_from_sv(sv str)
+      {
+         std::array<T, N> res{};
+         constexpr auto bytes = sizeof(T);
+         for (size_t i = 0; i < N; ++i) {
+            for (size_t j = 0; j < bytes; ++j) {
+               res[i] |= T(str[i * bytes + j]) << (8 * j);
+            }
+         }
+         return res;
+      }
+   }
+
+   using hash_t = std::array<uint64_t, 2>;
    template <class T>
-   consteval auto hash() {
-      return trait<T>::hash;
+   consteval hash_t hash()
+   {
+      return detail::uint_array_from_sv<uint64_t, 2>(trait<T>::hash);
    }
 }

--- a/include/glaze/util/any.hpp
+++ b/include/glaze/util/any.hpp
@@ -128,7 +128,7 @@ namespace glz
          
          virtual std::unique_ptr<storage_base> clone() const = 0;
          virtual void* data() noexcept = 0;
-         std::string_view type_hash;
+         glz::hash_t type_hash;
      };
       
       std::unique_ptr<storage_base> instance;


### PR DESCRIPTION
Addresses #168. This is to make it easier for the compiler to optimize comparisons when both hashes are runtime values because it knows the size and memory comparisons with known sizes are faster.

Note that there is very little difference in perf if one of the string_views being compared was constexpr. And since this is a breaking change I was somewhat tempted not to do it. But its better to use something with compiletime known size just in case we have to do full runtime comparisons in the future. And I don't think many people were using glz::hash<T>() directly anyways.