### PR TITLE
Cleanup of jsonrpc

### DIFF
--- a/docs/json-rpc.md
+++ b/docs/json-rpc.md
@@ -44,15 +44,15 @@ int main() {
        client;
    
     // One long living callback per method for the server
-    server.on<"foo">([](foo_params const& params) -> glz::expected<foo_result, rpc::error> {
+    server.on<"foo">([](foo_params const& params) {
         // access to member variables for the request `foo`
         // params.foo_a 
         // params.foo_b
         return foo_result{.foo_c = true, .foo_d = "new world"};
         // Or return an error:
-        // return glz::unexpected(rpc::error{rpc::error_e::server_error_lower, "my error"});
+        // return rpc::error{rpc::error_e::server_error_lower, "my error"};
     });
-    server.on<"bar">([](bar_params const& params) -> glz::expected<bar_result, rpc::error> {
+    server.on<"bar">([](bar_params const& params) {
         return bar_result{.bar_c = true, .bar_d = "new world"};
     });
     

--- a/docs/json-rpc.md
+++ b/docs/json-rpc.md
@@ -12,23 +12,12 @@ struct foo_params
    int foo_a{};
    std::string foo_b{};
 };
-template <>
-struct glz::meta<foo_params>
-{
-   using T = foo_params;
-   static constexpr auto value{object(&T::foo_a, &T::foo_b)};
-};
+
 struct foo_result
 {
    bool foo_c{};
    std::string foo_d{};
    auto operator<=>(const foo_result&) const = default;
-};
-template <>
-struct glz::meta<foo_result>
-{
-   using T = foo_result;
-   static constexpr auto value{object(&T::foo_c, &T::foo_d)};
 };
 
 struct bar_params
@@ -36,23 +25,12 @@ struct bar_params
    int bar_a;
    std::string bar_b;
 };
-template <>
-struct glz::meta<bar_params>
-{
-   using T = bar_params;
-   static constexpr auto value{object(&T::bar_a, &T::bar_b)};
-};
+
 struct bar_result
 {
    bool bar_c{};
    std::string bar_d{};
    auto operator<=>(const bar_result&) const = default;
-};
-template <>
-struct glz::meta<bar_result>
-{
-   using T = bar_result;
-   static constexpr auto value{object(&T::bar_c, &T::bar_d)};
 };
 
 namespace rpc = glz::rpc;

--- a/include/glaze/ext/jsonrpc.hpp
+++ b/include/glaze/ext/jsonrpc.hpp
@@ -288,7 +288,7 @@ namespace glz::rpc
       }
 
       using raw_call_return_t = std::vector<raw_response_t>;
-      // Return json stringified std::vector<response_t> meaning it can both be error and non-error and batch request
+      // Return JSON stringified std::vector<response_t> meaning it can both be error and non-error and batch request
       // response. If `id` is null in json_request a response will not be generated
       // If you would like to handle errors for each request:
       // auto response_vector = server.call<decltype(server_instance)::raw_call_return_t>("...");
@@ -463,16 +463,16 @@ namespace glz::rpc
       // that the input was a notification or more serious, conflicting id, the provided id should be unique!
       template <string_literal Name>
       [[nodiscard]] std::pair<std::string, bool> request(id_t&& id, auto&& params, auto&& callback)
-      {
+      {         
          constexpr bool method_found = ((Method::name_v == Name) || ...);
          static_assert(method_found, "Method not declared in client.");
 
-         using params_type = std::remove_cvref_t<decltype(params)>;
-         constexpr bool params_type_found = (std::is_same_v<typename Method::params_t, params_type> || ...);
+         using Params = std::remove_cvref_t<decltype(params)>;
+         constexpr bool params_type_found = (std::is_same_v<typename Method::params_t, Params> || ...);
          static_assert(params_type_found, "Input parameters do not match constructed client parameter types.");
 
          constexpr bool method_params_match =
-            ((Method::name_v == Name && std::is_same_v<typename Method::params_t, params_type>) ||
+            ((Method::name_v == Name && std::is_same_v<typename Method::params_t, Params>) ||
              ...);
          static_assert(method_params_match, "Method name and given params type do not match.");
 
@@ -488,7 +488,7 @@ namespace glz::rpc
             using meth_t = std::remove_reference_t<decltype(method)>;
             if constexpr (Name == meth_t::name_v) {
                [[maybe_unused]] decltype(method.pending_requests.begin()) unused{}; // iterator_t
-               std::tie(unused, inserted) = method.pending_requests.emplace(std::make_pair(req.id, cb));
+               std::tie(unused, inserted) = method.pending_requests.emplace(std::pair{req.id, cb});
                return true; // break methods loop
             }
             else {

--- a/include/glaze/ext/jsonrpc.hpp
+++ b/include/glaze/ext/jsonrpc.hpp
@@ -211,10 +211,10 @@ namespace glz::rpc
                using params_t = typename M::params_t;
                using expected_t = expected<result_t, rpc::error>;
                if constexpr (std::is_invocable_r_v<result_t, decltype(callback), const params_t&>) {
-                  method.callback = [cb = std::move(callback)](const params_t& params) -> expected_t { return cb(params); };
+                  method.callback = [=](const params_t& params) -> expected_t { return callback(params); };
                }
                else if constexpr (std::is_invocable_r_v<rpc::error, decltype(callback), const params_t&>) {
-                  method.callback = [cb = std::move(callback)](const params_t& params) -> expected_t { return glz::unexpected{cb(params)}; };
+                  method.callback = [=](const params_t& params) -> expected_t { return glz::unexpected{callback(params)}; };
                }
                else {
                   static_assert(false_v<M>, "Method supplied is not invocable with registered types");

--- a/include/glaze/ext/jsonrpc.hpp
+++ b/include/glaze/ext/jsonrpc.hpp
@@ -99,12 +99,12 @@ namespace glz::rpc
       };
    };
 
-   template <class params_type>
+   template <class Params>
    struct request_t
    {
       id_t id{};
       std::string_view method{};
-      params_type params{};
+      Params params{};
       std::string_view version{rpc::supported_version};
 
       struct glaze
@@ -117,15 +117,15 @@ namespace glz::rpc
       };
    };
 
-   template <class params_type>
-   request_t(id_t&&, std::string_view, params_type&&) -> request_t<std::decay_t<params_type>>;
+   template <class Params>
+   request_t(id_t&&, std::string_view, Params&&) -> request_t<std::decay_t<Params>>;
 
    using generic_request_t = request_t<glz::raw_json_view>;
 
-   template <class result_type>
+   template <class Result>
    struct response_t
    {
-      using result_t = result_type;
+      using result_t = Result;
 
       response_t() = default;
       explicit response_t(rpc::error&& err) : error(std::move(err)) {}
@@ -146,12 +146,12 @@ namespace glz::rpc
    };
    using generic_response_t = response_t<glz::raw_json_view>;
 
-   template <string_literal name, class params_type, class result_type>
+   template <string_literal Name, class Params, class Result>
    struct method
    {
-      static constexpr std::string_view name_v{name};
-      using params_t = params_type;
-      using result_t = result_type;
+      static constexpr std::string_view name_v{Name};
+      using params_t = Params;
+      using result_t = Result;
    };
 
    namespace concepts

--- a/include/glaze/ext/jsonrpc.hpp
+++ b/include/glaze/ext/jsonrpc.hpp
@@ -95,7 +95,7 @@ namespace glz::rpc
       struct glaze
       {
          using T = error;
-         static constexpr auto value = glz::object("code", &T::code, "message", &T::message, "data", &T::data);
+         static constexpr auto value = glz::object(&T::code, &T::message, &T::data);
       };
    };
 
@@ -111,9 +111,9 @@ namespace glz::rpc
       {
          using T = request_t;
          static constexpr auto value = glz::object("jsonrpc", &T::version, //
-                                                   "method", &T::method, //
-                                                   "params", &T::params, //
-                                                   "id", &T::id);
+                                                   &T::method, //
+                                                   &T::params, //
+                                                   &T::id);
       };
    };
 
@@ -141,7 +141,7 @@ namespace glz::rpc
       {
          using T = response_t;
          static constexpr auto value{
-            glz::object("jsonrpc", &T::version, "result", &T::result, "error", &T::error, "id", &T::id)};
+            glz::object("jsonrpc", &T::version, &T::result, &T::error, &T::id)};
       };
    };
    using generic_response_t = response_t<glz::raw_json_view>;
