### PR TITLE
add support for modern C++ modules

### DIFF
--- a/include/glaze/api/name.hpp
+++ b/include/glaze/api/name.hpp
@@ -58,7 +58,7 @@ namespace glz
 #else
       template <const std::string_view&... Strs>
 #endif
-      static constexpr auto join_v = join<Strs...>();
+      constexpr auto join_v = join<Strs...>();
    }
 
    /*template <class T>

--- a/include/glaze/core/format.hpp
+++ b/include/glaze/core/format.hpp
@@ -8,13 +8,13 @@
 namespace glz
 {
    // format
-   static constexpr uint32_t binary = 0;
-   static constexpr uint32_t json = 10;
-   static constexpr uint32_t ndjson = 100; // new line delimited JSON
-   static constexpr uint32_t json_schema = 1000;
-   static constexpr uint32_t csv = 10000;
+   constexpr uint32_t binary = 0;
+   constexpr uint32_t json = 10;
+   constexpr uint32_t ndjson = 100; // new line delimited JSON
+   constexpr uint32_t json_schema = 1000;
+   constexpr uint32_t csv = 10000;
 
    // layout
-   static constexpr uint32_t rowwise = 0;
-   static constexpr uint32_t colwise = 1;
+   constexpr uint32_t rowwise = 0;
+   constexpr uint32_t colwise = 1;
 }

--- a/include/glaze/util/type_traits.hpp
+++ b/include/glaze/util/type_traits.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <tuple>
 #include <functional>
 
 namespace glz


### PR DESCRIPTION
This pull request fixes compilation on clang++ using `-stdlib=libc++` and `-fmodules` flags. The main `glaze/glaze.hpp` can now be used in a `.modulemap` file and it's also possible for it to be compiled into a PCM.

The changes are tiny, however, I'm not sure if `static` should be removed completely, or just replaced with an `extern` specifier.

I have not tested libstdc++, but it does seem to be working perfectly using libc++ with CMake.