### PR TITLE
Adding glz::raw_or_file

### DIFF
--- a/include/glaze/file/raw_or_file.hpp
+++ b/include/glaze/file/raw_or_file.hpp
@@ -1,0 +1,81 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include "glaze/core/common.hpp"
+
+#include <filesystem>
+
+namespace glz
+{
+   // Register this with an object to allow loading a file when a valid file path is given as a string
+   // If the file does not exist, the string is handled as a glz::raw_json
+   // This enables file including of unknown structures that will be decoded in the future when state is known
+   struct raw_or_file final
+   {
+      bool reflection_helper{};
+      raw_json value = R"("")";
+   };
+
+   namespace detail
+   {
+      template <>
+      struct from_json<raw_or_file>
+      {
+         template <auto Options>
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         {
+            constexpr auto Opts = ws_handled_off<Options>();
+            auto& v = value.value;
+            // check if we are decoding a string, which could be a file path
+            if (*it == '"') {
+               read<json>::op<Opts>(v.str, ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
+               
+               namespace fs = std::filesystem;
+               const auto path = relativize_if_not_absolute(fs::path(ctx.current_file).parent_path(),
+                                                                 fs::path{v.str});
+               
+               if (fs::exists(path) && fs::is_regular_file(path)) {
+                  const auto string_path = path.string();
+                  const auto ec = file_to_buffer(v.str, string_path);
+
+                  if (bool(ec)) [[unlikely]] {
+                     ctx.error = error_code::includer_error;
+                     auto& error_msg = error_buffer();
+                     error_msg = "file failed to open: " + string_path;
+                     ctx.includer_error = error_msg;
+                     return;
+                  }
+                  
+                  const auto ecode = validate_json(v.str);
+                  if (ecode) [[unlikely]] {
+                     ctx.error = error_code::includer_error;
+                     auto& error_msg = error_buffer();
+                     error_msg = glz::format_error(ecode, v.str);
+                     ctx.includer_error = error_msg;
+                     return;
+                  }
+               }
+            }
+            else {
+               read<json>::op<Opts>(v, ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
+            }
+         }
+      };
+      
+      template <>
+      struct to_json<raw_or_file>
+      {
+         template <auto Opts>
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix) noexcept
+         {
+            dump(value.value.str, b, ix);
+         }
+      };
+   }
+}

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -34,7 +34,7 @@ struct glz::meta<my_struct>
                                         "d", &T::d, //
                                         "hello", &T::hello, //
                                         "arr", &T::arr, //
-                                        "#include", glz::file_include{} //
+                                        "include", glz::file_include{} //
    );
 };
 
@@ -71,7 +71,7 @@ struct glz::meta<sub_thing2>
 {
    using T = sub_thing2;
    static constexpr std::string_view name = "sub_thing2";
-   static constexpr auto value = object("#include", glz::file_include{}, //
+   static constexpr auto value = object("include", glz::file_include{}, //
                                         "a", &T::a, "Test comment 1", //
                                         "b", &T::b, "Test comment 2", //
                                         "c", &T::c, //
@@ -560,7 +560,7 @@ template <>
 struct glz::meta<includer_struct>
 {
    using T = includer_struct;
-   static constexpr auto value = object("#include", glz::file_include{}, "str", &T::str, "i", &T::i, "j", &T::j);
+   static constexpr auto value = object("include", glz::file_include{}, "str", &T::str, "i", &T::i, "j", &T::j);
 };
 
 static_assert(glz::is_includer<glz::includer<includer_struct>>);

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -6874,6 +6874,46 @@ suite raw_or_file_tests = [] {
       std::string s{};
       glz::write_json(obj, s);
       expect(s == R"({"input":"","name":""})");
+      
+      const std::string secondary_file = "./secondary.json";
+      glz::obj primary{ "input", secondary_file, "name", "Edward" };
+      const auto primary_json = glz::write_json(primary);
+      
+      {
+         std::vector<int> x{1, 2, 3};
+         const auto ec = glz::write_file_json(x, secondary_file, std::string{});
+         expect(!bool(ec));
+      }
+      
+      expect(!glz::read_json(obj, primary_json));
+      expect(obj.input.str == R"([1,2,3])");
+      expect(obj.name == "Edward");
+      
+      glz::write_json(obj, s);
+      expect(s == R"({"input":[1,2,3],"name":"Edward"})");
+      
+      obj = {};
+      expect(!glz::read_json(obj, s));
+      expect(obj.input.str == R"([1,2,3])");
+      expect(obj.name == "Edward");
+      
+      {
+         std::string hello = "Hello from Mars";
+         const auto ec = glz::write_file_json(hello, secondary_file, std::string{});
+         expect(!bool(ec));
+      }
+      
+      expect(!glz::read_json(obj, primary_json));
+      expect(obj.input.str == R"("Hello from Mars")");
+      expect(obj.name == "Edward");
+      
+      glz::write_json(obj, s);
+      expect(s == R"({"input":"Hello from Mars","name":"Edward"})");
+      
+      obj = {};
+      expect(!glz::read_json(obj, s));
+      expect(obj.input.str == R"("Hello from Mars")");
+      expect(obj.name == "Edward");
    };
 };
 

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -2962,7 +2962,7 @@ struct glz::meta<nested0>
 {
    static constexpr std::string_view name = "nested0";
    using T = nested0;
-   static constexpr auto value = object("#include", glz::file_include{}, "a", &T::a, "b", &T::b);
+   static constexpr auto value = object("include", glz::file_include{}, "a", &T::a, "b", &T::b);
 };
 
 suite nested_file_include_test = [] {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -23,6 +23,7 @@
 #include "boost/ut.hpp"
 #include "glaze/api/impl.hpp"
 #include "glaze/file/hostname_include.hpp"
+#include "glaze/file/raw_or_file.hpp"
 #include "glaze/json/json_ptr.hpp"
 #include "glaze/json/prettify.hpp"
 #include "glaze/json/ptr.hpp"
@@ -6855,6 +6856,24 @@ suite glz_text_tests = [] {
       text.str.clear();
       expect(!glz::read_json(text, out));
       expect(text.str == "Hello World");
+   };
+};
+
+struct raw_or_file_tester
+{
+   glz::raw_or_file input{};
+   std::string name{};
+};
+
+static_assert(glz::detail::count_members<raw_or_file_tester> == 2);
+
+suite raw_or_file_tests = [] {
+   "raw_or_file"_test = [] {
+      raw_or_file_tester obj{};
+      
+      std::string s{};
+      glz::write_json(obj, s);
+      expect(s == R"({"input":"","name":""})");
    };
 };
 


### PR DESCRIPTION
`glz::raw_or_file` is somewhat like a `glz::file_include`, but also handles serialization. The purpose is to allow JSON files to be optionally referred to within higher level configuration files, but once loaded, the files behave as `glz::raw_json`, where the format does not need to be understood until deserialized.

How `glz::raw_or_file` behaves:
- If the input is a valid file path within a string, the entire file will be read into a `std::string` within the `glz::raw_or_file` member. The internal buffer does not escape characters, as it is handled like `glz::raw_json`.
- If the input is not a valid file path or not a string, the value is simply validated and stored like `glz::raw_json`
- When serialized, the value is dumped like `glz::raw_json`, which means it will look like the input file was copied and pasted into the higher level document.

Benefits of this approach include:
- The layout for the file loaded into `glz::raw_or_file` does not need to be known by the program. As long as it is valid JSON it can be passed along.
- The serialized output after loading the file looks like a combined file, which is easier to read and format than an escaped string version of the file. It is also more efficient because escaping/unescaping doesn't need to be performed, only validation.