### PR TITLE
Fix address sanitizers complaining about string writing

### DIFF
--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -343,7 +343,13 @@ namespace glz
                   else {
                      dump_unchecked<'"'>(b, ix);
 
-                     if constexpr (string_t<T> && !std::is_const_v<std::remove_reference_t<decltype(value)>>) {
+                     // IMPORTANT: This code breaks address sanitizers (GCC and MSVC), because they don't like
+                     // string memory being read beyond the length of the string, even if there is properly
+                     // allocated memory.
+                     // Also, this is only valid if Small String Optimization also has enough aligned memory when parsing
+                     // reserving extra space does nothing for SSO and we must rely on padded alignment,
+                     // which has always worked but is risky
+                     /*if constexpr (string_t<T> && !std::is_const_v<std::remove_reference_t<decltype(value)>>) {
                         // we know the output buffer has enough space, but we must ensure the string buffer has space
                         // for swar as well
                         // say a string is of length 16, then the null character sits at index 16, which means we need
@@ -352,7 +358,7 @@ namespace glz
                         value.reserve(round_up_to_multiple<8>(n + 1));
                         serialize_string<8>(value.data(), data_ptr(b), ix);
                      }
-                     else {
+                     else*/ {
                         const auto* c = str.data();
                         const auto* const e = c + n;
 

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -388,7 +388,7 @@ namespace glz
 
                         // Tail end of buffer. Uncommon for long strings.
                         for (; c < e; ++c) {
-                           if (const auto escaped = char_escape_table[uint8_t(*c)]; escaped) [[likely]] {
+                           if (const auto escaped = char_escape_table[uint8_t(*c)]; escaped) {
                               std::memcpy(data_ptr(b) + ix, &escaped, 2);
                               ix += 2;
                            }


### PR DESCRIPTION
MSVC (and I think GCC) address sanitizers complain when we read beyond the size of a `std::string`, even the there is sufficient memory allocated in the capacity. This comments out the use of the more optimized `serialize_string` function for the sake of satisfying address sanitizers. There may be a way to gain back this performance in the future, or file an issue with MSVC.