### PR TITLE
JsonSchema add advanced flag and unit support

### DIFF
--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -26,14 +26,12 @@ namespace glz
    namespace detail
    {
       enum struct defined_formats : std::uint8_t;
-      struct out_of_spec final
+      struct ExtUnits final
       {
-         std::optional<std::string_view> unit_ascii{}; // ascii representation of the unit, e.g. "m^2" for square meters
+         std::optional<std::string_view> unitAscii{}; // ascii representation of the unit, e.g. "m^2" for square meters
          std::optional<std::string_view>
-            unit_unicode{}; // unicode representation of the unit, e.g. "m²" for square meters
-         std::optional<bool>
-            advanced{}; // flag to indicate that the parameter is advanced and can be hidden in default views
-         constexpr bool operator==(const out_of_spec&) const noexcept = default;
+            unitUnicode{}; // unicode representation of the unit, e.g. "m²" for square meters
+         constexpr bool operator==(const ExtUnits&) const noexcept = default;
       };
    }
    struct schema final
@@ -78,8 +76,10 @@ namespace glz
       // properties
       std::optional<std::span<const std::string_view>> enumeration{}; // enum
 
-      // out of spec
-      std::optional<detail::out_of_spec> outOfSpec{};
+      // out of json schema specification
+      std::optional<detail::ExtUnits> extUnits{};
+      std::optional<bool>
+         extAdvanced{}; // flag to indicate that the parameter is advanced and can be hidden in default views
 
       static constexpr auto schema_attributes{true}; // allowance flag to indicate metadata within glz::object(...)
 
@@ -116,7 +116,8 @@ namespace glz
                                                    "maxContains", &T::maxContains, //
                                                    "uniqueItems", &T::uniqueItems, //
                                                    "enum", &T::enumeration, //
-                                                   "outOfSpec", &T::outOfSpec);
+                                                   "extUnits", &T::extUnits, //
+                                                   "extAdvanced", &T::extAdvanced);
       };
    };
 

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -23,6 +23,10 @@
 
 namespace glz
 {
+   namespace detail
+   {
+      enum struct defined_formats : std::uint8_t;
+   }
    struct schema final
    {
       bool reflection_helper{}; // needed to support automatic reflection, because ref is a std::optional
@@ -43,6 +47,8 @@ namespace glz
       std::optional<std::uint64_t> minLength{};
       std::optional<std::uint64_t> maxLength{};
       std::optional<std::string_view> pattern{};
+      // https://www.learnjsonschema.com/2020-12/format-annotation/format/
+      std::optional<detail::defined_formats> format{};
       // number only keywords
       schema_number minimum{};
       schema_number maximum{};
@@ -82,6 +88,7 @@ namespace glz
                                                    "minLength", &T::minLength, //
                                                    "maxLength", &T::maxLength, //
                                                    "pattern", &T::pattern, //
+                                                   "format", &T::format, //
                                                    "minimum", &T::minimum, //
                                                    "maximum", &T::maximum, //
                                                    "exclusiveMinimum", &T::exclusiveMinimum, //
@@ -116,8 +123,56 @@ namespace glz
          std::optional<std::vector<std::string_view>> required{};
          std::optional<std::vector<std::string_view>> examples{};
       };
+      enum struct defined_formats : std::uint8_t {
+         datetime,
+         date,
+         time,
+         duration,
+         email,
+         idn_email,
+         hostname,
+         idn_hostname,
+         ipv4,
+         ipv6,
+         uri,
+         uri_reference,
+         iri,
+         iri_reference,
+         uuid,
+         uri_template,
+         json_pointer,
+         relative_json_pointer,
+         regex
+       };
    }
 }
+
+
+template <>
+struct glz::meta<glz::detail::defined_formats> {
+   using enum detail::defined_formats;
+   static constexpr std::string_view name = "defined_formats";
+   static constexpr auto value = enumerate(
+       "date-time", datetime, //
+       "date", date, //
+       "time", time, //
+       "duration", duration, //
+       "email", email, //
+       "idn-email", idn_email, //
+       "hostname", hostname, //
+       "idn-hostname", idn_hostname, //
+       "ipv4", ipv4, //
+       "ipv6",ipv6, //
+       "uri", uri, //
+       "uri-reference", uri_reference, //
+       "iri",iri, //
+       "iri-reference", iri_reference, //
+       "uuid", uuid, //
+       "uri-template", uri_template, //
+       "json-pointer", json_pointer, //
+       "relative-json-pointer", relative_json_pointer, //
+       "regex", regex);
+};
 
 template <>
 struct glz::meta<glz::detail::schematic>

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -26,6 +26,15 @@ namespace glz
    namespace detail
    {
       enum struct defined_formats : std::uint8_t;
+      struct out_of_spec final
+      {
+         std::optional<std::string_view> unit_ascii{}; // ascii representation of the unit, e.g. "m^2" for square meters
+         std::optional<std::string_view>
+            unit_unicode{}; // unicode representation of the unit, e.g. "m²" for square meters
+         std::optional<bool>
+            advanced{}; // flag to indicate that the parameter is advanced and can be hidden in default views
+         constexpr bool operator==(const out_of_spec&) const noexcept = default;
+      };
    }
    struct schema final
    {
@@ -69,6 +78,9 @@ namespace glz
       // properties
       std::optional<std::span<const std::string_view>> enumeration{}; // enum
 
+      // out of spec
+      std::optional<detail::out_of_spec> outOfSpec{};
+
       static constexpr auto schema_attributes{true}; // allowance flag to indicate metadata within glz::object(...)
 
       // TODO switch to using variants when we have write support to get rid of nulls
@@ -103,7 +115,8 @@ namespace glz
                                                    "minContains", &T::minContains, //
                                                    "maxContains", &T::maxContains, //
                                                    "uniqueItems", &T::uniqueItems, //
-                                                   "enum", &T::enumeration);
+                                                   "enum", &T::enumeration, //
+                                                   "outOfSpec", &T::outOfSpec);
       };
    };
 
