### PR TITLE
fix reading empty struct with reflection

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1553,7 +1553,7 @@ namespace glz
                   return std::tuple_size_v<meta_t<T>>;
                }
             }();
-            if constexpr (glaze_object_t<T> && num_members == 0 && Opts.error_on_unknown_keys) {
+            if constexpr ((glaze_object_t<T> || reflectable<T>)&&num_members == 0 && Opts.error_on_unknown_keys) {
                if (*it == '}') [[likely]] {
                   ++it;
                   return;

--- a/tests/reflection_test/reflection_test.cpp
+++ b/tests/reflection_test/reflection_test.cpp
@@ -407,6 +407,17 @@ suite json_schema = [] {
    };
 };
 
+struct empty_t
+{};
+
+suite empty_test = [] {
+   "empty_t"_test = [] {
+      empty_t obj;
+      expect(glz::write_json(obj) == "{}");
+      expect(!glz::read_json(obj, "{}"));
+   };
+};
+
 int main()
 { // Explicitly run registered test suites and report errors
    // This prevents potential issues with thread local variables


### PR DESCRIPTION
The PR fixes the compile error to read an empty struct without explicit meta object. 