### PR TITLE
Faster and cleaner code for naming std types

### DIFF
--- a/include/glaze/api/std/deque.hpp
+++ b/include/glaze/api/std/deque.hpp
@@ -10,12 +10,8 @@
 namespace glz
 {
    template <class T>
-   concept deque = is_specialization_v<T, std::deque>;
-
-   template <deque T>
-   struct meta<T>
+   struct meta<std::deque<T>>
    {
-      using V = typename T::value_type;
-      static constexpr std::string_view name = detail::join_v<chars<"std::deque<">, name_v<V>, chars<">">>;
+      static constexpr std::string_view name = detail::join_v<chars<"std::deque<">, name_v<T>, chars<">">>;
    };
 }

--- a/include/glaze/api/std/list.hpp
+++ b/include/glaze/api/std/list.hpp
@@ -10,12 +10,8 @@
 namespace glz
 {
    template <class T>
-   concept list = is_specialization_v<T, std::list>;
-
-   template <list T>
-   struct meta<T>
+   struct meta<std::list<T>>
    {
-      using V = typename T::value_type;
-      static constexpr std::string_view name = detail::join_v<chars<"std::list<">, name_v<V>, chars<">">>;
+      static constexpr std::string_view name = detail::join_v<chars<"std::list<">, name_v<T>, chars<">">>;
    };
 }

--- a/include/glaze/api/std/map.hpp
+++ b/include/glaze/api/std/map.hpp
@@ -9,15 +9,10 @@
 
 namespace glz
 {
-   template <class T>
-   concept map = is_specialization_v<T, std::map>;
-
-   template <map T>
-   struct meta<T>
+   template <class Key, class Mapped>
+   struct meta<std::map<Key, Mapped>>
    {
-      using Key = typename T::key_type;
-      using V = typename T::mapped_type;
       static constexpr std::string_view name =
-         detail::join_v<chars<"std::map<">, name_v<Key>, chars<",">, name_v<V>, chars<">">>;
+         detail::join_v<chars<"std::map<">, name_v<Key>, chars<",">, name_v<Mapped>, chars<">">>;
    };
 }

--- a/include/glaze/api/std/optional.hpp
+++ b/include/glaze/api/std/optional.hpp
@@ -10,12 +10,8 @@
 namespace glz
 {
    template <class T>
-   concept optional = is_specialization_v<T, std::optional>;
-
-   template <optional T>
-   struct meta<T>
+   struct meta<std::optional<T>>
    {
-      using V = typename T::value_type;
-      static constexpr std::string_view name = detail::join_v<chars<"std::optional<">, name_v<V>, chars<">">>;
+      static constexpr std::string_view name = detail::join_v<chars<"std::optional<">, name_v<T>, chars<">">>;
    };
 }

--- a/include/glaze/api/std/set.hpp
+++ b/include/glaze/api/std/set.hpp
@@ -10,12 +10,8 @@
 namespace glz
 {
    template <class T>
-   concept set = is_specialization_v<T, std::set>;
-
-   template <set T>
-   struct meta<T>
+   struct meta<std::set<T>>
    {
-      using V = typename T::value_type;
-      static constexpr std::string_view name = detail::join_v<chars<"std::set<">, name_v<V>, chars<">">>;
+      static constexpr std::string_view name = detail::join_v<chars<"std::set<">, name_v<T>, chars<">">>;
    };
 }

--- a/include/glaze/api/std/shared_ptr.hpp
+++ b/include/glaze/api/std/shared_ptr.hpp
@@ -10,12 +10,8 @@
 namespace glz
 {
    template <class T>
-   concept shared_ptr = is_specialization_v<T, std::shared_ptr>;
-
-   template <shared_ptr T>
-   struct meta<T>
+   struct meta<std::shared_ptr<T>>
    {
-      using V = typename T::element_type;
-      static constexpr std::string_view name = detail::join_v<chars<"std::shared_ptr<">, name_v<V>, chars<">">>;
+      static constexpr std::string_view name = detail::join_v<chars<"std::shared_ptr<">, name_v<T>, chars<">">>;
    };
 }

