### PR TITLE
float_max_write_precision option and wrapper

### DIFF
--- a/docs/max-float-precision.md
+++ b/docs/max-float-precision.md
@@ -2,7 +2,7 @@
 
 Glaze provides a compile time option (`float_max_write_precision`) to limit the precision when writing numbers to JSON. This improves performance when high precision is not needed in the resulting JSON.
 
-The wrappers `glz::write_float32` and `glz::write_float64` set this compile time option on individual numbers, arrays, or objects.
+The wrappers `glz::write_float32` and `glz::write_float64` set this compile time option on individual numbers, arrays, or objects. The wrapper `glz::write_float_full` turns off higher level float precision wrapper options.
 
 Example unit tests:
 

--- a/docs/max-float-precision.md
+++ b/docs/max-float-precision.md
@@ -1,0 +1,47 @@
+# Maximum Floating Point Precision (Writing)
+
+Glaze provides a compile time option (`float_max_write_precision`) to limit the precision when writing numbers to JSON. This improves performance when high precision is not needed in the resulting JSON.
+
+The wrappers `glz::write_float32` and `glz::write_float64` set this compile time option on individual numbers, arrays, or objects.
+
+Example unit tests:
+
+```c++
+struct write_precision_t
+{
+   double pi = std::numbers::pi_v<double>;
+   
+   struct glaze
+   {
+      using T = write_precision_t;
+      static constexpr auto value = glz::object("pi", glz::write_float32<&T::pi>);
+   };
+};
+
+suite max_write_precision_tests = [] {
+   "max_write_precision"_test = [] {
+      double pi = std::numbers::pi_v<double>;
+      std::string json_double = glz::write_json(pi);
+      
+      constexpr glz::opts options{.float_max_write_precision = glz::float_precision::float32};
+      std::string json_float = glz::write<options>(pi);
+      expect(json_double != json_float);
+      expect(json_float == glz::write_json(std::numbers::pi_v<float>));
+      expect(!glz::read_json(pi, json_float));
+      
+      std::vector<double> double_array{ pi, 2 * pi };
+      json_double = glz::write_json(double_array);
+      json_float = glz::write<options>(double_array);
+      expect(json_double != json_float);
+      expect(json_float == glz::write_json(std::array{std::numbers::pi_v<float>, 2 * std::numbers::pi_v<float>}));
+      expect(!glz::read_json(double_array, json_float));
+   };
+   
+   "write_precision_t"_test = [] {
+      write_precision_t obj{};
+      std::string json_float = glz::write_json(obj);
+      expect(json_float == R"({"pi":3.1415927})") << json_float;
+   };
+};
+```
+

--- a/docs/wrappers.md
+++ b/docs/wrappers.md
@@ -41,5 +41,8 @@ glz::custom<&T::read, &T::write> // calls custom read and write std::functions o
 glz::manage<&T::x, &T::read_x, &T::write_x> // calls read_x() after reading x and calls write_x() before writing x
 glz::raw<&T::x> // write out string like types without quotes
 glz::raw_string<&T::string> // do not decode/encode escaped characters for strings (improves read/write performance)
