### PR TITLE
Fix negation bug in json_exceptions.hpp

### DIFF
--- a/include/glaze/exceptions/json_exceptions.hpp
+++ b/include/glaze/exceptions/json_exceptions.hpp
@@ -31,7 +31,7 @@ namespace glz::ex
    [[nodiscard]] T read_json(Buffer&& buffer)
    {
       const auto ex = glz::read_json<T>(std::forward<Buffer>(buffer));
-      if (ex) {
+      if (!ex) {
          throw std::runtime_error("read_json error: " + glz::format_error(ex.error(), buffer));
       }
       return ex.value();


### PR DESCRIPTION
A variable of type "expected" converts to true if there was no error and false if there was one. This commit fixes a bug where an expected variable was treated as an error code (which behaves the other way round).

fixes #484