### PR TITLE
Enum reflection within glz::meta

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -719,6 +719,19 @@ namespace glz
             return {first};
          }
       }
+      
+      template <class T, size_t I>
+      constexpr auto get_enum_value() noexcept
+      {
+         constexpr auto first = get<0>(get<I>(meta_v<T>));
+         using T0 = std::decay_t<decltype(first)>;
+         if constexpr (std::is_enum_v<T0>) {
+            return first;
+         }
+         else {
+            return get<1>(get<I>(meta_v<T>));
+         }
+      }
 
       template <class T, size_t I>
       struct meta_sv
@@ -783,7 +796,7 @@ namespace glz
          return make_map_impl<std::decay_t<T>, use_hash_comparison>(indices);
       }
 
-      template <class T, size_t... I>
+      /*template <class T, size_t... I>
       constexpr auto make_int_storage_impl(std::index_sequence<I...>)
       {
          using value_t = value_tuple_variant_t<meta_t<T>>;
@@ -795,13 +808,13 @@ namespace glz
       {
          constexpr auto indices = std::make_index_sequence<std::tuple_size_v<meta_t<T>>>{};
          return make_int_storage_impl<T>(indices);
-      }
+      }*/
 
       template <class T, size_t... I>
       constexpr auto make_key_int_map_impl(std::index_sequence<I...>)
       {
          return normal_map<sv, size_t, std::tuple_size_v<meta_t<T>>>(
-            {std::make_pair<sv, size_t>(glz::get<0>(glz::get<I>(meta_v<T>)), I)...});
+            {std::make_pair<sv, size_t>(get_enum_key<T, I>(), I)...});
       }
 
       template <class T>
@@ -816,7 +829,7 @@ namespace glz
       {
          using key_t = std::underlying_type_t<T>;
          return normal_map<key_t, sv, std::tuple_size_v<meta_t<T>>>({std::make_pair<key_t, sv>(
-            static_cast<key_t>(glz::get<1>(glz::get<I>(meta_v<T>))), sv(glz::get<0>(glz::get<I>(meta_v<T>))))...});
+            static_cast<key_t>(get_enum_value<T, I>()), get_enum_key<T, I>())...});
       }
 
       template <class T>
@@ -832,7 +845,7 @@ namespace glz
       {
          std::array<sv, std::tuple_size_v<meta_t<T>>> arr;
          for_each<std::tuple_size_v<meta_t<T>>>(
-            [&](auto I) { arr[I] = enum_name_v<static_cast<T>(decltype(I)::value)>; });
+                                                [&](auto I) { arr[I] = get_enum_key<T, I>(); });
          return arr;
       }
 
@@ -1150,6 +1163,21 @@ struct glz::meta<glz::error_code>
 
 namespace glz
 {
+   template <auto Enum>
+      requires(std::is_enum_v<decltype(Enum)>)
+   constexpr sv enum_name_v = []() -> std::string_view {
+      using T = std::decay_t<decltype(Enum)>;
+
+      if constexpr (detail::glaze_t<T>) {
+         
+         using U = std::underlying_type_t<T>;
+         return detail::get_enum_key<T, static_cast<U>(Enum)>();
+      }
+      else {
+         return "glz::unknown";
+      }
+   }();
+   
    [[nodiscard]] inline std::string format_error(const parse_error& pe, const auto& buffer)
    {
       static constexpr auto arr = detail::make_enum_to_string_array<error_code>();

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -706,6 +706,19 @@ namespace glz
             return {first};
          }
       }
+      
+      template <class T, size_t I>
+      constexpr sv get_enum_key() noexcept
+      {
+         constexpr auto first = get<0>(get<I>(meta_v<T>));
+         using T0 = std::decay_t<decltype(first)>;
+         if constexpr (std::is_enum_v<T0>) {
+            return get_name<first>();
+         }
+         else {
+            return {first};
+         }
+      }
 
       template <class T, size_t I>
       struct meta_sv

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -853,7 +853,7 @@ namespace glz
       constexpr auto make_string_to_enum_map_impl(std::index_sequence<I...>)
       {
          return normal_map<sv, T, std::tuple_size_v<meta_t<T>>>({std::make_pair<sv, T>(
-            sv(glz::get<0>(glz::get<I>(meta_v<T>))), T(glz::get<1>(glz::get<I>(meta_v<T>))))...});
+                                                                                       get_enum_key<T, I>(), T(get_enum_value<T, I>()))...});
       }
 
       template <class T>

--- a/include/glaze/core/meta.hpp
+++ b/include/glaze/core/meta.hpp
@@ -233,20 +233,6 @@ namespace glz
       }
    }();
 
-   template <auto Enum>
-      requires(std::is_enum_v<decltype(Enum)>)
-   inline constexpr std::string_view enum_name_v = []() -> std::string_view {
-      using T = std::decay_t<decltype(Enum)>;
-
-      if constexpr (detail::glaze_t<T>) {
-         using U = std::underlying_type_t<T>;
-         return glz::get<0>(glz::get<static_cast<U>(Enum)>(meta_v<T>));
-      }
-      else {
-         return "glz::unknown";
-      }
-   }();
-
    using version_t = std::array<uint32_t, 3>;
 
    template <class T>

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -816,7 +816,7 @@ namespace glz
                   return;
             }
 
