### PR TITLE
Removing GLZ macros

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-2022
+    runs-on: windows-latest
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -14,6 +14,7 @@ on:
   workflow_dispatch:
 
 env:
+  CTEST_OUTPUT_ON_FAILURE: 1
   BUILD_TYPE: Debug
 
 jobs:
@@ -32,4 +33,4 @@ jobs:
 
     - name: Test
       working-directory: build
-      run: ctest -C ${{env.BUILD_TYPE}} --parallel --output-on-failure
+      run: ctest --build-config ${{env.BUILD_TYPE}}

--- a/docs/macros-for-structs.md
+++ b/docs/macros-for-structs.md
@@ -1,31 +1,8 @@
-# Struct Registration Macros
+# Struct Registration Macros (REMOVED)
+
+GLZ_META, GLZ_LOCAL_META, and associated macros have been removed.
+
+> If you desperately want them, you can go to an older version of Glaze (v2.1.6 and older) and copy the macros and add them to your codebase. But, we are moving away from macros in the API for the sake of C++20 modules and better code overall.
 
 Glaze supports reflection for aggregate initializable structs, and for member object pointers. So,
-these macros no longer save typing and have much less flexibility. *They will be deprecated in the
-future*.
-
-**Macros must be explicitly included via: `#include "glaze/core/macros.hpp"`**
-
-- GLZ_META is for external registration
-- GLZ_LOCAL_META is for internal registration
-
-```c++
-struct macro_t {
-   double x = 5.0;
-   std::string y = "yay!";
-   int z = 55;
-};
-
-GLZ_META(macro_t, x, y, z);
-
-struct local_macro_t {
-   double x = 5.0;
-   std::string y = "yay!";
-   int z = 55;
-
-   GLZ_LOCAL_META(local_macro_t, x, y, z);
-};
-```
-
-Instead of these macros, don't write anything and let [pure reflection](./pure-reflection.md) do the
-work :)
+these macros no longer save typing and have much less flexibility. More reflection is coming as well.

--- a/include/glaze/core/macros.hpp
+++ b/include/glaze/core/macros.hpp
@@ -3,42 +3,12 @@
 
 #pragma once
 
-// utility macros
-
-// https://www.scs.stanford.edu/~dm/blog/va-opt.html
-
-#define GLZ_PARENS ()
-
-#define GLZ_EXPAND(...) GLZ_EXPAND4(GLZ_EXPAND4(GLZ_EXPAND4(GLZ_EXPAND4(__VA_ARGS__))))
-#define GLZ_EXPAND4(...) GLZ_EXPAND3(GLZ_EXPAND3(GLZ_EXPAND3(GLZ_EXPAND3(__VA_ARGS__))))
-#define GLZ_EXPAND3(...) GLZ_EXPAND2(GLZ_EXPAND2(GLZ_EXPAND2(GLZ_EXPAND2(__VA_ARGS__))))
-#define GLZ_EXPAND2(...) GLZ_EXPAND1(GLZ_EXPAND1(GLZ_EXPAND1(GLZ_EXPAND1(__VA_ARGS__))))
-#define GLZ_EXPAND1(...) __VA_ARGS__
-
-#define GLZ_FOR_EACH(macro, ...) __VA_OPT__(GLZ_EXPAND(GLZ_FOR_EACH_HELPER(macro, __VA_ARGS__)))
-#define GLZ_FOR_EACH_HELPER(macro, a, ...) \
-   macro(a) __VA_OPT__(, ) __VA_OPT__(GLZ_FOR_EACH_AGAIN GLZ_PARENS(macro, __VA_ARGS__))
-#define GLZ_FOR_EACH_AGAIN() GLZ_FOR_EACH_HELPER
-
 // Glaze specific macros
 
-#define GLZ_X(a) #a, &GLZ_T::a
-#define GLZ_QUOTED_X(a) #a, glz::quoted<&GLZ_T::a>
-#define GLZ_QUOTED_NUM_X(a) #a, glz::quoted_num<&GLZ_T::a>
+#define GLZ_X(a) static_assert(false, "GLZ_X macro has been removed with the addition of member object and pure reflection")
+#define GLZ_QUOTED_X(a) static_assert(false, "GLZ_QUOTED_X macro has been removed with the addition of member object and pure reflection")
+#define GLZ_QUOTED_NUM_X(a) static_assert(false, "GLZ_QUOTED_NUM_X macro has been removed with the addition of member object and pure reflection")
 
-#define GLZ_META(C, ...)                                                      \
-   template <>                                                                \
-   struct glz::meta<C>                                                        \
-   {                                                                          \
-      using GLZ_T = C;                                                        \
-      [[maybe_unused]] static constexpr std::string_view name = #C;           \
-      static constexpr auto value = object(GLZ_FOR_EACH(GLZ_X, __VA_ARGS__)); \
-   }
+#define GLZ_META(C, ...) static_assert(false, "GLZ_META macro has been removed with the addition of member object and pure reflection")
 
-#define GLZ_LOCAL_META(C, ...)                                                     \
-   struct glaze                                                                    \
-   {                                                                               \
-      using GLZ_T = C;                                                             \
-      [[maybe_unused]] static constexpr std::string_view name = #C;                \
-      static constexpr auto value = glz::object(GLZ_FOR_EACH(GLZ_X, __VA_ARGS__)); \
-   }
+#define GLZ_LOCAL_META(C, ...) static_assert(false, "GLZ_LOCAL_META macro has been removed with the addition of member object and pure reflection")

