### PR TITLE
fix error handling

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1186,6 +1186,9 @@ namespace glz
                            read<json>::op<ws_handled<Opts>()>(get_member(value, member_ptr), ctx, it, end);
                         },
                         member_it->second);
+                     if (static_cast<bool>(ctx.error)) [[unlikely]] {
+                        return;
+                     }
                   }
                   else [[unlikely]] {
                      if constexpr (Opts.error_on_unknown_keys) {
@@ -1209,6 +1212,9 @@ namespace glz
                else {
                   std::string& key = string_buffer();
                   read<json>::op<Opts>(key, ctx, it, end);
+                  if (static_cast<bool>(ctx.error)) [[unlikely]] {
+                     return;
+                  }
 
                   skip_ws<Opts>(ctx, it, end);
                   match<':'>(ctx, it, end);

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -4192,10 +4192,10 @@ suite required_keys = [] {
       expect(glz::read<glz::opts{.error_on_missing_keys = true}>(obj, buffer) == glz::error_code::none);
       buffer = R"({"req": 0, "opt": null, "opt2": 0})";
       expect(glz::read_json(obj, buffer) == glz::error_code::none);
-      expect(glz::read<glz::opts{.error_on_missing_keys = true}>(obj, buffer) != glz::error_code::none);
+      expect(glz::read<glz::opts{.error_on_missing_keys = true}>(obj, buffer) == glz::error_code::missing_key);
       buffer = R"({"opt": null, "req2": 0, "opt2": 0})";
       expect(glz::read_json(obj, buffer) == glz::error_code::none);
-      expect(glz::read<glz::opts{.error_on_missing_keys = true}>(obj, buffer) != glz::error_code::none);
+      expect(glz::read<glz::opts{.error_on_missing_keys = true}>(obj, buffer) == glz::error_code::missing_key);
       buffer = R"({"req": 0, "req2": 0, "opt2": 0})";
       expect(glz::read_json(obj, buffer) == glz::error_code::none);
       expect(glz::read<glz::opts{.error_on_missing_keys = true}>(obj, buffer) == glz::error_code::none);
@@ -4229,7 +4229,7 @@ suite required_keys = [] {
       )";
       ec = glz::read<glz::opts{.error_on_unknown_keys = false, .error_on_missing_keys = true}>(order_book,
                                                                                                order_book_str_missing);
-      expect(ec != glz::error_code::none);
+      expect(ec == glz::error_code::missing_key);
    };
 };
 


### PR DESCRIPTION
Theoretically should check error after every `op` call, but maybe a performance impact.