### PR TITLE
Support writing unsized, uncommon ranges.

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -142,10 +142,10 @@ namespace glz
 
    template <class T>
    concept range = requires(T& t) {
-      requires !std::same_as<void, decltype(t.begin())>;
-      requires !std::same_as<void, decltype(t.end())>;
-      requires std::input_iterator<decltype(t.begin())>;
-   };
+                      requires !std::same_as<void, decltype(t.begin())>;
+                      requires !std::same_as<void, decltype(t.end())>;
+                      requires std::input_iterator<decltype(t.begin())>;
+                   };
 
    // range like
    template <class T>
@@ -164,14 +164,14 @@ namespace glz
       if constexpr (requires() {
                        {
                           rng.empty()
-                       } -> std::convertible_to<bool>;
+                          } -> std::convertible_to<bool>;
                     }) {
          return rng.empty();
       }
       else if constexpr (requires() {
                             {
                                rng.size()
-                            } -> std::same_as<std::size_t>;
+                               } -> std::same_as<std::size_t>;
                          }) {
          return rng.size() == std::size_t{0};
       }
@@ -296,35 +296,36 @@ namespace glz
          std::same_as<std::decay_t<T>, bool> || std::same_as<std::decay_t<T>, std::vector<bool>::reference>;
 
       template <class T>
-      concept int_t = std::integral<std::decay_t<T>> && !char_t<std::decay_t<T>> && !bool_t<T>;
+      concept int_t = std::integral<std::decay_t<T>> && !
+      char_t<std::decay_t<T>> && !bool_t<T>;
 
       template <class T>
       concept num_t = std::floating_point<std::decay_t<T>> || int_t<T>;
 
       template <typename T>
       concept complex_t = requires(T a, T b) {
-         {
-            a.real()
-         } -> std::convertible_to<typename T::value_type>;
-         {
-            a.imag()
-         } -> std::convertible_to<typename T::value_type>;
-         {
-            T(a.real(), a.imag())
-         } -> std::same_as<T>;
-         {
-            a + b
-         } -> std::same_as<T>;
-         {
-            a - b
-         } -> std::same_as<T>;
-         {
-            a* b
-         } -> std::same_as<T>;
-         {
-            a / b
-         } -> std::same_as<T>;
-      };
+                             {
+                                a.real()
+                                } -> std::convertible_to<typename T::value_type>;
+                             {
+                                a.imag()
+                                } -> std::convertible_to<typename T::value_type>;
+                             {
+                                T(a.real(), a.imag())
+                                } -> std::same_as<T>;
+                             {
+                                a + b
+                                } -> std::same_as<T>;
+                             {
+                                a - b
+                                } -> std::same_as<T>;
+                             {
+                                a* b
+                                } -> std::same_as<T>;
+                             {
+                                a / b
+                                } -> std::same_as<T>;
+                          };
 
       template <class T>
       concept constructible = requires { meta<std::decay_t<T>>::construct; } || local_construct_t<std::decay_t<T>>;
@@ -333,14 +334,16 @@ namespace glz
       concept meta_value_t = glaze_t<std::decay_t<T>>;
 
       template <class T>
-      concept str_t = !std::same_as<std::nullptr_t, T> && std::convertible_to<std::decay_t<T>, std::string_view>;
+      concept str_t = !
+      std::same_as<std::nullptr_t, T>&& std::convertible_to<std::decay_t<T>, std::string_view>;
 
       template <class T>
       concept has_push_back = requires(T t, typename T::value_type v) { t.push_back(v); };
 
       // this concept requires that T is string and copies the string in json
       template <class T>
-      concept string_t = str_t<T> && !std::same_as<std::decay_t<T>, std::string_view> && has_push_back<T>;
+      concept string_t = str_t<T> && !
+      std::same_as<std::decay_t<T>, std::string_view>&& has_push_back<T>;
 
       template <class T>
       concept char_array_t = str_t<T> && std::is_array_v<std::remove_pointer_t<std::remove_reference_t<T>>>;
