### PR TITLE
Fixed seek for glaze_value_t

### DIFF
--- a/include/glaze/core/meta.hpp
+++ b/include/glaze/core/meta.hpp
@@ -96,7 +96,7 @@ namespace glz
    };
 
    template <class T>
-   inline constexpr auto meta_wrapper_v = [] {
+   inline constexpr decltype(auto) meta_wrapper_v = [] {
       if constexpr (detail::local_meta_t<T>) {
          return T::glaze::value;
       }

--- a/include/glaze/json/json_ptr.hpp
+++ b/include/glaze/json/json_ptr.hpp
@@ -179,6 +179,17 @@ namespace glz
          if (!value) return false;
          return seek_impl(std::forward<F>(func), *value, json_ptr);
       }
+      
+      template <class F, class T>
+         requires glaze_value_t<T>
+      bool seek_impl(F&& func, T&& value, sv json_ptr) noexcept
+      {
+         if (json_ptr.empty()) {
+            func(get_member(std::forward<T>(value), meta_wrapper_v<std::remove_cvref_t<T>>));
+            return true;
+         }
+         return seek_impl(std::forward<F>(func), get_member(std::forward<T>(value), meta_wrapper_v<std::remove_cvref_t<T>>), json_ptr);
+      }
    } // namespace detail
 
    // Call a function on an value at the location of a json_ptr

--- a/include/glaze/json/json_ptr.hpp
+++ b/include/glaze/json/json_ptr.hpp
@@ -184,7 +184,8 @@ namespace glz
          requires glaze_value_t<T>
       bool seek_impl(F&& func, T&& value, sv json_ptr) noexcept
       {
-         decltype(auto) member = get_member(value, meta_wrapper_v<std::remove_cvref_t<T>>);
+         constexpr auto wrapper = meta_wrapper_v<std::remove_cvref_t<T>>;
+         decltype(auto) member = get_member(value, wrapper);
          if (json_ptr.empty()) {
             func(member);
             return true;

--- a/include/glaze/json/json_ptr.hpp
+++ b/include/glaze/json/json_ptr.hpp
@@ -184,11 +184,12 @@ namespace glz
          requires glaze_value_t<T>
       bool seek_impl(F&& func, T&& value, sv json_ptr) noexcept
       {
+         decltype(auto) member = get_member(value, meta_wrapper_v<std::remove_cvref_t<T>>);
          if (json_ptr.empty()) {
-            func(get_member(std::forward<T>(value), meta_wrapper_v<std::remove_cvref_t<T>>));
+            func(member);
             return true;
          }
-         return seek_impl(std::forward<F>(func), get_member(std::forward<T>(value), meta_wrapper_v<std::remove_cvref_t<T>>), json_ptr);
+         return seek_impl(std::forward<F>(func), member, json_ptr);
       }
    } // namespace detail
 

--- a/include/glaze/json/json_ptr.hpp
+++ b/include/glaze/json/json_ptr.hpp
@@ -20,6 +20,10 @@ namespace glz
    namespace detail
    {
       template <class F, class T>
+         requires glaze_value_t<T>
+      bool seek_impl(F&& func, T&& value, sv json_ptr) noexcept;
+      
+      template <class F, class T>
          requires glaze_array_t<T> || tuple_t<std::decay_t<T>> || array_t<std::decay_t<T>> ||
                   is_std_tuple<std::decay_t<T>>
       bool seek_impl(F&& func, T&& value, sv json_ptr) noexcept;
@@ -184,8 +188,7 @@ namespace glz
          requires glaze_value_t<T>
       bool seek_impl(F&& func, T&& value, sv json_ptr) noexcept
       {
-         constexpr auto wrapper = meta_wrapper_v<std::remove_cvref_t<T>>;
-         decltype(auto) member = get_member(value, wrapper);
+         decltype(auto) member = get_member(value, meta_wrapper_v<std::remove_cvref_t<T>>);
          if (json_ptr.empty()) {
             func(member);
             return true;

--- a/tests/reflection_test/reflection_test.cpp
+++ b/tests/reflection_test/reflection_test.cpp
@@ -137,6 +137,15 @@ struct Thing
    std::map<std::string, int> map{{"eleven", 11}, {"twelve", 12}};
 };
 
+struct thing_wrapper
+{
+   Thing thing{};
+   
+   struct glaze {
+      static constexpr auto value{ &thing_wrapper::thing };
+   };
+};
+
 suite user_types = [] {
    "complex user obect"_test = [] {
       Thing obj{};
@@ -184,6 +193,14 @@ suite user_types = [] {
 
       expect(glz::seek([&](auto& value) { glz::write_json(value, out); }, obj, "/thing_ptr/b"));
 
+      expect(out == R"("stuff")");
+   };
+   
+   "thing_wrapper seek"_test = [] {
+      thing_wrapper obj{};
+      std::string out;
+      expect(glz::seek([&](auto& value) { glz::write_json(value, out); }, obj, "/thing_ptr/b"));
+      
       expect(out == R"("stuff")");
    };
 };

--- a/tests/reflection_test/reflection_test.cpp
+++ b/tests/reflection_test/reflection_test.cpp
@@ -196,6 +196,10 @@ suite user_types = [] {
       expect(out == R"("stuff")");
    };
    
+#if ((defined _MSC_VER) && (!defined __clang__))
+   // The "thing_wrapper seek" test is broken in MSVC, because MSVC has internal compiler errors for seeking glaze_value_t
+   // Uncomment this when MSVC is fixed
+#else
    "thing_wrapper seek"_test = [] {
       thing_wrapper obj{};
       std::string out;
@@ -203,6 +207,7 @@ suite user_types = [] {
       
       expect(out == R"("stuff")");
    };
+#endif
 };
 
 struct single_t


### PR DESCRIPTION
Seeking did not work for `glaze_value_t`. This adds support for seeking on `glaze_value_t` structs for GCC and Clang. MSVC generates internal compiler errors and I don't know how to fix them right now, so we'll uncomment the test in the future when MSVC is fixed.