### PR TITLE
Supports glz::meta JSON schema reflection

### DIFF
--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -123,6 +123,64 @@ namespace glz
 {
    namespace detail
    {
+      template <class Tuple>
+      consteval size_t count_schema_elements() {
+         constexpr auto N = std::tuple_size_v<Tuple>;
+         
+         size_t i{};
+         for_each<N>([&](auto I) {
+            if constexpr (std::same_as<std::decay_t<std::tuple_element_t<I, Tuple>>, schema>) {
+               ++i;
+            }
+         });
+         
+         return i;
+      }
+      
+      template <class T>
+      consteval auto make_reflection_schema_array() {
+         glz::meta<T> meta_instance{};
+         auto tuple = to_tuple(meta_instance);
+         using V = decltype(tuple);
+         constexpr auto N = std::tuple_size_v<V>;
+         if constexpr (N > 0) {
+            constexpr auto names = member_names<glz::meta<T>>;
+            
+            constexpr auto n_schema_elements = count_schema_elements<V>();
+            std::array<std::pair<sv, schema>, n_schema_elements> ret{};
+            
+            size_t i{};
+            for_each<N>([&](auto I) {
+               if constexpr (std::same_as<std::decay_t<std::tuple_element_t<I, V>>, schema>) {
+                  ret[i] = std::pair{ names[I], std::get<I>(tuple) };
+               }
+               ++i;
+            });
+            
+            return ret;
+         }
+         else {
+            return std::array<std::pair<sv, schema>, 0>{};
+         }
+      };
+      
+      template <size_t N, size_t... I>
+      constexpr auto make_reflection_schema_map_impl(auto& arr, std::index_sequence<I...>)
+      {
+         return glz::detail::normal_map<sv, schema, N>(
+            {std::get<I>(arr)...});
+      }
+      
+      // The reflection schema map makes a map of all schema types within a glz::meta
+      // and returns a map of these schemas with their reflected names.
+      template <class T>
+      constexpr auto make_reflection_schema_map() {
+         constexpr auto arr = make_reflection_schema_array<T>();
+         constexpr auto N = arr.size();
+         constexpr auto indices = std::make_index_sequence<N>{};
+         return make_reflection_schema_map_impl<N>(arr, indices);
+      }
+      
       template <class T = void>
       struct to_json_schema
       {
@@ -336,6 +394,9 @@ namespace glz
                   return std::tuple_size_v<meta_t<T>>;
                }
             }();
+            
+            [[maybe_unused]] static constexpr auto schema_map = make_reflection_schema_map<T>();
+            
             s.properties = std::map<sv, schema, std::less<>>();
             for_each<N>([&](auto I) {
                using Element = glaze_tuple_element<I, N, T>;
@@ -346,7 +407,19 @@ namespace glz
                if (!def.type) {
                   to_json_schema<val_t>::template op<Opts>(def, defs);
                }
-               auto ref_val = schema{join_v<chars<"#/$defs/">, name_v<val_t>>};
+               
+               constexpr sv key = key_name<I, T, Element::use_reflection>;
+               
+               schema ref_val{};
+               if constexpr (schema_map.size()) {
+                  if (const auto& it = schema_map.find(key); it != schema_map.end()) {
+                     ref_val = it->second;
+                  }
+               }
+               if (ref_val.ref == "") {
+                  ref_val.ref = join_v<chars<"#/$defs/">, name_v<val_t>>;
+               }
+               
                static constexpr size_t comment_index = member_index + 1;
                static constexpr auto Size = std::tuple_size_v<typename Element::Item>;
 
@@ -361,8 +434,7 @@ namespace glz
                      ref_val.ref = join_v<chars<"#/$defs/">, name_v<val_t>>;
                   }
                }
-
-               constexpr sv key = key_name<I, T, Element::use_reflection>;
+                             
                (*s.properties)[key] = ref_val;
             });
             s.additionalProperties = false;

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -141,7 +141,7 @@ namespace glz
       consteval auto make_reflection_schema_array() {
          glz::meta<T> meta_instance{};
          auto tuple = to_tuple(meta_instance);
-         using V = decltype(tuple);
+         using V = std::decay_t<decltype(tuple)>;
          constexpr auto N = std::tuple_size_v<V>;
          if constexpr (N > 0) {
             constexpr auto names = member_names<glz::meta<T>>;

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -412,8 +412,12 @@ namespace glz
                
                schema ref_val{};
                if constexpr (schema_map.size()) {
-                  if (const auto& it = schema_map.find(key); it != schema_map.end()) {
+                  static constexpr auto it = schema_map.find(key);
+                  if constexpr (it != schema_map.end()) {
                      ref_val = it->second;
+                  }
+                  else {
+                     static_assert(it != schema_map.end(), "schema value's name in glz::meta<T> is unmmatched");
                   }
                }
                if (ref_val.ref == "") {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -6798,6 +6798,35 @@ suite nested_partial_read_tests = [] {
    };
 };
 
+struct meta_schema_t
+{
+   int x{};
+   std::string file_name{};
+   bool is_valid{};
+};
+
+template <>
+struct glz::meta<meta_schema_t>
+{
+   schema x{.description = "x is a special integer"};
+   schema file_name{.description = "provide a file name to load"};
+   schema is_valid{.description = "for validation"};
+   using T = meta_schema_t;
+   static constexpr auto value = object(&T::x, &T::file_name, &T::is_valid);
+};
+
+suite meta_schema_tests = [] {
+   "meta_schema"_test = [] {
+      meta_schema_t obj;
+      std::string buffer{};
+      glz::write_json(obj, buffer);
+      expect(buffer == R"({"x":0,"file_name":"","is_valid":false})") << buffer;
+      
+      const auto json_schema = glz::write_json_schema<meta_schema_t>();
+      expect(json_schema == R"({"type":["object"],"properties":{"file_name":{"$ref":"#/$defs/std::string","description":"provide a file name to load"},"is_valid":{"$ref":"#/$defs/bool","description":"for validation"},"x":{"$ref":"#/$defs/int32_t","description":"x is a special integer"}},"additionalProperties":false,"$defs":{"bool":{"type":["boolean"]},"int32_t":{"type":["integer"]},"std::string":{"type":["string"]}}})") << json_schema;
+   };
+};
+
 int main()
 {
    // Explicitly run registered test suites and report errors

--- a/tests/reflection_test/reflection_test.cpp
+++ b/tests/reflection_test/reflection_test.cpp
@@ -444,7 +444,7 @@ struct glz::meta<meta_schema_t>
 {
    schema x{.description = "x is a special integer"};
    schema file_name{.description = "provide a file name to load"};
-   schema boolean{.description = "for validation"};
+   schema is_valid{.description = "for validation"};
 };
 
 static_assert(glz::detail::reflectable<glz::meta<meta_schema_t>>);
@@ -458,7 +458,7 @@ suite meta_schema_reflection_tests = [] {
       expect(buffer == R"({"x":0,"file_name":"","is_valid":false})") << buffer;
       
       const auto json_schema = glz::write_json_schema<meta_schema_t>();
-      expect(json_schema == R"({"type":["object"],"properties":{"file_name":{"$ref":"#/$defs/std::string","description":"provide a file name to load"},"is_valid":{"$ref":"#/$defs/bool"},"x":{"$ref":"#/$defs/int32_t","description":"x is a special integer"}},"additionalProperties":false,"$defs":{"bool":{"type":["boolean"]},"int32_t":{"type":["integer"]},"std::string":{"type":["string"]}}})") << json_schema;
+      expect(json_schema == R"({"type":["object"],"properties":{"file_name":{"$ref":"#/$defs/std::string","description":"provide a file name to load"},"is_valid":{"$ref":"#/$defs/bool","description":"for validation"},"x":{"$ref":"#/$defs/int32_t","description":"x is a special integer"}},"additionalProperties":false,"$defs":{"bool":{"type":["boolean"]},"int32_t":{"type":["integer"]},"std::string":{"type":["string"]}}})") << json_schema;
    };
 };
 

--- a/tests/reflection_test/reflection_test.cpp
+++ b/tests/reflection_test/reflection_test.cpp
@@ -456,6 +456,9 @@ suite meta_schema_reflection_tests = [] {
       std::string buffer{};
       glz::write_json(obj, buffer);
       expect(buffer == R"({"x":0,"file_name":"","is_valid":false})") << buffer;
+      
+      const auto json_schema = glz::write_json_schema<meta_schema_t>();
+      expect(json_schema == R"({"type":["object"],"properties":{"file_name":{"$ref":"#/$defs/std::string","description":"provide a file name to load"},"is_valid":{"$ref":"#/$defs/bool"},"x":{"$ref":"#/$defs/int32_t","description":"x is a special integer"}},"additionalProperties":false,"$defs":{"bool":{"type":["boolean"]},"int32_t":{"type":["integer"]},"std::string":{"type":["string"]}}})") << json_schema;
    };
 };
 

--- a/tests/reflection_test/reflection_test.cpp
+++ b/tests/reflection_test/reflection_test.cpp
@@ -432,6 +432,33 @@ suite prefix_key_name_test = [] {
    };
 };
 
+struct meta_schema_t
+{
+   int x{};
+   std::string file_name{};
+   bool is_valid{};
+};
+
+template <>
+struct glz::meta<meta_schema_t>
+{
+   schema x{.description = "x is a special integer"};
+   schema file_name{.description = "provide a file name to load"};
+   schema boolean{.description = "for validation"};
+};
+
+static_assert(glz::detail::reflectable<glz::meta<meta_schema_t>>);
+static_assert(glz::detail::count_members<glz::meta<meta_schema_t>> == 3);
+
+suite meta_schema_reflection_tests = [] {
+   "meta_schema_reflection"_test = [] {
+      meta_schema_t obj;
+      std::string buffer{};
+      glz::write_json(obj, buffer);
+      expect(buffer == R"({"x":0,"file_name":"","is_valid":false})") << buffer;
+   };
+};
+
 int main()
 { // Explicitly run registered test suites and report errors
    // This prevents potential issues with thread local variables


### PR DESCRIPTION
This adds the feature of being able to write comments and other JSON schema document when using pure reflection or traditional glz::meta reflection. It allows users to add `glz::schema` fields to the `glz::meta` specialization that match the name of the variable.

See an example below:
```c++
struct meta_schema_t
{
   int x{};
   std::string file_name{};
   bool is_valid{};
};

template <>
struct glz::meta<meta_schema_t>
{
   schema x{.description = "x is a special integer"};
   schema file_name{.description = "provide a file name to load"};
   schema boolean{.description = "for validation"};
};
```

Which can be used to generate a JSON schema document:
```c++
const auto json_schema = glz::write_json_schema<meta_schema_t>();
```

This will produce:
```json
{
  "type": [
    "object"
  ],
  "properties": {
    "file_name": {
      "$ref": "#/$defs/std::string",
      "description": "provide a file name to load"
    },
    "is_valid": {
      "$ref": "#/$defs/bool",
      "description": "for validation"
    },
    "x": {
      "$ref": "#/$defs/int32_t",
      "description": "x is a special integer"
    }
  },
  "additionalProperties": false,
  "$defs": {
    "bool": {
      "type": [
        "boolean"
      ]
    },
    "int32_t": {
      "type": [
        "integer"
      ]
    },
    "std::string": {
      "type": [
        "string"
      ]
    }
  }
}
```