### PR TITLE
Removing unnecessary assertions

### DIFF
--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -19,7 +19,6 @@ namespace glz
    {
       GLZ_ALWAYS_INLINE void dump_type(auto&& value, auto&& b, auto&& ix) noexcept
       {
-         assert(ix <= b.size());
          constexpr auto n = sizeof(std::decay_t<decltype(value)>);
          if (ix + n > b.size()) [[unlikely]] {
             b.resize((std::max)(b.size() * 2, ix + n));
@@ -309,7 +308,6 @@ namespace glz
             const auto n = value.size();
             dump_compressed_int<Opts>(n, b, ix);
 
-            assert(ix <= b.size());
             if (ix + n > b.size()) [[unlikely]] {
                b.resize((std::max)(b.size() * 2, ix + n));
             }
@@ -323,7 +321,6 @@ namespace glz
          {
             dump_compressed_int<Opts>(value.size(), b, ix);
 
-            assert(ix <= b.size());
             const auto n = value.size();
             if (ix + n > b.size()) [[unlikely]] {
                b.resize((std::max)(b.size() * 2, ix + n));
@@ -382,7 +379,6 @@ namespace glz
 
                if constexpr (contiguous<T>) {
                   auto dump_array = [&](auto&& b, auto&& ix) {
-                     assert(ix <= b.size());
                      const auto n = value.size() * sizeof(V);
                      if (ix + n > b.size()) [[unlikely]] {
                         b.resize((std::max)(b.size() * 2, ix + n));
@@ -411,7 +407,6 @@ namespace glz
                   dump_compressed_int<Opts>(x.size(), args...);
 
                   auto dump_array = [&](auto&& b, auto&& ix) {
-                     assert(ix <= b.size());
                      const auto n = x.size();
                      if (ix + n > b.size()) [[unlikely]] {
                         b.resize((std::max)(b.size() * 2, ix + n));

--- a/include/glaze/ext/glaze_asio.hpp
+++ b/include/glaze/ext/glaze_asio.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <asio.hpp>
+#include <cassert>
 #include <coroutine>
 
 #include "glaze/rpc/repe.hpp"

--- a/include/glaze/ext/jsonrpc.hpp
+++ b/include/glaze/ext/jsonrpc.hpp
@@ -269,9 +269,7 @@ namespace glz::rpc
             }
          });
 
-         assert(return_ptr != nullptr); // static_assert above should guarantee this
-
-         return *return_ptr;
+         return *return_ptr; // static_assert above should guarantee return_ptr is never null
       }
    }
 

--- a/include/glaze/util/dump.hpp
+++ b/include/glaze/util/dump.hpp
@@ -12,7 +12,6 @@ namespace glz::detail
 {
    GLZ_ALWAYS_INLINE void dump(const char c, vector_like auto& b, auto& ix) noexcept
    {
-      assert(ix <= b.size());
       if (ix == b.size()) [[unlikely]] {
          b.resize(b.size() == 0 ? 128 : b.size() * 2);
       }
@@ -30,7 +29,6 @@ namespace glz::detail
    template <char c>
    GLZ_ALWAYS_INLINE void dump(vector_like auto& b, auto& ix) noexcept
    {
-      assert(ix <= b.size());
       if (ix == b.size()) [[unlikely]] {
          b.resize(b.size() == 0 ? 128 : b.size() * 2);
       }
@@ -206,7 +204,6 @@ namespace glz::detail
    template <std::byte c, class B>
    GLZ_ALWAYS_INLINE void dump(B&& b, auto& ix) noexcept
    {
-      assert(ix <= b.size());
       if (ix == b.size()) [[unlikely]] {
          b.resize(b.size() == 0 ? 128 : b.size() * 2);
       }
@@ -243,7 +240,6 @@ namespace glz::detail
    template <class B>
    GLZ_ALWAYS_INLINE void dump(std::byte c, auto&& b, auto& ix) noexcept
    {
-      assert(ix <= b.size());
       if (ix == b.size()) [[unlikely]] {
          b.resize(b.size() == 0 ? 128 : b.size() * 2);
       }
@@ -273,7 +269,6 @@ namespace glz::detail
    template <class B>
    GLZ_ALWAYS_INLINE void dump(const std::span<const std::byte> bytes, B&& b, auto& ix) noexcept
    {
-      assert(ix <= b.size());
       const auto n = bytes.size();
       if (ix + n > b.size()) [[unlikely]] {
          b.resize((std::max)(b.size() * 2, ix + n));
@@ -286,7 +281,6 @@ namespace glz::detail
    template <size_t N, class B>
    GLZ_ALWAYS_INLINE void dump(const std::array<uint8_t, N>& bytes, B&& b, auto& ix) noexcept
    {
-      assert(ix <= b.size());
       if (ix + N > b.size()) [[unlikely]] {
          b.resize((std::max)(b.size() * 2, ix + N));
       }

--- a/include/glaze/util/hash_map.hpp
+++ b/include/glaze/util/hash_map.hpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <array>
 #include <bit>
-#include <cassert>
 #include <cmath>
 #include <concepts>
 #include <cstddef>
@@ -514,7 +513,9 @@ namespace glz::detail
    {
       constexpr auto N = D.N;
       static_assert(N < 256);
-      assert(pairs.size() == N);
+      if (pairs.size() != N) {
+         std::abort();
+      }
       single_char_map<T, D> ht{};
 
       uint8_t i = 0;


### PR DESCRIPTION
These assertions were making the binary larger and code more complex even when code was compiled in release (looked at GCC 13.2 and latest Clang). However, none of these are actually needed and should be handled by having proper code. Massive issues that would cause these assertions to fail should appear in other major errors. It does not make sense to make the program slower for these very commonly used functions.