### PR TITLE
Adding support for reflectable wrappers with REPE registry

### DIFF
--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -397,16 +397,7 @@ namespace glz::repe
                };
             }
             else if constexpr (glaze_object_t<E> || reflectable<E>) {
-               decltype(auto) member = [&]() -> decltype(auto) {
-                  if constexpr (reflectable<T>) {
-                     return std::get<I>(t);
-                  }
-                  else {
-                     return get<Element::member_index>(get<I>(meta_v<T>));
-                  }
-               }();
-               
-               on<std::decay_t<E>, full_key>(get_member(value, member));
+               on<std::decay_t<E>, full_key>(get_member(value, func));
 
                // build read/write calls to the object as a variable
                methods[full_key] = [this, &func](repe::state&& state) {

--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -397,13 +397,16 @@ namespace glz::repe
                });
             }
             else if constexpr (glaze_object_t<E> || reflectable<E>) {
-               if constexpr (reflectable<T>) {
-                  on<std::decay_t<E>, full_key>(std::get<I>(t));
-               }
-               else {
-                  decltype(auto) member = get_member(value, get<Element::member_index>(get<I>(meta_v<T>)));
-                  on<std::decay_t<E>, full_key>(member);
-               }
+               decltype(auto) member = [&]() -> decltype(auto) {
+                  if constexpr (reflectable<T>) {
+                     return std::get<I>(t);
+                  }
+                  else {
+                     return get<Element::member_index>(get<I>(meta_v<T>));
+                  }
+               }();
+               
+               on<std::decay_t<E>, full_key>(get_member(value, member));
 
                // build read/write calls to the object as a variable
                methods.emplace(full_key, [this, &func](repe::state&& state) {

--- a/tests/repe_test/repe_test.cpp
+++ b/tests/repe_test/repe_test.cpp
@@ -348,7 +348,7 @@ suite structs_of_functions = [] {
    };
 };
 
-/*template <class T>
+template <class T>
 struct wrapper_t
 {
    T* sub{};
@@ -358,8 +358,8 @@ suite wrapper_tests = [] {
    "wrapper"_test = [] {
       repe::registry server{};
       
-      my_functions_t instance{};
-      wrapper_t<my_functions_t> obj{&instance};
+      my_nested_functions_t instance{};
+      wrapper_t<my_nested_functions_t> obj{&instance};
       
       server.on(obj);
 
@@ -377,7 +377,7 @@ suite wrapper_tests = [] {
 
       expect(server.response == R"([[0,0,0,"/sub/my_functions/hello",null],"Hello"])");
    };
-};*/
+};
 
 int main()
 {

--- a/tests/repe_test/repe_test.cpp
+++ b/tests/repe_test/repe_test.cpp
@@ -353,6 +353,7 @@ struct wrapper_t
 {
    T* sub{};
    
+   // TODO: support meta wrappers and not only reflectable wrappers (I don't know why this isn't working)
    /*struct glaze {
       static constexpr auto value = glz::object(&wrapper_t::sub);
    };*/

--- a/tests/repe_test/repe_test.cpp
+++ b/tests/repe_test/repe_test.cpp
@@ -348,6 +348,37 @@ suite structs_of_functions = [] {
    };
 };
 
+/*template <class T>
+struct wrapper_t
+{
+   T* sub{};
+};
+
+suite wrapper_tests = [] {
+   "wrapper"_test = [] {
+      repe::registry server{};
+      
+      my_functions_t instance{};
+      wrapper_t<my_functions_t> obj{&instance};
+      
+      server.on(obj);
+
+      {
+         auto request = repe::request_json({"/sub/my_functions/void_func"});
+         server.call(request);
+      }
+
+      expect(server.response == R"([[0,0,2,"/sub/my_functions/void_func",null],null])") << server.response;
+
+      {
+         auto request = repe::request_json({"/sub/my_functions/hello"});
+         server.call(request);
+      }
+
+      expect(server.response == R"([[0,0,0,"/sub/my_functions/hello",null],"Hello"])");
+   };
+};*/
+
 int main()
 {
    const auto result = boost::ut::cfg<>.run({.report_errors = true});

--- a/tests/repe_test/repe_test.cpp
+++ b/tests/repe_test/repe_test.cpp
@@ -352,6 +352,10 @@ template <class T>
 struct wrapper_t
 {
    T* sub{};
+   
+   /*struct glaze {
+      static constexpr auto value = glz::object(&wrapper_t::sub);
+   };*/
 };
 
 suite wrapper_tests = [] {


### PR DESCRIPTION
- Allows re-registration by using [] instead of emplace on the registry's map