### PR TITLE
indent for prettify only when [] is empty

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -333,6 +333,9 @@ namespace glz
       concept has_size = requires(T container) { container.size(); };
 
       template <class T>
+      concept has_empty = requires(T container) { {container.empty()} -> std::convertible_to<bool>; };
+
+      template <class T>
       concept has_data = requires(T container) { container.data(); };
 
       template <class T>

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -304,11 +304,11 @@ namespace glz
          {
             dump<'['>(args...);
             const auto is_empty = [&]() -> bool {
-               if constexpr (has_size<T>) {
-                  return value.size() ? false : true;
+               if constexpr (has_empty<T>) {
+                  return value.empty();
                }
                else {
-                  return value.empty();
+                  return value.size() ? false : true;
                }
             }();
 

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -303,11 +303,6 @@ namespace glz
          GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
          {
             dump<'['>(args...);
-            if constexpr (Opts.prettify) {
-               ctx.indentation_level += Opts.indentation_width;
-               dump<'\n'>(args...);
-               dumpn<Opts.indentation_char>(ctx.indentation_level, args...);
-            }
             const auto is_empty = [&]() -> bool {
                if constexpr (has_size<T>) {
                   return value.size() ? false : true;
@@ -318,6 +313,12 @@ namespace glz
             }();
 
             if (!is_empty) {
+               if constexpr (Opts.prettify) {
+                  ctx.indentation_level += Opts.indentation_width;
+                  dump<'\n'>(args...);
+                  dumpn<Opts.indentation_char>(ctx.indentation_level, args...);
+               }
+
                auto it = value.begin();
                write<json>::op<Opts>(*it, ctx, args...);
                ++it;


### PR DESCRIPTION
Previously, indentation was dumped when prettifying arrays even when they were empty. This caused prettified objects with empty arrays to shift all successive members by an indentation width. 

Example before:

```json
{
   "type": "array",
   "description": "a sample array2 (mat) parameter definition",
   "nullable": false,
   "default_value": [
      ], // this guy
      "choices": null,
      "element_type": {
         "type": "array",
         "description": "array in array",
         "nullable": false,
         "default_value": [
            1,
            2.3,
            3.9
         ],
         "choices": null,
         "element_type": {
            "type": "number",
            "description": "mat elements",
            "nullable": false,
            "default_value": 1,
            "choices": null,
            "min": null,
            "max": null
         },
         "min_size": null,
         "max_size": null
      },
      "min_size": null,
      "max_size": null
   }
``` 


Example After:
```json
{
   "type": "array",
   "description": "a sample array2 (mat) parameter definition",
   "nullable": false,
   "default_value": [],
   "choices": null,
   "element_type": {
      "type": "array",
      "description": "array in array",
      "nullable": false,
      "default_value": [
         1,
         2.3,
         3.9
      ],
      "choices": null,
      "element_type": {
         "type": "number",
         "description": "mat elements",
         "nullable": false,
         "default_value": 1,
         "choices": null,
         "min": null,
         "max": null
      },
      "min_size": null,
      "max_size": null
   },
   "min_size": null,
   "max_size": null
}
```



## Separate Question

Why does the `is_empty` function here prefer to use the provided member's `size()` function over `empty()`? Wouldn't `empty()` be preferred, as for numerous collections, it's guaranteed to be constant time while `size()` isn't? Obviously, this isn't the case for contiguous arrays, but lists would be an example. 