### PR TITLE
Simplified object key parsing and fixed issue with key parsing for variants

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -10,7 +10,6 @@
 #include <iterator>
 #include <locale>
 #include <ranges>
-#include <sstream>
 #include <type_traits>
 
 #include "glaze/core/common.hpp"

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1507,9 +1507,9 @@ namespace glz
       }
 
       // Key parsing for meta objects or variants of meta objects.
+      // We do not check for an ending quote, we simply parse up to the quote
       // TODO We could expand this to compiletime known strings in general like enums
       template <class T, auto Opts, string_literal tag = "">
-         requires(Opts.error_on_unknown_keys)
       GLZ_ALWAYS_INLINE std::string_view parse_object_key(is_context auto&& ctx, auto&& it, auto&& end)
       {
          // skip white space and escape characters and find the string
@@ -1534,97 +1534,7 @@ namespace glz
                it = start;
                std::string& static_key = string_buffer();
                read<json>::op<opening_handled<Opts>()>(static_key, ctx, it, end);
-               return static_key;
-            }
-            else [[likely]] {
-               const sv key{start, size_t(it - start)};
-               ++it;
-               return key;
-            }
-         }
-         else if constexpr (std::tuple_size_v<meta_t<T>> > 0) {
-            static constexpr auto stats = key_stats<T, tag>();
-            if constexpr (stats.length_range < 16 && Opts.error_on_unknown_keys) {
-               if ((it + stats.max_length) < end) [[likely]] {
-                  if constexpr (stats.length_range == 0) {
-                     const sv key{it, stats.max_length};
-                     it += stats.max_length;
-                     if (*it != '"') [[unlikely]] {
-                        ctx.error = error_code::unknown_key;
-                     }
-                     ++it;
-                     return key;
-                  }
-                  else if constexpr (stats.length_range == 1) {
-                     auto start = it;
-                     it += stats.min_length;
-                     if (*it == '"') {
-                        const sv key{start, size_t(it - start)};
-                        ++it;
-                        return key;
-                     }
-                     else {
-                        ++it;
-                        const sv key{start, size_t(it - start)};
-                        if (*it != '"') [[unlikely]] {
-                           ctx.error = error_code::unknown_key;
-                        }
-                        ++it;
-                        return key;
-                     }
-                  }
-                  else if constexpr (stats.length_range < 4) {
-                     auto start = it;
-                     it += stats.min_length;
-                     for (const auto e = it + stats.length_range + 1; it < e; ++it) {
-                        if (*it == '"') {
-                           const sv key{start, size_t(it - start)};
-                           ++it;
-                           return key;
-                        }
-                     }
-                     ctx.error = error_code::unknown_key;
-                     return {};
-                  }
-                  else {
-                     return parse_key_cx<stats.min_length, stats.length_range>(ctx, it);
-                  }
-               }
-            }
-         }
-
-         return parse_unescaped_key(ctx, it, end);
-      }
-
-      // This version is for when we do not error on unknown keys
-      // We do not parse the quote here so that we can skip to unknown key handling if it doesn't exist
-      template <class T, opts Opts, string_literal tag = "">
-         requires(!Opts.error_on_unknown_keys)
-      GLZ_ALWAYS_INLINE std::string_view parse_object_key(is_context auto&& ctx, auto&& it, auto&& end)
-      {
-         // skip white space and escape characters and find the string
-         if constexpr (!Opts.ws_handled) {
-            skip_ws<Opts>(ctx, it, end);
-            if (bool(ctx.error)) [[unlikely]]
-               return {};
-         }
-         match<'"'>(ctx, it, end);
-         if (bool(ctx.error)) [[unlikely]]
-            return {};
-
-         if constexpr (keys_may_contain_escape<T>()) {
-            auto start = it;
-
-            skip_till_escape_or_quote(ctx, it, end);
-            if (bool(ctx.error)) [[unlikely]]
-               return {};
-            if (*it == '\\') [[unlikely]] {
-               // we don't optimize this currently because it would increase binary size significantly with the
-               // complexity of generating escaped compile time versions of keys
-               it = start;
-               std::string& static_key = string_buffer();
-               read<json>::op<opening_handled<Opts>()>(static_key, ctx, it, end);
-               --it; // revert the '"'
+               --it; // reveal the quote
                return static_key;
             }
             else [[likely]] {
@@ -1636,9 +1546,9 @@ namespace glz
             if constexpr (stats.length_range < 16) {
                if ((it + stats.max_length) < end) [[likely]] {
                   if constexpr (stats.length_range == 0) {
-                     auto start = it;
+                     const sv key{it, stats.max_length};
                      it += stats.max_length;
-                     return {start, stats.max_length};
+                     return key;
                   }
                   else if constexpr (stats.length_range == 1) {
                      auto start = it;
@@ -1659,18 +1569,18 @@ namespace glz
                            return {start, size_t(it - start)};
                         }
                      }
-                     return {start, size_t(it - start - 1)};
+                     return {start, size_t(it - start)};
                   }
                   else {
-                     return parse_key_cx<Opts, stats.min_length, stats.length_range>(it);
+                     return parse_key_cx<stats.min_length, stats.length_range>(it);
                   }
                }
             }
          }
