### PR TITLE
Unicode surrogate pair support and faster unicode performance

### DIFF
--- a/include/glaze/concepts/container_concepts.hpp
+++ b/include/glaze/concepts/container_concepts.hpp
@@ -19,12 +19,16 @@ namespace glz::detail
 {
    template <class T>
    concept char_t = std::same_as<std::decay_t<T>, char>;
+   
+   template <class T>
+   concept wide_char_t = std::same_as<std::decay_t<T>, char16_t> ||
+                       std::same_as<std::decay_t<T>, char32_t> || std::same_as<std::decay_t<T>, wchar_t>;
 
    template <class T>
    concept bool_t = std::same_as<std::decay_t<T>, bool> || std::same_as<std::decay_t<T>, std::vector<bool>::reference>;
 
    template <class T>
-   concept int_t = std::integral<std::decay_t<T>> && !char_t<std::decay_t<T>> && !bool_t<T>;
+   concept int_t = std::integral<std::decay_t<T>> && !char_t<T> && !wide_char_t<T> && !bool_t<T>;
 
    template <class T>
    concept num_t = std::floating_point<std::decay_t<T>> || int_t<T>;

--- a/include/glaze/concepts/container_concepts.hpp
+++ b/include/glaze/concepts/container_concepts.hpp
@@ -18,8 +18,7 @@ namespace glz
 namespace glz::detail
 {
    template <class T>
-   concept char_t = std::same_as<std::decay_t<T>, char> || std::same_as<std::decay_t<T>, char16_t> ||
-                    std::same_as<std::decay_t<T>, char32_t> || std::same_as<std::decay_t<T>, wchar_t>;
+   concept char_t = std::same_as<std::decay_t<T>, char>;
 
    template <class T>
    concept bool_t = std::same_as<std::decay_t<T>, bool> || std::same_as<std::decay_t<T>, std::vector<bool>::reference>;

--- a/include/glaze/core/context.hpp
+++ b/include/glaze/core/context.hpp
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <iterator>
+#include <string>
 #include <string_view>
 
 namespace glz

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -83,6 +83,12 @@ namespace glz::detail
       t['7'] = 7;
       t['8'] = 8;
       t['9'] = 9;
+      t['a'] = 0xA;
+      t['b'] = 0xB;
+      t['c'] = 0xC;
+      t['d'] = 0xD;
+      t['e'] = 0xE;
+      t['f'] = 0xF;
       t['A'] = 0xA;
       t['B'] = 0xB;
       t['C'] = 0xC;

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -1111,7 +1111,7 @@ namespace glz::detail
             else if (escape_char == '\\') {
                escape_char = in[next + 1];
                if (escape_char == 'u') [[unlikely]] {
-                  in += next;
+                  in += next + 2;
                   out += next;
                   if (!handle_unicode_code_point(in, out)) {
                      ctx.error = error_code::unicode_escape_conversion_failure;
@@ -1151,6 +1151,7 @@ namespace glz::detail
             else if (escape_char == '\\') {
                escape_char = in[1];
                if (escape_char == 'u') {
+                  in += 2;
                   if (!handle_unicode_code_point(in, out)) {
                      ctx.error = error_code::unicode_escape_conversion_failure;
                      return in;

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -207,7 +207,7 @@ namespace glz::detail
    }
    
    template <class Char>
-   [[nodiscard]] GLZ_ALWAYS_INLINE bool handle_unicode_code_point(const Char*& src, Char* dst) {
+   [[nodiscard]] GLZ_ALWAYS_INLINE bool handle_unicode_code_point(const Char*& src, Char*& dst) {
       constexpr uint32_t generic_surrogate_mask = 0xF800;
       constexpr uint32_t generic_surrogate_value = 0xD800;
       

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -133,6 +133,7 @@ namespace glz::detail
    [[nodiscard]] GLZ_ALWAYS_INLINE uint32_t hex_to_u32(const char* c) noexcept {
       const auto& t = digit_hex_table;
       const uint8_t arr[4]{ t[c[3]], t[c[2]], t[c[1]], t[c[0]] };
+      // TODO: Use std::byteswap when available (C++23)
       uint32_t chunk;
       std::memcpy(&chunk, arr, 4);
       if (is_less_16_u32(chunk)) [[likely]] {

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -106,12 +106,12 @@ namespace glz::detail
    
    GLZ_ALWAYS_INLINE constexpr uint32_t has_zero_u32(const uint32_t chunk) noexcept
    {
-      return (((chunk - 0x01010101) & ~chunk) & 0x80808080);
+      return (((chunk - 0x01010101u) & ~chunk) & 0x80808080u);
    }
 
    GLZ_ALWAYS_INLINE constexpr uint32_t is_less_16_u32(const uint32_t chunk) noexcept
    {
-      return has_zero_u32(chunk & repeat_byte4(0b11110000));
+      return has_zero_u32(chunk & repeat_byte4(0b11110000u));
    }
    
    template <class T>
@@ -323,7 +323,7 @@ namespace glz::detail
 
    GLZ_ALWAYS_INLINE constexpr auto has_zero(const uint64_t chunk) noexcept
    {
-      return (((chunk - 0x0101010101010101) & ~chunk) & 0x8080808080808080);
+      return (((chunk - 0x0101010101010101u) & ~chunk) & 0x8080808080808080u);
    }
 
    GLZ_ALWAYS_INLINE constexpr auto has_quote(const uint64_t chunk) noexcept
@@ -349,12 +349,12 @@ namespace glz::detail
 
    GLZ_ALWAYS_INLINE constexpr uint64_t is_less_16(const uint64_t chunk) noexcept
    {
-      return has_zero(chunk & repeat_byte8(0b11110000));
+      return has_zero(chunk & repeat_byte8(0b11110000u));
    }
 
    GLZ_ALWAYS_INLINE constexpr uint64_t is_greater_15(const uint64_t chunk) noexcept
    {
-      return (chunk & repeat_byte8(0b11110000));
+      return (chunk & repeat_byte8(0b11110000u));
    }
 
    template <opts Opts>

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -132,7 +132,7 @@ namespace glz::detail
    
    [[nodiscard]] GLZ_ALWAYS_INLINE uint32_t hex_to_u32(const char* c) noexcept {
       const auto& t = digit_hex_table;
-      const uint8_t arr[]{ t[c[3]], t[c[2]], t[c[1]], t[c[0]] };
+      const uint8_t arr[4]{ t[c[3]], t[c[2]], t[c[1]], t[c[0]] };
       uint32_t chunk;
       std::memcpy(&chunk, arr, 4);
       if (is_less_16_u32(chunk)) [[likely]] {

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -133,7 +133,6 @@ namespace glz::detail
    [[nodiscard]] GLZ_ALWAYS_INLINE uint32_t hex_to_u32(const char* c) noexcept {
       const auto& t = digit_hex_table;
       const uint8_t arr[4]{ t[c[3]], t[c[2]], t[c[1]], t[c[0]] };
-      // TODO: Use std::byteswap when available (C++23)
       uint32_t chunk;
       std::memcpy(&chunk, arr, 4);
       if (is_less_16_u32(chunk)) [[likely]] {

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -145,25 +145,25 @@ namespace glz::detail
    // Standard proposal: https://eisenwave.github.io/cpp-proposals/bit-permutations.html
    // Same as pdep
    template <std::unsigned_integral T>
-   [[nodiscard]] constexpr T bit_expandr(T x, T m) noexcept
+   [[nodiscard]] constexpr T bit_expandr(const T x, const T m) noexcept
    {
-       T result = 0;
-       for (int i = 0, j = 0; i < std::numeric_limits<T>::digits; ++i) {
-           const bool mask_bit = (m >> i) & 1;
-           result |= (mask_bit & (x >> j)) << i;
-           j += mask_bit;
-       }
-       return result;
+      T result{};
+      for (int i = 0, j = 0; i < std::numeric_limits<T>::digits; ++i) {
+         const bool mask_bit = (m >> i) & 1;
+         result |= (mask_bit & (x >> j)) << i;
+         j += mask_bit;
+      }
+      return result;
    }
    
    template <class Char>
    [[nodiscard]] GLZ_ALWAYS_INLINE uint32_t code_point_to_utf8(const uint32_t code_point, Char* c) {
       if (code_point < 128) {
-         c[0] = static_cast<Char>(code_point);
+         c[0] = Char(code_point);
          return 1;
       }
       
-      const auto leading_zeros = std::countr_zero(code_point);
+      const auto leading_zeros = std::countl_zero(code_point);
       if (leading_zeros >= 11) {
          const uint32_t pattern = bit_expandr(0x3F00u, code_point) | 0xC0u;
          c[0] = Char(pattern >> 8);

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -282,6 +282,13 @@ suite escaping_tests = [] {
       expect(obj.escaped_key == 5);
       expect(obj.escaped_key2 == "bye");
    };
+   
+   "\u11FF read"_test = [] {
+      std::string in = R"("\u11FF")";
+      std::string str{};
+      expect(!glz::read_json(str, in));
+      expect(str == "ᇿ") << str;
+   };
 
    "escaped_characters read"_test = [] {
       std::string in = R"({"escape_chars":"\b\f\n\r\t\u11FF"})";

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -313,17 +313,6 @@ suite escaping_tests = [] {
       in = R"("\t")";
       expect(glz::read_json(c, in) == glz::error_code::none);
       expect(c == '\t');
-
-      in = R"("\u11FF")";
-      char32_t c32{};
-      expect(glz::read_json(c32, in) == glz::error_code::none);
-      expect(static_cast<uint32_t>(c32) == 0x11FF);
-
-      in = R"("\u732B")";
-      char16_t c16{};
-      expect(glz::read_json(c16, in) == glz::error_code::none);
-      char16_t uc = u'\u732b';
-      expect(c16 == uc);
    };
 
    "escaped_characters write"_test = [] {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -2058,14 +2058,6 @@ suite write_tests = [] {
       }
       {
          std::string s;
-         wchar_t v{'a'};
-         glz::write_json(v, s); // This line gives warning about converting wchar to char, is that fine? Should we
-                                // write a to_buffer template to handle type wchar?
-         // Is the below what we actually expect?
-         expect(s == R"("a")"); // std::to_string(static_cast<int>('a')));
-      }
-      {
-         std::string s;
          short v{1};
          glz::write_json(v, s);
          expect(s == "1");
@@ -3356,17 +3348,6 @@ suite small_chars = [] {
    };
 };
 
-suite char16_test = [] {
-   "char16_test"_test = [] {
-      {
-         char16_t c{};
-         expect(glz::read_json(c, R"("H")") == glz::error_code::none);
-
-         expect(c == u'H');
-      }
-   };
-};
-
 suite ndjson_test = [] {
    "ndjson"_test = [] {
       std::vector<std::string> x = {"Hello", "World", "Ice", "Cream"};
@@ -4547,7 +4528,7 @@ break"])";
 1e00,2e+00,2e-00
 ,"rosebud"])";
       auto ec_pass1 = glz::read<glz::opts{.force_conformance = true}>(json, pass1);
-      expect(ec_pass1 == glz::error_code::none);
+      expect(ec_pass1 == glz::error_code::none) << glz::format_error(ec_pass1, pass1);
       expect(glz::validate_json(pass1) == glz::error_code::none);
 
       std::string pass2 = R"([[[[[[[[[[[[[[[[[[["Not too deep"]]]]]]]]]]]]]]]]]]])";

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -3892,6 +3892,13 @@ suite unicode_tests = [] {
 
       expect(obj.text == "ᇿ");
    };
+   
+   "surrogate pair"_test = [] {
+      const char* json = R"("\uD83C\uDF40")"; //🍀
+      std::string val;
+      expect(!glz::read_json(val, json));
+      expect(val == "🍀");
+   };
 };
 
 struct value_t

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -3899,6 +3899,20 @@ suite unicode_tests = [] {
       expect(!glz::read_json(val, json));
       expect(val == "🍀");
    };
+   
+   "mixed unicode"_test = [] {
+      const char* json = R"("\u11FF\uD83C\uDF40ᇿ🍀\u11FF")"; //ᇿ🍀ᇿ🍀ᇿ
+      std::string val;
+      expect(!glz::read_json(val, json));
+      expect(val == "ᇿ🍀ᇿ🍀ᇿ");
+   };
+   
+   "multi surrogate unicode"_test = [] {
+      const char* json = R"("\uD83D\uDE00\uD83C\uDF40😀🍀\uD83D\uDE00")"; //😀🍀😀🍀😀
+      std::string val;
+      expect(!glz::read_json(val, json));
+      expect(val == "😀🍀😀🍀😀");
+   };
 };
 
 struct value_t


### PR DESCRIPTION
## Unicode surrogate pair support

```c++
const char* json = R"("\uD83D\uDE00\uD83C\uDF40😀🍀\uD83D\uDE00")"; //😀🍀😀🍀😀
std::string val;
expect(!glz::read_json(val, json));
expect(val == "😀🍀😀🍀😀");
```

- Faster escaped unicode handling
- Also removes C++ support for larger character types, as this doesn't fit into UTF8 and the most recent JSON specification
- Removes the dependency on `<locale>`