### PR TITLE
Can set port and added init to asio_server and using init_registry

### DIFF
--- a/tests/asio_repe/client/repe_client.cpp
+++ b/tests/asio_repe/client/repe_client.cpp
@@ -10,7 +10,7 @@
 void asio_client_test()
 {
    try {
-      glz::asio_client client{};
+      glz::asio_client<> client{"localhost", "8080"};
       client.init();
 
       std::vector<int> data{};

--- a/tests/asio_repe/server/repe_server.cpp
+++ b/tests/asio_repe/server/repe_server.cpp
@@ -20,9 +20,9 @@ void run_server()
    std::cout << "Server active...\n";
 
    try {
-      glz::asio_server<glz::repe::registry<>> server{};
+      glz::asio_server<glz::repe::registry<>> server{.port = 8080};
       api methods{};
-      server.init = [&](glz::repe::registry<>& registry) { registry.on(methods); };
+      server.init_registry = [&](glz::repe::registry<>& registry) { registry.on(methods); };
       server.run();
    }
    catch (std::exception& e) {


### PR DESCRIPTION
This fixes and improves `glz::asio_server`, which had a hardcoded port <face slap!>. It also separates the instantiation like `glz::asio_client`, which allows the class to be read/written via Glaze before/after initialization.

A breaking change is that the function to setup the registry is no longer called `init`, but instead `init_registry`