### PR TITLE
Added glz_custom_read and glz_custom_write

### DIFF
--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -222,7 +222,7 @@ namespace glz
          }
       };
 
-      template <array_t T>
+      template <readable_array_t T>
       struct from_binary<T> final
       {
          template <auto Opts>

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -250,7 +250,7 @@ namespace glz
          }
       };
 
-      template <array_t T>
+      template <writable_array_t T>
       struct to_binary<T> final
       {
          template <auto Opts, class... Args>

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -30,6 +30,17 @@
 
 namespace glz
 {
+   // Allows developers to add `static constexpr auto custom_read = true;` to their classes to prevent ambiguous partial specialization for custom parsers
+   template <class T>
+   concept custom_read = requires {
+      T::glz_custom_read;
+   };
+   
+   template <class T>
+   concept custom_write = requires {
+      T::glz_custom_write;
+   };
+   
    template <class... T>
    struct obj final
    {
@@ -325,11 +336,11 @@ namespace glz
                                   };
 
       template <class T>
-      concept readable_map_t = !
+      concept readable_map_t = !custom_read<T> && !
       complex_t<T> && !str_t<T> && range<T> && pair_t<range_value_t<T>> && map_subscriptable<T>;
 
       template <class T>
-      concept writable_map_t = !
+      concept writable_map_t = !custom_write<T> && !
       complex_t<T> && !str_t<T> && range<T> && pair_t<range_value_t<T>>;
 
       template <class Map>
@@ -339,9 +350,15 @@ namespace glz
                                               std::same_as<typename Map::key_compare, std::greater<>> ||
                                               requires { typename Map::key_compare::is_transparent; });
                                   };
-
+      
       template <class T>
       concept array_t = (!complex_t<T> && !str_t<T> && !(readable_map_t<T> || writable_map_t<T>) && range<T>);
+
+      template <class T>
+      concept readable_array_t = (!custom_read<T> && array_t<T>);
+      
+      template <class T>
+      concept writable_array_t = (!custom_write<T> && array_t<T>);
 
       template <class T>
       concept emplace_backable = requires(T container) {

--- a/include/glaze/csv/read.hpp
+++ b/include/glaze/csv/read.hpp
@@ -168,7 +168,7 @@ namespace glz
          }
       };
 
-      template <array_t T>
+      template <readable_array_t T>
       struct from_csv<T>
       {
          template <auto Opts, class It>

--- a/include/glaze/csv/write.hpp
+++ b/include/glaze/csv/write.hpp
@@ -65,7 +65,7 @@ namespace glz
          }
       };
 
-      template <array_t T>
+      template <writable_array_t T>
       struct to_csv<T>
       {
          template <auto Opts, class B>
@@ -190,7 +190,7 @@ namespace glz
                   using item_type = std::decay_t<decltype(get_member(value, glz::tuplet::get<1>(item)))>;
                   using V = typename item_type::value_type;
 
-                  if constexpr (array_t<V>) {
+                  if constexpr (writable_array_t<V>) {
                      auto&& member = get_member(value, glz::tuplet::get<1>(item));
                      const auto count = member.size();
                      const auto size = member[0].size();

--- a/include/glaze/json/ndjson.hpp
+++ b/include/glaze/json/ndjson.hpp
@@ -26,7 +26,7 @@ namespace glz
       };
 
       template <class T>
-         requires array_t<T> && (emplace_backable<T> || !resizeable<T>)
+         requires readable_array_t<T> && (emplace_backable<T> || !resizeable<T>)
       struct from_ndjson<T>
       {
          template <auto Opts>
@@ -168,7 +168,7 @@ namespace glz
          }
       };
 
-      template <array_t T>
+      template <writable_array_t T>
       struct to_ndjson<T>
       {
          template <auto Opts, class... Args>

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -825,7 +825,7 @@ namespace glz
 
       // for set types
       template <class T>
-         requires(array_t<T> && !emplace_backable<T> && !resizeable<T> && emplaceable<T>)
+         requires(readable_array_t<T> && !emplace_backable<T> && !resizeable<T> && emplaceable<T>)
       struct from_json<T>
       {
          template <auto Options>
@@ -873,7 +873,7 @@ namespace glz
       };
 
       template <class T>
-         requires(array_t<T> && (emplace_backable<T> || !resizeable<T>) && !emplaceable<T>)
+         requires(readable_array_t<T> && (emplace_backable<T> || !resizeable<T>) && !emplaceable<T>)
       struct from_json<T>
       {
          template <auto Options>
@@ -1031,7 +1031,7 @@ namespace glz
       }
 
       template <class T>
-         requires array_t<T> && (!emplace_backable<T> && resizeable<T>)
+         requires readable_array_t<T> && (!emplace_backable<T> && resizeable<T>)
       struct from_json<T>
       {
          template <auto Options>

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -330,7 +330,7 @@ namespace glz
          }
       }
 
-      template <array_t T>
+      template <writable_array_t T>
       struct to_json<T>
       {
          template <auto Opts, class... Args>

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -4976,6 +4976,48 @@ suite read_as_json_raw = [] {
    };
 };
 
+struct vec_t {
+   static constexpr auto glz_custom_read = true;
+   
+    constexpr virtual std::string string() const = 0;
+    constexpr virtual std::size_t size() const noexcept = 0;
+
+    constexpr double* begin() noexcept { return (double*)this + 1; };
+    constexpr double* end() noexcept { return (double*)this+size() + 1; };
+
+};
+
+struct vec3_t : public vec_t {
+
+    union { double x, r; };
+    union { double y, g; };
+    union { double z, b; };
+
+    constexpr std::string string() const override { return ""; }
+    constexpr std::size_t size() const noexcept override { return 3; }
+
+};
+
+namespace glz::detail
+{
+   template <class T> requires std::derived_from<T, vec3_t>
+   struct from_json <T> {
+
+       template <auto Opts>
+       static void op (T&, auto&&...) noexcept {
+          
+       }
+   };
+}
+
+suite read_custom_vec = [] {
+   "read_custom_vec"_test = [] {
+      vec3_t vec{};
+      std::string s = R"([1,2,3])";
+      expect(!glz::read_json(vec, s));
+   };
+};
+
 int main()
 {
    // Explicitly run registered test suites and report errors


### PR DESCRIPTION
Allows developers to avoid ambiguous partial specialization when making custom parsers.