### PR TITLE
clang + libstdc++ workaround

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2040,8 +2040,14 @@ namespace glz
             }
             else {
                if (!value) {
-                  if constexpr (is_specialization_v<T, std::optional>)
-                     value = std::make_optional<typename T::value_type>();
+                  if constexpr (is_specialization_v<T, std::optional>) {
+                     if constexpr (requires { value.emplace(); }) {
+                        value.emplace();
+                     }
+                     else {
+                        value = typename T::value_type{};
+                     }
+                  }
                   else if constexpr (is_specialization_v<T, std::unique_ptr>)
                      value = std::make_unique<typename T::element_type>();
                   else if constexpr (is_specialization_v<T, std::shared_ptr>)


### PR DESCRIPTION
This is a workaround for the compilation issue with clang++ with libstdc++ as described in https://github.com/llvm/llvm-project/issues/50248.

https://godbolt.org/z/bndzMjMsM demonstrates this problem. 