### PR TITLE
BEVE read validation and null termination requirement

### DIFF
--- a/include/glaze/binary/beve_to_json.hpp
+++ b/include/glaze/binary/beve_to_json.hpp
@@ -17,9 +17,9 @@ namespace glz
          const uint8_t byte_count = detail::byte_count_lookup[tag >> 5];
 
          auto write_number = [&]<class T>(T&& value) {
-            std::memcpy(&value, &(*it), sizeof(T));
+            std::memcpy(&value, it, sizeof(T));
             to_json<T>::template op<Opts>(value, ctx, out, ix);
-            std::advance(it, sizeof(T));
+            it += sizeof(T);
          };
 
          switch (number_type) {
@@ -132,7 +132,7 @@ namespace glz
             const auto n = detail::int_from_compressed(ctx, it, end);
             const sv value{reinterpret_cast<const char*>(&*it), n};
             to_json<sv>::template op<Opts>(value, ctx, out, ix);
-            std::advance(it, n);
+            it += n;
             break;
          }
          case tag::object: {
@@ -161,7 +161,7 @@ namespace glz
                   else {
                      dump<':'>(out, ix);
                   }
-                  std::advance(it, n);
+                  it += n;
                   // convert the value
                   beve_to_json_value<Opts>(ctx, it, end, out, ix);
                   if (i != n_fields - 1) {
@@ -196,9 +196,9 @@ namespace glz
             auto write_array = [&]<class T>(T&& value) {
                const auto n = int_from_compressed(ctx, it, end);
                for (size_t i = 0; i < n; ++i) {
-                  std::memcpy(&value, &(*it), sizeof(T));
+                  std::memcpy(&value, it, sizeof(T));
                   to_json<T>::template op<Opts>(value, ctx, out, ix);
-                  std::advance(it, sizeof(T));
+                  it += sizeof(T);
                   if (i != n - 1) {
                      dump<','>(out, ix);
                   }
@@ -295,7 +295,7 @@ namespace glz
                      const auto n = detail::int_from_compressed(ctx, it, end);
                      const sv value{reinterpret_cast<const char*>(&*it), n};
                      to_json<sv>::template op<Opts>(value, ctx, out, ix);
-                     std::advance(it, n);
+                     it += n;
                      if (i != n_strings - 1) {
                         dump<','>(out, ix);
                      }

--- a/include/glaze/binary/beve_to_json.hpp
+++ b/include/glaze/binary/beve_to_json.hpp
@@ -129,7 +129,7 @@ namespace glz
          }
          case tag::string: {
             ++it;
-            const auto n = detail::int_from_compressed(it, end);
+            const auto n = detail::int_from_compressed(ctx, it, end);
             const sv value{reinterpret_cast<const char*>(&*it), n};
             to_json<sv>::template op<Opts>(value, ctx, out, ix);
             std::advance(it, n);
@@ -149,10 +149,10 @@ namespace glz
             switch (key_type) {
             case 0: {
                // string key
-               const auto n_fields = detail::int_from_compressed(it, end);
+               const auto n_fields = detail::int_from_compressed(ctx, it, end);
                for (size_t i = 0; i < n_fields; ++i) {
                   // convert the key
-                  const auto n = detail::int_from_compressed(it, end);
+                  const auto n = detail::int_from_compressed(ctx, it, end);
                   const sv key{reinterpret_cast<const char*>(&*it), n};
                   to_json<sv>::template op<Opts>(key, ctx, out, ix);
                   if constexpr (Opts.prettify) {
@@ -194,7 +194,7 @@ namespace glz
             const uint8_t byte_count = detail::byte_count_lookup[tag >> 5];
 
             auto write_array = [&]<class T>(T&& value) {
-               const auto n = int_from_compressed(it, end);
+               const auto n = int_from_compressed(ctx, it, end);
                for (size_t i = 0; i < n; ++i) {
                   std::memcpy(&value, &(*it), sizeof(T));
                   to_json<T>::template op<Opts>(value, ctx, out, ix);
@@ -290,9 +290,9 @@ namespace glz
                }
                case 1: {
                   // array of strings
-                  const auto n_strings = int_from_compressed(it, end);
+                  const auto n_strings = int_from_compressed(ctx, it, end);
                   for (size_t i = 0; i < n_strings; ++i) {
-                     const auto n = detail::int_from_compressed(it, end);
+                     const auto n = detail::int_from_compressed(ctx, it, end);
                      const sv value{reinterpret_cast<const char*>(&*it), n};
                      to_json<sv>::template op<Opts>(value, ctx, out, ix);
                      std::advance(it, n);
@@ -321,7 +321,7 @@ namespace glz
          }
          case tag::generic_array: {
             ++it;
-            const auto n = int_from_compressed(it, end);
+            const auto n = int_from_compressed(ctx, it, end);
             dump<'['>(out, ix);
             for (size_t i = 0; i < n; ++i) {
                beve_to_json_value<Opts>(ctx, it, end, out, ix);
@@ -344,7 +344,7 @@ namespace glz
             case 1: {
                // variants
                ++it;
-               const auto index = int_from_compressed(it, end);
+               const auto index = int_from_compressed(ctx, it, end);
 
                dump<'{'>(out, ix);
                if constexpr (Opts.prettify) {
@@ -456,7 +456,7 @@ namespace glz
                if (complex_type) {
                   // complex array
                   const auto number_tag = complex_header & 0b111'00000;
-                  const auto n = int_from_compressed(it, end);
+                  const auto n = int_from_compressed(ctx, it, end);
                   dump<'['>(out, ix);
                   for (size_t i = 0; i < n; ++i) {
                      dump<'['>(out, ix);

--- a/include/glaze/binary/header.hpp
+++ b/include/glaze/binary/header.hpp
@@ -38,7 +38,7 @@ namespace glz::detail
    [[nodiscard]] GLZ_ALWAYS_INLINE constexpr size_t int_from_compressed(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       uint8_t header;
-      std::memcpy(&header, &(*it), 1);
+      std::memcpy(&header, it, 1);
       const uint8_t config = header & 0b000000'11;
       
       if ((it + byte_count_lookup[config]) > end) [[unlikely]] {
@@ -52,19 +52,19 @@ namespace glz::detail
          return header >> 2;
       case 1: {
          uint16_t h;
-         std::memcpy(&h, &(*it), 2);
+         std::memcpy(&h, it, 2);
          it += 2;
          return h >> 2;
       }
       case 2: {
          uint32_t h;
-         std::memcpy(&h, &(*it), 4);
+         std::memcpy(&h, it, 4);
          it += 4;
          return h >> 2;
       }
       case 3: {
          uint64_t h;
-         std::memcpy(&h, &(*it), 8);
+         std::memcpy(&h, it, 8);
          it += 8;
          return h >> 2;
       }
@@ -76,7 +76,7 @@ namespace glz::detail
    GLZ_ALWAYS_INLINE constexpr void skip_compressed_int(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       uint8_t header;
-      std::memcpy(&header, &(*it), 1);
+      std::memcpy(&header, it, 1);
       const uint8_t config = header & 0b000000'11;
       
       if ((it + byte_count_lookup[config]) > end) [[unlikely]] {

--- a/include/glaze/binary/header.hpp
+++ b/include/glaze/binary/header.hpp
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <iterator>
 
+#include "glaze/core/context.hpp"
 #include "glaze/util/inline.hpp"
 
 namespace glz::tag
@@ -29,11 +30,21 @@ namespace glz::tag
 
 namespace glz::detail
 {
-   [[nodiscard]] GLZ_ALWAYS_INLINE constexpr size_t int_from_compressed(auto&& it, auto&&) noexcept
+   template <class T>
+   constexpr uint8_t byte_count = uint8_t(std::bit_width(sizeof(T)) - 1);
+
+   constexpr std::array<uint8_t, 8> byte_count_lookup{1, 2, 4, 8, 16, 32, 64, 128};
+   
+   [[nodiscard]] GLZ_ALWAYS_INLINE constexpr size_t int_from_compressed(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       uint8_t header;
       std::memcpy(&header, &(*it), 1);
       const uint8_t config = header & 0b000000'11;
+      
+      if ((it + byte_count_lookup[config]) > end) [[unlikely]] {
+         ctx.error = error_code::unexpected_end;
+         return 0;
+      }
 
       switch (config) {
       case 0:
@@ -62,35 +73,35 @@ namespace glz::detail
       }
    }
 
-   GLZ_ALWAYS_INLINE constexpr void skip_compressed_int(auto&& it, auto&&) noexcept
+   GLZ_ALWAYS_INLINE constexpr void skip_compressed_int(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       uint8_t header;
       std::memcpy(&header, &(*it), 1);
       const uint8_t config = header & 0b000000'11;
+      
+      if ((it + byte_count_lookup[config]) > end) [[unlikely]] {
+         ctx.error = error_code::unexpected_end;
+         return;
+      }
 
       switch (config) {
       case 0:
          ++it;
          return;
       case 1: {
-         std::advance(it, 2);
+         it += 2;
          return;
       }
       case 2: {
-         std::advance(it, 4);
+         it += 4;
          return;
       }
       case 3: {
-         std::advance(it, 8);
+         it += 8;
          return;
       }
       default:
          return;
       }
    }
-
-   template <class T>
-   inline constexpr uint8_t byte_count = uint8_t(std::bit_width(sizeof(T)) - 1);
-
-   inline constexpr std::array<uint8_t, 8> byte_count_lookup{1, 2, 4, 8, 16, 32, 64, 128};
 }

--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -110,7 +110,7 @@ namespace glz
             uint8_t data[Length];
 
             std::memcpy(data, &(*it), Length);
-            std::advance(it, Length);
+            it += Length;
 
             for_each<N>([&](auto I) {
                static constexpr auto item = glz::get<I>(meta_v<T>);
@@ -130,7 +130,7 @@ namespace glz
             if constexpr (Opts.no_header) {
                using V = std::decay_t<T>;
                std::memcpy(&value, &(*it), sizeof(V));
-               std::advance(it, sizeof(V));
+               it += sizeof(V);
             }
             else {
                constexpr uint8_t type =
@@ -147,7 +147,7 @@ namespace glz
 
                using V = std::decay_t<decltype(value)>;
                std::memcpy(&value, &(*it), sizeof(V));
-               std::advance(it, sizeof(V));
+               it += sizeof(V);
             }
          }
       };
@@ -163,7 +163,7 @@ namespace glz
 
             if constexpr (Opts.no_header) {
                std::memcpy(&value, &(*it), sizeof(V));
-               std::advance(it, sizeof(V));
+               it += sizeof(V);
             }
             else {
                constexpr uint8_t type =
@@ -179,7 +179,7 @@ namespace glz
                ++it;
 
                std::memcpy(&value, &(*it), sizeof(V));
-               std::advance(it, sizeof(V));
+               it += sizeof(V);
             }
          }
       };
@@ -194,7 +194,7 @@ namespace glz
             if constexpr (Opts.no_header) {
                using V = std::decay_t<T>;
                std::memcpy(&value, &(*it), sizeof(V));
-               std::advance(it, sizeof(V));
+               it += sizeof(V);
             }
             else {
                constexpr uint8_t header = tag::extensions | 0b00011'000;
@@ -220,7 +220,7 @@ namespace glz
                ++it;
 
                std::memcpy(&value, &(*it), 2 * sizeof(V));
-               std::advance(it, 2 * sizeof(V));
+               it += 2 * sizeof(V);
             }
          }
       };
@@ -319,7 +319,7 @@ namespace glz
                }
                value.resize(n);
                std::memcpy(value.data(), &(*it), n);
-               std::advance(it, n);
+               it += n;
             }
             else {
                constexpr uint8_t header = tag::string;
@@ -339,7 +339,7 @@ namespace glz
                }
                value.resize(n);
                std::memcpy(value.data(), &(*it), n);
-               std::advance(it, n);
+               it += n;
             }
          }
       };
@@ -403,7 +403,7 @@ namespace glz
                for (size_t i = 0; i < n; ++i) {
                   V x;
                   std::memcpy(&x, &*it, sizeof(V));
-                  std::advance(it, sizeof(V));
+                  it += sizeof(V);
                   value.emplace(x);
                }
             }
@@ -435,7 +435,7 @@ namespace glz
                   V str;
                   str.resize(length);
                   std::memcpy(str.data(), &*it, length);
-                  std::advance(it, length);
+                  it += length;
                   value.emplace(std::move(str));
                }
             }
@@ -541,12 +541,12 @@ namespace glz
 
                if constexpr (contiguous<T>) {
                   std::memcpy(value.data(), &*it, n * sizeof(V));
-                  std::advance(it, n * sizeof(V));
+                  it += n * sizeof(V);
                }
                else {
                   for (auto&& x : value) {
                      std::memcpy(&x, &*it, sizeof(V));
-                     std::advance(it, sizeof(V));
+                     it += sizeof(V);
                   }
                }
             }
@@ -587,7 +587,7 @@ namespace glz
                   }
 
                   std::memcpy(x.data(), &*it, length);
-                  std::advance(it, length);
+                  it += length;
                }
             }
             else if constexpr (complex_t<V>) {
@@ -630,12 +630,12 @@ namespace glz
 
                if constexpr (contiguous<T>) {
                   std::memcpy(value.data(), &*it, n * sizeof(V));
-                  std::advance(it, n * sizeof(V));
+                  it += n * sizeof(V);
                }
                else {
                   for (auto&& x : value) {
                      std::memcpy(&x, &*it, sizeof(V));
-                     std::advance(it, sizeof(V));
+                     it += sizeof(V);
                   }
                }
             }
@@ -901,7 +901,7 @@ namespace glz
 
                const std::string_view key{it, length};
 
-               std::advance(it, length);
+               it += length;
 
                if constexpr (N > 0) {
                   if (const auto& p = storage.find(key); p != storage.end()) [[likely]] {

--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -801,9 +801,6 @@ namespace glz
          {
             if constexpr (Opts.no_header) {
                skip_compressed_int(ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]] {
-                  return;
-               }
             }
             else {
                constexpr uint8_t header = tag::string;

--- a/include/glaze/binary/skip.hpp
+++ b/include/glaze/binary/skip.hpp
@@ -43,7 +43,7 @@ namespace glz::detail
       if ((tag & 0b00000'111) == tag::string) {
          for (size_t i = 0; i < n_keys; ++i) {
             const auto string_length = int_from_compressed(ctx, it, end);
-            std::advance(it, string_length);
+            it += string_length;
             if (bool(ctx.error)) [[unlikely]]
                return;
 
@@ -56,7 +56,7 @@ namespace glz::detail
          const uint8_t byte_count = byte_count_lookup[tag >> 5];
          for (size_t i = 0; i < n_keys; ++i) {
             const auto n = int_from_compressed(ctx, it, end);
-            std::advance(it, byte_count * n);
+            it += byte_count * n;
             if (bool(ctx.error)) [[unlikely]]
                return;
 
@@ -83,7 +83,7 @@ namespace glz::detail
          ++it;
          const auto n = int_from_compressed(ctx, it, end);
          const uint8_t byte_count = byte_count_lookup[tag >> 5];
-         std::advance(it, byte_count * n);
+         it += byte_count * n;
          break;
       }
       case 3: { // bool or string
@@ -92,11 +92,11 @@ namespace glz::detail
          if (is_bool) {
             const auto n = int_from_compressed(ctx, it, end);
             const auto num_bytes = (n + 7) / 8;
-            std::advance(it, num_bytes);
+            it += num_bytes;
          }
          else {
             const auto n = int_from_compressed(ctx, it, end);
-            std::advance(it, n);
+            it += n;
          }
          break;
       }

--- a/include/glaze/binary/skip.hpp
+++ b/include/glaze/binary/skip.hpp
@@ -14,11 +14,14 @@ namespace glz::detail
    template <opts Opts>
    inline void skip_value_binary(is_context auto&&, auto&&, auto&&) noexcept;
 
-   inline void skip_string_binary(is_context auto&&, auto&& it, auto&& end) noexcept
+   inline void skip_string_binary(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       ++it;
-      const auto n = int_from_compressed(it, end);
-      std::advance(it, n);
+      const auto n = int_from_compressed(ctx, it, end);
+      if (bool(ctx.error)) [[unlikely]] {
+         return;
+      }
+      it += n;
    }
 
    inline void skip_number_binary(is_context auto&&, auto&& it, auto&&) noexcept
@@ -26,8 +29,7 @@ namespace glz::detail
       const auto tag = uint8_t(*it);
       const uint8_t byte_count = byte_count_lookup[tag >> 5];
       ++it;
-
-      std::advance(it, byte_count);
+      it += byte_count;
    }
 
    template <opts Opts>
@@ -36,11 +38,11 @@ namespace glz::detail
       const auto tag = uint8_t(*it);
       ++it;
 
-      const auto n_keys = int_from_compressed(it, end);
+      const auto n_keys = int_from_compressed(ctx, it, end);
 
       if ((tag & 0b00000'111) == tag::string) {
          for (size_t i = 0; i < n_keys; ++i) {
-            const auto string_length = int_from_compressed(it, end);
+            const auto string_length = int_from_compressed(ctx, it, end);
             std::advance(it, string_length);
             if (bool(ctx.error)) [[unlikely]]
                return;
@@ -53,7 +55,7 @@ namespace glz::detail
       else if ((tag & 0b00000'111) == tag::number) {
          const uint8_t byte_count = byte_count_lookup[tag >> 5];
          for (size_t i = 0; i < n_keys; ++i) {
-            const auto n = int_from_compressed(it, end);
+            const auto n = int_from_compressed(ctx, it, end);
             std::advance(it, byte_count * n);
             if (bool(ctx.error)) [[unlikely]]
                return;
@@ -79,7 +81,7 @@ namespace glz::detail
       case 1: // signed integer (fallthrough)
       case 2: { // unsigned integer
          ++it;
-         const auto n = int_from_compressed(it, end);
+         const auto n = int_from_compressed(ctx, it, end);
          const uint8_t byte_count = byte_count_lookup[tag >> 5];
          std::advance(it, byte_count * n);
          break;
@@ -88,12 +90,12 @@ namespace glz::detail
          const bool is_bool = (tag & 0b00'1'00'000) >> 5;
          ++it;
          if (is_bool) {
-            const auto n = int_from_compressed(it, end);
+            const auto n = int_from_compressed(ctx, it, end);
             const auto num_bytes = (n + 7) / 8;
             std::advance(it, num_bytes);
          }
          else {
-            const auto n = int_from_compressed(it, end);
+            const auto n = int_from_compressed(ctx, it, end);
             std::advance(it, n);
          }
          break;
@@ -107,7 +109,7 @@ namespace glz::detail
    inline void skip_untyped_array_binary(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       ++it;
-      const auto n = int_from_compressed(it, end);
+      const auto n = int_from_compressed(ctx, it, end);
       for (size_t i = 0; i < n; ++i) {
          skip_value_binary<Opts>(ctx, it, end);
       }

--- a/include/glaze/core/read.hpp
+++ b/include/glaze/core/read.hpp
@@ -21,7 +21,7 @@ namespace glz
 
       using Buffer = std::decay_t<decltype(buffer)>;
       if constexpr (is_specialization_v<Buffer, std::basic_string> ||
-                    is_specialization_v<Buffer, std::basic_string_view> || span<Buffer> || Opts.format == binary) {
+                    is_specialization_v<Buffer, std::basic_string_view> || span<Buffer>) {
          e += buffer.size();
 
          if (b == e) {
@@ -29,14 +29,15 @@ namespace glz
          }
       }
       else {
-         // if not a std::string or a std::string_view, check that the last character is a null character
-         // this is not required for binary specification reading, because we require the data to be properly formatted
+         // if not a std::string, std::string_view, or span, check that the last character is a null character
          if (buffer.empty()) {
             ctx.error = error_code::no_read_input;
          }
-         e += buffer.size() - 1;
-         if (*e != '\0') {
-            ctx.error = error_code::data_must_be_null_terminated;
+         else {
+            e += buffer.size() - 1;
+            if (*e != '\0') {
+               ctx.error = error_code::data_must_be_null_terminated;
+            }
          }
       }
 
@@ -57,7 +58,7 @@ namespace glz
 
       using Buffer = std::decay_t<decltype(buffer)>;
       if constexpr (is_specialization_v<Buffer, std::basic_string> ||
-                    is_specialization_v<Buffer, std::basic_string_view> || span<Buffer> || Opts.format == binary) {
+                    is_specialization_v<Buffer, std::basic_string_view> || span<Buffer>) {
          e += buffer.size();
 
          if (b == e) {
@@ -66,8 +67,7 @@ namespace glz
          }
       }
       else {
-         // if not a std::string or a std::string_view, check that the last character is a null character
-         // this is not required for binary specification reading, because we require the data to be properly formatted
+         // if not a std::string, std::string_view, or span, check that the last character is a null character
          if (buffer.empty()) {
             ctx.error = error_code::no_read_input;
             return {ctx.error, 0};
@@ -90,7 +90,7 @@ namespace glz
          }
       }
 
-      return {ctx.error, static_cast<size_t>(std::distance(start, b)), ctx.includer_error};
+      return {ctx.error, static_cast<size_t>(b - start), ctx.includer_error};
    }
 
    template <opts Opts, class T>

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -281,7 +281,7 @@ namespace glz
                   return;
             }
 
-            if (std::distance(it, end) < 4) [[unlikely]] {
+            if (size_t(end - it) < 4) [[unlikely]] {
                ctx.error = error_code::expected_true_or_false;
                return;
             }
@@ -289,11 +289,11 @@ namespace glz
             uint64_t c{};
             // Note that because our buffer must be null terminated, we can read one more index without checking:
             // std::distance(it, end) < 5
-            std::memcpy(&c, &*it, 5);
+            std::memcpy(&c, it, 5);
             constexpr uint64_t u_true = 0b00000000'00000000'00000000'00000000'01100101'01110101'01110010'01110100;
             constexpr uint64_t u_false = 0b00000000'00000000'00000000'01100101'01110011'01101100'01100001'01100110;
             // We have to wipe the 5th character for true testing
-            if ((c & 0b11111111'11111111'11111111'00000000'11111111'11111111'11111111'11111111) == u_true) {
+            if ((c & 0xFF'FF'FF'00'FF'FF'FF'FF) == u_true) {
                value = true;
                it += 4;
             }

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -288,7 +288,6 @@ namespace glz
 
             uint64_t c{};
             // Note that because our buffer must be null terminated, we can read one more index without checking:
-            // std::distance(it, end) < 5
             std::memcpy(&c, it, 5);
             constexpr uint64_t u_true = 0b00000000'00000000'00000000'00000000'01100101'01110101'01110010'01110100;
             constexpr uint64_t u_false = 0b00000000'00000000'00000000'01100101'01110011'01101100'01100001'01100110;

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1749,12 +1749,12 @@ namespace glz
                         }
                         else [[unlikely]] {
                            if constexpr (tag.sv().empty()) {
-                              std::advance(it, -int64_t(key.size()));
+                              it -= int64_t(key.size());
                               ctx.error = error_code::unknown_key;
                               return;
                            }
                            else if (key != tag.sv()) {
-                              std::advance(it, -int64_t(key.size()));
+                              it -= int64_t(key.size());
                               ctx.error = error_code::unknown_key;
                               return;
                            }
@@ -2024,12 +2024,12 @@ namespace glz
                   }
                   else [[unlikely]] {
                      if constexpr (tag.sv().empty()) {
-                        std::advance(it, -int64_t(key.size()));
+                        it -= int64_t(key.size());
                         ctx.error = error_code::unknown_key;
                         return;
                      }
                      else if (key != tag.sv()) {
-                        std::advance(it, -int64_t(key.size()));
+                        it -= int64_t(key.size());
                         ctx.error = error_code::unknown_key;
                         return;
                      }

--- a/include/glaze/json/skip.hpp
+++ b/include/glaze/json/skip.hpp
@@ -183,6 +183,6 @@ namespace glz::detail
    {
       auto start = it;
       skip_value<Opts>(ctx, it, end);
-      return std::span{start, static_cast<size_t>(std::distance(start, it))};
+      return std::span{start, size_t(it - start)};
    }
 }

--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -100,6 +100,7 @@ namespace glz::repe
          auto [b, e] = read_iterators<Opts>(ctx, state.message);
          if (bool(ctx.error)) [[unlikely]] {
             return 0;
+         }
          auto start = b;
 
          glz::detail::read<Opts.format>::template op<Opts>(std::forward<Value>(value), ctx, b, e);
@@ -174,6 +175,7 @@ namespace glz::repe
       auto [b, e] = read_iterators<Opts>(ctx, buffer);
       if (bool(ctx.error)) [[unlikely]] {
          return error_t{error_e::parse_error};
+      }
       auto start = b;
 
       // clang 14 won't build when capturing from structured binding
@@ -585,6 +587,7 @@ namespace glz::repe
          auto [b, e] = read_iterators<Opts>(ctx, msg);
          if (bool(ctx.error)) [[unlikely]] {
             return error_t{error_e::parse_error};
+         }
          auto start = b;
 
          auto handle_error = [&](auto& it) {

--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -98,6 +98,8 @@ namespace glz::repe
       if constexpr (Opts.format == json) {
          glz::context ctx{};
          auto [b, e] = read_iterators<Opts>(ctx, state.message);
+         if (bool(ctx.error)) [[unlikely]] {
+            return 0;
          auto start = b;
 
          glz::detail::read<Opts.format>::template op<Opts>(std::forward<Value>(value), ctx, b, e);
@@ -170,6 +172,8 @@ namespace glz::repe
       repe::header h;
       context ctx{};
       auto [b, e] = read_iterators<Opts>(ctx, buffer);
+      if (bool(ctx.error)) [[unlikely]] {
+         return error_t{error_e::parse_error};
       auto start = b;
 
       // clang 14 won't build when capturing from structured binding
@@ -579,6 +583,8 @@ namespace glz::repe
          header h;
          context ctx{};
          auto [b, e] = read_iterators<Opts>(ctx, msg);
+         if (bool(ctx.error)) [[unlikely]] {
+            return error_t{error_e::parse_error};
          auto start = b;
 
          auto handle_error = [&](auto& it) {

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -204,7 +204,7 @@ void write_tests()
 
    "round_trip"_test = [] {
       {
-         std::vector<std::byte> s;
+         std::string s;
          float f{0.96875f};
          auto start = f;
          s.resize(sizeof(float));
@@ -217,7 +217,7 @@ void write_tests()
    "bool"_test = [] {
       {
          bool b = true;
-         std::vector<std::byte> out;
+         std::string out;
          glz::write_binary(b, out);
          bool b2{};
          expect(!glz::read_binary(b2, out));
@@ -228,7 +228,7 @@ void write_tests()
    "float"_test = [] {
       {
          float f = 1.5f;
-         std::vector<std::byte> out;
+         std::string out;
          glz::write_binary(f, out);
          float f2{};
          expect(!glz::read_binary(f2, out));
@@ -239,7 +239,7 @@ void write_tests()
    "string"_test = [] {
       {
          std::string s = "Hello World";
-         std::vector<std::byte> out;
+         std::string out;
          glz::write_binary(s, out);
          std::string s2{};
          expect(!glz::read_binary(s2, out));
@@ -250,7 +250,7 @@ void write_tests()
    "array"_test = [] {
       {
          std::array<float, 3> arr = {1.2f, 3434.343f, 0.f};
-         std::vector<std::byte> out;
+         std::string out;
          glz::write_binary(arr, out);
          std::array<float, 3> arr2{};
          expect(!glz::read_binary(arr2, out));
@@ -261,7 +261,7 @@ void write_tests()
    "vector"_test = [] {
       {
          std::vector<float> v = {1.2f, 3434.343f, 0.f};
-         std::vector<std::byte> out;
+         std::string out;
          glz::write_binary(v, out);
          std::vector<float> v2;
          expect(!glz::read_binary(v2, out));
@@ -273,7 +273,7 @@ void write_tests()
       my_struct s{};
       s.i = 5;
       s.hello = "Wow!";
-      std::vector<std::byte> out;
+      std::string out;
       glz::write_binary(s, out);
       my_struct s2{};
       expect(!glz::read_binary(s2, out));
@@ -282,7 +282,7 @@ void write_tests()
    };
 
    "nullable"_test = [] {
-      std::vector<std::byte> out;
+      std::string out;
 
       std::optional<int> op_int{};
       glz::write_binary(op_int, out);
@@ -322,7 +322,7 @@ void write_tests()
    };
 
    "map"_test = [] {
-      std::vector<std::byte> out;
+      std::string out;
 
       std::map<std::string, int> str_map{{"a", 1}, {"b", 10}, {"c", 100}, {"d", 1000}};
 
@@ -351,7 +351,7 @@ void write_tests()
 
    "enum"_test = [] {
       Color color = Color::Green;
-      std::vector<std::byte> buffer{};
+      std::string buffer{};
       glz::write_binary(color, buffer);
 
       Color color_read = Color::Red;
@@ -360,7 +360,7 @@ void write_tests()
    };
 
    "complex user obect"_test = [] {
-      std::vector<std::byte> buffer{};
+      std::string buffer{};
 
       Thing obj{};
       obj.thing.a = 5.7;
@@ -422,7 +422,7 @@ void bench()
 #endif
       Thing thing{};
 
-      std::vector<std::byte> buffer;
+      std::string buffer;
       // std::string buffer;
 
       auto tstart = std::chrono::high_resolution_clock::now();
@@ -522,7 +522,7 @@ void test_partial()
    std::string buffer = R"({"i":2,"map":{"fish":5,"cake":2,"bear":3}})";
    expect(glz::read_json(s, buffer) == false);
 
-   std::vector<std::byte> out;
+   std::string out;
    static constexpr auto partial = glz::json_ptrs("/i", "/d", "/hello", "/sub/x", "/sub/y", "/map/fish", "/map/bear");
 
    static constexpr auto sorted = glz::sort_json_ptrs(partial);
@@ -793,10 +793,8 @@ suite byte_buffer = [] {
       TestMsg msg{};
       msg.id = 5;
       msg.val = "hello";
-      std::vector<std::byte> buffer{};
+      std::string buffer{};
       glz::write_binary(msg, buffer);
-
-      buffer.emplace_back(static_cast<std::byte>('\0'));
 
       msg.id = 0;
       msg.val = "";

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -772,6 +772,23 @@ struct glz::meta<TestMsg>
 };
 
 suite byte_buffer = [] {
+   "std::byte buffer"_test = [] {
+      TestMsg msg{};
+      msg.id = 5;
+      msg.val = "hello";
+      std::vector<std::byte> buffer{};
+      glz::write_binary(msg, buffer);
+      
+      buffer.emplace_back(static_cast<std::byte>('\0'));
+
+      msg.id = 0;
+      msg.val = "";
+
+      expect(!glz::read_binary(msg, buffer));
+      expect(msg.id == 5);
+      expect(msg.val == "hello");
+   };
+   
    "uint8_t buffer"_test = [] {
       TestMsg msg{};
       msg.id = 5;
@@ -789,7 +806,7 @@ suite byte_buffer = [] {
       expect(msg.val == "hello");
    };
 
-   "std::byte buffer"_test = [] {
+   "std::string buffer"_test = [] {
       TestMsg msg{};
       msg.id = 5;
       msg.val = "hello";

--- a/tests/eigen_test/eigen_test.cpp
+++ b/tests/eigen_test/eigen_test.cpp
@@ -40,7 +40,7 @@ int main()
    "binary"_test = [] {
       Eigen::Matrix<double, 2, 2> m{};
       m << 1, 2, 3, 4;
-      std::vector<std::byte> b;
+      std::string b;
       glz::write_binary(m, b);
       Eigen::Matrix<double, 2, 2> e{};
       expect(!glz::read_binary(e, b));
@@ -51,7 +51,7 @@ int main()
    "binary"_test = [] {
       Eigen::MatrixXd m(2, 2);
       m << 1, 2, 3, 4;
-      std::vector<std::byte> b;
+      std::string b;
       glz::write_binary(m, b);
       Eigen::MatrixXd e(2, 2);
       expect(!glz::read_binary(e, b));
@@ -62,7 +62,7 @@ int main()
    "beve_to_json"_test = [] {
       Eigen::MatrixXd m(2, 2);
       m << 1, 2, 3, 4;
-      std::vector<std::byte> b;
+      std::string b;
       glz::write_binary(m, b);
       std::string json{};
       expect(!glz::beve_to_json(b, json));
@@ -71,7 +71,7 @@ int main()
 
    "array"_test = [] {
       Eigen::Vector3d m{1, 2, 3};
-      std::vector<std::byte> b;
+      std::string b;
       glz::write_binary(m, b);
       Eigen::Vector3d e{};
       expect(!glz::read_binary(e, b));
@@ -97,7 +97,7 @@ int main()
       for (int i = 0; i < m.size(); ++i) {
          m[i] = i;
       }
-      std::vector<std::byte> b;
+      std::string b;
       glz::write_binary(m, b);
       Eigen::VectorXd e{};
       expect(!glz::read_binary(e, b));
@@ -110,7 +110,7 @@ int main()
       for (int i = 0; i < m.size(); ++i) {
          m[i] = {double(i), 2 * double(i)};
       }
-      std::vector<std::byte> b;
+      std::string b;
       glz::write_binary(m, b);
       Eigen::VectorXcd e{};
       expect(!glz::read_binary(e, b));
@@ -123,7 +123,7 @@ int main()
       for (int i = 0; i < m.size(); ++i) {
          m.array()(i) = {double(i), 2 * double(i)};
       }
-      std::vector<std::byte> b;
+      std::string b;
       glz::write_binary(m, b);
       Eigen::MatrixXcd e(3, 3);
       expect(!glz::read_binary(e, b));

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -6221,13 +6221,13 @@ struct request_t
 struct QuoteData
 {
    // session
-   uint64_t time;
-   std::string action; // send, recv
-   std::string quote; // order, kill
-   std::string account;
-   uint32_t uid;
-   uint32_t session_id;
-   uint32_t request_id;
+   uint64_t time{};
+   std::string action{}; // send, recv
+   std::string quote{}; // order, kill
+   std::string account{};
+   uint32_t uid{};
+   uint32_t session_id{};
+   uint32_t request_id{};
    // order
    int state = 0;
    std::string order_id = "";


### PR DESCRIPTION
This is a breaking change that requires BEVE input buffers to be null terminated. It is recommended to use std::string as binary format buffers for this reason.

This change is due to the fact that we want BEVE to be able to accept data from untrusted sources, like JSON.