--- a/include/glaze/api/std/tuple.hpp
+++ b/include/glaze/api/std/tuple.hpp
@@ -11,23 +11,20 @@ namespace glz
 {
    namespace detail
    {
-      template <class Tuple, size_t... I>
+      template <class... T, size_t... I>
       constexpr std::string_view tuple_name_impl(std::index_sequence<I...>)
       {
          return join_v<chars<"std::tuple<">,
-                       ((I != std::tuple_size_v<Tuple> - 1) ? join_v<name_v<std::tuple_element_t<I, Tuple>>, chars<",">>
-                                                            : join_v<name_v<std::tuple_element_t<I, Tuple>>>)...,
+                       ((I != sizeof...(T) - 1) ? join_v<name_v<T>, chars<",">>
+                                                            : join_v<name_v<T>>)...,
                        chars<">">>;
       }
    }
 
-   template <class T>
-   concept tuple = is_specialization_v<T, std::tuple>;
-
-   template <tuple T>
-   struct meta<T>
+   template <class... T>
+   struct meta<std::tuple<T...>>
    {
       static constexpr std::string_view name =
-         detail::tuple_name_impl<T>(std::make_index_sequence<std::tuple_size_v<T>>());
+         detail::tuple_name_impl<T...>(std::make_index_sequence<sizeof...(T)>());
    };
 }

--- a/include/glaze/api/std/unique_ptr.hpp
+++ b/include/glaze/api/std/unique_ptr.hpp
@@ -10,12 +10,8 @@
 namespace glz
 {
    template <class T>
-   concept unique_ptr = is_specialization_v<T, std::unique_ptr>;
-
-   template <unique_ptr T>
-   struct meta<T>
+   struct meta<std::unique_ptr<T>>
    {
-      using V = typename T::element_type;
-      static constexpr std::string_view name = detail::join_v<chars<"std::unique_ptr<">, name_v<V>, chars<">">>;
+      static constexpr std::string_view name = detail::join_v<chars<"std::unique_ptr<">, name_v<T>, chars<">">>;
    };
 }

--- a/include/glaze/api/std/unordered_map.hpp
+++ b/include/glaze/api/std/unordered_map.hpp
@@ -9,15 +9,10 @@
 
 namespace glz
 {
-   template <class T>
-   concept unordered_map = is_specialization_v<T, std::unordered_map>;
-
-   template <unordered_map T>
-   struct meta<T>
+   template <class Key, class Mapped>
+   struct meta<std::unordered_map<Key, Mapped>>
    {
-      using Key = typename T::key_type;
-      using V = typename T::mapped_type;
       static constexpr std::string_view name =
-         detail::join_v<chars<"std::unordered_map<">, name_v<Key>, chars<",">, name_v<V>, chars<">">>;
+         detail::join_v<chars<"std::unordered_map<">, name_v<Key>, chars<",">, name_v<Mapped>, chars<">">>;
    };
 }

--- a/include/glaze/api/std/unordered_set.hpp
+++ b/include/glaze/api/std/unordered_set.hpp
@@ -10,12 +10,8 @@
 namespace glz
 {
    template <class T>
-   concept unordered_set = is_specialization_v<T, std::unordered_set>;
-
-   template <unordered_set T>
-   struct meta<T>
+   struct meta<std::unordered_set<T>>
    {
-      using V = typename T::value_type;
-      static constexpr std::string_view name = detail::join_v<chars<"std::unordered_set<">, name_v<V>, chars<">">>;
+      static constexpr std::string_view name = detail::join_v<chars<"std::unordered_set<">, name_v<T>, chars<">">>;
    };
 }

