### PR TITLE
add glaze_loacl_enum_t to support local enum

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -558,7 +558,8 @@ namespace glz
          }
       };
 
-      template <glaze_enum_t T>
+      template <class T>
+         requires glaze_local_enum_t<T> || glaze_enum_t<T>
       struct from_json<T>
       {
          template <auto Opts>
@@ -574,7 +575,12 @@ namespace glz
                static constexpr auto frozen_map = detail::make_string_to_enum_map<T>();
                const auto& member_it = frozen_map.find(frozen::string(*key));
                if (member_it != frozen_map.end()) {
-                  value = member_it->second;
+                  if constexpr (glaze_local_enum_t<T>) {
+                     value.val = member_it->second;
+                  }
+                  else {
+                     value = member_it->second;
+                  }
                }
                else [[unlikely]] {
                   ctx.error = error_code::unexpected_enum;

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -307,9 +307,12 @@ namespace glz
                // What do we want to happen if the value doesnt have a mapped
                // string
                if constexpr (glaze_local_enum_t<T>) {
+                  using member_t = std::decay_t<member_t<T, decltype(&T::val)>>;
+                  using key_t = std::underlying_type_t<member_t>;
                   write<json>::op<Opts>(static_cast<key_t>(value.val), ctx, std::forward<Args>(args)...);
                }
                else {
+                  using key_t = std::underlying_type_t<T>;
                   write<json>::op<Opts>(static_cast<key_t>(value), ctx, std::forward<Args>(args)...);
                }
             }

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -310,8 +310,7 @@ namespace glz
                   write<json>::op<Opts>(static_cast<key_t>(value.val), ctx, std::forward<Args>(args)...);
                }
                else {
-                  write<json>::op<Opts>(static_cast<key_t>(value), ctx,
-                                        std::forward<Args>(args)...);
+                  write<json>::op<Opts>(static_cast<key_t>(value), ctx, std::forward<Args>(args)...);
                }
             }
          }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -619,30 +619,31 @@ suite nullable_types = [] {
    };
 };
 
-namespace city {
-
-enum class Status { alive, dead };
-
-struct Status_
+namespace city
 {
-   Status val;
-   Status_(const Status& st) : val(st) {}
-   operator Status() const { return val; }
-   operator Status&() { return val; }
-   struct glaze
-   {
-      static constexpr auto value = glz::enumerate("alive", Status::alive, "dead", Status::dead);
-   };
-};
 
-struct Person
-{
-   Status_ status;
-   struct glaze
+   enum class Status { alive, dead };
+
+   struct Status_
    {
-      static constexpr auto value = glz::object("status", &Person::status);
+      Status val;
+      Status_(const Status& st) : val(st) {}
+      operator Status() const { return val; }
+      operator Status&() { return val; }
+      struct glaze
+      {
+         static constexpr auto value = glz::enumerate("alive", Status::alive, "dead", Status::dead);
+      };
    };
-};
+
+   struct Person
+   {
+      Status_ status;
+      struct glaze
+      {
+         static constexpr auto value = glz::object("status", &Person::status);
+      };
+   };
 }
 
 suite enum_types = [] {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -619,6 +619,8 @@ suite nullable_types = [] {
    };
 };
 
+namespace city {
+
 enum class Status { alive, dead };
 
 struct Status_
@@ -641,6 +643,7 @@ struct Person
       static constexpr auto value = glz::object("status", &Person::status);
    };
 };
+}
 
 suite enum_types = [] {
    using namespace boost::ut;
@@ -657,14 +660,14 @@ suite enum_types = [] {
       expect(buffer == "\"Green\"");
    };
    "enum_struct"_test = [] {
-      Person e{Status::alive};
+      city::Person e{city::Status::alive};
       std::string buffer3{};
       glz::write_json(e, buffer3);
       expect(buffer3 == R"({"status":"alive"})");
 
       buffer3 = R"({"status":"dead"})";
       expect(glz::read_json(e, buffer3) == glz::error_code::none);
-      expect(e.status == Status::dead);
+      expect(e.status == city::Status::dead);
    };
 };
 


### PR DESCRIPTION
Currently, the enum parser can only be defined in the global namespace, which is inconvenient. This PR adds glaze_local_enum_t, which allows users to define an enum wrapper struct locally. 