### PR TITLE
support file_include and hostname_include in structs

### DIFF
--- a/include/glaze/file/hostname_include.hpp
+++ b/include/glaze/file/hostname_include.hpp
@@ -33,14 +33,17 @@ namespace glz
 
    // Register this with an object to allow file including based on the hostname
    // This is useful for configuration files that should be specific to a host
-   struct hostname_include
+   struct hostname_include final
    {
-      constexpr decltype(auto) operator()(auto&& value) const
-      {
-         return detail::hostname_includer<std::decay_t<decltype(value)>>{value};
-      }
-
+      bool reflection_helper{}; // needed for count_members
       static constexpr auto glaze_includer = true;
+      static constexpr auto reflect = false;
+      
+      constexpr decltype(auto) operator()(auto&& value) const noexcept
+      {
+         using V = std::decay_t<decltype(value)>;
+         return detail::hostname_includer<V>{value};
+      }
    };
 
    namespace detail
@@ -82,7 +85,7 @@ namespace glz
       struct from_json<hostname_includer<T>>
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
             std::string& path = string_buffer();
             read<json>::op<Opts>(path, ctx, it, end);

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1241,7 +1241,7 @@ namespace glz
       struct from_json<includer<T>>
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
             std::string& path = string_buffer();
             read<json>::op<Opts>(path, ctx, it, end);

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -6434,44 +6434,42 @@ suite custom_object_variant_test = [] {
 
 struct hostname_include_struct
 {
+   glz::hostname_include hostname_include{};
    std::string str = "Hello";
    int i = 55;
 };
 
-template <>
-struct glz::meta<hostname_include_struct>
-{
-   using T = hostname_include_struct;
-   static constexpr auto value = object("#hostname_include", glz::hostname_include{}, "str", &T::str, "i", &T::i);
-};
+static_assert(glz::detail::count_members<hostname_include_struct> == 3);
 
 suite hostname_include_test = [] {
-   hostname_include_struct obj{};
+   "hostname_include"_test = [] {
+      hostname_include_struct obj{};
 
-   glz::context ctx{};
-   const auto hostname = glz::detail::get_hostname(ctx);
+      glz::context ctx{};
+      const auto hostname = glz::detail::get_hostname(ctx);
 
-   std::string file_name = "../{}_config.json";
-   glz::detail::replace_first_braces(file_name, hostname);
+      std::string file_name = "../{}_config.json";
+      glz::detail::replace_first_braces(file_name, hostname);
 
-   expect(glz::write_file_json(obj, file_name, std::string{}) == glz::error_code::none);
+      expect(glz::write_file_json(obj, file_name, std::string{}) == glz::error_code::none);
 
-   obj.str = "";
-   obj.i = 0;
+      obj.str = "";
+      obj.i = 0;
 
-   std::string s = R"({"#hostname_include": "../{}_config.json", "i": 100})";
-   const auto ec = glz::read_json(obj, s);
-   expect(ec == glz::error_code::none) << glz::format_error(ec, s);
+      std::string s = R"({"hostname_include": "../{}_config.json", "i": 100})";
+      const auto ec = glz::read_json(obj, s);
+      expect(ec == glz::error_code::none) << glz::format_error(ec, s);
 
-   expect(obj.str == "Hello") << obj.str;
-   expect(obj.i == 100) << obj.i;
+      expect(obj.str == "Hello") << obj.str;
+      expect(obj.i == 100) << obj.i;
 
-   obj.str = "";
+      obj.str = "";
 
-   std::string buffer{};
-   glz::read_file_json(obj, file_name, buffer);
-   expect(obj.str == "Hello") << obj.str;
-   expect(obj.i == 55) << obj.i;
+      std::string buffer{};
+      glz::read_file_json(obj, file_name, buffer);
+      expect(obj.str == "Hello") << obj.str;
+      expect(obj.i == 55) << obj.i;
+   };
 };
 
 enum class some_enum {


### PR DESCRIPTION
This merge adds the generic ability to use invocable structs on the parent within reflectable structs. This means that we can add helpers like `glz::file_include` to structs and reflect on them.