### PR TITLE
Just use the Murmur bitmix function.

### DIFF
--- a/include/glaze/util/hash_map.hpp
+++ b/include/glaze/util/hash_map.hpp
@@ -100,14 +100,14 @@ namespace glz::detail
    // This is one such terible hashing alg
    struct naive_hash
    {
-      // TODO Use better constants calculated by something like
-      // skeeto/hash-prospector.
-      static constexpr uint64_t bitmix(uint64_t x)
+      static constexpr uint64_t bitmix(uint64_t h)
       {
-         x ^= x >> 33;
-         x *= 0xff51afd7ed558ccdL;
-         x ^= x >> 31;
-         return x;
+         h ^= h >> 33;
+         h *= 0xff51afd7ed558ccdL;
+         h ^= h >> 33;
+         h *= 0xc4ceb9fe1a85ec53L;
+         h ^= h >> 33;
+         return h;
       };
 
       // static constexpr uint64_t bitmix(uint64_t x)


### PR DESCRIPTION
We have no idea what the statistical properties are of the current bitmixer so the chance of failing to find a perfect hash function may be way worse than anticipated. Partially in response to #258 but they likely dont have a problem on the latest version.