### PR TITLE
Fall back to inclusion check of `<dlfcn.h>` and assume unix-like os for shared lib extension and prefix

### DIFF
--- a/include/glaze/api/lib.hpp
+++ b/include/glaze/api/lib.hpp
@@ -29,7 +29,7 @@
 #include <dlfcn.h>
 #define SHARED_LIBRARY_EXTENSION ".dylib"
 #define SHARED_LIBRARY_PREFIX "lib"
-#elif __linux__
+#elif __has_include(<dlfcn.h>)
 #include <dlfcn.h>
 #define SHARED_LIBRARY_EXTENSION ".so"
 #define SHARED_LIBRARY_PREFIX "lib"


### PR DESCRIPTION
I'm [packaging](https://github.com/build2-packaging/glaze) this for [build2](https://www.build2.org) and when pushing to its CI servers I noticed FreeBSD failing, see [here](https://ci.stage.build2.org/@869a3194-af30-42e0-a514-6bf49380a0d7?builds=&pv=&th=*&tg=&tc=&pc=&rs=error).
See [here](https://ci.stage.build2.org/@869a3194-af30-42e0-a514-6bf49380a0d7?builds=&pv=&th=*&tg=&tc=&pc=&rs=error) for the rest of the failing builds (most of them failing because of a bug in Clang that gets triggered by `<ranges>` or another bug in `msvc`with the use of `using-alias` inside lambdas).

Can't test FreeBSD myself but I figured this change seems sane enough regardless.