### PR TITLE
Implemented a new SWAR-enabled comparison function to accelerate string comparisons.

### DIFF
--- a/include/glaze/util/compare.hpp
+++ b/include/glaze/util/compare.hpp
@@ -1,0 +1,68 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include <cstdint>
+
+namespace glz
+{
+   template <typename... types>
+   struct type_list;
+
+   template <typename value_type, typename... rest>
+   struct type_list<value_type, rest...>
+   {
+      using current_type = value_type;
+      using remaining_types = type_list<rest...>;
+      static constexpr uint64_t size = 1 + sizeof...(rest);
+   };
+
+   template <typename value_type>
+   struct type_list<value_type>
+   {
+      using current_type = value_type;
+      static constexpr uint64_t size = 1;
+   };
+
+   template <typename type_list, uint64_t Index>
+   struct get_type_at_index;
+
+   template <typename value_type, typename... rest>
+   struct get_type_at_index<type_list<value_type, rest...>, 0>
+   {
+      using type = value_type;
+   };
+
+   template <typename value_type, typename... rest, uint64_t Index>
+   struct get_type_at_index<type_list<value_type, rest...>, Index>
+   {
+      using type = typename get_type_at_index<type_list<rest...>, Index - 1>::type;
+   };
+
+   using integer_list = type_list<uint64_t, uint32_t, uint16_t, uint8_t>;
+
+   template <uint64_t index = 0, typename char_type01, typename char_type02>
+   GLZ_ALWAYS_INLINE bool compare(char_type01* string1, char_type02* string2, uint64_t lengthNew)
+   {
+      using integer_type = typename get_type_at_index<integer_list, index>::type;
+      static constexpr uint64_t size{sizeof(integer_type)};
+      integer_type value01[2]{};
+      while (lengthNew >= size) {
+         std::memcpy(value01, string1, sizeof(integer_type));
+         std::memcpy(value01 + 1, string2, sizeof(integer_type));
+         lengthNew -= size;
+         string1 += size;
+         string2 += size;
+         if (value01[0] != value01[1]) {
+            return false;
+         }
+      }
+      if constexpr (index < integer_list::size - 1) {
+         return compare<index + 1>(string1, string2, lengthNew);
+      }
+      else {
+         return true;
+      }
+   }
+}

--- a/include/glaze/util/hash_map.hpp
+++ b/include/glaze/util/hash_map.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <glaze/util/compare.hpp>
 #include <algorithm>
 #include <array>
 #include <bit>
@@ -595,10 +596,10 @@ namespace glz::detail
       }
       else {
          if constexpr (CheckSize) {
-            return (key.size() == n) && (std::memcmp(key.data(), S.data(), n) == 0);
+            return (key.size() == n) && compare(key.data(), S.data(), n);
          }
          else {
-            return std::memcmp(key.data(), S.data(), n) == 0;
+            return compare(key.data(), S.data(), n);
          }
       }
    }


### PR DESCRIPTION
Achieves the following numbers under Windows-x64 MSVC 2022, where the top values are using memcmp and the bottom values are using the new compare function:
2-Characters:
2800ns
2400ns
3-Characters:
3100ns
2600ns
4-Characters:
4100ns
2600ns
5-Characters:
3900ns
2600ns
6-Characters:
5000ns
2600ns
7-Characters:
5000ns
2800ns
8-Characters:
5200ns
3600ns
9-Characters:
4400ns
2800ns
10-Characters:
4300ns
3500ns
11-Characters:
4500ns
3300ns
12-Characters:
5100ns
3100ns
13-Characters:
5600ns
3300ns
14-Characters:
6200ns
3300ns
15-Characters:
6400ns
3600ns
16-Characters:
6500ns
3900ns
17-Characters:
4700ns
3100ns
31-Characters:
6400ns
5000ns
32-Characters:
7400ns
5500ns
64-Characters:
7400ns
6900ns