-
-         const sv key = parse_unescaped_key(ctx, it, end);
-         --it; // rewind to expose the quote
-         return key;
+         
+         auto start = it;
+         skip_till_quote(ctx, it, end);
+         return {start, size_t(it - start)};
       }
 
       template <pair_t T>
@@ -1826,6 +1736,12 @@ namespace glz
                      // whitespace and the colon must run after checking if the key exists
 
                      if constexpr (Opts.error_on_unknown_keys) {
+                        if (*it != '"') [[unlikely]] {
+                           ctx.error = error_code::unknown_key;
+                           return;
+                        }
+                        ++it;
+                        
                         static constexpr auto frozen_map = detail::make_map<T, Opts.use_hash_comparison>();
                         if (const auto& member_it = frozen_map.find(key); member_it != frozen_map.end()) [[likely]] {
                            parse_object_entry_sep<Opts>(ctx, it, end);
@@ -2150,6 +2066,9 @@ namespace glz
                               return;
                         }
                         const sv key = parse_object_key<T, Opts, tag_literal>(ctx, it, end);
+                        if (bool(ctx.error)) [[unlikely]]
+                           return;
+                        match<'"'>(ctx, it, end);
                         if (bool(ctx.error)) [[unlikely]]
                            return;
 
@@ -2496,6 +2415,9 @@ namespace glz
                      const sv key = parse_object_key<T, ws_handled<Opts>(), tag>(ctx, it, end);
                      if (bool(ctx.error)) [[unlikely]]
                         return;
+                     match<'"'>(ctx, it, end);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
 
                      if constexpr (Opts.error_on_unknown_keys) {
                         if constexpr (tag.sv().empty()) {
@@ -2521,6 +2443,9 @@ namespace glz
                   }
                   else {
                      const sv key = parse_object_key<T, ws_handled<Opts>(), tag>(ctx, it, end);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                     match<'"'>(ctx, it, end);
                      if (bool(ctx.error)) [[unlikely]]
                         return;
 

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -125,12 +125,8 @@ namespace glz::detail
    }
 
    template <opts Opts>
-   GLZ_ALWAYS_INLINE void skip_ws(is_context auto&& ctx, auto&& it, auto&& end) noexcept
+   GLZ_ALWAYS_INLINE void skip_ws_no_pre_check(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
-      if (bool(ctx.error)) [[unlikely]] {
-         return;
-      }
-
       while (true) {
          switch (*it) {
          case '\t':
@@ -159,33 +155,13 @@ namespace glz::detail
    }
 
    template <opts Opts>
-   GLZ_ALWAYS_INLINE void skip_ws_no_pre_check(is_context auto&& ctx, auto&& it, auto&& end) noexcept
+   GLZ_ALWAYS_INLINE void skip_ws(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
-      while (true) {
-         switch (*it) {
-         case '\t':
-         case '\n':
-         case '\r':
-         case ' ':
-            ++it;
-            break;
-         case '/': {
-            if constexpr (Opts.force_conformance) {
-               ctx.error = error_code::syntax_error;
-               return;
-            }
-            else {
-               skip_comment(ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]] {
-                  return;
-               }
-               break;
-            }
-         }
-         default:
-            return;
-         }
+      if (bool(ctx.error)) [[unlikely]] {
+         return;
       }
+
+      skip_ws_no_pre_check<Opts>(ctx, it, end);
    }
 
    GLZ_ALWAYS_INLINE void skip_till_escape_or_quote(is_context auto&& ctx, auto&& it, auto&& end) noexcept
@@ -436,14 +412,14 @@ namespace glz::detail
                   }
                   continue;
                }
-                  [[unlikely]] default:
-                  {
-                     ctx.error = error_code::syntax_error;
-                     return;
-                  }
+               [[unlikely]] default: {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
                }
             }
-               [[likely]] default : ++it;
+            [[likely]] default:
+               ++it;
             }
          }
       }

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -239,71 +239,6 @@ namespace glz::detail
 
    // very similar code to skip_till_quote, but it consumes the iterator and returns the key
    template <uint32_t MinLength, uint32_t LengthRange>
