### PR TITLE
Enable get_source_location for all buffer types

### DIFF
--- a/include/glaze/util/validate.hpp
+++ b/include/glaze/util/validate.hpp
@@ -21,7 +21,7 @@ namespace glz
          size_t rear_truncation{};
       };
 
-      inline std::optional<source_info> get_source_info(const std::string_view buffer, const size_t index)
+      inline std::optional<source_info> get_source_info(const auto& buffer, const size_t index)
       {
          if (index >= buffer.size()) {
             return std::nullopt;


### PR DESCRIPTION
It was not possible to use non string buffers in the exception API.