### PR TITLE
jsonrpc multiple definition fixed

### DIFF
--- a/include/glaze/ext/jsonrpc.hpp
+++ b/include/glaze/ext/jsonrpc.hpp
@@ -62,7 +62,7 @@ namespace glz::rpc
 
    namespace detail
    {
-      std::string id_to_string(const jsonrpc_id_type& id)
+      static std::string id_to_string(const jsonrpc_id_type& id)
       {
          if (std::holds_alternative<glz::json_t::null_t>(id)) {
             return "null";


### PR DESCRIPTION
fix linker error 
```bash
/usr/bin/ld: exes/gpiod/CMakeFiles/gpiod.dir/src/gpio.cpp.o: in function `glz::rpc::detail::id_to_string(std::variant<double*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, long> const&)':
/home/jonb/Projects/framework/vcpkg-sysroot-gcc-libstdcxx-dynamic/x64-linux-gcc-dynamic/include/glaze/glaze/ext/jsonrpc.hpp:66: multiple definition of `glz::rpc::detail::id_to_string(std::variant<double*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, long> const&)'; exes/gpiod/CMakeFiles/gpiod.dir/src/main.cpp.o:/home/jonb/Projects/framework/vcpkg-sysroot-gcc-libstdcxx-dynamic/x64-linux-gcc-dynamic/include/glaze/glaze/ext/jsonrpc.hpp:66: first defined here
collect2: error: ld returned 1 exit status
```