### PR TITLE
nullable_wrapper concept and support

### DIFF
--- a/include/glaze/json/quoted.hpp
+++ b/include/glaze/json/quoted.hpp
@@ -15,6 +15,8 @@ namespace glz
    template <class T>
    struct quoted_num_t
    {
+      static constexpr bool glaze_wrapper = true;
+      using value_type = T;
       T& val;
    };
 
@@ -22,6 +24,8 @@ namespace glz
    template <class T>
    struct quoted_t
    {
+      static constexpr bool glaze_wrapper = true;
+      using value_type = T;
       T& val;
    };
 
@@ -29,6 +33,8 @@ namespace glz
    template <class T>
    struct number_t
    {
+      static constexpr bool glaze_wrapper = true;
+      using value_type = T;
       T& val;
    };
 

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1176,7 +1176,7 @@ namespace glz
                      return;
                   else {
                      auto is_null = [&]() {
-                        if constexpr (raw_nullable<val_t>) {
+                        if constexpr (nullable_wrapper<val_t>) {
                            return !bool(member(value).val);
                         }
                         else {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -4791,6 +4791,39 @@ suite quote_map = [] {
    };
 };
 
+struct nullable_quoted_num_t
+{
+   std::optional<int> i{};
+   
+   struct glaze {
+      using T = nullable_quoted_num_t;
+      static constexpr auto value = glz::object("i", glz::quoted_num<&T::i>);
+   };
+};
+
+suite nullable_quoted_num = [] {
+   "nullable_quoted_num"_test = [] {
+      std::string_view json = R"({"i":"42"})";
+      nullable_quoted_num_t obj{};
+      expect(!glz::read_json(obj, json));
+      expect(obj.i.value() == 42);
+      
+      json = R"({"i":null})";
+      expect(!glz::read_json(obj, json));
+      expect(!obj.i.has_value());
+      
+      json = R"({"i":""})";
+      expect(glz::read_json(obj, json) == glz::error_code::parse_number_failure);
+   };
+   
+   "nullable_quoted_num error_on_missing_keys"_test = [] {
+      std::string_view json = R"({})";
+      nullable_quoted_num_t obj{};
+      expect(!glz::read<glz::opts{.error_on_missing_keys = true}>(obj, json));
+      expect(!obj.i.has_value());
+   };
+};
+
 struct bool_map
 {
    std::map<bool, std::string> x;


### PR DESCRIPTION
Adds a `nullable_wrapper` concept and `glaze_wrapper` tags. This enables wrappers to be used like other nullable types, but to their underlying reference.

Addresses #541 