### PR TITLE
CMake Upgrades

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -43,10 +43,3 @@ jobs:
     - name: Test
       working-directory: build
       run: ctest -j 2 --output-on-failure
-      
-    - name: Test Install/find_package
-      working-directory: build
-      run: |
-        sudo cmake --build . --target install
-        cmake -S ${{github.workspace}}/tests/find_package -B ${{github.workspace}}/tests/find_package/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
-        cmake --build ${{github.workspace}}/tests/find_package/build -j 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *build/
 *bin/
+.idea/
 .vscode/
 .cache/
 conan/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,6 @@ if(NOT CMAKE_SKIP_INSTALL_RULES)
   include(cmake/install-rules.cmake)
 endif()
 
-if (PROJECT_IS_TOP_LEVEL)
+if (glaze_DEVELOPER_MODE)
   include(cmake/dev-mode.cmake)
 endif()

--- a/cmake/install-rules.cmake
+++ b/cmake/install-rules.cmake
@@ -1,7 +1,3 @@
-if(PROJECT_IS_TOP_LEVEL)
-  set(CMAKE_INSTALL_INCLUDEDIR include/glaze CACHE PATH "")
-endif()
-
 # Project is configured with no languages, so tell GNUInstallDirs the lib dir
 set(CMAKE_INSTALL_LIBDIR lib CACHE PATH "")
 

--- a/cmake/variables.cmake
+++ b/cmake/variables.cmake
@@ -1,3 +1,5 @@
+include(CMakeDependentOption)
+
 # ---- Developer mode ----
 
 # Developer mode enables targets and code paths in the CMake scripts that are
@@ -5,7 +7,10 @@
 # Targets necessary to build the project must be provided unconditionally, so
 # consumers can trivially build and package the project
 if(PROJECT_IS_TOP_LEVEL)
-  option(glaze_DEVELOPER_MODE "Enable developer mode" OFF)
+  cmake_dependent_option(
+    glaze_DEVELOPER_MODE "Enable developer mode" ON
+    "PROJECT_IS_TOP_LEVEL" OFF
+  )
 endif()
 
 # ---- Warning guard ----

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,3 +41,37 @@ add_subdirectory(eigen_test)
 add_subdirectory(json_test)
 add_subdirectory(jsonrpc_test)
 add_subdirectory(lib_test)
+
+add_test(
+  NAME glaze-install_test
+  COMMAND
+  "${CMAKE_COMMAND}"
+  --install "${PROJECT_BINARY_DIR}"
+  --prefix "${CMAKE_CURRENT_BINARY_DIR}/install"
+  --config $<CONFIG>
+  --verbose
+)
+
+add_test(
+  NAME find_package_test
+  COMMAND
+  "${CMAKE_CTEST_COMMAND}"
+  --verbose
+  --output-on-failure
+  --build-noclean
+  --build-project "${PROJECT_NAME}" # helps msvc when --build-target
+  --build-generator "${CMAKE_GENERATOR}"
+  --build-config $<CONFIG>
+  --build-and-test
+  "${CMAKE_CURRENT_SOURCE_DIR}/find_package"
+  "${CMAKE_CURRENT_BINARY_DIR}/find_package"
+  --build-options
+  "-Dglaze_ROOT:PATH=${CMAKE_CURRENT_BINARY_DIR}/install"
+  "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+  "-DBUILD_TESTING=ON"
+  --test-command "${CMAKE_CTEST_COMMAND}" --verbose --output-on-failure # inner ctest command
+)
+
+set_tests_properties(glaze-install_test PROPERTIES FIXTURES_SETUP glaze-install-fixture)
+set_tests_properties(find_package_test PROPERTIES FIXTURES_REQUIRED glaze-install-fixture)
+

--- a/tests/find_package/CMakeLists.txt
+++ b/tests/find_package/CMakeLists.txt
@@ -8,8 +8,11 @@ project(
 
 file(GLOB srcs src/*.cpp include/*.hpp)
 
-find_package(glaze REQUIRED)
+find_package(glaze CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} ${srcs})
 target_include_directories(${PROJECT_NAME} PRIVATE include)
 target_link_libraries(${PROJECT_NAME} PRIVATE glaze::glaze)
+
+include(CTest)
+add_test(NAME ${PROJECT_NAME}_test COMMAND ${PROJECT_NAME})

--- a/tests/find_package/include/example.hpp
+++ b/tests/find_package/include/example.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "glaze/glaze.hpp"
+#include <glaze/glaze.hpp>
 
 namespace example
 {

--- a/tests/find_package/src/example.cpp
+++ b/tests/find_package/src/example.cpp
@@ -18,9 +18,8 @@ int main()
    std::string another_buffer{};
    glz::write_json(another_directory, another_buffer);
 
-   if (buffer == another_buffer) {
-      std::cout << "Directories are the same!\n";
-   }
+   std::cout << "Directories are " << (buffer != another_buffer ? "NOT" : "") << "the same!\n";
 
-   return 0;
+   const auto success = buffer == another_buffer;
+   return static_cast<int>(!success);
 }


### PR DESCRIPTION
While writing a vcpkg port for glaze (which has since been added by others), I noticed a few areas where glaze's CMake build-system could be enhanced.

## Changes

1. The option `glaze_DEVELOPER_MODE` was introduced by not used.
    Toggling developer mode was always based upon the `PROJECT_IS_TOP_LEVEL` variable. This caused the *glaze_ide* binary to be built in any situation where the project was built independently, for example, when building the vcpkg port. The vcpkg port introduced by others still builds this unnecessary target.
    
2. The explicitly introduced cache variable `CMAKE_INSTALL_INCLUDEDIR` doubly nested glaze's installed headers.
    When installing glaze, the headers would be placed in `.../include/glaze/glaze/` instead of `.../include/glaze/`. I'm not sure if this nesting was intentional, but assuming it was not, CMake's *GNUInstallDirs* module already introduces this cache variable.
    
 3. Tests for installing & finding glaze were registered with CTest.
     Now, glaze's installation and the finding & usage of *that* installed glaze instance are tested as part of glaze's automated tests.

## Future Work

Should these changes be incorporated into glaze, I would like to edit the upstream vcpkg port & add basic documentation into glaze for using it through vcpkg.

## Questions

Is my understanding correct that Eigen is not treated as a dependency, even though it's part of `ext/eigen.hpp`?
Would the introduction of the CMake component *ext*, to provide the target `glaze::ext` with an interface dependency on *Eigen3* be of interest? This would involve adding a call to `find_dependency(Eigen3)` in `install-config.cmake` that's conditional upon a user's call to `find_package(glaze REQUIRED COMPONENTS ext)`. 

