### PR TITLE
Support parsing any map key type from string

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -47,11 +47,10 @@ namespace glz
       {};
 
       template <auto Opts, class T, class Ctx, class It0, class It1>
-      concept read_json_invocable =
-         requires(T&& value, Ctx&& ctx, It0&& it, It1&& end) {
-            from_json<std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
-                                                                 std::forward<It0>(it), std::forward<It1>(end));
-         };
+      concept read_json_invocable = requires(T&& value, Ctx&& ctx, It0&& it, It1&& end) {
+         from_json<std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+                                                              std::forward<It0>(it), std::forward<It1>(end));
+      };
 
       template <>
       struct read<json>
@@ -1634,7 +1633,7 @@ namespace glz
                         read<json>::op<opt_true<Opts, &opts::quoted_num>>(key_value, ctx, it, end);
                      }
                      else {
-                        read<json>::op<opt_false<Opts, &opts::raw_string>>(quoted_t{key_value}, ctx, it, end);
+                        read<json>::op<opt_false<Opts, &opts::raw_string>>(quoted_t<k_t>{key_value}, ctx, it, end);
                      }
                      if (bool(ctx.error)) [[unlikely]]
                         return;

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -47,10 +47,11 @@ namespace glz
       {};
 
       template <auto Opts, class T, class Ctx, class It0, class It1>
-      concept read_json_invocable = requires(T&& value, Ctx&& ctx, It0&& it, It1&& end) {
-         from_json<std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
-                                                              std::forward<It0>(it), std::forward<It1>(end));
-      };
+      concept read_json_invocable =
+         requires(T&& value, Ctx&& ctx, It0&& it, It1&& end) {
+            from_json<std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+                                                                 std::forward<It0>(it), std::forward<It1>(end));
+         };
 
       template <>
       struct read<json>
@@ -1633,7 +1634,7 @@ namespace glz
                         read<json>::op<opt_true<Opts, &opts::quoted_num>>(key_value, ctx, it, end);
                      }
                      else {
-                        read<json>::op<Opts>(::glz::quoted_t{key_value}, ctx, it, end);
+                        read<json>::op<opt_false<Opts, &opts::raw_string>>(quoted_t{key_value}, ctx, it, end);
                      }
                      if (bool(ctx.error)) [[unlikely]]
                         return;

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -422,15 +422,15 @@ namespace glz
       {
          if constexpr (str_t<Key> || char_t<Key> || glaze_enum_t<Key> || Opts.quoted_num) {
             write<json>::op<Opts>(key, ctx, args...);
-            dump<':'>(args...);
          }
          else {
-            dump<'"'>(args...);
-            write<json>::op<Opts>(key, ctx, args...);
-            dump<R"(":)">(args...);
+            write<json>::op<opt_false<Opts, &opts::raw_string>>(glz::quoted_t{key}, ctx, args...);
          }
          if constexpr (Opts.prettify) {
-            dump<' '>(args...);
+            dump<": ">(args...);
+         }
+         else {
+            dump<':'>(args...);
          }
 
          write<json>::op<opening_and_closing_handled_off<Opts>()>(value, ctx, args...);

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -25,11 +25,10 @@ namespace glz
       {};
 
       template <auto Opts, class T, class Ctx, class B, class IX>
-      concept write_json_invocable =
-         requires(T&& value, Ctx&& ctx, B&& b, IX&& ix) {
-            to_json<std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
-                                                               std::forward<B>(b), std::forward<IX>(ix));
-         };
+      concept write_json_invocable = requires(T&& value, Ctx&& ctx, B&& b, IX&& ix) {
+         to_json<std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+                                                            std::forward<B>(b), std::forward<IX>(ix));
+      };
 
       template <>
       struct write<json>
