### PR TITLE
add emplacer style reader for glz::custom

### DIFF
--- a/include/glaze/json/custom.hpp
+++ b/include/glaze/json/custom.hpp
@@ -49,11 +49,8 @@ namespace glz
                      }
                      else if constexpr (std::tuple_size_v<Tuple> == 1) {
                         using Input = std::decay_t<std::tuple_element_t<0, Tuple>>;
-                        const auto dummy_emplacer = [](auto& i) {};
-                        if (std::invocable<std::remove_cvref_t<decltype(value.val.*(value.from))>,
-                                           decltype(dummy_emplacer)>) {
-                           const auto emplacer = [&](auto& input) { read<json>::op<Opts>(input, ctx, it, end); };
-                           (value.val.*(value.from))(emplacer);
+                        if constexpr (std::is_base_of_v<std::_Function_base, Input>) {
+                           (value.val.*(value.from))([&](auto& input) { read<json>::op<Opts>(input, ctx, it, end); });
                            if (bool(ctx.error)) [[unlikely]]
                               return;
                         }


### PR DESCRIPTION
`glz::custom` accepts a function with a signature like `void read_x(const std::string& s)` as its `read function` for a member. In its implement, a std::string will be built on the stack and modified when parsing the json. Then the variable will be called as the argument in `read_x`. The overhead is very small for those data structures that have an efficient `std::move`, like `std::vector`. For those with a less efficient move function, the copy is inevitable. And for a `std::span`, the temporary variable is empty, which makes it not work.

I added some codes to support another kind of function, with a signature like `void read_x(const std::function<void(std::string&)>& x_builder)`. This will help to reduce runtime overhead for some cases, and support those data structures do not **own** the memory resource.

In theory, the read function should support any callable with correct sigature as its argument. However, when registering `glz::object`, a concrete type must be provided. Thus I constrain the input must be a `std::function` with unary augument.