### PR TITLE
Improved read/write supported concepts

### DIFF
--- a/include/glaze/binary/beve_to_json.hpp
+++ b/include/glaze/binary/beve_to_json.hpp
@@ -455,14 +455,14 @@ namespace glz
                const auto complex_type = complex_header & 0b0000000'1;
                if (complex_type) {
                   // complex array
-                  const auto tag = complex_header & 0b111'00000;
+                  const auto number_tag = complex_header & 0b111'00000;
                   const auto n = int_from_compressed(it, end);
                   dump<'['>(out, ix);
                   for (size_t i = 0; i < n; ++i) {
                      dump<'['>(out, ix);
-                     beve_to_json_number<Opts>(tag, ctx, it, end, out, ix);
+                     beve_to_json_number<Opts>(number_tag, ctx, it, end, out, ix);
                      dump<','>(out, ix);
-                     beve_to_json_number<Opts>(tag, ctx, it, end, out, ix);
+                     beve_to_json_number<Opts>(number_tag, ctx, it, end, out, ix);
                      dump<']'>(out, ix);
                      if (i != n - 1) {
                         dump<','>(out, ix);
@@ -472,11 +472,11 @@ namespace glz
                }
                else {
                   // complex number
-                  const auto tag = complex_header & 0b111'00000;
+                  const auto number_tag = complex_header & 0b111'00000;
                   dump<'['>(out, ix);
-                  beve_to_json_number<Opts>(tag, ctx, it, end, out, ix);
+                  beve_to_json_number<Opts>(number_tag, ctx, it, end, out, ix);
                   dump<','>(out, ix);
-                  beve_to_json_number<Opts>(tag, ctx, it, end, out, ix);
+                  beve_to_json_number<Opts>(number_tag, ctx, it, end, out, ix);
                   dump<']'>(out, ix);
                }
 

--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -995,5 +995,5 @@ namespace glz
 
    template <class T>
    concept read_binary_supported =
-      detail::read_binary_invocable<glz::opts{}, std::add_lvalue_reference<T>, glz::context&, const char*&, const char*>;
+      detail::read_binary_invocable<glz::opts{.format = binary}, std::add_lvalue_reference<T>, glz::context&, const char*&, const char*>;
 }

--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -995,5 +995,5 @@ namespace glz
 
    template <class T>
    concept read_binary_supported =
-      detail::read_binary_invocable<glz::opts{}, std::add_lvalue_reference<T>, glz::context, const char*, const char*>;
+      detail::read_binary_invocable<glz::opts{}, std::add_lvalue_reference<T>, glz::context&, const char*&, const char*>;
 }

--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -16,8 +16,7 @@ namespace glz
    namespace detail
    {
       template <class T = void>
-      struct from_binary
-      {};
+      struct from_binary;
 
       template <>
       struct read<binary>

--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -926,19 +926,17 @@ namespace glz
    }
    
    template <class T>
-   concept read_binary_supported = requires(T&& value, glz::context& ctx, const char*& it, const char* end) {
-      detail::from_binary<std::remove_cvref_t<T>>::template op<glz::opts{.format = binary}>(std::forward<T>(value), ctx, it, end);
+   concept read_binary_supported = requires {
+      detail::from_binary<std::remove_cvref_t<T>>{};
    };
 
-   template <class T, class Buffer>
-      requires read_binary_supported<T&>
+   template <read_binary_supported T, class Buffer>
    [[nodiscard]] inline parse_error read_binary(T&& value, Buffer&& buffer) noexcept
    {
       return read<opts{.format = binary}>(value, std::forward<Buffer>(buffer));
    }
 
-   template <class T, class Buffer>
-      requires read_binary_supported<T&>
+   template <read_binary_supported T, class Buffer>
    [[nodiscard]] inline expected<T, parse_error> read_binary(Buffer&& buffer) noexcept
    {
       T value{};
@@ -949,8 +947,7 @@ namespace glz
       return value;
    }
 
-   template <opts Opts = opts{}, class T>
-      requires read_binary_supported<T&>
+   template <opts Opts = opts{}, read_binary_supported T>
    [[nodiscard]] inline parse_error read_file_binary(T& value, const sv file_name, auto&& buffer) noexcept
    {
       context ctx{};
@@ -965,16 +962,14 @@ namespace glz
       return read<set_binary<Opts>()>(value, buffer, ctx);
    }
 
-   template <class T, class Buffer>
-      requires read_binary_supported<T&>
+   template <read_binary_supported T, class Buffer>
    [[nodiscard]] inline parse_error read_binary_untagged(T&& value, Buffer&& buffer) noexcept
    {
       return read<opts{.format = binary, .structs_as_arrays = true}>(std::forward<T>(value),
                                                                      std::forward<Buffer>(buffer));
    }
 
-   template <class T, class Buffer>
-      requires read_binary_supported<T&>
+   template <read_binary_supported T, class Buffer>
    [[nodiscard]] inline expected<T, parse_error> read_binary_untagged(Buffer&& buffer) noexcept
    {
       T value{};
@@ -985,8 +980,7 @@ namespace glz
       return value;
    }
 
-   template <opts Opts = opts{}, class T>
-      requires read_binary_supported<T&>
+   template <opts Opts = opts{}, read_binary_supported T>
    [[nodiscard]] inline parse_error read_file_binary_untagged(T& value, const std::string& file_name,
                                                               auto&& buffer) noexcept
    {

--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -15,9 +15,6 @@ namespace glz
 {
    namespace detail
    {
-      template <class T = void>
-      struct from_binary;
-
       template <>
       struct read<binary>
       {
@@ -923,11 +920,6 @@ namespace glz
          }
       };
    }
-   
-   template <class T>
-   concept read_binary_supported = requires {
-      detail::from_binary<std::remove_cvref_t<T>>{};
-   };
 
    template <read_binary_supported T, class Buffer>
    [[nodiscard]] inline parse_error read_binary(T&& value, Buffer&& buffer) noexcept

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -76,9 +76,6 @@ namespace glz
          }
       }
 