-            const auto key = parse_key(ctx, it, end);
+            const auto key = parse_key(ctx, it, end); // TODO: Use more optimal enum key parsing
             if (bool(ctx.error)) [[unlikely]]
                return;
 

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -199,11 +199,15 @@ namespace glz
             // });
             s.oneOf = std::vector<schematic>(N);
             for_each<N>([&](auto I) {
-               static constexpr auto item = glz::get<I>(meta_v<V>);
+               static constexpr auto item = get<I>(meta_v<V>);
+               using T0 = std::decay_t<decltype(get<0>(item))>;
                auto& enumeration = (*s.oneOf)[I.value];
-               enumeration.constant = glz::get<0>(item);
-               if constexpr (std::tuple_size_v < decltype(item) >> 2) {
-                  enumeration.description = std::get<2>(item);
+               enumeration.constant = get_enum_key<V, I>();
+               static constexpr size_t member_index = std::is_enum_v<T0> ? 0 : 1;
+               static constexpr size_t comment_index = member_index + 1;
+               constexpr auto Size = std::tuple_size_v<decltype(item)>;
+               if constexpr (Size > comment_index) {
+                  enumeration.description = get<comment_index>(item);
                }
             });
          }

--- a/include/glaze/reflection/get_name.hpp
+++ b/include/glaze/reflection/get_name.hpp
@@ -22,15 +22,16 @@ namespace glz::detail
    template <class T>
    extern const T external;
 
+   // using const char* simplifies the complier's output and should improve compile times
    template <auto Ptr>
-   [[nodiscard]] consteval std::string_view get_mangled_name()
+   [[nodiscard]] consteval const char* get_mangled_name()
    {
       // return std::source_location::current().function_name();
       return GLZ_PRETTY_FUNCTION;
    }
 
    template <class T>
