### PR TITLE
Add `build2` package reference to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,14 @@ find_package(glaze REQUIRED)
 target_link_libraries(main PRIVATE glaze::glaze)
 ```
 
+### [build2](https://build2.org)
+
+- Available on [cppget](https://cppget.org/libglaze)
+
+```
+import libs = libglaze%lib{glaze}
+```
+
 ### Arch Linux
 
 - AUR packages: [glaze](https://aur.archlinux.org/packages/glaze) and [glaze-git](https://aur.archlinux.org/packages/glaze-git)


### PR DESCRIPTION
Hi! I've packaged this (amazing) library for [build2](https://build2.org), so figured I might as well add it as a reference.
You can find the package [here](https://github.com/build2-packaging/glaze).

`v2.4.0` has already been released and I'm just about to publish `v2.5.3`.

You can see all the `v2.5.3` CI builds [here](https://queue.cppget.org/libglaze/2.5.3) (60 different configurations, freely available as part of `build2`).