+ 
+glz::write_float32<&T::x> // writes out numbers with a maximum precision of float32_t
+glz::write_float64<&T::x> // writes out numbers with a maximum precision of float64_t
 ```
 

--- a/docs/wrappers.md
+++ b/docs/wrappers.md
@@ -41,8 +41,9 @@ glz::custom<&T::read, &T::write> // calls custom read and write std::functions o
 glz::manage<&T::x, &T::read_x, &T::write_x> // calls read_x() after reading x and calls write_x() before writing x
 glz::raw<&T::x> // write out string like types without quotes
 glz::raw_string<&T::string> // do not decode/encode escaped characters for strings (improves read/write performance)
- 
+
 glz::write_float32<&T::x> // writes out numbers with a maximum precision of float32_t
 glz::write_float64<&T::x> // writes out numbers with a maximum precision of float64_t
+glz::write_float_full<&T::x> // writes out numbers with full precision (turns off higher level float precision wrappers)
 ```
 

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -21,7 +21,7 @@ namespace glz
    
    enum struct float_precision : uint8_t
    {
-      none,
+      full,
       float32 = 4,
       float64 = 8,
       float128 = 16

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -18,6 +18,14 @@ namespace glz
    // layout
    constexpr uint32_t rowwise = 0;
    constexpr uint32_t colwise = 1;
+   
+   enum struct float_precision : uint8_t
+   {
+      none,
+      float32 = 4,
+      float64 = 8,
+      float128 = 16
+   };
 
    struct opts
    {
@@ -38,7 +46,12 @@ namespace glz
                                           // skip_null_members = false to require nullable members
       bool error_on_const_read =
          false; // Error if attempt is made to read into a const value, by default the value is skipped without error
+      
       uint32_t layout = rowwise; // CSV row wise output/input
+      
+      // the maximum precision type used for writing floats, higher precision floats will be cast down to this precision
+      float_precision float_max_write_precision{};
+      
       bool quoted_num = false; // treat numbers as quoted or array-like types as having quoted numbers
       bool number = false; // read numbers as strings and write these string as numbers
       bool raw = false; // write out string like values without quotes

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -123,6 +123,14 @@ namespace glz
       ret.ws_handled = false;
       return ret;
    }
+   
+   template <opts Opts, auto member_ptr>
+   constexpr auto set_opt(auto&& value)
+   {
+      opts ret = Opts;
+      ret.*member_ptr = value;
+      return ret;
+   }
 
    template <opts Opts, auto member_ptr>
    constexpr auto opt_on()

--- a/include/glaze/json.hpp
+++ b/include/glaze/json.hpp
@@ -7,6 +7,7 @@
 #include "glaze/json/invoke.hpp"
 #include "glaze/json/json_ptr.hpp"
 #include "glaze/json/manage.hpp"
+#include "glaze/json/max_write_precision.hpp"
 #include "glaze/json/minify.hpp"
 #include "glaze/json/ndjson.hpp"
 #include "glaze/json/prettify.hpp"

--- a/include/glaze/json/max_write_precision.hpp
+++ b/include/glaze/json/max_write_precision.hpp
@@ -1,0 +1,54 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include <type_traits>
+
+#include "glaze/core/opts.hpp"
+#include "glaze/json/read.hpp"
+#include "glaze/json/write.hpp"
+
+namespace glz
+{
+   // set the maximum precision for writing floats
+   template <class T>
+   struct max_write_precision_t
+   {
+      static constexpr bool glaze_wrapper = true;
+      using value_type = T;
+      T& val;
+   };
+
+   namespace detail
+   {
+      template <class T>
+      struct from_json<max_write_precision_t<T>>
+      {
+         template <auto Opts>
+         GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args) noexcept
+         {
+            read<json>::op<Opts>(value.val, args...); // no difference reading
+         }
+      };
+
+      template <class T>
+      struct to_json<max_write_precision_t<T>>
+      {
+         template <auto Opts>
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+         {
+            write<json>::op<opt_true<Opts, &opts::float_max_write_precision>>(value.val, ctx, args...);
+         }
+      };
+
+      template <auto MemPtr>
+      inline constexpr decltype(auto) max_write_precision_impl() noexcept
+      {
+         return [](auto&& val) { return max_write_precision_t<std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
+      }
+   }
+
+   template <auto MemPtr>
+   constexpr auto max_write_precision = detail::max_write_precision_impl<MemPtr>();
+}

--- a/include/glaze/json/max_write_precision.hpp
+++ b/include/glaze/json/max_write_precision.hpp
@@ -41,6 +41,21 @@ namespace glz
       static constexpr bool custom_write = true;
       static constexpr auto value{[](auto& s) -> auto& { return s.val; }}; // reading just uses the value directly
    };
+   
+   template <class T>
+   struct write_float_full_t
+   {
+      static constexpr bool glaze_wrapper = true;
+      using value_type = T;
+      T& val;
+   };
+   
+   template <class T>
+   struct meta<write_float_full_t<T>>
+   {
+      static constexpr bool custom_write = true;
+      static constexpr auto value{[](auto& s) -> auto& { return s.val; }}; // reading just uses the value directly
+   };
 
    namespace detail
    {
@@ -63,6 +78,16 @@ namespace glz
             write<json>::op<set_opt<Opts, &opts::float_max_write_precision>(float_precision::float64)>(value.val, ctx, args...);
          }
       };
