### PR TITLE
Fix for reflection writing const structs

### DIFF
--- a/include/glaze/json/custom.hpp
+++ b/include/glaze/json/custom.hpp
@@ -196,13 +196,18 @@ namespace glz
                }
             }
             else {
-               write<json>::op<Opts>(get_member(value.val, value.to), ctx, args...);
+               if constexpr (std::invocable<To, decltype(value.val)>) {
+                  write<json>::op<Opts>(std::invoke(value.to, value.val), ctx, args...);
+               }
+               else {
+                  static_assert(false_v<To>, "expected invocable function, perhaps you need const qualified input on your lambda");
+               }
             }
          }
       };
 
       template <auto From, auto To>
-      inline constexpr decltype(auto) custom_impl() noexcept
+      inline constexpr auto custom_impl() noexcept
       {
          return [](auto&& v) { return custom_t{v, From, To}; };
       }

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1084,9 +1084,16 @@ namespace glz
 
             [[maybe_unused]] decltype(auto) t = [&] {
                if constexpr (reflectable<T>) {
-                  static constinit auto tuple_of_ptrs = make_tuple_from_struct<T>();
-                  populate_tuple_ptr(value, tuple_of_ptrs);
-                  return tuple_of_ptrs;
+                  if constexpr (std::is_const_v<std::remove_reference_t<decltype(value)>>) {
+                     static constinit auto tuple_of_ptrs = make_const_tuple_from_struct<T>();
+                     populate_tuple_ptr(value, tuple_of_ptrs);
+                     return tuple_of_ptrs;
+                  }
+                  else {
+                     static constinit auto tuple_of_ptrs = make_tuple_from_struct<T>();
+                     populate_tuple_ptr(value, tuple_of_ptrs);
+                     return tuple_of_ptrs;
+                  }
                }
                else {
                   return nullptr;

--- a/include/glaze/reflection/reflect.hpp
+++ b/include/glaze/reflection/reflect.hpp
@@ -96,32 +96,47 @@ namespace glz
                &std::get<I>(t);
          });
       }
-
+      
+      // We create const and not-const versions for when our reflected struct is const or non-const qualified
       template <class Tuple>
       struct tuple_ptr;
-
+      
       template <class... Ts>
       struct tuple_ptr<std::tuple<Ts...>>
       {
          using type = std::tuple<std::add_pointer_t<Ts>...>;
       };
-
+      
       template <class Tuple>
-      using tuple_ptr_t = typename tuple_ptr<Tuple>::type;
+      struct tuple_ptr_const;
 
-      // This is needed to hack a fix for MSVC evaluating wrong if constexpr branches
+      template <class... Ts>
+      struct tuple_ptr_const<std::tuple<Ts...>>
+      {
+         using type = std::tuple<std::add_pointer_t<std::add_const_t<std::remove_reference_t<Ts>>>...>;
+      };
+
+      // This is needed to hack a fix for MSVC evaluating wrong `if constexpr` branches
       template <class T>
          requires(!reflectable<T>)
       constexpr auto make_tuple_from_struct() noexcept
       {
          return std::tuple{};
       }
-
+      
+      // This needs to produce const qualified pointers so that we can write out const structs
       template <reflectable T>
       constexpr auto make_tuple_from_struct() noexcept
       {
-         using V = decltype(to_tuple(std::declval<T>()));
+         using V = std::decay_t<decltype(to_tuple(std::declval<T>()))>;
          return typename tuple_ptr<V>::type{};
+      }
+      
+      template <reflectable T>
+      constexpr auto make_const_tuple_from_struct() noexcept
+      {
+         using V = std::decay_t<decltype(to_tuple(std::declval<T>()))>;
+         return typename tuple_ptr_const<V>::type{};
       }
 
       template <reflectable T, class TuplePtrs>

--- a/tests/reflection_test/reflection_test.cpp
+++ b/tests/reflection_test/reflection_test.cpp
@@ -347,6 +347,28 @@ suite testing_structures = [] {
    };
 };
 
+struct structure_t
+{
+    std::string doc;
+    std::string id;
+};
+
+suite const_object_test = [] {
+   "const_object"_test = [] {
+      std::string buffer = R"({"doc":"aaa","id":"1111"})";
+      structure_t obj{};
+      
+      expect(!glz::read_json(obj, buffer));
+      
+      const structure_t const_obj = obj;
+      
+      static_assert(std::is_const_v<std::remove_reference_t<decltype(const_obj)>>);
+      std::string s{};
+      glz::write_json(const_obj, s);
+      expect(buffer == s);
+   };
+};
+
 int main()
 { // Explicitly run registered test suites and report errors
    // This prevents potential issues with thread local variables


### PR DESCRIPTION
This allows writing const structs when using reflection.

Also added more stringent conditions for glz::custom, requiring an invocable lambda rather than passing through any member. This is to avoid issues of the program forever looping when a const parent object was provided but the lambda only accepts non-const inputs.