### PR TITLE
JSON includer error handling

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -1159,7 +1159,8 @@ struct glz::meta<glz::error_code>
                 "unknown_distribution", glz::error_code::unknown_distribution, //
                 "invalid_distribution_elements", glz::error_code::invalid_distribution_elements, //
                 "missing_key", glz::error_code::missing_key, //
-                "hostname_failure", glz::error_code::hostname_failure //
+                "hostname_failure", glz::error_code::hostname_failure, //
+                "includer_error", glz::error_code::includer_error //
       );
 };
 
@@ -1186,9 +1187,19 @@ namespace glz
 
       const auto info = detail::get_source_info(buffer, pe.location);
       if (info) {
-         return detail::generate_error_string(error_type_str, *info);
+         auto error_str = detail::generate_error_string(error_type_str, *info);
+         if (pe.includer_error.size()) {
+            error_str += "\n";
+            error_str += pe.includer_error;
+         }
+         return error_str;
       }
-      return std::string(error_type_str);
+      auto error_str = std::string(error_type_str);
+      if (pe.includer_error.size()) {
+         error_str += "\n";
+         error_str += pe.includer_error;
+      }
+      return error_str;
    }
 }
 

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -1189,14 +1189,12 @@ namespace glz
       if (info) {
          auto error_str = detail::generate_error_string(error_type_str, *info);
          if (pe.includer_error.size()) {
-            error_str += "\n";
             error_str += pe.includer_error;
          }
          return error_str;
       }
       auto error_str = std::string(error_type_str);
       if (pe.includer_error.size()) {
-         error_str += "\n";
          error_str += pe.includer_error;
       }
       return error_str;

--- a/include/glaze/core/context.hpp
+++ b/include/glaze/core/context.hpp
@@ -58,13 +58,15 @@ namespace glz
       unknown_distribution,
       invalid_distribution_elements,
       missing_key,
-      hostname_failure
+      hostname_failure,
+      includer_error
    };
 
    struct parse_error final
    {
       error_code ec{};
       size_t location{};
+      std::string_view includer_error{}; // error from a nested file includer
 
       operator bool() const { return ec != error_code::none; }
 
@@ -87,6 +89,7 @@ namespace glz
       // INTERNAL USE
       uint32_t indentation_level{};
       std::string current_file; // top level file path
+      std::string_view includer_error{}; // error from a nested file includer
       error_code error{};
    };
 

--- a/include/glaze/core/read.hpp
+++ b/include/glaze/core/read.hpp
@@ -90,7 +90,7 @@ namespace glz
          }
       }
 
-      return {ctx.error, static_cast<size_t>(std::distance(start, b))};
+      return {ctx.error, static_cast<size_t>(std::distance(start, b)), ctx.includer_error};
    }
 
    template <opts Opts>

--- a/include/glaze/file/hostname_include.hpp
+++ b/include/glaze/file/hostname_include.hpp
@@ -105,16 +105,24 @@ namespace glz
             const auto ec = file_to_buffer(buffer, string_file_path);
 
             if (bool(ec)) [[unlikely]] {
-               ctx.error = ec;
+               ctx.error = error_code::includer_error;
+               auto& error_msg = error_buffer();
+               error_msg = "file failed to open: " + string_file_path;
+               ctx.includer_error = error_msg;
                return;
             }
 
             const auto current_file = ctx.current_file;
             ctx.current_file = string_file_path;
 
