### PR TITLE
read_allocated option with tuple, array, vector support

### DIFF
--- a/include/glaze/core/meta.hpp
+++ b/include/glaze/core/meta.hpp
@@ -286,17 +286,11 @@ namespace glz
    // Allows developers to add `static constexpr auto custom_read = true;` to their glz::meta to prevent ambiguous
    // partial specialization for custom parsers
    template <class T>
-   concept custom_read = requires { meta<T>::custom_read == true; };
+   concept custom_read = requires { requires meta<T>::custom_read == true ; };
 
    template <class T>
-   concept custom_write = requires { meta<T>::custom_write == true; };
+   concept custom_write = requires { requires meta<T>::custom_write == true; };
 
    template <class T>
-   concept partial_read = requires { meta<T>::partial_read == true; };
-
-   template <typename T>
-   concept specialized_with_custom_write = requires { requires(meta<T>::custom_write == true); };
-
-   template <typename T>
-   concept specialized_with_custom_read = requires { requires(meta<T>::custom_read == true); };
+   concept partial_read = requires { requires meta<T>::partial_read == true; };
 }

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -62,6 +62,8 @@ namespace glz
       bool raw = false; // write out string like values without quotes
       bool raw_string = false; // do not decode/encode escaped characters for strings (improves read/write performance)
       bool structs_as_arrays = false; // Handle structs (reading/writing) without keys, which applies to reflectable and
+      
+      bool read_allocated = false; // Reads into only allocated memory and then exits without parsing the rest of the input
 
       // glaze_object_t concepts
       bool partial_read_nested = false; // Advance the partially read struct to the end of the struct

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -124,7 +124,7 @@ namespace glz
       };
 
       template <class T>
-         requires(glaze_value_t<T> && !specialized_with_custom_read<T>)
+         requires(glaze_value_t<T> && !custom_read<T>)
       struct from_json<T>
       {
          template <auto Opts, class Value, is_context Ctx, class It0, class It1>
@@ -857,7 +857,7 @@ namespace glz
       };
 
       template <class T>
-         requires(glaze_enum_t<T> && !specialized_with_custom_read<T>)
+         requires(glaze_enum_t<T> && !custom_read<T>)
       struct from_json<T>
       {
          template <auto Opts>
@@ -883,7 +883,7 @@ namespace glz
       };
 
       template <class T>
