### PR TITLE
Added structs_as_arrays option for binary

### DIFF
--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -722,7 +722,41 @@ namespace glz
          requires glaze_object_t<T> || reflectable<T>
       struct from_binary<T> final
       {
-         template <auto Opts>
+         template <auto Opts> requires (Opts.structs_as_arrays == true)
+         GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         {
+            if constexpr (reflectable<T>) {
+               auto t = to_tuple(value);
+               read<binary>::op<Opts>(t, ctx, it, end);
+            }
+            else {
+               const auto tag = uint8_t(*it);
+               if (tag != tag::generic_array) [[unlikely]] {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
+               ++it;
+
+               skip_compressed_int(it, end);
+
+               using V = std::decay_t<T>;
+               for_each<std::tuple_size_v<V>>([&](auto I) { read<binary>::op<Opts>(std::get<I>(value), ctx, it, end); });
+               
+               using V = std::decay_t<T>;
+               static constexpr auto N = std::tuple_size_v<meta_t<V>>;
+               skip_compressed_int(it, end);
+               
+               for_each<N>([&](auto I) {
+                  static constexpr auto item = get<I>(meta_v<V>);
+                  using T0 = std::decay_t<decltype(get<0>(item))>;
+                  static constexpr bool use_reflection = std::is_member_object_pointer_v<T0>;
+                  static constexpr auto member_index = use_reflection ? 0 : 1;
+                  read<binary>::op<Opts>(get_member(value, get<member_index>(item)), ctx, it, end);
+               });
+            }
+         }
+         
+         template <auto Opts> requires (Opts.structs_as_arrays == false)
          GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
             constexpr uint8_t type = 0; // string key

--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -871,7 +871,7 @@ namespace glz
       return value;
    }
 
-   template <class T>
+   template <opts Opts = opts{}, class T>
    [[nodiscard]] inline parse_error read_file_binary(T& value, const sv file_name, auto&& buffer) noexcept
    {
       context ctx{};
@@ -883,6 +883,6 @@ namespace glz
          return parse_error{file_error};
       }
 
-      return read<opts{.format = binary}>(value, buffer, ctx);
+      return read<set_binary<Opts>()>(value, buffer, ctx);
    }
 }

--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -736,11 +736,6 @@ namespace glz
                   return;
                }
                ++it;
-
-               skip_compressed_int(it, end);
-
-               using V = std::decay_t<T>;
-               for_each<std::tuple_size_v<V>>([&](auto I) { read<binary>::op<Opts>(std::get<I>(value), ctx, it, end); });
                
                using V = std::decay_t<T>;
                static constexpr auto N = std::tuple_size_v<meta_t<V>>;

--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -885,4 +885,27 @@ namespace glz
 
       return read<set_binary<Opts>()>(value, buffer, ctx);
    }
+   
+   template <class T, class Buffer>
+   [[nodiscard]] inline parse_error read_binary_untagged(T&& value, Buffer&& buffer) noexcept
+   {
+      return read<opts{.format = binary, .structs_as_arrays = true}>(std::forward<T>(value), std::forward<Buffer>(buffer));
+   }
+
+   template <class T, class Buffer>
+   [[nodiscard]] inline expected<T, parse_error> read_binary_untagged(Buffer&& buffer) noexcept
+   {
+      T value{};
+      const auto pe = read<opts{.format = binary, .structs_as_arrays = true}>(value, std::forward<Buffer>(buffer));
+      if (pe) [[unlikely]] {
+         return unexpected(pe);
+      }
+      return value;
+   }
+   
+   template <opts Opts = opts{}, class T>
+   [[nodiscard]] inline parse_error read_file_binary_untagged(T& value, const std::string& file_name, auto&& buffer) noexcept
+   {
+      return read_file_binary<opt_on<Opts, &opts::structs_as_arrays>()>(value, file_name, buffer);
+   }
 }

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -631,13 +631,13 @@ namespace glz
    }
 
    template <class T, class Buffer>
