### PR TITLE
Add intermediate error checks to read for better error messages.

### DIFF
--- a/include/glaze/json/json_ptr.hpp
+++ b/include/glaze/json/json_ptr.hpp
@@ -641,8 +641,13 @@ namespace glz
                while (true) {
                   skip_ws<Opts>(ctx, it, end);
                   const auto k = parse_key(ctx, it, end);
-                  if (k) {
-                     if (cx_string_cmp<key>(*k)) {
+                  if (bool(ctx.error)) [[unlikely]] {
+                     ret = unexpected(
+                        parse_error{error_code::syntax_error, static_cast<size_t>(std::distance(start, it))});
+                     return;
+                  }
+                  else {
+                     if (cx_string_cmp<key>(k)) {
                         skip_ws<Opts>(ctx, it, end);
                         match<':'>(ctx, it, end);
                         skip_ws<Opts>(ctx, it, end);
@@ -661,11 +666,6 @@ namespace glz
                         }
                         ++it;
                      }
-                  }
-                  else {
-                     ret = unexpected(
-                        parse_error{error_code::syntax_error, static_cast<size_t>(std::distance(start, it))});
-                     return;
                   }
                }
             }

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -23,7 +23,7 @@
 
 #if defined(GLZ_USE_ALWAYS_INLINE) && defined(NDEBUG)
 #ifndef GLZ_ALWAYS_INLINE
-#if __has_attribute(flatten)
+#if defined(__clang__)
 #define GLZ_ALWAYS_INLINE inline __attribute__((always_inline)) __attribute__((flatten))
 #else
 #define GLZ_ALWAYS_INLINE inline __attribute__((always_inline))
@@ -35,7 +35,7 @@
 #define GLZ_ALWAYS_INLINE inline
 #endif
 
-#if (defined(__clang__) || defined(__GNUC__)) && __has_attribute(flatten) && defined(NDEBUG)
+#if defined(__clang__) && defined(NDEBUG)
 #ifndef GLZ_FLATTEN
 #define GLZ_FLATTEN inline __attribute__((flatten))
 #endif

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -23,7 +23,11 @@
 
 #if defined(GLZ_USE_ALWAYS_INLINE) && defined(NDEBUG)
 #ifndef GLZ_ALWAYS_INLINE
+#if __has_attribute(flatten)
+#define GLZ_ALWAYS_INLINE inline __attribute__((always_inline)) __attribute__((flatten))
+#else
 #define GLZ_ALWAYS_INLINE inline __attribute__((always_inline))
+#endif
 #endif
 #endif
 
@@ -31,7 +35,7 @@
 #define GLZ_ALWAYS_INLINE inline
 #endif
 
-#if defined(__clang__) && defined(NDEBUG)
+#if (defined(__clang__) || defined(__GNUC__)) && __has_attribute(flatten) && defined(NDEBUG)
 #ifndef GLZ_FLATTEN
 #define GLZ_FLATTEN inline __attribute__((flatten))
 #endif
@@ -116,6 +120,7 @@ namespace glz::detail
          case '/': {
             if constexpr (Opts.force_conformance) {
                ctx.error = error_code::syntax_error;
+               return;
             }
             else {
                skip_comment(ctx, it, end);
@@ -302,8 +307,8 @@ namespace glz::detail
             return ret;
          }
       }
-
-      ctx.error = error_code::expected_quote;
+      
+      ctx.error = error_code::unknown_key;
       return {};
    }
 
@@ -523,18 +528,19 @@ namespace glz::detail
    GLZ_ALWAYS_INLINE void skip_value(is_context auto&& ctx, auto&& it, auto&& end) noexcept;
 
    // expects opening whitespace to be handled