@@ -351,39 +354,39 @@ namespace glz
 
       template <class T>
       concept pair_t = requires(T pair) {
-         {
-            pair.first
-         } -> std::same_as<typename T::first_type&>;
-         {
-            pair.second
-         } -> std::same_as<typename T::second_type&>;
-      };
+                          {
+                             pair.first
+                             } -> std::same_as<typename T::first_type&>;
+                          {
+                             pair.second
+                             } -> std::same_as<typename T::second_type&>;
+                       };
 
       template <class T>
       concept map_subscriptable = requires(T container) {
-         {
-            container[std::declval<typename T::key_type>()]
-         } -> std::same_as<typename T::mapped_type&>;
-      };
+                                     {
+                                        container[std::declval<typename T::key_type>()]
+                                        } -> std::same_as<typename T::mapped_type&>;
+                                  };
 
       template <class T>
-      concept readable_map_t = !custom_read<T> && !meta_value_t<T> && !str_t<T> && range<T> &&
-                               pair_t<range_value_t<T>> && map_subscriptable<T>;
+      concept readable_map_t = !
+      custom_read<T> && !meta_value_t<T> && !str_t<T> && range<T> && pair_t<range_value_t<T>> && map_subscriptable<T>;
 
       template <class T>
-      concept writable_map_t =
-         !custom_write<T> && !meta_value_t<T> && !str_t<T> && range<T> && pair_t<range_value_t<T>>;
+      concept writable_map_t = !
+      custom_write<T> && !meta_value_t<T> && !str_t<T> && range<T> && pair_t<range_value_t<T>>;
 
       template <class Map>
       concept heterogeneous_map = requires {
-         typename Map::key_compare;
-         requires(std::same_as<typename Map::key_compare, std::less<>> ||
-                  std::same_as<typename Map::key_compare, std::greater<>> ||
-                  requires { typename Map::key_compare::is_transparent; });
-      };
+                                     typename Map::key_compare;
+                                     requires(std::same_as<typename Map::key_compare, std::less<>> ||
+                                              std::same_as<typename Map::key_compare, std::greater<>> ||
+                                              requires { typename Map::key_compare::is_transparent; });
+                                  };
 
       template <class T>
-      concept array_t = (!meta_value_t<T> && !str_t<T> && !(readable_map_t<T> || writable_map_t<T>)&&range<T>);
+      concept array_t = (!meta_value_t<T> && !str_t<T> && !(readable_map_t<T> || writable_map_t<T>) && range<T>);
 
       template <class T>
       concept readable_array_t = (!custom_read<T> && array_t<T>);
@@ -393,24 +396,24 @@ namespace glz
 
       template <class T>
       concept emplace_backable = requires(T container) {
-         {
-            container.emplace_back()
-         } -> std::same_as<typename T::reference>;
-      };
+                                    {
+                                       container.emplace_back()
+                                       } -> std::same_as<typename T::reference>;
+                                 };
 
       template <class T>
       concept emplaceable = requires(T container) {
-         {
-            container.emplace(std::declval<typename T::value_type>())
-         };
-      };
+                               {
+                                  container.emplace(std::declval<typename T::value_type>())
+                               };
+                            };
 
       template <class T>
       concept push_backable = requires(T container) {
-         {
-            container.push_back(std::declval<typename T::value_type>())
-         };
-      };
+                                 {
+                                    container.push_back(std::declval<typename T::value_type>())
+                                 };
+                              };
 
       template <class T>
       concept resizeable = requires(T container) { container.resize(0); };
@@ -419,18 +422,18 @@ namespace glz
       concept erasable = requires(T container) { container.erase(container.cbegin(), container.cend()); };
 
       template <class T>
-      concept fixed_array_value_t = array_t<std::decay_t<decltype(std::declval<T>()[0])>> &&
-                                    !resizeable<std::decay_t<decltype(std::declval<T>()[0])>>;
+      concept fixed_array_value_t = array_t<std::decay_t<decltype(std::declval<T>()[0])>> && !
+      resizeable<std::decay_t<decltype(std::declval<T>()[0])>>;
 
       template <class T>
       concept has_size = requires(T container) { container.size(); };
 
       template <class T>
       concept has_empty = requires(T container) {
-         {
-            container.empty()
-         } -> std::convertible_to<bool>;
-      };
+                             {
+                                container.empty()
+                                } -> std::convertible_to<bool>;
+                          };
 
       template <class T>
       concept has_data = requires(T container) { container.data(); };