-         requires(std::is_enum_v<T> && !glaze_enum_t<T> && !specialized_with_custom_read<T>)
+         requires(std::is_enum_v<T> && !glaze_enum_t<T> && !custom_read<T>)
       struct from_json<T>
       {
          template <auto Opts>

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1697,7 +1697,7 @@ namespace glz
                }();
                
                decltype(auto) fields = [&]() -> decltype(auto) {
-                  if constexpr (Opts.error_on_missing_keys || partial_read<T>) {
+                  if constexpr (Opts.error_on_missing_keys || partial_read<T> || Opts.read_allocated) {
                      return bit_array<num_members>{};
                   }
                   else {
@@ -1730,7 +1730,7 @@ namespace glz
 
                bool first = true;
                while (true) {
-                  if constexpr (partial_read<T>) {
+                  if constexpr (partial_read<T> || Opts.read_allocated) {
                      if ((all_fields & fields) == all_fields) {
                         if constexpr (Opts.partial_read_nested) {
                            skip_until_closed<Opts, '{', '}'>(ctx, it, end);
@@ -1740,7 +1740,7 @@ namespace glz
                   }
 
                   if (*it == '}') {
-                     if constexpr (partial_read<T> && Opts.error_on_missing_keys) {
+                     if constexpr ((partial_read<T> || Opts.read_allocated) && Opts.error_on_missing_keys) {
                         ctx.error = error_code::missing_key;
                      }
                      else {
@@ -1817,7 +1817,7 @@ namespace glz
                            if (bool(ctx.error)) [[unlikely]]
                               return;
 
-                           if constexpr (Opts.error_on_missing_keys || partial_read<T>) {
+                           if constexpr (Opts.error_on_missing_keys || partial_read<T> || Opts.read_allocated) {
                               // TODO: Kludge/hack. Should work but could easily cause memory issues with small changes.
                               // At the very least if we are going to do this add a get_index method to the maps and
                               // call that
@@ -1884,7 +1884,7 @@ namespace glz
                               if (bool(ctx.error)) [[unlikely]]
                                  return;
 
-                              if constexpr (Opts.error_on_missing_keys || partial_read<T>) {
+                              if constexpr (Opts.error_on_missing_keys || partial_read<T> || Opts.read_allocated) {
                                  // TODO: Kludge/hack. Should work but could easily cause memory issues with small
                                  // changes. At the very least if we are going to do this add a get_index method to the
                                  // maps and call that

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1047,144 +1047,149 @@ namespace glz
                   return;
                }
             }
+            
+            if constexpr (Opts.read_allocated) {
+               return;
+            }
+            else {
+               // growing
+               if constexpr (emplace_backable<T>) {
+                  // This optimization is useful when a std::vector contains large types (greater than 4096 bytes)
+                  // It is faster to simply use emplace_back for small types and reasonably lengthed vectors
+                  // (less than a million elements)
+                  // https://baptiste-wicht.com/posts/2012/12/cpp-benchmark-vector-list-deque.html
+                  if constexpr (has_reserve<T> && has_capacity<T> &&
+                                requires { requires(sizeof(typename T::value_type) > 4096); }) {
+                     // If we can reserve memmory, like std::vector, then we want to check the capacity
+                     // and use a temporary buffer if the capacity needs to grow
+                     if (value.capacity() == 0) {
+                        value.reserve(1); // we want to directly use our vector for the first element
+                     }
+                     const auto capacity = value.capacity();
+                     for (size_t i = value.size(); i < capacity; ++i) {
+                        // emplace_back while we have capacity
+                        read<json>::op<ws_handled<Opts>()>(value.emplace_back(), ctx, it, end);
+                        if (bool(ctx.error)) [[unlikely]]
+                           return;
+                        GLZ_SKIP_WS;
+                        if (*it == ',') [[likely]] {
+                           ++it;
 
-            // growing
-            if constexpr (emplace_backable<T>) {
-               // This optimization is useful when a std::vector contains large types (greater than 4096 bytes)
-               // It is faster to simply use emplace_back for small types and reasonably lengthed vectors
-               // (less than a million elements)
-               // https://baptiste-wicht.com/posts/2012/12/cpp-benchmark-vector-list-deque.html
-               if constexpr (has_reserve<T> && has_capacity<T> &&
-                             requires { requires(sizeof(typename T::value_type) > 4096); }) {
-                  // If we can reserve memmory, like std::vector, then we want to check the capacity
-                  // and use a temporary buffer if the capacity needs to grow
-                  if (value.capacity() == 0) {
-                     value.reserve(1); // we want to directly use our vector for the first element
-                  }
-                  const auto capacity = value.capacity();
-                  for (size_t i = value.size(); i < capacity; ++i) {
-                     // emplace_back while we have capacity
-                     read<json>::op<ws_handled<Opts>()>(value.emplace_back(), ctx, it, end);
-                     if (bool(ctx.error)) [[unlikely]]
-                        return;
-                     GLZ_SKIP_WS;
-                     if (*it == ',') [[likely]] {
-                        ++it;
-
-                        if constexpr (!Opts.minified) {
-                           if (ws_size && ws_size < size_t(end - it)) {
-                              skip_matching_ws(ws_start, it, ws_size);
+                           if constexpr (!Opts.minified) {
+                              if (ws_size && ws_size < size_t(end - it)) {
+                                 skip_matching_ws(ws_start, it, ws_size);
+                              }
                            }
+
+                           GLZ_SKIP_WS;
+                        }
+                        else if (*it == ']') {
+                           ++it;
+                           return;
+                        }
+                        else [[unlikely]] {
+                           ctx.error = error_code::expected_bracket;
+                           return;
+                        }
+                     }
+
+                     using value_type = typename T::value_type;
+
+                     std::vector<std::vector<value_type>> intermediate;
+                     intermediate.reserve(48);
+                     auto* active = &intermediate.emplace_back();
+                     active->reserve(2);
+                     while (it < end) {
+                        if (active->size() == active->capacity()) {
+                           // we want to populate the next vector
+                           const auto former_capacity = active->capacity();
+                           active = &intermediate.emplace_back();
+                           active->reserve(2 * former_capacity);
                         }
 
+                        read<json>::op<ws_handled<Opts>()>(active->emplace_back(), ctx, it, end);
+                        if (bool(ctx.error)) [[unlikely]]
+                           return;
                         GLZ_SKIP_WS;
-                     }
-                     else if (*it == ']') {
-                        ++it;
-                        return;
-                     }
-                     else [[unlikely]] {
-                        ctx.error = error_code::expected_bracket;
-                        return;
-                     }
-                  }
+                        if (*it == ',') [[likely]] {
+                           ++it;
 
-                  using value_type = typename T::value_type;
+                           if constexpr (!Opts.minified) {
+                              if (ws_size && ws_size < size_t(end - it)) {
+                                 skip_matching_ws(ws_start, it, ws_size);
+                              }
+                           }
 
-                  std::vector<std::vector<value_type>> intermediate;
-                  intermediate.reserve(48);
-                  auto* active = &intermediate.emplace_back();
-                  active->reserve(2);
-                  while (it < end) {
-                     if (active->size() == active->capacity()) {
-                        // we want to populate the next vector
-                        const auto former_capacity = active->capacity();
-                        active = &intermediate.emplace_back();
-                        active->reserve(2 * former_capacity);
+                           GLZ_SKIP_WS;
+                        }
+                        else if (*it == ']') {
+                           ++it;
+                           break;
+                        }
+                        else [[unlikely]] {
+                           ctx.error = error_code::expected_bracket;
+                           return;
+                        }
                      }
 
-                     read<json>::op<ws_handled<Opts>()>(active->emplace_back(), ctx, it, end);
-                     if (bool(ctx.error)) [[unlikely]]
-                        return;
-                     GLZ_SKIP_WS;
-                     if (*it == ',') [[likely]] {
-                        ++it;
+                     const auto intermediate_size = intermediate.size();
+                     size_t reserve_size = value.size();
+                     for (size_t i = 0; i < intermediate_size; ++i) {
+                        reserve_size += intermediate[i].size();
+                     }
 
-                        if constexpr (!Opts.minified) {
-                           if (ws_size && ws_size < size_t(end - it)) {
-                              skip_matching_ws(ws_start, it, ws_size);
+                     if constexpr (std::is_trivially_copyable_v<value_type> && !std::same_as<T, std::vector<bool>>) {
+                        const auto original_size = value.size();
+                        value.resize(reserve_size);
+                        auto* dest = value.data() + original_size;
+                        for (const auto& vector : intermediate) {
+                           const auto vector_size = vector.size();
+                           std::memcpy(dest, vector.data(), vector_size * sizeof(value_type));
+                           dest += vector_size;
+                        }
+                     }
+                     else {
+                        value.reserve(reserve_size);
+                        for (const auto& vector : intermediate) {
+                           const auto inter_end = vector.end();
+                           for (auto inter = vector.begin(); inter < inter_end; ++inter) {
+                              value.emplace_back(std::move(*inter));
                            }
                         }
-
-                        GLZ_SKIP_WS;
-                     }
-                     else if (*it == ']') {
-                        ++it;
-                        break;
-                     }
-                     else [[unlikely]] {
-                        ctx.error = error_code::expected_bracket;
-                        return;
-                     }
-                  }
-
-                  const auto intermediate_size = intermediate.size();
-                  size_t reserve_size = value.size();
-                  for (size_t i = 0; i < intermediate_size; ++i) {
-                     reserve_size += intermediate[i].size();
-                  }
-
-                  if constexpr (std::is_trivially_copyable_v<value_type> && !std::same_as<T, std::vector<bool>>) {
-                     const auto original_size = value.size();
-                     value.resize(reserve_size);
-                     auto* dest = value.data() + original_size;
-                     for (const auto& vector : intermediate) {
-                        const auto vector_size = vector.size();
-                        std::memcpy(dest, vector.data(), vector_size * sizeof(value_type));
-                        dest += vector_size;
                      }
                   }
                   else {
-                     value.reserve(reserve_size);
-                     for (const auto& vector : intermediate) {
-                        const auto inter_end = vector.end();
-                        for (auto inter = vector.begin(); inter < inter_end; ++inter) {
-                           value.emplace_back(std::move(*inter));
+                     // If we don't have reserve (like std::deque) or we have small sized elements
+                     while (it < end) {
+                        read<json>::op<ws_handled<Opts>()>(value.emplace_back(), ctx, it, end);
+                        if (bool(ctx.error)) [[unlikely]]
+                           return;
+                        GLZ_SKIP_WS;
+                        if (*it == ',') [[likely]] {
+                           ++it;
+
+                           if constexpr (!Opts.minified) {
+                              if (ws_size && ws_size < size_t(end - it)) {
+                                 skip_matching_ws(ws_start, it, ws_size);
+                              }
+                           }
+
+                           GLZ_SKIP_WS;
+                        }
+                        else if (*it == ']') {
+                           ++it;
+                           return;
+                        }
+                        else [[unlikely]] {
+                           ctx.error = error_code::expected_bracket;
+                           return;
                         }
                      }
                   }
                }
                else {
-                  // If we don't have reserve (like std::deque) or we have small sized elements
-                  while (it < end) {
-                     read<json>::op<ws_handled<Opts>()>(value.emplace_back(), ctx, it, end);
-                     if (bool(ctx.error)) [[unlikely]]
-                        return;
-                     GLZ_SKIP_WS;
-                     if (*it == ',') [[likely]] {
-                        ++it;
-
-                        if constexpr (!Opts.minified) {
-                           if (ws_size && ws_size < size_t(end - it)) {
-                              skip_matching_ws(ws_start, it, ws_size);
-                           }
-                        }
-
-                        GLZ_SKIP_WS;
-                     }
-                     else if (*it == ']') {
-                        ++it;
-                        return;
-                     }
-                     else [[unlikely]] {
-                        ctx.error = error_code::expected_bracket;
-                        return;
-                     }
-                  }
+                  ctx.error = error_code::exceeded_static_array_size;
                }
-            }
-            else {
-               ctx.error = error_code::exceeded_static_array_size;
             }
          }
       };
@@ -1331,8 +1336,13 @@ namespace glz
                }
                GLZ_SKIP_WS;
             });
-
-            match<']'>(ctx, it);
+            
+            if constexpr (Opts.read_allocated) {
+               return;
+            }
+            else {
+               match<']'>(ctx, it);
+            }
          }
       };
 

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1661,11 +1661,11 @@ namespace glz
       {
          bit_array<NumMembers> fields{};
          static constexpr bit_array<NumMembers> all_fields = [] {
-            bit_array<NumMembers> fields{};
+            bit_array<NumMembers> arr{};
             for (size_t i = 0; i < NumMembers; ++i) {
-               fields[i] = true;
+               arr[i] = true;
             }
-            return fields;
+            return arr;
          }();
       };
 

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -33,7 +33,7 @@ namespace glz
       };
 
       template <class T>
-         requires(glaze_value_t<T> && !specialized_with_custom_write<T>)
+         requires(glaze_value_t<T> && !custom_write<T>)
       struct to_json<T>
       {
          template <auto Opts, class Value, is_context Ctx, class B, class IX>
@@ -427,7 +427,7 @@ namespace glz
       };
 
       template <class T>
-         requires(glaze_enum_t<T> && !specialized_with_custom_write<T>)
+         requires(glaze_enum_t<T> && !custom_write<T>)
       struct to_json<T>
       {
          template <auto Opts, class... Args>
@@ -452,7 +452,7 @@ namespace glz
       };
 
       template <class T>
-         requires(std::is_enum_v<std::decay_t<T>> && !glaze_enum_t<T> && !specialized_with_custom_write<T>)
+         requires(std::is_enum_v<std::decay_t<T>> && !glaze_enum_t<T> && !custom_write<T>)
       struct to_json<T>
       {
          template <auto Opts, class... Args>

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -8071,6 +8071,14 @@ suite read_allocated_tests = [] {
       expect(v[0] = 1);
       expect(v[1] = 2);
    };
+   
+   "read_allocated map"_test = [] {
+      std::string s = R"({"1":1,"2":2,"3":3})";
+      std::map<std::string, int> obj{{"2",0}};
+      expect(!glz::read<options>(obj, s));
+      expect(obj.size() == 1);
+      expect(obj.at("2") = 2);
+   };
 };
 
 int main()

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -8052,6 +8052,27 @@ suite bools_as_numbers_test = [] {
    };
 };
 
+suite read_allocated_tests = [] {
+   static constexpr glz::opts options{.read_allocated = true};
+   
+   "read_allocated tuple"_test = [] {
+      std::string s = R"(["hello",88,"a string we don't care about"])";
+      std::tuple<std::string, int> obj{};
+      expect(!glz::read<options>(obj, s));
+      expect(std::get<0>(obj) == "hello");
+      expect(std::get<1>(obj) == 88);
+   };
+   
+   "read_allocated vector"_test = [] {
+      std::string s = R"([1,2,3,4,5])";
+      std::vector<int> v(2);
+      expect(!glz::read<options>(v, s));
+      expect(v.size() == 2);
+      expect(v[0] = 1);
+      expect(v[1] = 2);
+   };
+};
+
 int main()
 {
    trace.begin("json_test", "Full test suite duration.");


### PR DESCRIPTION
Adding a new compile time option `read_allocated`, which will only read in the allocated memory. Once the allocated memory has been read in, we early exit.

This is very useful for reading headers.

Support has been added for types like `std::tuple`, `std::array`, `std::vector`, `std::map`, `std::unordered_map`, glaze meta objects, and reflected structs.