### PR TITLE
Moving schema from glz::meta to glz::json_schema

### DIFF
--- a/include/glaze/core/format.hpp
+++ b/include/glaze/core/format.hpp
@@ -11,7 +11,6 @@ namespace glz
    constexpr uint32_t binary = 0;
    constexpr uint32_t json = 10;
    constexpr uint32_t ndjson = 100; // new line delimited JSON
-   constexpr uint32_t json_schema = 1000;
    constexpr uint32_t csv = 10000;
 
    // layout

--- a/include/glaze/core/meta.hpp
+++ b/include/glaze/core/meta.hpp
@@ -16,6 +16,10 @@ namespace glz
    template <class T>
    struct meta
    {};
+   
+   template <class T>
+   struct json_schema
+   {};
 
    namespace detail
    {
@@ -75,6 +79,15 @@ namespace glz
 
       template <class T>
       concept has_unknown_reader = requires { meta<T>::unknown_read; } || requires { T::glaze::unknown_read; };
+      
+      template <class T>
+      concept local_json_schema_t = requires { std::decay_t<T>::glaze_json_schema; };
+
+      template <class T>
+      concept global_json_schema_t = requires { sizeof(json_schema<std::decay_t<T>>) > 1; };
+
+      template <class T>
+      concept json_schema_t = requires { local_json_schema_t<T>; } || requires { global_json_schema_t<T>; };
    }
 
    struct empty
@@ -247,4 +260,17 @@ namespace glz
          return {0, 0, 1};
       }
    }();
+   
+   template <class T>
+   inline constexpr auto json_schema_v = [] {
+      if constexpr (detail::local_json_schema_t<T>) {
+         return typename std::decay_t<T>::glaze_json_schema{};
+      }
+      else if constexpr (detail::global_json_schema_t<T>) {
+         return json_schema<std::decay_t<T>>{};
+      }
+   }();
+   
+   template <class T>
+   using json_schema_type = std::decay_t<decltype(json_schema_v<T>)>;
 }

--- a/include/glaze/core/meta.hpp
+++ b/include/glaze/core/meta.hpp
@@ -81,10 +81,10 @@ namespace glz
       concept has_unknown_reader = requires { meta<T>::unknown_read; } || requires { T::glaze::unknown_read; };
       
       template <class T>
-      concept local_json_schema_t = requires { std::decay_t<T>::glaze_json_schema; };
+      concept local_json_schema_t = requires { typename std::decay_t<T>::glaze_json_schema; };
 
       template <class T>