@@ -198,10 +198,10 @@ namespace glz::rpc
 
    namespace detail
    {
-      template <string_literal name, class... method_type>
-      inline constexpr void set_callback(glz::tuplet::tuple<method_type...>& methods, const auto& callback)
+      template <string_literal name, class... Method>
+      inline constexpr void set_callback(glz::tuplet::tuple<Method...>& methods, const auto& callback)
       {
-         constexpr bool method_found = ((method_type::name_v == name) || ...);
+         constexpr bool method_found = ((Method::name_v == name) || ...);
          static_assert(method_found, "Method not settable in given tuple.");
 
          methods.any([&callback](auto&& method) -> bool {
@@ -237,17 +237,17 @@ namespace glz::rpc
          static constexpr std::size_t index = (std::numeric_limits<size_t>::max)();
       };
 
-      template <class map_t, string_literal name, class... method_type>
-      auto get_request_map(glz::tuplet::tuple<method_type...>& methods) -> map_t&
+      template <class Map, string_literal Name, class... Method>
+      auto get_request_map(glz::tuplet::tuple<Method...>& methods) -> Map&
       {
-         constexpr bool method_found = ((method_type::name_v == name) || ...);
+         constexpr bool method_found = ((Method::name_v == Name) || ...);
          static_assert(method_found, "Method not declared in client.");
 
-         map_t* return_ptr{nullptr};
+         Map* return_ptr{nullptr};
 
          methods.any([&return_ptr](auto&& method) -> bool {
             using meth_t = std::remove_reference_t<decltype(method)>;
-            if constexpr (name == meth_t::name_v) {
+            if constexpr (Name == meth_t::name_v) {
                return_ptr = &method.pending_requests;
                return true; // break methods loop
             }
@@ -262,12 +262,12 @@ namespace glz::rpc
       }
    }
 
-   template <concepts::method_type... method_type>
+   template <concepts::method_type... Method>
    struct server
    {
       using raw_response_t = response_t<glz::raw_json>;
 
-      glz::tuplet::tuple<server_method_t<method_type>...> methods{};
+      glz::tuplet::tuple<server_method_t<Method>...> methods{};
 
       template <string_literal name>
       constexpr void on(const auto& callback) // std::function<expected<result_t, rpc::error>(params_t const&)>
@@ -284,15 +284,15 @@ namespace glz::rpc
       template <concepts::call_return_type return_t = std::string>
       return_t call(std::string_view json_request)
       {
-         constexpr auto return_helper = []<typename input_type>(input_type&& response) -> auto {
+         constexpr auto return_helper = []<class Input>(Input&& response) -> auto {
             if constexpr (std::same_as<return_t, std::string>) {
-               return glz::write_json(std::forward<input_type>(response));
+               return glz::write_json(std::forward<Input>(response));
             }
-            else if constexpr (std::same_as<input_type, raw_response_t>) {
-               return std::vector<raw_response_t>{std::forward<input_type>(response)};
+            else if constexpr (std::same_as<Input, raw_response_t>) {
+               return std::vector<raw_response_t>{std::forward<Input>(response)};
             }
             else {
-               return std::forward<input_type>(response);
+               return std::forward<Input>(response);
             }
          };
 
@@ -384,10 +384,10 @@ namespace glz::rpc
       }
    };
 
-   template <concepts::method_type... method_type>
+   template <concepts::method_type... Method>
    struct client
    {
-      glz::tuplet::tuple<client_method_t<method_type>...> methods{};
+      glz::tuplet::tuple<client_method_t<Method>...> methods{};
 
       rpc::error call(std::string_view json_response)
       {
@@ -449,22 +449,22 @@ namespace glz::rpc
       // const&)> where result_t is the result type declared for the given method name returns the request string and
       // whether the callback was inserted into the queue if the callback was not inserted into the queue it can mean
       // that the input was a notification or more serious, conflicting id, the provided id should be unique!
-      template <string_literal method_name>
+      template <string_literal Name>
       [[nodiscard]] std::pair<std::string, bool> request(id_t&& id, auto&& params, auto&& callback)
       {
-         constexpr bool method_found = ((method_type::name_v == method_name) || ...);
+         constexpr bool method_found = ((Method::name_v == Name) || ...);
          static_assert(method_found, "Method not declared in client.");
 
          using params_type = std::remove_cvref_t<decltype(params)>;
-         constexpr bool params_type_found = (std::is_same_v<typename method_type::params_t, params_type> || ...);
+         constexpr bool params_type_found = (std::is_same_v<typename Method::params_t, params_type> || ...);
          static_assert(params_type_found, "Input parameters do not match constructed client parameter types.");
 
          constexpr bool method_params_match =
-            ((method_type::name_v == method_name && std::is_same_v<typename method_type::params_t, params_type>) ||
+            ((Method::name_v == Name && std::is_same_v<typename Method::params_t, params_type>) ||
              ...);
          static_assert(method_params_match, "Method name and given params type do not match.");
 
-         rpc::request_t req{std::forward<decltype(id)>(id), method_name.sv(), std::forward<decltype(params)>(params)};
+         rpc::request_t req{std::forward<decltype(id)>(id), Name.sv(), std::forward<decltype(params)>(params)};
 
          if (std::holds_alternative<glz::json_t::null_t>(id)) {
             return {glz::write_json(std::move(req)), false};
@@ -474,7 +474,7 @@ namespace glz::rpc
          bool inserted{false};
          methods.any([&inserted, &req, cb = std::forward<decltype(callback)>(callback)](auto&& method) -> bool {
             using meth_t = std::remove_reference_t<decltype(method)>;
-            if constexpr (method_name == meth_t::name_v) {
+            if constexpr (Name == meth_t::name_v) {
                [[maybe_unused]] decltype(method.pending_requests.begin()) unused{}; // iterator_t
                std::tie(unused, inserted) = method.pending_requests.emplace(std::make_pair(req.id, cb));
                return true; // break methods loop
@@ -487,29 +487,29 @@ namespace glz::rpc
          return {glz::write_json(std::move(req)), inserted};
       }
 
-      template <string_literal method_name>
+      template <string_literal Name>
       [[nodiscard]] auto notify(auto&& params) -> std::string
       {
          auto placebo{[](auto&, auto&) {}};
-         return request<method_name>(glz::json_t::null_t{}, params, std::move(placebo)).first;
+         return request<Name>(glz::json_t::null_t{}, params, std::move(placebo)).first;
       }
 
-      template <string_literal method_name>
+      template <string_literal Name>
       [[nodiscard]] const auto& get_request_map() const
       {
-         constexpr auto idx = detail::index_of_name<decltype(method_name), method_name, method_type...>::index;
-         using method_element = std::tuple_element_t<idx, std::tuple<client_method_t<method_type>...>>;
+         constexpr auto idx = detail::index_of_name<decltype(Name), Name, Method...>::index;
+         using method_element = std::tuple_element_t<idx, std::tuple<client_method_t<Method>...>>;
          using request_map_t = decltype(method_element().pending_requests);
-         return detail::get_request_map<request_map_t, method_name>(methods);
+         return detail::get_request_map<request_map_t, Name>(methods);
       }
 
-      template <string_literal method_name>
+      template <string_literal Name>
       [[nodiscard]] auto& get_request_map()
       {
-         constexpr auto idx = detail::index_of_name<decltype(method_name), method_name, method_type...>::index;
-         using method_element = std::tuple_element_t<idx, std::tuple<client_method_t<method_type>...>>;
+         constexpr auto idx = detail::index_of_name<decltype(Name), Name, Method...>::index;
+         using method_element = std::tuple_element_t<idx, std::tuple<client_method_t<Method>...>>;
          using request_map_t = decltype(method_element().pending_requests);
-         return detail::get_request_map<request_map_t, method_name>(methods);
+         return detail::get_request_map<request_map_t, Name>(methods);
       }
    };
 } // namespace glz::rpc

--- a/include/glaze/ext/jsonrpc.hpp
+++ b/include/glaze/ext/jsonrpc.hpp
@@ -209,11 +209,12 @@ namespace glz::rpc
             if constexpr (name == M::name_v) {
                using result_t = typename M::result_t;
                using params_t = typename M::params_t;
+               using expected_t = expected<result_t, rpc::error>;
                if constexpr (std::is_invocable_r_v<result_t, decltype(callback), const params_t&>) {
-                  method.callback = [cb = std::move(callback)](const params_t& params) -> expected<result_t, rpc::error> { return cb(params); };
+                  method.callback = [cb = std::move(callback)](const params_t& params) -> expected_t { return cb(params); };
                }
                else if constexpr (std::is_invocable_r_v<rpc::error, decltype(callback), const params_t&>) {
-                  method.callback = [cb = std::move(callback)](const params_t& params) -> expected<result_t, rpc::error> { return glz::unexpected{cb(params)}; };
+                  method.callback = [cb = std::move(callback)](const params_t& params) -> expected_t { return glz::unexpected{cb(params)}; };
                }
                else {
                   static_assert(false_v<M>, "Method supplied is not invocable with registered types");

--- a/tests/jsonrpc_test/jsonrpc_test.cpp
+++ b/tests/jsonrpc_test/jsonrpc_test.cpp
@@ -14,7 +14,7 @@ ut::suite valid_vector_test_cases_server = [] {
 
    rpc::server<rpc::method<"add", vec_t, int>> server;
 
-   server.on<"add">([](vec_t const& vec) -> glz::expected<int, rpc::error> {
+   server.on<"add">([](const vec_t& vec) -> glz::expected<int, rpc::error> {
       int sum{std::reduce(std::cbegin(vec), std::cend(vec))};
       return sum;
    });
@@ -33,7 +33,7 @@ ut::suite valid_vector_test_cases_server = [] {
    std::string raw_json;
    std::string resulting_request;
 
-   for (auto const& pair : valid_requests) {
+   for (const auto& pair : valid_requests) {
       std::tie(raw_json, resulting_request) = pair;
       auto stripped{std::make_shared<std::string>(resulting_request)};
       stripped->erase(std::remove_if(stripped->begin(), stripped->end(), ::isspace), stripped->end());
@@ -55,7 +55,7 @@ ut::suite vector_test_cases = [] {
    rpc::server<rpc::method<"summer", vec_t, int>> server;
    rpc::client<rpc::method<"summer", vec_t, int>> client;
 
-   server.on<"summer">([](vec_t const& vec) -> glz::expected<int, rpc::error> {
+   server.on<"summer">([](const vec_t& vec) -> glz::expected<int, rpc::error> {
       int sum{std::reduce(std::cbegin(vec), std::cend(vec))};
       return sum;
    });
@@ -76,7 +76,7 @@ ut::suite vector_test_cases = [] {
       ut::expect(requests.size() == 1);
       ut::expect(requests.contains(1)); // the id is 1
 
-      server.on<"summer">([](vec_t const& vec) -> glz::expected<int, rpc::error> {
+      server.on<"summer">([](const vec_t& vec) -> glz::expected<int, rpc::error> {
          ut::expect(vec == std::vector{1, 2, 3});
          int sum{std::reduce(std::cbegin(vec), std::cend(vec))};
          return sum;
@@ -133,7 +133,7 @@ ut::suite struct_test_cases = [] {
       ut::expect(request_str.first ==
                  R"({"jsonrpc":"2.0","method":"foo","params":{"foo_a":1337,"foo_b":"hello world"},"id":"42"})");
 
-      server.on<"foo">([](foo_params const& params) -> glz::expected<foo_result, rpc::error> {
+      server.on<"foo">([](const foo_params& params) -> glz::expected<foo_result, rpc::error> {
          ut::expect(params.foo_a == 1337);
          ut::expect(params.foo_b == "hello world");
          return foo_result{.foo_c = true, .foo_d = "new world"};
@@ -145,7 +145,7 @@ ut::suite struct_test_cases = [] {
       client.call(response);
       ut::expect(called);
 
-      server.on<"foo">([](foo_params const&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
    };
 
    ut::test("valid bar request") = [&server, &client] {
@@ -162,7 +162,7 @@ ut::suite struct_test_cases = [] {
       ut::expect(request_str.first ==
                  R"({"jsonrpc":"2.0","method":"bar","params":{"bar_a":1337,"bar_b":"hello world"},"id":"bar-uuid"})");
 
-      server.on<"bar">([](bar_params const& params) -> glz::expected<bar_result, rpc::error> {
+      server.on<"bar">([](const bar_params& params) -> glz::expected<bar_result, rpc::error> {
          ut::expect(params.bar_a == 1337);
          ut::expect(params.bar_b == "hello world");
          return bar_result{.bar_c = true, .bar_d = "new world"};
@@ -174,7 +174,7 @@ ut::suite struct_test_cases = [] {
       client.call(response);
       ut::expect(called);
 
-      server.on<"bar">([](bar_params const&) -> glz::expected<bar_result, rpc::error> { return {}; });
+      server.on<"bar">([](const bar_params&) -> glz::expected<bar_result, rpc::error> { return {}; });
    };
 
    ut::test("foo request error") = [&server, &client] {
@@ -192,7 +192,7 @@ ut::suite struct_test_cases = [] {
       ut::expect(request_str.first ==
                  R"({"jsonrpc":"2.0","method":"foo","params":{"foo_a":1337,"foo_b":"hello world"},"id":"42"})");
 
-      server.on<"foo">([](foo_params const& params) -> glz::expected<foo_result, rpc::error> {
+      server.on<"foo">([](const foo_params& params) -> glz::expected<foo_result, rpc::error> {
          ut::expect(params.foo_a == 1337);
          ut::expect(params.foo_b == "hello world");
          return glz::unexpected(rpc::error{rpc::error_e::server_error_lower, "my error"});
@@ -205,11 +205,11 @@ ut::suite struct_test_cases = [] {
       client.call(response);
       ut::expect(called);
 
-      server.on<"foo">([](foo_params const&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
    };
 
    ut::test("server invalid version error") = [&server] {
-      server.on<"foo">([](foo_params const&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
 
       // invalid jsonrpc version
       auto response_vec = server.call<std::vector<rpc::response_t<glz::raw_json>>>(
@@ -223,7 +223,7 @@ ut::suite struct_test_cases = [] {
    };
 
    ut::test("server method not found") = [&server] {
-      server.on<"foo">([](foo_params const&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
 
       // invalid method name
       auto response_vec = server.call<std::vector<rpc::response_t<glz::raw_json>>>(
@@ -237,7 +237,7 @@ ut::suite struct_test_cases = [] {
    };
 
    ut::test("server invalid json") = [&server] {
-      server.on<"foo">([](foo_params const&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
 
       // key "id" illformed missing `"`
       auto response_vec = server.call<std::vector<rpc::response_t<glz::raw_json>>>(
@@ -254,7 +254,7 @@ ut::suite struct_test_cases = [] {
    };
 
    ut::test("server invalid json batch") = [&server] {
-      server.on<"foo">([](foo_params const&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
 
       // batch cut at params key
       auto response_vec = server.call<std::vector<rpc::response_t<glz::raw_json>>>(
@@ -270,7 +270,7 @@ ut::suite struct_test_cases = [] {
    };
 
    ut::test("server invalid json batch empty array") = [&server] {
-      server.on<"foo">([](foo_params const&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
 
       auto response_vec = server.call<std::vector<rpc::response_t<glz::raw_json>>>(R"([])");
 
@@ -282,7 +282,7 @@ ut::suite struct_test_cases = [] {
    };
 
    ut::test("server invalid json illformed batch one item") = [&server] {
-      server.on<"foo">([](foo_params const&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
 
       auto response_vec = server.call<std::vector<rpc::response_t<glz::raw_json>>>(R"([1])");
 
@@ -295,7 +295,7 @@ ut::suite struct_test_cases = [] {
    };
 
    ut::test("server invalid json illformed batch three items") = [&server] {
-      server.on<"foo">([](foo_params const&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
 
       auto response_vec = server.call<std::vector<rpc::response_t<glz::raw_json>>>(R"([1,2,3])");
 
@@ -310,8 +310,8 @@ ut::suite struct_test_cases = [] {
    };
 
    "server batch with both invalid and valid"_test = [&server] {
-      server.on<"foo">([](foo_params const&) -> glz::expected<foo_result, rpc::error> { return {}; });
-      server.on<"bar">([](bar_params const&) -> glz::expected<bar_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"bar">([](const bar_params&) -> glz::expected<bar_result, rpc::error> { return {}; });
 
       std::string response = server.call(R"(
       [
@@ -332,7 +332,7 @@ ut::suite struct_test_cases = [] {
    };
 
    "server weird id values"_test = [&server] {
-      server.on<"foo">([](foo_params const&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
 
       auto response_vec = server.call<std::vector<rpc::response_t<glz::raw_json>>>(R"(
       [
@@ -347,7 +347,7 @@ ut::suite struct_test_cases = [] {
       }
    };
    "server invalid jsonrpc value"_test = [&server] {
-      server.on<"foo">([](foo_params const&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
 
       auto response_vec = server.call<std::vector<rpc::response_t<glz::raw_json>>>(R"(
       [
@@ -407,7 +407,7 @@ ut::suite struct_test_cases = [] {
       map.clear();
    };
    "client notification"_test = [&client] {
-      auto const notify_str{client.notify<"foo">(foo_params{})};
+      const auto notify_str{client.notify<"foo">(foo_params{})};
       ut::expect(notify_str == R"({"jsonrpc":"2.0","method":"foo","params":{"foo_a":0,"foo_b":""},"id":null})");
    };
    "client call erases id from queue"_test = [&client, &server] {

--- a/tests/jsonrpc_test/jsonrpc_test.cpp
+++ b/tests/jsonrpc_test/jsonrpc_test.cpp
@@ -94,23 +94,12 @@ struct foo_params
    int foo_a{};
    std::string foo_b{};
 };
-template <>
-struct glz::meta<foo_params>
-{
-   using T = foo_params;
-   static constexpr auto value{object(&T::foo_a, &T::foo_b)};
-};
+
 struct foo_result
 {
    bool foo_c{};
    std::string foo_d{};
    bool operator==(const foo_result& rhs) const noexcept { return foo_c == rhs.foo_c && foo_d == rhs.foo_d; }
-};
-template <>
-struct glz::meta<foo_result>
-{
-   using T = foo_result;
-   static constexpr auto value{object(&T::foo_c, &T::foo_d)};
 };
 
 struct bar_params
@@ -118,23 +107,12 @@ struct bar_params
    int bar_a;
    std::string bar_b;
 };
-template <>
-struct glz::meta<bar_params>
-{
-   using T = bar_params;
-   static constexpr auto value{object(&T::bar_a, &T::bar_b)};
-};
+
 struct bar_result
 {
    bool bar_c{};
    std::string bar_d{};
    bool operator==(const bar_result& rhs) const noexcept { return bar_c == rhs.bar_c && bar_d == rhs.bar_d; }
-};
-template <>
-struct glz::meta<bar_result>
-{
-   using T = bar_result;
-   static constexpr auto value{object("bar_c", &T::bar_c, "bar_d", &T::bar_d)};
 };
 
 ut::suite struct_test_cases = [] {
@@ -460,7 +438,7 @@ ut::suite struct_test_cases = [] {
    };
 };
 
-auto main(int, char**) -> int
+auto main() -> int
 {
    const auto result = boost::ut::cfg<>.run({.report_errors = true});
    return result;

--- a/tests/jsonrpc_test/jsonrpc_test.cpp
+++ b/tests/jsonrpc_test/jsonrpc_test.cpp
@@ -14,7 +14,7 @@ ut::suite valid_vector_test_cases_server = [] {
 
    rpc::server<rpc::method<"add", vec_t, int>> server;
 
-   server.on<"add">([](const vec_t& vec) -> glz::expected<int, rpc::error> {
+   server.on<"add">([](const vec_t& vec) {
       int sum{std::reduce(std::cbegin(vec), std::cend(vec))};
       return sum;
    });
@@ -55,7 +55,7 @@ ut::suite vector_test_cases = [] {
    rpc::server<rpc::method<"summer", vec_t, int>> server;
    rpc::client<rpc::method<"summer", vec_t, int>> client;
 
-   server.on<"summer">([](const vec_t& vec) -> glz::expected<int, rpc::error> {
+   server.on<"summer">([](const vec_t& vec) {
       int sum{std::reduce(std::cbegin(vec), std::cend(vec))};
       return sum;
    });
@@ -76,7 +76,7 @@ ut::suite vector_test_cases = [] {
       ut::expect(requests.size() == 1);
       ut::expect(requests.contains(1)); // the id is 1
 
-      server.on<"summer">([](const vec_t& vec) -> glz::expected<int, rpc::error> {
+      server.on<"summer">([](const vec_t& vec) {
          ut::expect(vec == std::vector{1, 2, 3});
          int sum{std::reduce(std::cbegin(vec), std::cend(vec))};
          return sum;
@@ -133,7 +133,7 @@ ut::suite struct_test_cases = [] {
       ut::expect(request_str.first ==
                  R"({"jsonrpc":"2.0","method":"foo","params":{"foo_a":1337,"foo_b":"hello world"},"id":"42"})");
 
-      server.on<"foo">([](const foo_params& params) -> glz::expected<foo_result, rpc::error> {
+      server.on<"foo">([](const foo_params& params) {
          ut::expect(params.foo_a == 1337);
          ut::expect(params.foo_b == "hello world");
          return foo_result{.foo_c = true, .foo_d = "new world"};
@@ -145,7 +145,7 @@ ut::suite struct_test_cases = [] {
       client.call(response);
       ut::expect(called);
 
-      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> foo_result { return {}; });
    };
 
    ut::test("valid bar request") = [&server, &client] {
@@ -162,7 +162,7 @@ ut::suite struct_test_cases = [] {
       ut::expect(request_str.first ==
                  R"({"jsonrpc":"2.0","method":"bar","params":{"bar_a":1337,"bar_b":"hello world"},"id":"bar-uuid"})");
 
-      server.on<"bar">([](const bar_params& params) -> glz::expected<bar_result, rpc::error> {
+      server.on<"bar">([](const bar_params& params) {
          ut::expect(params.bar_a == 1337);
          ut::expect(params.bar_b == "hello world");
          return bar_result{.bar_c = true, .bar_d = "new world"};
@@ -174,7 +174,7 @@ ut::suite struct_test_cases = [] {
       client.call(response);
       ut::expect(called);
 
-      server.on<"bar">([](const bar_params&) -> glz::expected<bar_result, rpc::error> { return {}; });
+      server.on<"bar">([](const bar_params&) -> bar_result { return {}; });
    };
 
    ut::test("foo request error") = [&server, &client] {
@@ -192,10 +192,10 @@ ut::suite struct_test_cases = [] {
       ut::expect(request_str.first ==
                  R"({"jsonrpc":"2.0","method":"foo","params":{"foo_a":1337,"foo_b":"hello world"},"id":"42"})");
 
-      server.on<"foo">([](const foo_params& params) -> glz::expected<foo_result, rpc::error> {
+      server.on<"foo">([](const foo_params& params) {
          ut::expect(params.foo_a == 1337);
          ut::expect(params.foo_b == "hello world");
-         return glz::unexpected(rpc::error{rpc::error_e::server_error_lower, "my error"});
+         return rpc::error{rpc::error_e::server_error_lower, "my error"};
       });
 
       std::string response = server.call(request_str.first);
@@ -205,11 +205,11 @@ ut::suite struct_test_cases = [] {
       client.call(response);
       ut::expect(called);
 
-      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> foo_result { return {}; });
    };
 
    ut::test("server invalid version error") = [&server] {
-      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> foo_result { return {}; });
 
       // invalid jsonrpc version
       auto response_vec = server.call<std::vector<rpc::response_t<glz::raw_json>>>(
@@ -223,7 +223,7 @@ ut::suite struct_test_cases = [] {
    };
 
    ut::test("server method not found") = [&server] {
-      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> foo_result { return {}; });
 
       // invalid method name
       auto response_vec = server.call<std::vector<rpc::response_t<glz::raw_json>>>(
@@ -237,7 +237,7 @@ ut::suite struct_test_cases = [] {
    };
 
    ut::test("server invalid json") = [&server] {
-      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> foo_result { return {}; });
 
       // key "id" illformed missing `"`
       auto response_vec = server.call<std::vector<rpc::response_t<glz::raw_json>>>(
@@ -254,7 +254,7 @@ ut::suite struct_test_cases = [] {
    };
 
    ut::test("server invalid json batch") = [&server] {
-      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> foo_result { return {}; });
 
       // batch cut at params key
       auto response_vec = server.call<std::vector<rpc::response_t<glz::raw_json>>>(
@@ -270,7 +270,7 @@ ut::suite struct_test_cases = [] {
    };
 
    ut::test("server invalid json batch empty array") = [&server] {
-      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> foo_result { return {}; });
 
       auto response_vec = server.call<std::vector<rpc::response_t<glz::raw_json>>>(R"([])");
 
@@ -282,7 +282,7 @@ ut::suite struct_test_cases = [] {
    };
 
    ut::test("server invalid json illformed batch one item") = [&server] {
-      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> foo_result { return {}; });
 
       auto response_vec = server.call<std::vector<rpc::response_t<glz::raw_json>>>(R"([1])");
 
@@ -295,7 +295,7 @@ ut::suite struct_test_cases = [] {
    };
 
    ut::test("server invalid json illformed batch three items") = [&server] {
-      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> foo_result { return {}; });
 
       auto response_vec = server.call<std::vector<rpc::response_t<glz::raw_json>>>(R"([1,2,3])");
 
@@ -310,8 +310,8 @@ ut::suite struct_test_cases = [] {
    };
 
    "server batch with both invalid and valid"_test = [&server] {
-      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
-      server.on<"bar">([](const bar_params&) -> glz::expected<bar_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> foo_result { return {}; });
+      server.on<"bar">([](const bar_params&) -> bar_result { return {}; });
 
       std::string response = server.call(R"(
       [
@@ -332,7 +332,7 @@ ut::suite struct_test_cases = [] {
    };
 
    "server weird id values"_test = [&server] {
-      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> foo_result { return {}; });
 
       auto response_vec = server.call<std::vector<rpc::response_t<glz::raw_json>>>(R"(
       [
@@ -347,7 +347,7 @@ ut::suite struct_test_cases = [] {
       }
    };
    "server invalid jsonrpc value"_test = [&server] {
-      server.on<"foo">([](const foo_params&) -> glz::expected<foo_result, rpc::error> { return {}; });
+      server.on<"foo">([](const foo_params&) -> foo_result { return {}; });
 
       auto response_vec = server.call<std::vector<rpc::response_t<glz::raw_json>>>(R"(
       [

--- a/tests/jsonrpc_test/jsonrpc_test.cpp
+++ b/tests/jsonrpc_test/jsonrpc_test.cpp
@@ -62,14 +62,14 @@ ut::suite vector_test_cases = [] {
 
    ut::test("sum_result = 6") = [&server, &client] {
       bool called{};
-      auto request_str{client.request<"summer">(1, std::vector{1, 2, 3},
+      auto request_str = client.request<"summer">(1, std::vector{1, 2, 3},
                                                 [&called](glz::expected<int, rpc::error> value, rpc::id_t id) -> void {
                                                    called = true;
                                                    ut::expect(value.has_value());
                                                    ut::expect(value.value() == 6);
                                                    ut::expect(std::holds_alternative<std::int64_t>(id));
                                                    ut::expect(std::get<std::int64_t>(id) == std::int64_t{1});
-                                                })};
+                                                });
       ut::expect(request_str.first == R"({"jsonrpc":"2.0","method":"summer","params":[1,2,3],"id":1})");
 
       [[maybe_unused]] auto& requests = client.get_request_map<"summer">();


### PR DESCRIPTION
I'm working on a significant cleanup of the JSON RPC code. The aim is to make the API simpler and more straightforward for users.

- Using reflection for tests, examples, and member object reflection for some internals

- Hiding `expected` from the `server.on` registration. The user can just return their result type or an `rpc::error` and the internals will wrap that call to produce an `expected`