### PR TITLE
Cleaner and faster compiling reflection

### DIFF
--- a/include/glaze/core/meta.hpp
+++ b/include/glaze/core/meta.hpp
@@ -9,6 +9,7 @@
 #include "glaze/util/for_each.hpp"
 #include "glaze/util/type_traits.hpp"
 #include "glaze/util/variant.hpp"
+#include "glaze/reflection/get_name.hpp"
 
 namespace glz
 {
@@ -189,7 +190,7 @@ namespace glz
          static_assert(false_v<T>, "name_v used on unnamed type");
       }
       else {
-         return "glz::unknown";
+         return type_name<std::decay_t<T>>;
       }
    }();
 

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1192,7 +1192,7 @@ namespace glz
                      write_entry_separator<Opts>(ctx, b, ix);
                   }
 
-                  const auto key = get<I>(members).name;
+                  const auto key = get<I>(members);
 
                   write<json>::op<Opts>(key, ctx, b, ix);
                   dump<':'>(b, ix);

--- a/include/glaze/reflection/get_name.hpp
+++ b/include/glaze/reflection/get_name.hpp
@@ -127,7 +127,7 @@ namespace glz
 #if defined(_MSC_VER)
       using T = remove_member_pointer<std::decay_t<decltype(P)>>::type;
       constexpr auto p = P;
-      return get_name_msvc<T, &(external<T>.*p)>();
+      return get_name_msvc<T, &(detail::external<T>.*p)>();
 #else
       // TODO: Use std::source_location when deprecating clang 14
       // std::string_view str = std::source_location::current().function_name();

--- a/include/glaze/reflection/get_name.hpp
+++ b/include/glaze/reflection/get_name.hpp
@@ -55,10 +55,10 @@ namespace glz
 {
    template <auto N, class T>
    static constexpr auto nameof = [] {
-       const auto name = detail::get_name_impl<N, T>;
-       const auto begin = name.find(detail::reflector_end);
-       const auto tmp = name.substr(0, begin);
-       return tmp.substr(tmp.find_last_of(detail::reflector_begin) + 1);
+      constexpr auto name = detail::get_name_impl<N, T>;
+      constexpr auto begin = name.find(detail::reflector_end);
+      constexpr auto tmp = name.substr(0, begin);
+      return tmp.substr(tmp.find_last_of(detail::reflector_begin) + 1);
    }();
 }
 

--- a/include/glaze/reflection/get_name.hpp
+++ b/include/glaze/reflection/get_name.hpp
@@ -7,12 +7,62 @@
 // #include <source_location>
 #include <string_view>
 
+#include "glaze/reflection/to_tuple.hpp"
+
 #if defined(__clang__) || defined(__GNUC__)
 #define GLZ_PRETTY_FUNCTION __PRETTY_FUNCTION__
 #elif defined(_MSC_VER)
 #define GLZ_PRETTY_FUNCTION __FUNCSIG__
 #endif
 
