### PR TITLE
glz::opts support for write_json_schema

### DIFF
--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -425,20 +425,20 @@ namespace glz
 
    }
 
-   template <class T, class Buffer>
+   template <class T, opts Opts = opts{}, class Buffer>
    inline void write_json_schema(Buffer&& buffer) noexcept
    {
       detail::schematic s{};
       s.defs.emplace();
-      detail::to_json_schema<std::decay_t<T>>::template op<opts{}>(s, *s.defs);
-      write<opts{.write_type_info = false}>(std::move(s), std::forward<Buffer>(buffer));
+      detail::to_json_schema<std::decay_t<T>>::template op<Opts>(s, *s.defs);
+      write<opt_false<Opts, &opts::write_type_info>>(std::move(s), std::forward<Buffer>(buffer));
    }
 
-   template <class T>
+   template <class T, opts Opts = opts{}>
    [[nodiscard]] inline auto write_json_schema() noexcept
    {
       std::string buffer{};
-      write_json_schema<T>(buffer);
+      write_json_schema<T, Opts>(buffer);
       return buffer;
    }
 }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -6796,6 +6796,55 @@ suite meta_schema_tests = [] {
          R"({"type":["object"],"properties":{"file_name":{"$ref":"#/$defs/std::string","description":"provide a file name to load"},"is_valid":{"$ref":"#/$defs/bool","description":"for validation"},"x":{"$ref":"#/$defs/int32_t","description":"x is a special integer"}},"additionalProperties":false,"$defs":{"bool":{"type":["boolean"]},"int32_t":{"type":["integer"]},"std::string":{"type":["string"]}}})")
          << json_schema;
    };
+   
+   "meta_schema prettified"_test = [] {
+      meta_schema_t obj;
+      std::string buffer{};
+      glz::write_json(obj, buffer);
+      expect(buffer == R"({"x":0,"file_name":"","is_valid":false})") << buffer;
+
+      const auto json_schema = glz::write_json_schema<meta_schema_t, glz::opts{.prettify = true}>();
+      expect(
+         json_schema ==
+         R"({
+   "type": [
+      "object"
+   ],
+   "properties": {
+      "file_name": {
+         "$ref": "#/$defs/std::string",
+         "description": "provide a file name to load"
+      },
+      "is_valid": {
+         "$ref": "#/$defs/bool",
+         "description": "for validation"
+      },
+      "x": {
+         "$ref": "#/$defs/int32_t",
+         "description": "x is a special integer"
+      }
+   },
+   "additionalProperties": false,
+   "$defs": {
+      "bool": {
+         "type": [
+            "boolean"
+         ]
+      },
+      "int32_t": {
+         "type": [
+            "integer"
+         ]
+      },
+      "std::string": {
+         "type": [
+            "string"
+         ]
+      }
+   }
+})")
+         << json_schema;
+   };
 };
 
 suite glz_text_tests = [] {


### PR DESCRIPTION
One benefit is that we can now pretty-print JSON schema without needing to make an additional glz::prettify call.