### PR TITLE
Partial read quick exits even when error_on_unknown_keys is false

### DIFF
--- a/docs/partial-read.md
+++ b/docs/partial-read.md
@@ -13,6 +13,10 @@ At times it is not necessary to read the entire JSON document, but rather just a
 
 When `partial_read` is `true`, parsing will end once all the keys defined in the struct have been parsed.
 
+## partial_read_nested
+
+If your object that you wish to only read part of is nested within other objects, set `partial_read_nested = true` so that Glaze will properly parse the parent objects by skipping to the end of the partially read object.
+
 ## Example
 
 ```c++
@@ -38,8 +42,6 @@ expect(glz::read_json(h, buf) == glz::error_code::none);
 expect(h.id == "51e2affb");
 expect(h.type == "message_type");
 ```
-
->  If `error_on_unknown_keys` is set to `false`, then the JSON will be parsed until the end.
 
 ## Unit Test Examples
 

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -64,7 +64,7 @@ namespace glz
       bool structs_as_arrays = false; // Handle structs (reading/writing) without keys, which applies to reflectable and
 
       // glaze_object_t concepts
-      bool partial_read_nested = false; // Rewind forward the partially readed struct to the end of the struct
+      bool partial_read_nested = false; // Advance the partially read struct to the end of the struct
       bool concatenate = true; // Concatenates ranges of std::pair into single objects when writing
 
       bool hide_non_invocable =


### PR DESCRIPTION
Once the desired keys are read, we don't need to parse any more of the file. This was true before for partial reading when `error_on_unknown_keys` was true. But, now this more efficient quick exiting also applies to when `error_on_unknown_keys` is false.