--- a/include/glaze/api/std/variant.hpp
+++ b/include/glaze/api/std/variant.hpp
@@ -11,25 +11,22 @@ namespace glz
 {
    namespace detail
    {
-      template <class Variant, size_t... I>
+      template <class... T, size_t... I>
       constexpr std::string_view variant_name_impl(std::index_sequence<I...>)
       {
          return join_v<chars<"std::variant<">,
-                       ((I != std::variant_size_v<Variant> - 1)
-                           ? join_v<name_v<std::variant_alternative_t<I, Variant>>, chars<",">>
-                           : join_v<name_v<std::variant_alternative_t<I, Variant>>>)...,
+                       ((I != sizeof...(T) - 1)
+                           ? join_v<name_v<T>, chars<",">>
+                           : join_v<name_v<T>>)...,
                        chars<">">>;
       }
    }
 
-   template <class T>
-   concept variant_specialization = is_specialization_v<T, std::variant>;
-
-   template <variant_specialization T>
-   struct meta<T>
+   template <class... T>
+   struct meta<std::variant<T...>>
    {
       static constexpr std::string_view name =
-         detail::variant_name_impl<T>(std::make_index_sequence<std::variant_size_v<T>>());
+         detail::variant_name_impl<T...>(std::make_index_sequence<sizeof...(T)>());
    };
 
    template <>

--- a/include/glaze/api/std/vector.hpp
+++ b/include/glaze/api/std/vector.hpp
@@ -10,12 +10,8 @@
 namespace glz
 {
    template <class T>
-   concept vector = is_specialization_v<T, std::vector>;
-
-   template <vector T>
-   struct meta<T>
+   struct meta<std::vector<T>>
    {
-      using V = typename T::value_type;
-      static constexpr std::string_view name = detail::join_v<chars<"std::vector<">, name_v<V>, chars<">">>;
+      static constexpr std::string_view name = detail::join_v<chars<"std::vector<">, name_v<T>, chars<">">>;
    };
 }

--- a/include/glaze/api/tuplet.hpp
+++ b/include/glaze/api/tuplet.hpp
@@ -10,21 +10,20 @@ namespace glz
 {
    namespace detail
    {
-      template <class Tuple, size_t... I>
+      template <class... T, size_t... I>
       constexpr std::string_view tuplet_name_impl(std::index_sequence<I...>)
       {
          return join_v<chars<"glz::tuplet::tuple<">,
-                       ((I != std::tuple_size_v<Tuple> - 1) ? join_v<name_v<std::tuple_element_t<I, Tuple>>, chars<",">>
-                                                            : join_v<name_v<std::tuple_element_t<I, Tuple>>>)...,
+                       ((I != sizeof(T) - 1) ? join_v<name_v<T>, chars<",">>
+                                                            : join_v<name_v<T>>)...,
                        chars<">">>;
       }
    }
 
-   template <class T>
-      requires is_specialization_v<T, glz::tuplet::tuple>
-   struct meta<T>
+   template <class... T>
+   struct meta<glz::tuplet::tuple<T...>>
    {
       static constexpr std::string_view name =
-         detail::tuplet_name_impl<T>(std::make_index_sequence<std::tuple_size_v<T>>());
+         detail::tuplet_name_impl<T...>(std::make_index_sequence<sizeof...(T)>());
    };
 }

--- a/include/glaze/api/tuplet.hpp
+++ b/include/glaze/api/tuplet.hpp
@@ -14,7 +14,7 @@ namespace glz
       constexpr std::string_view tuplet_name_impl(std::index_sequence<I...>)
       {
          return join_v<chars<"glz::tuplet::tuple<">,
-                       ((I != sizeof(T) - 1) ? join_v<name_v<T>, chars<",">>
+                       ((I != sizeof...(T) - 1) ? join_v<name_v<T>, chars<",">>
                                                             : join_v<name_v<T>>)...,
                        chars<">">>;
       }

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -1194,7 +1194,7 @@ namespace glz
          return detail::get_enum_key<T, static_cast<U>(Enum)>();
       }
       else {
-         return "glz::unknown";
+         static_assert(false_v<decltype(Enum)>, "Enum requires glaze metadata for name");
       }
    }();
 

--- a/include/glaze/core/meta.hpp
+++ b/include/glaze/core/meta.hpp
@@ -178,29 +178,18 @@ namespace glz
    template <class T>
    concept named = requires { meta<T>::name; } || requires { T::glaze::name; };
 
-   template <class T, bool fail_on_unknown = false>
+   template <class T>
    inline constexpr std::string_view name_v = [] {
       if constexpr (named<T>) {
          if constexpr (requires { T::glaze::name; }) {
-            if constexpr (fail_on_unknown) {
-               static_assert(T::glaze::name.find("glz::unknown") == std::string_view::npos,
-                             "name_v used on unnamed type");
-            }
             return T::glaze::name;
          }
          else {
-            if constexpr (fail_on_unknown) {
-               static_assert(meta<T>::name.find("glz::unknown") == std::string_view::npos,
-                             "name_v used on unnamed type");
-            }
             return meta<T>::name;
          }
       }
       else if constexpr (std::is_void_v<T>) {
          return "void";
-      }
-      else if constexpr (fail_on_unknown) {
-         static_assert(false_v<T>, "name_v used on unnamed type");
       }
       else {
          return type_name<std::decay_t<T>>;


### PR DESCRIPTION
Removed "glz::unknown" as we now have good type reflection