-   [[nodiscard]] GLZ_ALWAYS_INLINE const sv parse_key_cx(is_context auto&& ctx, auto&& it) noexcept
-   {
-      static_assert(std::contiguous_iterator<std::decay_t<decltype(it)>>);
-
-      auto start = it;
-      it += MinLength; // immediately skip minimum length
-
-      static_assert(LengthRange < 16);
-      if constexpr (LengthRange == 7) {
-         uint64_t chunk; // no need to default initialize
-         std::memcpy(&chunk, it, 8);
-         const uint64_t test_chunk = has_quote(chunk);
-         if (test_chunk != 0) [[likely]] {
-            it += (std::countr_zero(test_chunk) >> 3);
-
-            sv ret{start, size_t(it - start)};
-            ++it;
-            return ret;
-         }
-      }
-      else if constexpr (LengthRange > 7) {
-         uint64_t chunk; // no need to default initialize
-         std::memcpy(&chunk, it, 8);
-         uint64_t test_chunk = has_quote(chunk);
-         if (test_chunk != 0) {
-            it += (std::countr_zero(test_chunk) >> 3);
-
-            sv ret{start, size_t(it - start)};
-            ++it;
-            return ret;
-         }
-         else {
-            it += 8;
-            static constexpr auto rest = LengthRange + 1 - 8;
-            chunk = 0; // must zero out the chunk
-            std::memcpy(&chunk, it, rest);
-            test_chunk = has_quote(chunk);
-            if (test_chunk != 0) {
-               it += (std::countr_zero(test_chunk) >> 3);
-
-               sv ret{start, size_t(it - start)};
-               ++it;
-               return ret;
-            }
-         }
-      }
-      else {
-         uint64_t chunk{};
-         std::memcpy(&chunk, it, LengthRange + 1);
-         const uint64_t test_chunk = has_quote(chunk);
-         if (test_chunk != 0) [[likely]] {
-            it += (std::countr_zero(test_chunk) >> 3);
-
-            sv ret{start, size_t(it - start)};
-            ++it;
-            return ret;
-         }
-      }
-
-      ctx.error = error_code::unknown_key;
-      return {};
-   }
-
-   template <opts Opts, uint32_t MinLength, uint32_t LengthRange>
-      requires(!Opts.error_on_unknown_keys)
    [[nodiscard]] GLZ_ALWAYS_INLINE const sv parse_key_cx(auto&& it) noexcept
    {
       static_assert(std::contiguous_iterator<std::decay_t<decltype(it)>>);
@@ -355,7 +290,7 @@ namespace glz::detail
          }
       }
 
-      return {it, size_t(it - start)};
+      return {start, size_t(it - start)};
    }
 
    template <opts Opts>

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -157,11 +157,9 @@ namespace glz::detail
    template <opts Opts>
    GLZ_ALWAYS_INLINE void skip_ws(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
-      if (bool(ctx.error)) [[unlikely]] {
-         return;
+      if (ctx.error == error_code::none) [[likely]] {
+         skip_ws_no_pre_check<Opts>(ctx, it, end);
       }
-
-      skip_ws_no_pre_check<Opts>(ctx, it, end);
    }
 
    GLZ_ALWAYS_INLINE void skip_till_escape_or_quote(is_context auto&& ctx, auto&& it, auto&& end) noexcept


### PR DESCRIPTION
A failing test case was added. 
The issue stems from the fact that the two overloads of `parse_object_key` have different behaviour for the closing quote. 
I would say that it's a mistake to have this changing behviour, as all callers of `parse_objet_key` then need to offer subsequent code to match both overloads.

@stephenberry  looking into solutions now

