### PR TITLE
workaround to fix msvc compilation error

### DIFF
--- a/include/glaze/csv/write.hpp
+++ b/include/glaze/csv/write.hpp
@@ -205,7 +205,7 @@ namespace glz
                   using Element = glaze_tuple_element<I, N, T>;
                   static constexpr size_t member_index = Element::member_index;
 
-                  using item_type = std::decay_t<typename Element::type>;
+                  using item_type = typename std::decay<typename Element::type>::type;
                   using value_type = typename item_type::value_type;
 
                   static constexpr sv key = key_name<I, T, Element::use_reflection>;


### PR DESCRIPTION
Thank a lot for developing great library.
I met compilation error on at least one version of MSVC.

MSVC: 19.36.32532.0
MSBuild: 17.6.3+07e294721

```
\include\expected(12): warning STL4038: The contents of <expected> are available only with C++23 or later.
\include\glaze/csv/write.hpp(208,59): error C2653: 'Element': is not a class or namespace name
\include\glaze/csv/write.hpp(181,22): message : This diagnostic occurred in the compiler generated function 'void glz::detail::to_csv<T>::op(_T0 &&,_T1 &&,B &&,_T2 &&) noexcept' 
\include\glaze/csv/write.hpp(352,8): message : see reference to class template instantiation 'glz::detail::to_csv<T>' being compiled 
```
full version is [here](https://c3i.jfrog.io/c3i/misc-v2/logs/pr/21748/3-windows-msvc/glaze/1.9.7//da39a3ee5e6b4b0d3255bfef95601890afd80709-test.txt)

But It works fine on MSVC 19.37.32824.0.
It seems to be a MSVC bug which has been fixed already.

I have found a workaround for this error and have created a PR.
However, it is an ad hoc workaround for a bug that has already been fixed in the latest MSVC.

I leave it to your judgment whether it could be merged.