-      template <class T = void>
-      struct to_binary;
-
       template <>
       struct write<binary>
       {
@@ -817,11 +814,6 @@ namespace glz
          }
       };
    }
-      
-   template <class T>
-   concept write_binary_supported = requires {
-      detail::to_binary<std::remove_cvref_t<T>>{};
-   };
 
    template <write_binary_supported T, class Buffer>
    inline void write_binary(T&& value, Buffer&& buffer) noexcept

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -893,6 +893,6 @@ namespace glz
 
    template <class T>
    concept write_binary_supported =
-      detail::write_binary_invocable<glz::opts{}, std::add_const_t<std::add_lvalue_reference_t<T>>, glz::context,
-                                     std::string, size_t>;
+      detail::write_binary_invocable<glz::opts{}, std::add_const_t<std::add_lvalue_reference_t<T>>, glz::context&,
+   std::string&, size_t&>;
 }

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -818,21 +818,19 @@ namespace glz
          }
       };
    }
-   
+      
    template <class T>
-   concept write_binary_supported = requires(T&& value, glz::context& ctx, std::string& b, size_t& ix) {
-      detail::to_binary<std::remove_cvref_t<T>>::template op<glz::opts{.format = binary}>(std::forward<T>(value), ctx, b, ix);
+   concept write_binary_supported = requires {
+      detail::to_binary<std::remove_cvref_t<T>>{};
    };
 
-   template <class T, class Buffer>
-      requires write_binary_supported<const T&>
+   template <write_binary_supported T, class Buffer>
    inline void write_binary(T&& value, Buffer&& buffer) noexcept
    {
       write<opts{.format = binary}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <opts Opts = opts{}, class T>
-      requires write_binary_supported<const T&>
+   template <opts Opts = opts{}, write_binary_supported T>
    inline auto write_binary(T&& value) noexcept
    {
       std::string buffer{};
@@ -840,16 +838,14 @@ namespace glz
       return buffer;
    }
 
-   template <auto& Partial, class T, class Buffer>
-      requires write_binary_supported<const T&>
+   template <auto& Partial, write_binary_supported T, class Buffer>
    inline auto write_binary(T&& value, Buffer&& buffer) noexcept
    {
       return write<Partial, opts{.format = binary}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
    // std::string file_name needed for std::ofstream
-   template <opts Opts = opts{}, class T>
-      requires write_binary_supported<const T&>
+   template <opts Opts = opts{}, write_binary_supported T>
    [[nodiscard]] inline write_error write_file_binary(T&& value, const std::string& file_name, auto&& buffer) noexcept
    {
       static_assert(sizeof(decltype(*buffer.data())) == 1);
@@ -868,15 +864,13 @@ namespace glz
       return {};
    }
 
-   template <class T, class Buffer>
-      requires write_binary_supported<const T&>
+   template <write_binary_supported T, class Buffer>
    inline void write_binary_untagged(T&& value, Buffer&& buffer) noexcept
    {
       write<opts{.format = binary, .structs_as_arrays = true}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <class T>
-      requires write_binary_supported<const T&>
+   template <write_binary_supported T>
    inline auto write_binary_untagged(T&& value) noexcept
    {
       std::string buffer{};
@@ -884,8 +878,7 @@ namespace glz
       return buffer;
    }
 
-   template <opts Opts = opts{}, class T>
-      requires write_binary_supported<const T&>
+   template <opts Opts = opts{}, write_binary_supported T>
    [[nodiscard]] inline write_error write_file_binary_untagged(T&& value, const std::string& file_name,
                                                                auto&& buffer) noexcept
    {

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -77,8 +77,7 @@ namespace glz
       }
 
       template <class T = void>
-      struct to_binary
-      {};
+      struct to_binary;
 
       template <>
       struct write<binary>

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -893,6 +893,6 @@ namespace glz
 
    template <class T>
    concept write_binary_supported =
-      detail::write_binary_invocable<glz::opts{}, std::add_const_t<std::add_lvalue_reference_t<T>>, glz::context&,
+      detail::write_binary_invocable<glz::opts{.format = binary}, std::add_const_t<std::add_lvalue_reference_t<T>>, glz::context&,
    std::string&, size_t&>;
 }

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -975,6 +975,7 @@ struct glz::meta<glz::error_code>
                            "seek_failure", seek_failure, //
                            "unicode_escape_conversion_failure", unicode_escape_conversion_failure, //
                            "file_open_failure", file_open_failure, //
+                           "file_close_failure", file_close_failure, //
                            "file_include_error", file_include_error, //
                            "dump_int_error", dump_int_error, //
                            "get_nonexistent_json_ptr", get_nonexistent_json_ptr, //

--- a/include/glaze/core/context.hpp
+++ b/include/glaze/core/context.hpp
@@ -43,6 +43,7 @@ namespace glz
       seek_failure,
       unicode_escape_conversion_failure,
       file_open_failure,
+      file_close_failure,
       file_include_error,
       dump_int_error,
       get_nonexistent_json_ptr,

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -170,16 +170,22 @@ namespace glz
    namespace detail
    {
       template <class T = void>
+      struct to_binary;
+      
+      template <class T = void>
+      struct from_binary;
+      
+      template <class T = void>
       struct to_json;
       
       template <class T = void>
       struct from_json;
       
       template <class T = void>
-      struct to_binary;
+      struct to_ndjson;
       
       template <class T = void>
-      struct from_binary;
+      struct from_ndjson;
       
       template <class T = void>
       struct to_csv;
@@ -187,6 +193,16 @@ namespace glz
       template <class T = void>
       struct from_csv;
    }
+   
+   template <class T>
+   concept write_binary_supported = requires {
+      detail::to_binary<std::remove_cvref_t<T>>{};
+   };
+   
+   template <class T>
+   concept read_binary_supported = requires {
+      detail::from_binary<std::remove_cvref_t<T>>{};
+   };
    
    template <class T>
    concept write_json_supported = requires {
@@ -199,13 +215,13 @@ namespace glz
    };
    
    template <class T>
-   concept write_binary_supported = requires {
-      detail::to_binary<std::remove_cvref_t<T>>{};
+   concept write_ndjson_supported = requires {
+      detail::to_ndjson<std::remove_cvref_t<T>>{};
    };
    
    template <class T>
-   concept read_binary_supported = requires {
-      detail::from_binary<std::remove_cvref_t<T>>{};
+   concept read_ndjson_supported = requires {
+      detail::from_ndjson<std::remove_cvref_t<T>>{};
    };
    
    template <class T>
@@ -226,6 +242,9 @@ namespace glz
       else if constexpr (Opts.format == json) {
          return write_json_supported<T>;
       }
+      else if constexpr (Opts.format == ndjson) {
+         return write_ndjson_supported<T>;
+      }
       else if constexpr (Opts.format == csv) {
          return write_csv_supported<T>;
       }
@@ -241,6 +260,9 @@ namespace glz
       }
       else if constexpr (Opts.format == json) {
          return read_json_supported<T>;
+      }
+      else if constexpr (Opts.format == ndjson) {
+         return read_ndjson_supported<T>;
       }
       else if constexpr (Opts.format == csv) {
          return read_csv_supported<T>;

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -234,18 +234,18 @@ namespace glz
       detail::from_csv<std::remove_cvref_t<T>>{};
    };
    
-   template <opts Opts, class T>
+   template <uint32_t Format, class T>
    consteval bool write_format_supported() {
-      if constexpr (Opts.format == binary) {
+      if constexpr (Format == binary) {
          return write_binary_supported<T>;
       }
-      else if constexpr (Opts.format == json) {
+      else if constexpr (Format == json) {
          return write_json_supported<T>;
       }
-      else if constexpr (Opts.format == ndjson) {
+      else if constexpr (Format == ndjson) {
          return write_ndjson_supported<T>;
       }
-      else if constexpr (Opts.format == csv) {
+      else if constexpr (Format == csv) {
          return write_csv_supported<T>;
       }
       else {
@@ -253,18 +253,18 @@ namespace glz
       }
    }
    
-   template <opts Opts, class T>
+   template <uint32_t Format, class T>
    consteval bool read_format_supported() {
-      if constexpr (Opts.format == binary) {
+      if constexpr (Format == binary) {
          return read_binary_supported<T>;
       }
-      else if constexpr (Opts.format == json) {
+      else if constexpr (Format == json) {
          return read_json_supported<T>;
       }
-      else if constexpr (Opts.format == ndjson) {
+      else if constexpr (Format == ndjson) {
          return read_ndjson_supported<T>;
       }
-      else if constexpr (Opts.format == csv) {
+      else if constexpr (Format == csv) {
          return read_csv_supported<T>;
       }
       else {
@@ -272,9 +272,9 @@ namespace glz
       }
    }
    
-   template <opts Opts, class T>
-   concept write_supported = write_format_supported<Opts, T>();
+   template <uint32_t Format, class T>
+   concept write_supported = write_format_supported<Format, T>();
    
-   template <opts Opts, class T>
-   concept read_supported = read_format_supported<Opts, T>();
+   template <uint32_t Format, class T>
+   concept read_supported = read_format_supported<Format, T>();
 }

--- a/include/glaze/core/read.hpp
+++ b/include/glaze/core/read.hpp
@@ -46,7 +46,7 @@ namespace glz
 
    // For reading json from a std::vector<char>, std::deque<char> and the like
    template <opts Opts, class T>
-      requires read_supported<Opts, T>
+      requires read_supported<Opts.format, T>
    [[nodiscard]] inline parse_error read(T& value, detail::contiguous auto&& buffer, is_context auto&& ctx) noexcept
    {
       static_assert(sizeof(decltype(*buffer.data())) == 1);
@@ -95,7 +95,7 @@ namespace glz
    }
 
    template <opts Opts, class T>
-      requires read_supported<Opts, T>
+      requires read_supported<Opts.format, T>
    [[nodiscard]] inline parse_error read(T& value, detail::contiguous auto&& buffer) noexcept
    {
       context ctx{};
@@ -107,7 +107,7 @@ namespace glz
 
    // for char array input
    template <opts Opts, class T, string_viewable Buffer>
-      requires read_supported<Opts, T>
+      requires read_supported<Opts.format, T>
    [[nodiscard]] inline parse_error read(T& value, Buffer&& buffer, auto&& ctx) noexcept
    {
       const auto str = std::string_view{std::forward<Buffer>(buffer)};
@@ -118,7 +118,7 @@ namespace glz
    }
 
    template <opts Opts, class T, string_viewable Buffer>
-      requires read_supported<Opts, T>
+      requires read_supported<Opts.format, T>
    [[nodiscard]] inline parse_error read(T& value, Buffer&& buffer) noexcept
    {
       context ctx{};

--- a/include/glaze/core/read.hpp
+++ b/include/glaze/core/read.hpp
@@ -45,8 +45,9 @@ namespace glz
    }
 
    // For reading json from a std::vector<char>, std::deque<char> and the like
-   template <opts Opts>
-   [[nodiscard]] inline parse_error read(auto& value, detail::contiguous auto&& buffer, is_context auto&& ctx) noexcept
+   template <opts Opts, class T>
+      requires read_supported<Opts, T>
+   [[nodiscard]] inline parse_error read(T& value, detail::contiguous auto&& buffer, is_context auto&& ctx) noexcept
    {
       static_assert(sizeof(decltype(*buffer.data())) == 1);
 
@@ -93,8 +94,9 @@ namespace glz
       return {ctx.error, static_cast<size_t>(std::distance(start, b)), ctx.includer_error};
    }
 
-   template <opts Opts>
-   [[nodiscard]] inline parse_error read(auto& value, detail::contiguous auto&& buffer) noexcept
+   template <opts Opts, class T>
+      requires read_supported<Opts, T>
+   [[nodiscard]] inline parse_error read(T& value, detail::contiguous auto&& buffer) noexcept
    {
       context ctx{};
       return read<Opts>(value, buffer, ctx);
@@ -105,6 +107,7 @@ namespace glz
 
    // for char array input
    template <opts Opts, class T, string_viewable Buffer>
+      requires read_supported<Opts, T>
    [[nodiscard]] inline parse_error read(T& value, Buffer&& buffer, auto&& ctx) noexcept
    {
       const auto str = std::string_view{std::forward<Buffer>(buffer)};
@@ -115,6 +118,7 @@ namespace glz
    }
 
    template <opts Opts, class T, string_viewable Buffer>
+      requires read_supported<Opts, T>
    [[nodiscard]] inline parse_error read(T& value, Buffer&& buffer) noexcept
    {
       context ctx{};

--- a/include/glaze/core/write.hpp
+++ b/include/glaze/core/write.hpp
@@ -30,6 +30,7 @@ namespace glz
 
    // For writing to a std::string, std::vector<char>, std::deque<char> and the like
    template <opts Opts, class T, output_buffer Buffer>
+      requires write_supported<Opts, T>
    inline void write(T&& value, Buffer& buffer, is_context auto&& ctx) noexcept
    {
       if constexpr (detail::resizeable<Buffer>) {
@@ -45,6 +46,7 @@ namespace glz
    }
 
    template <auto& Partial, opts Opts, class T, output_buffer Buffer>
+      requires write_supported<Opts, T>
    [[nodiscard]] inline write_error write(T&& value, Buffer& buffer) noexcept
    {
       if constexpr (detail::resizeable<Buffer>) {
@@ -63,6 +65,7 @@ namespace glz
    }
 
    template <opts Opts, class T, output_buffer Buffer>
+      requires write_supported<Opts, T>
    inline void write(T&& value, Buffer& buffer) noexcept
    {
       context ctx{};
@@ -70,6 +73,7 @@ namespace glz
    }
 
    template <opts Opts, class T>
+      requires write_supported<Opts, T>
    [[nodiscard]] inline std::string write(T&& value) noexcept
    {
       std::string buffer{};
@@ -79,6 +83,7 @@ namespace glz
    }
 
    template <opts Opts, class T, raw_buffer Buffer>
+      requires write_supported<Opts, T>
    [[nodiscard]] inline size_t write(T&& value, Buffer&& buffer, is_context auto&& ctx) noexcept
    {
       size_t ix = 0;
@@ -87,6 +92,7 @@ namespace glz
    }
 
    template <opts Opts, class T, raw_buffer Buffer>
+      requires write_supported<Opts, T>
    [[nodiscard]] inline size_t write(T&& value, Buffer&& buffer) noexcept
    {
       context ctx{};

--- a/include/glaze/core/write.hpp
+++ b/include/glaze/core/write.hpp
@@ -30,7 +30,7 @@ namespace glz
 
    // For writing to a std::string, std::vector<char>, std::deque<char> and the like
    template <opts Opts, class T, output_buffer Buffer>
-      requires write_supported<Opts, T>
+      requires write_supported<Opts.format, T>
    inline void write(T&& value, Buffer& buffer, is_context auto&& ctx) noexcept
    {
       if constexpr (detail::resizeable<Buffer>) {
@@ -46,7 +46,7 @@ namespace glz
    }
 
    template <auto& Partial, opts Opts, class T, output_buffer Buffer>
-      requires write_supported<Opts, T>
+      requires write_supported<Opts.format, T>
    [[nodiscard]] inline write_error write(T&& value, Buffer& buffer) noexcept
    {
       if constexpr (detail::resizeable<Buffer>) {
@@ -65,7 +65,7 @@ namespace glz
    }
 
    template <opts Opts, class T, output_buffer Buffer>
-      requires write_supported<Opts, T>
+      requires write_supported<Opts.format, T>
    inline void write(T&& value, Buffer& buffer) noexcept
    {
       context ctx{};
@@ -73,7 +73,7 @@ namespace glz
    }
 
    template <opts Opts, class T>
-      requires write_supported<Opts, T>
+      requires write_supported<Opts.format, T>
    [[nodiscard]] inline std::string write(T&& value) noexcept
    {
       std::string buffer{};
@@ -83,7 +83,7 @@ namespace glz
    }
 
    template <opts Opts, class T, raw_buffer Buffer>
-      requires write_supported<Opts, T>
+      requires write_supported<Opts.format, T>
    [[nodiscard]] inline size_t write(T&& value, Buffer&& buffer, is_context auto&& ctx) noexcept
    {
       size_t ix = 0;
@@ -92,7 +92,7 @@ namespace glz
    }
 
    template <opts Opts, class T, raw_buffer Buffer>
-      requires write_supported<Opts, T>
+      requires write_supported<Opts.format, T>
    [[nodiscard]] inline size_t write(T&& value, Buffer&& buffer) noexcept
    {
       context ctx{};

--- a/include/glaze/csv/read.hpp
+++ b/include/glaze/csv/read.hpp
@@ -16,10 +16,6 @@ namespace glz
 {
    namespace detail
    {
-      template <class T = void>
-      struct from_csv
-      {};
-
       template <>
       struct read<csv>
       {
@@ -554,13 +550,13 @@ namespace glz
       };
    }
 
-   template <uint32_t layout = rowwise, class T, class Buffer>
+   template <uint32_t layout = rowwise, read_csv_supported T, class Buffer>
    [[nodiscard]] inline auto read_csv(T&& value, Buffer&& buffer) noexcept
    {
       return read<opts{.format = csv, .layout = layout}>(value, std::forward<Buffer>(buffer));
    }
 
-   template <uint32_t layout = rowwise, class T, class Buffer>
+   template <uint32_t layout = rowwise, read_csv_supported T, class Buffer>
    [[nodiscard]] inline auto read_csv(Buffer&& buffer) noexcept
    {
       T value{};
@@ -568,7 +564,7 @@ namespace glz
       return value;
    }
 
-   template <uint32_t layout = rowwise, class T>
+   template <uint32_t layout = rowwise, read_csv_supported T>
    [[nodiscard]] inline parse_error read_file_csv(T& value, const sv file_name)
    {
       context ctx{};

--- a/include/glaze/csv/write.hpp
+++ b/include/glaze/csv/write.hpp
@@ -13,10 +13,6 @@ namespace glz
 {
    namespace detail
    {
-      template <class T = void>
-      struct to_csv
-      {};
-
       template <>
       struct write<csv>
       {
@@ -345,13 +341,13 @@ namespace glz
       };
    }
 
-   template <uint32_t layout = rowwise, class T, class Buffer>
+   template <uint32_t layout = rowwise, write_csv_supported T, class Buffer>
    GLZ_ALWAYS_INLINE auto write_csv(T&& value, Buffer&& buffer) noexcept
    {
       return write<opts{.format = csv, .layout = layout}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <uint32_t layout = rowwise, class T>
+   template <uint32_t layout = rowwise, write_csv_supported T>
    GLZ_ALWAYS_INLINE auto write_csv(T&& value) noexcept
    {
       std::string buffer{};
@@ -359,7 +355,7 @@ namespace glz
       return buffer;
    }
 
-   template <uint32_t layout = rowwise, class T>
+   template <uint32_t layout = rowwise, write_csv_supported T>
    [[nodiscard]] inline write_error write_file_csv(T&& value, const std::string& file_name, auto&& buffer) noexcept
    {
       write<opts{.format = csv, .layout = layout}>(std::forward<T>(value), buffer);

--- a/include/glaze/file/file_ops.hpp
+++ b/include/glaze/file/file_ops.hpp
@@ -9,6 +9,12 @@
 
 #include "glaze/core/context.hpp"
 
+#ifdef _MSC_VER
+// Turn off MSVC warning for unsafe fopen
+#pragma warning( push )
+#pragma warning(disable : 4996)
+#endif
+
 namespace glz
 {
    template <class T>
@@ -68,3 +74,8 @@ namespace glz
       return working_directory / filepath;
    }
 }
+
+#ifdef _MSC_VER
+// restore disabled warning
+#pragma warning( pop )
+#endif

--- a/include/glaze/file/file_ops.hpp
+++ b/include/glaze/file/file_ops.hpp
@@ -37,7 +37,9 @@ namespace glz
          return error_code::file_open_failure;
       }
 
-      std::fclose(file);
+      if (std::fclose(file)) {
+         return error_code::file_close_failure;
+      }
 
       return {};
    }

--- a/include/glaze/json/ndjson.hpp
+++ b/include/glaze/json/ndjson.hpp
@@ -10,10 +10,6 @@ namespace glz
 {
    namespace detail
    {
-      template <class T = void>
-      struct from_ndjson
-      {};
-
       template <>
       struct read<ndjson>
       {
@@ -156,10 +152,6 @@ namespace glz
          }
       };
 
-      template <class T = void>
-      struct to_ndjson
-      {};
-
       template <>
       struct write<ndjson>
       {
@@ -264,14 +256,14 @@ namespace glz
       };
    } // namespace detail
 
-   template <class T, class Buffer>
+   template <read_ndjson_supported T, class Buffer>
    [[nodiscard]] inline auto read_ndjson(T& value, Buffer&& buffer)
    {
       context ctx{};
       return read<opts{.format = ndjson}>(value, std::forward<Buffer>(buffer), ctx);
    }
 
-   template <class T, class Buffer>
+   template <read_ndjson_supported T, class Buffer>
    [[nodiscard]] inline expected<T, parse_error> read_ndjson(Buffer&& buffer)
    {
       T value{};
@@ -283,7 +275,7 @@ namespace glz
       return unexpected(ec);
    }
 
-   template <auto Opts = opts{.format = ndjson}, class T>
+   template <auto Opts = opts{.format = ndjson}, read_ndjson_supported T>
    [[nodiscard]] inline parse_error read_file_ndjson(T& value, const sv file_name)
    {
       context ctx{};
@@ -300,13 +292,13 @@ namespace glz
       return read<Opts>(value, buffer, ctx);
    }
 
-   template <class T, class Buffer>
+   template <write_ndjson_supported T, class Buffer>
    [[nodiscard]] inline auto write_ndjson(T&& value, Buffer&& buffer)
    {
       return write<opts{.format = ndjson}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <class T>
+   template <write_ndjson_supported T>
    [[nodiscard]] inline auto write_ndjson(T&& value)
    {
       std::string buffer{};
@@ -314,7 +306,7 @@ namespace glz
       return buffer;
    }
 
-   template <class T>
+   template <write_ndjson_supported T>
    [[nodiscard]] inline write_error write_file_ndjson(T&& value, const std::string& file_name, auto&& buffer) noexcept
    {
       write<opts{.format = ndjson}>(std::forward<T>(value), buffer);

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1102,9 +1102,9 @@ namespace glz
                      value.resize(reserve_size);
                      auto* dest = value.data() + original_size;
                      for (const auto& vector : intermediate) {
-                        const auto n = vector.size();
-                        std::memcpy(dest, vector.data(), n * sizeof(value_type));
-                        dest += n;
+                        const auto vector_size = vector.size();
+                        std::memcpy(dest, vector.data(), vector_size * sizeof(value_type));
+                        dest += vector_size;
                      }
                   }
                   else {

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2789,5 +2789,5 @@ namespace glz
 
    template <class T>
    concept read_json_supported =
-      detail::read_json_invocable<glz::opts{}, std::add_lvalue_reference<T>, glz::context, const char*, const char*>;
+      detail::read_json_invocable<glz::opts{}, std::add_lvalue_reference<T>, glz::context&, const char*&, const char*>;
 }

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -48,9 +48,6 @@ namespace glz
          static thread_local std::string buffer(256, ' ');
          return buffer;
       }
-
-      template <class T = void>
-      struct from_json;
       
       template <>
       struct read<json>
@@ -2740,11 +2737,6 @@ namespace glz
       glz::skip skip_value{};
       return read<opts{}>(skip_value, std::forward<Buffer>(buffer), ctx);
    }
-   
-   template <class T>
-   concept read_json_supported = requires {
-      detail::from_json<std::remove_cvref_t<T>>{};
-   };
 
    template <read_json_supported T, class Buffer>
    [[nodiscard]] inline parse_error read_json(T& value, Buffer&& buffer) noexcept

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -50,8 +50,7 @@ namespace glz
       }
 
       template <class T = void>
-      struct from_json
-      {};
+      struct from_json;
       
       template <>
       struct read<json>

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2743,20 +2743,18 @@ namespace glz
    }
    
    template <class T>
-   concept read_json_supported = requires(T&& value, glz::context& ctx, const char*& it, const char* end) {
-      detail::from_json<std::remove_cvref_t<T>>::template op<glz::opts{}>(std::forward<T>(value), ctx, it, end);
+   concept read_json_supported = requires {
+      detail::from_json<std::remove_cvref_t<T>>{};
    };
 
-   template <class T, class Buffer>
-      requires read_json_supported<T&>
+   template <read_json_supported T, class Buffer>
    [[nodiscard]] inline parse_error read_json(T& value, Buffer&& buffer) noexcept
    {
       context ctx{};
       return read<opts{}>(value, std::forward<Buffer>(buffer), ctx);
    }
 
-   template <class T, class Buffer>
-      requires read_json_supported<T&>
+   template <read_json_supported T, class Buffer>
    [[nodiscard]] inline expected<T, parse_error> read_json(Buffer&& buffer) noexcept
    {
       T value{};
@@ -2768,8 +2766,7 @@ namespace glz
       return value;
    }
 
-   template <auto Opts = opts{}, class T>
-      requires read_json_supported<T&>
+   template <auto Opts = opts{}, read_json_supported T>
    inline parse_error read_file_json(T& value, const sv file_name, auto&& buffer) noexcept
    {
       context ctx{};

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -21,9 +21,6 @@ namespace glz
 {
    namespace detail
    {
-      template <class T = void>
-      struct to_json;
-
       template <>
       struct write<json>
       {
@@ -1444,11 +1441,6 @@ namespace glz
          }
       };
    } // namespace detail
-   
-   template <class T>
-   concept write_json_supported = requires {
-      detail::to_json<std::remove_cvref_t<T>>{};
-   };
 
    template <write_json_supported T, class Buffer>
    [[nodiscard]] inline auto write_json(T&& value, Buffer&& buffer) noexcept

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1500,6 +1500,6 @@ namespace glz
 
    template <class T>
    concept write_json_supported =
-      detail::write_json_invocable<glz::opts{}, std::add_const_t<std::add_lvalue_reference_t<T>>, glz::context,
-                                   std::string, size_t>;
+      detail::write_json_invocable<glz::opts{}, std::add_const_t<std::add_lvalue_reference_t<T>>, glz::context&,
+   std::string&, size_t&>;
 }

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -25,25 +25,14 @@ namespace glz
       struct to_json
       {};
 
-      template <auto Opts, class T, class Ctx, class B, class IX>
-      concept write_json_invocable = requires(T&& value, Ctx&& ctx, B&& b, IX&& ix) {
-         to_json<std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
-                                                            std::forward<B>(b), std::forward<IX>(ix));
-      };
-
       template <>
       struct write<json>
       {
          template <auto Opts, class T, is_context Ctx, class B, class IX>
          GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix) noexcept
          {
-            if constexpr (write_json_invocable<Opts, T, Ctx, B, IX>) {
-               to_json<std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
-                                                                  std::forward<B>(b), std::forward<IX>(ix));
-            }
-            else {
-               static_assert(false_v<T>, "Glaze metadata is probably needed for your type");
-            }
+            to_json<std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+                                                               std::forward<B>(b), std::forward<IX>(ix));
          }
       };
 
@@ -1456,14 +1445,21 @@ namespace glz
          }
       };
    } // namespace detail
+   
+   template <class T>
+   concept write_json_supported = requires(T&& value, glz::context& ctx, std::string& b, size_t& ix) {
+      detail::to_json<std::remove_cvref_t<T>>::template op<glz::opts{}>(std::forward<T>(value), ctx, b, ix);
+   };
 
    template <class T, class Buffer>
+      requires write_json_supported<const T&>
    [[nodiscard]] inline auto write_json(T&& value, Buffer&& buffer) noexcept
    {
       return write<opts{}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
    template <class T>
+      requires write_json_supported<const T&>
    [[nodiscard]] inline auto write_json(T&& value) noexcept
    {
       std::string buffer{};
@@ -1472,18 +1468,21 @@ namespace glz
    }
 
    template <auto& Partial, class T, class Buffer>
+      requires write_json_supported<const T&>
    [[nodiscard]] inline auto write_json(T&& value, Buffer&& buffer) noexcept
    {
       return write<Partial, opts{}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
    template <class T, class Buffer>
+      requires write_json_supported<const T&>
    inline void write_jsonc(T&& value, Buffer&& buffer) noexcept
    {
       write<opts{.comments = true}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
    template <class T>
+      requires write_json_supported<const T&>
    [[nodiscard]] inline auto write_jsonc(T&& value) noexcept
    {
       std::string buffer{};
@@ -1492,14 +1491,10 @@ namespace glz
    }
 
    template <opts Opts = opts{}, class T>
+      requires write_json_supported<const T&>
    [[nodiscard]] inline write_error write_file_json(T&& value, const std::string& file_name, auto&& buffer) noexcept
    {
       write<set_json<Opts>()>(std::forward<T>(value), buffer);
       return {buffer_to_file(buffer, file_name)};
    }
-
-   template <class T>
-   concept write_json_supported =
-      detail::write_json_invocable<glz::opts{}, std::add_const_t<std::add_lvalue_reference_t<T>>, glz::context&,
-   std::string&, size_t&>;
 }

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1447,19 +1447,17 @@ namespace glz
    } // namespace detail
    
    template <class T>
-   concept write_json_supported = requires(T&& value, glz::context& ctx, std::string& b, size_t& ix) {
-      detail::to_json<std::remove_cvref_t<T>>::template op<glz::opts{}>(std::forward<T>(value), ctx, b, ix);
+   concept write_json_supported = requires {
+      detail::to_json<std::remove_cvref_t<T>>{};
    };
 
-   template <class T, class Buffer>
-      requires write_json_supported<const T&>
+   template <write_json_supported T, class Buffer>
    [[nodiscard]] inline auto write_json(T&& value, Buffer&& buffer) noexcept
    {
       return write<opts{}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <class T>
-      requires write_json_supported<const T&>
+   template <write_json_supported T>
    [[nodiscard]] inline auto write_json(T&& value) noexcept
    {
       std::string buffer{};
@@ -1467,22 +1465,19 @@ namespace glz
       return buffer;
    }
 
-   template <auto& Partial, class T, class Buffer>
-      requires write_json_supported<const T&>
+   template <auto& Partial, write_json_supported T, class Buffer>
    [[nodiscard]] inline auto write_json(T&& value, Buffer&& buffer) noexcept
    {
       return write<Partial, opts{}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <class T, class Buffer>
-      requires write_json_supported<const T&>
+   template <write_json_supported T, class Buffer>
    inline void write_jsonc(T&& value, Buffer&& buffer) noexcept
    {
       write<opts{.comments = true}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <class T>
-      requires write_json_supported<const T&>
+   template <write_json_supported T>
    [[nodiscard]] inline auto write_jsonc(T&& value) noexcept
    {
       std::string buffer{};
@@ -1490,8 +1485,7 @@ namespace glz
       return buffer;
    }
 
-   template <opts Opts = opts{}, class T>
-      requires write_json_supported<const T&>
+   template <opts Opts = opts{}, write_json_supported T>
    [[nodiscard]] inline write_error write_file_json(T&& value, const std::string& file_name, auto&& buffer) noexcept
    {
       write<set_json<Opts>()>(std::forward<T>(value), buffer);

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -22,8 +22,7 @@ namespace glz
    namespace detail
    {
       template <class T = void>
-      struct to_json
-      {};
+      struct to_json;
 
       template <>
       struct write<json>

--- a/include/glaze/util/hash_map.hpp
+++ b/include/glaze/util/hash_map.hpp
@@ -19,6 +19,7 @@
 
 #ifdef _MSC_VER
 // Turn off broken warning from MSVC for << operator precedence
+#pragma warning( push )
 #pragma warning(disable : 4554)
 #endif
 
@@ -602,3 +603,8 @@ namespace glz::detail
       }
    };
 }
+
+#ifdef _MSC_VER
+// restore disabled warning
+#pragma warning( pop )
+#endif

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -253,7 +253,7 @@ namespace glz::detail
             uint64_t chunk;
             std::memcpy(&chunk, it, 8);
             uint64_t test_chars = has_quote(chunk);
-            escaped |= has_escape(chunk);
+            escaped |= static_cast<bool>(has_escape(chunk));
             if (test_chars) {
                it += (std::countr_zero(test_chars) >> 3);
 

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -18,6 +18,9 @@
 #include "glaze/binary/beve_to_json.hpp"
 #include "glaze/binary/read.hpp"
 #include "glaze/binary/write.hpp"
+#include "glaze/api/impl.hpp"
+#include "glaze/json/json_ptr.hpp"
+#include "glaze/json/read.hpp"
 
 struct my_struct
 {
@@ -504,10 +507,6 @@ struct glz::meta<some_struct>
       "map", &T::map //
    );
 };
-
-#include "glaze/api/impl.hpp"
-#include "glaze/json/json_ptr.hpp"
-#include "glaze/json/read.hpp"
 
 void test_partial()
 {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -7275,9 +7275,6 @@ suite filesystem_tests = [] {
       obj.p.clear();
       expect(!glz::read_json(obj, buffer));
       expect(obj.p == "./my_path");
-      
-      std::ifstream ifstream{};
-      std::ignore = glz::read_json(ifstream, buffer);
    };
 };
 

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -7275,6 +7275,9 @@ suite filesystem_tests = [] {
       obj.p.clear();
       expect(!glz::read_json(obj, buffer));
       expect(obj.p == "./my_path");
+      
+      std::ifstream ifstream{};
+      std::ignore = glz::read_json(ifstream, buffer);
    };
 };
 


### PR DESCRIPTION
The `read_json_supported`, `write_json_supported`, and corresponding binary concepts now simply check for the existence of a template specialization for the underlying to/from functor. This simplifies the concepts, makes them more understandable, and reduces compile time. If we were to use simpler concepts that tried to invoke `op`, then we would be asking the compiler to see if it can instantiate versions of templates that we weren't even using, which is a bad idea from a compilation standpoint (both for performance and potential obscure issues in differences).

This update also adds concepts to the core read/write functions that take in configuration options. This allows us to reduce the depth of the template errors and make the output more manageable.