### PR TITLE
Member function const support

### DIFF
--- a/include/glaze/util/type_traits.hpp
+++ b/include/glaze/util/type_traits.hpp
@@ -67,11 +67,23 @@ namespace glz
       using type = Result (*)(void*, std::decay_t<Args>&&...);
    };
 
+   template <class ClassType, class Result, class... Args>
+   struct function_signature<Result (ClassType::*)(Args...) const>
+   {
+      using type = Result (*)(void*, std::decay_t<Args>&&...);
+   };
+
    template <class T>
    struct std_function_signature;
 
    template <class ClassType, class Result, class... Args>
    struct std_function_signature<Result (ClassType::*)(Args...)>
+   {
+      using type = std::function<Result(Args...)>;
+   };
+
+   template <class ClassType, class Result, class... Args>
+   struct std_function_signature<Result (ClassType::*)(Args...) const>
    {
       using type = std::function<Result(Args...)>;
    };
@@ -95,11 +107,23 @@ namespace glz
       using type = std::function<Result(keep_non_const_ref_t<Args>...)>;
    };
 
+   template <class ClassType, class Result, class... Args>
+   struct std_function_signature_decayed_keep_non_const_ref<Result (ClassType::*)(Args...) const>
+   {
+      using type = std::function<Result(keep_non_const_ref_t<Args>...)>;
+   };
+
    template <class T>
    struct return_type;
 
    template <class ClassType, class Result, class... Args>
    struct return_type<Result (ClassType::*)(Args...)>
+   {
+      using type = Result;
+   };
+
+   template <class ClassType, class Result, class... Args>
+   struct return_type<Result (ClassType::*)(Args...) const>
    {
       using type = Result;
    };
@@ -113,11 +137,23 @@ namespace glz
       using type = std::tuple<Args...>;
    };
 
+   template <class ClassType, class Result, class... Args>
+   struct inputs_as_tuple<Result (ClassType::*)(Args...) const>
+   {
+      using type = std::tuple<Args...>;
+   };
+
    template <class T>
    struct parent_of_fn;
 
    template <class ClassType, class Result, class... Args>
    struct parent_of_fn<Result (ClassType::*)(Args...)>
+   {
+      using type = ClassType;
+   };
+
+   template <class ClassType, class Result, class... Args>
+   struct parent_of_fn<Result (ClassType::*)(Args...) const>
    {
       using type = ClassType;
    };
@@ -133,6 +169,16 @@ namespace glz
 
    template <auto MemPtr, class T, class R, class... Args>
    struct arguments<MemPtr, R (T::*)(Args...)>
+   {
+      static constexpr auto op(void* ptr, std::decay_t<Args>&&... args)
+         -> std::invoke_result_t<decltype(std::mem_fn(MemPtr)), T, Args...>
+      {
+         return (reinterpret_cast<T*>(ptr)->*MemPtr)(std::forward<Args>(args)...);
+      }
+   };
+
+   template <auto MemPtr, class T, class R, class... Args>
+   struct arguments<MemPtr, R (T::*)(Args...) const>
    {
       static constexpr auto op(void* ptr, std::decay_t<Args>&&... args)
          -> std::invoke_result_t<decltype(std::mem_fn(MemPtr)), T, Args...>

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -5611,6 +5611,35 @@ suite custom_buffer_input_test = [] {
    };
 };
 
+class class_with_const_mem_func
+{
+public:
+  int get_i() const { return i; }  // This only works if it's non-const
+  void set_i(int I) { i = I; }
+
+private:
+  int i = 0;
+};
+
+template <>
+struct glz::meta<class_with_const_mem_func>
+{
+   using T = class_with_const_mem_func;
+  static constexpr auto value = object("i", custom<&T::set_i, &T::get_i>);
+};
+
+suite const_mem_func_tests = [] {
+   "const_mem_func"_test = [] {
+      class_with_const_mem_func obj{};
+      std::string s = R"({"i":55})";
+      expect(!glz::read_json(obj, s));
+      expect(obj.get_i() == 55);
+      s.clear();
+      glz::write_json(obj, s);
+      expect(s == R"({"i":55})");
+   };
+};
+
 struct client_state
 {
    uint64_t id{};


### PR DESCRIPTION
Found an issue where custom read/write was not accepting a `const` getter member function. Added more specialization that takes in `const` member function in `type_traits.hpp`
Eg.
```C++
class Foo
{
public:
  int get_i() const { return i; }  // This only works if it's non-const
  void set_i(int I) { i = I; }

private:
  int i = 0;
};

template <>
struct glz::meta<Foo>
{
  static constexpr auto value = object("i", custom<&Foo::set_i, &Foo::get_i>);
};

// The above snippet would not compile in the latest release
```