### PR TITLE
Fix SEGFAULT introduced by writing empty strings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ out/
 **/bin/
 **/build*/
 **/lib*/
+**/*-build*/
 
 # CMake spesific settings
 CMakeUserPresets.json

--- a/README.md
+++ b/README.md
@@ -715,8 +715,8 @@ struct opts {
   bool force_conformance = false; // Do not allow invalid json normally accepted such as comments, nan, inf.
   bool error_on_missing_keys = false; // Require all non nullable keys to be present in the object. Use
                                       // skip_null_members = false to require nullable members
-  bool error_on_const_read =
-     false; // Error if attempt is made to read into a const value, by default the value is skipped without error
+  bool error_on_const_read = false; // Error if attempt is made to read into a const value, by 
+                                    // default the value is skipped without error
   uint32_t layout = rowwise; // CSV row wise output/input
   bool quoted_num = false; // treat numbers as quoted or array-like types as having quoted numbers
   bool number = false; // read numbers as strings and write these string as numbers

--- a/README.md
+++ b/README.md
@@ -702,22 +702,26 @@ The struct below shows the available options and the default behavior.
 
 ```c++
 struct opts {
-   uint32_t format = json;
-      bool comments = false; // Write out comments
-      bool error_on_unknown_keys = true; // Error when an unknown key is encountered
-      bool skip_null_members = true; // Skip writing out params in an object if the value is null
-      bool use_hash_comparison = true; // Will replace some string equality checks with hash checks
-      bool prettify = false; // Write out prettified JSON
-      char indentation_char = ' '; // Prettified JSON indentation char
-      uint8_t indentation_width = 3; // Prettified JSON indentation size
-      bool shrink_to_fit = false; // Shrinks dynamic containers to new size to save memory
-      bool write_type_info = true; // Write type info for meta objects in variants
-      bool force_conformance = false; // Do not allow invalid json normally accepted such as comments, nan, inf.
-      bool error_on_missing_keys = false; // Require all non nullable keys to be present in the object. Use
-                                          // skip_null_members = false to require nullable members
-      uint32_t layout = rowwise; // CSV row wise output/input
-      bool quoted_num = false; // treat numbers as quoted or array-like types as having quoted numbers
-      bool number = false; // read numbers as strings and write these string as numbers
+  uint32_t format = json;
+  bool comments = false; // Write out comments
+  bool error_on_unknown_keys = true; // Error when an unknown key is encountered
+  bool skip_null_members = true; // Skip writing out params in an object if the value is null
+  bool use_hash_comparison = true; // Will replace some string equality checks with hash checks
+  bool prettify = false; // Write out prettified JSON
+  char indentation_char = ' '; // Prettified JSON indentation char
+  uint8_t indentation_width = 3; // Prettified JSON indentation size
+  bool shrink_to_fit = false; // Shrinks dynamic containers to new size to save memory
+  bool write_type_info = true; // Write type info for meta objects in variants
+  bool force_conformance = false; // Do not allow invalid json normally accepted such as comments, nan, inf.
+  bool error_on_missing_keys = false; // Require all non nullable keys to be present in the object. Use
+                                      // skip_null_members = false to require nullable members
+  bool error_on_const_read =
+     false; // Error if attempt is made to read into a const value, by default the value is skipped without error
+  uint32_t layout = rowwise; // CSV row wise output/input
+  bool quoted_num = false; // treat numbers as quoted or array-like types as having quoted numbers
+  bool number = false; // read numbers as strings and write these string as numbers
+  bool raw = false; // write out string like values without quotes
+  bool raw_string = false; // do not decode/encode escaped characters for strings (improves read/write performance)
 };
 ```
 

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -303,8 +303,8 @@ namespace glz
                      dump_unchecked<'"'>(b, ix);
 
                      if (!str.empty()) {
-                        auto c = str.cbegin();
-                        const auto e = c + n;
+                        const auto* c = str.data();
+                        const auto* const e = c + n;
 
                         for (const auto end_m7 = e - 7; c < end_m7;) {
                            auto* const chunk = reinterpret_cast<uint64_t*>(data_ptr(b) + ix);

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -437,10 +437,38 @@ suite basic_types = [] {
       expect(buffer == "\"as\\\"df\\\\ghjkl\"");
 
       "empty"_test = [] {
-         static constexpr std::string_view expected{"\"\""};
-         expect(that % glz::write_json(std::string_view{}) == expected);
-         expect(that % glz::write_json(std::string{}) == expected);
-         expect(that % glz::write_json("") == expected);
+         static constexpr std::string_view expected_empty{"\"\""};
+         static constexpr std::string_view expected_nothing{};
+         expect(that % glz::write_json(std::string_view{}) == expected_empty);
+         expect(that % glz::write_json(std::string{}) == expected_empty);
+         expect(that % glz::write_json("") == expected_empty);
+
+         auto write_raw = [](const auto& input) {
+            std::string result{};
+            glz::write<glz::opts{.raw = true}>(input, result);
+            return result;
+         };
+         expect(that % write_raw(std::string_view{}) == expected_nothing);
+         expect(that % write_raw(std::string{}) == expected_nothing);
+         expect(that % write_raw("") == expected_nothing);
+
+         auto write_raw_str = [](const auto& input) {
+            std::string result{};
+            glz::write<glz::opts{.raw_string = true}>(input, result);
+            return result;
+         };
+         expect(that % write_raw_str(std::string_view{}) == expected_empty);
+         expect(that % write_raw_str(std::string{}) == expected_empty);
+         expect(that % write_raw_str("") == expected_empty);
+
+         auto write_num = [](const auto& input) {
+            std::string result{};
+            glz::write<glz::opts{.number = true}>(input, result);
+            return result;
+         };
+         expect(that % write_num(std::string_view{}) == expected_nothing);
+         expect(that % write_num(std::string{}) == expected_nothing);
+         expect(that % write_num("") == expected_nothing);
       };
    };
 

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -435,6 +435,13 @@ suite basic_types = [] {
       buffer.clear();
       glz::write_json("as\"df\\ghjkl", buffer);
       expect(buffer == "\"as\\\"df\\\\ghjkl\"");
+
+      "empty"_test = [] {
+         static constexpr std::string_view expected{"\"\""};
+         expect(that % glz::write_json(std::string_view{}) == expected);
+         expect(that % glz::write_json(std::string{}) == expected);
+         expect(that % glz::write_json("") == expected);
+      };
    };
 
    "backslash testing"_test = [] {


### PR DESCRIPTION
Additionally,
 - updated the README for the latest opts members.
 - removed the unnecessary nesting of `if constexpr (char_t<T>)` in the string writing function for JSON.
 - lots of tests for empty strings. These previously reproduced the segfaulting behavior w/o these changes.