### PR TITLE
supporting constexpr values/types in variant

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -535,6 +535,9 @@ namespace glz
       concept glaze_value_t =
          glaze_t<T> && !(glaze_array_t<T> || glaze_object_t<T> || glaze_enum_t<T> || glaze_flags_t<T>);
 
+      template <class T>
+      concept glaze_const_value_t = glaze_value_t<T> && std::is_pointer_v<glz::meta_wrapper_t<T>> && std::is_const_v<std::remove_pointer_t<glz::meta_wrapper_t<T>>>;
+
       template <class From, class To>
       concept non_narrowing_convertable = requires(From from, To to) {
 #if __GNUC__

--- a/include/glaze/core/meta.hpp
+++ b/include/glaze/core/meta.hpp
@@ -111,6 +111,19 @@ namespace glz
    using meta_wrapper_t = std::decay_t<decltype(meta_wrapper_v<std::decay_t<T>>)>;
 
    template <class T>
+   struct remove_meta_wrapper
+   {
+      using type = T;
+   };
+   template <detail::glaze_t T>
+   struct remove_meta_wrapper<T>
+   {
+      using type = std::remove_pointer_t<std::remove_const_t<meta_wrapper_t<T>>>;
+   };
+   template <class T>
+   using remove_meta_wrapper_t = typename remove_meta_wrapper<T>::type;
+
+   template <class T>
    concept named = requires { meta<T>::name; } || requires { T::glaze::name; };
 
    template <class T, bool fail_on_unknown = false>

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1687,15 +1687,15 @@ namespace glz
       struct variant_types<std::variant<Ts...>>
       {
          // TODO this way of filtering types is compile time intensive.
-         using bool_types = decltype(std::tuple_cat(std::conditional_t<bool_t<Ts>, std::tuple<Ts>, std::tuple<>>{}...));
+         using bool_types = decltype(std::tuple_cat(std::conditional_t<bool_t<remove_meta_wrapper_t<Ts>>, std::tuple<Ts>, std::tuple<>>{}...));
          using number_types = decltype(std::tuple_cat(
             std::conditional_t<num_t<remove_meta_wrapper_t<Ts>>, std::tuple<Ts>, std::tuple<>>{}...));
-         using string_types = decltype(std::tuple_cat(std::conditional_t < str_t<Ts> || glaze_enum_t<Ts>,
+         using string_types = decltype(std::tuple_cat(std::conditional_t < str_t<remove_meta_wrapper_t<Ts>> || glaze_enum_t<Ts>,
                                                       std::tuple<Ts>, std::tuple < >> {}...));
          using object_types =
             decltype(std::tuple_cat(std::conditional_t < readable_map_t<Ts> || writable_map_t<Ts> || glaze_object_t<Ts>,
                                     std::tuple<Ts>, std::tuple < >> {}...));
-         using array_types = decltype(std::tuple_cat(std::conditional_t < array_t<Ts> || glaze_array_t<Ts>,
+         using array_types = decltype(std::tuple_cat(std::conditional_t < array_t<remove_meta_wrapper_t<Ts>> || glaze_array_t<Ts>,
                                                      std::tuple<Ts>, std::tuple < >> {}...));
          using nullable_types =
             decltype(std::tuple_cat(std::conditional_t<null_t<Ts>, std::tuple<Ts>, std::tuple<>>{}...));
@@ -1712,6 +1712,53 @@ namespace glz
             decltype(std::tuple_cat(std::conditional_t<glaze_const_value_t<Ts>, std::tuple<Ts>, std::tuple<>>{}...));
          using glaze_non_const_types =
             decltype(std::tuple_cat(std::conditional_t<!glaze_const_value_t<Ts>, std::tuple<Ts>, std::tuple<>>{}...));
+      };
+
+      template <typename tuple_types_t>
+      struct process_arithmetic_boolean_string_or_array
+      {
+         template <auto Options>
+         GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+         {
+            if constexpr (std::tuple_size_v<tuple_types_t> < 1) {
+               ctx.error = error_code::no_matching_variant_type;
+            }
+            else {
+               using const_glaze_types = typename tuple_types<tuple_types_t>::glaze_const_types;
+               bool found_match{};
+               for_each<std::tuple_size_v<const_glaze_types>>([&]([[maybe_unused]] auto I) mutable {
+                  if (found_match) {
+                     return;
+                  }
+                  using V = std::tuple_element_t<I, const_glaze_types>;
+                  // run time substitute to compare to const value
+                  std::remove_const_t<std::remove_pointer_t<std::remove_const_t<meta_wrapper_t<V>>>> substitute{};
+                  auto copy_it{it};
+                  read<json>::op<ws_handled<Options>()>(substitute, ctx, it, end);
+                  static constexpr auto const_value{*meta_wrapper_v<V>};
+                  if (substitute == const_value) {
+                     found_match = true;
+                     if (!std::holds_alternative<V>(value)) value = V{};
+                  }
+                  else {
+                     it = copy_it;
+                  }
+               });
+               if (found_match) {
+                  return;
+               }
+
+               using non_const_types = typename tuple_types<tuple_types_t>::glaze_non_const_types;
+               if constexpr (std::tuple_size_v<non_const_types> > 0) {
+                  using V = std::tuple_element_t<0, non_const_types>;
+                  if (!std::holds_alternative<V>(value)) value = V{};
+                  read<json>::op<ws_handled<Options>()>(std::get<V>(value), ctx, it, end);
+               }
+               else {
+                  ctx.error = error_code::no_matching_variant_type;
+               }
+            }
+         }
       };
 
       template <is_variant T>
@@ -1895,38 +1942,17 @@ namespace glz
                   break;
                case '[':
                   using array_types = typename variant_types<T>::array_types;
-                  if constexpr (std::tuple_size_v<array_types> < 1) {
-                     ctx.error = error_code::no_matching_variant_type;
-                  }
-                  else {
-                     using V = std::tuple_element_t<0, array_types>;
-                     if (!std::holds_alternative<V>(value)) value = V{};
-                     read<json>::op<ws_handled<Opts>()>(std::get<V>(value), ctx, it, end);
-                  }
+                  process_arithmetic_boolean_string_or_array<array_types>::template op<Opts>(value, ctx, it, end);
                   break;
                case '"': {
                   using string_types = typename variant_types<T>::string_types;
-                  if constexpr (std::tuple_size_v<string_types> < 1) {
-                     ctx.error = error_code::no_matching_variant_type;
-                  }
-                  else {
-                     using V = std::tuple_element_t<0, string_types>;
-                     if (!std::holds_alternative<V>(value)) value = V{};
-                     read<json>::op<ws_handled<Opts>()>(std::get<V>(value), ctx, it, end);
-                  }
+                  process_arithmetic_boolean_string_or_array<string_types>::template op<Opts>(value, ctx, it, end);
                   break;
                }
                case 't':
                case 'f': {
                   using bool_types = typename variant_types<T>::bool_types;
-                  if constexpr (std::tuple_size_v<bool_types> < 1) {
-                     ctx.error = error_code::no_matching_variant_type;
-                  }
-                  else {
-                     using V = std::tuple_element_t<0, bool_types>;
-                     if (!std::holds_alternative<V>(value)) value = V{};
-                     read<json>::op<ws_handled<Opts>()>(std::get<V>(value), ctx, it, end);
-                  }
+                  process_arithmetic_boolean_string_or_array<bool_types>::template op<Opts>(value, ctx, it, end);
                   break;
                }
                case 'n':
@@ -1943,40 +1969,7 @@ namespace glz
                default: {
                   // Not bool, string, object, or array so must be number or null
                   using number_types = typename variant_types<T>::number_types;
-                  if constexpr (std::tuple_size_v<number_types> < 1) {
-                     ctx.error = error_code::no_matching_variant_type;
-                  }
-                  else {
-                     using const_glaze_types = typename tuple_types<number_types>::glaze_const_types;
-                     bool found_match{};
-                     for_each<std::tuple_size_v<const_glaze_types>>([&]([[maybe_unused]] auto I) mutable  {
-                        if (found_match) {
-                           return;
-                        }
-                        using V = std::tuple_element_t<I, const_glaze_types>;
-                        // run time substitute to compare to const value
-                        std::remove_const_t<std::remove_pointer_t<std::remove_const_t<meta_wrapper_t<V>>>> substitute{};
-                        auto copy_it{it};
-                        read<json>::op<ws_handled<Opts>()>(substitute, ctx, it, end);
-                        static constexpr auto const_value{*meta_wrapper_v<V>};
-                        if (substitute == const_value) {
-                           found_match = true;
-                           if (!std::holds_alternative<V>(value)) value = V{};
-                        }
-                        else {
-                           it = copy_it;
-                        }
-                     });
-                     using other_types = typename tuple_types<number_types>::glaze_non_const_types;
-                     if constexpr (std::tuple_size_v<other_types> > 0) {
-                        using V = std::tuple_element_t<0, other_types>;
-                        if (!std::holds_alternative<V>(value)) value = V{};
-                        read<json>::op<ws_handled<Opts>()>(std::get<V>(value), ctx, it, end);
-                     }
-                     else if (!found_match) {
-                        ctx.error = error_code::no_matching_variant_type;
-                     }
-                  }
+                  process_arithmetic_boolean_string_or_array<number_types>::template op<Opts>(value, ctx, it, end);
                }
                }
             }
@@ -2097,36 +2090,6 @@ namespace glz
             }
          }
       };
