### PR TITLE
Compile time minified option

### DIFF
--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -34,6 +34,7 @@ namespace glz
       bool skip_null_members = true; // Skip writing out params in an object if the value is null
       bool use_hash_comparison = true; // Will replace some string equality checks with hash checks
       bool prettify = false; // Write out prettified JSON
+      bool minified = false; // Require minified input for JSON, which results in faster read performance
       char indentation_char = ' '; // Prettified JSON indentation char
       uint8_t indentation_width = 3; // Prettified JSON indentation size
       bool new_lines_in_arrays = true; // Whether prettified arrays should have new lines for each element

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -510,22 +510,25 @@ namespace glz::detail
    template <opts Opts>
    GLZ_ALWAYS_INLINE void skip_ws_no_pre_check(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
-      if constexpr (!Opts.force_conformance) {
-         while (whitespace_comment_table[*it]) {
-            if (*it == '/') [[unlikely]] {
-               skip_comment(ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]] {
-                  return;
+      if constexpr (!Opts.minified)
+      {
+         if constexpr (!Opts.force_conformance) {
+            while (whitespace_comment_table[*it]) {
+               if (*it == '/') [[unlikely]] {
+                  skip_comment(ctx, it, end);
+                  if (bool(ctx.error)) [[unlikely]] {
+                     return;
+                  }
+               }
+               else [[likely]] {
+                  ++it;
                }
             }
-            else [[likely]] {
+         }
+         else {
+            while (whitespace_table[*it]) {
                ++it;
             }
-         }
-      }
-      else {
-         while (whitespace_table[*it]) {
-            ++it;
          }
       }
    }
@@ -533,9 +536,12 @@ namespace glz::detail
    template <opts Opts>
    GLZ_ALWAYS_INLINE void skip_ws(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
-      if (bool(ctx.error)) [[unlikely]]
-         return;
-      skip_ws_no_pre_check<Opts>(ctx, it, end);
+      if constexpr (!Opts.minified)
+      {
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+         skip_ws_no_pre_check<Opts>(ctx, it, end);
+      }
    }
 
    GLZ_ALWAYS_INLINE void skip_matching_ws(const auto* ws, auto&& it, uint64_t length) noexcept

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -1102,6 +1102,7 @@ suite user_types = [] {
       const auto minified = glz::minify_jsonc(thing_pretty);
       expect(json == minified);
       expect(!glz::read_json(obj, minified));
+      expect(!glz::read<glz::opts{.minified = true}>(obj, minified));
    };
 
    "complex user obect roundtrip"_test = [] {
@@ -1312,7 +1313,16 @@ suite minified_custom_object = [] {
       std::string buffer = glz::write_json(obj);
       std::string prettified = glz::prettify_json(buffer);
       std::string minified = glz::minify_json(prettified);
-      expect(glz::read_json(obj, minified) == glz::error_code::none);
+      expect(!glz::read_json(obj, minified));
+      expect(buffer == minified);
+   };
+   
+   "minified compile time option"_test = [] {
+      Thing obj{};
+      std::string buffer = glz::write_json(obj);
+      std::string prettified = glz::prettify_json(buffer);
+      std::string minified = glz::minify_json(prettified);
+      expect(!glz::read<glz::opts{.minified = true}>(obj, minified));
       expect(buffer == minified);
    };
 };

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -999,7 +999,10 @@ suite user_types = [] {
 })";
       expect(thing_pretty == buffer);
 
-      expect(json == glz::minify_json(thing_pretty));
+      const auto minified = glz::minify_json(thing_pretty);
+      expect(json == minified);
+      const auto ec = glz::read<glz::opts{.minified = true}>(obj, minified);
+      expect(!ec) << glz::format_error(ec, minified);
    };
 
    "complex user obect prettify_jsonc/minify_jsonc"_test = [] {
@@ -1102,7 +1105,6 @@ suite user_types = [] {
       const auto minified = glz::minify_jsonc(thing_pretty);
       expect(json == minified);
       expect(!glz::read_json(obj, minified));
-      expect(!glz::read<glz::opts{.minified = true}>(obj, minified));
    };
 
    "complex user obect roundtrip"_test = [] {


### PR DESCRIPTION
This adds a compile time option for when a JSON read call will always get minified data or the user wants to require minified data. This improves read performance when minified data is guaranteed.

```c++
auto ec = glz::read<glz::opts{.minified}>(...);
```