-   GLZ_ALWAYS_INLINE expected<sv, error_code> parse_key(is_context auto&& ctx, auto&& it, auto&& end) noexcept
+   GLZ_ALWAYS_INLINE sv parse_key(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
-      if (static_cast<bool>(ctx.error)) [[unlikely]] {
-         return unexpected(ctx.error);
-      }
+      // TODO this assumes no escapes.
+      if (bool(ctx.error)) [[unlikely]]
+         return {};
 
       match<'"'>(ctx, it, end);
+      if (bool(ctx.error)) [[unlikely]]
+         return {};
       auto start = it;
       skip_till_quote(ctx, it, end);
-      if (static_cast<bool>(ctx.error)) [[unlikely]] {
-         return unexpected(ctx.error);
-      }
+      if (bool(ctx.error)) [[unlikely]]
+         return {};
       return sv{start, static_cast<size_t>(it++ - start)};
    }
 
@@ -552,6 +558,8 @@ namespace glz::detail
       else {
          ++it;
          skip_ws<Opts>(ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
          if (*it == '}') {
             ++it;
             return;
@@ -562,13 +570,27 @@ namespace glz::detail
                return;
             }
             skip_string<Opts>(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
             skip_ws<Opts>(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
             match<':'>(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
             skip_ws<Opts>(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
             skip_value<Opts>(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
             skip_ws<Opts>(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
             if (*it != ',') break;
             skip_ws<Opts>(ctx, ++it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
          }
          match<'}'>(ctx, it, end);
       }
@@ -588,15 +610,23 @@ namespace glz::detail
       else {
          ++it;
          skip_ws<Opts>(ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
          if (*it == ']') {
             ++it;
             return;
          }
          while (true) {
             skip_value<Opts>(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
             skip_ws<Opts>(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
             if (*it != ',') break;
             skip_ws<Opts>(ctx, ++it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
          }
          match<']'>(ctx, it, end);
       }
@@ -618,22 +648,31 @@ namespace glz::detail
             switch (*it) {
             case '{':
                skip_until_closed<'{', '}'>(ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
                break;
             case '[':
                skip_until_closed<'[', ']'>(ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
                break;
             case '"':
                skip_string<Opts>(ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
                break;
             case '/':
                skip_comment(ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
                continue;
             case ',':
             case '}':
             case ']':
                break;
             case '\0':
-               break;
+               ctx.error = error_code::unexpected_end;
+               return;
             default: {
                ++it;
                continue;

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -307,7 +307,7 @@ namespace glz::detail
             return ret;
          }
       }
-      
+
       ctx.error = error_code::unknown_key;
       return {};
    }

--- a/include/glaze/util/strod.hpp
+++ b/include/glaze/util/strod.hpp
@@ -60,6 +60,8 @@ namespace glz::detail
 #pragma GCC diagnostic ignored "-Wpedantic"
       unsigned __int128 prod = a * static_cast<unsigned __int128>(b);
 #pragma GCC diagnostic pop
+#else
+      unsigned __int128 prod = a * static_cast<unsigned __int128>(b);
 #endif
       return prod >> 64;
    }
@@ -378,7 +380,7 @@ namespace glz::detail
                data[idx + move] = num;
             }
             data[move] = data[0] << shft;
-            if (data.back() == 0) data.resize(data.size() - 1);
+            if (data.back() == 0) data.pop_back();
             while (move) data[--move] = 0;
          }
       }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -1950,7 +1950,7 @@ suite error_outputs = [] {
       auto ex = glz::read_json<error_comma_obj>(s);
       expect(!ex.has_value());
       auto err = glz::format_error(ex.error(), s);
-      expect(err == "10:7: syntax_error\n        ]\n  }\n         ^\n") << err;
+      expect(err == "10:6: syntax_error\n        ]\n        ^\n") << err;
    };
 };
 

--- a/tests/jsonrpc_test/jsonrpc_test.cpp
+++ b/tests/jsonrpc_test/jsonrpc_test.cpp
@@ -282,7 +282,7 @@ ut::suite struct_test_cases = [] {
       ut::expect(response_vec.size() == 1);
       ut::expect(
          glz::write_json(response_vec) ==
-         R"([{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error","data":"1:133: syntax_error\n   [{\"jsonrpc\":\"2.0\",\"method\":\"invalid_method_name\",\"params\":{},\"id\":\"uuid\"},{\"jsonrpc\":\"2.0\",\"method\":\"invalid_method_name\",\"params\":]\"\n                                                                                                                                       ^\n"},"id":null}])");
+         R"([{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error","data":"1:132: syntax_error\n   [{\"jsonrpc\":\"2.0\",\"method\":\"invalid_method_name\",\"params\":{},\"id\":\"uuid\"},{\"jsonrpc\":\"2.0\",\"method\":\"invalid_method_name\",\"params\":]\"\n                                                                                                                                      ^\n"},"id":null}])");
       ut::expect(response_vec.at(0).error.has_value());
       ut::expect(response_vec.at(0).error->get_code().value() == rpc::error_e::parse_error);
    };
@@ -350,11 +350,11 @@ ut::suite struct_test_cases = [] {
 {"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found","data":"Method: \"invalid_method_name\" not found"},"id":"2"},
 {"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request","data":"1:9: unknown_key\n   {\"foo\": \"boo\"}\n           ^\n"},"id":null},
 {"jsonrpc":"2.0","result":{"foo_c":false,"foo_d":""},"id":"4222222"},
-{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request","data":"1:21: syntax_error\n   {\"jsonrpc\":\"2.0\",\"invalid_method_key\":\"foo\",\"params\":{},\"id\":\"4222222\"}\n                       ^\n"},"id":"4222222"}
+{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request","data":"1:21: unknown_key\n   {\"jsonrpc\":\"2.0\",\"invalid_method_key\":\"foo\",\"params\":{},\"id\":\"4222222\"}\n                       ^\n"},"id":"4222222"}
 ])"};
       ut::expect(
          response ==
-         R"([{"jsonrpc":"2.0","result":{"foo_c":false,"foo_d":""},"id":"42"},{"jsonrpc":"2.0","result":{"bar_c":false,"bar_d":""},"id":"bar-uuid"},{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found","data":"Method: \"invalid_method_name\" not found"},"id":"2"},{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request","data":"1:9: unknown_key\n   {\"foo\": \"boo\"}\n           ^\n"},"id":null},{"jsonrpc":"2.0","result":{"foo_c":false,"foo_d":""},"id":"4222222"},{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request","data":"1:21: syntax_error\n   {\"jsonrpc\":\"2.0\",\"invalid_method_key\":\"foo\",\"params\":{},\"id\":\"4222222\"}\n                       ^\n"},"id":"4222222"}])");
+         R"([{"jsonrpc":"2.0","result":{"foo_c":false,"foo_d":""},"id":"42"},{"jsonrpc":"2.0","result":{"bar_c":false,"bar_d":""},"id":"bar-uuid"},{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found","data":"Method: \"invalid_method_name\" not found"},"id":"2"},{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request","data":"1:9: unknown_key\n   {\"foo\": \"boo\"}\n           ^\n"},"id":null},{"jsonrpc":"2.0","result":{"foo_c":false,"foo_d":""},"id":"4222222"},{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request","data":"1:21: unknown_key\n   {\"jsonrpc\":\"2.0\",\"invalid_method_key\":\"foo\",\"params\":{},\"id\":\"4222222\"}\n                       ^\n"},"id":"4222222"}])");
    };
 
    "server weird id values"_test = [&server] {


### PR DESCRIPTION
This should prevent the iterator advancing and the error code from changing.
- Should get optimized away if inlined. https://godbolt.org/z/GdToboW9a
- This based off of the discussion in #222
- I just did it for the read_json stuff
- I see a ~8% read performance improvement on the benchmark using clang on my machine but that is likely just more stuff getting inlined. 
   - gcc performance appears to be unchanged. I expect MSVC to be slower with these changes based on how it handles intermediate checks in godbolt and lack of inlineing.
- I might have missed some error checks since we dont return an error code using [[nodiscard]]
   - That might make it harder to shoot yourself in the foot with error checking
   - Right now its pretty much checking after everything that takes the context as an argument
   - Any lamdas that capture the context should be checked as well
- I got rid of some of the error checks at the top since they should no longer be needed, that might break some code if people are writing custom parsers but all those methods are in the detail namespace so I think its probably fine

I miss exceptions.