-      concept global_json_schema_t = requires { sizeof(json_schema<std::decay_t<T>>) > 1; };
+      concept global_json_schema_t = requires { is_specialization_v<std::decay_t<T>, json_schema>; };
 
       template <class T>
       concept json_schema_t = requires { local_json_schema_t<T>; } || requires { global_json_schema_t<T>; };

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -123,40 +123,20 @@ namespace glz
 {
    namespace detail
    {
-      template <class Tuple>
-      consteval size_t count_schema_elements()
-      {
-         constexpr auto N = std::tuple_size_v<Tuple>;
-
-         size_t i{};
-         for_each<N>([&](auto I) {
-            if constexpr (std::same_as<std::decay_t<std::tuple_element_t<I, Tuple>>, schema>) {
-               ++i;
-            }
-         });
-
-         return i;
-      }
-
       template <class T>
       consteval auto make_reflection_schema_array()
       {
-         glz::meta<T> meta_instance{};
-         auto tuple = to_tuple(meta_instance);
+         auto schema_instance = json_schema_v<T>;
+         auto tuple = to_tuple(schema_instance);
          using V = std::decay_t<decltype(tuple)>;
          constexpr auto N = std::tuple_size_v<V>;
          if constexpr (N > 0) {
-            constexpr auto names = member_names<glz::meta<T>>;
+            constexpr auto names = member_names<json_schema_type<T>>; // TODO: use a reference
 
-            constexpr auto n_schema_elements = count_schema_elements<V>();
-            std::array<std::pair<sv, schema>, n_schema_elements> ret{};
+            std::array<std::pair<sv, schema>, N> ret{};
 
-            size_t i{};
             for_each<N>([&](auto I) {
-               if constexpr (std::same_as<std::decay_t<std::tuple_element_t<I, V>>, schema>) {
-                  ret[i] = std::pair{names[I], std::get<I>(tuple)};
-               }
-               ++i;
+               ret[I] = std::pair{names[I], std::get<I>(tuple)};
             });
 
             return ret;

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -6808,11 +6808,16 @@ struct meta_schema_t
 template <>
 struct glz::meta<meta_schema_t>
 {
+   using T = meta_schema_t;
+   static constexpr auto value = object(&T::x, &T::file_name, &T::is_valid);
+};
+
+template <>
+struct glz::json_schema<meta_schema_t>
+{
    schema x{.description = "x is a special integer"};
    schema file_name{.description = "provide a file name to load"};
    schema is_valid{.description = "for validation"};
-   using T = meta_schema_t;
-   static constexpr auto value = object(&T::x, &T::file_name, &T::is_valid);
 };
 
 suite meta_schema_tests = [] {

--- a/tests/reflection_test/reflection_test.cpp
+++ b/tests/reflection_test/reflection_test.cpp
@@ -450,6 +450,22 @@ struct glz::json_schema<meta_schema_t>
 static_assert(glz::detail::reflectable<glz::json_schema<meta_schema_t>>);
 static_assert(glz::detail::count_members<glz::json_schema<meta_schema_t>> == 3);
 
+struct local_schema_t
+{
+   int x{};
+   std::string file_name{};
+   bool is_valid{};
+   
+   struct glaze_json_schema
+   {
+      glz::schema x{.description = "x is a special integer", .minimum = 1};
+      glz::schema file_name{.description = "provide a file name to load"};
+      glz::schema is_valid{.description = "for validation"};
+   };
+};
+
+static_assert(glz::detail::local_json_schema_t<local_schema_t>);
+
 suite meta_schema_reflection_tests = [] {
    "meta_schema_reflection"_test = [] {
       meta_schema_t obj;
@@ -458,6 +474,19 @@ suite meta_schema_reflection_tests = [] {
       expect(buffer == R"({"x":0,"file_name":"","is_valid":false})") << buffer;
 
       const auto json_schema = glz::write_json_schema<meta_schema_t>();
+      expect(
+         json_schema ==
+         R"({"type":["object"],"properties":{"file_name":{"$ref":"#/$defs/std::string","description":"provide a file name to load"},"is_valid":{"$ref":"#/$defs/bool","description":"for validation"},"x":{"$ref":"#/$defs/int32_t","description":"x is a special integer","minimum":1}},"additionalProperties":false,"$defs":{"bool":{"type":["boolean"]},"int32_t":{"type":["integer"]},"std::string":{"type":["string"]}}})")
+         << json_schema;
+   };
+   
+   "local_schema"_test = [] {
+      local_schema_t obj;
+      std::string buffer{};
+      glz::write_json(obj, buffer);
+      expect(buffer == R"({"x":0,"file_name":"","is_valid":false})") << buffer;
+
+      const auto json_schema = glz::write_json_schema<local_schema_t>();
       expect(
          json_schema ==
          R"({"type":["object"],"properties":{"file_name":{"$ref":"#/$defs/std::string","description":"provide a file name to load"},"is_valid":{"$ref":"#/$defs/bool","description":"for validation"},"x":{"$ref":"#/$defs/int32_t","description":"x is a special integer","minimum":1}},"additionalProperties":false,"$defs":{"bool":{"type":["boolean"]},"int32_t":{"type":["integer"]},"std::string":{"type":["string"]}}})")

--- a/tests/reflection_test/reflection_test.cpp
+++ b/tests/reflection_test/reflection_test.cpp
@@ -440,15 +440,15 @@ struct meta_schema_t
 };
 
 template <>
-struct glz::meta<meta_schema_t>
+struct glz::json_schema<meta_schema_t>
 {
    schema x{.description = "x is a special integer", .minimum = 1};
    schema file_name{.description = "provide a file name to load"};
    schema is_valid{.description = "for validation"};
 };
 
-static_assert(glz::detail::reflectable<glz::meta<meta_schema_t>>);
-static_assert(glz::detail::count_members<glz::meta<meta_schema_t>> == 3);
+static_assert(glz::detail::reflectable<glz::json_schema<meta_schema_t>>);
+static_assert(glz::detail::count_members<glz::json_schema<meta_schema_t>> == 3);
 
 suite meta_schema_reflection_tests = [] {
    "meta_schema_reflection"_test = [] {


### PR DESCRIPTION
To avoid name collisions, we add JSON Schema data to a new specialization.