-
-      // template <glaze_const_value_t T>
-      // struct from_json<T>
-      // {
-      //    // First attempt, This fails because you will read and increment `it` for each none_match so second attempt is
-      //    // indexing bogus memory etc. Would be nice if this could be here
-      //    template <auto Options>
-      //    GLZ_FLATTEN static void op([[maybe_unused]] auto&& value, [[maybe_unused]] is_context auto&& ctx,
-      //                               [[maybe_unused]] auto&& it, [[maybe_unused]] auto&& end) noexcept
-      //    {
-      //       auto copy_it{it};
-      //       std::remove_const_t<std::remove_pointer_t<std::remove_const_t<meta_wrapper_t<T>>>> substitute{};
-      //       read<json>::op<Options>(substitute, ctx, it, end);
-      //
-      //       // from_json<decltype(substitute)>::template op<Options>(substitute, ctx, it, end);
-      //       static constexpr auto const_value{*meta_wrapper_v<T>};
-      //       if (substitute == const_value) {
-      //          if (ctx.error == error_code::no_matching_variant_type) {
-      //             // clear error because we found a match
-      //             ctx.error = error_code::none;
-      //          }
-      //       }
-      //       else {
-      //          // reset it to its previous form because we did not read an actual value
-      //          it = copy_it;
-      //          ctx.error = error_code::no_matching_variant_type;
-      //       }
-      //    }
-      // };
-
    } // namespace detail
 
    template <class Buffer>

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1687,18 +1687,18 @@ namespace glz
       struct variant_types<std::variant<Ts...>>
       {
          // TODO this way of filtering types is compile time intensive.
-         using bool_types = decltype(std::tuple_cat(std::conditional_t<bool_t<remove_meta_wrapper_t<Ts>>, std::tuple<Ts>, std::tuple<>>{}...));
-         using number_types = decltype(std::tuple_cat(
-            std::conditional_t<num_t<remove_meta_wrapper_t<Ts>>, std::tuple<Ts>, std::tuple<>>{}...));
-         using string_types = decltype(std::tuple_cat(std::conditional_t < str_t<remove_meta_wrapper_t<Ts>> || glaze_enum_t<remove_meta_wrapper_t<Ts>>,
-                                                      std::tuple<Ts>, std::tuple < >> {}...));
+         using bool_types = decltype(tuplet::tuple_cat(std::conditional_t<bool_t<remove_meta_wrapper_t<Ts>>, tuplet::tuple<Ts>, tuplet::tuple<>>{}...));
+         using number_types = decltype(tuplet::tuple_cat(
+            std::conditional_t<num_t<remove_meta_wrapper_t<Ts>>, tuplet::tuple<Ts>, tuplet::tuple<>>{}...));
+         using string_types = decltype(tuplet::tuple_cat(std::conditional_t < str_t<remove_meta_wrapper_t<Ts>> || glaze_enum_t<remove_meta_wrapper_t<Ts>>,
+                                                      tuplet::tuple<Ts>, tuplet::tuple < >> {}...));
          using object_types =
-            decltype(std::tuple_cat(std::conditional_t < readable_map_t<Ts> || writable_map_t<Ts> || glaze_object_t<Ts>,
-                                    std::tuple<Ts>, std::tuple < >> {}...));
-         using array_types = decltype(std::tuple_cat(std::conditional_t < array_t<remove_meta_wrapper_t<Ts>> || glaze_array_t<Ts>,
-                                                     std::tuple<Ts>, std::tuple < >> {}...));
+            decltype(tuplet::tuple_cat(std::conditional_t < readable_map_t<Ts> || writable_map_t<Ts> || glaze_object_t<Ts>,
+                                    tuplet::tuple<Ts>, tuplet::tuple < >> {}...));
+         using array_types = decltype(tuplet::tuple_cat(std::conditional_t < array_t<remove_meta_wrapper_t<Ts>> || glaze_array_t<Ts>,
+                                                     tuplet::tuple<Ts>, tuplet::tuple < >> {}...));
          using nullable_types =
-            decltype(std::tuple_cat(std::conditional_t<null_t<Ts>, std::tuple<Ts>, std::tuple<>>{}...));
+            decltype(tuplet::tuple_cat(std::conditional_t<null_t<Ts>, tuplet::tuple<Ts>, tuplet::tuple<>>{}...));
       };
 
       // post process output of variant_types
