### PR TITLE
Cleanup of dump.hpp

### DIFF
--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -523,7 +523,7 @@ namespace glz
                write<binary>::op<Opts>(*value, ctx, args...);
             }
             else {
-               dump<std::byte(tag::null)>(args...);
+               dump<tag::null>(args...);
             }
          }
       };
@@ -605,7 +605,7 @@ namespace glz
                write<binary>::op<Opts>(t, ctx, args...);
             }
             else {
-               dump<std::byte(tag::generic_array)>(args...);
+               dump<tag::generic_array>(args...);
 
                using V = std::decay_t<T>;
                static constexpr auto N = glz::tuple_size_v<meta_t<V>>;
@@ -669,7 +669,7 @@ namespace glz
          template <auto Opts, class... Args>
          GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
          {
-            dump<std::byte(tag::generic_array)>(args...);
+            dump<tag::generic_array>(args...);
 
             static constexpr auto N = glz::tuple_size_v<meta_t<T>>;
             dump_compressed_int<N>(args...);
@@ -687,7 +687,7 @@ namespace glz
          template <auto Opts, class... Args>
          GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
          {
-            dump<std::byte(tag::generic_array)>(args...);
+            dump<tag::generic_array>(args...);
 
             static constexpr auto N = glz::tuple_size_v<T>;
             dump_compressed_int<N>(args...);

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -126,8 +126,7 @@ namespace glz
                   bytes[byte_i] |= uint8_t(value[i]) << uint8_t(bit_i);
                }
             }
-            //dump(bytes, args...);
-            dump(std::as_bytes(std::span{bytes}), args...);
+            dump(bytes, args...);
          }
       };
 

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -126,7 +126,8 @@ namespace glz
                   bytes[byte_i] |= uint8_t(value[i]) << uint8_t(bit_i);
                }
             }
-            dump(bytes, args...);
+            //dump(bytes, args...);
+            dump(std::as_bytes(std::span{bytes}), args...);
          }
       };
 

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -126,8 +126,7 @@ namespace glz
                   bytes[byte_i] |= uint8_t(value[i]) << uint8_t(bit_i);
                }
             }
-            // dump(bytes, args...);
-            dump(std::as_bytes(std::span{bytes}), args...);
+            dump(bytes, args...);
          }
       };
 

--- a/include/glaze/util/dump.hpp
+++ b/include/glaze/util/dump.hpp
@@ -233,52 +233,37 @@ namespace glz::detail
       ix += n;
    }
 
-   GLZ_ALWAYS_INLINE void dump_not_empty(const sv str, vector_like auto& b, auto& ix) noexcept
+   template <class B>
+   GLZ_ALWAYS_INLINE void dump_not_empty(const sv str, B& b, auto& ix) noexcept
    {
       const auto n = str.size();
-      if (ix + n > b.size()) [[unlikely]] {
-         b.resize((std::max)(b.size() * 2, ix + n));
-      }
-
-      std::memcpy(b.data() + ix, str.data(), n);
-      ix += n;
-   }
-
-   GLZ_ALWAYS_INLINE void dump_not_empty(const sv str, auto* b, auto& ix) noexcept
-   {
-      const auto n = str.size();
-
-      std::memcpy(b + ix, str.data(), n);
-      ix += n;
-   }
-
-   GLZ_ALWAYS_INLINE void dump_maybe_empty(const sv str, vector_like auto& b, auto& ix) noexcept
-   {
-      const auto n = str.size();
-      if (n) {
+      if constexpr (vector_like<B>) {
          if (ix + n > b.size()) [[unlikely]] {
             b.resize((std::max)(b.size() * 2, ix + n));
          }
-
          std::memcpy(b.data() + ix, str.data(), n);
-         ix += n;
       }
+      else {
+         std::memcpy(b + ix, str.data(), n);
+      }
+      ix += n;
    }
 
-   GLZ_ALWAYS_INLINE void dump_maybe_empty(const sv str, auto* b, auto& ix) noexcept
+   template <class B>
+   GLZ_ALWAYS_INLINE void dump_maybe_empty(const sv str, B& b, auto& ix) noexcept
    {
       const auto n = str.size();
       if (n) {
-         std::memcpy(b + ix, str.data(), n);
+         if constexpr (vector_like<B>) {
+            if (ix + n > b.size()) [[unlikely]] {
+               b.resize((std::max)(b.size() * 2, ix + n));
+            }
+            std::memcpy(b.data() + ix, str.data(), n);
+         }
+         else {
+            std::memcpy(b + ix, str.data(), n);
+         }
          ix += n;
-      }
-   }
-
-   GLZ_ALWAYS_INLINE void dump(const sv str, char*& b) noexcept
-   {
-      for (auto& c : str) {
-         *b = c;
-         ++b;
       }
    }
 

--- a/include/glaze/util/dump.hpp
+++ b/include/glaze/util/dump.hpp
@@ -114,7 +114,7 @@ namespace glz::detail
       ix += n;
    }
 
-   template <char c>
+   template <byte_sized auto c>
    GLZ_ALWAYS_INLINE void dump_unchecked(auto& b, auto& ix) noexcept
    {
       assign_maybe_cast<c>(b, ix);
@@ -155,7 +155,7 @@ namespace glz::detail
       ix += n;
    }
 