+// For struct fields
+namespace glz::detail
+{
+   template <class T>
+   extern const T external;
+   
+   template <auto Ptr>
+   [[nodiscard]] consteval std::string_view get_mangled_name() {
+      //return std::source_location::current().function_name();
+      return GLZ_PRETTY_FUNCTION;
+   }
+   
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
+   template <auto N, class T>
+   constexpr auto get_name_impl = get_mangled_name<get_ptr<N>(external<T>)>();
+#pragma clang diagnostic pop
+#elif __GNUC__
+   template <auto N, class T>
+   constexpr auto get_name_impl = get_mangled_name<get_ptr<N>(external<T>)>();
+#else
+   template <auto N, class T>
+   constexpr auto get_name_impl = get_mangled_name<get_ptr<N>(external<T>)>();
+#endif
+   
+   struct reflector {
+      int glaze_field;
+   };
+   static constexpr auto reflector_name = detail::get_name_impl<0, reflector>;
+   static constexpr auto reflector_end = reflector_name.substr(
+                                                               reflector_name.find("glaze_field") + sizeof("glaze_field") - 1);
+   static constexpr auto reflector_begin =
+   reflector_name[reflector_name.find("glaze_field") - 1];
+}
+
+namespace glz
+{
+   template <auto N, class T>
+   static constexpr auto nameof = [] {
+       const auto name = detail::get_name_impl<N, T>;
+       const auto begin = name.find(detail::reflector_end);
+       const auto tmp = name.substr(0, begin);
+       return tmp.substr(tmp.find_last_of(detail::reflector_begin) + 1);
+   }();
+}
+
+// For member object pointers
 namespace glz
 {
    template <class T>

--- a/include/glaze/reflection/get_name.hpp
+++ b/include/glaze/reflection/get_name.hpp
@@ -66,9 +66,6 @@ namespace glz
 namespace glz
 {
    template <class T>
-   extern const T fake_object;
-
-   template <class T>
    struct remove_member_pointer
    {
       using type = T;
@@ -107,7 +104,7 @@ namespace glz
 #if defined(_MSC_VER)
       using T = remove_member_pointer<std::decay_t<decltype(P)>>::type;
       constexpr auto p = P;
-      return get_name_msvc<T, &(fake_object<T>.*p)>();
+      return get_name_msvc<T, &(external<T>.*p)>();
 #else
       // TODO: Use std::source_location when deprecating clang 14
       // std::string_view str = std::source_location::current().function_name();

--- a/include/glaze/reflection/get_name.hpp
+++ b/include/glaze/reflection/get_name.hpp
@@ -62,7 +62,11 @@ namespace glz::detail
        static constexpr auto name = get_mangled_name<GLAZE_REFLECTOR>();
        static constexpr auto end =
            name.substr(name.find("GLAZE_REFLECTOR") + sizeof("GLAZE_REFLECTOR") - 1);
-       static constexpr auto begin = name.substr(name.find("glz::detail::GLAZE_REFLECTOR") - 4, 4);
+#if defined(__clang__) || defined(__GNUC__)
+      static constexpr auto begin = "T = ";
+#else
+      static constexpr auto begin = "T = ";
+#endif
    };
 }
 

--- a/include/glaze/reflection/get_name.hpp
+++ b/include/glaze/reflection/get_name.hpp
@@ -62,7 +62,7 @@ namespace glz::detail
        static constexpr auto name = get_mangled_name<GLAZE_REFLECTOR>();
        static constexpr auto end =
            name.substr(name.find("GLAZE_REFLECTOR") + sizeof("GLAZE_REFLECTOR") - 1);
-       static constexpr auto begin = name[name.find("GLAZE_REFLECTOR") - 1];
+       static constexpr auto begin = name.substr(name.find("glz::detail::GLAZE_REFLECTOR") - 4, 4);
    };
 }
 

--- a/include/glaze/reflection/to_tuple.hpp
+++ b/include/glaze/reflection/to_tuple.hpp
@@ -209,11 +209,72 @@ namespace glz
          const T* ptr;
       };
 