@@ -424,7 +423,7 @@ namespace glz
             write<json>::op<Opts>(key, ctx, args...);
          }
          else {
-            write<json>::op<opt_false<Opts, &opts::raw_string>>(glz::quoted_t{key}, ctx, args...);
+            write<json>::op<opt_false<Opts, &opts::raw_string>>(quoted_t<const Key>{key}, ctx, args...);
          }
          if constexpr (Opts.prettify) {
             dump<": ">(args...);

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -22,7 +22,9 @@
 #include "glaze/json/json_ptr.hpp"
 #include "glaze/json/prettify.hpp"
 #include "glaze/json/ptr.hpp"
+#include "glaze/json/quoted.hpp"
 #include "glaze/json/read.hpp"
+#
 #include "glaze/json/write.hpp"
 #include "glaze/record/recorder.hpp"
 #include "glaze/util/progress_bar.hpp"

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -24,7 +24,6 @@
 #include "glaze/json/ptr.hpp"
 #include "glaze/json/quoted.hpp"
 #include "glaze/json/read.hpp"
-#
 #include "glaze/json/write.hpp"
 #include "glaze/record/recorder.hpp"
 #include "glaze/util/progress_bar.hpp"

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -12,6 +12,7 @@
 #include <map>
 #include <random>
 #include <ranges>
+#include <tuple>
 #include <unordered_map>
 #include <variant>
 
@@ -1948,6 +1949,7 @@ suite write_tests = [] {
          Write_pair_test_case{0.78, std::array{1, 2, 3}, R"({"0.78":[1,2,3]})"},
          Write_pair_test_case{"k", glz::obj{"in1", 1, "in2", "v"}, R"({"k":{"in1":1,"in2":"v"}})"},
          Write_pair_test_case{std::array{1, 2}, 99, R"({"[1,2]":99})"},
+         Write_pair_test_case{std::array{"one", "two"}, 99, R"({"[\"one\",\"two\"]":99})"},
          Write_pair_test_case{"knot", std::nullopt, "{}"}, // nullopt_t, not std::optional
          Write_pair_test_case{"kmaybe", std::optional<int>{}, "{}"},
       };
@@ -4453,6 +4455,73 @@ suite map_with_bool_key = [] {
       expect(glz::read_json(a, buffer) == glz::error_code::none);
       expect(a.x == std::map<bool, std::string>{{false, "false"}});
    };
+};
+
+struct array_map
+{
+   std::map<std::array<int, 3>, std::string> x;
+};
+
+template <>
+struct glz::meta<array_map>
+{
+   static constexpr auto value = object("x", &array_map::x);
+};
+
+struct custom_key_map
+{
+   struct key_type
+   {
+      int field1{};
+      std::string field2{};
+
+      [[nodiscard]] std::strong_ordering operator<=>(const key_type&) const noexcept = default;
+
+      struct glaze
+      {
+         static constexpr auto value = glz::object("field1", &key_type::field1, "field2", &key_type::field2);
+      };
+   };
+
+   std::map<key_type, std::string> x;
+};
+
+template <>
+struct glz::meta<custom_key_map>
+{
+   static constexpr auto value = object("x", &custom_key_map::x);
+};
+
+template <typename Map>
+struct Arbitrary_key_test_case
+{
+   std::string_view name{};
+   Map input{};
+   std::string_view serialized{};
+};
+
+suite arbitrary_key_maps = [] {
+   using namespace boost::ut;
+   using namespace boost::ut::operators;
+   "arbitrary_key_maps"_test =
+      [](const auto& test_case) {
+         const auto& [name, input, serialized] = test_case;
+         std::string buffer{};
+         glz::write_json(input, buffer);
+         expect(buffer == serialized);
+
+         std::decay_t<decltype(input)> parsed{};
+         expect(glz::read_json(parsed, serialized) == glz::error_code::none);
+         expect(parsed.x == input.x);
+      } |
+      std::tuple{Arbitrary_key_test_case<array_map>{.name = "array_map",
+                                                    .input = {.x = {{{1, 2, 3}, "hello"}, {{4, 5, 6}, "goodbye"}}},
+                                                    .serialized = R"({"x":{"[1,2,3]":"hello","[4,5,6]":"goodbye"}})"},
+                 Arbitrary_key_test_case<custom_key_map>{
+                    .name = "custom_key_map",
+                    .input = {.x = {{{-1, "k.2"}, "value"}}},
+                    .serialized = R"({"x":{"{\"field1\":-1,\"field2\":\"k.2\"}":"value"}})",
+                 }};
 };
 
 suite char_array = [] {

--- a/util/run_clang-format.sh
+++ b/util/run_clang-format.sh
@@ -46,4 +46,4 @@ if [ "$format_files" = "false" ]; then
 fi
 
 # Format each file.
-clang-format --verbose -i --style=file "${FILE_LIST_ARRAY[@]}"
+/opt/clang-format-static/clang-format-15 --verbose -i --style=file "${FILE_LIST_ARRAY[@]}"


### PR DESCRIPTION
Closes #507

Additionally, although `writiable_map`s could accept key types other than strings, no key type was tested that *contained* a string. An issue existed where these weren't properly escaped to be contained within the string keys of all JSON objects, thereby writing out invalid JSON.
As an example, a key value of `"["first","second"]"` would be written instead of `"[\"first\",\"second\"]"`.

Note that the implementation for both writing and reading object keys of custom types uses `glz::quoted_t`, and therefore serializes/deserializes to/from the thread local string internal to `quoted_t`. However, its possible that the `quoted_t` implementation could be changed by wrapping the output iterators in some smart output iterators that escape all assigned escape sequences. 

Lastly,  `glaze/json/read.hpp` and `glaze/json/write.hpp` are both included in `glaze/json/quoted.hpp`, but also use `quoted_t`, thereby needing its definition. This likely alludes to organizational changes, but for the immediate time it means that to avoid circular includes, users who wish to read/write custom keys must also include `glaze/json/quoted.hpp`. Thoughts on how to correct that?