### PR TITLE
fix write of long long and unsigned long long

### DIFF
--- a/include/glaze/core/write_chars.hpp
+++ b/include/glaze/core/write_chars.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "glaze/core/common.hpp"
 #include "glaze/core/opts.hpp"
 #include "glaze/util/dtoa.hpp"
@@ -14,10 +16,10 @@ namespace glz::detail
    GLZ_ALWAYS_INLINE constexpr auto sized_integer_conversion() noexcept
    {
       if constexpr (std::is_signed_v<T>) {
-         if constexpr (sizeof(T) <= 32) {
+         if constexpr (sizeof(T) <= sizeof(int32_t)) {
             return int32_t{};
          }
-         else if constexpr (sizeof(T) <= 64) {
+         else if constexpr (sizeof(T) <= sizeof(int64_t)) {
             return int64_t{};
          }
          else {
@@ -25,10 +27,10 @@ namespace glz::detail
          }
       }
       else {
-         if constexpr (sizeof(T) <= 32) {
+         if constexpr (sizeof(T) <= sizeof(uint32_t)) {
             return uint32_t{};
          }
-         else if constexpr (sizeof(T) <= 64) {
+         else if constexpr (sizeof(T) <= sizeof(uint64_t)) {
             return uint64_t{};
          }
          else {
@@ -36,6 +38,8 @@ namespace glz::detail
          }
       }
    }
+   static_assert(std::is_same_v<decltype(sized_integer_conversion<long long>()), int64_t>);
+   static_assert(std::is_same_v<decltype(sized_integer_conversion<unsigned long long>()), uint64_t>);
 
    struct write_chars
    {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -1729,9 +1729,9 @@ suite write_tests = [] {
       }
       {
          std::string s;
-         long long v{1};
+         long long v{-193582804324766};
          glz::write_json(v, s);
-         expect(s == "1");
+         expect(s == "-193582804324766");
       }
       {
          std::string s;
@@ -1753,9 +1753,9 @@ suite write_tests = [] {
       }
       {
          std::string s;
-         unsigned long long v{1};
+         unsigned long long v{193582804324766};
          glz::write_json(v, s);
-         expect(s == "1");
+         expect(s == "193582804324766");
       }
    };
 


### PR DESCRIPTION
compare integer size in bytes, not bits