@@ -440,10 +443,10 @@ namespace glz
 
       template <class T>
       concept accessible = requires(T container) {
-         {
-            container[size_t{}]
-         } -> std::same_as<typename T::reference>;
-      };
+                              {
+                                 container[size_t{}]
+                                 } -> std::same_as<typename T::reference>;
+                           };
 
       template <class T>
       concept boolean_like = std::same_as<T, bool> || std::same_as<T, std::vector<bool>::reference> ||
@@ -454,19 +457,20 @@ namespace glz
 
       template <class T>
       concept is_span = requires(T t) {
-         T::extent;
-         typename T::element_type;
-      };
+                           T::extent;
+                           typename T::element_type;
+                        };
 
       template <class T>
       concept is_dynamic_span = T::extent == static_cast<size_t>(-1);
 
       template <class T>
-      concept has_static_size = (is_span<T> && !is_dynamic_span<T>) || (requires(T container) {
-                                   {
-                                      std::bool_constant<(std::decay_t<T>{}.size(), true)>()
-                                   } -> std::same_as<std::true_type>;
-                                } && std::decay_t<T>{}.size() > 0);
+      concept has_static_size = (is_span<T> && !is_dynamic_span<T>) ||
+                                (requires(T container) {
+                                    {
+                                       std::bool_constant<(std::decay_t<T>{}.size(), true)>()
+                                       } -> std::same_as<std::true_type>;
+                                 } && std::decay_t<T>{}.size() > 0);
 
       template <class T>
       constexpr size_t get_size() noexcept
@@ -484,21 +488,23 @@ namespace glz
 
       template <class T>
       concept tuple_t = requires(T t) {
-         std::tuple_size<T>::value;
-         glz::tuplet::get<0>(t);
-      } && !meta_value_t<T> && !range<T>;
+                           std::tuple_size<T>::value;
+                           glz::tuplet::get<0>(t);
+                        } && !
+      meta_value_t<T> && !range<T>;
 
       template <class T>
       concept always_null_t =
          std::same_as<T, std::nullptr_t> || std::convertible_to<T, std::monostate> || std::same_as<T, std::nullopt_t>;
 
       template <class T>
-      concept nullable_t = !meta_value_t<T> && !str_t<T> && requires(T t) {
-         bool(t);
-         {
-            *t
-         };
-      };
+      concept nullable_t = !
+      meta_value_t<T> && !str_t<T> && requires(T t) {
+                                         bool(t);
+                                         {
+                                            *t
+                                         };
+                                      };
 
       template <class T>
       concept raw_nullable = is_specialization_v<T, raw_t> && requires { requires nullable_t<typename T::value_type>; };
@@ -508,9 +514,10 @@ namespace glz
 
       template <class T>
       concept func_t = requires(T t) {
-         typename T::result_type;
-         std::function(t);
-      } && !glaze_t<T>;
+                          typename T::result_type;
+                          std::function(t);
+                       } && !
+      glaze_t<T>;
 
       template <class T>
       concept glaze_array_t = glaze_t<T> && is_specialization_v<meta_wrapper_t<T>, Array>;
@@ -531,12 +538,12 @@ namespace glz
       template <class From, class To>
       concept non_narrowing_convertable = requires(From from, To to) {
 #if __GNUC__
-         // TODO: guard gcc against narrowing conversions when fixed
-         to = from;
+                                             // TODO: guard gcc against narrowing conversions when fixed
+                                             to = from;
 #else
-         To{from};
+                                             To{from};
 #endif
-      };
+                                          };
 
       // from
       // https://stackoverflow.com/questions/55941964/how-to-filter-duplicate-types-from-tuple-c

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -142,10 +142,10 @@ namespace glz
 
    template <class T>
    concept range = requires(T& t) {
-                      requires !std::same_as<void, decltype(t.begin())>;
-                      requires !std::same_as<void, decltype(t.end())>;
-                      requires std::input_iterator<decltype(t.begin())>;
-                   };
+      requires !std::same_as<void, decltype(t.begin())>;
+      requires !std::same_as<void, decltype(t.end())>;
+      requires std::input_iterator<decltype(t.begin())>;
+   };
 
    // range like
    template <class T>