--- a/include/glaze/core/meta.hpp
+++ b/include/glaze/core/meta.hpp
@@ -181,7 +181,7 @@ namespace glz
    template <class T, bool fail_on_unknown = false>
    inline constexpr std::string_view name_v = [] {
       if constexpr (named<T>) {
-         if constexpr (detail::local_meta_t<T>) {
+         if constexpr (requires { T::glaze::name; }) {
             if constexpr (fail_on_unknown) {
                static_assert(T::glaze::name.find("glz::unknown") == std::string_view::npos,
                              "name_v used on unnamed type");

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -2193,13 +2193,11 @@ struct error_comma_obj
    struct error_comma_data
    {
       std::string instId;
-      GLZ_LOCAL_META(error_comma_data, instId);
    };
 
    std::string code;
    std::string msg;
    std::vector<error_comma_data> data;
-   GLZ_LOCAL_META(error_comma_obj, data, code, msg);
 };
 
 suite error_outputs = [] {
@@ -2831,42 +2829,6 @@ suite array_of_objects = [] {
       std::string s = R"({"vec": [{"a": {"i":5}}, {"a":{ "i":2 }}]})";
       holder2_t arr{};
       expect(glz::read_json(arr, s) == glz::error_code::none);
-   };
-};
-
-struct macro_t
-{
-   double x = 5.0;
-   std::string y = "yay!";
-   int z = 55;
-};
-
-GLZ_META(macro_t, x, y, z);
-
-struct local_macro_t
-{
-   double x = 5.0;
-   std::string y = "yay!";
-   int z = 55;
-
-   GLZ_LOCAL_META(local_macro_t, x, y, z);
-};
-
-suite macro_tests = [] {
-   "macro test"_test = [] {
-      macro_t obj{};
-      std::string b{};
-      glz::write_json(obj, b);
-
-      expect(b == R"({"x":5,"y":"yay!","z":55})");
-   };
-
-   "local macro test"_test = [] {
-      local_macro_t obj{};
-      std::string b{};
-      glz::write_json(obj, b);
-
-      expect(b == R"({"x":5,"y":"yay!","z":55})");
    };
 };
 
@@ -4353,14 +4315,12 @@ suite bit_field_test = []
 struct StructE
 {
    std::string e;
-   GLZ_LOCAL_META(StructE, e);
 };
 
 struct Sample
 {
    int a;
    StructE d;
-   GLZ_LOCAL_META(Sample, a, d);
 };
 
 suite invalid_keys = [] {
@@ -4482,10 +4442,6 @@ struct OKX_OrderBook_Data
    std::string stk;
    std::string tickSz;
    std::string uly;
-
-   GLZ_LOCAL_META(OKX_OrderBook_Data, alias, baseCcy, category, ctMult, ctType, ctVal, ctValCcy, expTime, instFamily,
-                  instId, instType, lever, listTime, lotSz, maxIcebergSz, maxLmtSz, maxMktSz, maxStopSz, maxTriggerSz,
-                  maxTwapSz, minSz, optType, quoteCcy, settleCcy, state, stk, tickSz, uly);
 };
 
 struct OKX_OrderBook
@@ -5484,8 +5440,6 @@ struct name_t
 {
    std::string first{};
    std::string last{};
-
-   GLZ_LOCAL_META(name_t, first, last);
 };
 
 suite error_message_test = [] {
@@ -5834,12 +5788,18 @@ suite manage_test = [] {
 };
 
 struct varx
-{
-   GLZ_LOCAL_META(varx);
+{   
+   struct glaze {
+      static constexpr std::string_view name = "varx";
+      static constexpr auto value = glz::object();
+   };
 };
 struct vary
 {
-   GLZ_LOCAL_META(vary);
+   struct glaze {
+      static constexpr std::string_view name = "vary";
+      static constexpr auto value = glz::object();
+   };
 };
 
 using vari = std::variant<varx, vary>;
@@ -5906,9 +5866,6 @@ struct QuoteData
 };
 
 typedef request_t<QuoteData> SaveQuote;
-
-GLZ_META(QuoteData, time, action, quote, account, uid, session_id, request_id, state, order_id, exchange, type, tif,
-         offset, side, symbol, price, quantity, traded);
 
 suite trade_quote_test = [] {
    "trade_quote"_test = [] {
@@ -5983,8 +5940,13 @@ struct updater
       square = [&] { x *= x; };
       add_one = [&] { x += 1; };
    }
+};
 
-   GLZ_LOCAL_META(updater, x, square, add_one);
+template <>
+struct glz::meta<updater>
+{
+   using T = updater;
+   static constexpr auto value = object(&T::x, &T::square, &T::add_one);
 };
 
 suite invoke_updater_test = [] {
@@ -6100,7 +6062,6 @@ World)");
 struct Update
 {
    int64_t time;
-   GLZ_LOCAL_META(Update, time);
 };
 
 suite ndjson_error_test = [] {


### PR DESCRIPTION
Removing GLZ macros since we now have various forms of reflection that significantly reduce typing. The other reflection approaches are either more powerful or less typing, and are easier to work with and add features to than the macros approach.

Removing these macros simplifies the code and moves us closer to adding C++20 module support.