### PR TITLE
wrap unexpected to prevent compile errors with clang 16 & libc++ 16

### DIFF
--- a/include/glaze/util/expected.hpp
+++ b/include/glaze/util/expected.hpp
@@ -59,7 +59,11 @@ namespace glz
    using expected = std::expected<expected_t, unexpected_t>;
 
    template <class unexpected_t>
-   using unexpected = std::unexpected<unexpected_t>;
+   struct unexpected : public std::unexpected<unexpected_t> {
+      using std::unexpected<unexpected_t>::unexpected;
+   };
+   template <class unexpected_t>
+   unexpected(unexpected_t) -> unexpected<unexpected_t>;
 }
 #else
 


### PR DESCRIPTION
template deduction is not supported for alias from the cpp standard


the error: 

```bash
error: alias template 'unexpected' requires template arguments; argument deduction only allowed for class templates
                  return unexpected(error_code::unknown_key);
                         ^
```