@@ -155,26 +155,30 @@ namespace glz
    using range_value_t = std::iter_value_t<iterator_t<R>>;
 
    template <range R>
-   [[nodiscard]] bool empty_range(const R& rng)
+   [[nodiscard]] constexpr bool empty_range(R&& rng)
    {
+#ifdef __cpp_lib_ranges
+      return std::ranges::empty(rng);
+#else
       // in lieu of std::ranges::empty
       if constexpr (requires() {
                        {
                           rng.empty()
-                          } -> std::convertible_to<bool>;
+                       } -> std::convertible_to<bool>;
                     }) {
          return rng.empty();
       }
       else if constexpr (requires() {
                             {
                                rng.size()
-                               } -> std::same_as<std::size_t>;
+                            } -> std::same_as<std::size_t>;
                          }) {
-         return rng.size() == 0;
+         return rng.size() == std::size_t{0};
       }
       else {
          return std::cbegin(rng) == std::cend(rng);
       }
+#endif
    }
 
    template <class T>
@@ -292,36 +296,35 @@ namespace glz
          std::same_as<std::decay_t<T>, bool> || std::same_as<std::decay_t<T>, std::vector<bool>::reference>;
 
       template <class T>
-      concept int_t = std::integral<std::decay_t<T>> && !
-      char_t<std::decay_t<T>> && !bool_t<T>;
+      concept int_t = std::integral<std::decay_t<T>> && !char_t<std::decay_t<T>> && !bool_t<T>;
 
       template <class T>
       concept num_t = std::floating_point<std::decay_t<T>> || int_t<T>;
 
       template <typename T>
       concept complex_t = requires(T a, T b) {
-                             {
-                                a.real()
-                                } -> std::convertible_to<typename T::value_type>;
-                             {
-                                a.imag()
-                                } -> std::convertible_to<typename T::value_type>;
-                             {
-                                T(a.real(), a.imag())
-                                } -> std::same_as<T>;
-                             {
-                                a + b
-                                } -> std::same_as<T>;
-                             {
-                                a - b
-                                } -> std::same_as<T>;
-                             {
-                                a* b
-                                } -> std::same_as<T>;
-                             {
-                                a / b
-                                } -> std::same_as<T>;
-                          };
+         {
+            a.real()
+         } -> std::convertible_to<typename T::value_type>;
+         {
+            a.imag()
+         } -> std::convertible_to<typename T::value_type>;
+         {
+            T(a.real(), a.imag())
+         } -> std::same_as<T>;
+         {
+            a + b
+         } -> std::same_as<T>;
+         {
+            a - b
+         } -> std::same_as<T>;
+         {
+            a* b
+         } -> std::same_as<T>;
+         {
+            a / b
+         } -> std::same_as<T>;
+      };
 
       template <class T>
       concept constructible = requires { meta<std::decay_t<T>>::construct; } || local_construct_t<std::decay_t<T>>;
@@ -330,16 +333,14 @@ namespace glz
       concept meta_value_t = glaze_t<std::decay_t<T>>;
 
       template <class T>
-      concept str_t = !
-      std::same_as<std::nullptr_t, T>&& std::convertible_to<std::decay_t<T>, std::string_view>;
+      concept str_t = !std::same_as<std::nullptr_t, T> && std::convertible_to<std::decay_t<T>, std::string_view>;
 
       template <class T>
       concept has_push_back = requires(T t, typename T::value_type v) { t.push_back(v); };
 
       // this concept requires that T is string and copies the string in json
       template <class T>