@@ -143,36 +156,9 @@ namespace glz
          json_pointer,
          relative_json_pointer,
          regex
-       };
+      };
    }
 }
-
-
-template <>
-struct glz::meta<glz::detail::defined_formats> {
-   using enum detail::defined_formats;
-   static constexpr std::string_view name = "defined_formats";
-   static constexpr auto value = enumerate(
-       "date-time", datetime, //
-       "date", date, //
-       "time", time, //
-       "duration", duration, //
-       "email", email, //
-       "idn-email", idn_email, //
-       "hostname", hostname, //
-       "idn-hostname", idn_hostname, //
-       "ipv4", ipv4, //
-       "ipv6",ipv6, //
-       "uri", uri, //
-       "uri-reference", uri_reference, //
-       "iri",iri, //
-       "iri-reference", iri_reference, //
-       "uuid", uuid, //
-       "uri-template", uri_template, //
-       "json-pointer", json_pointer, //
-       "relative-json-pointer", relative_json_pointer, //
-       "regex", regex);
-};
 
 template <>
 struct glz::meta<glz::detail::schematic>
@@ -190,6 +176,32 @@ struct glz::meta<glz::detail::schematic>
                                              "const", &T::constant, //
                                              "required", &T::required, //
                                              "examples", raw<&T::examples>);
+};
+
+template <>
+struct glz::meta<glz::detail::defined_formats>
+{
+   using enum detail::defined_formats;
+   static constexpr std::string_view name = "defined_formats";
+   static constexpr auto value = enumerate("date-time", datetime, //
+                                           "date", date, //
+                                           "time", time, //
+                                           "duration", duration, //
+                                           "email", email, //
+                                           "idn-email", idn_email, //
+                                           "hostname", hostname, //
+                                           "idn-hostname", idn_hostname, //
+                                           "ipv4", ipv4, //
+                                           "ipv6", ipv6, //
+                                           "uri", uri, //
+                                           "uri-reference", uri_reference, //
+                                           "iri", iri, //
+                                           "iri-reference", iri_reference, //
+                                           "uuid", uuid, //
+                                           "uri-template", uri_template, //
+                                           "json-pointer", json_pointer, //
+                                           "relative-json-pointer", relative_json_pointer, //
+                                           "regex", regex);
 };
 
 namespace glz

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -77,9 +77,9 @@ namespace glz
       std::optional<std::span<const std::string_view>> enumeration{}; // enum
 
       // out of json schema specification
-      std::optional<detail::ExtUnits> extUnits{};
+      std::optional<detail::ExtUnits> ExtUnits{};
       std::optional<bool>
-         extAdvanced{}; // flag to indicate that the parameter is advanced and can be hidden in default views
+         ExtAdvanced{}; // flag to indicate that the parameter is advanced and can be hidden in default views
 
       static constexpr auto schema_attributes{true}; // allowance flag to indicate metadata within glz::object(...)
 
@@ -116,8 +116,8 @@ namespace glz
                                                    "maxContains", &T::maxContains, //
                                                    "uniqueItems", &T::uniqueItems, //
                                                    "enum", &T::enumeration, //
-                                                   "extUnits", &T::extUnits, //
-                                                   "extAdvanced", &T::extAdvanced);
+                                                   "ExtUnits", &T::ExtUnits, //
+                                                   "ExtAdvanced", &T::ExtAdvanced);
       };
    };
 

--- a/tests/json_test/CMakeLists.txt
+++ b/tests/json_test/CMakeLists.txt
@@ -11,3 +11,12 @@ endif ()
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
 
 target_code_coverage(${PROJECT_NAME} AUTO ALL)
+
+add_executable(jsonschema_test jsonschema_test.cpp)
+
+target_link_libraries(jsonschema_test PRIVATE glz_test_common)
+
+add_test(NAME jsonschema_test COMMAND jsonschema_test)
+
+target_code_coverage(jsonschema_test AUTO ALL)
+

--- a/tests/json_test/jsonschema_test.cpp
+++ b/tests/json_test/jsonschema_test.cpp
@@ -12,6 +12,8 @@ struct schema_obj
    std::string_view desc{"this variable has a description"};
    std::int64_t min1{2};
    std::int64_t max2{5};
+   // todo it is not currently supported to read glz::schema::schema_any, for reference see function variant_is_auto_deducible
+   // std::int64_t default_val{1337};
    std::string pattern{"[a-z]+"};
 };
 
@@ -21,15 +23,24 @@ struct glz::json_schema<schema_obj>
    schema desc{.description = "this is a description"};
    schema min1{.minimum = 1L};
    schema max2{.maximum = 2L};
+   // todo it is not currently supported to read glz::schema::schema_any, for reference see function variant_is_auto_deducible
+   // schema default_val{.defaultValue = 42L};
    schema pattern{.pattern = "[a-z]+"};
 };
 
