### PR TITLE
Fix MSVC warning for json_test and implicit conversion

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -3,14 +3,14 @@ name: msvc
 on:
   push:
     branches:
-    - main
-    - feature/*
+      - main
+      - 'feature/*'
     paths-ignore:
-    - '**.md'
+      - '**.md'
   pull_request:
     branches: [main]
     paths-ignore:
-    - '**.md'
+      - '**.md'
   workflow_dispatch:
 
 env:
@@ -22,11 +22,15 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 5
 
+    strategy:
+      matrix:
+        cpp_version: [20, 23]
+
     steps:
     - uses: actions/checkout@v4
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_STANDARD=${{matrix.cpp_version}}
 
     - name: Build
       run: cmake --build build --config ${{env.BUILD_TYPE}} --parallel

--- a/include/glaze/util/dtoa.hpp
+++ b/include/glaze/util/dtoa.hpp
@@ -886,7 +886,7 @@ namespace glz
     These digits are named as "aabbccddeeffgghhii" here.
     For example, input 1234567890123000, output "1234567890123".
     */
-   inline char* write_u64_len_15_to_17_trim(char* buf, uint64_t sig) noexcept
+   inline auto* write_u64_len_15_to_17_trim(auto* buf, uint64_t sig) noexcept
    {
       uint32_t tz1, tz2, tz; /* trailing zero */
 
@@ -970,7 +970,7 @@ namespace glz
    consteval uint32_t numbits(uint32_t x) noexcept { return x < 2 ? x : 1 + numbits(x >> 1); }
 
    template <std::floating_point T>
-   inline char* to_chars(char* buffer, T val) noexcept
+   inline auto* to_chars(auto* buffer, T val) noexcept
    {
       static_assert(std::numeric_limits<T>::is_iec559);
       static_assert(std::numeric_limits<T>::radix == 2);

--- a/include/glaze/util/itoa.hpp
+++ b/include/glaze/util/itoa.hpp
@@ -139,7 +139,9 @@ namespace glz
       return to_chars(buf + (x < 0), uint32_t(x ^ (x >> 31)) - (x >> 31));
    }
 
-   GLZ_ALWAYS_INLINE auto* to_chars_u64_len_8(auto* buf, uint32_t val) noexcept
+   template <class T>
+      requires (std::same_as<std::remove_cvref_t<T>, uint32_t>)
+   GLZ_ALWAYS_INLINE auto* to_chars_u64_len_8(auto* buf, T val) noexcept
    {
       /* 8 digits: aabbccdd */
       const uint32_t aabb = uint32_t((uint64_t(val) * 109951163) >> 40); /* (val / 10000) */
@@ -155,7 +157,9 @@ namespace glz
       return buf + 8;
    }
 
-   GLZ_ALWAYS_INLINE auto* to_chars_u64_len_4(auto* buf, uint32_t val) noexcept
+   template <class T>
+      requires (std::same_as<std::remove_cvref_t<T>, uint32_t>)
+   GLZ_ALWAYS_INLINE auto* to_chars_u64_len_4(auto* buf, T val) noexcept
    {
       /* 4 digits: aabb */
       const uint32_t aa = (val * 5243) >> 19; /* (val / 100) */
@@ -165,7 +169,9 @@ namespace glz
       return buf + 4;
    }
 
-   inline auto* to_chars_u64_len_1_8(auto* buf, uint32_t val) noexcept
+   template <class T>
+      requires (std::same_as<std::remove_cvref_t<T>, uint32_t>)
+   inline auto* to_chars_u64_len_1_8(auto* buf, T val) noexcept
    {
       uint32_t aa, bb, cc, dd, aabb, bbcc, ccdd, lz;
 
@@ -214,7 +220,9 @@ namespace glz
       }
    }
 
-   inline auto* to_chars_u64_len_5_8(auto* buf, uint32_t val) noexcept
+   template <class T>
+      requires (std::same_as<std::remove_cvref_t<T>, uint32_t>)
+   inline auto* to_chars_u64_len_5_8(auto* buf, T val) noexcept
    {
       if (val < 1000000) { /* 5-6 digits: aabbcc */
          const uint32_t aa = uint32_t((uint64_t(val) * 429497) >> 32); /* (val / 10000) */
@@ -246,7 +254,9 @@ namespace glz
       }
    }
 
-   inline auto* to_chars(auto* buf, uint64_t val) noexcept
+   template <class T>
+      requires (std::same_as<std::remove_cvref_t<T>, uint64_t>)
+   inline auto* to_chars(auto* buf, T val) noexcept
    {
       if (val < 100000000) { /* 1-8 digits */
          buf = to_chars_u64_len_1_8(buf, uint32_t(val));

--- a/tests/asio_repe/client/repe_client.cpp
+++ b/tests/asio_repe/client/repe_client.cpp
@@ -38,8 +38,8 @@ void asio_client_test()
             }
 
             int sum{};
-            if (auto ec = client.call({"/sum"}, data, sum); ec) {
-               std::cerr << glz::write_json(ec) << '\n';
+            if (auto e_call = client.call({"/sum"}, data, sum); e_call) {
+               std::cerr << glz::write_json(e_call) << '\n';
             }
             else {
                std::cout << "i: " << i << ", " << sum << '\n';

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -7837,7 +7837,7 @@ struct glz::meta<Address>
    static constexpr auto value = [](Address& self) -> FixedName<10> {
       FixedName<10> val;
       std::memcpy(val.buf.data(), self.test.data(), self.test.size() + 1);
-      val.len = self.test.size();
+      val.len = uint16_t(self.test.size());
       return val;
    };
 };


### PR DESCRIPTION
- This fixes #1007 fully, as I had not realized an implicit conversion was created from float to an integer
- Now writing numbers are blocked from implicit conversions