### PR TITLE
Support equality comparison on opts

### DIFF
--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -37,6 +37,8 @@ namespace glz
       bool ws_handled = false; // whitespace has already been parsed
       bool no_header = false; // whether or not a binary header is needed
       bool write_unknown = true; // whether to write unkwown fields
+
+      [[nodscard]] constexpr bool operator==(const opts&) const noexcept = default;
    };
 
    template <opts Opts>

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -38,7 +38,7 @@ namespace glz
       bool no_header = false; // whether or not a binary header is needed
       bool write_unknown = true; // whether to write unkwown fields
 
-      [[nodscard]] constexpr bool operator==(const opts&) const noexcept = default;
+      [[nodiscard]] constexpr bool operator==(const opts&) const noexcept = default;
    };
 
    template <opts Opts>


### PR DESCRIPTION
The compelling use case is where serialized JSON is already available, as generated with a given set of opts, and it's to be determined whether the available JSON can be reused or should be regenerated.
