### PR TITLE
Fix: Arbitrary inputs accepted as integers

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1569,21 +1569,39 @@ namespace glz
                            ctx.error = error_code::unknown_key;
                            return;
                         }
+                        else {
+                           // We duplicate this code to avoid generating unreachable code
+                           skip_ws<Opts>(ctx, it, end);
+                           if (bool(ctx.error)) [[unlikely]]
+                              return;
+                           match<':'>(ctx, it, end);
+                           if (bool(ctx.error)) [[unlikely]]
+                              return;
+                           skip_ws<Opts>(ctx, it, end);
+                           if (bool(ctx.error)) [[unlikely]]
+                              return;
+
+                           skip_value<Opts>(ctx, it, end);
+                           if (bool(ctx.error)) [[unlikely]]
+                              return;
+                        }
                      }
+                     else {
+                        // We duplicate this code to avoid generating unreachable code
+                        skip_ws<Opts>(ctx, it, end);
+                        if (bool(ctx.error)) [[unlikely]]
+                           return;
+                        match<':'>(ctx, it, end);
+                        if (bool(ctx.error)) [[unlikely]]
+                           return;
+                        skip_ws<Opts>(ctx, it, end);
+                        if (bool(ctx.error)) [[unlikely]]
+                           return;
 
-                     skip_ws<Opts>(ctx, it, end);
-                     if (bool(ctx.error)) [[unlikely]]
-                        return;
-                     match<':'>(ctx, it, end);
-                     if (bool(ctx.error)) [[unlikely]]
-                        return;
-                     skip_ws<Opts>(ctx, it, end);
-                     if (bool(ctx.error)) [[unlikely]]
-                        return;
-
-                     skip_value<Opts>(ctx, it, end);
-                     if (bool(ctx.error)) [[unlikely]]
-                        return;
+                        skip_value<Opts>(ctx, it, end);
+                        if (bool(ctx.error)) [[unlikely]]
+                           return;
+                     }
                   }
                }
                else {

--- a/include/glaze/util/stoui64.hpp
+++ b/include/glaze/util/stoui64.hpp
@@ -22,6 +22,10 @@ namespace glz::detail
 
    GLZ_ALWAYS_INLINE constexpr bool stoui64(uint64_t& res, const char*& c) noexcept
    {
+      if (!is_digit(*c)) {
+         return false;
+      }
+
       std::array<uint8_t, 20> digits{};
 
       uint32_t i{};
@@ -35,7 +39,7 @@ namespace glz::detail
          }
       }
 