@@ -1706,12 +1706,12 @@ namespace glz
       struct tuple_types;
 
       template <typename... Ts>
-      struct tuple_types<std::tuple<Ts...>>
+      struct tuple_types<tuplet::tuple<Ts...>>
       {
          using glaze_const_types =
-            decltype(std::tuple_cat(std::conditional_t<glaze_const_value_t<Ts>, std::tuple<Ts>, std::tuple<>>{}...));
+            decltype(tuplet::tuple_cat(std::conditional_t<glaze_const_value_t<Ts>, tuplet::tuple<Ts>, tuplet::tuple<>>{}...));
          using glaze_non_const_types =
-            decltype(std::tuple_cat(std::conditional_t<!glaze_const_value_t<Ts>, std::tuple<Ts>, std::tuple<>>{}...));
+            decltype(tuplet::tuple_cat(std::conditional_t<!glaze_const_value_t<Ts>, tuplet::tuple<Ts>, tuplet::tuple<>>{}...));
       };
 
       template <typename tuple_types_t>

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1690,7 +1690,7 @@ namespace glz
          using bool_types = decltype(std::tuple_cat(std::conditional_t<bool_t<remove_meta_wrapper_t<Ts>>, std::tuple<Ts>, std::tuple<>>{}...));
          using number_types = decltype(std::tuple_cat(
             std::conditional_t<num_t<remove_meta_wrapper_t<Ts>>, std::tuple<Ts>, std::tuple<>>{}...));