-      template <auto N, class T, size_t M = count_members<T>()>
-         requires(M <= 24)
+      template <size_t N, class T, size_t M = count_members<T>()>
+         requires(M <= 26)
       constexpr auto get_ptr(T&& t) noexcept
       {
-         if constexpr (M == 24) {
+         if constexpr (M == 26) {
+            auto&& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22,
+                    p23, p24, p25, p26] = t;
+            // structure bindings is not constexpr :/
+            if constexpr (N == 0) return ptr_t<decltype(p1)>{&p1};
+            if constexpr (N == 1) return ptr_t<decltype(p2)>{&p2};
+            if constexpr (N == 2) return ptr_t<decltype(p3)>{&p3};
+            if constexpr (N == 3) return ptr_t<decltype(p4)>{&p4};
+            if constexpr (N == 4) return ptr_t<decltype(p5)>{&p5};
+            if constexpr (N == 5) return ptr_t<decltype(p6)>{&p6};
+            if constexpr (N == 6) return ptr_t<decltype(p7)>{&p7};
+            if constexpr (N == 7) return ptr_t<decltype(p8)>{&p8};
+            if constexpr (N == 8) return ptr_t<decltype(p9)>{&p9};
+            if constexpr (N == 9) return ptr_t<decltype(p10)>{&p10};
+            if constexpr (N == 10) return ptr_t<decltype(p11)>{&p11};
+            if constexpr (N == 11) return ptr_t<decltype(p12)>{&p12};
+            if constexpr (N == 12) return ptr_t<decltype(p13)>{&p13};
+            if constexpr (N == 13) return ptr_t<decltype(p14)>{&p14};
+            if constexpr (N == 14) return ptr_t<decltype(p15)>{&p15};
+            if constexpr (N == 15) return ptr_t<decltype(p16)>{&p16};
+            if constexpr (N == 16) return ptr_t<decltype(p17)>{&p17};
+            if constexpr (N == 17) return ptr_t<decltype(p18)>{&p18};
+            if constexpr (N == 18) return ptr_t<decltype(p19)>{&p19};
+            if constexpr (N == 19) return ptr_t<decltype(p20)>{&p20};
+            if constexpr (N == 20) return ptr_t<decltype(p21)>{&p21};
+            if constexpr (N == 21) return ptr_t<decltype(p22)>{&p22};
+            if constexpr (N == 22) return ptr_t<decltype(p23)>{&p23};
+            if constexpr (N == 23) return ptr_t<decltype(p24)>{&p24};
+            if constexpr (N == 24) return ptr_t<decltype(p25)>{&p25};
+            if constexpr (N == 25) return ptr_t<decltype(p26)>{&p26};
+         }
+         else if constexpr (M == 25) {
+            auto&& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22,
+                    p23, p24, p25] = t;
+            // structure bindings is not constexpr :/
+            if constexpr (N == 0) return ptr_t<decltype(p1)>{&p1};
+            if constexpr (N == 1) return ptr_t<decltype(p2)>{&p2};
+            if constexpr (N == 2) return ptr_t<decltype(p3)>{&p3};
+            if constexpr (N == 3) return ptr_t<decltype(p4)>{&p4};
+            if constexpr (N == 4) return ptr_t<decltype(p5)>{&p5};
+            if constexpr (N == 5) return ptr_t<decltype(p6)>{&p6};
+            if constexpr (N == 6) return ptr_t<decltype(p7)>{&p7};
+            if constexpr (N == 7) return ptr_t<decltype(p8)>{&p8};
+            if constexpr (N == 8) return ptr_t<decltype(p9)>{&p9};
+            if constexpr (N == 9) return ptr_t<decltype(p10)>{&p10};
+            if constexpr (N == 10) return ptr_t<decltype(p11)>{&p11};
+            if constexpr (N == 11) return ptr_t<decltype(p12)>{&p12};
+            if constexpr (N == 12) return ptr_t<decltype(p13)>{&p13};
+            if constexpr (N == 13) return ptr_t<decltype(p14)>{&p14};
+            if constexpr (N == 14) return ptr_t<decltype(p15)>{&p15};
+            if constexpr (N == 15) return ptr_t<decltype(p16)>{&p16};
+            if constexpr (N == 16) return ptr_t<decltype(p17)>{&p17};
+            if constexpr (N == 17) return ptr_t<decltype(p18)>{&p18};
+            if constexpr (N == 18) return ptr_t<decltype(p19)>{&p19};
+            if constexpr (N == 19) return ptr_t<decltype(p20)>{&p20};
+            if constexpr (N == 20) return ptr_t<decltype(p21)>{&p21};
+            if constexpr (N == 21) return ptr_t<decltype(p22)>{&p22};
+            if constexpr (N == 22) return ptr_t<decltype(p23)>{&p23};
+            if constexpr (N == 23) return ptr_t<decltype(p24)>{&p24};
+            if constexpr (N == 24) return ptr_t<decltype(p25)>{&p25};
+         }
+         else if constexpr (M == 24) {
             auto&& [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22,
                     p23, p24] = t;
             // structure bindings is not constexpr :/

--- a/tests/reflection_test/reflection_test.cpp
+++ b/tests/reflection_test/reflection_test.cpp
@@ -17,6 +17,8 @@ struct my_struct
 
 static_assert(glz::detail::reflectable<my_struct>);
 
+static_assert(glz::name_v<my_struct> == "my_struct");
+
 suite reflection = [] {
    "reflect_write"_test = [] {
       std::string buffer = R"({"i":287,"d":3.14,"hello":"Hello World","arr":[1,2,3]})";


### PR DESCRIPTION
- A more efficient approach for reflection to reduce compile times.
- Added name_v reflection for types, which is used for JSON schema and the shared library API
- Increased the number of allowed fields
- Cleaned up reflection code