-      concept string_t = str_t<T> && !
-      std::same_as<std::decay_t<T>, std::string_view>&& has_push_back<T>;
+      concept string_t = str_t<T> && !std::same_as<std::decay_t<T>, std::string_view> && has_push_back<T>;
 
       template <class T>
       concept char_array_t = str_t<T> && std::is_array_v<std::remove_pointer_t<std::remove_reference_t<T>>>;
@@ -350,39 +351,39 @@ namespace glz
 
       template <class T>
       concept pair_t = requires(T pair) {
-                          {
-                             pair.first
-                             } -> std::same_as<typename T::first_type&>;
-                          {
-                             pair.second
-                             } -> std::same_as<typename T::second_type&>;
-                       };
+         {
+            pair.first
+         } -> std::same_as<typename T::first_type&>;
+         {
+            pair.second
+         } -> std::same_as<typename T::second_type&>;
+      };
 
       template <class T>
       concept map_subscriptable = requires(T container) {
-                                     {
-                                        container[std::declval<typename T::key_type>()]
-                                        } -> std::same_as<typename T::mapped_type&>;
-                                  };
+         {
+            container[std::declval<typename T::key_type>()]
+         } -> std::same_as<typename T::mapped_type&>;
+      };
 
       template <class T>
-      concept readable_map_t = !
-      custom_read<T> && !meta_value_t<T> && !str_t<T> && range<T> && pair_t<range_value_t<T>> && map_subscriptable<T>;
+      concept readable_map_t = !custom_read<T> && !meta_value_t<T> && !str_t<T> && range<T> &&
+                               pair_t<range_value_t<T>> && map_subscriptable<T>;
 
       template <class T>
-      concept writable_map_t = !
-      custom_write<T> && !meta_value_t<T> && !str_t<T> && range<T> && pair_t<range_value_t<T>>;
+      concept writable_map_t =
+         !custom_write<T> && !meta_value_t<T> && !str_t<T> && range<T> && pair_t<range_value_t<T>>;
 
       template <class Map>
       concept heterogeneous_map = requires {
-                                     typename Map::key_compare;
-                                     requires(std::same_as<typename Map::key_compare, std::less<>> ||
-                                              std::same_as<typename Map::key_compare, std::greater<>> ||
-                                              requires { typename Map::key_compare::is_transparent; });
-                                  };
+         typename Map::key_compare;
+         requires(std::same_as<typename Map::key_compare, std::less<>> ||
+                  std::same_as<typename Map::key_compare, std::greater<>> ||
+                  requires { typename Map::key_compare::is_transparent; });
+      };
 
       template <class T>
-      concept array_t = (!meta_value_t<T> && !str_t<T> && !(readable_map_t<T> || writable_map_t<T>) && range<T>);
+      concept array_t = (!meta_value_t<T> && !str_t<T> && !(readable_map_t<T> || writable_map_t<T>)&&range<T>);
 
       template <class T>
       concept readable_array_t = (!custom_read<T> && array_t<T>);
@@ -392,24 +393,24 @@ namespace glz
 
       template <class T>
       concept emplace_backable = requires(T container) {
-                                    {
-                                       container.emplace_back()
-                                       } -> std::same_as<typename T::reference>;
-                                 };
+         {
+            container.emplace_back()
+         } -> std::same_as<typename T::reference>;
+      };
 
       template <class T>
       concept emplaceable = requires(T container) {
-                               {
-                                  container.emplace(std::declval<typename T::value_type>())
-                               };
-                            };
+         {
+            container.emplace(std::declval<typename T::value_type>())
+         };
+      };
 
       template <class T>
       concept push_backable = requires(T container) {
-                                 {
-                                    container.push_back(std::declval<typename T::value_type>())
-                                 };
-                              };
+         {
+            container.push_back(std::declval<typename T::value_type>())
+         };
+      };
 
       template <class T>
       concept resizeable = requires(T container) { container.resize(0); };
@@ -418,18 +419,18 @@ namespace glz
       concept erasable = requires(T container) { container.erase(container.cbegin(), container.cend()); };
 
       template <class T>