+      
+      template <class T>
+      struct to_json<write_float_full_t<T>>
+      {
+         template <auto Opts>
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+         {
+            write<json>::op<set_opt<Opts, &opts::float_max_write_precision>(float_precision::full)>(value.val, ctx, args...);
+         }
+      };
 
       template <auto MemPtr>
       inline constexpr decltype(auto) write_float32_t_impl() noexcept
@@ -75,6 +100,12 @@ namespace glz
       {
          return [](auto&& val) { return write_float64_t<std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
       }
+      
+      template <auto MemPtr>
+      inline constexpr decltype(auto) write_float_full_impl() noexcept
+      {
+         return [](auto&& val) { return write_float_full_t<std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
+      }
    }
 
    template <auto MemPtr>
@@ -82,4 +113,7 @@ namespace glz
    
    template <auto MemPtr>
    constexpr auto write_float64 = detail::write_float64_impl<MemPtr>();
+   
+   template <auto MemPtr>
+   constexpr auto write_float_full = detail::write_float_full_impl<MemPtr>();
 }

--- a/include/glaze/json/max_write_precision.hpp
+++ b/include/glaze/json/max_write_precision.hpp
@@ -13,42 +13,73 @@ namespace glz
 {
    // set the maximum precision for writing floats
    template <class T>
-   struct max_write_precision_t
+   struct write_float32_t
    {
       static constexpr bool glaze_wrapper = true;
       using value_type = T;
       T& val;
    };
+   
+   template <class T>
+   struct meta<write_float32_t<T>>
+   {
+      static constexpr bool custom_write = true;
+      static constexpr auto value{[](auto& s) -> auto& { return s.val; }}; // reading just uses the value directly
+   };
+   
+   template <class T>
+   struct write_float64_t
+   {
+      static constexpr bool glaze_wrapper = true;
+      using value_type = T;
+      T& val;
+   };
+   
+   template <class T>
+   struct meta<write_float64_t<T>>
+   {
+      static constexpr bool custom_write = true;
+      static constexpr auto value{[](auto& s) -> auto& { return s.val; }}; // reading just uses the value directly
+   };
 
    namespace detail
    {
       template <class T>
-      struct from_json<max_write_precision_t<T>>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args) noexcept
-         {
-            read<json>::op<Opts>(value.val, args...); // no difference reading
-         }
-      };
-
-      template <class T>
-      struct to_json<max_write_precision_t<T>>
+      struct to_json<write_float32_t<T>>
       {
          template <auto Opts>
          GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
          {
-            write<json>::op<opt_true<Opts, &opts::float_max_write_precision>>(value.val, ctx, args...);
+            write<json>::op<set_opt<Opts, &opts::float_max_write_precision>(float_precision::float32)>(value.val, ctx, args...);
+         }
+      };
+      
+      template <class T>
+      struct to_json<write_float64_t<T>>
+      {
+         template <auto Opts>
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+         {
+            write<json>::op<set_opt<Opts, &opts::float_max_write_precision>(float_precision::float64)>(value.val, ctx, args...);
          }
       };
 
       template <auto MemPtr>
