### PR TITLE
support for const qualified values in read_json (skips them)

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -45,8 +45,14 @@ namespace glz
          template <auto Opts, class T, is_context Ctx, class It0, class It1>
          GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
          {
-            from_json<std::decay_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
-                                                          std::forward<It0>(it), std::forward<It1>(end));
+            if constexpr (std::is_const_v<std::remove_reference_t<T>>) {
+               // do not read anything into the const value
+               skip_value<Opts>(std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
+            }
+            else {
+               from_json<std::decay_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+                                                             std::forward<It0>(it), std::forward<It1>(end));
+            }
          }
       };
 

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -4401,11 +4401,20 @@ struct glz::meta<cx_values>
 };
 
 suite constexpr_values_test = [] {
-   "constexpr_values"_test = [] {
+   "constexpr_values_write"_test = [] {
       cx_values obj{};
       std::string s{};
       glz::write_json(obj, s);
       expect(s == R"({"info":"information","index":42,"value":""})");
+   };
+   
+   "constexpr_values_read"_test = [] {
+      cx_values obj{};
+      std::string s = R"({"info":"hello","index":2,"value":"special"})";
+      expect(!glz::read_json(obj, s));
+      expect(obj.info == "information");
+      expect(obj.index == 42);
+      expect(obj.value == "special");
    };
 };
 


### PR DESCRIPTION
skips const qualified values