### PR TITLE
Requiring glaze/util/poly.hpp to be explicitly included by users

### DIFF
--- a/include/glaze/ext/cli_menu.hpp
+++ b/include/glaze/ext/cli_menu.hpp
@@ -95,7 +95,7 @@ namespace glz
                         static_assert(N == 1, "Only one input is allowed for your function");
                         static thread_local std::array<char, 256> input{};
                         std::printf("json> ");
-                        if (fgets(input.data(), input.size(), stdin)) {
+                        if (fgets(input.data(), int(input.size()), stdin)) {
                            std::string_view input_sv{input.data()};
                            if (input_sv.back() == '\n') {
                               input_sv = input_sv.substr(0, input_sv.size() - 1);

--- a/include/glaze/json/json_ptr.hpp
+++ b/include/glaze/json/json_ptr.hpp
@@ -12,7 +12,6 @@
 #include "glaze/core/read.hpp"
 #include "glaze/json/read.hpp"
 #include "glaze/util/parse.hpp"
-#include "glaze/util/poly.hpp"
 #include "glaze/util/string_view.hpp"
 
 namespace glz

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -17,7 +17,6 @@
 #include "boost/ut.hpp"
 #include "glaze/binary/read.hpp"
 #include "glaze/binary/write.hpp"
-#include "glaze/core/macros.hpp"
 
 struct my_struct
 {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -30,6 +30,7 @@
 #include "glaze/json/read.hpp"
 #include "glaze/json/write.hpp"
 #include "glaze/record/recorder.hpp"
+#include "glaze/util/poly.hpp"
 #include "glaze/util/progress_bar.hpp"
 
 using namespace boost::ut;

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -22,7 +22,6 @@
 
 #include "boost/ut.hpp"
 #include "glaze/api/impl.hpp"
-#include "glaze/core/macros.hpp"
 #include "glaze/file/hostname_include.hpp"
 #include "glaze/json/json_ptr.hpp"
 #include "glaze/json/prettify.hpp"


### PR DESCRIPTION
`glz::poly` is a neat polymorphism tool without inheritance. It is not used by any other Glaze functions.
This merge will require `glaze/util/poly.hpp` to be explicitly included by users of `glz::poly`, so that normal Glaze users do not have to deal with the additional headers.