-   [[nodiscard]] consteval std::string_view get_mangled_name()
+   [[nodiscard]] consteval const char* get_mangled_name()
    {
       // return std::source_location::current().function_name();
       return GLZ_PRETTY_FUNCTION;
@@ -40,14 +41,14 @@ namespace glz::detail
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Weverything"
    template <auto N, class T>
-   constexpr auto get_name_impl = get_mangled_name<get_ptr<N>(external<T>)>();
+   constexpr std::string_view get_name_impl = get_mangled_name<get_ptr<N>(external<T>)>();
 #pragma clang diagnostic pop
 #elif __GNUC__
    template <auto N, class T>
-   constexpr auto get_name_impl = get_mangled_name<get_ptr<N>(external<T>)>();
+   constexpr std::string_view get_name_impl = get_mangled_name<get_ptr<N>(external<T>)>();
 #else
    template <auto N, class T>
-   constexpr auto get_name_impl = get_mangled_name<get_ptr<N>(external<T>)>();
+   constexpr std::string_view get_name_impl = get_mangled_name<get_ptr<N>(external<T>)>();
 #endif
 
    struct GLAZE_REFLECTOR
@@ -64,7 +65,7 @@ namespace glz::detail
 
    struct reflect_type
    {
-      static constexpr auto name = get_mangled_name<GLAZE_REFLECTOR>();
+      static constexpr std::string_view name = get_mangled_name<GLAZE_REFLECTOR>();
       static constexpr auto end = name.substr(name.find("GLAZE_REFLECTOR") + sizeof("GLAZE_REFLECTOR") - 1);
 #if defined(__GNUC__) || defined(__clang__)
       static constexpr auto begin = std::string_view{"T = "};
@@ -86,7 +87,7 @@ namespace glz
 
    template <class T>
    static constexpr auto type_name = [] {
-      constexpr auto name = detail::get_mangled_name<T>();
+      constexpr std::string_view name = detail::get_mangled_name<T>();
       constexpr auto begin = name.find(detail::reflect_type::end);
       constexpr auto tmp = name.substr(0, begin);
 #if defined(__GNUC__) || defined(__clang__)

--- a/include/glaze/reflection/get_name.hpp
+++ b/include/glaze/reflection/get_name.hpp
@@ -24,14 +24,14 @@ namespace glz::detail
 
    // using const char* simplifies the complier's output and should improve compile times
    template <auto Ptr>
-   [[nodiscard]] consteval const char* get_mangled_name()
+   [[nodiscard]] consteval auto get_mangled_name()
    {
       // return std::source_location::current().function_name();
       return GLZ_PRETTY_FUNCTION;
    }
 
    template <class T>
-   [[nodiscard]] consteval const char* get_mangled_name()
+   [[nodiscard]] consteval auto get_mangled_name()
    {
       // return std::source_location::current().function_name();
       return GLZ_PRETTY_FUNCTION;

--- a/include/glaze/reflection/get_name.hpp
+++ b/include/glaze/reflection/get_name.hpp
@@ -24,14 +24,14 @@ namespace glz::detail
 
    // using const char* simplifies the complier's output and should improve compile times
    template <auto Ptr>
-   [[nodiscard]] consteval auto get_mangled_name()
+   [[nodiscard]] consteval auto mangled_name()
    {
       // return std::source_location::current().function_name();
       return GLZ_PRETTY_FUNCTION;
    }
 
    template <class T>
-   [[nodiscard]] consteval auto get_mangled_name()
+   [[nodiscard]] consteval auto mangled_name()
    {
       // return std::source_location::current().function_name();
       return GLZ_PRETTY_FUNCTION;
@@ -41,14 +41,14 @@ namespace glz::detail
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Weverything"
    template <auto N, class T>
-   constexpr std::string_view get_name_impl = get_mangled_name<get_ptr<N>(external<T>)>();
+   constexpr std::string_view get_name_impl = mangled_name<get_ptr<N>(external<T>)>();
 #pragma clang diagnostic pop
 #elif __GNUC__
    template <auto N, class T>
-   constexpr std::string_view get_name_impl = get_mangled_name<get_ptr<N>(external<T>)>();
+   constexpr std::string_view get_name_impl = mangled_name<get_ptr<N>(external<T>)>();
 #else
    template <auto N, class T>
-   constexpr std::string_view get_name_impl = get_mangled_name<get_ptr<N>(external<T>)>();
+   constexpr std::string_view get_name_impl = mangled_name<get_ptr<N>(external<T>)>();
 #endif
 
    struct GLAZE_REFLECTOR
@@ -65,12 +65,12 @@ namespace glz::detail
 
    struct reflect_type
    {
-      static constexpr std::string_view name = get_mangled_name<GLAZE_REFLECTOR>();
+      static constexpr std::string_view name = mangled_name<GLAZE_REFLECTOR>();
       static constexpr auto end = name.substr(name.find("GLAZE_REFLECTOR") + sizeof("GLAZE_REFLECTOR") - 1);
 #if defined(__GNUC__) || defined(__clang__)
       static constexpr auto begin = std::string_view{"T = "};
 #else
-      static constexpr auto begin = std::string_view{"glz::detail::get_mangled_name<"};
+      static constexpr auto begin = std::string_view{"glz::detail::mangled_name<"};
 #endif
    };
 }
@@ -87,7 +87,7 @@ namespace glz
 
    template <class T>
    static constexpr auto type_name = [] {
-      constexpr std::string_view name = detail::get_mangled_name<T>();
+      constexpr std::string_view name = detail::mangled_name<T>();
       constexpr auto begin = name.find(detail::reflect_type::end);
       constexpr auto tmp = name.substr(0, begin);
 #if defined(__GNUC__) || defined(__clang__)

--- a/include/glaze/reflection/get_name.hpp
+++ b/include/glaze/reflection/get_name.hpp
@@ -157,4 +157,18 @@ namespace glz
       return str.substr(str.rfind("::") + 2);
 #endif
    }
+   
+   template <auto E> requires (std::is_enum_v<decltype(E)>)
+   consteval auto get_name()
+   {
+#if defined(_MSC_VER) && !defined(__clang__)
+      std::string_view str = GLZ_PRETTY_FUNCTION;
+      str = str.substr(str.rfind("::") + 2);
+      return str.substr(0, str.find('>'));
+#else
+      std::string_view str = GLZ_PRETTY_FUNCTION;
+      str = str.substr(str.rfind("::") + 2);
+      return str.substr(0, str.find(']'));
+#endif
+   }
 }

--- a/include/glaze/util/tuple.hpp
+++ b/include/glaze/util/tuple.hpp
@@ -74,6 +74,18 @@ namespace glz
                indices[i++] = I;
             }
          }
+         else if constexpr (std::is_enum_v<V>) {
+            if constexpr (I == 0) {
+               indices[i++] = 0;
+            }
+            else if constexpr (std::convertible_to<std::tuple_element_t<I - 1, Tuple>, std::string_view>) {
+               // If the previous element in the tuple is convertible to a std::string_view, then we treat it as the key
+               indices[i++] = I - 1;
+            }
+            else {
+               indices[i++] = I;
+            }
+         }
          else if constexpr (!(std::convertible_to<V, std::string_view> || is_schema_class<V> ||
                               std::same_as<V, comment>)) {
             indices[i++] = I - 1;

--- a/tests/reflection_test/reflection_test.cpp
+++ b/tests/reflection_test/reflection_test.cpp
@@ -103,10 +103,9 @@ enum class Color { Red, Green, Blue };
 template <>
 struct glz::meta<Color>
 {
-   static constexpr std::string_view name = "Color";
-   static constexpr auto value = enumerate("Red", Color::Red, //
-                                           "Green", Color::Green, //
-                                           "Blue", Color::Blue //
+   static constexpr auto value = enumerate(Color::Red, //
+                                           Color::Green, //
+                                           Color::Blue //
    );
 };
 


### PR DESCRIPTION
This adds enum reflection within glz::meta, so you don't have to duplicate typing out enum names. It works the same way as glz::meta for structs, where keys can be individually customized.

Also shortened mangled name generation to help reduce compiler overhead.