### PR TITLE
Handle string_view dereference nullptr

### DIFF
--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -194,10 +194,10 @@ namespace glz
                   dump<'"'>(b, ix);
                }
                else {
-                  const sv str = [&]() -> const std::decay_t<T>& {
+                  const sv str = [&]() -> sv {
                      if constexpr (std::is_pointer_v<std::decay_t<T>>) {
                         if (value == nullptr) {
-                           return const_cast<std::decay_t<T>>("");
+                           return "";
                         }
                      }
 

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -196,7 +196,7 @@ namespace glz
                else {
                   const sv str = [&]() -> sv {
                      if constexpr (std::is_pointer_v<std::decay_t<T>>) {
-                        if (value == nullptr) {
+                        if (*&value == nullptr) {
                            return "";
                         }
                      }

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -194,7 +194,15 @@ namespace glz
                   dump<'"'>(b, ix);
                }
                else {
-                  const sv str = value;
+                  const sv str = [&]() -> const std::decay_t<T>& {
+                     if constexpr (std::is_pointer_v<std::decay_t<T>>) {
+                        if (value == nullptr) {
+                           return const_cast<std::decay_t<T>>("");
+                        }
+                     }
+
+                     return value;
+                  }();
                   const auto n = str.size();
 
                   // we use 4 * n to handle potential escape characters and quoted bounds


### PR DESCRIPTION
https://github.com/stephenberry/glaze/issues/335
The second issue is when `string_view` dereference `nullptr` of unset `char*` and similar.