### PR TITLE
Support for glz/std::expected with JSON

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -1205,6 +1205,25 @@ struct glz::meta<glz::error_code>
 
 namespace glz
 {
+   // This wraps glz::expected error (unexpected) values in an object with an "error" key
+   // This makes them discernable from the expected value
+   template <class T>
+   struct unexpected_wrapper
+   {
+      T* unexpected;
+      
+      struct glaze {
+         using V = unexpected_wrapper;
+         static constexpr auto value = glz::object("unexpected", &V::unexpected);
+      };
+   };
+   
+   template <class T>
+   unexpected_wrapper(T*) -> unexpected_wrapper<T>;
+}
+
+namespace glz
+{
    template <auto Enum>
       requires(std::is_enum_v<decltype(Enum)>)
    constexpr sv enum_name_v = []() -> std::string_view {

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2465,20 +2465,80 @@ namespace glz
                   return;
             }
             
-            auto start = it;
             if (*it == '{') {
-               // either we have an unexpected value or we are decoding an object
-               
-               
-            }
-            
-            /*using value_type = typename std::decay_t<decltype(value)>::value_type;
-            if constexpr () {
-               
+               auto start = it;
+               ++it;
+               skip_ws<Opts>(ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
+               if (*it == '}') {
+                  it = start;
+                  // empty object
+                  if (value) {
+                     read<json>::op<Opts>(*value, ctx, it, end);
+                  }
+                  else {
+                     value.emplace();
+                     read<json>::op<Opts>(*value, ctx, it, end);
+                  }
+               }
+               else {
+                  // either we have an unexpected value or we are decoding an object
+                  auto& key = string_buffer();
+                  read<json>::op<Opts>(key, ctx, it, end);
+                  if (bool(ctx.error)) [[unlikely]]
+                     return;
+                  if (key == "unexpected") {
+                     skip_ws<Opts>(ctx, it, end);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                     match<':'>(ctx, it);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                     // read in unexpected value
+                     if (!value) {
+                        read<json>::op<Opts>(value.error(), ctx, it, end);
+                        if (bool(ctx.error)) [[unlikely]]
+                           return;
+                     }
+                     else {
+                        // set value to unexpected
+                        using error_type = typename std::decay_t<decltype(value)>::error_type;
+                        std::decay_t<error_type> error{};
+                        read<json>::op<Opts>(error, ctx, it, end);
+                        if (bool(ctx.error)) [[unlikely]]
+                           return;
+                        value = glz::unexpected(error);
+                     }
+                     skip_ws<Opts>(ctx, it, end);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                     match<'}'>(ctx, it);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                  }
+                  else {
+                     it = start;
+                     if (value) {
+                        read<json>::op<Opts>(*value, ctx, it, end);
+                     }
+                     else {
+                        value.emplace();
+                        read<json>::op<Opts>(*value, ctx, it, end);
+                     }
+                  }
+               }
             }
             else {
-               
-            }*/
+               // this is not an object and therefore cannot be an unexpected value
+               if (value) {
+                  read<json>::op<Opts>(*value, ctx, it, end);
+               }
+               else {
+                  value.emplace();
+                  read<json>::op<Opts>(*value, ctx, it, end);
+               }
+            }
          }
       };
 

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2452,8 +2452,38 @@ namespace glz
             match<']'>(ctx, it);
          }
       };
+      
+      template <is_expected T>
+      struct from_json<T>
+      {
+         template <auto Opts, class... Args>
+         GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         {
+            if constexpr (!Opts.ws_handled) {
+               skip_ws<Opts>(ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
+            }
+            
+            auto start = it;
+            if (*it == '{') {
+               // either we have an unexpected value or we are decoding an object
+               
+               
+            }
+            
+            /*using value_type = typename std::decay_t<decltype(value)>::value_type;
+            if constexpr () {
+               
+            }
+            else {
+               
+            }*/
+         }
+      };
 
       template <nullable_t T>
+         requires (!is_expected<T>)
       struct from_json<T>
       {
          template <auto Options>

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -703,15 +703,32 @@ namespace glz
             }
          }
       };
-
-      template <nullable_t T>
+      
+      template <is_expected T>
       struct to_json<T>
       {
          template <auto Opts, class... Args>
          GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
          {
-            if (value)
+            if (value) {
                write<json>::op<Opts>(*value, ctx, std::forward<Args>(args)...);
+            }
+            else {
+               write<json>::op<Opts>(unexpected_wrapper{&value.error()}, ctx, std::forward<Args>(args)...);
+            }
+         }
+      };
+
+      template <nullable_t T>
+         requires (!is_expected<T>)
+      struct to_json<T>
+      {
+         template <auto Opts, class... Args>
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         {
+            if (value) {
+               write<json>::op<Opts>(*value, ctx, std::forward<Args>(args)...);
+            }
             else {
                dump<"null">(std::forward<Args>(args)...);
             }

--- a/include/glaze/util/expected.hpp
+++ b/include/glaze/util/expected.hpp
@@ -69,6 +69,10 @@ namespace glz
    };
    template <class unexpected_t>
    unexpected(unexpected_t) -> unexpected<unexpected_t>;
+   
+   template <typename T>
+   concept is_expected =
+      std::same_as<std::remove_cvref_t<T>, expected<typename T::value_type, typename T::error_type> >;
 }
 #else
 

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -7019,7 +7019,17 @@ suite expected_tests = [] {
       
       obj = glz::unexpected(5);
       glz::write_json(obj, s);
-      expect(s == R"({"error":5})") << s;
+      expect(s == R"({"unexpected":5})") << s;
+      
+      obj = "hello";
+      expect(!glz::read_json(obj, s));
+      expect(!obj);
+      expect(obj.error() == 5);
+      
+      s = R"("hello")";
+      expect(!glz::read_json(obj, s));
+      expect(bool(obj));
+      expect(obj.value() == "hello");
    };
 };
 

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -7010,6 +7010,19 @@ suite error_on_unknown_keys_test = [] {
    };
 };
 
+suite expected_tests = [] {
+   "expected<std::string, int>"_test = [] {
+      glz::expected<std::string, int> obj = "hello";
+      std::string s{};
+      glz::write_json(obj, s);
+      expect(s == R"("hello")") << s;
+      
+      obj = glz::unexpected(5);
+      glz::write_json(obj, s);
+      expect(s == R"({"error":5})") << s;
+   };
+};
+
 int main()
 {
    // Explicitly run registered test suites and report errors


### PR DESCRIPTION
The expected value will be directly written out as JSON. The unexpected value will be written/read as an object with the key `unexpected`.

An example of a string error from an expected:
```json
{"unexpected": "my error"}
```