+struct test_case
+{
+   std::string schema_str = glz::write_json_schema<schema_obj>();
+   glz::expected<glz::detail::schematic, glz::parse_error> obj{glz::read_json<glz::detail::schematic>(schema_str)};
+};
+
 template <auto Member>
-auto expect_property(glz::expected<glz::detail::schematic, glz::parse_error> schematic, std::string_view key, auto value) {
-   expect(schematic.has_value() >> fatal);
+auto expect_property(test_case test, std::string_view key, auto value) {
+   auto schematic = test.obj;
+   expect(fatal(schematic.has_value())) << "hello world";
    expect(schematic->properties->contains(key) >> fatal);
    glz::schema prop = schematic->properties->at(key);
-   auto prop_value = prop.*Member;
+   auto prop_value = glz::detail::get_member(prop, Member);
    expect(prop_value.has_value() >> fatal);
    using prop_value_t = std::decay_t<decltype(prop_value)>;
    if constexpr (std::same_as<prop_value_t, glz::schema::schema_number>) {
@@ -44,26 +55,26 @@ auto expect_property(glz::expected<glz::detail::schematic, glz::parse_error> sch
 
 
 suite schema_attributes = [] {
-   struct test_case
-   {
-      std::string schema_str = glz::write_json_schema<schema_obj>();
-      glz::expected<glz::detail::schematic, glz::parse_error> obj{glz::read_json<glz::detail::schematic>(schema_str)};
+   "parsing"_test = [] {
+      test_case const test{};
+      expect(test.obj.has_value());// << format_error(test.obj.error(), test.schema_str);
+      expect(fatal(test.obj.has_value()));
    };
    "description"_test = [] {
       test_case const test{};
-      expect_property<&glz::schema::description>(test.obj, "desc", "this is a description");
+      expect_property<&glz::schema::description>(test, "desc", "this is a description");
    };
    "min1"_test = [] {
       test_case const test{};
-      expect_property<&glz::schema::minimum>(test.obj, "min1", 1L);
+      expect_property<&glz::schema::minimum>(test, "min1", 1L);
    };
   "max2"_test = [] {
       test_case const test{};
-      expect_property<&glz::schema::maximum>(test.obj, "max2", 2L);
+      expect_property<&glz::schema::maximum>(test, "max2", 2L);
    };
    "pattern"_test = [] {
       test_case const test{};
-      expect_property<&glz::schema::pattern>(test.obj, "pattern", std::string_view{"[a-z]+"});
+      expect_property<&glz::schema::pattern>(test, "pattern", std::string_view{"[a-z]+"});
   };
 };
 

--- a/tests/json_test/jsonschema_test.cpp
+++ b/tests/json_test/jsonschema_test.cpp
@@ -17,19 +17,47 @@ struct schema_obj
 template <>
 struct glz::json_schema<schema_obj>
 {
-   schema min1{.minimum = 1};
-   schema max2{.maximum = 2};
+   schema min1{.minimum = 1L};
+   schema max2{.maximum = 2L};
    schema pattern{.pattern = "[a-z]+"};
 };
 
+template <auto Member>
+auto expect_property(glz::expected<glz::detail::schematic, glz::parse_error> schematic, std::string_view key, auto value) {
+   expect(schematic.has_value() >> fatal);
+   expect(schematic->properties->contains(key) >> fatal);
+   glz::schema prop = schematic->properties->at(key);
+   auto prop_value = prop.*Member;
+   expect(prop_value.has_value() >> fatal);
+   using prop_value_t = std::decay_t<decltype(prop_value)>;
+   if constexpr (std::same_as<prop_value_t, glz::schema::schema_number>) {
+      using input_value_t = std::decay_t<decltype(value)>;
+      expect(std::holds_alternative<input_value_t>(prop_value.value()) >> fatal);
+      expect(std::get<input_value_t>(prop_value.value()) == value);
+   }
+   else {
+      expect(prop_value.value() == value);
+   }
+}
+
 
 suite schema_attributes = [] {
-   "min1"_test = [] {
-     auto schema_str = glz::write_json_schema<schema_obj>();
-      auto schema_obj = glz::read_json<glz::detail::schematic>(schema_str);
-      expect(schema_obj.has_value() >> fatal);
 
+   "min1"_test = [] {
+      auto schema_str = glz::write_json_schema<schema_obj>();
+      auto schema_obj = glz::read_json<glz::detail::schematic>(schema_str);
+      expect_property<&glz::schema::minimum>(schema_obj, "min1", 1L);
    };
+  "max2"_test = [] {
+        auto schema_str = glz::write_json_schema<schema_obj>();
+        auto schema_obj = glz::read_json<glz::detail::schematic>(schema_str);
+        expect_property<&glz::schema::maximum>(schema_obj, "max2", 2L);
+   };
+   "pattern"_test = [] {
+        auto schema_str = glz::write_json_schema<schema_obj>();
+        auto schema_obj = glz::read_json<glz::detail::schematic>(schema_str);
+        expect_property<&glz::schema::pattern>(schema_obj, "pattern", std::string_view{"[a-z]+"});
+  };
 };
 
 int main()

--- a/tests/json_test/jsonschema_test.cpp
+++ b/tests/json_test/jsonschema_test.cpp
@@ -1,0 +1,38 @@
+#include <cstdint>
+#include <string>
+
+#include <boost/ut.hpp>
+#include <glaze/json.hpp>
+#include <glaze/json/schema.hpp>
+
+using namespace boost::ut;
+
+struct schema_obj
+{
+   std::int64_t min1{2};
+   std::int64_t max2{5};
+   std::string pattern{"[a-z]+"};
+};
+
+template <>
+struct glz::json_schema<schema_obj>
+{
+   schema min1{.minimum = 1};
+   schema max2{.maximum = 2};
+   schema pattern{.pattern = "[a-z]+"};
+};
+
+
+suite schema_attributes = [] {
+   "min1"_test = [] {
+     auto schema_str = glz::write_json_schema<schema_obj>();
+      auto schema_obj = glz::read_json<glz::detail::schematic>(schema_str);
+      expect(schema_obj.has_value() >> fatal);
+
+   };
+};
+
+int main()
+{
+   return boost::ut::cfg<>.run({.report_errors = true});
+}

--- a/tests/json_test/jsonschema_test.cpp
+++ b/tests/json_test/jsonschema_test.cpp
@@ -9,6 +9,7 @@ using namespace boost::ut;
 
 struct schema_obj
 {
+   std::string_view desc{"this variable has a description"};
    std::int64_t min1{2};
    std::int64_t max2{5};
    std::string pattern{"[a-z]+"};
@@ -17,6 +18,7 @@ struct schema_obj
 template <>
 struct glz::json_schema<schema_obj>
 {
+   schema desc{.description = "this is a description"};
    schema min1{.minimum = 1L};
    schema max2{.maximum = 2L};
    schema pattern{.pattern = "[a-z]+"};
@@ -42,21 +44,26 @@ auto expect_property(glz::expected<glz::detail::schematic, glz::parse_error> sch
 
 
 suite schema_attributes = [] {
-
+   struct test_case
+   {
+      std::string schema_str = glz::write_json_schema<schema_obj>();
+      glz::expected<glz::detail::schematic, glz::parse_error> obj{glz::read_json<glz::detail::schematic>(schema_str)};
+   };
+   "description"_test = [] {
+      test_case const test{};
+      expect_property<&glz::schema::description>(test.obj, "desc", "this is a description");
+   };
    "min1"_test = [] {
-      auto schema_str = glz::write_json_schema<schema_obj>();
-      auto schema_obj = glz::read_json<glz::detail::schematic>(schema_str);
-      expect_property<&glz::schema::minimum>(schema_obj, "min1", 1L);
+      test_case const test{};
+      expect_property<&glz::schema::minimum>(test.obj, "min1", 1L);
    };
   "max2"_test = [] {
-        auto schema_str = glz::write_json_schema<schema_obj>();
-        auto schema_obj = glz::read_json<glz::detail::schematic>(schema_str);
-        expect_property<&glz::schema::maximum>(schema_obj, "max2", 2L);
+      test_case const test{};
+      expect_property<&glz::schema::maximum>(test.obj, "max2", 2L);
    };
    "pattern"_test = [] {
-        auto schema_str = glz::write_json_schema<schema_obj>();
-        auto schema_obj = glz::read_json<glz::detail::schematic>(schema_str);
-        expect_property<&glz::schema::pattern>(schema_obj, "pattern", std::string_view{"[a-z]+"});
+      test_case const test{};
+      expect_property<&glz::schema::pattern>(test.obj, "pattern", std::string_view{"[a-z]+"});
   };
 };
 

--- a/tests/json_test/jsonschema_test.cpp
+++ b/tests/json_test/jsonschema_test.cpp
@@ -42,8 +42,8 @@ struct glz::json_schema<schema_obj>
       .maxContains = 2UL,
       .uniqueItems = true,
       // .enumeration = , // read of std::span is not supported
-      .extUnits = detail::ExtUnits{.unitAscii = "m^2", .unitUnicode = "m²"},
-      .extAdvanced = true,
+      .ExtUnits = detail::ExtUnits{.unitAscii = "m^2", .unitUnicode = "m²"},
+      .ExtAdvanced = true,
    };
    // schema examples{.examples = example_arr};
 };
@@ -179,12 +179,12 @@ suite schema_attributes = [] {
    };
    "extUnits"_test = [] {
       test_case const test{};
-      expect_property<&glz::schema::extUnits>(test, "variable",
+      expect_property<&glz::schema::ExtUnits>(test, "variable",
                                               glz::detail::ExtUnits{.unitAscii = "m^2", .unitUnicode = "m²"});
    };
    "extAdvanced"_test = [] {
       test_case const test{};
-      expect_property<&glz::schema::extAdvanced>(test, "variable", true);
+      expect_property<&glz::schema::ExtAdvanced>(test, "variable", true);
    };
 };
 

--- a/tests/json_test/jsonschema_test.cpp
+++ b/tests/json_test/jsonschema_test.cpp
@@ -53,7 +53,7 @@ auto expect_property(test_case test, std::string_view key, Value value) {
       expect(std::holds_alternative<Value>(prop_value.value()) >> fatal);
       expect(std::get<Value>(prop_value.value()) == value);
    }
-   else if constexpr (glz::is_specialization_v<prop_value_t, std::optional> && glz::is_specialization_v<typename prop_value_t::value_type, std::span>) {
+   else if constexpr (glz::is_specialization_v<prop_value_t, std::optional> && glz::detail::is_span<typename prop_value_t::value_type>) {
       expect(fatal(prop_value.value().size() == value.size()));
       for (std::size_t i = 0; i < prop_value.value().size(); ++i) {
         expect(prop_value.value()[i] == value[i]);
@@ -66,6 +66,7 @@ auto expect_property(test_case test, std::string_view key, Value value) {
 
 
 suite schema_attributes = [] {
+   using std::literals::operator""s;
    "parsing"_test = [] {
       test_case const test{};
       expect(test.obj.has_value()) << format_error(!test.obj.has_value() ? test.obj.error() : glz::parse_error{}, test.schema_str);
@@ -73,7 +74,7 @@ suite schema_attributes = [] {
    };
    "description"_test = [] {
       test_case const test{};
-      expect_property<&glz::schema::description>(test, "desc", "this is a description");
+      expect_property<&glz::schema::description>(test, "desc", "this is a description"s);
    };
    "min1"_test = [] {
       test_case const test{};

--- a/tests/json_test/jsonschema_test.cpp
+++ b/tests/json_test/jsonschema_test.cpp
@@ -9,29 +9,41 @@ using namespace boost::ut;
 
 struct schema_obj
 {
-   std::string_view desc{"this variable has a description"};
-   std::int64_t min1{2};
-   std::int64_t max2{5};
-   // todo it is not currently supported to read glz::schema::schema_any, for reference see function variant_is_auto_deducible
-   // std::int64_t default_val{1337};
-   std::string pattern{"[a-z]+"};
-   bool is_deprecated{};
-   std::string_view examples{"this is an example"};
+   std::int64_t variable{2};
 };
 
-static constexpr auto example_arr = std::array<std::string_view, 1>{ "this is an example" };
+// static constexpr auto example_arr = std::array<std::string_view, 1>{ "\"this is an example\"" };
 
 template <>
 struct glz::json_schema<schema_obj>
 {
-   schema desc{.description = "this is a description"};
-   schema min1{.minimum = 1L};
-   schema max2{.maximum = 2L};
-   // todo it is not currently supported to read glz::schema::schema_any, for reference see function variant_is_auto_deducible
-   // schema default_val{.defaultValue = 42L};
-   schema pattern{.pattern = "[a-z]+"};
-   schema is_deprecated{.deprecated = true};
-   schema examples{.examples = example_arr};
+   schema variable{
+      .description = "this is a description",
+      // .defaultValue = 42L, // todo it is not currently supported to read glz::schema::schema_any, for reference see
+      // function variant_is_auto_deducible
+      .deprecated = true,
+      .readOnly = true,
+      .writeOnly = true,
+      .constant = "some constant value",
+      .minLength = 1L,
+      .maxLength = 2L,
+      .pattern = "[a-z]+",
+      .minimum = 1L,
+      .maximum = 2L,
+      .exclusiveMinimum = 1L,
+      .exclusiveMaximum = 2L,
+      .multipleOf = 3L,
+      .minProperties = 4UL,
+      .maxProperties = std::numeric_limits<std::uint64_t>::max(),
+      // .required = , // read of std::span is not supported
+      .minItems = 1UL,
+      .maxItems = 2UL,
+      .minContains = 1UL,
+      .maxContains = 2UL,
+      .uniqueItems = true,
+      // .enumeration = , // read of std::span is not supported
+   };
+   // schema examples{.examples = example_arr};
 };
 
 struct test_case
@@ -40,8 +52,12 @@ struct test_case
    glz::expected<glz::detail::schematic, glz::parse_error> obj{glz::read_json<glz::detail::schematic>(schema_str)};
 };
 
+template <class T>
+concept is_optional = glz::is_specialization_v<T, std::optional>;
+
 template <auto Member, typename Value>
-auto expect_property(test_case test, std::string_view key, Value value) {
+auto expect_property(test_case test, std::string_view key, Value value)
+{
    auto schematic = test.obj;
    expect(fatal(schematic.has_value())) << "hello world";
    expect(schematic->properties->contains(key) >> fatal);
@@ -49,14 +65,14 @@ auto expect_property(test_case test, std::string_view key, Value value) {
    auto prop_value = glz::detail::get_member(prop, Member);
    expect(prop_value.has_value() >> fatal);
    using prop_value_t = std::decay_t<decltype(prop_value)>;
-   if constexpr (std::same_as<prop_value_t, glz::schema::schema_number>) {
+   if constexpr (is_optional<prop_value_t> && glz::is_variant<typename prop_value_t::value_type>) {
       expect(std::holds_alternative<Value>(prop_value.value()) >> fatal);
       expect(std::get<Value>(prop_value.value()) == value);
    }
-   else if constexpr (glz::is_specialization_v<prop_value_t, std::optional> && glz::detail::is_span<typename prop_value_t::value_type>) {
+   else if constexpr (is_optional<prop_value_t> && glz::detail::is_span<typename prop_value_t::value_type>) {
       expect(fatal(prop_value.value().size() == value.size()));
       for (std::size_t i = 0; i < prop_value.value().size(); ++i) {
-        expect(prop_value.value()[i] == value[i]);
+         expect(prop_value.value()[i] == value[i]);
       }
    }
    else {
@@ -64,41 +80,99 @@ auto expect_property(test_case test, std::string_view key, Value value) {
    }
 }
 
-
 suite schema_attributes = [] {
    using std::literals::operator""s;
+   using std::literals::operator""sv;
    "parsing"_test = [] {
       test_case const test{};
-      expect(test.obj.has_value()) << format_error(!test.obj.has_value() ? test.obj.error() : glz::parse_error{}, test.schema_str);
+      expect(test.obj.has_value()) << format_error(!test.obj.has_value() ? test.obj.error() : glz::parse_error{},
+                                                   test.schema_str);
       expect(fatal(test.obj.has_value()));
    };
    "description"_test = [] {
       test_case const test{};
-      expect_property<&glz::schema::description>(test, "desc", "this is a description"s);
+      expect_property<&glz::schema::description>(test, "variable", "this is a description"s);
    };
-   "min1"_test = [] {
+   "deprecated"_test = [] {
       test_case const test{};
-      expect_property<&glz::schema::minimum>(test, "min1", std::int64_t{1});
+      expect_property<&glz::schema::deprecated>(test, "variable", true);
    };
-  "max2"_test = [] {
+   // skip / "examples"_test = [] {
+   //    test_case const test{};
+   //    expect_property<&glz::schema::examples>(test, "examples", std::span{ example_arr });
+   // };
+   "readOnly"_test = [] {
       test_case const test{};
-      expect_property<&glz::schema::maximum>(test, "max2", std::int64_t{2});
+      expect_property<&glz::schema::readOnly>(test, "variable", true);
+   };
+   "writeOnly"_test = [] {
+      test_case const test{};
+      expect_property<&glz::schema::writeOnly>(test, "variable", true);
+   };
+   "constant"_test = [] {
+      test_case const test{};
+      expect_property<&glz::schema::constant>(test, "variable", "some constant value"sv);
+   };
+   "minLength"_test = [] {
+      test_case const test{};
+      expect_property<&glz::schema::minLength>(test, "variable", std::uint64_t{1});
+   };
+   "maxLength"_test = [] {
+      test_case const test{};
+      expect_property<&glz::schema::maxLength>(test, "variable", std::uint64_t{2});
    };
    "pattern"_test = [] {
       test_case const test{};
-      expect_property<&glz::schema::pattern>(test, "pattern", std::string_view{"[a-z]+"});
-  };
-   "deprecated"_test = [] {
-      test_case const test{};
-      expect_property<&glz::schema::deprecated>(test, "is_deprecated", true);
+      expect_property<&glz::schema::pattern>(test, "variable", "[a-z]+"sv);
    };
-   "examples"_test = [] {
+   "minimum"_test = [] {
       test_case const test{};
-      expect_property<&glz::schema::examples>(test, "examples", std::span{ example_arr });
+      expect_property<&glz::schema::minimum>(test, "variable", std::int64_t{1});
+   };
+   "maximum"_test = [] {
+      test_case const test{};
+      expect_property<&glz::schema::maximum>(test, "variable", std::int64_t{2});
+   };
+   "exclusiveMinimum"_test = [] {
+      test_case const test{};
+      expect_property<&glz::schema::exclusiveMinimum>(test, "variable", std::int64_t{1});
+   };
+   "exclusiveMaximum"_test = [] {
+      test_case const test{};
+      expect_property<&glz::schema::exclusiveMaximum>(test, "variable", std::int64_t{2});
+   };
+   "multipleOf"_test = [] {
+      test_case const test{};
+      expect_property<&glz::schema::multipleOf>(test, "variable", std::int64_t{3});
+   };
+   "minProperties"_test = [] {
+      test_case const test{};
+      expect_property<&glz::schema::minProperties>(test, "variable", std::uint64_t{4});
+   };
+   "maxProperties"_test = [] {
+      test_case const test{};
+      expect_property<&glz::schema::maxProperties>(test, "variable", std::numeric_limits<std::uint64_t>::max());
+   };
+   "minItems"_test = [] {
+      test_case const test{};
+      expect_property<&glz::schema::minItems>(test, "variable", std::uint64_t{1});
+   };
+   "maxItems"_test = [] {
+      test_case const test{};
+      expect_property<&glz::schema::maxItems>(test, "variable", std::uint64_t{2});
+   };
+   "minContains"_test = [] {
+      test_case const test{};
+      expect_property<&glz::schema::minContains>(test, "variable", std::uint64_t{1});
+   };
+   "maxContains"_test = [] {
+      test_case const test{};
+      expect_property<&glz::schema::maxContains>(test, "variable", std::uint64_t{2});
+   };
+   "uniqueItems"_test = [] {
+      test_case const test{};
+      expect_property<&glz::schema::uniqueItems>(test, "variable", true);
    };
 };
 
-int main()
-{
-   return boost::ut::cfg<>.run({.report_errors = true});
-}
+int main() { return boost::ut::cfg<>.run({.report_errors = true}); }

--- a/tests/json_test/jsonschema_test.cpp
+++ b/tests/json_test/jsonschema_test.cpp
@@ -82,8 +82,6 @@ auto expect_property(test_case test, std::string_view key, Value value)
 }
 
 suite schema_attributes = [] {
-   using std::literals::operator""s;
-   using std::literals::operator""sv;
    "parsing"_test = [] {
       test_case const test{};
       expect(test.obj.has_value()) << format_error(!test.obj.has_value() ? test.obj.error() : glz::parse_error{},
@@ -92,7 +90,7 @@ suite schema_attributes = [] {
    };
    "description"_test = [] {
       test_case const test{};
-      expect_property<&glz::schema::description>(test, "variable", "this is a description"s);
+      expect_property<&glz::schema::description>(test, "variable", std::string{"this is a description"});
    };
    "deprecated"_test = [] {
       test_case const test{};
@@ -112,7 +110,7 @@ suite schema_attributes = [] {
    };
    "constant"_test = [] {
       test_case const test{};
-      expect_property<&glz::schema::constant>(test, "variable", "some constant value"sv);
+      expect_property<&glz::schema::constant>(test, "variable", std::string_view{"some constant value"});
    };
    "minLength"_test = [] {
       test_case const test{};
@@ -124,7 +122,7 @@ suite schema_attributes = [] {
    };
    "pattern"_test = [] {
       test_case const test{};
-      expect_property<&glz::schema::pattern>(test, "variable", "[a-z]+"sv);
+      expect_property<&glz::schema::pattern>(test, "variable", std::string_view{"[a-z]+"});
    };
    "format"_test = [] {
       test_case const test{};

--- a/tests/json_test/jsonschema_test.cpp
+++ b/tests/json_test/jsonschema_test.cpp
@@ -42,7 +42,8 @@ struct glz::json_schema<schema_obj>
       .maxContains = 2UL,
       .uniqueItems = true,
       // .enumeration = , // read of std::span is not supported
-      .outOfSpec = detail::out_of_spec{.unit_ascii = "m^2", .unit_unicode = "m²", .advanced = true},
+      .extUnits = detail::ExtUnits{.unitAscii = "m^2", .unitUnicode = "m²"},
+      .extAdvanced = true,
    };
    // schema examples{.examples = example_arr};
 };
@@ -176,9 +177,14 @@ suite schema_attributes = [] {
       test_case const test{};
       expect_property<&glz::schema::uniqueItems>(test, "variable", true);
    };
-   "outOfSpec"_test = [] {
+   "extUnits"_test = [] {
       test_case const test{};
-      expect_property<&glz::schema::outOfSpec>(test, "variable", glz::detail::out_of_spec{.unit_ascii = "m^2", .unit_unicode = "m²", .advanced = true});
+      expect_property<&glz::schema::extUnits>(test, "variable",
+                                              glz::detail::ExtUnits{.unitAscii = "m^2", .unitUnicode = "m²"});
+   };
+   "extAdvanced"_test = [] {
+      test_case const test{};
+      expect_property<&glz::schema::extAdvanced>(test, "variable", true);
    };
 };
 

--- a/tests/json_test/jsonschema_test.cpp
+++ b/tests/json_test/jsonschema_test.cpp
@@ -1,9 +1,8 @@
-#include <cstdint>
-#include <string>
-
 #include <boost/ut.hpp>
+#include <cstdint>
 #include <glaze/json.hpp>
 #include <glaze/json/schema.hpp>
+#include <string>
 
 using namespace boost::ut;
 
@@ -43,6 +42,7 @@ struct glz::json_schema<schema_obj>
       .maxContains = 2UL,
       .uniqueItems = true,
       // .enumeration = , // read of std::span is not supported
+      .outOfSpec = detail::out_of_spec{.unit_ascii = "m^2"},
    };
    // schema examples{.examples = example_arr};
 };
@@ -177,6 +177,10 @@ suite schema_attributes = [] {
    "uniqueItems"_test = [] {
       test_case const test{};
       expect_property<&glz::schema::uniqueItems>(test, "variable", true);
+   };
+   "outOfSpec"_test = [] {
+      test_case const test{};
+      expect_property<&glz::schema::outOfSpec>(test, "variable", glz::detail::out_of_spec{.unit_ascii = "m^2"});
    };
 };
 

--- a/tests/json_test/jsonschema_test.cpp
+++ b/tests/json_test/jsonschema_test.cpp
@@ -65,11 +65,11 @@ suite schema_attributes = [] {
    };
    "min1"_test = [] {
       test_case const test{};
-      expect_property<&glz::schema::minimum>(test, "min1", 1L);
+      expect_property<&glz::schema::minimum>(test, "min1", std::int64_t{1});
    };
   "max2"_test = [] {
       test_case const test{};
-      expect_property<&glz::schema::maximum>(test, "max2", 2L);
+      expect_property<&glz::schema::maximum>(test, "max2", std::int64_t{2});
    };
    "pattern"_test = [] {
       test_case const test{};

--- a/tests/json_test/jsonschema_test.cpp
+++ b/tests/json_test/jsonschema_test.cpp
@@ -11,8 +11,6 @@ struct schema_obj
    std::int64_t variable{2};
 };
 
-// static constexpr auto example_arr = std::array<std::string_view, 1>{ "\"this is an example\"" };
-
 template <>
 struct glz::json_schema<schema_obj>
 {
@@ -21,6 +19,7 @@ struct glz::json_schema<schema_obj>
       // .defaultValue = 42L, // todo it is not currently supported to read glz::schema::schema_any, for reference see
       // function variant_is_auto_deducible
       .deprecated = true,
+      // .examples = {"foo", "bar"}, // read of std::span is not supported
       .readOnly = true,
       .writeOnly = true,
       .constant = "some constant value",
@@ -45,7 +44,6 @@ struct glz::json_schema<schema_obj>
       .ExtUnits = detail::ExtUnits{.unitAscii = "m^2", .unitUnicode = "m²"},
       .ExtAdvanced = true,
    };
-   // schema examples{.examples = example_arr};
 };
 
 struct test_case
@@ -58,7 +56,7 @@ template <class T>
 concept is_optional = glz::is_specialization_v<T, std::optional>;
 
 template <auto Member, typename Value>
-auto expect_property(test_case test, std::string_view key, Value value)
+auto expect_property(test_case const& test, std::string_view key, Value value)
 {
    auto schematic = test.obj;
    expect(fatal(schematic.has_value()));
@@ -97,10 +95,6 @@ suite schema_attributes = [] {
       test_case const test{};
       expect_property<&glz::schema::deprecated>(test, "variable", true);
    };
-   // skip / "examples"_test = [] {
-   //    test_case const test{};
-   //    expect_property<&glz::schema::examples>(test, "examples", std::span{ example_arr });
-   // };
    "readOnly"_test = [] {
       test_case const test{};
       expect_property<&glz::schema::readOnly>(test, "variable", true);

--- a/tests/json_test/jsonschema_test.cpp
+++ b/tests/json_test/jsonschema_test.cpp
@@ -34,8 +34,8 @@ struct test_case
    glz::expected<glz::detail::schematic, glz::parse_error> obj{glz::read_json<glz::detail::schematic>(schema_str)};
 };
 
-template <auto Member>
-auto expect_property(test_case test, std::string_view key, auto value) {
+template <auto Member, typename Value>
+auto expect_property(test_case test, std::string_view key, Value value) {
    auto schematic = test.obj;
    expect(fatal(schematic.has_value())) << "hello world";
    expect(schematic->properties->contains(key) >> fatal);
@@ -44,9 +44,8 @@ auto expect_property(test_case test, std::string_view key, auto value) {
    expect(prop_value.has_value() >> fatal);
    using prop_value_t = std::decay_t<decltype(prop_value)>;
    if constexpr (std::same_as<prop_value_t, glz::schema::schema_number>) {
-      using input_value_t = std::decay_t<decltype(value)>;
-      expect(std::holds_alternative<input_value_t>(prop_value.value()) >> fatal);
-      expect(std::get<input_value_t>(prop_value.value()) == value);
+      expect(std::holds_alternative<Value>(prop_value.value()) >> fatal);
+      expect(std::get<Value>(prop_value.value()) == value);
    }
    else {
       expect(prop_value.value() == value);

--- a/tests/json_test/jsonschema_test.cpp
+++ b/tests/json_test/jsonschema_test.cpp
@@ -28,6 +28,7 @@ struct glz::json_schema<schema_obj>
       .minLength = 1L,
       .maxLength = 2L,
       .pattern = "[a-z]+",
+      .format = detail::defined_formats::hostname,
       .minimum = 1L,
       .maximum = 2L,
       .exclusiveMinimum = 1L,
@@ -59,7 +60,7 @@ template <auto Member, typename Value>
 auto expect_property(test_case test, std::string_view key, Value value)
 {
    auto schematic = test.obj;
-   expect(fatal(schematic.has_value())) << "hello world";
+   expect(fatal(schematic.has_value()));
    expect(schematic->properties->contains(key) >> fatal);
    glz::schema prop = schematic->properties->at(key);
    auto prop_value = glz::detail::get_member(prop, Member);
@@ -124,6 +125,10 @@ suite schema_attributes = [] {
    "pattern"_test = [] {
       test_case const test{};
       expect_property<&glz::schema::pattern>(test, "variable", "[a-z]+"sv);
+   };
+   "format"_test = [] {
+      test_case const test{};
+      expect_property<&glz::schema::format>(test, "variable", glz::detail::defined_formats::hostname);
    };
    "minimum"_test = [] {
       test_case const test{};

--- a/tests/json_test/jsonschema_test.cpp
+++ b/tests/json_test/jsonschema_test.cpp
@@ -42,7 +42,7 @@ struct glz::json_schema<schema_obj>
       .maxContains = 2UL,
       .uniqueItems = true,
       // .enumeration = , // read of std::span is not supported
-      .outOfSpec = detail::out_of_spec{.unit_ascii = "m^2"},
+      .outOfSpec = detail::out_of_spec{.unit_ascii = "m^2", .unit_unicode = "m²", .advanced = true},
    };
    // schema examples{.examples = example_arr};
 };
@@ -178,7 +178,7 @@ suite schema_attributes = [] {
    };
    "outOfSpec"_test = [] {
       test_case const test{};
-      expect_property<&glz::schema::outOfSpec>(test, "variable", glz::detail::out_of_spec{.unit_ascii = "m^2"});
+      expect_property<&glz::schema::outOfSpec>(test, "variable", glz::detail::out_of_spec{.unit_ascii = "m^2", .unit_unicode = "m²", .advanced = true});
    };
 };
 


### PR DESCRIPTION
Two additional json schema features,

- format https://www.learnjsonschema.com/2020-12/format-annotation/format/
- out of specification
  - unit ascii 
  - unit unicode
  - advanced flag

The out of specification is up for discussion, the use case for units relates to usage of https://github.com/mpusz/mp-units units library, to reflect on the actual type and scaler of each number. The use case of `advanced` is generation of configuration view in UI, so the programmer writing logic can mark parameter advanced so it would not show in default view.

I will follow up with small json schema changes after this PR.