-            std::ignore = glz::read<Opts>(value.value, buffer, ctx);
-            if (bool(ctx.error)) [[unlikely]]
+            const auto ecode = glz::read<Opts>(value.value, buffer, ctx);
+            if (bool(ctx.error)) [[unlikely]] {
+               ctx.error = error_code::includer_error;
+               auto& error_msg = error_buffer();
+               error_msg = glz::format_error(ecode, buffer);
+               ctx.includer_error = error_msg;
                return;
+            }
 
             ctx.current_file = current_file;
          }

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -33,10 +33,16 @@ namespace glz
 
    namespace detail
    {
-      // Unless we can mutate the input buffer we need somewhere to store escaped strings for key lookup and such
-      // Could put this in the context but tls overhead isnt that bad. Will need to figure out when heap allocations are
-      // not allowed or restricted
+      // Unless we can mutate the input buffer we need somewhere to store escaped strings for key lookup, etc.
+      // We don't put this in the context because we don't want to continually reallocate.
       GLZ_ALWAYS_INLINE std::string& string_buffer() noexcept
+      {
+         static thread_local std::string buffer(256, ' ');
+         return buffer;
+      }
+      
+      // We use an error buffer to avoid multiple allocations in the case that errors occur multiple times.
+      GLZ_ALWAYS_INLINE std::string& error_buffer() noexcept
       {
          static thread_local std::string buffer(256, ' ');
          return buffer;

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1264,16 +1264,24 @@ namespace glz
             const auto ec = file_to_buffer(buffer, string_file_path);
 
             if (bool(ec)) [[unlikely]] {
-               ctx.error = ec;
+               ctx.error = error_code::includer_error;
+               auto& error_msg = error_buffer();
+               error_msg = "file failed to open: " + string_file_path;
+               ctx.includer_error = error_msg;
                return;
             }
 
             const auto current_file = ctx.current_file;
             ctx.current_file = string_file_path;
 
-            std::ignore = glz::read<Opts>(value.value, buffer, ctx);
-            if (bool(ctx.error)) [[unlikely]]
+            const auto ecode = glz::read<Opts>(value.value, buffer, ctx);
+            if (bool(ctx.error)) [[unlikely]] {
+               ctx.error = error_code::includer_error;
+               auto& error_msg = error_buffer();
+               error_msg = glz::format_error(ecode, buffer);
+               ctx.includer_error = error_msg;
                return;
+            }
 
             ctx.current_file = current_file;
          }

--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -91,7 +91,7 @@ namespace glz::repe
          glz::detail::read<Opts.format>::template op<Opts>(std::forward<Value>(value), ctx, b, e);
 
          if (bool(ctx.error)) {
-            parse_error ec{ctx.error, size_t(std::distance(start, b))};
+            parse_error ec{ctx.error, size_t(std::distance(start, b)), ctx.includer_error};
             write_json(std::forward_as_tuple(header{.error = true},
                                              error_t{error_e::parse_error, format_error(ec, state.message)}),
                        response);
@@ -137,7 +137,7 @@ namespace glz::repe
       // clang 14 won't build when capturing from structured binding
       auto handle_error = [&](auto& it) {
          ctx.error = error_code::syntax_error;
-         parse_error pe{ctx.error, size_t(std::distance(start, it))};
+         parse_error pe{ctx.error, size_t(std::distance(start, it)), ctx.includer_error};
          return error_t{error_e::parse_error, format_error(pe, buffer)};
       };
 
@@ -151,7 +151,7 @@ namespace glz::repe
       glz::detail::read<Opts.format>::template op<Opts>(h, ctx, b, e);
 
       if (bool(ctx.error)) {
-         parse_error pe{ctx.error, size_t(std::distance(start, b))};
+         parse_error pe{ctx.error, size_t(std::distance(start, b)), ctx.includer_error};
          return {error_e::parse_error, format_error(pe, buffer)};
       }
 
@@ -171,7 +171,7 @@ namespace glz::repe
       }
 
       if (bool(ctx.error)) {
-         parse_error pe{ctx.error, size_t(std::distance(start, b))};
+         parse_error pe{ctx.error, size_t(std::distance(start, b)), ctx.includer_error};
          return {error_e::parse_error, format_error(pe, buffer)};
       }
       return {};
@@ -310,7 +310,7 @@ namespace glz::repe
 
          auto handle_error = [&](auto& it) {
             ctx.error = error_code::syntax_error;
-            parse_error pe{ctx.error, size_t(std::distance(start, it))};
+            parse_error pe{ctx.error, size_t(std::distance(start, it)), ctx.includer_error};
             write_json(
                std::forward_as_tuple(header{.error = true}, error_t{error_e::parse_error, format_error(pe, msg)}),
                response);
@@ -327,7 +327,7 @@ namespace glz::repe
          glz::detail::read<Opts.format>::template op<Opts>(h, ctx, b, e);
 
          if (bool(ctx.error)) {
-            parse_error pe{ctx.error, size_t(std::distance(start, b))};
+            parse_error pe{ctx.error, size_t(std::distance(start, b)), ctx.includer_error};
             response = format_error(pe, msg);
             return !h.notification;
          }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -2935,6 +2935,36 @@ suite file_include_test = [] {
       expect(obj.str == "Hello") << obj.str;
       expect(obj.i == 55) << obj.i;
    };
+   
+   "file_include error handling"_test = [] {
+      includer_struct obj{};
+      
+      auto output = glz::write_json(obj);
+      output.erase(0, 1); // create an error
+
+      expect(glz::buffer_to_file(output, "../alabastar.json") == glz::error_code::none);
+
+      obj.str = "";
+
+      std::string s = R"({"include": "../alabastar.json", "i": 100})";
+      const auto ec = glz::read_json(obj, s);
+      expect(bool(ec));
+   };
+   
+   "file_include error handling"_test = [] {
+      includer_struct obj{};
+      
+      auto output = glz::write_json(obj);
+      
+      expect(glz::buffer_to_file(output, "../alabastar.json") == glz::error_code::none);
+
+      obj.str = "";
+      
+      // make the path incorrect
+      std::string s = R"({"include": "../abs.json", "i": 100})";
+      const auto ec = glz::read_json(obj, s);
+      expect(bool(ec));
+   };
 };
 
 suite file_include_test_auto = [] {


### PR DESCRIPTION
Propagates nested includer errors. This produces much better error messages when included files are missing or there are syntax errors within them.