### PR TITLE
Using 256 byte tables for invalid JSON safety

### DIFF
--- a/include/glaze/json/json_format.hpp
+++ b/include/glaze/json/json_format.hpp
@@ -25,8 +25,8 @@ namespace glz::detail
       Comment = '/'
    };
 
-   constexpr std::array<json_type, 128> ascii_json_types = [] {
-      std::array<json_type, 128> t{};
+   constexpr std::array<json_type, 256> json_types = [] {
+      std::array<json_type, 256> t{};
       using enum json_type;
       t['"'] = String;
       t[','] = Comma;
@@ -148,7 +148,7 @@ namespace glz::detail
    inline sv read_json_number(auto&& it) noexcept
    {
       auto start = it;
-      while (numeric_ascii_table[*it]) {
+      while (numeric_table[*it]) {
          ++it;
       }
       return {start, size_t(it - start)};

--- a/include/glaze/json/minify.hpp
+++ b/include/glaze/json/minify.hpp
@@ -17,7 +17,7 @@ namespace glz
          using enum json_type;
 
          auto skip_whitespace = [&] {
-            while (ascii_whitespace_table[*it]) {
+            while (whitespace_table[*it]) {
                ++it;
             }
          };
@@ -25,7 +25,7 @@ namespace glz
          skip_whitespace();
 
          while (it < end) {
-            switch (ascii_json_types[size_t(*it)]) {
+            switch (json_types[size_t(*it)]) {
             case String: {
                const auto value = read_json_string(it, end);
                dump(value, b, ix);

--- a/include/glaze/json/prettify.hpp
+++ b/include/glaze/json/prettify.hpp
@@ -23,7 +23,7 @@ namespace glz
          int64_t indent{};
 
          while (it < end) {
-            switch (ascii_json_types[size_t(*it)]) {
+            switch (json_types[size_t(*it)]) {
             case String: {
                const auto value = read_json_string(it, end);
                dump(value, b, ix);

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -19,8 +19,8 @@
 
 namespace glz::detail
 {
-   constexpr std::array<bool, 128> numeric_ascii_table = [] {
-      std::array<bool, 128> t{};
+   constexpr std::array<bool, 256> numeric_table = [] {
+      std::array<bool, 256> t{};
       t['0'] = true;
       t['1'] = true;
       t['2'] = true;
@@ -52,8 +52,8 @@ namespace glz::detail
       return t;
    }();
 
-   constexpr std::array<bool, 128> ascii_whitespace_table = [] {
-      std::array<bool, 128> t{};
+   constexpr std::array<bool, 256> whitespace_table = [] {
+      std::array<bool, 256> t{};
       t['\n'] = true;
       t['\t'] = true;
       t['\r'] = true;
@@ -61,8 +61,8 @@ namespace glz::detail
       return t;
    }();
 
-   constexpr std::array<bool, 128> ascii_whitespace_comment_table = [] {
-      std::array<bool, 128> t{};
+   constexpr std::array<bool, 256> whitespace_comment_table = [] {
+      std::array<bool, 256> t{};
       t['\n'] = true;
       t['\t'] = true;
       t['\r'] = true;
@@ -190,7 +190,7 @@ namespace glz::detail
    GLZ_ALWAYS_INLINE void skip_ws_no_pre_check(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       if constexpr (!Opts.force_conformance) {
-         while (ascii_whitespace_comment_table[*it]) {
+         while (whitespace_comment_table[*it]) {
             if (*it == '/') [[unlikely]] {
                skip_comment(ctx, it, end);
                if (bool(ctx.error)) [[unlikely]] {
@@ -203,7 +203,7 @@ namespace glz::detail
          }
       }
       else {
-         while (ascii_whitespace_table[*it]) {
+         while (whitespace_table[*it]) {
             ++it;
          }
       }
@@ -890,7 +890,7 @@ namespace glz::detail
    GLZ_ALWAYS_INLINE void skip_number(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       if constexpr (!Opts.force_conformance) {
-         while (numeric_ascii_table[*it]) {
+         while (numeric_table[*it]) {
             ++it;
          }
       }


### PR DESCRIPTION
Use 256 byte tables so that we don't read outside of bounds for invalid JSON. It uses a bit more memory, but using 256 byte tables instead of 128 byte tables makes it much easier to keep code memory safe.