### PR TITLE
properly serialize maps skipping nulls

### DIFF
--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -320,6 +320,16 @@ namespace glz
          }
       };
 
+      template <glz::opts Opts>
+      GLZ_ALWAYS_INLINE void write_entry_separator(is_context auto&& ctx, auto&&... args)
+      {
+         dump<','>(args...);
+         if constexpr (Opts.prettify) {
+            dump<'\n'>(args...);
+            dumpn<Opts.indentation_char>(ctx.indentation_level, args...);
+         }
+      }
+
       template <array_t T>
       struct to_json<T>
       {
@@ -338,11 +348,7 @@ namespace glz
                write<json>::op<Opts>(*it, ctx, args...);
                ++it;
                for (; it != std::cend(value); ++it) {
-                  dump<','>(args...);
-                  if constexpr (Opts.prettify) {
-                     dump<'\n'>(args...);
-                     dumpn<Opts.indentation_char>(ctx.indentation_level, args...);
-                  }
+                  write_entry_separator<Opts>(ctx, args...);
                   write<json>::op<Opts>(*it, ctx, args...);
                }
                if constexpr (Opts.prettify) {
@@ -358,10 +364,6 @@ namespace glz
       template <opts Opts, typename Key, typename Value, is_context Ctx>
       void write_pair_content(const Key& key, const Value& value, Ctx& ctx, auto&&... args) noexcept
       {
-         if constexpr (null_t<Value> && Opts.skip_null_members) {
-            if (!bool(value)) return;
-         }
-
          if constexpr (str_t<Key> || char_t<Key> || glaze_enum_t<Key>) {
             write<json>::op<Opts>(key, ctx, args...);
             dump<':'>(args...);
@@ -378,12 +380,30 @@ namespace glz
          write<json>::op<Opts>(value, ctx, args...);
       }
 
+      template <glz::opts Opts, typename Value>
+      [[nodiscard]] GLZ_ALWAYS_INLINE constexpr bool skip_member(const Value& value) noexcept
+      {
+         if constexpr (null_t<Value> && Opts.skip_null_members) {
+            if constexpr (always_null_t<Value>)
+               return true;
+            else {
+               return !bool(value);
+            }
+         }
+         return false;
+      }
+
       template <pair_t T>
       struct to_json<T>
       {
-         template <auto Opts, class... Args>
+         template <glz::opts Opts, class... Args>
          GLZ_ALWAYS_INLINE static void op(const T& value, is_context auto&& ctx, Args&&... args) noexcept
          {
+            const auto& [key, val] = value;
+            if (skip_member<Opts>(val)) {
+               return dump<"{}">(args...);
+            }
+
             dump<'{'>(args...);
             if constexpr (Opts.prettify) {
                ctx.indentation_level += Opts.indentation_width;
@@ -391,7 +411,6 @@ namespace glz
                dumpn<Opts.indentation_char>(ctx.indentation_level, args...);
             }
 
-            const auto& [key, val] = value;
             write_pair_content<Opts>(key, val, ctx, args...);
 
             if constexpr (Opts.prettify) {
@@ -406,7 +425,7 @@ namespace glz
       template <writable_map_t T>
       struct to_json<T>
       {
-         template <auto Opts, class... Args>
+         template <glz::opts Opts, class... Args>
          GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
          {
             if constexpr (!Opts.opening_handled) {
@@ -422,21 +441,38 @@ namespace glz
                   }
                }
 
-               auto it = std::cbegin(value);
-               {
-                  const auto& [first_key, first_val] = *it;
+               auto write_first_entry = [&ctx, &args...](const auto first_it) {
+                  const auto& [first_key, first_val] = *first_it;
+                  if (skip_member<Opts>(first_val)) {
+                     return true;
+                  }
                   write_pair_content<Opts>(first_key, first_val, ctx, args...);
-               }
+                  return false;
+               };
 
+               auto it = std::cbegin(value);
+               [[maybe_unused]] bool previous_skipped = write_first_entry(it);
                for (++it; it != std::cend(value); ++it) {
-                  dump<','>(args...);
-                  if constexpr (Opts.prettify) {
-                     dump<'\n'>(args...);
-                     dumpn<Opts.indentation_char>(ctx.indentation_level, args...);
+                  const auto& [key, entry_val] = *it;
+                  if (skip_member<Opts>(entry_val)) {
+                     previous_skipped = true;
+                     continue;
                   }
 
-                  const auto& [key, entry_val] = *it;
+                  // When Opts.skip_null_members, *any* entry may be skipped, meaning separator dumping must be
+                  // conditional for every entry. Avoid this branch when not skipping null members.
+                  // Alternatively, write separator after each entry, except on last entry but then branch is permanent
+                  if constexpr (Opts.skip_null_members) {
+                     if (!previous_skipped) {
+                        write_entry_separator<Opts>(ctx, args...);
+                     }
+                  }
+                  else {
+                     write_entry_separator<Opts>(ctx, args...);
+                  }
+
                   write_pair_content<Opts>(key, entry_val, ctx, args...);
+                  previous_skipped = false;
                }
 
                if constexpr (!Opts.closing_handled) {
@@ -573,11 +609,7 @@ namespace glz
                }
                constexpr bool needs_comma = I < N - 1;
                if constexpr (needs_comma) {
-                  dump<','>(args...);
-                  if constexpr (Opts.prettify) {
-                     dump<'\n'>(args...);
-                     dumpn<Opts.indentation_char>(ctx.indentation_level, args...);
-                  }
+                  write_entry_separator<Opts>(ctx, args...);
                }
             });
             if constexpr (N > 0 && Opts.prettify) {
@@ -621,11 +653,7 @@ namespace glz
                }
                constexpr bool needs_comma = I < N - 1;
                if constexpr (needs_comma) {
-                  dump<','>(args...);
-                  if constexpr (Opts.prettify) {
-                     dump<'\n'>(args...);
-                     dumpn<Opts.indentation_char>(ctx.indentation_level, args...);
-                  }
+                  write_entry_separator<Opts>(ctx, args...);
                }
             });
             if constexpr (N > 0 && Opts.prettify) {
@@ -677,11 +705,7 @@ namespace glz
                }
                constexpr bool needs_comma = I < N - 1;
                if constexpr (needs_comma) {
-                  dump<','>(args...);
-                  if constexpr (Opts.prettify) {
-                     dump<'\n'>(args...);
-                     dumpn<Opts.indentation_char>(ctx.indentation_level, args...);
-                  }
+                  write_entry_separator<Opts>(ctx, args...);
                }
             });
             if constexpr (N > 0 && Opts.prettify) {
@@ -738,13 +762,8 @@ namespace glz
                decltype(auto) item = glz::tuplet::get<2 * I + 1>(value.value);
                using val_t = std::decay_t<decltype(item)>;
 
-               if constexpr (null_t<val_t> && Opts.skip_null_members) {
-                  if constexpr (always_null_t<T>)
-                     return;
-                  else {
-                     auto is_null = [&]() { return !bool(item); }();
-                     if (is_null) return;
-                  }
+               if (skip_member<Opts>(item)) {
+                  return;
                }
 
                // skip file_include
@@ -761,11 +780,7 @@ namespace glz
                   else {
                      // Null members may be skipped so we cant just write it out for all but the last member unless
                      // trailing commas are allowed
-                     dump<','>(b, ix);
-                     if constexpr (Opts.prettify) {
-                        dump<'\n'>(b, ix);
-                        dumpn<Opts.indentation_char>(ctx.indentation_level, b, ix);
-                     }
+                     write_entry_separator<Opts>(ctx, b, ix);
                   }
 
                   using Key = typename std::decay_t<std::tuple_element_t<2 * I, V>>;
@@ -890,11 +905,7 @@ namespace glz
                   else {
                      // Null members may be skipped so we cant just write it out for all but the last member unless
                      // trailing commas are allowed
-                     dump<','>(b, ix);
-                     if constexpr (Opts.prettify) {
-                        dump<'\n'>(b, ix);
-                        dumpn<Opts.indentation_char>(ctx.indentation_level, b, ix);
-                     }
+                     write_entry_separator<Opts>(ctx, b, ix);
                   }
 
                   using Key = typename std::decay_t<std::tuple_element_t<0, decltype(item)>>;

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -1858,10 +1858,9 @@ suite write_tests = [] {
    };
 
    "Write array"_test = [] {
-      std::array<double, 4> v{1.1, 2.2, 3.3, 4.4};
       std::string s;
+      std::array<double, 4> v{1.1, 2.2, 3.3, 4.4};
       glz::write_json(v, s);
-
       expect(s == "[1.1,2.2,3.3,4.4]");
    };
 
@@ -1877,11 +1876,14 @@ suite write_tests = [] {
    };
 
    "Write map"_test = [] {
-      std::map<std::string, double> m{{"a", 2.2}, {"b", 11.111}, {"c", 211.2}};
       std::string s;
+      std::map<std::string, double> m{{"a", 2.2}, {"b", 11.111}, {"c", 211.2}};
       glz::write_json(m, s);
-
       expect(s == R"({"a":2.2,"b":11.111,"c":211.2})");
+
+      std::map<std::string, std::optional<double>> nullable{{"a", std::nullopt}, {"b", std::nullopt}, {"c", 211.2}};
+      glz::write_json(nullable, s);
+      expect(s == glz::sv{R"({"c":211.2})"});
    };
 
    "Write pair"_test =
@@ -1895,6 +1897,8 @@ suite write_tests = [] {
          Write_pair_test_case{0.78, std::array{1, 2, 3}, R"({"0.78":[1,2,3]})"},
          Write_pair_test_case{"k", glz::obj{"in1", 1, "in2", "v"}, R"({"k":{"in1":1,"in2":"v"}})"},
          Write_pair_test_case{std::array{1, 2}, 99, R"({"[1,2]":99})"},
+         Write_pair_test_case{"knot", std::nullopt, "{}"}, // nullopt_t, not std::optional
+         Write_pair_test_case{"kmaybe", std::optional<int>{}, "{}"},
       };
 
 #ifdef __cpp_lib_ranges


### PR DESCRIPTION
Previously, serializing map-like objects would incorrectly write commas when entries were skipped. This was because although the entry itself was skipped, the separator was not.

This PR changes that behaviour, and amalgamates some basic functionality used in the map serialization and many other serialization functions: writing entry separators and skipping members. Additionally, skipping nulls on pairs (single maps) has also been completed. With tests, of course.