### PR TITLE
detail reflection via reflection header

### DIFF
--- a/docs/macros-for-structs.md
+++ b/docs/macros-for-structs.md
@@ -1,6 +1,8 @@
 # Struct Registration Macros
 
-Glaze supports reflection for aggregate initializable structs, and for member object pointers. So, these macros no longer save typing and have much less flexibility. They will be deprecated in the future.
+Glaze supports reflection for aggregate initializable structs, and for member object pointers. So,
+these macros no longer save typing and have much less flexibility. *They will be deprecated in the
+future*.
 
 **Macros must be explicitly included via: `#include "glaze/core/macros.hpp"`**
 
@@ -20,9 +22,10 @@ struct local_macro_t {
    double x = 5.0;
    std::string y = "yay!";
    int z = 55;
-   
+
    GLZ_LOCAL_META(local_macro_t, x, y, z);
 };
 ```
 
-Instead of these macros don't write anything :)
+Instead of these macros, don't write anything and let [pure reflection](./pure-reflection.md) do the
+work :)

--- a/docs/pure-reflection.md
+++ b/docs/pure-reflection.md
@@ -2,7 +2,9 @@
 
 Version 1.9.0 adds pure reflection for aggregate initializable structs in Clang, MSVC, and GCC.
 
-No need to write any `glz::meta` structures or use any macros. The reflection is hidden from the user and computed at compile time.
+There's no need to write any `glz::meta` structures or use any macros. The reflection is hidden from
+the user and computed at compile time, available with the inclusion of
+`glaze/reflection/reflect.hpp`.
 
 - You can still write a `glz::meta` to customize your serialization, which will override the default reflection.
 - The `glz::meta` approach is still the most optimized. There is some work to be done to make the automatic reflection just as fast.


### PR DESCRIPTION
I avoid "convenience headers" because it bloats compile times.
So, when trying the new pure reflection for GCC, I couldn't find out why my aggregate wasn't reflecting. It was the lack of `#include <glaze/reflection/reflect.hpp>` in my test.

This simply documents the header that provides these new utilities.

Great work!