### PR TITLE
Global tracing

### DIFF
--- a/docs/time-trace.md
+++ b/docs/time-trace.md
@@ -43,3 +43,37 @@ trace.end("my event name");
 trace.disabled = true; // no data will be collected
 ```
 
+## Global tracing
+
+It can be bothersome to pass around a `glz::trace` instance. A global instance is available with a separate API to avoid needing to pass a trace instance around.
+
+`glz::disable_trace()` - Turns off the global tracing.
+`glz::enable_trace()` - Turns on the global tracing if it had been disabled (enabled by default).
+`glz::trace_begin("my event")` - Add a begin event for "my event"
+`glz::trace_end("my event")` - Add an end event for "my event"
+`glz::trace_async_begin("my event")` - Add an async_begin event for "my event"
+`glz::trace_async_end("my event")` - Add an aysnc_end event for "my event"
+
+Two structs are also provided that will automatically add the end events when they leave scope:
+`glz::duration_trace`
+`glz::async_trace`
+
+Example:
+```c++
+void my_function_to_profile()
+{
+   glz::duration_trace trace{"my function to profile"};
+   // do stuff here
+   // glz::duration_trace will automatically add the end event when it goes out of scope.
+}
+```
+
+Then, somewhere at the end of your program, write your global trace to file:
+
+```c++
+const auto ec = glz::write_file_trace("trace.json", std::string{});
+if (ec) {
+  std::cerr << "trace output failed\n";
+}
+```
+

--- a/include/glaze/trace/trace.hpp
+++ b/include/glaze/trace/trace.hpp
@@ -5,6 +5,7 @@
 
 #include <chrono>
 #include <deque>
+#include <mutex>
 #include <thread>
 
 #include "glaze/json/write.hpp"


### PR DESCRIPTION
This adds a bunch of global functions that can be used to avoid passing around a `glz::trace` reference. Although, that approach is still supported.

`glz::disable_trace()` - Turns off the global tracing.
`glz::enable_trace()` - Turns on the global tracing if it had been disabled (enabled by default).
`glz::trace_begin("my event")` - Add a begin event for "my event"
`glz::trace_end("my event")` - Add an end event for "my event"
`glz::trace_async_begin("my event")` - Add an async_begin event for "my event"
`glz::trace_async_end("my event")` - Add an aysnc_end event for "my event"

Two structs are also provided that will automatically add the end events when they leave scope:
`glz::duration_trace`
`glz::async_trace`

Example:
```c++
void my_function_to_profile()
{
   glz::duration_trace trace{"my function to profile"};
   // do stuff here
   // glz::duration_trace will automatically add the end event when it goes out of scope.
}
```

Then, somewhere at the end of your program, write your global trace to file:
```c++
const auto ec = glz::write_file_trace("binary_test.trace.json", std::string{});
if (ec) {
  std::cerr << "trace output failed\n";
}
```