### PR TITLE
Moving basic and basic_ptr into study.hpp

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -214,14 +214,6 @@ namespace glz
    using text = basic_text<std::string>;
    using text_view = basic_text<std::string_view>;
 
-   using basic = std::variant<bool, char, char8_t, unsigned char, signed char, short, unsigned short, float, int,
-                              unsigned int, long, unsigned long, double, long long, unsigned long long, std::string>;
-
-   // Explicitly defining basic_ptr to avoid additional template instantiations
-   using basic_ptr =
-      std::variant<bool*, char*, char8_t*, unsigned char*, signed char*, short*, unsigned short*, float*, int*,
-                   unsigned int*, long*, unsigned long*, double*, long long*, unsigned long long*, std::string*>;
-
    namespace detail
    {
       template <class T>

--- a/include/glaze/json/study.hpp
+++ b/include/glaze/json/study.hpp
@@ -16,6 +16,14 @@
 
 namespace glz
 {
+   using basic = std::variant<bool, char, char8_t, unsigned char, signed char, short, unsigned short, float, int,
+                              unsigned int, long, unsigned long, double, long long, unsigned long long, std::string>;
+
+   // Explicitly defining basic_ptr to avoid additional template instantiations
+   using basic_ptr =
+      std::variant<bool*, char*, char8_t*, unsigned char*, signed char*, short*, unsigned short*, float*, int*,
+                   unsigned int*, long*, unsigned long*, double*, long long*, unsigned long long*, std::string*>;
+   
    namespace study
    {
       struct param

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -2463,8 +2463,6 @@ suite error_outputs = [] {
    };
 };
 
-#include "glaze/json/study.hpp"
-
 struct study_obj
 {
    size_t x{};


### PR DESCRIPTION
This should remove the need for `char8_t` support for those who don't use `study.hpp`