### PR TITLE
Handling tabs in error formatting context

### DIFF
--- a/include/glaze/util/validate.hpp
+++ b/include/glaze/util/validate.hpp
@@ -20,6 +20,16 @@ namespace glz
          size_t front_truncation{};
          size_t rear_truncation{};
       };
+      
+      // We convert to only single spaces for error messages in order to keep the source info
+      // calculation more efficient and avoid needing to allocate more memory.
+      inline void convert_tabs_to_single_spaces(std::string& input) noexcept {
+          for (auto& c : input) {
+              if (c == '\t') {
+                  c = ' ';
+              }
+          }
+      }
 
       inline std::optional<source_info> get_source_info(const std::string_view buffer, const size_t index)
       {
@@ -63,10 +73,12 @@ namespace glz
          if constexpr (std::same_as<V, std::byte>) {
             std::string context{reinterpret_cast<const char*>(&(*context_begin)),
                                 reinterpret_cast<const char*>(&(*context_end))};
+            convert_tabs_to_single_spaces(context);
             return source_info{line, column, context, index, front_truncation, rear_truncation};
          }
          else {
             std::string context{context_begin, context_end};
+            convert_tabs_to_single_spaces(context);
             return source_info{line, column, context, index, front_truncation, rear_truncation};
          }
       }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -2209,6 +2209,15 @@ suite error_outputs = [] {
       auto err = glz::format_error(pe, s);
       expect(err == "1:17: syntax_error\n   {\"Hello\":\"World\"x, \"color\": \"red\"}\n                   ^\n") << err;
    };
+   
+   "invalid character with tabs in json"_test = [] {
+      std::string s = R"({"Hello":	" 	World"x, "color": 	"red"})";
+      std::map<std::string, std::string> m;
+      auto pe = glz::read_json(m, s);
+      expect(pe != glz::error_code::none);
+      auto err = glz::format_error(pe, s);
+      expect(err == "1:20: syntax_error\n   {\"Hello\": \"  World\"x, \"color\":  \"red\"}\n                      ^\n") << err;
+   };
 
    "extra comma"_test = [] {
       std::string s = R"({


### PR DESCRIPTION
In the formatter error output, we now convert tabs to single spaces. This allows consistent output and properly formatted errors when tabs occur. We only convert to single spaces to keep the context code cleaner and avoid more allocations.