-         using string_types = decltype(std::tuple_cat(std::conditional_t < str_t<remove_meta_wrapper_t<Ts>> || glaze_enum_t<Ts>,
+         using string_types = decltype(std::tuple_cat(std::conditional_t < str_t<remove_meta_wrapper_t<Ts>> || glaze_enum_t<remove_meta_wrapper_t<Ts>>,
                                                       std::tuple<Ts>, std::tuple < >> {}...));
          using object_types =
             decltype(std::tuple_cat(std::conditional_t < readable_map_t<Ts> || writable_map_t<Ts> || glaze_object_t<Ts>,

--- a/include/glaze/tuplet/tuple.hpp
+++ b/include/glaze/tuplet/tuple.hpp
@@ -187,7 +187,7 @@ namespace glz
       // This takes a forwarding tuple as a parameter. The forwarding tuple only
       // contains references, so it should just be taken by value.
       template <class T, class... Outer, class... Inner>
-      constexpr auto cat_impl(T tup, type_list<Outer...>, type_list<Inner...>) -> tuple<type_t<Inner>...>
+      constexpr auto cat_impl([[maybe_unused]] T tup, type_list<Outer...>, type_list<Inner...>) -> tuple<type_t<Inner>...>
       {
          return {{{static_cast<type_t<Outer>&&>(tup.identity_t<Outer>::value).identity_t<Inner>::value}...}};
       }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -4918,7 +4918,7 @@ suite constexpr_values_test = [] {
 
    "parse error direct_conversion_variant cx int"_test = [] {
       const_only_variant var{direct_cx_value_conversion{}};
-      auto parse_err{glz::read_json(var, R"(33)")};
+      auto const parse_err {glz::read_json(var, R"(33)")};
       expect(parse_err == glz::error_code::no_matching_variant_type);
    };
 

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -4808,15 +4808,15 @@ struct direct_cx_value_conversion_different_value
 };
 static_assert(glz::detail::glaze_const_value_t<direct_cx_value_conversion_different_value>);
 
-struct second_direct_cx_value_conversion
+struct string_direct_cx_value_conversion
 {
    static constexpr std::string_view other{"other"};
    struct glaze
    {
-      static constexpr auto value{&second_direct_cx_value_conversion::other};
+      static constexpr auto value{&string_direct_cx_value_conversion::other};
    };
 };
-static_assert(glz::detail::glaze_const_value_t<second_direct_cx_value_conversion>);
+static_assert(glz::detail::glaze_const_value_t<string_direct_cx_value_conversion>);
 
 struct non_cx_direct_value_conversion
 {
@@ -4874,15 +4874,16 @@ suite constexpr_values_test = [] {
       expect(parse_err == glz::error_code::none) << glz::format_error(parse_err, s);
       expect(std::holds_alternative<std::uint64_t>(var));
    };
-//   "constexpr_values_optional"_test = [] {
-//      std::optional<direct_cx_value_conversion> var{direct_cx_value_conversion{}};
-//      std::string s{};
-//      glz::write_json(var, s);
-//      expect(s == R"(42)");
-//      auto parse_err{glz::read_json(var, s)};
-//      expect(parse_err == glz::error_code::none) << glz::format_error(parse_err, s);
-//      expect(var.has_value());
-//   };
+
+   "constexpr blend with non constexpr variant string"_test = [] {
+      std::variant<std::monostate, string_direct_cx_value_conversion, std::string> var{string_direct_cx_value_conversion{}};
+      std::string s{};
+      glz::write_json(var, s);
+      expect(s == R"("other")") << s;
+      auto parse_err{glz::read_json(var, s)};
+      expect(parse_err == glz::error_code::none) << glz::format_error(parse_err, s);
+      expect(std::holds_alternative<string_direct_cx_value_conversion>(var));
+   };
 
 };
 

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -4904,7 +4904,7 @@ suite constexpr_values_test = [] {
    std::variant<direct_cx_value_conversion_different_value, direct_cx_value_conversion,
                 string_direct_cx_value_conversion, string_two_direct_cx_value_conversion,
                 array_direct_cx_value_conversion, array_two_direct_cx_value_conversion, const_red, const_green>;
-   "constexpr blend with non constexpr variant string"_test = []<typename const_t> {
+   "constexpr blend with non constexpr variant string"_test = []<typename const_t>() {
       const_only_variant var{const_t{}};
       std::string s{};
       glz::write_json(var, s);


### PR DESCRIPTION
Added support for handling reads of constexpr struct values in variants.

Introduced type handling of const types for glaze value, and split the const types from the non const types during the parse of variant types.

