### PR TITLE
support parsing empty sets

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -781,6 +781,10 @@ namespace glz
                return;
 
             value.clear();
+            if (*it == ']') [[unlikely]] {
+               ++it;
+               return;
+            }
 
             while (true) {
                using V = typename T::value_type;

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -3483,11 +3483,11 @@ static_assert(glz::detail::emplaceable<std::set<std::string>>);
 suite sets = [] {
    "std::unordered_set"_test = [] {
       std::unordered_set<std::string> set;
-      set.emplace("hello");
-      set.emplace("world");
+      expect(glz::read_json(set, "[]") == glz::error_code::none);
+      expect(set.empty());
 
+      set = {"hello", "world"};
       std::string b{};
-
       glz::write_json(set, b);
 
       expect(b == R"(["hello","world"])" || b == R"(["world","hello"])");
@@ -3501,7 +3501,11 @@ suite sets = [] {
    };
 
    "std::set"_test = [] {
-      std::set<int> set = {5, 4, 3, 2, 1};
+      std::set<int> set;
+      expect(glz::read_json(set, "[]") == glz::error_code::none);
+      expect(set.empty());
+
+      set = {5, 4, 3, 2, 1};
       std::string b{};
       glz::write_json(set, b);
 
@@ -3515,6 +3519,28 @@ suite sets = [] {
       expect(set.count(2) == 1);
       expect(set.count(3) == 1);
       expect(set.count(4) == 1);
+      expect(set.count(5) == 1);
+   };
+
+   "std::multiset"_test = [] {
+      std::multiset<int> set;
+      expect(glz::read_json(set, "[]") == glz::error_code::none);
+      expect(set.empty());
+
+      set = {5, 4, 3, 2, 1, 4, 1};
+      std::string b{};
+      glz::write_json(set, b);
+
+      expect(b == R"([1,1,2,3,4,4,5])");
+
+      set.clear();
+
+      expect(glz::read_json(set, b) == glz::error_code::none);
+
+      expect(set.count(1) == 2);
+      expect(set.count(2) == 1);
+      expect(set.count(3) == 1);
+      expect(set.count(4) == 2);
       expect(set.count(5) == 1);
    };
 };


### PR DESCRIPTION
Previously, glaze would emit a syntax error when parsing an empty JSON array (`[]`) to a set.

This PR adds a check against the parsed string being empty, like the parser for `std::vector`, and adds assertions in the unit tests to validate this for both `std::unordered_set` and `std::set`. 