### PR TITLE
Named null

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -483,7 +483,7 @@ namespace glz
 
       template <class T>
       concept always_null_t =
-         std::same_as<T, std::nullptr_t> || std::same_as<T, std::monostate> || std::same_as<T, std::nullopt_t>;
+         std::same_as<T, std::nullptr_t> || std::convertible_to<T, std::monostate> || std::same_as<T, std::nullopt_t>;
 
       template <class T>
       concept nullable_t = !

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -5097,6 +5097,18 @@ suite function_call = [] {
    };
 };
 
+struct named_always_null : std::monostate {};
+template<>
+struct glz::meta<named_always_null> {
+   static constexpr std::string_view name = "named_always_null";
+};
+suite nullable_type = [] {
+   "named_always_null"_test = [] {
+      expect("null" == glz::write_json(named_always_null{}));
+   };
+};
+
+
 int main()
 {
    // Explicitly run registered test suites and report errors


### PR DESCRIPTION
Use case 

```cpp
struct named_always_null : std::monostate {};
template<>
glz::meta<named_always_null> { static constexpr std::string_view name{ "my name" };

std::variant<named_always_null, int, std::string> my_variant{};
```
`glz::write_json_schema` ... would return title as the described name in `named_always_null`

Alternative would be defining `glz::to_json<>` `glz::from_json<>`

What are your thought on this?