### PR TITLE
patch for clang-cl bug

### DIFF
--- a/include/glaze/reflection/get_name.hpp
+++ b/include/glaze/reflection/get_name.hpp
@@ -143,7 +143,7 @@ namespace glz
       requires(std::is_member_object_pointer_v<decltype(P)>)
    consteval std::string_view get_name() noexcept
    {
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
       using T = remove_member_pointer<std::decay_t<decltype(P)>>::type;
       constexpr auto p = P;
       return get_name_msvc<T, &(detail::external<T>.*p)>();


### PR DESCRIPTION
A patch for the issue #695 

Clang on Windows defines `_MSC_VER` to be compatible with `MSVC`, however, `get_name_msvc` can only be called when compiling with `MSVC`.