-   template <char c, class B>
+   template <byte_sized auto c, class B>
    GLZ_ALWAYS_INLINE void dumpn(size_t n, B& b, auto& ix) noexcept
    {
       if constexpr (vector_like<B>) {
@@ -170,7 +170,7 @@ namespace glz::detail
       ix += n;
    }
 
-   template <char c, class B>
+   template <byte_sized auto c, class B>
    GLZ_ALWAYS_INLINE void dumpn_unchecked(size_t n, B& b, auto& ix) noexcept
    {
       if constexpr (vector_like<B>) {
@@ -266,19 +266,6 @@ namespace glz::detail
             std::memcpy(b + ix, str.data(), n);
          }
          ix += n;
-      }
-   }
-
-   template <std::byte c, class B>
-   GLZ_ALWAYS_INLINE void dump(B&& b) noexcept
-   {
-      using value_t = range_value_t<std::decay_t<B>>;
-      if constexpr (std::same_as<value_t, std::byte>) {
-         b.emplace_back(c);
-      }
-      else {
-         static_assert(sizeof(value_t) == sizeof(std::byte));
-         b.push_back(std::bit_cast<value_t>(c));
       }
    }
 

--- a/include/glaze/util/dump.hpp
+++ b/include/glaze/util/dump.hpp
@@ -270,18 +270,14 @@ namespace glz::detail
    }
    
    template <class B>
-   GLZ_ALWAYS_INLINE void dump(const vector_like auto& bytes, B& b, auto& ix) noexcept
+   GLZ_ALWAYS_INLINE void dump(const std::span<const std::byte> bytes, B&& b, auto& ix) noexcept
    {
       const auto n = bytes.size();
-      if constexpr (vector_like<B>) {
-         if (ix + n > b.size()) [[unlikely]] {
-            b.resize((std::max)(b.size() * 2, ix + n));
-         }
-         std::memcpy(b.data() + ix, bytes.data(), n);
+      if (ix + n > b.size()) [[unlikely]] {
+         b.resize((std::max)(b.size() * 2, ix + n));
       }
-      else {
-         std::memcpy(b + ix, bytes.data(), n);
-      }
+
+      std::memcpy(b.data() + ix, bytes.data(), n);
       ix += n;
    }
 

--- a/include/glaze/util/dump.hpp
+++ b/include/glaze/util/dump.hpp
@@ -270,14 +270,18 @@ namespace glz::detail
    }
    
    template <class B>
-   GLZ_ALWAYS_INLINE void dump(const std::span<const std::byte> bytes, B&& b, auto& ix) noexcept
+   GLZ_ALWAYS_INLINE void dump(const vector_like auto& bytes, B& b, auto& ix) noexcept
    {
       const auto n = bytes.size();
-      if (ix + n > b.size()) [[unlikely]] {
-         b.resize((std::max)(b.size() * 2, ix + n));
+      if constexpr (vector_like<B>) {
+         if (ix + n > b.size()) [[unlikely]] {
+            b.resize((std::max)(b.size() * 2, ix + n));
+         }
+         std::memcpy(b.data() + ix, bytes.data(), n);
       }
-
-      std::memcpy(b.data() + ix, bytes.data(), n);
+      else {
+         std::memcpy(b + ix, bytes.data(), n);
+      }
       ix += n;
    }
 

--- a/include/glaze/util/dump.hpp
+++ b/include/glaze/util/dump.hpp
@@ -47,7 +47,7 @@ namespace glz::detail
       }
    }
    
-   template <byte_sized auto c>
+   template <auto c>
    GLZ_ALWAYS_INLINE void assign_maybe_cast(auto& b, auto& ix) noexcept
    {
       using V = std::decay_t<decltype(b[0])>;
@@ -84,7 +84,7 @@ namespace glz::detail
       ++ix;
    }
 
-   template <byte_sized auto c, class B>
+   template <auto c, class B>
    GLZ_ALWAYS_INLINE void dump(B& b, auto& ix) noexcept
    {
       if constexpr (vector_like<B>) {
@@ -114,7 +114,7 @@ namespace glz::detail
       ix += n;
    }
 
-   template <byte_sized auto c>
+   template <auto c>
    GLZ_ALWAYS_INLINE void dump_unchecked(auto& b, auto& ix) noexcept
    {
       assign_maybe_cast<c>(b, ix);
@@ -155,7 +155,7 @@ namespace glz::detail
       ix += n;
    }
 
-   template <byte_sized auto c, class B>
+   template <auto c, class B>
    GLZ_ALWAYS_INLINE void dumpn(size_t n, B& b, auto& ix) noexcept
    {
       if constexpr (vector_like<B>) {
@@ -170,7 +170,7 @@ namespace glz::detail
       ix += n;
    }
 
-   template <byte_sized auto c, class B>
+   template <auto c, class B>
    GLZ_ALWAYS_INLINE void dumpn_unchecked(size_t n, B& b, auto& ix) noexcept
    {
       if constexpr (vector_like<B>) {

--- a/include/glaze/util/dump.hpp
+++ b/include/glaze/util/dump.hpp
@@ -268,9 +268,9 @@ namespace glz::detail
          ix += n;
       }
    }
-
+   
    template <class B>
-   GLZ_ALWAYS_INLINE void dump(const std::span<const std::byte> bytes, B& b, auto& ix) noexcept
+   GLZ_ALWAYS_INLINE void dump(const vector_like auto& bytes, B& b, auto& ix) noexcept
    {
       const auto n = bytes.size();
       if constexpr (vector_like<B>) {

--- a/include/glaze/util/dump.hpp
+++ b/include/glaze/util/dump.hpp
@@ -123,7 +123,6 @@ namespace glz::detail
 
    GLZ_ALWAYS_INLINE void dump_unchecked(const byte_sized auto c, auto& b, auto& ix) noexcept
    {
-      using V = std::decay_t<decltype(b[0])>;
       assign_maybe_cast(c, b, ix);
       ++ix;
    }


### PR DESCRIPTION
- Removed dead code
- More generic handling of buffer byte types, better support for std::byte
- Merged handling of raw buffer function calls and vector_like buffers