### PR TITLE
msvc iterator fix

### DIFF
--- a/include/glaze/csv/read.hpp
+++ b/include/glaze/csv/read.hpp
@@ -93,17 +93,11 @@ namespace glz
                }
             }
             else {
-               // TODO: fix this also, taken from json
-               using X =
-                  std::conditional_t<std::is_const_v<std::remove_pointer_t<std::remove_reference_t<decltype(it)>>>,
-                                     const uint8_t*, uint8_t*>;
-               auto cur = reinterpret_cast<X>(it);
-               auto s = parse_float<V, Opts.force_conformance>(value, cur);
+               auto s = parse_float<V, Opts.force_conformance>(value, it);
                if (!s) [[unlikely]] {
                   ctx.error = error_code::parse_number_failure;
                   return;
                }
-               it = reinterpret_cast<std::remove_reference_t<decltype(it)>>(cur);
             }
          }
       };

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -332,17 +332,11 @@ namespace glz
                }
             }
             else {
-               // TODO: fix this
-               using X =
-                  std::conditional_t<std::is_const_v<std::remove_pointer_t<std::remove_reference_t<decltype(it)>>>,
-                                     const uint8_t*, uint8_t*>;
-               auto cur = reinterpret_cast<X>(it);
-               auto s = parse_float<V, Options.force_conformance>(value, cur);
+               auto s = parse_float<V, Options.force_conformance>(value, it);
                if (!s) [[unlikely]] {
                   ctx.error = error_code::parse_number_failure;
                   return;
                }
-               it = reinterpret_cast<std::remove_reference_t<decltype(it)>>(cur);
             }
 
             if constexpr (Options.quoted_num) {

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -35,7 +35,7 @@ namespace glz::detail
    GLZ_ALWAYS_INLINE void match(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       const auto n = static_cast<size_t>(std::distance(it, end));
-      if ((n < str.size) || (std::memcmp(it, str.value, str.size) != 0)) [[unlikely]] {
+      if ((n < str.size) || (std::memcmp(&*it, str.value, str.size) != 0)) [[unlikely]] {
          ctx.error = error_code::syntax_error;
       }
       else {

--- a/include/glaze/util/stoui64.hpp
+++ b/include/glaze/util/stoui64.hpp
@@ -131,4 +131,17 @@ namespace glz::detail
 
       return true;
    }
+
+   template <class T = uint64_t>
+   GLZ_ALWAYS_INLINE constexpr bool stoui64(uint64_t& res, auto& it) noexcept
+   {
+      static_assert(sizeof(*it) == sizeof(char));
+      const char* cur = reinterpret_cast<const char*>(&*it);
+      const char* beg = cur;
+      if (stoui64(res, cur)) {
+         it += (cur - beg);
+         return true;
+      }
+      return false;
+   }
 }

--- a/include/glaze/util/strod.hpp
+++ b/include/glaze/util/strod.hpp
@@ -397,7 +397,7 @@ namespace glz::detail
    };
 
    template <std::floating_point T, bool force_conformance = false>
-   inline bool parse_float(T& val, auto*& cur) noexcept
+   inline bool parse_float(T& val, const uint8_t*& cur) noexcept
    {
       const uint8_t* sig_cut = nullptr; /* significant part cutting position for long number */
       [[maybe_unused]] const uint8_t* sig_end = nullptr; /* significant part ending position */
@@ -742,5 +742,17 @@ namespace glz::detail
       num += raw_t(round);
       std::memcpy(&val, &num, sizeof(T));
       return true;
+   }
+
+   template <std::floating_point T, bool force_conformance = false>
+   inline bool parse_float(T& val, auto& itr) noexcept
+   {
+      const uint8_t* cur = reinterpret_cast<const uint8_t*>(&*itr);
+      const uint8_t* beg = cur;
+      if (parse_float(val, cur)) {
+         itr += (cur - beg);
+         return true;
+      }
+      return false;
    }
 }

--- a/include/glaze/util/strod.hpp
+++ b/include/glaze/util/strod.hpp
@@ -749,7 +749,7 @@ namespace glz::detail
    {
       const uint8_t* cur = reinterpret_cast<const uint8_t*>(&*itr);
       const uint8_t* beg = cur;
-      if (parse_float(val, cur)) {
+      if (parse_float<T,force_conformance>(val, cur)) {
          itr += (cur - beg);
          return true;
       }


### PR DESCRIPTION
The PR fixes the problem in MSVC where the string_view::iterator is not convertible to pointer directly. 