### PR TITLE
requiring explicit study.hpp include

### DIFF
--- a/include/glaze/ext/cli_menu.hpp
+++ b/include/glaze/ext/cli_menu.hpp
@@ -3,8 +3,9 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdio>
-#include <glaze/glaze.hpp>
+#include "glaze/glaze.hpp"
 
 // The purpose of this command line interface menu is to use reflection to build the menu,
 // but also allow this menu to be registered as an RPC interface.

--- a/include/glaze/json.hpp
+++ b/include/glaze/json.hpp
@@ -14,5 +14,4 @@
 #include "glaze/json/raw_string.hpp"
 #include "glaze/json/read.hpp"
 #include "glaze/json/schema.hpp"
-#include "glaze/json/study.hpp"
 #include "glaze/json/write.hpp"

--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <mutex>
 #include <shared_mutex>
 
 #include "glaze/glaze.hpp"

--- a/tests/exceptions_test/exceptions_test.cpp
+++ b/tests/exceptions_test/exceptions_test.cpp
@@ -3,6 +3,7 @@
 
 #include "boost/ut.hpp"
 #include "glaze/glaze_exceptions.hpp"
+#include "glaze/thread/threadpool.hpp"
 
 using namespace boost::ut;
 

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -30,6 +30,7 @@
 #include "glaze/json/quoted.hpp"
 #include "glaze/json/read.hpp"
 #include "glaze/json/write.hpp"
+#include "glaze/json/study.hpp"
 #include "glaze/record/recorder.hpp"
 #include "glaze/util/poly.hpp"
 #include "glaze/util/progress_bar.hpp"


### PR DESCRIPTION
## Breaking Change
Removed `#include "glaze/json/study.hpp"` from the high level `glaze.hpp` and `json.hpp` headers. This header must now be included by the user where needed.
This removes `<thread>`, `<mutex>`, and `<future>` from being automatically included in `glaze.hpp`