### PR TITLE
Fix: variant tags rejected when last object entry

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -47,10 +47,11 @@ namespace glz
       {};
 
       template <auto Opts, class T, class Ctx, class It0, class It1>
-      concept read_json_invocable = requires(T&& value, Ctx&& ctx, It0&& it, It1&& end) {
-         from_json<std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
-                                                              std::forward<It0>(it), std::forward<It1>(end));
-      };
+      concept read_json_invocable =
+         requires(T&& value, Ctx&& ctx, It0&& it, It1&& end) {
+            from_json<std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+                                                                 std::forward<It0>(it), std::forward<It1>(end));
+         };
 
       template <>
       struct read<json>
@@ -212,10 +213,11 @@ namespace glz
                match<"alse">(ctx, it, end);
                break;
             }
-            [[unlikely]] default: {
-               ctx.error = error_code::expected_true_or_false;
-               return;
-            }
+               [[unlikely]] default:
+               {
+                  ctx.error = error_code::expected_true_or_false;
+                  return;
+               }
             }
 
             if constexpr (Opts.quoted_num) {
@@ -516,7 +518,7 @@ namespace glz
                      }
                      else {
                         switch (*it) {
-                        [[likely]] case '"': {
+                        [[likely]] case '"' : {
                            value.append(start, static_cast<size_t>(it - start));
                            ++it;
                            return;
@@ -525,15 +527,15 @@ namespace glz
                         [[unlikely]] case '\f':
                         [[unlikely]] case '\n':
                         [[unlikely]] case '\r':
-                        [[unlikely]] case '\t': {
+                        [[unlikely]] case '\t' : {
                            ctx.error = error_code::syntax_error;
                            return;
                         }
-                        [[unlikely]] case '\0': {
+                        [[unlikely]] case '\0' : {
                            ctx.error = error_code::unexpected_end;
                            return;
                         }
-                        [[unlikely]] case '\\': {
+                        [[unlikely]] case '\\' : {
                            value.append(start, static_cast<size_t>(it - start));
                            ++it;
                            handle_escaped();
@@ -542,8 +544,7 @@ namespace glz
                            start = it;
                            break;
                         }
-                        [[likely]] default:
-                           ++it;
+                           [[likely]] default : ++it;
                         }
                      }
                   }
@@ -1767,7 +1768,7 @@ namespace glz
                                     skip_ws<Opts>(ctx, it, end);
                                     if (bool(ctx.error)) [[unlikely]]
                                        return;
-                                    if(!(*it == ',' || *it == '}')) {
+                                    if (!(*it == ',' || *it == '}')) {
                                        ctx.error = error_code::syntax_error;
                                        return;
                                     }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -2426,8 +2426,16 @@ suite tagged_variant_tests = [] {
       expect(glz::read_json(var, R"({"action":"DELETE","data":"the_internet"})") == glz::error_code::none);
       expect(std::get<delete_action>(var).data == "the_internet");
 
+      // tag at end
+      expect(glz::read_json(var, R"({"data":"the_internet","action":"DELETE"})") == glz::error_code::none);
+      expect(std::get<delete_action>(var).data == "the_internet");
+
       tagged_variant2 var2{};
       expect(glz::read_json(var2, R"({"type":"put_action","data":{"x":100,"y":200}})") == glz::error_code::none);
+      expect(std::get<put_action>(var2).data["y"] == 200);
+
+      // tag at end
+      expect(glz::read_json(var2, R"({"data":{"x":100,"y":200},"type":"put_action"})") == glz::error_code::none);
       expect(std::get<put_action>(var2).data["y"] == 200);
    };
 

--- a/util/run_clang-format.sh
+++ b/util/run_clang-format.sh
@@ -46,4 +46,4 @@ if [ "$format_files" = "false" ]; then
 fi
 
 # Format each file.
-/opt/clang-format-static/clang-format-15 --verbose -i --style=file "${FILE_LIST_ARRAY[@]}"
+clang-format --verbose -i --style=file "${FILE_LIST_ARRAY[@]}"


### PR DESCRIPTION
1. Accept a '}' or ',', not just ',' following a variant tag in case it's the last entry in the object
2. parse the type IDs for the variant tag into string_view not string
3. restore `clang-format` executable in `util/` that I accidentally changed in previous merges.