-   inline void write_binary(T&& value, Buffer&& buffer)
+   inline void write_binary(T&& value, Buffer&& buffer) noexcept
    {
       write<opts{.format = binary}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
    template <class T>
-   inline auto write_binary(T&& value)
+   inline auto write_binary(T&& value) noexcept
    {
       std::string buffer{};
       write<opts{.format = binary}>(std::forward<T>(value), buffer);
@@ -738,7 +738,7 @@ namespace glz
    }
 
    template <auto& Partial, class T, class Buffer>
-   inline auto write_binary(T&& value, Buffer&& buffer)
+   inline auto write_binary(T&& value, Buffer&& buffer) noexcept
    {
       return write<Partial, opts{.format = binary}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
@@ -761,5 +761,25 @@ namespace glz
       }
 
       return {};
+   }
+   
+   template <class T, class Buffer>
+   inline void write_binary_untagged(T&& value, Buffer&& buffer) noexcept
+   {
+      write<opts{.format = binary, .structs_as_arrays = true}>(std::forward<T>(value), std::forward<Buffer>(buffer));
+   }
+
+   template <class T>
+   inline auto write_binary_untagged(T&& value) noexcept
+   {
+      std::string buffer{};
+      write<opts{.format = binary, .structs_as_arrays = true}>(std::forward<T>(value), buffer);
+      return buffer;
+   }
+   
+   template <opts Opts = opts{}, class T>
+   [[nodiscard]] inline write_error write_file_binary_untagged(T&& value, const std::string& file_name, auto&& buffer) noexcept
+   {
+      return write_file_binary<opt_on<Opts, &opts::structs_as_arrays>>(std::forward<T>(value), file_name, buffer);
    }
 }

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -744,12 +744,12 @@ namespace glz
    }
 
    // std::string file_name needed for std::ofstream
-   template <class T>
+   template <opts Opts = opts{}, class T>
    [[nodiscard]] inline write_error write_file_binary(T&& value, const std::string& file_name, auto&& buffer) noexcept
    {
       static_assert(sizeof(decltype(*buffer.data())) == 1);
-
-      write<opts{.format = binary}>(std::forward<T>(value), buffer);
+      
+      write<set_binary<Opts>()>(std::forward<T>(value), buffer);
 
       std::ofstream file(file_name, std::ios::binary);
 

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -129,4 +129,20 @@ namespace glz
       ret.write_unknown = true;
       return ret;
    }
+   
+   template <opts Opts>
+   constexpr auto set_binary()
+   {
+      opts ret = Opts;
+      ret.format = binary;
+      return ret;
+   }
+   
+   template <opts Opts>
+   constexpr auto set_json()
+   {
+      opts ret = Opts;
+      ret.format = json;
+      return ret;
+   }
 }

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -30,6 +30,7 @@ namespace glz
       bool number = false; // read numbers as strings and write these string as numbers
       bool raw = false; // write out string like values without quotes
       bool raw_string = false; // do not decode/encode escaped characters for strings (improves read/write performance)
+      bool structs_as_arrays = false; // Handle structs (reading/writing) without keys, which applies to reflectable and glaze_object_t concepts
 
       // INTERNAL USE
       bool opening_handled = false; // the opening character has been handled

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2297,6 +2297,6 @@ namespace glz
          return {ec};
       }
 
-      return read<Opts>(value, buffer, ctx);
+      return read<set_json<Opts>()>(value, buffer, ctx);
    }
 }

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1183,10 +1183,10 @@ namespace glz
       return buffer;
    }
 
-   template <class T>
+   template <opts Opts = opts{}, class T>
    [[nodiscard]] inline write_error write_file_json(T&& value, const std::string& file_name, auto&& buffer) noexcept
    {
-      write<opts{}>(std::forward<T>(value), buffer);
+      write<set_json<Opts>()>(std::forward<T>(value), buffer);
       return {buffer_to_file(buffer, file_name)};
    }
 }

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -1356,6 +1356,28 @@ suite example_reflection_without_keys_test = [] {
    };
 };
 
