### PR TITLE
Fix writing maps with internally skipped null members

### DIFF
--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -542,21 +542,18 @@ namespace glz
                };
 
                auto it = std::begin(value);
-               [[maybe_unused]] bool previous_skipped = write_first_entry(it);
-               const auto fin = std::end(value);
-               for (++it; it != fin; ++it) {
+               [[maybe_unused]] bool starting = write_first_entry(it);
+               for (++it; it != std::end(value); ++it) {
                   const auto& [key, entry_val] = *it;
                   if (skip_member<Opts>(entry_val)) {
-                     previous_skipped = true;
                      continue;
                   }
 
                   // When Opts.skip_null_members, *any* entry may be skipped, meaning separator dumping must be
                   // conditional for every entry. Avoid this branch when not skipping null members.
-                  // Alternatively, write separator after each entry, except on last entry but then branch is
-                  // permanent
+                  // Alternatively, write separator after each entry except last but then branch is permanent
                   if constexpr (Opts.skip_null_members) {
-                     if (!previous_skipped) {
+                     if (!starting) {
                         write_entry_separator<Opts>(ctx, args...);
                      }
                   }
@@ -565,7 +562,7 @@ namespace glz
                   }
 
                   write_pair_content<Opts>(key, entry_val, ctx, args...);
-                  previous_skipped = false;
+                  starting = false;
                }
 
                if constexpr (!Opts.closing_handled) {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -1985,13 +1985,14 @@ suite write_tests = [] {
 
    "Write map"_test = [] {
       std::string s;
-      std::map<std::string, double> m{{"a", 2.2}, {"b", 11.111}, {"c", 211.2}};
+      const std::map<std::string, double> m{{"a", 2.2}, {"b", 11.111}, {"c", 211.2}};
       glz::write_json(m, s);
       expect(s == R"({"a":2.2,"b":11.111,"c":211.2})");
 
-      std::map<std::string, std::optional<double>> nullable{{"a", std::nullopt}, {"b", std::nullopt}, {"c", 211.2}};
+      const std::map<std::string, std::optional<double>> nullable{
+         {"a", std::nullopt}, {"b", 13.4}, {"c", std::nullopt}, {"d", 211.2}, {"e", std::nullopt}};
       glz::write_json(nullable, s);
-      expect(s == glz::sv{R"({"c":211.2})"});
+      expect(s == glz::sv{R"({"b":13.4,"d":211.2})"});
    };
 
    "Write pair"_test =


### PR DESCRIPTION
Previously, invalid JSON was serialized for `writable_map`s when "internal" nulls were skipped. 
Commas were missed for every entry following a skipped entry, producing JSON like `{"hello":4"there":"bob"}`.

The logic previously wrote entry separators when the previous entry was **not** skipped. However, as soon as the first entry is written, an entry separator can be written in front of every subsequent entry. The serialization only needs to avoid these separators while it's starting the object - i.e skipping **leading** entries - meaning only a `{` has been serialized. After that, no matter how many internal entries are skipped, there's always a serialized entry that needs separation.

