### PR TITLE
Lamda wrapper

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -1,12 +1,6 @@
 name: code_coverage
 
 on:
-  push:
-    branches:
-    - main
-    - feature/*
-    paths-ignore:
-    - '**.md'
   workflow_dispatch:
 
 env:

--- a/include/glaze/api/api.hpp
+++ b/include/glaze/api/api.hpp
@@ -53,12 +53,12 @@ namespace glz
          }
 
          /// unchecked `void*` access for low level programming (prefer templated get)
-         [[nodiscard]] virtual std::pair<void*, sv> get(const sv path) noexcept = 0;
+         [[nodiscard]] virtual std::pair<void*, glz::hash_t> get(const sv path) noexcept = 0;
       protected:
 
-         virtual bool caller(const sv path, const sv type_hash, void*& ret, std::span<void*> args) noexcept = 0;
+         virtual bool caller(const sv path, const glz::hash_t type_hash, void*& ret, std::span<void*> args) noexcept = 0;
 
-         virtual std::unique_ptr<void, void(*)(void*)> get_fn(const sv path, const sv type_hash) noexcept = 0;
+         virtual std::unique_ptr<void, void (*)(void*)> get_fn(const sv path, const glz::hash_t type_hash) noexcept = 0;
 
          std::string error{};
       };

--- a/include/glaze/api/impl.hpp
+++ b/include/glaze/api/impl.hpp
@@ -35,7 +35,7 @@ namespace glz
    {
       UserType user{};
       
-      std::pair<void*, sv> get(const sv path) noexcept override
+      std::pair<void*, glz::hash_t> get(const sv path) noexcept override
       {
          return get_void(user, path);
       }
@@ -93,7 +93,7 @@ namespace glz
          }
       }
       
-      std::unique_ptr<void, void(*)(void*)> get_fn(const sv path, const sv type_hash) noexcept override
+      std::unique_ptr<void, void (*)(void*)> get_fn(const sv path, const glz::hash_t type_hash) noexcept override
       {
          return get_void_fn(user, path, type_hash);
       }
@@ -114,7 +114,7 @@ namespace glz
          return f(parent, to_ref<std::tuple_element_t<Is, Arg_tuple>>(args[Is])...);
       }
       
-      bool caller(const sv path, const sv type_hash, void*& ret, std::span<void*> args) noexcept override
+      bool caller(const sv path, const glz::hash_t type_hash, void*& ret, std::span<void*> args) noexcept override
       {
          auto p = parent_last_json_ptrs(path);
          const auto parent_ptr = p.first;
@@ -204,11 +204,11 @@ namespace glz
       // Get a pointer to a value at the location of a json_ptr. Will return
       // nullptr if value doesnt exist or is wrong type
       template <class T>
-      std::pair<void*, sv> get_void(T&& root_value, const sv json_ptr)
+      std::pair<void*, hash_t> get_void(T&& root_value, const sv json_ptr)
       {
          void* result{};
          
-         sv type_hash{};
+         glz::hash_t type_hash{};
          
          const auto success = detail::seek_impl(
             [&](auto&& val) {
@@ -225,18 +225,18 @@ namespace glz
             std::forward<T>(root_value), json_ptr);
          
          if (!error.empty()) {
-            return { nullptr, "" };
+            return {nullptr, {}};
          }
          else if (!success) {
             error = "invalid path";
-            return { nullptr, "" };
+            return {nullptr, {}};
          }
          
          return { result, type_hash };
       }
       
       template <class T>
-      auto get_void_fn(T&& root_value, const sv json_ptr, const sv type_hash)
+      auto get_void_fn(T&& root_value, const sv json_ptr, const glz::hash_t type_hash)
       {
          std::unique_ptr<void, void(*)(void*)> result{ nullptr, nullptr };
          

--- a/include/glaze/api/trait.hpp
+++ b/include/glaze/api/trait.hpp
@@ -121,9 +121,27 @@ namespace glz
       
       static constexpr sv hash = hash128_v<to_hash>;
    };
-   
+
+   namespace detail
+   {
+      template <std::unsigned_integral T, size_t N>
+      constexpr std::array<T, N> uint_array_from_sv(sv str)
+      {
+         std::array<T, N> res{};
+         constexpr auto bytes = sizeof(T);
+         for (size_t i = 0; i < N; ++i) {
+            for (size_t j = 0; j < bytes; ++j) {
+               res[i] |= T(str[i * bytes + j]) << (8 * j);
+            }
+         }
+         return res;
+      }
+   }
+
+   using hash_t = std::array<uint64_t, 2>;
    template <class T>
-   consteval auto hash() {
-      return trait<T>::hash;
+   consteval hash_t hash()
+   {
+      return detail::uint_array_from_sv<uint64_t, 2>(trait<T>::hash);
    }
 }

--- a/include/glaze/json/json_ptr.hpp
+++ b/include/glaze/json/json_ptr.hpp
@@ -619,7 +619,7 @@ namespace glz
                         const auto k = parse_key(ctx, it, end);
                         if (cx_string_cmp<key>(k)) {
                            skip_ws<Opts>(ctx, it, end);
-                           match<':'>(ctx, it);
+                           match<':'>(ctx, it, end);
                            skip_ws<Opts>(ctx, it, end);
                            
                            if constexpr (I == (N - 1)) {
@@ -654,7 +654,7 @@ namespace glz
                }
             }
             else {
-               match<'{'>(ctx, it);
+               match<'{'>(ctx, it, end);
                
                while (true) {
                   skip_ws<Opts>(ctx, it, end);
@@ -662,7 +662,7 @@ namespace glz
                   if (k) {
                      if (cx_string_cmp<key>(*k)) {
                         skip_ws<Opts>(ctx, it, end);
-                        match<':'>(ctx, it);
+                        match<':'>(ctx, it, end);
                         skip_ws<Opts>(ctx, it, end);
                         
                         if constexpr (I == (N - 1)) {

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -283,7 +283,7 @@ namespace glz
                   skip_ws<Opts>(ctx, it, end);
                }
 
-               match<'"'>(ctx, it);
+               match<'"'>(ctx, it, end);
             }
 
             // overwrite portion
@@ -395,7 +395,7 @@ namespace glz
                   skip_ws<Opts>(ctx, it, end);
                }
 
-               match<'"'>(ctx, it);
+               match<'"'>(ctx, it, end);
             }
 
             if (*it == '\\') [[unlikely]] {
@@ -449,7 +449,7 @@ namespace glz
                }
                value = *it++;
             }
-            match<'"'>(ctx, it);
+            match<'"'>(ctx, it, end);
          }
       };
 
@@ -487,9 +487,9 @@ namespace glz
             if constexpr (!Opts.ws_handled) {
                skip_ws<Opts>(ctx, it, end);
             }
-            match<'"'>(ctx, it);
+            match<'"'>(ctx, it, end);
             skip_till_quote(ctx, it, end);
-            match<'"'>(ctx, it);
+            match<'"'>(ctx, it, end);
          }
       };
 
@@ -520,7 +520,7 @@ namespace glz
             }
             static constexpr auto Opts = ws_handled_off<Options>();
 
-            match<'['>(ctx, it);
+            match<'['>(ctx, it, end);
             skip_ws<Opts>(ctx, it, end);
 
             value.clear();
@@ -542,7 +542,7 @@ namespace glz
                   ++it;
                   return;
                }
-               match<','>(ctx, it);
+               match<','>(ctx, it, end);
             }
          }
       };
@@ -562,7 +562,7 @@ namespace glz
             }
             static constexpr auto Opts = ws_handled_off<Options>();
 
-            match<'['>(ctx, it);
+            match<'['>(ctx, it, end);
             skip_ws<Opts>(ctx, it, end);
 
             if (*it == ']') [[unlikely]] {
@@ -688,7 +688,7 @@ namespace glz
             }
             static constexpr auto Opts = ws_handled_off<Options>();
 
-            match<'['>(ctx, it);
+            match<'['>(ctx, it, end);
             const auto n = number_of_array_elements<Opts>(ctx, it, end);
             if (n) {
                value.resize(*n);
@@ -697,11 +697,11 @@ namespace glz
                read<json>::op<Opts>(x, ctx, it, end);
                   skip_ws<Opts>(ctx, it, end);
                   if (i < *n - 1) {
-                     match<','>(ctx, it);
+                     match<','>(ctx, it, end);
                }
                ++i;
             }
-               match<']'>(ctx, it);
+            match<']'>(ctx, it, end);
          }
          }
       };
@@ -730,7 +730,7 @@ namespace glz
                skip_ws<Opts>(ctx, it, end);
             }
 
-            match<'['>(ctx, it);
+            match<'['>(ctx, it, end);
             skip_ws<Opts>(ctx, it, end);
 
             for_each<N>([&](auto I) {
@@ -738,7 +738,7 @@ namespace glz
                   return;
                }
                if constexpr (I != 0) {
-                  match<','>(ctx, it);
+                  match<','>(ctx, it, end);
                   skip_ws<Opts>(ctx, it, end);
                }
                if constexpr (is_std_tuple<T>) {
@@ -753,7 +753,7 @@ namespace glz
                skip_ws<Opts>(ctx, it, end);
             });
 
-            match<']'>(ctx, it);
+            match<']'>(ctx, it, end);
          }
       };
 
@@ -767,7 +767,7 @@ namespace glz
                skip_ws<Opts>(ctx, it, end);
             }
 
-            match<'['>(ctx, it);
+            match<'['>(ctx, it, end);
 
             std::string& s = string_buffer();
 
@@ -792,7 +792,7 @@ namespace glz
                   ++it;
                   return;
                }
-               match<','>(ctx, it);
+               match<','>(ctx, it, end);
             }
          }
       };
@@ -948,7 +948,7 @@ namespace glz
          if constexpr (!Opts.ws_handled) {
             skip_ws<Opts>(ctx, it, end);
          }
-         match<'"'>(ctx, it);
+         match<'"'>(ctx, it, end);
 
          if constexpr (keys_may_contain_escape<T>()) {
             auto start = it;
@@ -978,7 +978,7 @@ namespace glz
                   if constexpr (stats.length_range == 0) {
                      const sv key{it, stats.max_length};
                      it += stats.max_length;
-                     match<'"'>(ctx, it);
+                     match<'"'>(ctx, it, end);
                      return key;
                   }
                   else if constexpr (stats.length_range < 4) {
@@ -1021,7 +1021,7 @@ namespace glz
                if constexpr (!Options.ws_handled) {
                   skip_ws<Options>(ctx, it, end);
                }
-               match<'{'>(ctx, it);
+               match<'{'>(ctx, it, end);
             }
 
             skip_ws<Options>(ctx, it, end);
@@ -1037,7 +1037,7 @@ namespace glz
                else if (first) [[unlikely]]
                   first = false;
                else [[likely]] {
-                  match<','>(ctx, it);
+                  match<','>(ctx, it, end);
                   skip_ws<Opts>(ctx, it, end);
                }
 
@@ -1045,7 +1045,7 @@ namespace glz
                   const sv key = parse_object_key<T, ws_handled<Opts>(), tag>(ctx, it, end);
 
                   skip_ws<Opts>(ctx, it, end);
-                  match<':'>(ctx, it);
+                  match<':'>(ctx, it, end);
                   skip_ws<Opts>(ctx, it, end);
 
                   if (static_cast<bool>(ctx.error)) [[unlikely]] { return; }
@@ -1083,7 +1083,7 @@ namespace glz
                   read<json>::op<Opts>(key, ctx, it, end);
 
                   skip_ws<Opts>(ctx, it, end);
-                  match<':'>(ctx, it);
+                  match<':'>(ctx, it, end);
                   skip_ws<Opts>(ctx, it, end);
 
                   if (static_cast<bool>(ctx.error)) [[unlikely]] { return; }
@@ -1177,7 +1177,7 @@ namespace glz
                          auto start = it;
                          while (*it != '}') {
                             if (it != start) {
-                               match<','>(ctx, it);
+                               match<','>(ctx, it, end);
                             }
                             std::string_view key = parse_object_key<T, Opts, tag_literal>(ctx, it, end);
                             auto deduction_it = deduction_map.find(key);
@@ -1188,12 +1188,12 @@ namespace glz
                                if constexpr (!tag_v<T>.empty()) {
                                   if (key == tag_v<T>) {
                                      skip_ws<Opts>(ctx, it, end);
-                                     match<':'>(ctx, it);
+                                     match<':'>(ctx, it, end);
 
                                      std::string& type_id = string_buffer();
                                      read<json>::op<Opts>(type_id, ctx, it, end);
                                      skip_ws<Opts>(ctx, it, end);
-                                     match<','>(ctx, it);
+                                     match<','>(ctx, it, end);
 
                                      static constexpr auto id_map = make_variant_id_map<T>();
                                      auto id_it = id_map.find(std::string_view{type_id});
@@ -1249,7 +1249,7 @@ namespace glz
                                return;
                             }
                             skip_ws<Opts>(ctx, it, end);
-                            match<':'>(ctx, it);
+                            match<':'>(ctx, it, end);
                             skip_ws<Opts>(ctx, it, end);
                             skip_value<Opts>(ctx, it, end);
                             skip_ws<Opts>(ctx, it, end);

--- a/include/glaze/record/recorder.hpp
+++ b/include/glaze/record/recorder.hpp
@@ -119,7 +119,7 @@ namespace glz
             
             if constexpr (!Options.opening_handled) {
                skip_ws<Options>(ctx, it, end);
-               match<'{'>(ctx, it);
+               match<'{'>(ctx, it, end);
             }
             
             skip_ws<Options>(ctx, it, end);
@@ -144,7 +144,7 @@ namespace glz
                }
                
                skip_ws<Opts>(ctx, it, end);
-               match<':'>(ctx, it);
+               match<':'>(ctx, it, end);
                skip_ws<Opts>(ctx, it, end);
                
                std::visit([&](auto&& deq) {
@@ -153,13 +153,13 @@ namespace glz
                
                if (i < n - 1) {
                   skip_ws<Opts>(ctx, it, end);
-                  match<','>(ctx, it);
+                  match<','>(ctx, it, end);
                   skip_ws<Opts>(ctx, it, end);
                }
             }
             
             skip_ws<Opts>(ctx, it, end);
-            match<'}'>(ctx, it);
+            match<'}'>(ctx, it, end);
          }
       };
    }

--- a/include/glaze/util/any.hpp
+++ b/include/glaze/util/any.hpp
@@ -128,7 +128,7 @@ namespace glz
          
          virtual std::unique_ptr<storage_base> clone() const = 0;
          virtual void* data() noexcept = 0;
-         std::string_view type_hash;
+         glz::hash_t type_hash;
      };
       
       std::unique_ptr<storage_base> instance;

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -45,7 +45,7 @@ namespace glz::detail
 {
    // assumes null terminated
    template <char c>
-   GLZ_ALWAYS_INLINE void match(is_context auto&& ctx, auto&& it) noexcept
+   GLZ_ALWAYS_INLINE void match(is_context auto&& ctx, auto&& it, auto&&) noexcept
    {
       if (*it != c) [[unlikely]] {
          ctx.error = error_code::syntax_error;
@@ -506,7 +506,7 @@ namespace glz::detail
    {
       if (static_cast<bool>(ctx.error)) [[unlikely]] { return unexpected(ctx.error); }
       
-      match<'"'>(ctx, it);
+      match<'"'>(ctx, it, end);
       auto start = it;
       skip_till_quote(ctx, it, end);
       if (static_cast<bool>(ctx.error)) [[unlikely]] { return unexpected(ctx.error); }
@@ -538,14 +538,14 @@ namespace glz::detail
             }
             skip_string<Opts>(ctx, it, end);
             skip_ws<Opts>(ctx, it, end);
-            match<':'>(ctx, it);
+            match<':'>(ctx, it, end);
             skip_ws<Opts>(ctx, it, end);
             skip_value<Opts>(ctx, it, end);
             skip_ws<Opts>(ctx, it, end);
             if (*it != ',') break;
             skip_ws<Opts>(ctx, ++it, end);
          }
-         match<'}'>(ctx, it);
+         match<'}'>(ctx, it, end);
       }
    }
 
@@ -573,7 +573,7 @@ namespace glz::detail
             if (*it != ',') break;
             skip_ws<Opts>(ctx, ++it, end);
          }
-         match<']'>(ctx, it);
+         match<']'>(ctx, it, end);
       }
    }
 

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -745,7 +745,7 @@ struct lambda_value_t
 template <>
 struct glz::meta<lambda_value_t>
 {
-   static constexpr auto value = [](auto& self) -> auto& { return self.x; };
+   static constexpr auto value = [](auto&& self) -> auto& { return self.x; };
 };
 
 suite value_test = []

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -4126,7 +4126,7 @@ namespace glz::detail
 template<auto MemPtr>
 constexpr decltype(auto) qouted()
 {
-   return [](auto&& val) { return qouted_t<std::decay_t<decltype(val.*MemPtr)>>(val.*MemPtr); };
+   return [](auto&& val) { return qouted_t{val.*MemPtr}; };
 }
 
 struct A

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -4126,7 +4126,7 @@ namespace glz::detail
 template<auto MemPtr>
 constexpr decltype(auto) qouted()
 {
-   return [](auto&& val) { return qouted_t{val.*MemPtr}; };
+   return [](auto&& val) { return qouted_t<std::decay_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
 }
 
 struct A

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -4126,7 +4126,7 @@ namespace glz::detail
 template<auto MemPtr>
 constexpr decltype(auto) qouted()
 {
-   return [](auto&& val) { return qouted_t(val.*MemPtr); };
+   return [](auto&& val) { return qouted_t<std::decay_t<decltype(val.*MemPtr)>>(val.*MemPtr); };
 }
 
 struct A

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -3314,7 +3314,7 @@ struct lambda_value_t
 template <>
 struct glz::meta<lambda_value_t>
 {
-   static constexpr auto value = [](auto& self) -> auto& { return self.x; };
+   static constexpr auto value = [](auto&& self) -> auto& { return self.x; };
 };
 
 suite value_test = []
@@ -4088,6 +4088,72 @@ suite long_object = [] {
    };
 };
 
+template<class T>
+struct qouted_t
+{
+   T& val;
+};
+
+namespace glz::detail
+{
+   template <class T>
+   struct from_json<qouted_t<T>>
+   {
+      template <auto Opts>
+      static void op(auto&& value, auto&&... args)
+      {
+         skip_ws<Opts>(args...);
+         match<'"'>(args...);
+         read<json>::op<Opts>(value.val, args...);
+         match<'"'>(args...);
+      }
+   };
+
+   template <class T>
+   struct to_json<qouted_t<T>>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+      {
+         dump<'"'>(args...);
+         write<json>::op<Opts>(value.val, ctx, args...);
+         dump<'"'>(args...);
+      }
+   };
+}
+
+
+template<auto MemPtr>
+constexpr decltype(auto) qouted()
+{
+   return [](auto&& val) { return qouted_t(val.*MemPtr); };
+}
+
+struct A
+{
+   double x;
+};
+
+template <>
+struct glz::meta<A>
+{
+   //static constexpr auto value = object("x", [](auto&& val) { return qouted_t(val.x); });
+   static constexpr auto value = object("x", qouted<&A::x>());
+};
+
+suite lamda_wrapper = [] {
+   "lamda_wrapper"_test = [] {
+
+      A a{3.14};
+      std::string buffer{};
+      glz::write_json(a, buffer);
+      expect(buffer == R"({"x":"3.14"})");
+
+      buffer = R"({"x":"999.2"})";
+      expect(glz::read_json(a, buffer) == glz::error_code::none);
+      expect(a.x == 999.2);
+   };
+};
 
 int main()
 {


### PR DESCRIPTION
Test out a workaround for doing custom wrappers before we add actual support for such.

This is a way of overriding parsing behavior on a per member basis.