-      inline constexpr decltype(auto) max_write_precision_impl() noexcept
+      inline constexpr decltype(auto) write_float32_t_impl() noexcept
       {
-         return [](auto&& val) { return max_write_precision_t<std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
+         return [](auto&& val) { return write_float32_t<std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
+      }
+      
+      template <auto MemPtr>
+      inline constexpr decltype(auto) write_float64_impl() noexcept
+      {
+         return [](auto&& val) { return write_float64_t<std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
       }
    }
 
    template <auto MemPtr>
-   constexpr auto max_write_precision = detail::max_write_precision_impl<MemPtr>();
+   constexpr auto write_float32 = detail::write_float32_t_impl<MemPtr>();
+   
+   template <auto MemPtr>
+   constexpr auto write_float64 = detail::write_float64_impl<MemPtr>();
 }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <list>
 #include <map>
+#include <numbers>
 #include <random>
 #include <ranges>
 #if defined(__STDCPP_FLOAT128_T__)
@@ -7639,6 +7640,26 @@ suite sum_hash_obj_test = [] {
       const auto s = glz::write_json(obj);
       expect(s == R"({"aa":0,"aab":0,"cab":0,"zac":0})");
       expect(!glz::read_json(obj, s));
+   };
+};
+
+suite max_write_precision_tests = [] {
+   "max_write_precision"_test = [] {
+      double pi = std::numbers::pi_v<double>;
+      std::string json_double = glz::write_json(pi);
+      
+      constexpr glz::opts options{.float_max_write_precision = glz::float_precision::float32};
+      std::string json_float = glz::write<options>(pi);
+      expect(json_double != json_float);
+      expect(json_float == glz::write_json(std::numbers::pi_v<float>));
+      expect(!glz::read_json(pi, json_float));
+      
+      std::vector<double> double_array{ pi, 2 * pi };
+      json_double = glz::write_json(double_array);
+      json_float = glz::write<options>(double_array);
+      expect(json_double != json_float);
+      expect(json_float == glz::write_json(std::array{std::numbers::pi_v<float>, 2 * std::numbers::pi_v<float>}));
+      expect(!glz::read_json(double_array, json_float));
    };
 };
 

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -7643,6 +7643,17 @@ suite sum_hash_obj_test = [] {
    };
 };
 
+struct write_precision_t
+{
+   double pi = std::numbers::pi_v<double>;
+   
+   struct glaze
+   {
+      using T = write_precision_t;
+      static constexpr auto value = glz::object("pi", glz::write_float32<&T::pi>);
+   };
+};
+
 suite max_write_precision_tests = [] {
    "max_write_precision"_test = [] {
       double pi = std::numbers::pi_v<double>;
@@ -7660,6 +7671,12 @@ suite max_write_precision_tests = [] {
       expect(json_double != json_float);
       expect(json_float == glz::write_json(std::array{std::numbers::pi_v<float>, 2 * std::numbers::pi_v<float>}));
       expect(!glz::read_json(double_array, json_float));
+   };
+   
+   "write_precision_t"_test = [] {
+      write_precision_t obj{};
+      std::string json_float = glz::write_json(obj);
+      expect(json_float == R"({"pi":3.1415927})") << json_float;
    };
 };
 


### PR DESCRIPTION
Addresses #934 

Adds the compile time option `float_max_write_precision` to limit the precision of writing out floating point values. This improves performance when high precision is not needed in the JSON.

Also adds the wrappers: `glz::write_float32` and `glz::write_float64`, which only affect the writing precision.

Unit test example:
```c++
struct write_precision_t
{
   double pi = std::numbers::pi_v<double>;
   
   struct glaze
   {
      using T = write_precision_t;
      static constexpr auto value = glz::object("pi", glz::write_float32<&T::pi>);
   };
};

suite max_write_precision_tests = [] {
   "max_write_precision"_test = [] {
      double pi = std::numbers::pi_v<double>;
      std::string json_double = glz::write_json(pi);
      
      constexpr glz::opts options{.float_max_write_precision = glz::float_precision::float32};
      std::string json_float = glz::write<options>(pi);
      expect(json_double != json_float);
      expect(json_float == glz::write_json(std::numbers::pi_v<float>));
      expect(!glz::read_json(pi, json_float));
      
      std::vector<double> double_array{ pi, 2 * pi };
      json_double = glz::write_json(double_array);
      json_float = glz::write<options>(double_array);
      expect(json_double != json_float);
      expect(json_float == glz::write_json(std::array{std::numbers::pi_v<float>, 2 * std::numbers::pi_v<float>}));
      expect(!glz::read_json(double_array, json_float));
   };
   
   "write_precision_t"_test = [] {
      write_precision_t obj{};
      std::string json_float = glz::write_json(obj);
      expect(json_float == R"({"pi":3.1415927})") << json_float;
   };
};
```