### PR TITLE
Add json partial read mode

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -44,6 +44,9 @@ namespace glz
    template <class T>
    concept custom_write = requires { meta<T>::custom_write == true; };
 
+   template <class T>
+   concept partial_read = requires { meta<T>::partial_read == true; };
+
    template <class... T>
    struct obj final
    {

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -32,6 +32,7 @@ namespace glz
       bool raw_string = false; // do not decode/encode escaped characters for strings (improves read/write performance)
       bool structs_as_arrays = false; // Handle structs (reading/writing) without keys, which applies to reflectable and
                                       // glaze_object_t concepts
+      bool partial_read_nested = false; // Rewind forward the partially readed struct to the end of the struct
 
       // INTERNAL USE
       bool opening_handled = false; // the opening character has been handled

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1812,6 +1812,209 @@ namespace glz
          }
       };
 
+      template <class T>
+         requires (glaze_object_t<T> || reflectable<T>) && partial_read<T>
+      struct from_json<T>
+      {
+         template <auto Options, string_literal tag = "">
+         GLZ_FLATTEN static void op(T& value, is_context auto&& ctx, auto&& it, auto&& end)
+         {
+            static constexpr auto num_members = [] {
+               if constexpr (reflectable<T>) {
+                  return std::tuple_size_v<decltype(to_tuple(std::declval<T>()))>;
+               }
+               else {
+                  return std::tuple_size_v<meta_t<T>>;
+               }
+            }();
+
+            if constexpr (num_members == 0) {
+               static_assert(false_v<T>, "No members to read for partial read");
+            }
+
+            parse_object_opening<Options>(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
+
+            static constexpr auto Opts = opening_handled_off<ws_handled_off<Options>()>();
+
+            // Only used if partial_read_nested = true
+            [[maybe_unused]] uint32_t opening_counter = 1;
+
+            bit_array<num_members> fields{};
+            bit_array<num_members> all_fields{};
+            for_each<num_members>([&](auto I) constexpr { all_fields[I] = true; });
+
+            decltype(auto) frozen_map = [&] {
+               if constexpr (reflectable<T> && num_members > 0) {
+                  static constinit auto cmap = make_map<T, Opts.use_hash_comparison>();
+                  // We want to run this populate outside of the while loop
+                  populate_map(value, cmap); // Function required for MSVC to build
+                  return cmap;
+               }
+               else if constexpr (glaze_object_t<T> && num_members > 0) {
+                  static constexpr auto cmap = make_map<T, Opts.use_hash_comparison>();
+                  return cmap;
+               }
+               else {
+                  return nullptr;
+               }
+            }();
+
+            bool first = true;
+            while (true) {
+               if ((all_fields & fields) == all_fields) [[unlikely]] {
+                  if constexpr (Opts.partial_read_nested) {
+                     while(it != end) {
+                        if (*it == '}') [[unlikely]]
+                           --opening_counter;
+                        if (*it == '{') [[unlikely]]
+                           ++opening_counter;
+                        ++it;
+                        if(opening_counter == 0) [[unlikely]]
+                           return;
+                     }
+                  }
+                  else
+                     return;
+               }
+               else if (*it == '}') [[unlikely]] {
+                  if constexpr (Opts.error_on_missing_keys) {
+                     ctx.error = error_code::missing_key;
+                  }
+                  return;
+               }
+               else if (first) [[unlikely]]
+                  first = false;
+               else [[likely]] {
+                  match<','>(ctx, it, end);
+                  if (bool(ctx.error)) [[unlikely]]
+                     return;
+                  skip_ws_no_pre_check<Opts>(ctx, it, end);
+                  if (bool(ctx.error)) [[unlikely]]
+                     return;
+               }
+
+               std::conditional_t<Opts.error_on_unknown_keys, const sv, sv> key =
+                  parse_object_key<T, ws_handled<Opts>(), tag>(ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
+
+                      // Because parse_object_key does not necessarily return a valid JSON key, the logic for handling
+                      // whitespace and the colon must run after checking if the key exists
+
+               if constexpr (Opts.error_on_unknown_keys) {
+                  if (*it != '"') [[unlikely]] {
+                     ctx.error = error_code::unknown_key;
+                     return;
+                  }
+                  ++it;
+
+                  if (const auto& member_it = frozen_map.find(key); member_it != frozen_map.end()) [[likely]] {
+                     parse_object_entry_sep<Opts>(ctx, it, end);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+
+                            // TODO: Kludge/hack. Should work but could easily cause memory issues with small changes.
+                            // At the very least if we are going to do this add a get_index method to the maps and
+                            // call that
+                     auto index = member_it - frozen_map.begin();
+                     fields[index] = true;
+
+                     std::visit(
+                        [&](auto&& member_ptr) {
+                           read<json>::op<ws_handled<Opts>()>(get_member(value, member_ptr), ctx, it, end);
+                        },
+                        member_it->second);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                  }
+                  else [[unlikely]] {
+                     if constexpr (tag.sv().empty()) {
+                        std::advance(it, -int64_t(key.size()));
+                        ctx.error = error_code::unknown_key;
+                        return;
+                     }
+                     else if (key != tag.sv()) {
+                        std::advance(it, -int64_t(key.size()));
+                        ctx.error = error_code::unknown_key;
+                        return;
+                     }
+                     else {
+                        // We duplicate this code to avoid generating unreachable code
+                        parse_object_entry_sep<Opts>(ctx, it, end);
+                        if (bool(ctx.error)) [[unlikely]]
+                           return;
+
+                        read<json>::handle_unknown<Opts>(key, value, ctx, it, end);
+                        if (bool(ctx.error)) [[unlikely]]
+                           return;
+                     }
+                  }
+               }
+               else {
+                  if (const auto& member_it = frozen_map.find(key); member_it != frozen_map.end()) [[likely]] {
+                     match<'"'>(ctx, it, end);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+
+                     parse_object_entry_sep<Opts>(ctx, it, end);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+
+                            // TODO: Kludge/hack. Should work but could easily cause memory issues with small changes.
+                            // At the very least if we are going to do this add a get_index method to the maps and
+                            // call that
+                     auto index = member_it - frozen_map.begin();
+                     fields[index] = true;
+
+                     std::visit(
+                        [&](auto&& member_ptr) {
+                           read<json>::op<ws_handled<Opts>()>(get_member(value, member_ptr), ctx, it, end);
+                        },
+                        member_it->second);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                  }
+                  else [[unlikely]] {
+                     it -= key.size(); // rewind to skip the potentially escaped key
+
+                            // Unknown key handler does not unescape keys or want unescaped keys. Unknown escaped keys
+                            // are handled by the user.
+
+                     const auto start = it;
+                     while (true) {
+                        skip_till_escape_or_quote(ctx, it, end);
+                        if (bool(ctx.error)) [[unlikely]]
+                           return;
+
+                        if (*it == '"') [[likely]] {
+                           key = {start, size_t(it - start)};
+                           ++it;
+                           break;
+                        }
+                        else {
+                           ++it; // skip the escape
+                           if (*it == '"') {
+                              ++it; // skip the escaped quote
+                           }
+                        }
+                     }
+
+                            // We duplicate this code to avoid generating unreachable code
+                     parse_object_entry_sep<Opts>(ctx, it, end);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+
+                     read<json>::handle_unknown<Opts>(key, value, ctx, it, end);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                  }
+               }
+            }
+         }
+      };
+
       template <is_variant T>
       GLZ_ALWAYS_INLINE constexpr auto variant_is_auto_deducible()
       {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -6644,6 +6644,109 @@ suite address_sanitizer_test = [] {
    };
 };
 
+struct Header
+{
+   std::string id;
+   std::string type;
+};
+
+template <>
+struct glz::meta<Header>
+{
+   static constexpr auto partial_read = true;
+};
+
+struct NestedPartialRead
+{
+   std::string method;
+   Header header;
+   int number;
+};
+
+suite partial_read_tests = [] {
+   using namespace boost::ut;
+
+   "partial read"_test = [] {
+      Header h{};
+      std::string buf = R"({"id":"51e2affb","type":"message_type","unknown key":"value"})";
+
+      expect(glz::read_json(h, buf) == glz::error_code::none);
+      expect(h.id == "51e2affb");
+      expect(h.type == "message_type");
+   };
+
+   "partial read 2"_test = [] {
+      Header h{};
+      // closing curly bracket is missing
+      std::string buf = R"({"id":"51e2affb","type":"message_type","unknown key":"value"})";
+
+      expect(glz::read_json(h, buf) == glz::error_code::none);
+      expect(h.id == "51e2affb");
+      expect(h.type == "message_type");
+   };
+
+   "partial read unknown key"_test = [] {
+      Header h{};
+      std::string buf = R"({"id":"51e2affb","unknown key":"value","type":"message_type"})";
+
+      expect(glz::read_json(h, buf) == glz::error_code::unknown_key);
+      expect(h.id == "51e2affb");
+      expect(h.type.empty());
+   };
+
+   "partial read unknown key 2"_test = [] {
+      Header h{};
+      std::string buf = R"({"id":"51e2affb","unknown key":"value","type":"message_type"})";
+
+      expect(glz::read<glz::opts{.error_on_unknown_keys = false}>(h, buf) == glz::error_code::none);
+      expect(h.id == "51e2affb");
+      expect(h.type == "message_type");
+   };
+
+   "partial read missing key"_test = [] {
+      Header h{};
+      std::string buf = R"({"id":"51e2affb","unknown key":"value"})";
+
+      expect(glz::read<glz::opts{.error_on_unknown_keys = false}>(h, buf) != glz::error_code::missing_key);
+      expect(h.id == "51e2affb");
+      expect(h.type.empty());
+   };
+
+   "partial read missing key 2"_test = [] {
+      Header h{};
+      std::string buf = R"({"id":"51e2affb",""unknown key":"value"})";
+
+      expect(glz::read<glz::opts{.error_on_unknown_keys = false, .error_on_missing_keys = false}>(h, buf) != glz::error_code::none);
+      expect(h.id == "51e2affb");
+      expect(h.type.empty());
+   };
+};
+
+suite nested_partial_read_tests = [] {
+   using namespace boost::ut;
+
+   "nested object partial read"_test = [] {
+      NestedPartialRead n{};
+      std::string buf = R"({"method":"m1","header":{"id":"51e2affb","type":"message_type","unknown key":"value"},"number":51})";
+
+      expect(glz::read_json(n, buf) == glz::error_code::unknown_key);
+      expect(n.method == "m1");
+      expect(n.header.id == "51e2affb");
+      expect(n.header.type == "message_type");
+      expect(n.number == 0);
+   };
+
+   "nested object partial read 2"_test = [] {
+      NestedPartialRead n{};
+      std::string buf = R"({"method":"m1","header":{"id":"51e2affb","type":"message_type","unknown key":"value"},"number":51})";
+
+      expect(glz::read<glz::opts{.partial_read_nested = true}>(n, buf) == glz::error_code::none);
+      expect(n.method == "m1");
+      expect(n.header.id == "51e2affb");
+      expect(n.header.type == "message_type");
+   };
+};
+
 int main()
 {
    // Explicitly run registered test suites and report errors


### PR DESCRIPTION
<details><summary>Hello spoiler</summary>
<p>
Thank you for such an amazing library! I'm learning a lot of new stuff from it, and it looks like an endless process.

After creating a custom read specialization to read only the part of the JSON, I thought it might be helpful for others. So, I decided to make a pull request, and here we are. 

Please feel free to close this pull request if you find that this feature is unnecessary or if it is implemented in an improper way.
</p>
</details> 

### Partial read
Partial read stops the JSON reading at the moment when all required data members are populated.

**Use case:** All requests include a 'header' determining whether the request should be processed or not. It is unnecessary to read a large JSON object in its entirety every time.
```json
{
  "id": "187d3cb2-942d-484c-8271-4e2141bbadb1",
  "messageType": "not supported"
            .....
  the rest of the large JSON
}
```
Using a structure like `Header` with the `.error_on_unknown_keys = false` option can be beneficial, though the JSON is still processed until the end.
```cpp
struct Header
{
    std::string id;
    std::string messageType;
};
```
**To achieve the goal** (do not read the JSON completely) the next changes were made:
- a new concept `partial_read` was added
- a new specialization of the `from_json` was added.

**The new _partial_read_ `from_json` specialization.**

The new  `from_json` is based (was copied) from the another `from_json` specialization - `requires readable_map_t<T> || glaze_object_t<T> || reflectable<T>` and it has requirements
- `requires (glaze_object_t<T> || reflectable<T>) && partial_read<T>`

All data members are considered **required for population**; empty structs without data members are not allowed as there is nothing to read.
**The reader returns** when all member fields are populated or when the end of the JSON object is reached. In the former case, the remaining portion of the JSON object is ignored, it can be even broken. Additionally, if the required field is the last in the JSON object or is missing, the reader will proceed to read the entire JSON object as usual

Enabling the `partial_read` option in the `Header` type's metadata activates the partial reading mode for the `Header` type.
```cpp
struct glz::meta<Header>
{
    static constexpr auto partial_read = true;
};
```

### Nested partial read

Including a data type with the `partial_read` option enabled into another type, such as `AnotherType`, can lead to issues when reading `AnotherType` from the JSON. This is because the partial read can stop reading 'in the middle' of the JSON object, returning an iterator that points not to the end of this JSON object.
```cpp
struct AnotherType
{
    std::string method;
    Header header; // partial read is enabled for this data member
    int number;
};
```
To resolve this issue a new option `partial_read_nested = false` has been added to the `opts` struct. This new option impacts only the new `from_json` specialization. When all required members are populated with data, this option enables rewinding the read iterator forward to the end of the JSON object. To achieve this the `opening_counter` counter is used, it increments on an opening curly bracket symbol `{`  and decrements on a closing curly bracket symbol `}`. When the counter equals zero, it indicates that the end of the JSON object has been reached and the reader returns.

This approach closely resembles the behavior when the option `.error_on_unknown_keys = false` is used. The key difference is that the reader doesn't inspect the remaining data of the JSON object; it registers only the curly bracket symbols. It looks like it can be a little bit faster compared with the `.error_on_unknown_keys = false`  approach. Or maybe not.



<details><summary>Some Catch2 unit tests</summary>
<p>

```cpp
#include <catch2/catch_test_macros.hpp>
#include <glaze/glaze.hpp>

struct Header
{
    std::string id;
    std::string type;
};

template <>
struct glz::meta<Header>
{
    static constexpr auto partial_read = true;
};

struct AnotherType
{
    std::string method;
    Header header;
    int number;
};

// NOLINTBEGIN (readability-function-cognitive-complexity)
namespace entrance::tests
{
//clazy:excludeall=non-pod-global-static

SCENARIO("Partial read", "[partial_read]")
{
    const std::string_view EXPECTED_ID = "51e2affb-0aba-4821-ba75-f2625006eb43";
    const std::string_view EXPECTED_TYPE = "message_type";

    glz::context context{};

    WHEN("The JSON object contains all required data at the beginning")
    {
        std::string json = R"({"id":"51e2affb-0aba-4821-ba75-f2625006eb43","type":"message_type","unknown key":"value"})";

        THEN("The reader processes the JSON object only until all required data is read")
        {
            Header header;
            auto pe = glz::read<glz::opts{.error_on_unknown_keys = true}>(header, json, context);

            CHECK(pe.ec == glz::error_code::none);
            CHECK(header.id == EXPECTED_ID);
            CHECK(header.type == EXPECTED_TYPE);
        }
    }

    WHEN("The JSON object contains all required data at the beginning but is broken afterward")
    {
        // closing curly bracket is missing
        std::string json = R"({"id":"51e2affb-0aba-4821-ba75-f2625006eb43","type":"message_type","unknown key":"value")";

        THEN("The reader successfully processes the JSON object until all required data is read")
        {
            Header header;
            auto pe = glz::read<glz::opts{.error_on_unknown_keys = true}>(header, json, context);

            CHECK(pe.ec == glz::error_code::none);
            CHECK(header.id == EXPECTED_ID);
            CHECK(header.type == EXPECTED_TYPE);
        }
    }

    WHEN("The JSON object has an unknown key between the known keys")
    {
        std::string json = R"({"id":"51e2affb-0aba-4821-ba75-f2625006eb43","unknown key":"value","type":"message_type"})";

        AND_WHEN("The option error_on_unknown_keys is enabled")
        {
            Header header;
            auto pe = glz::read<glz::opts{.error_on_unknown_keys = true}>(header, json, context);

            THEN("The reader fails to process the JSON object with the error: unknown key")
            {
                CHECK(pe.ec == glz::error_code::unknown_key);
                CHECK(header.id == EXPECTED_ID);
                CHECK(header.type.empty());
            }
        }

        AND_WHEN("The option error_on_unknown_keys is disabled")
        {
            Header header;
            auto pe = glz::read<glz::opts{.error_on_unknown_keys = false}>(header, json, context);

            THEN("The reader processes the JSON object without errors")
            {
                CHECK(pe.ec == glz::error_code::none);
                CHECK(header.id == EXPECTED_ID);
                CHECK(header.type == EXPECTED_TYPE);
            }
        }
    }

    WHEN("The JSON object does not contain all required data")
    {
        std::string json = R"({"id":"51e2affb-0aba-4821-ba75-f2625006eb43","unknown key":"value"})";

        AND_WHEN("The option error_on_missing_keys is enabled")
        {
            Header header;
            auto pe = glz::read<glz::opts{.error_on_unknown_keys = false, .error_on_missing_keys = true}>(header, json, context);

            THEN("The reader processes the JSON object completely and returns the error: missing key")
            {
                CHECK(pe.ec == glz::error_code::missing_key);
                CHECK(header.id == EXPECTED_ID);
                CHECK(header.type.empty());
            }
        }

        AND_WHEN("The option error_on_missing_keys is disabled")
        {
            Header header;
            auto pe = glz::read<glz::opts{.error_on_unknown_keys = false, .error_on_missing_keys = false}>(header, json, context);

            THEN("The reader processes the JSON object till the end without errors")
            {
                CHECK(pe.ec == glz::error_code::none);
                CHECK(header.id == EXPECTED_ID);
                CHECK(header.type.empty());
            }
        }
    }
}

SCENARIO("Nested partial read", "[partial_read]")
{
    const std::string_view EXPECTED_ID = "51e2affb-0aba-4821-ba75-f2625006eb43";
    const std::string_view EXPECTED_TYPE = "message_type";
    const std::string_view EXPECTED_METHOD = "m1";
    const int EXPECTED_NUMBER = 51;

    glz::context context{};

    WHEN("The JSON object contains the struct for partial reading in the middle of the object")
    {
        std::string json = R"({"method":"m1","header":{"id":"51e2affb-0aba-4821-ba75-f2625006eb43","type":"message_type","unknown key":"value"},"number":51})";

        AND_WHEN("The option partial_read_nested is disabled")
        {
            AnotherType anoterType;
            auto pe = glz::read<glz::opts{.error_on_unknown_keys = true, .partial_read_nested = false}>(anoterType, json, context);

            THEN("The reader processes the JSON object completely and returns an error: unknown key")
            {
                CHECK(pe.ec == glz::error_code::unknown_key);
                CHECK(anoterType.method == EXPECTED_METHOD);
                CHECK(anoterType.header.id == EXPECTED_ID);
                CHECK(anoterType.header.type == EXPECTED_TYPE);

                // members that are located after the partial-read struct are NOT populated
                CHECK(anoterType.number == 0);
            }
        }

        AND_WHEN("The option partial_read_nested is enabled")
        {
            AnotherType anotherType;
            auto pe = glz::read<glz::opts{.error_on_unknown_keys = true, .partial_read_nested = true}>(anotherType, json, context);

            THEN("The reader processes the JSON object until all required data is read")
            {
                CHECK(pe.ec == glz::error_code::none);
                CHECK(anotherType.method == EXPECTED_METHOD);
                CHECK(anotherType.header.id == EXPECTED_ID);
                CHECK(anotherType.header.type == EXPECTED_TYPE);

                // members located after the partial-read struct are populated
                CHECK(anotherType.number == EXPECTED_NUMBER);
            }
        }
    }
}

} // namespace entrance::tests
// NOLINTBEGIN (readability-function-cognitive-complexity)
```

</p>
</details> 