### PR TITLE
using erase rather than resize

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -366,6 +366,9 @@ namespace glz
 
       template <class T>
       concept resizeable = requires(T container) { container.resize(0); };
+      
+      template <class T>
+      concept erasable = requires(T container) { container.erase(container.cbegin(), container.cend()); };
 
       template <class T>
       concept fixed_array_value_t = array_t<std::decay_t<decltype(std::declval<T>()[0])>> && !

--- a/include/glaze/json/ndjson.hpp
+++ b/include/glaze/json/ndjson.hpp
@@ -69,12 +69,13 @@ namespace glz
             for (size_t i = 0; i < n; ++i) {
                read<json>::op<Opts>(*value_it++, ctx, it, end);
                if (it == end) {
-                  value.resize(i + 1);
+                  if constexpr (erasable<T>) {
+                     value.erase(value_it, value.end()); // use erase rather than resize for non-default constructible elements
 
-                  if constexpr (Opts.shrink_to_fit) {
-                     value.shrink_to_fit();
+                     if constexpr (Opts.shrink_to_fit) {
+                        value.shrink_to_fit();
+                     }
                   }
-
                   return;
                }
 

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -924,8 +924,8 @@ namespace glz
                }
                else if (*it == ']') {
                   ++it;
-                  if constexpr (resizeable<T>) {
-                     value.resize(i + 1);
+                  if constexpr (erasable<T>) {
+                     value.erase(value_it, value.end()); // use erase rather than resize for non-default constructible elements
 
                      if constexpr (Opts.shrink_to_fit) {
                         value.shrink_to_fit();


### PR DESCRIPTION
Erase allows the removal of non-default constructible classes