### PR TITLE
Properly limiting variant scope in JSON schema

### DIFF
--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -37,7 +37,7 @@ namespace glz
       std::optional<bool> read_only{};
       std::optional<bool> write_only{};
       // hereafter validation keywords, ref: https://www.learnjsonschema.com/2020-12/validation/
-      std::optional<bool> constant{};
+      std::optional<std::variant<bool, std::string_view>> constant{};
       // string only keywords
       std::optional<std::uint64_t> min_length{};
       std::optional<std::uint64_t> max_length{};
@@ -354,6 +354,7 @@ namespace glz
                (*s.type).emplace_back("null");
             }
             s.oneOf = std::vector<schematic>(N);
+            
             for_each<N>([&](auto I) {
                using V = std::decay_t<std::variant_alternative_t<I, T>>;
                auto& schema_val = (*s.oneOf)[I.value];
@@ -367,7 +368,7 @@ namespace glz
                   if constexpr (!tag_v<T>.empty()) {
                      auto& properties = (*schema_val.properties)[tag_v<T>] =
                         schema{join_v<chars<"#/$defs/">, name_v<std::string>>};
-                     properties.enumeration = ids_v<T>;
+                     properties.constant = ids_v<T>[I];
                   }
                }
             });

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -358,18 +358,16 @@ namespace glz
             for_each<N>([&](auto I) {
                using V = std::decay_t<std::variant_alternative_t<I, T>>;
                auto& schema_val = (*s.oneOf)[I.value];
-               // TODO: use ref to avoid duplication in schema
                to_json_schema<V>::template op<Opts>(schema_val, defs);
-               if constexpr (glaze_object_t<V> || reflectable<V>) {
+               if constexpr ((glaze_object_t<V> || reflectable<V>) && !tag_v<T>.empty()) {
                   auto& def = defs[name_v<std::string>];
                   if (!def.type) {
                      to_json_schema<std::string>::template op<Opts>(def, defs);
                   }
-                  if constexpr (!tag_v<T>.empty()) {
-                     auto& properties = (*schema_val.properties)[tag_v<T>] =
-                        schema{join_v<chars<"#/$defs/">, name_v<std::string>>};
-                     properties.constant = ids_v<T>[I];
-                  }
+                  
+                  auto& properties = (*schema_val.properties)[tag_v<T>] =
+                     schema{join_v<chars<"#/$defs/">, name_v<std::string>>};
+                  properties.constant = ids_v<T>[I];
                }
             });
          }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -2585,7 +2585,7 @@ suite tagged_variant_tests = [] {
       auto s = glz::write_json_schema<tagged_variant>();
       expect(
          s ==
-         R"({"type":["object"],"$defs":{"int32_t":{"type":["integer"]},"std::map<std::string,int32_t>":{"type":["object"],"additionalProperties":{"$ref":"#/$defs/int32_t"}},"std::string":{"type":["string"]}},"oneOf":[{"type":["object"],"properties":{"action":{"$ref":"#/$defs/std::string","enum":["PUT","DELETE"]},"data":{"$ref":"#/$defs/std::map<std::string,int32_t>"}},"additionalProperties":false},{"type":["object"],"properties":{"action":{"$ref":"#/$defs/std::string","enum":["PUT","DELETE"]},"data":{"$ref":"#/$defs/std::string"}},"additionalProperties":false}]})")
+         R"({"type":["object"],"$defs":{"int32_t":{"type":["integer"]},"std::map<std::string,int32_t>":{"type":["object"],"additionalProperties":{"$ref":"#/$defs/int32_t"}},"std::string":{"type":["string"]}},"oneOf":[{"type":["object"],"properties":{"action":{"$ref":"#/$defs/std::string","const":"PUT"},"data":{"$ref":"#/$defs/std::map<std::string,int32_t>"}},"additionalProperties":false},{"type":["object"],"properties":{"action":{"$ref":"#/$defs/std::string","const":"DELETE"},"data":{"$ref":"#/$defs/std::string"}},"additionalProperties":false}]})")
          << s;
    };
 
@@ -2620,7 +2620,7 @@ suite tagged_variant_tests = [] {
       const auto schema = glz::write_json_schema<std::shared_ptr<tagged_variant2>>();
       expect(
          schema ==
-         R"({"type":["object","null"],"$defs":{"int32_t":{"type":["integer"]},"std::map<std::string,int32_t>":{"type":["object"],"additionalProperties":{"$ref":"#/$defs/int32_t"}},"std::string":{"type":["string"]}},"oneOf":[{"type":["object"],"properties":{"data":{"$ref":"#/$defs/std::map<std::string,int32_t>"},"type":{"$ref":"#/$defs/std::string","enum":["put_action","delete_action","std::monostate"]}},"additionalProperties":false},{"type":["object"],"properties":{"data":{"$ref":"#/$defs/std::string"},"type":{"$ref":"#/$defs/std::string","enum":["put_action","delete_action","std::monostate"]}},"additionalProperties":false},{"type":["null"]}]})")
+         R"({"type":["object","null"],"$defs":{"int32_t":{"type":["integer"]},"std::map<std::string,int32_t>":{"type":["object"],"additionalProperties":{"$ref":"#/$defs/int32_t"}},"std::string":{"type":["string"]}},"oneOf":[{"type":["object"],"properties":{"data":{"$ref":"#/$defs/std::map<std::string,int32_t>"},"type":{"$ref":"#/$defs/std::string","const":"put_action"}},"additionalProperties":false},{"type":["object"],"properties":{"data":{"$ref":"#/$defs/std::string"},"type":{"$ref":"#/$defs/std::string","const":"delete_action"}},"additionalProperties":false},{"type":["null"]}]})")
          << schema;
    };
 };
@@ -5864,7 +5864,7 @@ suite empty_variant_objects = [] {
       const auto s = glz::write_json_schema<var_schema>();
       expect(
          s ==
-         R"({"type":["object"],"properties":{"$schema":{"$ref":"#/$defs/std::string"},"variant":{"$ref":"#/$defs/vari"}},"additionalProperties":false,"$defs":{"std::string":{"type":["string"]},"vari":{"type":["object"],"oneOf":[{"type":["object"],"properties":{"type":{"$ref":"#/$defs/std::string","enum":["varx","vary"]}},"additionalProperties":false},{"type":["object"],"properties":{"type":{"$ref":"#/$defs/std::string","enum":["varx","vary"]}},"additionalProperties":false}]}}})")
+         R"({"type":["object"],"properties":{"$schema":{"$ref":"#/$defs/std::string"},"variant":{"$ref":"#/$defs/vari"}},"additionalProperties":false,"$defs":{"std::string":{"type":["string"]},"vari":{"type":["object"],"oneOf":[{"type":["object"],"properties":{"type":{"$ref":"#/$defs/std::string","const":"varx"}},"additionalProperties":false},{"type":["object"],"properties":{"type":{"$ref":"#/$defs/std::string","const":"vary"}},"additionalProperties":false}]}}})")
          << s;
    };
 };


### PR DESCRIPTION
Once a tag field has been populated an IDE like Visual Studio Code will only recommend fields from the variant.