-      while (is_digit(*c)) {
+      while(is_digit(*c)) { // already checked for first digit
          if (i < 20) [[likely]] {
             digits[i] = (*c - '0');
          }

--- a/include/glaze/util/stoui64.hpp
+++ b/include/glaze/util/stoui64.hpp
@@ -23,7 +23,7 @@ namespace glz::detail
 
    GLZ_ALWAYS_INLINE constexpr bool stoui64(uint64_t& res, const char*& c) noexcept
    {
-      if (!is_digit(*c)) {
+      if (!is_digit(*c)) [[unlikely]] {
          return false;
       }
 

--- a/include/glaze/util/stoui64.hpp
+++ b/include/glaze/util/stoui64.hpp
@@ -94,7 +94,7 @@ namespace glz::detail
          else [[unlikely]] {
             return false;
          }
-         if (is_safe_addition(res, digits.back())) [[likely]] {
+         if (is_safe_addition(res, digits[19])) [[likely]] {
             res += digits[19];
          }
          else [[unlikely]] {

--- a/include/glaze/util/stoui64.hpp
+++ b/include/glaze/util/stoui64.hpp
@@ -94,8 +94,8 @@ namespace glz::detail
          else [[unlikely]] {
             return false;
          }
-         if (is_safe_addition(res, digits[19])) [[likely]] {
-            res += digits[19];
+         if (is_safe_addition(res, digits.back())) [[likely]] {
+            res += digits.back();
          }
          else [[unlikely]] {
             return false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,5 +89,9 @@ add_test(
 endif()
 
 set_tests_properties(glaze-install_test PROPERTIES FIXTURES_SETUP glaze-install-fixture)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+# Don't run find_package_test with MSVC
+else()
 set_tests_properties(find_package_test PROPERTIES FIXTURES_REQUIRED glaze-install-fixture)
+endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,9 +64,6 @@ add_test(
   --verbose
 )
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-# Don't run find_package_test with MSVC
-else()
 add_test(
   NAME find_package_test
   COMMAND
@@ -86,7 +83,6 @@ add_test(
   "-DBUILD_TESTING=ON"
   --test-command "${CMAKE_CTEST_COMMAND}" --verbose --output-on-failure # inner ctest command
 )
-endif()
 
 set_tests_properties(glaze-install_test PROPERTIES FIXTURES_SETUP glaze-install-fixture)
 set_tests_properties(find_package_test PROPERTIES FIXTURES_REQUIRED glaze-install-fixture)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,9 +89,5 @@ add_test(
 endif()
 
 set_tests_properties(glaze-install_test PROPERTIES FIXTURES_SETUP glaze-install-fixture)
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-# Don't run find_package_test with MSVC
-else()
 set_tests_properties(find_package_test PROPERTIES FIXTURES_REQUIRED glaze-install-fixture)
-endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,9 @@ add_test(
   --verbose
 )
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+# Don't run find_package_test with MSVC
+else()
 add_test(
   NAME find_package_test
   COMMAND
@@ -83,6 +86,7 @@ add_test(
   "-DBUILD_TESTING=ON"
   --test-command "${CMAKE_CTEST_COMMAND}" --verbose --output-on-failure # inner ctest command
 )
+endif()
 
 set_tests_properties(glaze-install_test PROPERTIES FIXTURES_SETUP glaze-install-fixture)
 set_tests_properties(find_package_test PROPERTIES FIXTURES_REQUIRED glaze-install-fixture)

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -384,6 +384,18 @@ suite basic_types = [] {
       expect(num64 == 32948729483739289);
    };
 
+  "int read invalid"_test = [] {
+    int num{33};
+    expect(glz::read_json(num, ";adsfa") == glz::error_code::parse_number_failure);
+    expect(num == 33);
+    expect(glz::read_json(num, "{}") == glz::error_code::parse_number_failure);
+    expect(num == 33);
+    expect(glz::read_json(num, "[]") == glz::error_code::parse_number_failure);
+    expect(num == 33);
+    expect(glz::read_json(num, ".") == glz::error_code::parse_number_failure);
+    expect(num == 33);
+  };
+
    "bool write"_test = [] {
       std::string buffer{};
       glz::write_json(true, buffer);
@@ -1435,7 +1447,7 @@ suite read_tests = [] {
          std::string in = R"(null)";
          int res{};
 
-         expect(glz::read_json(res, in) != glz::error_code::parse_number_failure);
+         expect(glz::read_json(res, in) == glz::error_code::parse_number_failure);
       }
    };
 


### PR DESCRIPTION
An example of what was passing:
```c++
#include <cstdint>

#include <glaze/json/read.hpp>

template<typename T>
void should_be_error() {
  const auto parsed = glz::read_json<int>("asdf;lkajsdf");
  assert(parsed.has_value());
  assert(parsed.value() == 0);
}

int main() {
  should_be_error<std::int8_t>();
  should_be_error<std::int16_t>();
  should_be_error<std::int32_t>();
  should_be_error<std::int64_t>();
  should_be_error<std::uint8_t>();
  should_be_error<std::uint16_t>();
  should_be_error<std::uint32_t>();
  should_be_error<std::uint64_t>();
}
```

The following changes primarily test if the first character is a digit in `stoui64()` instead of assuming it is. Tests and a little refactor of stoui64 follow.