### PR TITLE
Removing std specializations to hopefully help with C++20 modules

### DIFF
--- a/include/glaze/api/impl.hpp
+++ b/include/glaze/api/impl.hpp
@@ -90,11 +90,11 @@ namespace glz
       }
 
       template <class Arg_tuple, class F, class Parent, size_t... Is>
-         requires std::invocable<F, Parent, ref_t<std::tuple_element_t<Is, Arg_tuple>>...>
+         requires std::invocable<F, Parent, ref_t<glz::tuple_element_t<Is, Arg_tuple>>...>
       decltype(auto) call_args(F&& f, Parent&& parent, [[maybe_unused]] std::span<void*> args,
                                std::index_sequence<Is...>)
       {
-         return f(parent, to_ref<std::tuple_element_t<Is, Arg_tuple>>(args[Is])...);
+         return f(parent, to_ref<glz::tuple_element_t<Is, Arg_tuple>>(args[Is])...);
       }
 
       bool caller(const sv path, const glz::hash_t type_hash, void*& ret, std::span<void*> args) noexcept override
@@ -120,7 +120,7 @@ namespace glz
                            static constexpr auto h = glz::hash<F>();
                            using Ret = typename return_type<V>::type;
                            using Tuple = typename inputs_as_tuple<V>::type;
