### PR TITLE
Removed trailing new line on format error

### DIFF
--- a/include/glaze/util/validate.hpp
+++ b/include/glaze/util/validate.hpp
@@ -70,18 +70,19 @@ namespace glz
                }
             }
          }
-
-         if constexpr (std::same_as<V, std::byte>) {
-            std::string context{reinterpret_cast<const char*>(&(*context_begin)),
-                                reinterpret_cast<const char*>(&(*context_end))};
-            convert_tabs_to_single_spaces(context);
-            return source_info{line, column, context, index, front_truncation, rear_truncation};
-         }
-         else {
-            std::string context{context_begin, context_end};
-            convert_tabs_to_single_spaces(context);
-            return source_info{line, column, context, index, front_truncation, rear_truncation};
-         }
+         
+         std::string context = [&]() -> std::string {
+            if constexpr (std::same_as<V, std::byte>) {
+               return {reinterpret_cast<const char*>(&(*context_begin)),
+                                   reinterpret_cast<const char*>(&(*context_end))};
+            }
+            else {
+               return {context_begin, context_end};
+            }
+         }();
+         
+         convert_tabs_to_single_spaces(context);
+         return source_info{line, column, context, index, front_truncation, rear_truncation};
       }
 
       inline std::string generate_error_string(const std::string_view error, const source_info& info,

--- a/include/glaze/util/validate.hpp
+++ b/include/glaze/util/validate.hpp
@@ -113,7 +113,7 @@ namespace glz
          for (size_t i = 0; i < info.column - 1 - info.front_truncation; ++i) {
             s += " ";
          }
-         s += "^\n";
+         s += "^";
 
          return s;
       }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -2207,7 +2207,7 @@ suite error_outputs = [] {
       auto pe = glz::read_json(m, s);
       expect(pe != glz::error_code::none);
       auto err = glz::format_error(pe, s);
-      expect(err == "1:17: syntax_error\n   {\"Hello\":\"World\"x, \"color\": \"red\"}\n                   ^\n") << err;
+      expect(err == "1:17: syntax_error\n   {\"Hello\":\"World\"x, \"color\": \"red\"}\n                   ^") << err;
    };
 
    "invalid character with tabs in json"_test = [] {
@@ -2216,7 +2216,7 @@ suite error_outputs = [] {
       auto pe = glz::read_json(m, s);
       expect(pe != glz::error_code::none);
       auto err = glz::format_error(pe, s);
-      expect(err == "1:20: syntax_error\n   {\"Hello\": \"  World\"x, \"color\":  \"red\"}\n                      ^\n")
+      expect(err == "1:20: syntax_error\n   {\"Hello\": \"  World\"x, \"color\":  \"red\"}\n                      ^")
          << err;
    };
 
@@ -2235,7 +2235,7 @@ suite error_outputs = [] {
       auto ex = glz::read_json<error_comma_obj>(s);
       expect(!ex.has_value());
       auto err = glz::format_error(ex.error(), s);
-      expect(err == "10:6: syntax_error\n        ]\n        ^\n") << err;
+      expect(err == "10:6: syntax_error\n        ]\n        ^") << err;
    };
 };
 

--- a/tests/jsonrpc_test/jsonrpc_test.cpp
+++ b/tests/jsonrpc_test/jsonrpc_test.cpp
@@ -249,7 +249,7 @@ ut::suite struct_test_cases = [] {
       auto s = glz::write_json(response_vec);
       ut::expect(
          s ==
-         R"([{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error","data":"1:66: syntax_error\n..._method_name\",\"params\":{},\"id:\"uuid\"}\"\n                                  ^\n"},"id":null}])")
+         R"([{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error","data":"1:66: syntax_error\n..._method_name\",\"params\":{},\"id:\"uuid\"}\"\n                                  ^"},"id":null}])")
          << s;
       ut::expect(response_vec.at(0).error.has_value());
       ut::expect(response_vec.at(0).error->code == rpc::error_e::parse_error);
