### PR TITLE
Removing [[maybe_unused]] to help the compiler

### DIFF
--- a/include/glaze/reflection/reflect.hpp
+++ b/include/glaze/reflection/reflect.hpp
@@ -36,8 +36,8 @@ namespace glz
       {
          using V = decltype(to_tuple(std::declval<T>()));
          constexpr auto n = std::tuple_size_v<V>;
-         [[maybe_unused]] constexpr auto members = member_names<T>;
-         static_assert(count_members<T> == n);
+         constexpr auto members = member_names<T>;
+         static_assert(members.size() == n);
 
          using value_t = reflection_value_tuple_variant_t<V>;
 


### PR DESCRIPTION
This should allow the compiler to optimize away unused portions of compile time reflection strings, addressing #827 