### PR TITLE
Wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Glaze also supports binary messages via [BEVE](https://github.com/stephenberry/b
 Wrappers now consistently leave off the `()` for less typing
 
 - `glz::quoted` for reading numbers as strings and writing them as strings has been replaced with `glz::quoted_num`
-- The recent `glz::unquote` has been replaced with the name `glz::quoted`, which reads a string into a value and writes the value with quotes. This is less efficient for numbers than `glz::quoted_num`.
+- The recent `glz::unquote` has been replaced with the name `glz::quoted`, which reads a string into a value and writes the value with quotes. This is less efficient for numbers than `glz::quoted_num`. `glz::quoted_num` also handles nested decoding of numbers unlike `glz::quoted`.
 
 Below shows the format for adding wrappers within glaze metadata.
 ```c++

--- a/README.md
+++ b/README.md
@@ -3,6 +3,21 @@ One of the fastest JSON libraries in the world. Glaze reads and writes from C++ 
 
 Glaze also supports binary messages via [BEVE](https://github.com/stephenberry/beve) and CSV support. And, the library has many more useful features for building APIs.
 
+## Breaking Wrapper Changes! (v1.5.1)
+Wrappers now consistently leave off the `()` for less typing
+
+- `glz::quoted` for reading numbers as strings and writing them as strings has been replaced with `glz::quoted_num`
+- The recent `glz::unquote` has been replaced with the name `glz::quoted`, which reads a string into a value and writes the value with quotes. This is less efficient for numbers than `glz::quoted_num`.
+
+Below shows the format for adding wrappers within glaze metadata.
+```c++
+glz::quoted_num<&T::x> // reads a number as a string and writes it as a string
+glz::quoted<&T::x> // reads a value as a string and unescapes, to avoid the user having to parse twice
+glz::number<&T::x> // reads a string as a number and writes the string as a number
+glz::invoke<&T::func> // invokes a std::function or member function with n-arguments as an array input
+glz::custom<&T::read, &T::write> // calls custom read and write std::functions or member functions
+```
+
 ## New Custom JSON Read/Write Support!
 
 Glaze version 1.5.0 adds the ability to register member functions to customize reading and writing. See [Custom Read/Write](#custom-readwrite) for more information.

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -26,7 +26,7 @@ namespace glz
       bool error_on_const_read =
          false; // Error if attempt is made to read into a const value, by default the value is skipped without error
       uint32_t layout = rowwise; // CSV row wise output/input
-      bool quoted = false; // treat numbers as quoted or array-like types as having quoted numbers
+      bool quoted_num = false; // treat numbers as quoted or array-like types as having quoted numbers
       bool number = false; // read numbers as strings and write these string as numbers
 
       // INTERNAL USE

--- a/include/glaze/json/invoke.hpp
+++ b/include/glaze/json/invoke.hpp
@@ -118,17 +118,20 @@ namespace glz
             dump<']'>(args...);
          }
       };
+      
+      template <auto MemPtr>
+      inline constexpr decltype(auto) invoke_impl() noexcept
+      {
+         using V = decltype(MemPtr);
+         if constexpr (std::is_member_function_pointer_v<V>) {
+            return [](auto&& val) { return invoke_t<std::decay_t<V>>{val, MemPtr}; };
+         }
+         else {
+            return [](auto&& val) { return invoke_t<std::decay_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
+         }
+      }
    }
 
    template <auto MemPtr>
-   inline constexpr decltype(auto) invoke() noexcept
-   {
-      using V = decltype(MemPtr);
-      if constexpr (std::is_member_function_pointer_v<V>) {
-         return [](auto&& val) { return invoke_t<std::decay_t<V>>{val, MemPtr}; };
-      }
-      else {
-         return [](auto&& val) { return invoke_t<std::decay_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
-      }
-   }
+   constexpr auto invoke = detail::invoke_impl<MemPtr>();
 }

--- a/include/glaze/json/quoted.hpp
+++ b/include/glaze/json/quoted.hpp
@@ -9,7 +9,7 @@ namespace glz
 {
    // treat numbers as quoted or array-like types as having quoted numbers
    template <class T>
-   struct quoted_t
+   struct quoted_num_t
    {
       T& val;
    };
@@ -31,7 +31,7 @@ namespace glz
    namespace detail
    {
       template <class T>
-      struct from_json<quoted_t<T>>
+      struct from_json<quoted_num_t<T>>
       {
          template <auto Opts>
          GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args) noexcept
@@ -41,7 +41,7 @@ namespace glz
       };
 
       template <class T>
-      struct to_json<quoted_t<T>>
+      struct to_json<quoted_num_t<T>>
       {
          template <auto Opts>
          GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
@@ -96,6 +96,12 @@ namespace glz
             write<json>::op<opt_true<Opts, &opts::number>>(value.val, ctx, args...);
          }
       };
+      
+      template <auto MemPtr>
+      inline constexpr decltype(auto) quoted_num_impl() noexcept
+      {
+         return [](auto&& val) { return quoted_num_t<std::decay_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
+      }
 
       template <auto MemPtr>
       inline constexpr decltype(auto) unquote_impl() noexcept
@@ -105,10 +111,7 @@ namespace glz
    }
 
    template <auto MemPtr>
-   inline constexpr decltype(auto) quoted() noexcept
-   {
-      return [](auto&& val) { return quoted_t<std::decay_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
-   }
+   constexpr auto quoted_num = detail::quoted_num_impl<MemPtr>();
 
    template <auto MemPtr>
    inline constexpr decltype(auto) number() noexcept

--- a/include/glaze/json/quoted.hpp
+++ b/include/glaze/json/quoted.hpp
@@ -102,6 +102,12 @@ namespace glz
       {
          return [](auto&& val) { return quoted_num_t<std::decay_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
       }
+      
+      template <auto MemPtr>
+      inline constexpr decltype(auto) number_impl() noexcept
+      {
+         return [](auto&& val) { return number_t<std::decay_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
+      }
 
       template <auto MemPtr>
       inline constexpr decltype(auto) quoted_impl() noexcept
@@ -114,10 +120,7 @@ namespace glz
    constexpr auto quoted_num = detail::quoted_num_impl<MemPtr>();
 
    template <auto MemPtr>
-   inline constexpr decltype(auto) number() noexcept
-   {
-      return [](auto&& val) { return number_t<std::decay_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
-   }
+   constexpr auto number = detail::number_impl<MemPtr>();
 
    template <auto MemPtr>
    constexpr auto quoted = detail::quoted_impl<MemPtr>();

--- a/include/glaze/json/quoted.hpp
+++ b/include/glaze/json/quoted.hpp
@@ -36,7 +36,7 @@ namespace glz
          template <auto Opts>
          GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args) noexcept
          {
-            read<json>::op<opt_true<Opts, &opts::quoted>>(value.val, args...);
+            read<json>::op<opt_true<Opts, &opts::quoted_num>>(value.val, args...);
          }
       };
 
@@ -46,7 +46,7 @@ namespace glz
          template <auto Opts>
          GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
          {
-            write<json>::op<opt_true<Opts, &opts::quoted>>(value.val, ctx, args...);
+            write<json>::op<opt_true<Opts, &opts::quoted_num>>(value.val, ctx, args...);
          }
       };
 

--- a/include/glaze/json/quoted.hpp
+++ b/include/glaze/json/quoted.hpp
@@ -14,9 +14,9 @@ namespace glz
       T& val;
    };
 
-   // unquote a string input to avoid double parsing into a value
+   // treat a value as quoted to avoid double parsing into a value
    template <class T>
-   struct unquote_t
+   struct quoted_t
    {
       T& val;
    };
@@ -51,7 +51,7 @@ namespace glz
       };
 
       template <class T>
-      struct from_json<unquote_t<T>>
+      struct from_json<quoted_t<T>>
       {
          template <auto Opts>
          GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
@@ -66,7 +66,7 @@ namespace glz
       };
 
       template <class T>
-      struct to_json<unquote_t<T>>
+      struct to_json<quoted_t<T>>
       {
          template <auto Opts>
          GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
@@ -104,9 +104,9 @@ namespace glz
       }
 
       template <auto MemPtr>
-      inline constexpr decltype(auto) unquote_impl() noexcept
+      inline constexpr decltype(auto) quoted_impl() noexcept
       {
-         return [](auto&& val) { return unquote_t<std::decay_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
+         return [](auto&& val) { return quoted_t<std::decay_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
       }
    }
 
@@ -120,5 +120,5 @@ namespace glz
    }
 
    template <auto MemPtr>
-   constexpr auto unquote = detail::unquote_impl<MemPtr>();
+   constexpr auto quoted = detail::quoted_impl<MemPtr>();
 }

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -183,7 +183,7 @@ namespace glz
          template <auto Options, class It>
          GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end) noexcept
          {
-            if constexpr (Options.quoted) {
+            if constexpr (Options.quoted_num) {
                skip_ws<Options>(ctx, it, end);
                match<'"'>(ctx, it, end);
             }
@@ -248,7 +248,7 @@ namespace glz
                it = reinterpret_cast<std::remove_reference_t<decltype(it)>>(cur);
             }
 
-            if constexpr (Options.quoted) {
+            if constexpr (Options.quoted_num) {
                match<'"'>(ctx, it, end);
             }
          }
@@ -1651,7 +1651,7 @@ namespace glz
                      static_assert(std::is_arithmetic_v<k_t> || glaze_enum_t<k_t>);
                      k_t key_value{};
                      if constexpr (std::is_arithmetic_v<k_t>) {
-                        read<json>::op<opt_true<Opts, &opts::quoted>>(key_value, ctx, it, end);
+                        read<json>::op<opt_true<Opts, &opts::quoted_num>>(key_value, ctx, it, end);
                      }
                      else {
                         read<json>::op<Opts>(key_value, ctx, it, end);

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -149,11 +149,11 @@ namespace glz
          template <auto Opts, class B>
          GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix) noexcept
          {
-            if constexpr (Opts.quoted) {
+            if constexpr (Opts.quoted_num) {
                dump<'"'>(b, ix);
             }
             write_chars::op<Opts>(value, ctx, b, ix);
-            if constexpr (Opts.quoted) {
+            if constexpr (Opts.quoted_num) {
                dump<'"'>(b, ix);
             }
          }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -4328,7 +4328,7 @@ template <>
 struct glz::meta<A>
 {
    static constexpr auto value =
-      object("x", glz::quoted<&A::x>(), "y", glz::quoted<&A::y>(), "z", glz::quoted<&A::z>());
+      object("x", glz::quoted_num<&A::x>, "y", glz::quoted_num<&A::y>, "z", glz::quoted_num<&A::z>);
 };
 
 suite lamda_wrapper = [] {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -4695,7 +4695,7 @@ template <>
 struct glz::meta<invoke_struct>
 {
    using T = invoke_struct;
-   static constexpr auto value = object("square", invoke<&T::square>(), "add_one", invoke<&T::add_one>());
+   static constexpr auto value = object("square", invoke<&T::square>, "add_one", invoke<&T::add_one>);
 };
 
 suite invoke_test = [] {
@@ -5053,7 +5053,7 @@ struct glz::meta<Person>
    using T = Person;
    static constexpr auto value =
       glz::object("name", &T::name, "full_name", &T::name, "age", &T::age, "years_old", &T::age, "date_of_birth",
-                  invoke<&T::getAge>(), "city", &T::city, "residence", &T::residence);
+                  invoke<&T::getAge>, "city", &T::city, "residence", &T::residence);
 };
 
 suite function_call = [] {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -4498,7 +4498,7 @@ template <>
 struct glz::meta<numbers_as_strings>
 {
    using T = numbers_as_strings;
-   static constexpr auto value = object("x", glz::number<&T::x>(), "y", glz::number<&T::y>());
+   static constexpr auto value = object("x", glz::number<&T::x>, "y", glz::number<&T::y>);
 };
 
 suite numbers_as_strings_suite = [] {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -5156,7 +5156,7 @@ template <>
 struct glz::meta<client_state>
 {
    using T = client_state;
-   static constexpr auto value = object("id", &T::id, "layouts", unquote<&T::layouts>);
+   static constexpr auto value = object("id", &T::id, "layouts", quoted<&T::layouts>);
 };
 
 suite unquote_test = [] {


### PR DESCRIPTION
## Breaking Wrapper Changes
Wrappers now consistently leave off the `()` for less typing

- `glz::quoted` for reading numbers as strings and writing them as strings has been replaced with `glz::quoted_num`
- The recent `glz::unquote` has been replaced with the name `glz::quoted`, which reads a string into a value and writes the value with quotes. This is less efficient for numbers than `glz::quoted_num`.

Below shows the format for adding wrappers within glaze metadata.
```c++
glz::quoted_num<&T::x> // reads a number as a string and writes it as a string
glz::quoted<&T::x> // reads a value as a string and unescapes, to avoid the user having to parse twice
glz::number<&T::x> // reads a string as a number and writes the string as a number
glz::invoke<&T::func> // invokes a std::function or member function with n-arguments as an array input
glz::custom<&T::read, &T::write> // calls custom read and write std::functions or member functions
```