### PR TITLE
fix quoted compile error caused by error_on_missing_keys

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -815,8 +815,9 @@ namespace glz
          bit_array<n> fields{};
          if constexpr (Opts.error_on_missing_keys) {
             for_each<n>([&](auto I) constexpr {
-               fields[I] = Opts.skip_null_members == false ||
-                           !nullable_t<std::decay_t<std::tuple_element_t<I, member_tuple_t<T>>>>;
+               fields[I] =
+                  !static_cast<bool>(Opts.skip_null_members) ||
+                  !nullable_t<std::decay_t<member_t<T, std::tuple_element_t<1, std::tuple_element_t<I, meta_t<T>>>>>>;
             });
          }
          return fields;

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -4069,7 +4069,7 @@ suite long_object = [] {
 };
 
 template <class T>
-struct quoted
+struct quoted_t
 {
    T& val;
 };
@@ -4077,7 +4077,7 @@ struct quoted
 namespace glz::detail
 {
    template <class T>
-   struct from_json<quoted<T>>
+   struct from_json<quoted_t<T>>
    {
       template <auto Opts>
       static void op(auto&& value, auto&&... args)
@@ -4090,7 +4090,7 @@ namespace glz::detail
    };
 
    template <class T>
-   struct to_json<quoted<T>>
+   struct to_json<quoted_t<T>>
    {
       template <auto Opts>
       static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
@@ -4105,7 +4105,7 @@ namespace glz::detail
 template <auto MemPtr>
 constexpr decltype(auto) qouted()
 {
-   return [](auto&& val) { return quoted<std::decay_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
+   return [](auto&& val) { return quoted_t<std::decay_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
 }
 
 struct A


### PR DESCRIPTION
``` cpp
/Users/benben/dev/github/glaze/include/glaze/core/common.hpp:779:107: error: reference member of type 'double &' uninitialized
               std::decay_t<member_t<T, std::tuple_element_t<1, std::tuple_element_t<I, meta_t<T>>>>>...>{};
                                                                                                          ^
/Users/benben/dev/github/glaze/include/glaze/core/common.hpp:789:32: note: in instantiation of function template specialization 'glz::detail::members_from_meta_impl<A, 0UL>' requested he
re
         using type = decltype(members_from_meta_impl<T, I...>());
                               ^
/Users/benben/dev/github/glaze/include/glaze/core/common.hpp:793:7: note: in instantiation of template class 'glz::detail::members_from_meta<A, std::integer_sequence<unsigned long, 0>>'
requested here
      using member_tuple_t = typename members_from_meta<T>::type;
      ^
/Users/benben/dev/github/glaze/include/glaze/core/common.hpp:819:77: note: in instantiation of template type alias 'member_tuple_t' requested here
                           !nullable_t<std::decay_t<std::tuple_element_t<I, member_tuple_t<T>>>>;
                                                                            ^
/Users/benben/dev/github/glaze/include/glaze/json/read.hpp:1150:50: note: in instantiation of function template specialization 'glz::detail::required_fields<A, {10, false, true, true, fa
lse, false, 32, 3, false, true, true, false, true, false, false}>' requested here
                     constexpr auto req_fields = required_fields<T, Opts>();
                                                 ^
```
quoted holds reference in it and cannot be holds by tuple.