@@ -265,7 +265,7 @@ ut::suite struct_test_cases = [] {
       auto s = glz::write_json(response_vec);
       ut::expect(
          s ==
-         R"([{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error","data":"1:132: syntax_error\n...\"invalid_method_name\",\"params\":]\"\n                                  ^\n"},"id":null}])")
+         R"([{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error","data":"1:132: syntax_error\n...\"invalid_method_name\",\"params\":]\"\n                                  ^"},"id":null}])")
          << s;
       ut::expect(response_vec.at(0).error.has_value());
       ut::expect(response_vec.at(0).error->code == rpc::error_e::parse_error);
@@ -291,7 +291,7 @@ ut::suite struct_test_cases = [] {
       ut::expect(response_vec.size() == 1);
       ut::expect(
          glz::write_json(response_vec) ==
-         R"([{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request","data":"1:1: syntax_error\n   1\n   ^\n"},"id":null}])");
+         R"([{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request","data":"1:1: syntax_error\n   1\n   ^"},"id":null}])");
       ut::expect(response_vec.at(0).error.has_value());
       ut::expect(response_vec.at(0).error->code == rpc::error_e::invalid_request);
    };
@@ -304,7 +304,7 @@ ut::suite struct_test_cases = [] {
       ut::expect(response_vec.size() == 3);
       ut::expect(
          glz::write_json(response_vec) ==
-         R"([{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request","data":"1:1: syntax_error\n   1\n   ^\n"},"id":null},{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request","data":"1:1: syntax_error\n   2\n   ^\n"},"id":null},{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request","data":"1:1: syntax_error\n   3\n   ^\n"},"id":null}])");
+         R"([{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request","data":"1:1: syntax_error\n   1\n   ^"},"id":null},{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request","data":"1:1: syntax_error\n   2\n   ^"},"id":null},{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request","data":"1:1: syntax_error\n   3\n   ^"},"id":null}])");
       for (auto& response : response_vec) {
          ut::expect(response.error.has_value());
          ut::expect(response.error->code == glz::rpc::error_e::invalid_request);
@@ -329,7 +329,7 @@ ut::suite struct_test_cases = [] {
       // Note one of the requests is a valid notification(no id) a response won't be generated for it
       ut::expect(
          response ==
-         R"([{"jsonrpc":"2.0","result":{"foo_c":false,"foo_d":""},"id":"42"},{"jsonrpc":"2.0","result":{"bar_c":false,"bar_d":""},"id":"bar-uuid"},{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found","data":"Method: 'invalid_method_name' not found"},"id":"2"},{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request","data":"1:4: unknown_key\n   {\"foo\": \"boo\"}\n      ^\n"},"id":null},{"jsonrpc":"2.0","result":{"foo_c":false,"foo_d":""},"id":"4222222"},{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request","data":"1:21: unknown_key\n   {\"jsonrpc\":\"2.0\",\"invalid_method_key\":\"foo\",\"params\":{},\"id\":\"42\n                       ^\n"},"id":"4222222"}])")
+         R"([{"jsonrpc":"2.0","result":{"foo_c":false,"foo_d":""},"id":"42"},{"jsonrpc":"2.0","result":{"bar_c":false,"bar_d":""},"id":"bar-uuid"},{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found","data":"Method: 'invalid_method_name' not found"},"id":"2"},{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request","data":"1:4: unknown_key\n   {\"foo\": \"boo\"}\n      ^"},"id":null},{"jsonrpc":"2.0","result":{"foo_c":false,"foo_d":""},"id":"4222222"},{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request","data":"1:21: unknown_key\n   {\"jsonrpc\":\"2.0\",\"invalid_method_key\":\"foo\",\"params\":{},\"id\":\"42\n                       ^"},"id":"4222222"}])")
          << response;
    };
 


### PR DESCRIPTION
It is convention and more flexible to not force a new line at the end of a statement.