### PR TITLE
add missing 'fstream' header. Comp fail.

### DIFF
--- a/include/glaze/core/write.hpp
+++ b/include/glaze/core/write.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <fstream>
+
 #include "glaze/core/common.hpp"
 #include "glaze/core/opts.hpp"
 #include "glaze/util/validate.hpp"


### PR DESCRIPTION
Hit a compilation failure when packaging glaze internally. 
The `fstream` header isn't used in the consuming code, exposing this missing header as a consequence of compilation failures.

