### PR TITLE
deprecated bad read_file and write_file

### DIFF
--- a/docs/json-include.md
+++ b/docs/json-include.md
@@ -2,26 +2,21 @@
 
 When using JSON for configuration files it can be helpful to move object definitions into separate files. This reduces copying and the need to change inputs across multiple files.
 
-Glaze provides a `glz::file_include` type that can be added to the meta information for an object. The key may be anything, in this example we use choose `#include` to mimic C++.
+Glaze provides a `glz::file_include` type that can be added to your struct (or glz::meta). The key may be anything, in this example we use choose `include` to mimic C++.
 
 ```c++
 struct includer_struct {
-   std::string str = "Hello";
-   int i = 55;
-};
-
-template <>
-struct glz::meta<includer_struct> {
-   using T = includer_struct;
-   static constexpr auto value = object("#include", glz::file_include{}, &T::str, &T::i);
+  glz::file_include include{};
+  std::string str = "Hello";
+  int i = 55;
 };
 ```
 
-When this object is parsed, when the key `#include` is encountered the associated file will be read into the local object.
+When this object is parsed, when the key `include` is encountered the associated file will be read into the local object.
 
 ```c++
 includer_struct obj{};
-std::string s = R"({"#include": "./obj.json", "i": 100})";
+std::string s = R"({"include": "./obj.json", "i": 100})";
 glz::read_json(obj, s);
 ```
 

--- a/include/glaze/glaze.hpp
+++ b/include/glaze/glaze.hpp
@@ -41,74 +41,16 @@
 namespace glz
 {
    template <class T>
-   inline parse_error read_file(T& value, const sv file_name, auto&& buffer) noexcept
+   [[deprecated("Use specific read_file_json, etc. This old version was a bad design and would instatiate all formats")]]
+   inline parse_error read_file(T&, const sv, auto&&) noexcept
    {
-      context ctx{};
-      ctx.current_file = file_name;
-
-      std::filesystem::path path{file_name};
-
-      const auto ec = file_to_buffer(buffer, ctx.current_file);
-
-      if (bool(ec)) {
-         return {ec};
-      }
-
-      if (path.has_extension()) {
-         const auto extension = path.extension().string();
-
-         if (extension == ".json" || extension == ".jsonc") {
-            return read<opts{}>(value, buffer, ctx);
-         }
-         else if (extension == ".beve") {
-            return read<opts{.format = binary}>(value, buffer, ctx);
-         }
-         else {
-            return {error_code::file_extension_not_supported};
-         }
-      }
-      else {
-         return {error_code::could_not_determine_extension};
-      }
+      return {};
    }
-
+   
    template <class T>
-   [[nodiscard]] inline write_error write_file(T& value, const sv file_name, auto&& buffer) noexcept
+   [[deprecated("Use specific write_file_json, etc. This old version was a bad design and would instatiate all formats")]]
+   [[nodiscard]] inline write_error write_file(T&, const sv, auto&&) noexcept
    {
-      context ctx{};
-      ctx.current_file = file_name;
-
-      std::filesystem::path path{file_name};
-
-      if (path.has_extension()) {
-         const auto extension = path.extension().string();
-
-         if (extension == ".json") {
-            write<opts{}>(value, buffer, ctx);
-         }
-         else if (extension == ".jsonc") {
-            write<opts{.comments = true}>(value, buffer, ctx);
-         }
-         else if (extension == ".beve") {
-            write<opts{.format = binary}>(value, buffer, ctx);
-         }
-         else {
-            return {error_code::file_extension_not_supported};
-         }
-      }
-      else {
-         return {error_code::could_not_determine_extension};
-      }
-
-      std::ofstream file(std::string{file_name});
-
-      if (file) {
-         file << buffer;
-      }
-      else {
-         return {error_code::file_open_failure};
-      }
-
       return {};
    }
 }

--- a/include/glaze/glaze_exceptions.hpp
+++ b/include/glaze/glaze_exceptions.hpp
@@ -43,6 +43,7 @@ namespace glz::ex
 namespace glz::ex
 {
    template <class T>
+   [[deprecated("Use specific read_file_json, etc. This old version was a bad design and would instatiate all formats")]]
    void read_file(T& value, const sv file_name, auto&& buffer)
    {
       const auto ec = glz::read_file(value, file_name, buffer);
@@ -55,6 +56,7 @@ namespace glz::ex
    }
 
    template <class T>
+   [[deprecated("Use specific read_file_json, etc. This old version was a bad design and would instatiate all formats")]]
    void write_file(T& value, const sv file_name, auto&& buffer)
    {
       const auto ec = glz::write_file(value, file_name, buffer);

--- a/tests/exceptions_test/exceptions_test.cpp
+++ b/tests/exceptions_test/exceptions_test.cpp
@@ -130,24 +130,12 @@ suite read_file_test = [] {
 
       file_struct s;
       std::string buffer{};
-      glz::ex::read_file(s, filename, buffer);
+      glz::ex::read_file_json(s, filename, buffer);
    };
 
    "read_file invalid"_test = [] {
-      std::string filename = "../file.json";
-      {
-         std::ofstream out(filename);
-         expect(bool(out));
-         if (out) {
-            out << R"({
-     "name": "my",
-     "label": "label"
-   })";
-         }
-      }
-
       file_struct s;
-      expect(throws([&] { glz::ex::read_file(s, "../nonexsistant_file.json", std::string{}); }));
+      expect(throws([&] { glz::ex::read_file_json(s, "../nonexsistant_file.json", std::string{}); }));
    };
 };
 


### PR DESCRIPTION
This deprecates the generic `read_file` and `write_file` functions. They were bad because they required instantiation of all format paths. As glaze supports more formats and options this becomes a worse and worse idea. Instead, the specific format calls should be used and the read/write functions should support custom `glz::opts` options.