### PR TITLE
Using PROJECT_IS_TOP_LEVEL to control compiler and linker optimization flags (MSVC)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ include(cmake/variables.cmake)
 add_library(glaze_glaze INTERFACE)
 add_library(glaze::glaze ALIAS glaze_glaze)
 
+
 if (MSVC)
   string(REGEX MATCH "\/cl(.exe)?$" matched_cl ${CMAKE_CXX_COMPILER})
   if (matched_cl)
@@ -21,8 +22,12 @@ if (MSVC)
     target_compile_options(glaze_glaze INTERFACE "/Zc:preprocessor" /permissive- /Zc:lambda)
     
     if(PROJECT_IS_TOP_LEVEL)
-      target_compile_options(glaze_glaze INTERFACE /GL)
-      target_link_options(glaze_glaze INTERFACE /LTCG /INCREMENTAL:NO)
+      target_compile_options(glaze_glaze INTERFACE 
+        $<$<CONFIG:Release>:/GL>
+        $<$<CONFIG:MinSizeRel>:/GL>)
+      target_link_options(glaze_glaze INTERFACE 
+        $<$<CONFIG:Release>:/LTCG /INCREMENTAL:NO>
+        $<$<CONFIG:MinSizeRel>:/LTCG /INCREMENTAL:NO>)
     endif()
    endif()
 else()


### PR DESCRIPTION
When building on MSVC, adding some optimization flags _tout-court_ may cause some to clash with others already set previously.

In this case the `/GL` option was conflicting with `/ZI` in Debug builds, causing compilation errors and the need to manually disable the flag manually, which is clearly a workaround.

With this PR I added a CMake switch allowing the user to choose whether to activate the optimization flags or not.
Since this is an `INTERFACE` library, all options are then exposed to all the projects using this one and it seemed to me bad practice to make everybody inherit these properties by default; therefore I defaulted it to `OFF`.