### PR TITLE
Add error_on_missing_keys option

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,6 +609,7 @@ struct opts {
    bool write_type_info = true; // Write type info for meta objects in variants
    bool use_cx_tags = true; // whether binary output should write compile time known tags
    bool force_conformance = false; // Do not allow invalid json normally accepted when reading such as comments.
+   bool error_on_missing_keys = false;  // Require all non nullable keys to be present in the object. Use skip_null_members = false to require nullable members
 };
 ```
 

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -807,7 +807,21 @@ namespace glz
       {};
       template <class T>
       array_variant(T) -> array_variant<T>;  // Only needed on older compilers until we move to template alias deduction
-   }                                         // namespace detail
+
+      template <class T, auto Opts>
+      constexpr auto required_fields()
+      {
+         constexpr auto n = std::tuple_size_v<meta_t<T>>;
+         bit_array<n> fields{};
+         if constexpr (Opts.error_on_missing_keys) {
+            for_each<n>([&](auto I) constexpr {
+               fields[I] = Opts.skip_null_members == false ||
+                           !nullable_t<std::decay_t<std::tuple_element_t<I, member_tuple_t<T>>>>;
+            });
+         }
+         return fields;
+      }
+   }  // namespace detail
 
    constexpr auto array(auto &&...args) { return detail::Array{glz::tuplet::make_copy_tuple(args...)}; }
 

--- a/include/glaze/core/context.hpp
+++ b/include/glaze/core/context.hpp
@@ -54,7 +54,8 @@ namespace glz
       array_element_not_found,
       elements_not_convertible_to_design,
       unknown_distribution,
-      invalid_distribution_elements
+      invalid_distribution_elements,
+      missing_key
    };
 
    struct parse_error final

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -11,17 +11,19 @@ namespace glz
    {
       // USER CONFIGURABLE
       uint32_t format = json;
-      bool comments = false;              // write out comments
-      bool error_on_unknown_keys = true;  // error when an unknown key is encountered
-      bool skip_null_members = true;      // skip writing out params in an object if the value is null
-      bool allow_hash_check = false;      // Will replace some string equality checks with hash checks
-      bool prettify = false;              // write out prettified JSON
-      char indentation_char = ' ';        // prettified JSON indentation char
-      uint8_t indentation_width = 3;      // prettified JSON indentation size
-      bool shrink_to_fit = false;         // shrinks dynamic containers to new size to save memory
-      bool write_type_info = true;        // Write type info for meta objects in variants
-      bool use_cx_tags = true;            // whether binary output should write compile time known tags
-      bool force_conformance = false;     // Do not allow invalid json normally accepted such as comments, nan, inf.
+      bool comments = false;               // Write out comments
+      bool error_on_unknown_keys = true;   // Error when an unknown key is encountered
+      bool skip_null_members = true;       // Skip writing out params in an object if the value is null
+      bool allow_hash_check = false;       // Will replace some string equality checks with hash checks
+      bool prettify = false;               // Write out prettified JSON
+      char indentation_char = ' ';         // Prettified JSON indentation char
+      uint8_t indentation_width = 3;       // Prettified JSON indentation size
+      bool shrink_to_fit = false;          // Shrinks dynamic containers to new size to save memory
+      bool write_type_info = true;         // Write type info for meta objects in variants
+      bool use_cx_tags = true;             // Whether binary output should write compile time known tags
+      bool force_conformance = false;      // Do not allow invalid json normally accepted such as comments, nan, inf.
+      bool error_on_missing_keys = false;  // Require all non nullable keys to be present in the object. Use
+                                           // skip_null_members = false to require nullable members
 
       // INTERNAL USE
       bool opening_handled = false;  // the opening character has been handled

--- a/include/glaze/util/bit_array.hpp
+++ b/include/glaze/util/bit_array.hpp
@@ -11,11 +11,10 @@ namespace glz::detail
 {
    // Basicly std::bitset but exposes things normally not availible like the bitscan functions
    template <size_t N, std::unsigned_integral Chunk_t = uint64_t>
-      requires(N > 0)
    struct bit_array
    {
       static constexpr size_t n_chunk_bits = std::numeric_limits<Chunk_t>::digits;
-      static constexpr size_t n_chunks = (N - 1) / n_chunk_bits + 1;
+      static constexpr size_t n_chunks = (N == 0) ? 0 : (N - 1) / n_chunk_bits + 1;
 
       struct reference
       {
@@ -129,5 +128,13 @@ namespace glz::detail
          }
          return *this;
       }
+
+      constexpr bit_array operator&(const bit_array& rhs) const noexcept
+      {
+         auto ret = *this;
+         return ret &= rhs;
+      }
+
+      constexpr bool operator==(const bit_array& rhs) const noexcept { return data == rhs.data; }
    };
 }


### PR DESCRIPTION
Adds error_on_missing_keys option based on suggestion from @pwqbot [here](https://github.com/stephenberry/glaze/issues/207#issuecomment-1467293536).

Addresses #207 as long as we don't need more granular control of required keys. But we will cross that bridge later when people actually need that feature (YAGNI). 

Usage:
```c++
glz::read<glz::opts{.error_on_missing_keys = true}>(obj, buffer);
```