### PR TITLE
raw_string<&T::string> wrapper for more performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Glaze requires C++20, using concepts for cleaner code and more helpful errors.
 
 [Performance test code available here](https://github.com/stephenberry/json_performance)
 
-*Note: [simdjson](https://github.com/simdjson/simdjson) is great for parsing, but can experience major performance losses when the data is not in the expected sequence or any keys are missing (the problem grows as the file size increases, as it must re-iterate through the document). And for large, nested objects, simdjson typically requires significantly more coding from the user.*
+*Note: [simdjson](https://github.com/simdjson/simdjson) is great, but can experience major performance losses when the data is not in the expected sequence or any keys are missing (the problem grows as the file size increases, as it must re-iterate through the document). And for large, nested objects, simdjson typically requires significantly more coding from the user.*
 
 [ABC Test](https://github.com/stephenberry/json_performance) shows how simdjson has poor performance when keys are not in the expected sequence:
 

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -29,6 +29,7 @@ namespace glz
       bool quoted_num = false; // treat numbers as quoted or array-like types as having quoted numbers
       bool number = false; // read numbers as strings and write these string as numbers
       bool raw = false; // write out string like values without quotes
+      bool raw_string = false; // do not decode/encode escaped characters for strings
 
       // INTERNAL USE
       bool opening_handled = false; // the opening character has been handled

--- a/include/glaze/json.hpp
+++ b/include/glaze/json.hpp
@@ -11,6 +11,7 @@
 #include "glaze/json/prettify.hpp"
 #include "glaze/json/ptr.hpp"
 #include "glaze/json/quoted.hpp"
+#include "glaze/json/raw_string.hpp"
 #include "glaze/json/read.hpp"
 #include "glaze/json/schema.hpp"
 #include "glaze/json/study.hpp"

--- a/include/glaze/json/raw_string.hpp
+++ b/include/glaze/json/raw_string.hpp
@@ -1,0 +1,53 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include <type_traits>
+
+#include "glaze/core/format.hpp"
+#include "glaze/core/opts.hpp"
+#include "glaze/json/read.hpp"
+#include "glaze/json/write.hpp"
+
+namespace glz
+{
+   // do not decode/encode escaped characters for strings
+   template <class T>
+   struct raw_string_t
+   {
+      T& val;
+   };
+
+   namespace detail
+   {
+      template <class T>
+      struct from_json<raw_string_t<T>>
+      {
+         template <auto Opts>
+         GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args) noexcept
+         {
+            read<json>::op<opt_true<Opts, &opts::raw_string>>(value.val, args...);
+         }
+      };
+
+      template <class T>
+      struct to_json<raw_string_t<T>>
+      {
+         template <auto Opts>
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+         {
+            write<json>::op<opt_true<Opts, &opts::raw_string>>(value.val, ctx, args...);
+         }
+      };
+
+      template <auto MemPtr>
+      GLZ_ALWAYS_INLINE constexpr decltype(auto) raw_string_impl() noexcept
+      {
+         return [](auto&& val) { return raw_string_t<std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
+      }
+   }
+
+   template <auto MemPtr>
+   constexpr auto raw_string = detail::raw_string_impl<MemPtr>();
+}

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -236,61 +236,77 @@ namespace glz
                      }
                   }();
                   const auto n = str.size();
-
-                  // In the case n == 0 we need two characters for quotes.
-                  // For each individual character we need room for two characters to handle escapes.
-                  // So, we need 2 + 2 * n characters to handle all cases.
-                  if constexpr (detail::resizeable<B>) {
-                     const auto k = ix + 2 + 2 * n;
-                     if (k >= b.size()) [[unlikely]] {
-                        b.resize((std::max)(b.size() * 2, k));
-                     }
-                  }
-                  // now we don't have to check writing
-
-                  if constexpr (Opts.raw) {
-                     dump(str, b, ix);
-                  }
-                  else {
-                     dump_unchecked<'"'>(b, ix);
-
-                     for (auto&& c : str) {
-                        switch (c) {
-                        case '"':
-                           std::memcpy(data_ptr(b) + ix, R"(\")", 2);
-                           ix += 2;
-                           break;
-                        case '\\':
-                           std::memcpy(data_ptr(b) + ix, R"(\\)", 2);
-                           ix += 2;
-                           break;
-                        case '\b':
-                           std::memcpy(data_ptr(b) + ix, R"(\b)", 2);
-                           ix += 2;
-                           break;
-                        case '\f':
-                           std::memcpy(data_ptr(b) + ix, R"(\f)", 2);
-                           ix += 2;
-                           break;
-                        case '\n':
-                           std::memcpy(data_ptr(b) + ix, R"(\n)", 2);
-                           ix += 2;
-                           break;
-                        case '\r':
-                           std::memcpy(data_ptr(b) + ix, R"(\r)", 2);
-                           ix += 2;
-                           break;
-                        case '\t':
-                           std::memcpy(data_ptr(b) + ix, R"(\t)", 2);
-                           ix += 2;
-                           break;
-                        [[likely]] default:
-                           std::memcpy(data_ptr(b) + ix, &c, 1);
-                           ++ix;
+                  
+                  if constexpr (Opts.raw_string) {
+                     // We need at space for quotes and the string length: 2 + n.
+                     if constexpr (detail::resizeable<B>) {
+                        const auto k = ix + 2 + n;
+                        if (k >= b.size()) [[unlikely]] {
+                           b.resize((std::max)(b.size() * 2, k));
                         }
                      }
-
+                     // now we don't have to check writing
+                     
                      dump_unchecked<'"'>(b, ix);
+                     dump(str, b, ix);
+                     dump_unchecked<'"'>(b, ix);
+                  }
+                  else {
+                     // In the case n == 0 we need two characters for quotes.
+                     // For each individual character we need room for two characters to handle escapes.
+                     // So, we need 2 + 2 * n characters to handle all cases.
+                     if constexpr (detail::resizeable<B>) {
+                        const auto k = ix + 2 + 2 * n;
+                        if (k >= b.size()) [[unlikely]] {
+                           b.resize((std::max)(b.size() * 2, k));
+                        }
+                     }
+                     // now we don't have to check writing
+
+                     if constexpr (Opts.raw) {
+                        dump(str, b, ix);
+                     }
+                     else {
+                        dump_unchecked<'"'>(b, ix);
+
+                        for (auto&& c : str) {
+                           switch (c) {
+                           case '"':
+                              std::memcpy(data_ptr(b) + ix, R"(\")", 2);
+                              ix += 2;
+                              break;
+                           case '\\':
+                              std::memcpy(data_ptr(b) + ix, R"(\\)", 2);
+                              ix += 2;
+                              break;
+                           case '\b':
+                              std::memcpy(data_ptr(b) + ix, R"(\b)", 2);
+                              ix += 2;
+                              break;
+                           case '\f':
+                              std::memcpy(data_ptr(b) + ix, R"(\f)", 2);
+                              ix += 2;
+                              break;
+                           case '\n':
+                              std::memcpy(data_ptr(b) + ix, R"(\n)", 2);
+                              ix += 2;
+                              break;
+                           case '\r':
+                              std::memcpy(data_ptr(b) + ix, R"(\r)", 2);
+                              ix += 2;
+                              break;
+                           case '\t':
+                              std::memcpy(data_ptr(b) + ix, R"(\t)", 2);
+                              ix += 2;
+                              break;
+                           [[likely]] default:
+                              std::memcpy(data_ptr(b) + ix, &c, 1);
+                              ++ix;
+                           }
+                        }
+
+                        dump_unchecked<'"'>(b, ix);
+                     }
                   }
                }
             }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -5555,6 +5555,58 @@ suite invoke_updater_test = [] {
    };
 };
 
+struct raw_stuff
+{
+   std::string a{};
+   std::string b{};
+   std::string c{};
+   
+   struct glaze {
+      using T = raw_stuff;
+      static constexpr auto value = glz::object("a", &T::a, "b", &T::b, "c", &T::c);
+   };
+};
+
+struct raw_stuff_wrapper
+{
+   raw_stuff data{};
+   
+   struct glaze {
+      using T = raw_stuff_wrapper;
+      static constexpr auto value{glz::raw_string<&T::data>};
+   };
+};
+
+suite raw_string_test = [] {
+   "raw_string"_test = [] {
+      raw_stuff obj{};
+      std::string buffer = R"({"a":"Hello\nWorld","b":"Hello World","c":"\tHello\bWorld"})";
+      
+      expect(!glz::read<glz::opts{.raw_string = true}>(obj, buffer));
+      expect(obj.a == R"(Hello\nWorld)");
+      expect(obj.b == R"(Hello World)");
+      expect(obj.c == R"(\tHello\bWorld)");
+      
+      buffer.clear();
+      glz::write<glz::opts{.raw_string = true}>(obj, buffer);
+      expect(buffer == R"({"a":"Hello\nWorld","b":"Hello World","c":"\tHello\bWorld"})");
+   };
+   
+   "raw_string_wrapper"_test = [] {
+      raw_stuff_wrapper obj{};
+      std::string buffer = R"({"a":"Hello\nWorld","b":"Hello World","c":"\tHello\bWorld"})";
+      
+      expect(!glz::read_json(obj, buffer));
+      expect(obj.data.a == R"(Hello\nWorld)");
+      expect(obj.data.b == R"(Hello World)");
+      expect(obj.data.c == R"(\tHello\bWorld)");
+      
+      buffer.clear();
+      glz::write_json(obj, buffer);
+      expect(buffer == R"({"a":"Hello\nWorld","b":"Hello World","c":"\tHello\bWorld"})");
+   };
+};
+
 int main()
 {
    // Explicitly run registered test suites and report errors


### PR DESCRIPTION
Often times we know that an input string will not be escaped. Adding the `glz::raw_string` wrapper will boost the read/write performance of these strings.

Note that simdjson on demand does not handle escaped strings unless explicitly asked to. We could make this the default behavior in Glaze, but I would prefer for the default behavior to not surprise the user. And, this value can be set at the top level read call, so it only needs to be specified in one place.