-                           static constexpr auto N = std::tuple_size_v<Tuple>;
+                           static constexpr auto N = glz::tuple_size_v<Tuple>;
 
                            if (h == type_hash) [[likely]] {
                               if constexpr (std::is_void_v<Ret>) {
@@ -303,7 +303,7 @@ namespace glz
 
          constexpr auto N = sizeof...(Args);
          for_each<N>([&](auto I) {
-            using V = std::tuple_element_t<I, T>;
+            using V = glz::tuple_element_t<I, T>;
             ptr->emplace(name_v<V>, make_api<V>);
          });
 

--- a/include/glaze/api/std/functional.hpp
+++ b/include/glaze/api/std/functional.hpp
@@ -17,15 +17,15 @@ namespace glz
       {
          static constexpr auto impl() noexcept
          {
-            const auto N = std::tuple_size_v<Tuple>;
+            const auto N = glz::tuple_size_v<Tuple>;
             if constexpr (I >= N) {
                return Str;
             }
             else if constexpr (I == N - 1) {
-               return expander<join_v<Str, name_v<std::tuple_element_t<I, Tuple>>>, Tuple, I + 1>::value;
+               return expander<join_v<Str, name_v<glz::tuple_element_t<I, Tuple>>>, Tuple, I + 1>::value;
             }
             else {
-               return expander<join_v<Str, name_v<std::tuple_element_t<I, Tuple>>, chars<",">>, Tuple, I + 1>::value;
+               return expander<join_v<Str, name_v<glz::tuple_element_t<I, Tuple>>, chars<",">>, Tuple, I + 1>::value;
             }
          }
 

--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -104,7 +104,7 @@ namespace glz
          template <auto Opts, is_context Ctx, class It0, class It1>
          GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&&, It0&& it, It1&&)
          {
-            constexpr auto N = std::tuple_size_v<meta_t<T>>;
+            constexpr auto N = glz::tuple_size_v<meta_t<T>>;
 
             constexpr auto Length = byte_length<T>();
             uint8_t data[Length];
@@ -839,7 +839,7 @@ namespace glz
                ++it;
 
                using V = std::decay_t<T>;
-               constexpr auto N = std::tuple_size_v<meta_t<V>>;
+               constexpr auto N = glz::tuple_size_v<meta_t<V>>;
                if (int_from_compressed(ctx, it, end) != N) {
                   ctx.error = error_code::syntax_error;
                   return;
@@ -953,7 +953,7 @@ namespace glz
             ++it;
 
             using V = std::decay_t<T>;
-            constexpr auto N = std::tuple_size_v<meta_t<V>>;
+            constexpr auto N = glz::tuple_size_v<meta_t<V>>;
             if (int_from_compressed(ctx, it, end) != N) {
                ctx.error = error_code::syntax_error;
                return;
@@ -979,7 +979,7 @@ namespace glz
             ++it;
 
             using V = std::decay_t<T>;
-            constexpr auto N = std::tuple_size_v<V>;
+            constexpr auto N = glz::tuple_size_v<V>;
             if (int_from_compressed(ctx, it, end) != N) {
                ctx.error = error_code::syntax_error;
                return;

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -137,7 +137,7 @@ namespace glz
          template <auto Opts>
          GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix)
          {
-            static constexpr auto N = std::tuple_size_v<meta_t<T>>;
+            static constexpr auto N = glz::tuple_size_v<meta_t<T>>;
 
             std::array<uint8_t, byte_length<T>()> data{};
 
@@ -537,7 +537,7 @@ namespace glz
          GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
          {
             using V = std::decay_t<decltype(value.value)>;
-            static constexpr auto N = std::tuple_size_v<V> / 2;
+            static constexpr auto N = glz::tuple_size_v<V> / 2;
 
             if constexpr (!Options.opening_handled) {
                constexpr uint8_t type = 0; // string key
@@ -560,10 +560,10 @@ namespace glz
       {
          size_t count{};
          using Tuple = std::decay_t<decltype(std::declval<T>().value)>;
-         for_each<std::tuple_size_v<Tuple>>([&](auto I) constexpr {
-            using Value = std::decay_t<std::tuple_element_t<I, Tuple>>;
+         for_each<glz::tuple_size_v<Tuple>>([&](auto I) constexpr {
+            using Value = std::decay_t<glz::tuple_element_t<I, Tuple>>;
             if constexpr (is_specialization_v<Value, glz::obj> || is_specialization_v<Value, glz::obj_copy>) {
-               count += std::tuple_size_v<decltype(std::declval<Value>().value)> / 2;
+               count += glz::tuple_size_v<decltype(std::declval<Value>().value)> / 2;
             }
             else {
                count += reflection_count<Value>;
@@ -580,7 +580,7 @@ namespace glz
          GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
          {
             using V = std::decay_t<decltype(value.value)>;
-            static constexpr auto N = std::tuple_size_v<V>;
+            static constexpr auto N = glz::tuple_size_v<V>;
 
             constexpr uint8_t type = 0; // string key
             constexpr uint8_t tag = tag::object | type;
@@ -609,7 +609,7 @@ namespace glz
                dump<std::byte(tag::generic_array)>(args...);
 
                using V = std::decay_t<T>;
-               static constexpr auto N = std::tuple_size_v<meta_t<V>>;
+               static constexpr auto N = glz::tuple_size_v<meta_t<V>>;
                dump_compressed_int<N>(args...);
 
                for_each<N>([&](auto I) {
@@ -672,11 +672,11 @@ namespace glz
          {
             dump<std::byte(tag::generic_array)>(args...);
 
-            static constexpr auto N = std::tuple_size_v<meta_t<T>>;
+            static constexpr auto N = glz::tuple_size_v<meta_t<T>>;
             dump_compressed_int<N>(args...);
 
             using V = std::decay_t<T>;
-            for_each<std::tuple_size_v<meta_t<V>>>(
+            for_each<glz::tuple_size_v<meta_t<V>>>(
                [&](auto I) { write<binary>::op<Opts>(get_member(value, glz::get<I>(meta_v<V>)), ctx, args...); });
          }
       };
@@ -690,7 +690,7 @@ namespace glz
          {
             dump<std::byte(tag::generic_array)>(args...);
 
-            static constexpr auto N = std::tuple_size_v<T>;
+            static constexpr auto N = glz::tuple_size_v<T>;
             dump_compressed_int<N>(args...);
 
             if constexpr (is_std_tuple<T>) {
@@ -758,7 +758,7 @@ namespace glz
 
             static constexpr auto sorted = sort_json_ptrs(Partial);
             static constexpr auto groups = glz::group_json_ptrs<sorted>();
-            static constexpr auto N = std::tuple_size_v<std::decay_t<decltype(groups)>>;
+            static constexpr auto N = glz::tuple_size_v<std::decay_t<decltype(groups)>>;
 
             constexpr uint8_t type = 0; // string
             constexpr uint8_t tag = tag::object | type;

--- a/include/glaze/compare/approx.hpp
+++ b/include/glaze/compare/approx.hpp
@@ -13,7 +13,7 @@ namespace glz
       template <detail::glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
-         constexpr auto N = std::tuple_size_v<meta_t<T>>;
+         constexpr auto N = glz::tuple_size_v<meta_t<T>>;
 
          bool equal = true;
          for_each_short_circuit<N>([&](auto I) {

--- a/include/glaze/compare/compare.hpp
+++ b/include/glaze/compare/compare.hpp
@@ -18,7 +18,7 @@ namespace glz
             return lhs == rhs;
          }
          else {
-            constexpr auto N = std::tuple_size_v<meta_t<T>>;
+            constexpr auto N = glz::tuple_size_v<meta_t<T>>;
 
             bool equal = true;
             for_each_short_circuit<N>([&](auto I) {
@@ -41,7 +41,7 @@ namespace glz
       template <detail::glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
-         constexpr auto N = std::tuple_size_v<meta_t<T>>;
+         constexpr auto N = glz::tuple_size_v<meta_t<T>>;
 
          bool less_than = true;
          for_each_short_circuit<N>([&](auto I) {
@@ -63,7 +63,7 @@ namespace glz
       template <detail::glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
-         constexpr auto N = std::tuple_size_v<meta_t<T>>;
+         constexpr auto N = glz::tuple_size_v<meta_t<T>>;
 
          bool less_than = true;
          for_each_short_circuit<N>([&](auto I) {
@@ -85,7 +85,7 @@ namespace glz
       template <detail::glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
-         constexpr auto N = std::tuple_size_v<meta_t<T>>;
+         constexpr auto N = glz::tuple_size_v<meta_t<T>>;
 
          bool greater_than = true;
          for_each_short_circuit<N>([&](auto I) {
@@ -107,7 +107,7 @@ namespace glz
       template <detail::glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
-         constexpr auto N = std::tuple_size_v<meta_t<T>>;
+         constexpr auto N = glz::tuple_size_v<meta_t<T>>;
 
          bool greater_than = true;
          for_each_short_circuit<N>([&](auto I) {

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -398,14 +398,14 @@ namespace glz
       struct tuple_ptr_variant<std::pair<Ts...>> : unique<std::variant<>, std::add_pointer_t<Ts>...>
       {};
 
-      template <class Tuple, class = std::make_index_sequence<std::tuple_size<Tuple>::value>>
+      template <class Tuple, class = std::make_index_sequence<glz::tuple_size<Tuple>::value>>
       struct value_tuple_variant;
 
       template <class Tuple, size_t I>
       struct member_type
       {
-         using T0 = decay_keep_volatile_t<std::tuple_element_t<0, std::tuple_element_t<I, Tuple>>>;
-         using type = std::tuple_element_t<std::is_member_pointer_v<T0> ? 0 : 1, std::tuple_element_t<I, Tuple>>;
+         using T0 = decay_keep_volatile_t<glz::tuple_element_t<0, glz::tuple_element_t<I, Tuple>>>;
+         using type = glz::tuple_element_t<std::is_member_pointer_v<T0> ? 0 : 1, glz::tuple_element_t<I, Tuple>>;
       };
 
       template <class Tuple, size_t... I>
@@ -423,8 +423,8 @@ namespace glz
       {
          return []<size_t... I>(std::index_sequence<I...>) {
             using value_t = typename tuple_variant<meta_t<T>>::type;
-            return std::array<value_t, std::tuple_size_v<meta_t<T>>>{glz::get<I>(meta_v<T>)...};
-         }(std::make_index_sequence<std::tuple_size_v<meta_t<T>>>{});
+            return std::array<value_t, glz::tuple_size_v<meta_t<T>>>{glz::get<I>(meta_v<T>)...};
+         }(std::make_index_sequence<glz::tuple_size_v<meta_t<T>>>{});
       }
 
       template <class Tuple, std::size_t... Is>
@@ -433,7 +433,7 @@ namespace glz
          using value_t = typename tuple_ptr_variant<Tuple>::type;
          using tuple_ref = std::add_lvalue_reference_t<Tuple>;
          using getter_t = value_t (*)(tuple_ref);
-         return std::array<getter_t, std::tuple_size_v<Tuple>>{+[](tuple_ref t) -> value_t {
+         return std::array<getter_t, glz::tuple_size_v<Tuple>>{+[](tuple_ref t) -> value_t {
             if constexpr (is_std_tuple<Tuple>) {
                return &std::get<Is>(t);
             }
@@ -447,7 +447,7 @@ namespace glz
       inline auto get_runtime(Tuple&& t, const size_t index)
       {
          using T = std::decay_t<Tuple>;
-         static constexpr auto indices = std::make_index_sequence<std::tuple_size_v<T>>{};
+         static constexpr auto indices = std::make_index_sequence<glz::tuple_size_v<T>>{};
          static constexpr auto runtime_getter = tuple_runtime_getter<T>(indices);
          return runtime_getter[index](t);
       }
@@ -515,7 +515,7 @@ namespace glz
       constexpr auto make_map_impl(std::index_sequence<I...>)
       {
          using value_t = value_tuple_variant_t<meta_t<T>>;
-         constexpr auto n = std::tuple_size_v<meta_t<T>>;
+         constexpr auto n = glz::tuple_size_v<meta_t<T>>;
 
          if constexpr (n == 0) {
             return nullptr; // Hack to fix MSVC
@@ -570,16 +570,16 @@ namespace glz
          requires(!reflectable<T>)
       constexpr auto make_map()
       {
-         constexpr auto indices = std::make_index_sequence<std::tuple_size_v<meta_t<T>>>{};
+         constexpr auto indices = std::make_index_sequence<glz::tuple_size_v<meta_t<T>>>{};
          return make_map_impl<decay_keep_volatile_t<T>, use_hash_comparison>(indices);
       }
 
       template <class T>
       constexpr auto make_key_int_map()
       {
-         constexpr auto N = std::tuple_size_v<meta_t<T>>;
+         constexpr auto N = glz::tuple_size_v<meta_t<T>>;
          return [&]<size_t... I>(std::index_sequence<I...>) {
-            return normal_map<sv, size_t, std::tuple_size_v<meta_t<T>>>(
+            return normal_map<sv, size_t, glz::tuple_size_v<meta_t<T>>>(
                {std::make_pair<sv, size_t>(get_enum_key<T, I>(), I)...});
          }(std::make_index_sequence<N>{});
       }
@@ -587,7 +587,7 @@ namespace glz
       template <class T>
       constexpr auto make_enum_to_string_map()
       {
-         constexpr auto N = std::tuple_size_v<meta_t<T>>;
+         constexpr auto N = glz::tuple_size_v<meta_t<T>>;
          return [&]<size_t... I>(std::index_sequence<I...>) {
             using key_t = std::underlying_type_t<T>;
             return normal_map<key_t, sv, N>(
@@ -601,13 +601,13 @@ namespace glz
       {
          return []<size_t... I>(std::index_sequence<I...>) {
             return std::array<sv, sizeof...(I)>{get_enum_key<T, I>()...};
-         }(std::make_index_sequence<std::tuple_size_v<meta_t<T>>>{});
+         }(std::make_index_sequence<glz::tuple_size_v<meta_t<T>>>{});
       }
 
       template <class T>
       constexpr auto make_string_to_enum_map() noexcept
       {
-         constexpr auto N = std::tuple_size_v<meta_t<T>>;
+         constexpr auto N = glz::tuple_size_v<meta_t<T>>;
          return [&]<size_t... I>(std::index_sequence<I...>) {
             return normal_map<sv, T, N>({std::pair<sv, T>{get_enum_key<T, I>(), T(get_enum_value<T, I>())}...});
          }(std::make_index_sequence<N>{});
@@ -633,7 +633,7 @@ namespace glz
                res += count_members<V>;
             }
             else {
-               res += std::tuple_size_v<meta_t<V>>;
+               res += glz::tuple_size_v<meta_t<V>>;
             }
          });
          return res;
@@ -651,11 +651,11 @@ namespace glz
          for_each<N>([&](auto I) {
             using V = std::decay_t<std::variant_alternative_t<I, T>>;
             if constexpr (reflectable<V>) {
-               for_each<std::tuple_size_v<decltype(member_names<V>)>>(
+               for_each<glz::tuple_size_v<decltype(member_names<V>)>>(
                   [&](auto J) { (*data_ptr)[index++] = glz::get<J>(member_names<V>); });
             }
             else {
-               for_each<std::tuple_size_v<meta_t<V>>>([&](auto J) {
+               for_each<glz::tuple_size_v<meta_t<V>>>([&](auto J) {
                   constexpr auto item = get<J>(meta_v<V>);
                   using T0 = std::decay_t<decltype(get<0>(item))>;
                   auto key_getter = [&] {
@@ -697,11 +697,11 @@ namespace glz
          for_each<N>([&](auto I) {
             using V = decay_keep_volatile_t<std::variant_alternative_t<I, T>>;
             if constexpr (reflectable<V>) {
-               for_each<std::tuple_size_v<decltype(member_names<V>)>>(
+               for_each<glz::tuple_size_v<decltype(member_names<V>)>>(
                   [&](auto J) { deduction_map.find(get<J>(member_names<V>))->second[I] = true; });
             }
             else {
-               for_each<std::tuple_size_v<meta_t<V>>>([&](auto J) {
+               for_each<glz::tuple_size_v<meta_t<V>>>([&](auto J) {
                   constexpr auto item = get<J>(meta_v<V>);
                   using T0 = std::decay_t<decltype(get<0>(item))>;
                   auto key_getter = [&] {
@@ -776,7 +776,7 @@ namespace glz
       template <class T, class mptr_t>
       using member_t = decltype(get_member(std::declval<T>(), std::declval<std::decay_t<mptr_t>&>()));
 
-      template <class T, class = std::make_index_sequence<std::tuple_size<meta_t<T>>::value>>
+      template <class T, class = std::make_index_sequence<glz::tuple_size<meta_t<T>>::value>>
       struct members_from_meta;
 
       template <class T, size_t... I>
@@ -863,7 +863,7 @@ namespace glz
    template <detail::glaze_flags_t T>
    consteval auto byte_length() noexcept
    {
-      constexpr auto N = std::tuple_size_v<meta_t<T>>;
+      constexpr auto N = glz::tuple_size_v<meta_t<T>>;
 
       if constexpr (N % 8 == 0) {
          return N / 8;
@@ -882,7 +882,7 @@ namespace glz
          return detail::count_members<T>;
       }
       else {
-         return std::tuple_size_v<meta_t<T>>;
+         return glz::tuple_size_v<meta_t<T>>;
       }
    }();
 }
@@ -1026,10 +1026,10 @@ namespace glz::detail
    {
       using V = std::decay_t<T>;
       using Item = std::decay_t<decltype(glz::get<I>(meta_v<V>))>;
-      using T0 = std::decay_t<std::tuple_element_t<0, Item>>;
+      using T0 = std::decay_t<glz::tuple_element_t<0, Item>>;
       static constexpr bool use_reflection = std::is_member_pointer_v<T0>; // for member object reflection
       static constexpr size_t member_index = use_reflection ? 0 : 1;
-      using mptr_t = std::decay_t<std::tuple_element_t<member_index, Item>>;
+      using mptr_t = std::decay_t<glz::tuple_element_t<member_index, Item>>;
       using type = member_t<V, mptr_t>;
    };
 
@@ -1041,7 +1041,7 @@ namespace glz::detail
       static constexpr bool use_reflection = false; // for member object reflection
       static constexpr size_t member_index = 0;
       using Item = decltype(to_tuple(std::declval<T>()));
-      using mptr_t = std::tuple_element_t<I, Item>;
+      using mptr_t = glz::tuple_element_t<I, Item>;
       using type = member_t<V, mptr_t>;
       using T0 = mptr_t;
    };

--- a/include/glaze/ext/cli_menu.hpp
+++ b/include/glaze/ext/cli_menu.hpp
@@ -36,7 +36,7 @@ namespace glz
          }
          else if constexpr (readable_array_t<T> || tuple_t<T> || is_std_tuple<T>) {
             if constexpr (tuple_t<T> || is_std_tuple<T>) {
-               std::printf("json array[%d]>", int(std::tuple_size_v<T>));
+               std::printf("json array[%d]>", int(glz::tuple_size_v<T>));
             }
             else {
                std::printf("json array> ");
@@ -107,9 +107,9 @@ namespace glz
                   }
                   else if constexpr (is_invocable_concrete<std::remove_cvref_t<Func>>) {
                      using Tuple = invocable_args_t<std::remove_cvref_t<Func>>;
-                     using Params = std::tuple_element_t<0, Tuple>;
+                     using Params = glz::tuple_element_t<0, Tuple>;
                      using P = std::decay_t<Params>;
-                     constexpr auto N = std::tuple_size_v<Tuple>;
+                     constexpr auto N = glz::tuple_size_v<Tuple>;
                      static_assert(N == 1, "Only one input is allowed for your function");
                      static thread_local std::array<char, 256> input{};
                      if constexpr (is_help<P>) {

--- a/include/glaze/ext/jsonrpc.hpp
+++ b/include/glaze/ext/jsonrpc.hpp
@@ -514,7 +514,7 @@ namespace glz::rpc
       [[nodiscard]] const auto& get_request_map() const
       {
          constexpr auto idx = detail::index_of_name<decltype(Name), Name, Method...>::index;
-         using method_element = std::tuple_element_t<idx, std::tuple<client_method_t<Method>...>>;
+         using method_element = glz::tuple_element_t<idx, std::tuple<client_method_t<Method>...>>;
          using request_map_t = decltype(method_element().pending_requests);
          return detail::get_request_map<request_map_t, Name>(methods);
       }
@@ -523,7 +523,7 @@ namespace glz::rpc
       [[nodiscard]] auto& get_request_map()
       {
          constexpr auto idx = detail::index_of_name<decltype(Name), Name, Method...>::index;
-         using method_element = std::tuple_element_t<idx, std::tuple<client_method_t<Method>...>>;
+         using method_element = glz::tuple_element_t<idx, std::tuple<client_method_t<Method>...>>;
          using request_map_t = decltype(method_element().pending_requests);
          return detail::get_request_map<request_map_t, Name>(methods);
       }

--- a/include/glaze/json/custom.hpp
+++ b/include/glaze/json/custom.hpp
@@ -45,14 +45,14 @@ namespace glz
                   using Ret = typename return_type<From>::type;
                   if constexpr (std::is_void_v<Ret>) {
                      using Tuple = typename inputs_as_tuple<From>::type;
-                     if constexpr (std::tuple_size_v<Tuple> == 0) {
+                     if constexpr (glz::tuple_size_v<Tuple> == 0) {
                         skip_array<Opts>(ctx, it, end);
                         if (bool(ctx.error)) [[unlikely]]
                            return;
                         (value.val.*(value.from))();
                      }
-                     else if constexpr (std::tuple_size_v<Tuple> == 1) {
-                        std::decay_t<std::tuple_element_t<0, Tuple>> input{};
+                     else if constexpr (glz::tuple_size_v<Tuple> == 1) {
+                        std::decay_t<glz::tuple_element_t<0, Tuple>> input{};
                         read<json>::op<Opts>(input, ctx, it, end);
                         if (bool(ctx.error)) [[unlikely]]
                            return;
@@ -74,14 +74,14 @@ namespace glz
 
                      if constexpr (std::is_void_v<Ret>) {
                         using Tuple = typename function_traits<Func>::arguments;
-                        if constexpr (std::tuple_size_v<Tuple> == 0) {
+                        if constexpr (glz::tuple_size_v<Tuple> == 0) {
                            skip_array<Opts>(ctx, it, end);
                            if (bool(ctx.error)) [[unlikely]]
                               return;
                            from();
                         }
-                        else if constexpr (std::tuple_size_v<Tuple> == 1) {
-                           std::decay_t<std::tuple_element_t<0, Tuple>> input{};
+                        else if constexpr (glz::tuple_size_v<Tuple> == 1) {
+                           std::decay_t<glz::tuple_element_t<0, Tuple>> input{};
                            read<json>::op<Opts>(input, ctx, it, end);
                            if (bool(ctx.error)) [[unlikely]]
                               return;
@@ -108,7 +108,7 @@ namespace glz
                   using Ret = invocable_result_t<From>;
                   if constexpr (std::is_void_v<Ret>) {
                      using Tuple = invocable_args_t<From>;
-                     constexpr auto N = std::tuple_size_v<Tuple>;
+                     constexpr auto N = glz::tuple_size_v<Tuple>;
                      if constexpr (N == 0) {
                         static_assert(false_v<T>, "lambda must take in the class as the first argument");
                      }
@@ -119,7 +119,7 @@ namespace glz
                         value.from(value.val);
                      }
                      else if constexpr (N == 2) {
-                        std::decay_t<std::tuple_element_t<1, Tuple>> input{};
+                        std::decay_t<glz::tuple_element_t<1, Tuple>> input{};
                         read<json>::op<Opts>(input, ctx, it, end);
                         if (bool(ctx.error)) [[unlikely]]
                            return;
@@ -161,7 +161,7 @@ namespace glz
             if constexpr (std::is_member_pointer_v<To>) {
                if constexpr (std::is_member_function_pointer_v<To>) {
                   using Tuple = typename inputs_as_tuple<To>::type;
-                  if constexpr (std::tuple_size_v<Tuple> == 0) {
+                  if constexpr (glz::tuple_size_v<Tuple> == 0) {
                      write<json>::op<Opts>((value.val.*(value.to))(), ctx, args...);
                   }
                   else {
@@ -179,7 +179,7 @@ namespace glz
                      }
                      else {
                         using Tuple = typename function_traits<Func>::arguments;
-                        if constexpr (std::tuple_size_v<Tuple> == 0) {
+                        if constexpr (glz::tuple_size_v<Tuple> == 0) {
                            write<json>::op<Opts>(to(), ctx, args...);
                         }
                         else {

--- a/include/glaze/json/invoke.hpp
+++ b/include/glaze/json/invoke.hpp
@@ -46,7 +46,7 @@ namespace glz
 
                if constexpr (std::is_void_v<Ret>) {
                   using Tuple = typename inputs_as_tuple<M>::type;
-                  if constexpr (std::tuple_size_v<Tuple> == 0) {
+                  if constexpr (glz::tuple_size_v<Tuple> == 0) {
                      skip_array<Opts>(ctx, it, end);
                      if (bool(ctx.error)) [[unlikely]]
                         return;
@@ -71,7 +71,7 @@ namespace glz
 
                if constexpr (std::is_void_v<Ret>) {
                   using Tuple = typename function_traits<V>::arguments;
-                  if constexpr (std::tuple_size_v<Tuple> == 0) {
+                  if constexpr (glz::tuple_size_v<Tuple> == 0) {
                      skip_array<Opts>(ctx, it, end);
                      if (bool(ctx.error)) [[unlikely]]
                         return;
@@ -177,7 +177,7 @@ namespace glz
             using V = std::decay_t<decltype(value.func)>;
 
             using Tuple = typename function_traits<V>::arguments;
-            if constexpr (std::tuple_size_v<Tuple> == 0) {
+            if constexpr (glz::tuple_size_v<Tuple> == 0) {
                auto start = it;
                skip_array<Opts>(ctx, it, end);
                if (bool(ctx.error)) [[unlikely]]

--- a/include/glaze/json/json_ptr.hpp
+++ b/include/glaze/json/json_ptr.hpp
@@ -160,7 +160,7 @@ namespace glz
                member_array[index]);
          }
          else if constexpr (tuple_t<std::decay_t<T>> || is_std_tuple<std::decay_t<T>>) {
-            if (index >= std::tuple_size_v<std::decay_t<T>>) return false;
+            if (index >= glz::tuple_size_v<std::decay_t<T>>) return false;
             auto tuple_element_ptr = get_runtime(value, index);
             return std::visit(
                [&](auto&& element_ptr) { return seek_impl(std::forward<F>(func), *element_ptr, json_ptr); },
@@ -433,7 +433,7 @@ namespace glz
    // input array must be sorted
    inline constexpr auto group_json_ptrs_impl(const auto& arr)
    {
-      constexpr auto N = std::tuple_size_v<std::decay_t<decltype(arr)>>;
+      constexpr auto N = glz::tuple_size_v<std::decay_t<decltype(arr)>>;
 
       std::array<sv, N> first_keys;
       std::transform(arr.begin(), arr.end(), first_keys.begin(), first_key);

--- a/include/glaze/json/ndjson.hpp
+++ b/include/glaze/json/ndjson.hpp
@@ -109,10 +109,10 @@ namespace glz
 
             static constexpr auto N = []() constexpr {
                if constexpr (glaze_array_t<T>) {
-                  return std::tuple_size_v<meta_t<T>>;
+                  return glz::tuple_size_v<meta_t<T>>;
                }
                else {
-                  return std::tuple_size_v<T>;
+                  return glz::tuple_size_v<T>;
                }
             }();
 
@@ -200,10 +200,10 @@ namespace glz
          {
             static constexpr auto N = []() constexpr {
                if constexpr (glaze_array_t<std::decay_t<T>>) {
-                  return std::tuple_size_v<meta_t<std::decay_t<T>>>;
+                  return glz::tuple_size_v<meta_t<std::decay_t<T>>>;
                }
                else {
-                  return std::tuple_size_v<std::decay_t<T>>;
+                  return glz::tuple_size_v<std::decay_t<T>>;
                }
             }();
 
@@ -232,10 +232,10 @@ namespace glz
          {
             static constexpr auto N = []() constexpr {
                if constexpr (glaze_array_t<std::decay_t<T>>) {
-                  return std::tuple_size_v<meta_t<std::decay_t<T>>>;
+                  return glz::tuple_size_v<meta_t<std::decay_t<T>>>;
                }
                else {
-                  return std::tuple_size_v<std::decay_t<T>>;
+                  return glz::tuple_size_v<std::decay_t<T>>;
                }
             }();
 

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -98,8 +98,8 @@ namespace glz
                   using ReturnType = typename return_type<ReaderType>::type;
                   if constexpr (std::is_void_v<ReturnType>) {
                      using TupleType = typename inputs_as_tuple<ReaderType>::type;
-                     if constexpr (std::tuple_size_v<TupleType> == 2) {
-                        std::decay_t<std::tuple_element_t<1, TupleType>> input{};
+                     if constexpr (glz::tuple_size_v<TupleType> == 2) {
+                        std::decay_t<glz::tuple_element_t<1, TupleType>> input{};
                         read<json>::op<Opts>(input, ctx, it, end);
                         if (bool(ctx.error)) [[unlikely]]
                            return;
@@ -1279,10 +1279,10 @@ namespace glz
          {
             static constexpr auto N = []() constexpr {
                if constexpr (glaze_array_t<T>) {
-                  return std::tuple_size_v<meta_t<T>>;
+                  return glz::tuple_size_v<meta_t<T>>;
                }
                else {
-                  return std::tuple_size_v<T>;
+                  return glz::tuple_size_v<T>;
                }
             }();
 
@@ -1430,7 +1430,7 @@ namespace glz
          auto is_unicode = [](const auto c) { return (static_cast<uint8_t>(c) >> 7) > 0; };
 
          bool may_escape = false;
-         constexpr auto N = std::tuple_size_v<meta_t<T>>;
+         constexpr auto N = glz::tuple_size_v<meta_t<T>>;
          for_each<N>([&](auto I) {
             constexpr auto first = get<0>(get<I>(meta_v<T>));
             using T0 = std::decay_t<decltype(first)>;
@@ -2231,12 +2231,12 @@ namespace glz
       struct variant_type_count<std::variant<Ts...>>
       {
          using V = variant_types<std::variant<Ts...>>;
-         static constexpr auto n_bool = std::tuple_size_v<typename V::bool_types>;
-         static constexpr auto n_number = std::tuple_size_v<typename V::number_types>;
-         static constexpr auto n_string = std::tuple_size_v<typename V::string_types>;
-         static constexpr auto n_object = std::tuple_size_v<typename V::object_types>;
-         static constexpr auto n_array = std::tuple_size_v<typename V::array_types>;
-         static constexpr auto n_null = std::tuple_size_v<typename V::nullable_types>;
+         static constexpr auto n_bool = glz::tuple_size_v<typename V::bool_types>;
+         static constexpr auto n_number = glz::tuple_size_v<typename V::number_types>;
+         static constexpr auto n_string = glz::tuple_size_v<typename V::string_types>;
+         static constexpr auto n_object = glz::tuple_size_v<typename V::object_types>;
+         static constexpr auto n_array = glz::tuple_size_v<typename V::array_types>;
+         static constexpr auto n_null = glz::tuple_size_v<typename V::nullable_types>;
       };
 
       template <class Tuple>
@@ -2245,17 +2245,17 @@ namespace glz
          template <auto Options>
          GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
-            if constexpr (std::tuple_size_v<Tuple> < 1) {
+            if constexpr (glz::tuple_size_v<Tuple> < 1) {
                ctx.error = error_code::no_matching_variant_type;
             }
             else {
                using const_glaze_types = typename tuple_types<Tuple>::glaze_const_types;
                bool found_match{};
-               for_each<std::tuple_size_v<const_glaze_types>>([&]([[maybe_unused]] auto I) mutable {
+               for_each<glz::tuple_size_v<const_glaze_types>>([&]([[maybe_unused]] auto I) mutable {
                   if (found_match) {
                      return;
                   }
-                  using V = std::tuple_element_t<I, const_glaze_types>;
+                  using V = glz::tuple_element_t<I, const_glaze_types>;
                   // run time substitute to compare to const value
                   std::remove_const_t<std::remove_pointer_t<std::remove_const_t<meta_wrapper_t<V>>>> substitute{};
                   auto copy_it{it};
@@ -2274,8 +2274,8 @@ namespace glz
                }
 
                using non_const_types = typename tuple_types<Tuple>::glaze_non_const_types;
-               if constexpr (std::tuple_size_v < non_const_types >> 0) {
-                  using V = std::tuple_element_t<0, non_const_types>;
+               if constexpr (glz::tuple_size_v < non_const_types >> 0) {
+                  using V = glz::tuple_element_t<0, non_const_types>;
                   if (!std::holds_alternative<V>(value)) value = V{};
                   read<json>::op<ws_handled<Options>()>(std::get<V>(value), ctx, it, end);
                }
@@ -2307,12 +2307,12 @@ namespace glz
                case '{':
                   ++it;
                   using object_types = typename variant_types<T>::object_types;
-                  if constexpr (std::tuple_size_v<object_types> < 1) {
+                  if constexpr (glz::tuple_size_v<object_types> < 1) {
                      ctx.error = error_code::no_matching_variant_type;
                      return;
                   }
-                  else if constexpr (std::tuple_size_v<object_types> == 1) {
-                     using V = std::tuple_element_t<0, object_types>;
+                  else if constexpr (glz::tuple_size_v<object_types> == 1) {
+                     using V = glz::tuple_element_t<0, object_types>;
                      if (!std::holds_alternative<V>(value)) value = V{};
                      read<json>::op<opening_handled<Opts>()>(std::get<V>(value), ctx, it, end);
                      return;
@@ -2477,11 +2477,11 @@ namespace glz
                }
                case 'n':
                   using nullable_types = typename variant_types<T>::nullable_types;
-                  if constexpr (std::tuple_size_v<nullable_types> < 1) {
+                  if constexpr (glz::tuple_size_v<nullable_types> < 1) {
                      ctx.error = error_code::no_matching_variant_type;
                   }
                   else {
-                     using V = std::tuple_element_t<0, nullable_types>;
+                     using V = glz::tuple_element_t<0, nullable_types>;
                      if (!std::holds_alternative<V>(value)) value = V{};
                      match<"null", Opts>(ctx, it, end);
                   }

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -149,7 +149,7 @@ namespace glz
          auto schema_instance = json_schema_v<T>;
          auto tuple = to_tuple(schema_instance);
          using V = std::decay_t<decltype(tuple)>;
-         constexpr auto N = std::tuple_size_v<V>;
+         constexpr auto N = glz::tuple_size_v<V>;
          if constexpr (N > 0) {
             constexpr auto& names = member_names<json_schema_type<T>>;
             return [&]<size_t... I>(std::index_sequence<I...>) {
@@ -230,7 +230,7 @@ namespace glz
 
             // TODO use oneOf instead of enum to handle doc comments
             using V = std::decay_t<T>;
-            static constexpr auto N = std::tuple_size_v<meta_t<V>>;
+            static constexpr auto N = glz::tuple_size_v<meta_t<V>>;
             // s.enumeration = std::vector<std::string_view>(N);
             // for_each<N>([&](auto I) {
             //    static constexpr auto item = std::get<I>(meta_v<V>);
@@ -244,7 +244,7 @@ namespace glz
                enumeration.constant = get_enum_key<V, I>();
                static constexpr size_t member_index = std::is_enum_v<T0> ? 0 : 1;
                static constexpr size_t comment_index = member_index + 1;
-               constexpr auto Size = std::tuple_size_v<decltype(item)>;
+               constexpr auto Size = glz::tuple_size_v<decltype(item)>;
                if constexpr (Size > comment_index) {
                   enumeration.description = get<comment_index>(item);
                }
@@ -284,7 +284,7 @@ namespace glz
          template <auto Opts>
          static void op(auto& s, auto& defs) noexcept
          {
-            using V = std::decay_t<std::tuple_element_t<1, range_value_t<std::decay_t<T>>>>;
+            using V = std::decay_t<glz::tuple_element_t<1, range_value_t<std::decay_t<T>>>>;
             s.type = {"object"};
             auto& def = defs[name_v<V>];
             if (!def.type) {
@@ -459,7 +459,7 @@ namespace glz
                }
 
                static constexpr size_t comment_index = member_index + 1;
-               static constexpr auto Size = std::tuple_size_v<typename Element::Item>;
+               static constexpr auto Size = glz::tuple_size_v<typename Element::Item>;
 
                if constexpr (Size > comment_index && glaze_object_t<T>) {
                   static constexpr auto item = glz::get<I>(meta_v<V>);

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -65,7 +65,7 @@ namespace glz
          template <auto Opts>
          GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix) noexcept
          {
-            static constexpr auto N = std::tuple_size_v<meta_t<T>>;
+            static constexpr auto N = glz::tuple_size_v<meta_t<T>>;
 
             dump<'['>(b, ix);
 
@@ -749,7 +749,7 @@ namespace glz
                   using V = std::decay_t<decltype(val)>;
 
                   if constexpr (Opts.write_type_info && !tag_v<T>.empty() && glaze_object_t<V>) {
-                     constexpr auto num_members = std::tuple_size_v<meta_t<V>>;
+                     constexpr auto num_members = glz::tuple_size_v<meta_t<V>>;
 
                      // must first write out type
                      if constexpr (Opts.prettify) {
@@ -828,7 +828,7 @@ namespace glz
          GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
          {
             using V = std::decay_t<decltype(value.value)>;
-            static constexpr auto N = std::tuple_size_v<V>;
+            static constexpr auto N = glz::tuple_size_v<V>;
 
             dump<'['>(args...);
             if constexpr (N > 0 && Opts.prettify) {
@@ -866,10 +866,10 @@ namespace glz
          {
             static constexpr auto N = []() constexpr {
                if constexpr (glaze_array_t<std::decay_t<T>>) {
-                  return std::tuple_size_v<meta_t<std::decay_t<T>>>;
+                  return glz::tuple_size_v<meta_t<std::decay_t<T>>>;
                }
                else {
-                  return std::tuple_size_v<std::decay_t<T>>;
+                  return glz::tuple_size_v<std::decay_t<T>>;
                }
             }();
 
@@ -918,10 +918,10 @@ namespace glz
          {
             static constexpr auto N = []() constexpr {
                if constexpr (glaze_array_t<std::decay_t<T>>) {
-                  return std::tuple_size_v<meta_t<std::decay_t<T>>>;
+                  return glz::tuple_size_v<meta_t<std::decay_t<T>>>;
                }
                else {
-                  return std::tuple_size_v<std::decay_t<T>>;
+                  return glz::tuple_size_v<std::decay_t<T>>;
                }
             }();
 
@@ -989,7 +989,7 @@ namespace glz
             }
 
             using V = std::decay_t<decltype(value.value)>;
-            static constexpr auto N = std::tuple_size_v<V> / 2;
+            static constexpr auto N = glz::tuple_size_v<V> / 2;
 
             bool first = true;
             for_each<N>([&](auto I) {
@@ -1015,7 +1015,7 @@ namespace glz
                      write_entry_separator<Opts>(ctx, b, ix);
                   }
 
-                  using Key = typename std::decay_t<std::tuple_element_t<2 * I, V>>;
+                  using Key = typename std::decay_t<glz::tuple_element_t<2 * I, V>>;
 
                   if constexpr (str_t<Key> || char_t<Key>) {
                      const sv key = glz::get<2 * I>(value.value);
@@ -1063,7 +1063,7 @@ namespace glz
             }
 
             using V = std::decay_t<decltype(value.value)>;
-            static constexpr auto N = std::tuple_size_v<V>;
+            static constexpr auto N = glz::tuple_size_v<V>;
 
             for_each<N>([&](auto I) {
                write<json>::op<opening_and_closing_handled<Options>()>(glz::get<I>(value.value), ctx, b, ix);
@@ -1227,7 +1227,7 @@ namespace glz
                   write<json>::op<Opts>(get_member(value, member), ctx, b, ix);
 
                   static constexpr size_t comment_index = member_index + 1;
-                  static constexpr auto S = std::tuple_size_v<typename Element::Item>;
+                  static constexpr auto S = glz::tuple_size_v<typename Element::Item>;
                   if constexpr (Opts.comments && S > comment_index) {
                      static constexpr auto i = glz::get<I>(meta_v<std::decay_t<T>>);
                      if constexpr (std::is_convertible_v<decltype(get<comment_index>(i)), sv>) {
@@ -1306,7 +1306,7 @@ namespace glz
 
             static constexpr auto sorted = sort_json_ptrs(Partial);
             static constexpr auto groups = glz::group_json_ptrs<sorted>();
-            static constexpr auto N = std::tuple_size_v<std::decay_t<decltype(groups)>>;
+            static constexpr auto N = glz::tuple_size_v<std::decay_t<decltype(groups)>>;
 
             static constexpr auto num_members = reflection_count<T>;
 

--- a/include/glaze/reflection/reflect.hpp
+++ b/include/glaze/reflection/reflect.hpp
@@ -35,7 +35,7 @@ namespace glz
       constexpr auto make_reflection_map_impl(std::index_sequence<I...>)
       {
          using V = decltype(to_tuple(std::declval<T>()));
-         constexpr auto n = std::tuple_size_v<V>;
+         constexpr auto n = glz::tuple_size_v<V>;
          constexpr auto members = member_names<T>;
          static_assert(members.size() == n);
 
@@ -47,11 +47,11 @@ namespace glz
          }
          else if constexpr (n == 1) {
             return micro_map1<value_t, named_member<T, I>::value...>{
-               std::pair<sv, value_t>{get<I>(members), std::add_pointer_t<std::tuple_element_t<I, V>>{}}...};
+               std::pair<sv, value_t>{get<I>(members), std::add_pointer_t<glz::tuple_element_t<I, V>>{}}...};
          }
          else if constexpr (n == 2) {
             return micro_map2<value_t, named_member<T, I>::value...>{
-               std::pair<sv, value_t>{get<I>(members), std::add_pointer_t<std::tuple_element_t<I, V>>{}}...};
+               std::pair<sv, value_t>{get<I>(members), std::add_pointer_t<glz::tuple_element_t<I, V>>{}}...};
          }
          else if constexpr (n < 64) // don't even attempt a first character hash if we have too many keys
          {
@@ -60,7 +60,7 @@ namespace glz
 
             if constexpr (front_desc.valid) {
                return make_single_char_map<value_t, front_desc>(
-                  {{get<I>(members), std::add_pointer_t<std::tuple_element_t<I, V>>{}}...});
+                  {{get<I>(members), std::add_pointer_t<glz::tuple_element_t<I, V>>{}}...});
             }
             else {
                constexpr single_char_hash_opts rear_hash{.is_front_hash = false};
@@ -68,7 +68,7 @@ namespace glz
 
                if constexpr (back_desc.valid) {
                   return make_single_char_map<value_t, back_desc>(
-                     {{get<I>(members), std::add_pointer_t<std::tuple_element_t<I, V>>{}}...});
+                     {{get<I>(members), std::add_pointer_t<glz::tuple_element_t<I, V>>{}}...});
                }
                else {
                   constexpr single_char_hash_opts sum_hash{.is_front_hash = true, .is_sum_hash = true};
@@ -76,17 +76,17 @@ namespace glz
 
                   if constexpr (sum_desc.valid) {
                      return make_single_char_map<value_t, sum_desc>(
-                        {{get<I>(members), std::add_pointer_t<std::tuple_element_t<I, V>>{}}...});
+                        {{get<I>(members), std::add_pointer_t<glz::tuple_element_t<I, V>>{}}...});
                   }
                   else {
                      if constexpr (n <= naive_map_max_size) {
                         constexpr auto naive_desc = naive_map_hash<use_hash_comparison, n>(keys);
                         return glz::detail::make_naive_map<value_t, naive_desc>({std::pair<sv, value_t>{
-                           get<I>(members), std::add_pointer_t<std::tuple_element_t<I, V>>{}}...});
+                           get<I>(members), std::add_pointer_t<glz::tuple_element_t<I, V>>{}}...});
                      }
                      else {
                         return glz::detail::normal_map<sv, value_t, n, use_hash_comparison>({std::pair<sv, value_t>{
-                           get<I>(members), std::add_pointer_t<std::tuple_element_t<I, V>>{}}...});
+                           get<I>(members), std::add_pointer_t<glz::tuple_element_t<I, V>>{}}...});
                      }
                   }
                }
@@ -94,7 +94,7 @@ namespace glz
          }
          else {
             return glz::detail::normal_map<sv, value_t, n, use_hash_comparison>(
-               {std::pair<sv, value_t>{get<I>(members), std::add_pointer_t<std::tuple_element_t<I, V>>{}}...});
+               {std::pair<sv, value_t>{get<I>(members), std::add_pointer_t<glz::tuple_element_t<I, V>>{}}...});
          }
       }
 

--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -376,10 +376,10 @@ namespace glz::repe
             }
             else if constexpr (is_invocable_concrete<std::remove_cvref_t<Func>>) {
                using Tuple = invocable_args_t<std::remove_cvref_t<Func>>;
-               constexpr auto N = std::tuple_size_v<Tuple>;
+               constexpr auto N = glz::tuple_size_v<Tuple>;
                static_assert(N == 1, "Only one input is allowed for your function");
 
-               using Params = std::tuple_element_t<0, Tuple>;
+               using Params = glz::tuple_element_t<0, Tuple>;
                using Result = std::invoke_result_t<Func, Params>;
 
                methods[full_key] = [this, params = std::decay_t<Params>{}, result = std::decay_t<Result>{},
@@ -446,7 +446,7 @@ namespace glz::repe
                   using F = std::decay_t<Func>;
                   using Ret = typename return_type<F>::type;
                   using Tuple = typename inputs_as_tuple<F>::type;
-                  constexpr auto n_args = std::tuple_size_v<Tuple>;
+                  constexpr auto n_args = glz::tuple_size_v<Tuple>;
                   if constexpr (std::is_void_v<Ret>) {
                      if constexpr (n_args == 0) {
                         methods[full_key] = [&value, &func](repe::state&& state) {
@@ -461,7 +461,7 @@ namespace glz::repe
                         };
                      }
                      else if constexpr (n_args == 1) {
-                        using Input = std::decay_t<std::tuple_element_t<0, Tuple>>;
+                        using Input = std::decay_t<glz::tuple_element_t<0, Tuple>>;
                         methods[full_key] = [this, &value, &func, input = Input{}](repe::state&& state) mutable {
                            if (!(state.header.action & empty)) {
                               if (read_params<Opts>(input, state, response) == 0) {
@@ -502,7 +502,7 @@ namespace glz::repe
                         };
                      }
                      else if constexpr (n_args == 1) {
-                        using Input = std::decay_t<std::tuple_element_t<0, Tuple>>;
+                        using Input = std::decay_t<glz::tuple_element_t<0, Tuple>>;
                         methods[full_key] = [this, &value, &func, input = Input{}](repe::state&& state) mutable {
                            if (!(state.header.action & empty)) {
                               if (read_params<Opts>(input, state, response) == 0) {

--- a/include/glaze/tuplet/tuple.hpp
+++ b/include/glaze/tuplet/tuple.hpp
@@ -612,10 +612,20 @@ namespace glz
    } // namespace tuplet
 } // namespace glz
 
-// std::tuple_size specialization
-// std::tuple_element specialization
-namespace std
+namespace glz
 {
+   template <class... T>
+   struct tuple_size;
+   
+   template <class T>
+   constexpr size_t tuple_size_v = tuple_size<T>::value;
+   
+   template <size_t I, class... T>
+   struct tuple_element;
+   
+   template <size_t I, class Tuple>
+   using tuple_element_t = typename tuple_element<I, Tuple>::type;
+   
    template <class... T>
    struct tuple_size<glz::tuplet::tuple<T...>> : std::integral_constant<size_t, sizeof...(T)>
    {};
@@ -625,6 +635,7 @@ namespace std
    {
       using type = decltype(glz::tuplet::tuple<T...>::decl_elem(glz::tuplet::tag<I>()));
    };
+   
    template <class A, class B>
    struct tuple_size<glz::tuplet::pair<A, B>> : std::integral_constant<size_t, 2>
    {};
@@ -635,4 +646,4 @@ namespace std
       static_assert(I < 2, "tuplet::pair only has 2 elements");
       using type = std::conditional_t<I == 0, A, B>;
    };
-} // namespace std
+}

--- a/include/glaze/tuplet/tuple.hpp
+++ b/include/glaze/tuplet/tuple.hpp
@@ -612,19 +612,42 @@ namespace glz
    } // namespace tuplet
 } // namespace glz
 
+#include <array>
+#include <tuple>
+
 namespace glz
 {
    template <class... T>
    struct tuple_size;
    
    template <class T>
-   constexpr size_t tuple_size_v = tuple_size<T>::value;
+   constexpr size_t tuple_size_v = tuple_size<std::remove_const_t<T>>::value;
+   
+   template <class T, size_t N>
+   struct tuple_size<std::array<T, N>> {
+       static constexpr size_t value = N;
+   };
+   
+   template <class... Types>
+   struct tuple_size<std::tuple<Types...>> {
+       static constexpr size_t value = sizeof...(Types);
+   };
    
    template <size_t I, class... T>
    struct tuple_element;
    
    template <size_t I, class Tuple>
    using tuple_element_t = typename tuple_element<I, Tuple>::type;
+   
+   template <size_t I, class... T>
+   struct tuple_element<I, std::tuple<T...>> {
+       using type = typename std::tuple_element<I, std::tuple<T...>>::type;
+   };
+   
+   template <std::size_t I, typename T1, typename T2>
+   struct tuple_element<I, std::pair<T1, T2>> {
+       using type = typename std::conditional<I == 0, T1, T2>::type;
+   };
    
    template <class... T>
    struct tuple_size<glz::tuplet::tuple<T...>> : std::integral_constant<size_t, sizeof...(T)>

--- a/include/glaze/util/poly.hpp
+++ b/include/glaze/util/poly.hpp
@@ -25,7 +25,7 @@ namespace glz
    template <class Spec, size_t... I>
    inline constexpr auto make_mem_fn_wrapper_map_impl(std::index_sequence<I...>)
    {
-      constexpr auto N = std::tuple_size_v<meta_t<Spec>>;
+      constexpr auto N = glz::tuple_size_v<meta_t<Spec>>;
       return detail::normal_map<sv, fn_variant<Spec>, N>({std::make_pair<sv, fn_variant<Spec>>(
          sv(get<0>(get<I>(meta_v<Spec>))), get_argument<get<1>(get<I>(meta_v<Spec>))>())...});
    }
@@ -33,7 +33,7 @@ namespace glz
    template <class Spec>
    inline constexpr auto make_mem_fn_wrapper_map()
    {
-      constexpr auto N = std::tuple_size_v<meta_t<Spec>>;
+      constexpr auto N = glz::tuple_size_v<meta_t<Spec>>;
       return make_mem_fn_wrapper_map_impl<Spec>(std::make_index_sequence<N>{});
    }
 
@@ -73,7 +73,7 @@ namespace glz
       {
          raw_ptr = anything.data();
 
-         static constexpr auto N = std::tuple_size_v<meta_t<Spec>>;
+         static constexpr auto N = glz::tuple_size_v<meta_t<Spec>>;
          static constexpr auto frozen_map = detail::make_map<std::remove_pointer_t<T>, false>();
 
          for_each_poly<N>([&](auto I) {

--- a/include/glaze/util/tuple.hpp
+++ b/include/glaze/util/tuple.hpp
@@ -15,10 +15,10 @@ namespace glz
    template <class T>
    concept is_std_tuple = is_specialization_v<T, std::tuple>;
 
-   inline constexpr auto size_impl(auto&& t) { return std::tuple_size_v<std::decay_t<decltype(t)>>; }
+   inline constexpr auto size_impl(auto&& t) { return glz::tuple_size_v<std::decay_t<decltype(t)>>; }
 
    template <class T>
-   inline constexpr size_t size_v = std::tuple_size_v<std::decay_t<T>>;
+   inline constexpr size_t size_v = glz::tuple_size_v<std::decay_t<T>>;
 
    namespace detail
    {
@@ -32,7 +32,7 @@ namespace glz
    template <class Tuple, std::size_t... Is>
    auto tuple_split(Tuple&& tuple)
    {
-      static constexpr auto N = std::tuple_size_v<Tuple>;
+      static constexpr auto N = glz::tuple_size_v<Tuple>;
       static constexpr auto is = std::make_index_sequence<N / 2>{};
       return std::make_pair(detail::tuple_split_impl<0>(tuple, is), detail::tuple_split_impl<1>(tuple, is));
    }
@@ -106,7 +106,7 @@ namespace glz
    template <class Func, class Tuple>
    inline constexpr auto map_tuple(Func&& f, Tuple&& tuple)
    {
-      constexpr auto N = std::tuple_size_v<std::decay_t<Tuple>>;
+      constexpr auto N = glz::tuple_size_v<std::decay_t<Tuple>>;
       return detail::map_tuple(f, tuple, std::make_index_sequence<N>{});
    }
 

--- a/include/glaze/util/tuple.hpp
+++ b/include/glaze/util/tuple.hpp
@@ -57,16 +57,16 @@ namespace glz
    template <class Tuple>
    constexpr auto filter()
    {
-      constexpr auto n = std::tuple_size_v<Tuple>;
+      constexpr auto n = glz::tuple_size_v<Tuple>;
       std::array<uint64_t, n> indices{};
       size_t i = 0;
       for_each<n>([&](auto I) {
-         using V = std::decay_t<std::tuple_element_t<I, Tuple>>;
+         using V = std::decay_t<glz::tuple_element_t<I, Tuple>>;
          if constexpr (std::is_member_pointer_v<V>) {
             if constexpr (I == 0) {
                indices[i++] = 0;
             }
-            else if constexpr (std::convertible_to<std::tuple_element_t<I - 1, Tuple>, std::string_view>) {
+            else if constexpr (std::convertible_to<glz::tuple_element_t<I - 1, Tuple>, std::string_view>) {
                // If the previous element in the tuple is convertible to a std::string_view, then we treat it as the key
                indices[i++] = I - 1;
             }
@@ -78,7 +78,7 @@ namespace glz
             if constexpr (I == 0) {
                indices[i++] = 0;
             }
-            else if constexpr (std::convertible_to<std::tuple_element_t<I - 1, Tuple>, std::string_view>) {
+            else if constexpr (std::convertible_to<glz::tuple_element_t<I - 1, Tuple>, std::string_view>) {
                // If the previous element in the tuple is convertible to a std::string_view, then we treat it as the key
                indices[i++] = I - 1;
             }
@@ -152,7 +152,7 @@ namespace glz
    template <class Tuple>
    constexpr auto make_groups_helper()
    {
-      constexpr auto N = std::tuple_size_v<Tuple>;
+      constexpr auto N = glz::tuple_size_v<Tuple>;
 
       constexpr auto filtered = filter<Tuple>();
       constexpr auto starts = shrink_index_array<filtered.second>(filtered.first);

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -529,7 +529,7 @@ void test_partial()
 
    static constexpr auto groups = glz::group_json_ptrs<sorted>();
 
-   static constexpr auto N = std::tuple_size_v<decltype(groups)>;
+   static constexpr auto N = glz::tuple_size_v<decltype(groups)>;
    glz::for_each<N>([&](auto I) {
       const auto group = glz::get<I>(groups);
       std::cout << std::get<0>(group) << ": ";

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -5508,7 +5508,7 @@ suite write_to_map = [] {
       std::map<std::string, glz::raw_json> map;
       glz::obj obj{"arr", glz::arr{1, 2, 3}, "hello", "world"};
       using T = std::decay_t<decltype(obj.value)>;
-      glz::for_each<std::tuple_size_v<T>>([&](auto I) {
+      glz::for_each<glz::tuple_size_v<T>>([&](auto I) {
          if constexpr (I % 2 == 0) {
             map[std::string(glz::get<I>(obj.value))] = glz::write_json(glz::get<I + 1>(obj.value));
          }


### PR DESCRIPTION
Current C++20 module implementations can struggle exporting specializations in the `std` namespace. This updates the codebase to define a set of `glz` specializations for tuple_size_v and tuple_element_t

This is associated with #858 