### PR TITLE
removing compare.hpp and approx.hpp from glaze.hpp

### DIFF
--- a/include/glaze/glaze.hpp
+++ b/include/glaze/glaze.hpp
@@ -33,8 +33,6 @@
 #pragma once
 
 #include "glaze/binary.hpp"
-#include "glaze/compare/approx.hpp"
-#include "glaze/compare/compare.hpp"
 #include "glaze/csv.hpp"
 #include "glaze/file/file_ops.hpp"
 #include "glaze/json.hpp"

--- a/tests/compare_test/compare_test.cpp
+++ b/tests/compare_test/compare_test.cpp
@@ -6,7 +6,8 @@
 #endif
 
 #include "boost/ut.hpp"
-#include "glaze/glaze.hpp"
+#include "glaze/compare/approx.hpp"
+#include "glaze/compare/compare.hpp"
 
 using namespace boost::ut;
 


### PR DESCRIPTION
These comparison tools are very specialized, so I'd rather have users directly include them rather than bloat the includes for others