### PR TITLE
Handle hostname_includer in BEVE

### DIFF
--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -693,8 +693,8 @@ namespace glz
          }
       };
 
-      template <class T>
-      struct from_binary<includer<T>>
+      template <is_includer T>
+      struct from_binary<T>
       {
          template <auto Opts>
          GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, auto&& it, auto&& end) noexcept

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -174,9 +174,10 @@ namespace glz
          GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, Args&&...) noexcept
          {}
       };
-
-      template <class T>
-      struct to_binary<includer<T>>
+      
+      // // write includers as empty strings
+      template <is_includer T>
+      struct to_binary<T>
       {
          template <auto Opts, class... Args>
          GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, Args&&... args) noexcept

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -130,6 +130,7 @@ namespace glz
       T& value;
 
       static constexpr auto glaze_includer = true;
+      static constexpr auto glaze_reflect = false;
    };
 
    template <class T>
@@ -152,7 +153,7 @@ namespace glz
    };
 
    template <class T>
-   concept is_includer = requires(T t) { T::glaze_includer; };
+   concept is_includer = requires(T t) { requires T::glaze_includer == true; };
 
    template <class T>
    concept range = requires(T& t) {

--- a/include/glaze/file/hostname_include.hpp
+++ b/include/glaze/file/hostname_include.hpp
@@ -22,6 +22,7 @@ namespace glz
          T& value;
 
          static constexpr auto glaze_includer = true;
+         static constexpr auto glaze_reflect = false;
       };
    }
 

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -564,6 +564,8 @@ struct glz::meta<includer_struct>
    static constexpr auto value = object("#include", glz::file_include{}, "str", &T::str, "i", &T::i, "j", &T::j);
 };
 
+static_assert(glz::is_includer<glz::includer<includer_struct>>);
+
 void file_include_test()
 {
    includer_struct obj{};


### PR DESCRIPTION
Includers in binary simply write out an empty string. This allows binary files with `glz::hostname_include` to build. The change also allows `glaze_includer` to be explicitly turned off.