### PR TITLE
Adding volatile_array.hpp and volatile float parsing

### DIFF
--- a/include/glaze/hardware/volatile_array.hpp
+++ b/include/glaze/hardware/volatile_array.hpp
@@ -1,0 +1,199 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+// A matching std::array API for volatile data
+
+#include <cstddef>
+#include <initializer_list>
+#include <type_traits>
+
+namespace glz
+{
+   template <class T>
+   concept is_volatile_array = requires { std::decay_t<T>::glaze_volatile_array; };
+   
+   template <typename T, std::size_t N>
+   class volatile_array {
+   public:
+      static constexpr auto glaze_volatile_array = true;
+      static constexpr auto length = N;
+     using value_type = T;
+     using size_type = std::size_t;
+     using difference_type = std::ptrdiff_t;
+     using reference = volatile T&;
+     using const_reference = const volatile T&;
+     using pointer = volatile T*;
+     using const_pointer = const volatile T*;
+     using iterator = volatile T*;
+     using const_iterator = const volatile T*;
+     using reverse_iterator = std::reverse_iterator<iterator>;
+     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+      
+      volatile_array() noexcept = default;
+      volatile_array(std::initializer_list<T> init_list) noexcept {
+         auto first = init_list.begin();
+         auto last = init_list.end();
+         auto* it = data_;
+         for (; first != last; (void)++first, (void)++it) {
+             *it = *first;
+         }
+     }
+      volatile_array(const volatile_array&) noexcept = default;
+      volatile_array(volatile_array&&) noexcept = default;
+
+      template <is_volatile_array Other>
+     constexpr volatile volatile_array& operator=(const Other& other) volatile {
+         for (size_type i = 0; i < N; ++i) {
+             data_[i] = other.data_[i];
+         }
+         return *this;
+     }
+      
+     constexpr reference operator[](size_type pos) volatile noexcept {
+         return data_[pos];
+     }
+
+     constexpr const_reference operator[](size_type pos) const volatile noexcept {
+         return data_[pos];
+     }
+
+     constexpr reference front() volatile noexcept {
+         return data_[0];
+     }
+
+     constexpr const_reference front() const volatile noexcept {
+         return data_[0];
+     }
+
+     constexpr reference back() volatile noexcept {
+         return data_[N - 1];
+     }
+
+     constexpr const_reference back() const volatile noexcept {
+         return data_[N - 1];
+     }
+
+     constexpr pointer data() volatile noexcept {
+         return data_;
+     }
+
+     constexpr const_pointer data() const volatile noexcept {
+         return data_;
+     }
+
+     constexpr iterator begin() volatile noexcept {
+         return data_;
+     }
+
+     constexpr const_iterator begin() const volatile noexcept {
+         return data_;
+     }
+
+     constexpr const_iterator cbegin() const volatile noexcept {
+         return data_;
+     }
+
+     constexpr iterator end() volatile noexcept {
+         return data_ + N;
+     }
+
+     constexpr const_iterator end() const volatile noexcept {
+         return data_ + N;
+     }
+
+     constexpr const_iterator cend() const volatile noexcept {
+         return data_ + N;
+     }
+
+     constexpr reverse_iterator rbegin() volatile noexcept {
+         return reverse_iterator(end());
+     }
+
+     constexpr const_reverse_iterator rbegin() const volatile noexcept {
+         return const_reverse_iterator(end());
+     }
+
+     constexpr const_reverse_iterator crbegin() const volatile noexcept {
+         return const_reverse_iterator(cend());
+     }
+
+     constexpr reverse_iterator rend() volatile noexcept {
+         return reverse_iterator(begin());
+     }
+
+     constexpr const_reverse_iterator rend() const volatile noexcept {
+         return const_reverse_iterator(begin());
+     }
+
+     constexpr const_reverse_iterator crend() const volatile noexcept {
+         return const_reverse_iterator(cbegin());
+     }
+
+     constexpr bool empty() const volatile noexcept {
+         return N == 0;
+     }
+
+     constexpr size_type size() const volatile noexcept {
+         return N;
+     }
+
+     constexpr size_type max_size() const volatile noexcept {
+         return N;
+     }
+
+     constexpr void fill(const T& value) volatile {
+         for (size_type i = 0; i < N; ++i) {
+             data_[i] = value;
+         }
+     }
+      
+      template <is_volatile_array Other>
+     void swap(Other& other) volatile noexcept(std::is_nothrow_swappable_v<Other>) {
+         for (size_type i = 0; i < N; ++i) {
+             std::swap(data_[i], other.data_[i]);
+         }
+     }
+
+     volatile T data_[N];
+   };
+
+   // Comparison operators
+   template <is_volatile_array L, is_volatile_array R> requires (L::length == R::length)
+   constexpr bool operator==(const L& lhs, const R& rhs) noexcept {
+     for (std::size_t i = 0; i < L::length; ++i) {
+         if (lhs[i] != rhs[i]) return false;
+     }
+     return true;
+   }
+
+   template <is_volatile_array L, is_volatile_array R> requires (L::length == R::length)
+   constexpr bool operator!=(const L& lhs, const R& rhs) noexcept {
+     return !(lhs == rhs);
+   }
+
+   template <is_volatile_array L, is_volatile_array R> requires (L::length == R::length)
+   constexpr bool operator<(const L& lhs, const R& rhs) noexcept {
+     for (std::size_t i = 0; i < L::length; ++i) {
+         if (lhs[i] < rhs[i]) return true;
+         if (rhs[i] < lhs[i]) return false;
+     }
+     return false;
+   }
+
+   template <is_volatile_array L, is_volatile_array R> requires (L::length == R::length)
+   constexpr bool operator<=(const L& lhs, const R& rhs) noexcept {
+     return !(rhs < lhs);
+   }
+
+   template <is_volatile_array L, is_volatile_array R> requires (L::length == R::length)
+   constexpr bool operator>(const L& lhs, const R& rhs) noexcept {
+     return rhs < lhs;
+   }
+
+   template <is_volatile_array L, is_volatile_array R> requires (L::length == R::length)
+   constexpr bool operator>=(const L& lhs, const R& rhs) noexcept {
+     return !(lhs < rhs);
+   }
+}