-      concept fixed_array_value_t = array_t<std::decay_t<decltype(std::declval<T>()[0])>> && !
-      resizeable<std::decay_t<decltype(std::declval<T>()[0])>>;
+      concept fixed_array_value_t = array_t<std::decay_t<decltype(std::declval<T>()[0])>> &&
+                                    !resizeable<std::decay_t<decltype(std::declval<T>()[0])>>;
 
       template <class T>
       concept has_size = requires(T container) { container.size(); };
 
       template <class T>
       concept has_empty = requires(T container) {
-                             {
-                                container.empty()
-                                } -> std::convertible_to<bool>;
-                          };
+         {
+            container.empty()
+         } -> std::convertible_to<bool>;
+      };
 
       template <class T>
       concept has_data = requires(T container) { container.data(); };
@@ -439,10 +440,10 @@ namespace glz
 
       template <class T>
       concept accessible = requires(T container) {
-                              {
-                                 container[size_t{}]
-                                 } -> std::same_as<typename T::reference>;
-                           };
+         {
+            container[size_t{}]
+         } -> std::same_as<typename T::reference>;
+      };
 
       template <class T>
       concept boolean_like = std::same_as<T, bool> || std::same_as<T, std::vector<bool>::reference> ||
@@ -453,20 +454,19 @@ namespace glz
 
       template <class T>
       concept is_span = requires(T t) {
-                           T::extent;
-                           typename T::element_type;
-                        };
+         T::extent;
+         typename T::element_type;
+      };
 
       template <class T>
       concept is_dynamic_span = T::extent == static_cast<size_t>(-1);
 
       template <class T>
-      concept has_static_size = (is_span<T> && !is_dynamic_span<T>) ||
-                                (requires(T container) {
-                                    {
-                                       std::bool_constant<(std::decay_t<T>{}.size(), true)>()
-                                       } -> std::same_as<std::true_type>;
-                                 } && std::decay_t<T>{}.size() > 0);
+      concept has_static_size = (is_span<T> && !is_dynamic_span<T>) || (requires(T container) {
+                                   {
+                                      std::bool_constant<(std::decay_t<T>{}.size(), true)>()
+                                   } -> std::same_as<std::true_type>;
+                                } && std::decay_t<T>{}.size() > 0);
 
       template <class T>
       constexpr size_t get_size() noexcept
@@ -484,23 +484,21 @@ namespace glz
 
       template <class T>
       concept tuple_t = requires(T t) {
-                           std::tuple_size<T>::value;
-                           glz::tuplet::get<0>(t);
-                        } && !
-      meta_value_t<T> && !range<T>;
+         std::tuple_size<T>::value;
+         glz::tuplet::get<0>(t);
+      } && !meta_value_t<T> && !range<T>;
 
       template <class T>
       concept always_null_t =
          std::same_as<T, std::nullptr_t> || std::convertible_to<T, std::monostate> || std::same_as<T, std::nullopt_t>;
 
       template <class T>
-      concept nullable_t = !
-      meta_value_t<T> && !str_t<T> && requires(T t) {
-                                         bool(t);
-                                         {
-                                            *t
-                                         };
-                                      };
+      concept nullable_t = !meta_value_t<T> && !str_t<T> && requires(T t) {
+         bool(t);
+         {
+            *t
+         };
+      };
 
       template <class T>
       concept raw_nullable = is_specialization_v<T, raw_t> && requires { requires nullable_t<typename T::value_type>; };
@@ -510,10 +508,9 @@ namespace glz
 
       template <class T>
       concept func_t = requires(T t) {
-                          typename T::result_type;
-                          std::function(t);
-                       } && !
-      glaze_t<T>;
+         typename T::result_type;
+         std::function(t);
+      } && !glaze_t<T>;
 
       template <class T>
       concept glaze_array_t = glaze_t<T> && is_specialization_v<meta_wrapper_t<T>, Array>;
