### PR TITLE
Removed corner case support of large char types incompatible with JSON

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -295,12 +295,12 @@ namespace glz
    };
 
    using basic =
-      std::variant<bool, char, char8_t, unsigned char, signed char, char16_t, short, unsigned short, wchar_t, char32_t,
+      std::variant<bool, char, char8_t, unsigned char, signed char, short, unsigned short,
                    float, int, unsigned int, long, unsigned long, double, long long, unsigned long long, std::string>;
 
    // Explicitly defining basic_ptr to avoid additional template instantiations
-   using basic_ptr = std::variant<bool*, char*, char8_t*, unsigned char*, signed char*, char16_t*, short*,
-                                  unsigned short*, wchar_t*, char32_t*, float*, int*, unsigned int*, long*,
+   using basic_ptr = std::variant<bool*, char*, char8_t*, unsigned char*, signed char*, short*,
+                                  unsigned short*, float*, int*, unsigned int*, long*,
                                   unsigned long*, double*, long long*, unsigned long long*, std::string*>;
 
    namespace detail

--- a/include/glaze/core/write_chars.hpp
+++ b/include/glaze/core/write_chars.hpp
@@ -6,7 +6,6 @@
 #include <charconv>
 #include <type_traits>
 
-#include "common.hpp"
 #include "glaze/core/common.hpp"
 #include "glaze/core/opts.hpp"
 #include "glaze/util/dtoa.hpp"

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -516,24 +516,7 @@ namespace glz
                   }
                }
                else if constexpr (std::is_same_v<T, wchar_t>) {
-                  wchar_t bufferw[MB_LEN_MAX];
-                  std::mbstate_t statew{};
-                  auto buffer_ptr = reinterpret_cast<const char*>(buffer);
-                  auto n = std::mbsrtowcs(bufferw, &buffer_ptr, MB_LEN_MAX, &statew);
-                  if (n == (std::numeric_limits<std::size_t>::max)()) [[unlikely]] {
-                     ctx.error = error_code::unicode_escape_conversion_failure;
-                     return;
-                  }
-                  if constexpr (char_t<Val>) {
-                     if (n != 1) [[unlikely]] {
-                        ctx.error = error_code::unicode_escape_conversion_failure;
-                        return;
-                     }
-                     value = bufferw[0];
-                  }
-                  else {
-                     value.append(bufferw, n);
-                  }
+                  static_assert(false_v<T>, "wchar_t is unsupported, JSON requires UTF8");
                }
             }
          }

--- a/tests/reflection_test/reflection_test.cpp
+++ b/tests/reflection_test/reflection_test.cpp
@@ -442,7 +442,7 @@ struct meta_schema_t
 template <>
 struct glz::meta<meta_schema_t>
 {
-   schema x{.description = "x is a special integer"};
+   schema x{.description = "x is a special integer", .minimum = 1};
    schema file_name{.description = "provide a file name to load"};
    schema is_valid{.description = "for validation"};
 };
@@ -460,7 +460,7 @@ suite meta_schema_reflection_tests = [] {
       const auto json_schema = glz::write_json_schema<meta_schema_t>();
       expect(
          json_schema ==
-         R"({"type":["object"],"properties":{"file_name":{"$ref":"#/$defs/std::string","description":"provide a file name to load"},"is_valid":{"$ref":"#/$defs/bool","description":"for validation"},"x":{"$ref":"#/$defs/int32_t","description":"x is a special integer"}},"additionalProperties":false,"$defs":{"bool":{"type":["boolean"]},"int32_t":{"type":["integer"]},"std::string":{"type":["string"]}}})")
+         R"({"type":["object"],"properties":{"file_name":{"$ref":"#/$defs/std::string","description":"provide a file name to load"},"is_valid":{"$ref":"#/$defs/bool","description":"for validation"},"x":{"$ref":"#/$defs/int32_t","description":"x is a special integer","minimum":1}},"additionalProperties":false,"$defs":{"bool":{"type":["boolean"]},"int32_t":{"type":["integer"]},"std::string":{"type":["string"]}}})")
          << json_schema;
    };
 };


### PR DESCRIPTION
This removes support for `wchar_t`, which was not even being used and is not JSON compliant.

It also removes larger char types from the study code, to make the study code more JSON compliant.