### PR TITLE
Further fixes for specializing enumerations with partial enum specializaiton

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -797,7 +797,8 @@ namespace glz
          }
       };
 
-      template <glaze_enum_t T>
+      template <class T>
+         requires (glaze_enum_t<T> && !specialized_with_custom_read<T>)
       struct from_json<T>
       {
          template <auto Opts>

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -407,7 +407,8 @@ namespace glz
          }
       };
 
-      template <glaze_enum_t T>
+      template <class T>
+         requires (glaze_enum_t && !specialized_with_custom_write<T>)
       struct to_json<T>
       {
          template <auto Opts, class... Args>

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -408,7 +408,7 @@ namespace glz
       };
 
       template <class T>
-         requires (glaze_enum_t && !specialized_with_custom_write<T>)
+         requires (glaze_enum_t<T> && !specialized_with_custom_write<T>)
       struct to_json<T>
       {
          template <auto Opts, class... Args>


### PR DESCRIPTION
After this fix good news I alsmost got json schema working that way for any enumeration
still need a bit work on interleaving.
```
template<simple_enum::enum_concept enumeration_type>
struct meta<enumeration_type>
  {
  static constexpr bool custom_write = true;
  static constexpr bool custom_read = true;
  
  static constexpr auto color_values{simple_enum::enum_names_array<enumeration_type>};
  static constexpr auto color_names{simple_enum::enum_values_array<enumeration_type>};
  static constexpr auto interleaved = simple_enum::interleave(color_names, color_values);
  static constexpr std::string_view name = simple_enum::enumeration_name_v<enumeration_type>;
  static constexpr auto value = std::apply(
    [](auto &&... args) noexcept { return glz::enumerate(std::forward<decltype(args)>(args)...); }, interleaved
  );
  };

struct test_data_t
  {
  test_enum_e enum_field;
  };

enum class Color
  {
  Red,
  Green,
  Blue
  };

consteval auto adl_enum_bounds(Color)
  {
  using enum Color;
  return simple_enum::adl_info{Red, Blue};
  }
std::string schema = glz::write_json_schema<test_data_t>();
```
```
{
  "type": [
    "object"
  ],
  "properties": {
    "enum_field": {
      "$ref": "#/$defs/test_enum_e"
    }
  },
  "additionalProperties": false,
  "$defs": {
    "test_enum_e": {
      "type": [
        "string"
      ],
      "oneOf": [
        {
          "const": "foo"
        },
        {
          "const": "foo"
        },
        {
          "description": "baz",
          "const": "bar"
        }
      ]
    }
  }
}
```