@@ -534,12 +531,12 @@ namespace glz
       template <class From, class To>
       concept non_narrowing_convertable = requires(From from, To to) {
 #if __GNUC__
-                                             // TODO: guard gcc against narrowing conversions when fixed
-                                             to = from;
+         // TODO: guard gcc against narrowing conversions when fixed
+         to = from;
 #else
-                                             To{from};
+         To{from};
 #endif
-                                          };
+      };
 
       // from
       // https://stackoverflow.com/questions/55941964/how-to-filter-duplicate-types-from-tuple-c

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -25,10 +25,11 @@ namespace glz
       {};
 
       template <auto Opts, class T, class Ctx, class B, class IX>
-      concept write_json_invocable = requires(T&& value, Ctx&& ctx, B&& b, IX&& ix) {
-         to_json<std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
-                                                            std::forward<B>(b), std::forward<IX>(ix));
-      };
+      concept write_json_invocable =
+         requires(T&& value, Ctx&& ctx, B&& b, IX&& ix) {
+            to_json<std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+                                                               std::forward<B>(b), std::forward<IX>(ix));
+         };
 
       template <>
       struct write<json>
@@ -310,6 +311,21 @@ namespace glz
                }
             }
          }
+      };
+
+      template <range T>
+         requires char_t<range_value_t<C>>
+      struct as_string
+      {
+         T& data;
+      };
+
+      template <typename T>
+      struct to_json<as_string<T>>
+      {
+         template <auto Opts, class B>
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, B&& b, auto&& ix) noexcept
+         {}
       };
 
       template <glaze_enum_t T>

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -313,21 +313,6 @@ namespace glz
          }
       };
 
-      template <range T>
-         requires char_t<range_value_t<C>>
-      struct as_string
-      {
-         T& data;
-      };
-
-      template <typename T>
-      struct to_json<as_string<T>>
-      {
-         template <auto Opts, class B>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, B&& b, auto&& ix) noexcept
-         {}
-      };
-
       template <glaze_enum_t T>
       struct to_json<T>
       {

--- a/include/glaze/util/dump.hpp
+++ b/include/glaze/util/dump.hpp
@@ -79,6 +79,15 @@ namespace glz::detail
       ix += n;
    }
 
+   template <typename T>
+      requires range_value_t<>
+   GLZ_ALWAYS_INLINE void dump_unchecked(const sv str, vector_like auto& b, auto& ix) noexcept
+   {
+      const auto n = str.size();
+      std::memcpy(b.data() + ix, str.data(), n);
+      ix += n;
+   }
+
    template <char c>
    GLZ_ALWAYS_INLINE void dump(char*& b) noexcept
    {

--- a/include/glaze/util/dump.hpp
+++ b/include/glaze/util/dump.hpp
@@ -79,15 +79,6 @@ namespace glz::detail
       ix += n;
    }
 
-   template <typename T>
-      requires range_value_t<>
-   GLZ_ALWAYS_INLINE void dump_unchecked(const sv str, vector_like auto& b, auto& ix) noexcept
-   {
-      const auto n = str.size();
-      std::memcpy(b.data() + ix, str.data(), n);
-      ix += n;
-   }
-
    template <char c>
    GLZ_ALWAYS_INLINE void dump(char*& b) noexcept
    {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -1903,6 +1903,14 @@ suite write_tests = [] {
    "Write array-like input range"_test = [] {
 #ifdef __cpp_lib_ranges
       "sized range"_test = [] { expect(glz::write_json(std::views::iota(0, 3)) == glz::sv{R"([0,1,2])"}); };
+
+      "range"_test = [] {
+         auto range = std::views::iota(0, 5) //
+                      | std::views::filter([](const auto i) { return i % 2 == 0; }) //
+                      | std::views::transform([](const auto i) { return std::to_string(i); });
+
+         expect(glz::write_json(range) == glz::sv{R"(["0","2","4"])"});
+      };
 #endif
 
       "initializer list"_test = [] {


### PR DESCRIPTION
write functions for arrays and objects expected const input values, which prevents the writing of lazy ranges that mutate internal state. The qualifiers were changed and tests were added.

It would be really nice to support writing any range as a string, but that's something to tackle for a future day.