+suite my_struct_without_keys_test = [] {
+   "my_struct_without_keys"_test = [] {
+      std::string without_keys;
+      my_struct obj{.i = 55, .d = 3.14};
+      constexpr glz::opts options{.format = glz::binary, .structs_as_arrays = true};
+      glz::write<options>(obj, without_keys);
+      
+      std::string with_keys;
+      glz::write_binary(obj, with_keys);
+      
+      expect(without_keys.find("hello") == std::string::npos);
+      expect(with_keys.find("hello") != std::string::npos);
+      expect(without_keys != with_keys);
+      
+      obj = {};
+      expect(!glz::read<options>(obj, without_keys));
+      
+      expect(obj.i == 55);
+      expect(obj.d == 3.14);
+   };
+};
+
 int main()
 {
    write_tests();

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -1334,6 +1334,28 @@ suite example_reflection_test = [] {
    };
 };
 
+suite example_reflection_without_keys_test = [] {
+   "example_reflection_without_keys"_test = [] {
+      std::string without_keys;
+      my_example obj{.i = 55, .d = 3.14};
+      constexpr glz::opts options{.format = glz::binary, .structs_as_arrays = true};
+      glz::write<options>(obj, without_keys);
+      
+      std::string with_keys;
+      glz::write_binary(obj, with_keys);
+      
+      expect(without_keys.find("hello") == std::string::npos);
+      expect(with_keys.find("hello") != std::string::npos);
+      expect(without_keys != with_keys);
+      
+      obj = {};
+      expect(!glz::read<options>(obj, without_keys));
+      
+      expect(obj.i == 55);
+      expect(obj.d == 3.14);
+   };
+};
+
 int main()
 {
    write_tests();

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -1337,7 +1337,7 @@ suite example_reflection_test = [] {
 suite example_reflection_without_keys_test = [] {
    "example_reflection_without_keys"_test = [] {
       std::string without_keys;
-      my_example obj{.i = 55, .d = 3.14};
+      my_example obj{.i = 55, .d = 3.14, .hello = "happy"};
       constexpr glz::opts options{.format = glz::binary, .structs_as_arrays = true};
       glz::write<options>(obj, without_keys);
       
@@ -1353,13 +1353,14 @@ suite example_reflection_without_keys_test = [] {
       
       expect(obj.i == 55);
       expect(obj.d == 3.14);
+      expect(obj.hello == "happy");
    };
 };
 
 suite my_struct_without_keys_test = [] {
    "my_struct_without_keys"_test = [] {
       std::string without_keys;
-      my_struct obj{.i = 55, .d = 3.14};
+      my_struct obj{.i = 55, .d = 3.14, .hello = "happy"};
       constexpr glz::opts options{.format = glz::binary, .structs_as_arrays = true};
       glz::write<options>(obj, without_keys);
       
@@ -1375,6 +1376,7 @@ suite my_struct_without_keys_test = [] {
       
       expect(obj.i == 55);
       expect(obj.d == 3.14);
+      expect(obj.hello == "happy");
    };
 };
 

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -1355,6 +1355,26 @@ suite example_reflection_without_keys_test = [] {
       expect(obj.d == 3.14);
       expect(obj.hello == "happy");
    };
+   
+   "example_reflection_without_keys"_test = [] {
+      std::string without_keys;
+      my_example obj{.i = 55, .d = 3.14, .hello = "happy"};
+      glz::write_binary_untagged(obj, without_keys);
+      
+      std::string with_keys;
+      glz::write_binary(obj, with_keys);
+      
+      expect(without_keys.find("hello") == std::string::npos);
+      expect(with_keys.find("hello") != std::string::npos);
+      expect(without_keys != with_keys);
+      
+      obj = {};
+      expect(!glz::read_binary_untagged(obj, without_keys));
+      
+      expect(obj.i == 55);
+      expect(obj.d == 3.14);
+      expect(obj.hello == "happy");
+   };
 };
 
 suite my_struct_without_keys_test = [] {


### PR DESCRIPTION
This adds the option `structs_as_arrays` for binary output that is untagged. `write_binary_untagged` and `read_binary_untagged` helper functions have been added.