### PR TITLE
Fix for MSVC reflection multi-threading

### DIFF
--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -772,7 +772,7 @@ namespace glz
             decltype(auto) storage = [&] {
                if constexpr (reflectable<T>) {
 #if ((defined _MSC_VER) && (!defined __clang__))
-                  static constinit auto cmap = make_map<T, Opts.use_hash_comparison>();
+                  static thread_local auto cmap = make_map<T, Opts.use_hash_comparison>();
 #else
                   static thread_local constinit auto cmap = make_map<T, Opts.use_hash_comparison>();
 #endif

--- a/include/glaze/csv/read.hpp
+++ b/include/glaze/csv/read.hpp
@@ -376,7 +376,7 @@ namespace glz
             decltype(auto) frozen_map = [&] {
                if constexpr (reflectable<T> && num_members > 0) {
 #if ((defined _MSC_VER) && (!defined __clang__))
-                  static constinit auto cmap = make_map<T, Opts.use_hash_comparison>();
+                  static thread_local auto cmap = make_map<T, Opts.use_hash_comparison>();
 #else
                   static thread_local constinit auto cmap = make_map<T, Opts.use_hash_comparison>();
 #endif

--- a/include/glaze/json/json_ptr.hpp
+++ b/include/glaze/json/json_ptr.hpp
@@ -101,7 +101,7 @@ namespace glz
             decltype(auto) frozen_map = [&] {
                if constexpr (reflectable<T>) {
 #if ((defined _MSC_VER) && (!defined __clang__))
-                  static constinit auto cmap = make_map<T>();
+                  static thread_local auto cmap = make_map<T>();
 #else
                   static thread_local constinit auto cmap = make_map<T>();
 #endif

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1568,7 +1568,7 @@ namespace glz
                decltype(auto) frozen_map = [&] {
                   if constexpr (reflectable<T> && num_members > 0) {
 #if ((defined _MSC_VER) && (!defined __clang__))
-                     static constinit auto cmap = make_map<T, Opts.use_hash_comparison>();
+                     static thread_local auto cmap = make_map<T, Opts.use_hash_comparison>();
 #else
                      static thread_local constinit auto cmap = make_map<T, Opts.use_hash_comparison>();
 #endif

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1100,7 +1100,7 @@ namespace glz
                if constexpr (reflectable<T>) {
                   if constexpr (std::is_const_v<std::remove_reference_t<decltype(value)>>) {
 #if ((defined _MSC_VER) && (!defined __clang__))
-                     static constinit auto tuple_of_ptrs = make_const_tuple_from_struct<T>();
+                     static thread_local auto tuple_of_ptrs = make_const_tuple_from_struct<T>();
 #else
                      static thread_local constinit auto tuple_of_ptrs = make_const_tuple_from_struct<T>();
 #endif
@@ -1109,7 +1109,7 @@ namespace glz
                   }
                   else {
 #if ((defined _MSC_VER) && (!defined __clang__))
-                     static constinit auto tuple_of_ptrs = make_tuple_from_struct<T>();
+                     static thread_local auto tuple_of_ptrs = make_tuple_from_struct<T>();
 #else
                      static thread_local constinit auto tuple_of_ptrs = make_tuple_from_struct<T>();
 #endif


### PR DESCRIPTION
This fixes issues using reflection with MSVC and multi-threading. We have to remove constinit currently, which will likely result in worse runtime performance, but it is necessary until MSVC fixes bugs associated with `static thread_local constinit`