### PR TITLE
Using glaze_reflect rather than reflect

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -48,7 +48,7 @@ namespace glz
    struct obj final
    {
       glz::tuplet::tuple<std::conditional_t<std::is_convertible_v<std::decay_t<T>, sv>, sv, T>...> value;
-      static constexpr auto reflect = false;
+      static constexpr auto glaze_reflect = false;
    };
 
    template <class... T>
@@ -58,7 +58,7 @@ namespace glz
    struct obj_copy final
    {
       glz::tuplet::tuple<T...> value;
-      static constexpr auto reflect = false;
+      static constexpr auto glaze_reflect = false;
    };
 
    template <class... T>
@@ -68,7 +68,7 @@ namespace glz
    struct arr final
    {
       glz::tuplet::tuple<std::conditional_t<std::is_convertible_v<std::decay_t<T>, sv>, sv, T>...> value;
-      static constexpr auto reflect = false;
+      static constexpr auto glaze_reflect = false;
    };
 
    template <class... T>
@@ -88,7 +88,7 @@ namespace glz
    struct merge final
    {
       glz::tuplet::tuple<std::conditional_t<std::is_convertible_v<std::decay_t<T>, sv>, sv, T>...> value;
-      static constexpr auto reflect = false;
+      static constexpr auto glaze_reflect = false;
    };
 
    template <class... T>
@@ -143,7 +143,7 @@ namespace glz
    {
       bool reflection_helper{}; // needed for count_members
       static constexpr auto glaze_includer = true;
-      static constexpr auto reflect = false;
+      static constexpr auto glaze_reflect = false;
 
       constexpr decltype(auto) operator()(auto&& value) const noexcept
       {
@@ -476,7 +476,7 @@ namespace glz
       };
 
       template <class T>
-      concept is_no_reflect = requires(T t) { requires T::reflect == false; };
+      concept is_no_reflect = requires(T t) { requires T::glaze_reflect == false; };
 
       template <class T>
       concept is_dynamic_span = T::extent == static_cast<size_t>(-1);

--- a/include/glaze/file/hostname_include.hpp
+++ b/include/glaze/file/hostname_include.hpp
@@ -37,7 +37,7 @@ namespace glz
    {
       bool reflection_helper{}; // needed for count_members
       static constexpr auto glaze_includer = true;
-      static constexpr auto reflect = false;
+      static constexpr auto glaze_reflect = false;
 
       constexpr decltype(auto) operator()(auto&& value) const noexcept
       {

--- a/include/glaze/json/custom.hpp
+++ b/include/glaze/json/custom.hpp
@@ -16,7 +16,7 @@ namespace glz
       template <class T, class From, class To>
       struct custom_t final
       {
-         static constexpr auto reflect = false;
+         static constexpr auto glaze_reflect = false;
          using from_t = From;
          using to_t = To;
          T& val;

--- a/include/glaze/json/manage.hpp
+++ b/include/glaze/json/manage.hpp
@@ -15,7 +15,7 @@ namespace glz
       template <class T, class Member, class From, class To>
       struct manage_t
       {
-         static constexpr auto reflect = false;
+         static constexpr auto glaze_reflect = false;
          using from_t = From;
          using to_t = To;
          T& val;

--- a/include/glaze/record/recorder.hpp
+++ b/include/glaze/record/recorder.hpp
@@ -40,7 +40,7 @@ namespace glz
    template <class... Ts>
    struct recorder
    {
-      static constexpr auto reflect = false;
+      static constexpr auto glaze_reflect = false;
 
       using container_type = std::variant<std::deque<Ts>...>;
 


### PR DESCRIPTION
This is a breaking change, but it makes future code safer and is rare that users create custom types that need this feature.