--- a/include/glaze/json/json_ptr.hpp
+++ b/include/glaze/json/json_ptr.hpp
@@ -64,7 +64,7 @@ namespace glz
                return std::string{};
             }
          }();
-         using key_t = decltype(key);
+         using key_t = std::decay_t<decltype(key)>;
          static_assert(std::is_same_v<key_t, std::string> || num_t<key_t>);
 
          if constexpr (std::is_same_v<key_t, std::string>) {
@@ -90,7 +90,7 @@ namespace glz
          }
          else if constexpr (std::is_floating_point_v<key_t>) {
             auto it = reinterpret_cast<const uint8_t*>(json_ptr.data());
-            auto s = parse_float(key, it);
+            auto s = parse_float<key_t>(key, it);
             if (!s) return false;
             json_ptr = json_ptr.substr(reinterpret_cast<const char*>(it) - json_ptr.data());
          }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -24,6 +24,7 @@
 #include "glaze/api/impl.hpp"
 #include "glaze/file/hostname_include.hpp"
 #include "glaze/file/raw_or_file.hpp"
+#include "glaze/hardware/volatile_array.hpp"
 #include "glaze/json.hpp"
 #include "glaze/json/study.hpp"
 #include "glaze/record/recorder.hpp"
@@ -7138,6 +7139,66 @@ suite custom_struct_tests = [] {
 
       expect(!glz::read_json(obj, s));
       expect(obj.str == R"(writeread)") << obj.str;
+   };
+};
+
+struct struct_for_volatile
+{
+   glz::volatile_array<uint16_t, 4> a{};
+   bool b{};
+   int32_t c{};
+   double d{};
+   uint32_t e{};
+};
+
+template <>
+struct glz::meta<struct_for_volatile>
+{
+   using T = struct_for_volatile;
+   static constexpr auto value = object(&T::a, &T::b, &T::c, &T::d, &T::e);
+};
+
+suite volatile_tests = [] {
+   "basic volatile"_test = [] {
+      volatile int i = 5;
+      std::string s{};
+      glz::write_json(i, s);
+      expect(s == "5");
+
+      expect(!glz::read_json(i, "42"));
+      expect(i == 42);
+   };
+   
+   "basic volatile pointer"_test = [] {
+      volatile int i = 5;
+      volatile int* ptr = &i;
+      std::string s{};
+      glz::write_json(ptr, s);
+      expect(s == "5");
+
+      expect(!glz::read_json(i, "42"));
+      expect(*ptr == 42);
+      expect(i == 42);
+   };
+   
+   "volatile struct_for_volatile"_test = [] {
+      volatile struct_for_volatile obj{{1, 2, 3, 4}, true, -7, 9.9, 12};
+      std::string s{};
+      glz::write_json(obj, s);
+      expect(s == R"({"a":[1,2,3,4],"b":true,"c":-7,"d":9.9,"e":12})") << s;
+      
+      obj.a = glz::volatile_array<uint16_t, 4>{};
+      obj.b = false;
+      obj.c = 0;
+      obj.d = 0.0;
+      obj.e = 0;
+      
+      expect(!glz::read_json(obj, s));
+      expect(obj.a == glz::volatile_array<uint16_t, 4>{1, 2, 3, 4});
+      expect(obj.b == true);
+      expect(obj.c == -7);
+      expect(obj.d == 9.9);
+      expect(obj.e == 12);
    };
 };
 


### PR DESCRIPTION
`glz::volatile_array` has the same API as `std::array`, but supports volatile memory with volatile member functions.