### PR TITLE
partial_read wrapper and documentation

### DIFF
--- a/docs/partial-read.md
+++ b/docs/partial-read.md
@@ -1,6 +1,69 @@
 # Partial Read
 
-At times it is not necessary to read the entire JSON document, but rather just a header or some of the initial fields. Glaze supports this feature by providing a `partial_read` flag that can be set to `true` within the glaze metadata.
+At times it is not necessary to read the entire JSON document, but rather just a header or some of the initial fields. Glaze provides multiple solutions:
+
+- Partial reading with `read_allocated` in `glz::opts`
+- Partial reading with `partial_read` flag in `glz::meta`
+- Partial reading via [JSON Pointer syntax](./json-pointer-syntax.md)
+
+# Partial reading with read_allocated
+
+`read_allocated` is a compile time flag in `glz::opts` that indicates only allocated memory should be read into, and once the allocated memory has been read, parsing returns without iterating through the entire document.
+
+> A [wrapper](./wrappers.md) by the same name also exists.
+
+Example: read only the first two elements into a `std::tuple`
+
+```c++
+std::string s = R"(["hello",88,"a string we don't care about"])";
+std::tuple<std::string, int> obj{};
+expect(!glz::read<allocated>(obj, s));
+expect(std::get<0>(obj) == "hello");
+expect(std::get<1>(obj) == 88);
+```
+
+Example: read only the first two elements into a `std::vector`
+
+```c++
+std::string s = R"([1,2,3,4,5])";
+std::vector<int> v(2);
+expect(!glz::read<allocated>(v, s));
+expect(v.size() == 2);
+expect(v[0] = 1);
+expect(v[1] = 2);
+```
+
+Example: read only the allocated element in a `std::map`
+
+```c++
+std::string s = R"({"1":1,"2":2,"3":3})";
+std::map<std::string, int> obj{{"2", 0}};
+expect(!glz::read<allocated>(obj, s));
+expect(obj.size() == 1);
+expect(obj.at("2") = 2);
+```
+
+Example: read only the fields present in a struct
+
+```c++
+struct allocated_struct
+{
+   std::string string{};
+   int32_t integer{};
+};
+```
+
+```c++
+std::string s = R"({"integer":400,"string":"ha!",ignore})";
+allocated_struct obj{};
+expect(!glz::read<glz::opts{.read_allocated = true}>(obj, s));
+expect(obj.string == "ha!");
+expect(obj.integer == 400);
+```
+
+# Partial reading with partial_read
+
+Glaze allows a `partial_read` flag that can be set to `true` within the glaze metadata.
 
 ```json
 {

--- a/docs/partial-read.md
+++ b/docs/partial-read.md
@@ -2,13 +2,13 @@
 
 At times it is not necessary to read the entire JSON document, but rather just a header or some of the initial fields. Glaze provides multiple solutions:
 
-- Partial reading with `read_allocated` in `glz::opts`
-- Partial reading with `partial_read` flag in `glz::meta`
+-  `partial_read` in `glz::opts`
+-  `partial_read` in `glz::meta`
 - Partial reading via [JSON Pointer syntax](./json-pointer-syntax.md)
 
-# Partial reading with read_allocated
+# Partial reading with glz::opts
 
-`read_allocated` is a compile time flag in `glz::opts` that indicates only allocated memory should be read into, and once the allocated memory has been read, parsing returns without iterating through the entire document.
+`partial_read` is a compile time flag in `glz::opts` that indicates only existing array and object elements should be read into, and once the memory has been read, parsing returns without iterating through the rest of the document.
 
 > A [wrapper](./wrappers.md) by the same name also exists.
 
@@ -17,7 +17,7 @@ Example: read only the first two elements into a `std::tuple`
 ```c++
 std::string s = R"(["hello",88,"a string we don't care about"])";
 std::tuple<std::string, int> obj{};
-expect(!glz::read<allocated>(obj, s));
+expect(!glz::read<glz::opts{.partial_read = true}>(obj, s));
 expect(std::get<0>(obj) == "hello");
 expect(std::get<1>(obj) == 88);
 ```
@@ -27,7 +27,7 @@ Example: read only the first two elements into a `std::vector`
 ```c++
 std::string s = R"([1,2,3,4,5])";
 std::vector<int> v(2);
-expect(!glz::read<allocated>(v, s));
+expect(!glz::read<glz::opts{.partial_read = true}>(v, s));
 expect(v.size() == 2);
 expect(v[0] = 1);
 expect(v[1] = 2);
@@ -38,7 +38,7 @@ Example: read only the allocated element in a `std::map`
 ```c++
 std::string s = R"({"1":1,"2":2,"3":3})";
 std::map<std::string, int> obj{{"2", 0}};
-expect(!glz::read<allocated>(obj, s));
+expect(!glz::read<glz::opts{.partial_read = true}>(obj, s));
 expect(obj.size() == 1);
 expect(obj.at("2") = 2);
 ```
@@ -46,7 +46,7 @@ expect(obj.at("2") = 2);
 Example: read only the fields present in a struct
 
 ```c++
-struct allocated_struct
+struct partial_struct
 {
    std::string string{};
    int32_t integer{};
@@ -55,13 +55,13 @@ struct allocated_struct
 
 ```c++
 std::string s = R"({"integer":400,"string":"ha!",ignore})";
-allocated_struct obj{};
-expect(!glz::read<glz::opts{.read_allocated = true}>(obj, s));
+partial_struct obj{};
+expect(!glz::read<glz::opts{.partial_read = true}>(obj, s));
 expect(obj.string == "ha!");
 expect(obj.integer == 400);
 ```
 
-# Partial reading with partial_read
+# Partial reading with glz::meta
 
 Glaze allows a `partial_read` flag that can be set to `true` within the glaze metadata.
 

--- a/docs/wrappers.md
+++ b/docs/wrappers.md
@@ -296,31 +296,6 @@ Reads into existing object and array elements and then exits without parsing the
 
 > `partial_read` is useful when parsing header information before deciding how to decode the rest of a document. Or, when you only care about the first few elements of an array.
 
-```c++
-struct partial_meta
-{
-   std::string string{};
-   int32_t integer{};
-};
-
-template <>
-struct glz::meta<partial_meta>
-{
-   using T = partial_meta;
-   static constexpr auto value = object("string", partial_read<&T::string>, "integer", partial_read<&T::integer>);
-};
-```
-
-In use:
-
-```c++
-std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
-partial_meta obj{};
-expect(!glz::read<glz::opts{.error_on_unknown_keys = false, .read_allocated = true}>(obj, s));
-expect(obj.string == "ha!");
-expect(obj.integer == 400);
-```
-
 ## invoke
 
 Invoke a std::function or member function with n-arguments as an array input.

--- a/docs/wrappers.md
+++ b/docs/wrappers.md
@@ -13,7 +13,7 @@ glz::raw<&T::x> // Write out string like types without quotes
 glz::raw_string<&T::string> // Do not decode/encode escaped characters for strings (improves read/write performance)
 glz::escaped<&T::string> // Opposite of glz::raw_string, it turns off this behavior
 
-glz::read_allocated<&T::x> // Reads into only allocated memory and then exits without parsing the rest of the input
+glz::partial_read<&T::x> // Reads into only existing fields and elements and then exits without parsing the rest of the input
 
 glz::invoke<&T::func> // Invoke a std::function, lambda, or member function with n-arguments as an array input
   
@@ -290,24 +290,24 @@ glz::write_json(obj, buffer);
 expect(buffer == R"({"a":"Hello\nWorld","b":"","c":""})");
 ```
 
-## read_allocated
+## partial_read
 
-Reads into only allocated memory and then exits without parsing the rest of the input. More documentation concerning `read_allocated` can be found in the [Partial Read documentation](./partial-read.md).
+Reads into existing object and array elements and then exits without parsing the rest of the input. More documentation concerning `partial_read` can be found in the [Partial Read documentation](./partial-read.md).
 
-> `read_allocated` is useful when parsing header information before deciding how to decode the rest of a document. Or, when you only care about the first few elements of an array.
+> `partial_read` is useful when parsing header information before deciding how to decode the rest of a document. Or, when you only care about the first few elements of an array.
 
 ```c++
-struct allocated_meta
+struct partial_meta
 {
    std::string string{};
    int32_t integer{};
 };
 
 template <>
-struct glz::meta<allocated_meta>
+struct glz::meta<partial_meta>
 {
-   using T = allocated_meta;
-   static constexpr auto value = object("string", read_allocated<&T::string>, "integer", read_allocated<&T::integer>);
+   using T = partial_meta;
+   static constexpr auto value = object("string", partial_read<&T::string>, "integer", partial_read<&T::integer>);
 };
 ```
 
@@ -315,7 +315,7 @@ In use:
 
 ```c++
 std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
-allocated_meta obj{};
+partial_meta obj{};
 expect(!glz::read<glz::opts{.error_on_unknown_keys = false, .read_allocated = true}>(obj, s));
 expect(obj.string == "ha!");
 expect(obj.integer == 400);

--- a/include/glaze/binary.hpp
+++ b/include/glaze/binary.hpp
@@ -6,4 +6,5 @@
 #include "glaze/binary/header.hpp"
 #include "glaze/binary/ptr.hpp"
 #include "glaze/binary/read.hpp"
+#include "glaze/binary/wrappers.hpp"
 #include "glaze/binary/write.hpp"

--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -521,9 +521,13 @@ namespace glz
 
                ++it;
 
-               const auto n = int_from_compressed(ctx, it, end);
+               std::conditional_t<Opts.read_allocated, size_t, const size_t> n = int_from_compressed(ctx, it, end);
                if (bool(ctx.error)) [[unlikely]] {
                   return;
+               }
+               
+               if constexpr (Opts.read_allocated) {
+                  n = value.size();
                }
 
                if ((it + n * sizeof(V)) > end) [[unlikely]] {

--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -531,12 +531,12 @@ namespace glz
 
                ++it;
 
-               std::conditional_t<Opts.read_allocated, size_t, const size_t> n = int_from_compressed(ctx, it, end);
+               std::conditional_t<Opts.partial_read, size_t, const size_t> n = int_from_compressed(ctx, it, end);
                if (bool(ctx.error)) [[unlikely]] {
                   return;
                }
                
-               if constexpr (Opts.read_allocated) {
+               if constexpr (Opts.partial_read) {
                   n = value.size();
                }
 
@@ -576,12 +576,12 @@ namespace glz
 
                ++it;
 
-               std::conditional_t<Opts.read_allocated, size_t, const size_t> n = int_from_compressed(ctx, it, end);
+               std::conditional_t<Opts.partial_read, size_t, const size_t> n = int_from_compressed(ctx, it, end);
                if (bool(ctx.error)) [[unlikely]] {
                   return;
                }
                
-               if constexpr (Opts.read_allocated) {
+               if constexpr (Opts.partial_read) {
                   n = value.size();
                }
 
@@ -628,12 +628,12 @@ namespace glz
                }
                ++it;
 
-               std::conditional_t<Opts.read_allocated, size_t, const size_t> n = int_from_compressed(ctx, it, end);
+               std::conditional_t<Opts.partial_read, size_t, const size_t> n = int_from_compressed(ctx, it, end);
                if (bool(ctx.error)) [[unlikely]] {
                   return;
                }
                
-               if constexpr (Opts.read_allocated) {
+               if constexpr (Opts.partial_read) {
                   n = value.size();
                }
 
@@ -668,12 +668,12 @@ namespace glz
                }
                ++it;
 
-               std::conditional_t<Opts.read_allocated, size_t, const size_t> n = int_from_compressed(ctx, it, end);
+               std::conditional_t<Opts.partial_read, size_t, const size_t> n = int_from_compressed(ctx, it, end);
                if (bool(ctx.error)) [[unlikely]] {
                   return;
                }
                
-               if constexpr (Opts.read_allocated) {
+               if constexpr (Opts.partial_read) {
                   n = value.size();
                }
 
@@ -1006,7 +1006,7 @@ namespace glz
             
             using V = std::decay_t<T>;
             constexpr auto N = glz::tuple_size_v<V>;
-            if constexpr (Opts.read_allocated) {
+            if constexpr (Opts.partial_read) {
                const auto n = int_from_compressed(ctx, it, end);
 
                if constexpr (is_std_tuple<T>) {

--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -566,9 +566,13 @@ namespace glz
 
                ++it;
 
-               const auto n = int_from_compressed(ctx, it, end);
+               std::conditional_t<Opts.read_allocated, size_t, const size_t> n = int_from_compressed(ctx, it, end);
                if (bool(ctx.error)) [[unlikely]] {
                   return;
+               }
+               
+               if constexpr (Opts.read_allocated) {
+                  n = value.size();
                }
 
                if constexpr (resizable<T>) {
@@ -614,9 +618,13 @@ namespace glz
                }
                ++it;
 
-               const auto n = int_from_compressed(ctx, it, end);
+               std::conditional_t<Opts.read_allocated, size_t, const size_t> n = int_from_compressed(ctx, it, end);
                if (bool(ctx.error)) [[unlikely]] {
                   return;
+               }
+               
+               if constexpr (Opts.read_allocated) {
+                  n = value.size();
                }
 
                if ((it + n * sizeof(V)) > end) [[unlikely]] {
@@ -650,9 +658,13 @@ namespace glz
                }
                ++it;
 
-               const auto n = int_from_compressed(ctx, it, end);
+               std::conditional_t<Opts.read_allocated, size_t, const size_t> n = int_from_compressed(ctx, it, end);
                if (bool(ctx.error)) [[unlikely]] {
                   return;
+               }
+               
+               if constexpr (Opts.read_allocated) {
+                  n = value.size();
                }
 
                if constexpr (resizable<T>) {

--- a/include/glaze/binary/wrappers.hpp
+++ b/include/glaze/binary/wrappers.hpp
@@ -1,0 +1,34 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include <type_traits>
+
+#include "glaze/core/opts.hpp"
+#include "glaze/core/wrappers.hpp"
+#include "glaze/json/read.hpp"
+#include "glaze/json/write.hpp"
+
+namespace glz::detail
+{
+   template <is_opts_wrapper T>
+   struct from_binary<T>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args) noexcept
+      {
+         read<json>::op<opt_true<Opts, T::opts_member>>(value.val, args...);
+      }
+   };
+
+   template <is_opts_wrapper T>
+   struct to_binary<T>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+      {
+         write<json>::op<opt_true<Opts, T::opts_member>>(value.val, ctx, args...);
+      }
+   };
+}

--- a/include/glaze/core/meta.hpp
+++ b/include/glaze/core/meta.hpp
@@ -292,5 +292,5 @@ namespace glz
    concept custom_write = requires { requires meta<T>::custom_write == true; };
 
    template <class T>
-   concept partial_read = requires { requires meta<T>::partial_read == true; };
+   concept is_partial_read = requires { requires meta<T>::partial_read == true; };
 }

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -63,8 +63,8 @@ namespace glz
       bool raw_string = false; // do not decode/encode escaped characters for strings (improves read/write performance)
       bool structs_as_arrays = false; // Handle structs (reading/writing) without keys, which applies to reflectable and
 
-      bool read_allocated =
-         false; // Reads into only allocated memory and then exits without parsing the rest of the input
+      bool partial_read =
+         false; // Reads into only existing fields and elements and then exits without parsing the rest of the input
 
       // glaze_object_t concepts
       bool partial_read_nested = false; // Advance the partially read struct to the end of the struct

--- a/include/glaze/core/wrappers.hpp
+++ b/include/glaze/core/wrappers.hpp
@@ -56,7 +56,7 @@ namespace glz
    template <auto MemPtr>
    constexpr auto raw = detail::opts_wrapper<MemPtr, &opts::raw>();
    
-   // Reads into only allocated memory and then exits without parsing the rest of the input
+   // Reads into only existing fields and elements and then exits without parsing the rest of the input
    template <auto MemPtr>
-   constexpr auto read_allocated = detail::opts_wrapper<MemPtr, &opts::read_allocated>();
+   constexpr auto partial_read = detail::opts_wrapper<MemPtr, &opts::partial_read>();
 }

--- a/include/glaze/core/wrappers.hpp
+++ b/include/glaze/core/wrappers.hpp
@@ -1,0 +1,62 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include <type_traits>
+
+#include "glaze/core/opts.hpp"
+
+namespace glz
+{
+   namespace detail
+   {
+      template <class T, auto OptsMemPtr>
+      struct opts_wrapper_t
+      {
+         static constexpr bool glaze_wrapper = true;
+         static constexpr auto glaze_reflect = false;
+         static constexpr auto opts_member = OptsMemPtr;
+         using value_type = T;
+         T& val;
+      };
+
+      template <class T>
+      concept is_opts_wrapper = requires {
+         requires T::glaze_wrapper == true;
+         requires T::glaze_reflect == false;
+         T::opts_member;
+         typename T::value_type;
+         requires std::is_lvalue_reference_v<decltype(T::val)>;
+      };
+      
+      template <auto MemPtr, auto OptsMemPtr>
+      inline constexpr decltype(auto) opts_wrapper() noexcept
+      {
+         return [](auto&& val) {
+            using V = std::remove_reference_t<decltype(val.*MemPtr)>;
+            return opts_wrapper_t<V, OptsMemPtr>{val.*MemPtr};
+         };
+      }
+   }
+
+   // Read and write booleans as numbers
+   template <auto MemPtr>
+   constexpr auto bools_as_numbers = detail::opts_wrapper<MemPtr, &opts::bools_as_numbers>();
+
+   // Read and write numbers as strings
+   template <auto MemPtr>
+   constexpr auto quoted_num = detail::opts_wrapper<MemPtr, &opts::quoted_num>();
+
+   // Read numbers as strings and write these string as numbers
+   template <auto MemPtr>
+   constexpr auto number = detail::opts_wrapper<MemPtr, &opts::number>();
+
+   // Write out string like types without quotes
+   template <auto MemPtr>
+   constexpr auto raw = detail::opts_wrapper<MemPtr, &opts::raw>();
+   
+   // Reads into only allocated memory and then exits without parsing the rest of the input
+   template <auto MemPtr>
+   constexpr auto read_allocated = detail::opts_wrapper<MemPtr, &opts::read_allocated>();
+}

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1697,7 +1697,7 @@ namespace glz
                }();
 
                decltype(auto) fields = [&]() -> decltype(auto) {
-                  if constexpr (Opts.error_on_missing_keys || partial_read<T> || Opts.read_allocated) {
+                  if constexpr ((glaze_object_t<T> || reflectable<T>) && (Opts.error_on_missing_keys || partial_read<T> || Opts.read_allocated)) {
                      return bit_array<num_members>{};
                   }
                   else {
@@ -1730,7 +1730,7 @@ namespace glz
 
                bool first = true;
                while (true) {
-                  if constexpr (partial_read<T> || Opts.read_allocated) {
+                  if constexpr ((glaze_object_t<T> || reflectable<T>) && (partial_read<T> || Opts.read_allocated)) {
                      if ((all_fields & fields) == all_fields) {
                         if constexpr (Opts.partial_read_nested) {
                            skip_until_closed<Opts, '{', '}'>(ctx, it, end);
@@ -1740,7 +1740,7 @@ namespace glz
                   }
 
                   if (*it == '}') {
-                     if constexpr ((partial_read<T> || Opts.read_allocated) && Opts.error_on_missing_keys) {
+                     if constexpr ((glaze_object_t<T> || reflectable<T>) && ((partial_read<T> || Opts.read_allocated) && Opts.error_on_missing_keys)) {
                         ctx.error = error_code::missing_key;
                      }
                      else {

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1048,7 +1048,7 @@ namespace glz
                }
             }
 
-            if constexpr (Opts.read_allocated) {
+            if constexpr (Opts.partial_read) {
                return;
             }
             else {
@@ -1338,7 +1338,7 @@ namespace glz
                GLZ_SKIP_WS;
             });
 
-            if constexpr (Opts.read_allocated) {
+            if constexpr (Opts.partial_read) {
                return;
             }
             else {
@@ -1664,7 +1664,7 @@ namespace glz
          GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             static constexpr auto num_members = reflection_count<T>;
-            if constexpr (num_members == 0 && partial_read<T>) {
+            if constexpr (num_members == 0 && is_partial_read<T>) {
                static_assert(false_v<T>, "No members to read for partial read");
             }
 
@@ -1697,7 +1697,7 @@ namespace glz
                }();
 
                decltype(auto) fields = [&]() -> decltype(auto) {
-                  if constexpr ((glaze_object_t<T> || reflectable<T>) && (Opts.error_on_missing_keys || partial_read<T> || Opts.read_allocated)) {
+                  if constexpr ((glaze_object_t<T> || reflectable<T>) && (Opts.error_on_missing_keys || is_partial_read<T> || Opts.partial_read)) {
                      return bit_array<num_members>{};
                   }
                   else {
@@ -1705,7 +1705,7 @@ namespace glz
                   }
                }();
 
-               size_t read_count{}; // for read_allocated and dynamic objects
+               size_t read_count{}; // for partial_read and dynamic objects
 
                decltype(auto) frozen_map = [&]() -> decltype(auto) {
                   if constexpr (reflectable<T> && num_members > 0) {
@@ -1730,7 +1730,7 @@ namespace glz
 
                bool first = true;
                while (true) {
-                  if constexpr ((glaze_object_t<T> || reflectable<T>) && (partial_read<T> || Opts.read_allocated)) {
+                  if constexpr ((glaze_object_t<T> || reflectable<T>) && (is_partial_read<T> || Opts.partial_read)) {
                      if ((all_fields & fields) == all_fields) {
                         if constexpr (Opts.partial_read_nested) {
                            skip_until_closed<Opts, '{', '}'>(ctx, it, end);
@@ -1740,7 +1740,7 @@ namespace glz
                   }
 
                   if (*it == '}') {
-                     if constexpr ((glaze_object_t<T> || reflectable<T>) && ((partial_read<T> || Opts.read_allocated) && Opts.error_on_missing_keys)) {
+                     if constexpr ((glaze_object_t<T> || reflectable<T>) && ((is_partial_read<T> || Opts.partial_read) && Opts.error_on_missing_keys)) {
                         ctx.error = error_code::missing_key;
                      }
                      else {
@@ -1817,7 +1817,7 @@ namespace glz
                            if (bool(ctx.error)) [[unlikely]]
                               return;
 
-                           if constexpr (Opts.error_on_missing_keys || partial_read<T> || Opts.read_allocated) {
+                           if constexpr (Opts.error_on_missing_keys || is_partial_read<T> || Opts.partial_read) {
                               // TODO: Kludge/hack. Should work but could easily cause memory issues with small changes.
                               // At the very least if we are going to do this add a get_index method to the maps and
                               // call that
@@ -1884,7 +1884,7 @@ namespace glz
                               if (bool(ctx.error)) [[unlikely]]
                                  return;
 
-                              if constexpr (Opts.error_on_missing_keys || partial_read<T> || Opts.read_allocated) {
+                              if constexpr (Opts.error_on_missing_keys || is_partial_read<T> || Opts.partial_read) {
                                  // TODO: Kludge/hack. Should work but could easily cause memory issues with small
                                  // changes. At the very least if we are going to do this add a get_index method to the
                                  // maps and call that
@@ -1933,7 +1933,7 @@ namespace glz
 
                         parse_object_entry_sep<Opts>(ctx, it, end);
 
-                        if constexpr (Opts.read_allocated) {
+                        if constexpr (Opts.partial_read) {
                            if (auto element = value.find(key); element != value.end()) {
                               ++read_count;
                               read<json>::op<ws_handled<Opts>()>(element->second, ctx, it, end);
@@ -1961,7 +1961,7 @@ namespace glz
                         if (bool(ctx.error)) [[unlikely]]
                            return;
 
-                        if constexpr (Opts.read_allocated) {
+                        if constexpr (Opts.partial_read) {
                            if (auto element = value.find(key); element != value.end()) {
                               ++read_count;
                               read<json>::op<ws_handled<Opts>()>(element->second, ctx, it, end);
@@ -1998,7 +1998,7 @@ namespace glz
                         if (bool(ctx.error)) [[unlikely]]
                            return;
 
-                        if constexpr (Opts.read_allocated) {
+                        if constexpr (Opts.partial_read) {
                            if (auto element = value.find(key_value); element != value.end()) {
                               ++read_count;
                               read<json>::op<ws_handled<Opts>()>(element->second, ctx, it, end);

--- a/include/glaze/json/wrappers.hpp
+++ b/include/glaze/json/wrappers.hpp
@@ -123,4 +123,8 @@ namespace glz
    // Write out string like types without quotes
    template <auto MemPtr>
    constexpr auto raw = detail::opts_wrapper<MemPtr, &opts::raw>();
+   
+   // Reads into only allocated memory and then exits without parsing the rest of the input
+   template <auto MemPtr>
+   constexpr auto read_allocated = detail::opts_wrapper<MemPtr, &opts::read_allocated>();
 }

--- a/include/glaze/json/wrappers.hpp
+++ b/include/glaze/json/wrappers.hpp
@@ -6,6 +6,7 @@
 #include <type_traits>
 
 #include "glaze/core/opts.hpp"
+#include "glaze/core/wrappers.hpp"
 #include "glaze/json/read.hpp"
 #include "glaze/json/write.hpp"
 
@@ -18,25 +19,6 @@ namespace glz
       static constexpr bool glaze_wrapper = true;
       using value_type = T;
       T& val;
-   };
-
-   template <class T, auto OptsMemPtr>
-   struct opts_wrapper_t
-   {
-      static constexpr bool glaze_wrapper = true;
-      static constexpr auto glaze_reflect = false;
-      static constexpr auto opts_member = OptsMemPtr;
-      using value_type = T;
-      T& val;
-   };
-
-   template <class T>
-   concept is_opts_wrapper = requires {
-      requires T::glaze_wrapper == true;
-      requires T::glaze_reflect == false;
-      T::opts_member;
-      typename T::value_type;
-      requires std::is_lvalue_reference_v<decltype(T::val)>;
    };
 
    namespace detail
@@ -88,15 +70,6 @@ namespace glz
          }
       };
 
-      template <auto MemPtr, auto OptsMemPtr>
-      inline constexpr decltype(auto) opts_wrapper() noexcept
-      {
-         return [](auto&& val) {
-            using V = std::remove_reference_t<decltype(val.*MemPtr)>;
-            return opts_wrapper_t<V, OptsMemPtr>{val.*MemPtr};
-         };
-      }
-
       template <auto MemPtr>
       inline constexpr decltype(auto) quoted_impl() noexcept
       {
@@ -104,27 +77,7 @@ namespace glz
       }
    }
 
-   // Read and write booleans as numbers
-   template <auto MemPtr>
-   constexpr auto bools_as_numbers = detail::opts_wrapper<MemPtr, &opts::bools_as_numbers>();
-
-   // Read and write numbers as strings
-   template <auto MemPtr>
-   constexpr auto quoted_num = detail::opts_wrapper<MemPtr, &opts::quoted_num>();
-
-   // Read numbers as strings and write these string as numbers
-   template <auto MemPtr>
-   constexpr auto number = detail::opts_wrapper<MemPtr, &opts::number>();
-
    // Read a value as a string and unescape, to avoid the user having to parse twice
    template <auto MemPtr>
    constexpr auto quoted = detail::quoted_impl<MemPtr>();
-
-   // Write out string like types without quotes
-   template <auto MemPtr>
-   constexpr auto raw = detail::opts_wrapper<MemPtr, &opts::raw>();
-   
-   // Reads into only allocated memory and then exits without parsing the rest of the input
-   template <auto MemPtr>
-   constexpr auto read_allocated = detail::opts_wrapper<MemPtr, &opts::read_allocated>();
 }

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -1872,36 +1872,37 @@ suite read_allocated_tests = [] {
       expect(v[1] == "2");
    };
    
-   /*"partial_read map"_test = [] {
-    std::string s = R"({"1":1,"2":2,"3":3})";
-    std::map<std::string, int> obj{{"2", 0}};
-    expect(!glz::read<partial>(obj, s));
-    expect(obj.size() == 1);
-    expect(obj.at("2") = 2);
+   "partial_read map"_test = [] {
+      std::map<std::string, int> input{{"1",1},{"2",2},{"3",3}};
+      auto s = glz::write_binary(input);
+      std::map<std::string, int> obj{{"2", 0}};
+      expect(!glz::read<partial>(obj, s));
+      expect(obj.size() == 1);
+      expect(obj.at("2") = 2);
     };
     
-    "partial_read partial_struct"_test = [] {
-    std::string s = R"({"integer":400,"string":"ha!",ignore})";
-    partial_struct obj{};
-    expect(!glz::read<glz::opts{.format = glz::binary, .partial_read = true}>(obj, s));
-    expect(obj.string == "ha!");
-    expect(obj.integer == 400);
+    /*"partial_read partial_struct"_test = [] {
+       std::string s = R"({"integer":400,"string":"ha!",ignore})";
+       partial_struct obj{};
+       expect(!glz::read<glz::opts{.format = glz::binary, .partial_read = true}>(obj, s));
+       expect(obj.string == "ha!");
+       expect(obj.integer == 400);
     };
     
     "partial_read partial_struct, error_on_unknown_keys = false"_test = [] {
-    std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
-    partial_struct obj{};
-    expect(!glz::read<glz::opts{.format = glz::binary, .error_on_unknown_keys = false, .partial_read = true}>(obj, s));
-    expect(obj.string == "ha!");
-    expect(obj.integer == 400);
+       std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
+       partial_struct obj{};
+       expect(!glz::read<glz::opts{.format = glz::binary, .error_on_unknown_keys = false, .partial_read = true}>(obj, s));
+       expect(obj.string == "ha!");
+       expect(obj.integer == 400);
     };
     
     "partial_read partial_meta, error_on_unknown_keys = false"_test = [] {
-    std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
-    partial_meta obj{};
-    expect(!glz::read<glz::opts{.format = glz::binary, .error_on_unknown_keys = false, .partial_read = true}>(obj, s));
-    expect(obj.string == "ha!");
-    expect(obj.integer == 400);
+       std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
+       partial_meta obj{};
+       expect(!glz::read<glz::opts{.format = glz::binary, .error_on_unknown_keys = false, .partial_read = true}>(obj, s));
+       expect(obj.string == "ha!");
+       expect(obj.integer == 400);
     };*/
 };
    

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -1852,14 +1852,24 @@ suite read_allocated_tests = [] {
       expect(std::get<1>(obj) == 88);
    };
 
-   "read_allocated vector"_test = [] {
+   "read_allocated vector<int>"_test = [] {
       std::vector<int> input{1,2,3,4,5};
       auto s = glz::write_binary(input);
       std::vector<int> v(2);
       expect(!glz::read<allocated>(v, s));
       expect(v.size() == 2);
-      expect(v[0] = 1);
-      expect(v[1] = 2);
+      expect(v[0] == 1);
+      expect(v[1] == 2);
+   };
+   
+   "read_allocated vector<string>"_test = [] {
+      std::vector<std::string> input{"1","2","3","4","5"};
+      auto s = glz::write_binary(input);
+      std::vector<std::string> v(2);
+      expect(!glz::read<allocated>(v, s));
+      expect(v.size() == 2);
+      expect(v[0] == "1");
+      expect(v[1] == "2");
    };
 
    /*"read_allocated map"_test = [] {

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -1852,8 +1852,9 @@ suite read_allocated_tests = [] {
       expect(std::get<1>(obj) == 88);
    };
 
-   /*"read_allocated vector"_test = [] {
-      std::string s = R"([1,2,3,4,5])";
+   "read_allocated vector"_test = [] {
+      std::vector<int> input{1,2,3,4,5};
+      auto s = glz::write_binary(input);
       std::vector<int> v(2);
       expect(!glz::read<allocated>(v, s));
       expect(v.size() == 2);
@@ -1861,7 +1862,7 @@ suite read_allocated_tests = [] {
       expect(v[1] = 2);
    };
 
-   "read_allocated map"_test = [] {
+   /*"read_allocated map"_test = [] {
       std::string s = R"({"1":1,"2":2,"3":3})";
       std::map<std::string, int> obj{{"2", 0}};
       expect(!glz::read<allocated>(obj, s));

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -1820,6 +1820,80 @@ suite error_outputs = [] {
    };
 };
 
+struct allocated_struct
+{
+   std::string string{};
+   int32_t integer{};
+};
+
+struct allocated_meta
+{
+   std::string string{};
+   int32_t integer{};
+};
+
+template <>
+struct glz::meta<allocated_meta>
+{
+   using T = allocated_meta;
+   static constexpr auto value = object("string", read_allocated<&T::string>, "integer", read_allocated<&T::integer>);
+};
+
+suite read_allocated_tests = [] {
+   static constexpr glz::opts allocated{.format = glz::binary, .read_allocated = true};
+
+   "read_allocated tuple"_test = [] {
+      std::tuple<std::string, int, std::string> input{"hello", 88, "a string we don't care about"};
+      auto s = glz::write_binary(input);
+      std::tuple<std::string, int> obj{};
+      auto ec = glz::read<allocated>(obj, s);
+      expect(!ec) << glz::format_error(ec, s);
+      expect(std::get<0>(obj) == "hello");
+      expect(std::get<1>(obj) == 88);
+   };
+
+   /*"read_allocated vector"_test = [] {
+      std::string s = R"([1,2,3,4,5])";
+      std::vector<int> v(2);
+      expect(!glz::read<allocated>(v, s));
+      expect(v.size() == 2);
+      expect(v[0] = 1);
+      expect(v[1] = 2);
+   };
+
+   "read_allocated map"_test = [] {
+      std::string s = R"({"1":1,"2":2,"3":3})";
+      std::map<std::string, int> obj{{"2", 0}};
+      expect(!glz::read<allocated>(obj, s));
+      expect(obj.size() == 1);
+      expect(obj.at("2") = 2);
+   };
+
+   "read_allocated allocated_struct"_test = [] {
+      std::string s = R"({"integer":400,"string":"ha!",ignore})";
+      allocated_struct obj{};
+      expect(!glz::read<glz::opts{.format = glz::binary, .read_allocated = true}>(obj, s));
+      expect(obj.string == "ha!");
+      expect(obj.integer == 400);
+   };
+
+   "read_allocated allocated_struct, error_on_unknown_keys = false"_test = [] {
+      std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
+      allocated_struct obj{};
+      expect(!glz::read<glz::opts{.format = glz::binary, .error_on_unknown_keys = false, .read_allocated = true}>(obj, s));
+      expect(obj.string == "ha!");
+      expect(obj.integer == 400);
+   };
+   
+   "read_allocated allocated_meta, error_on_unknown_keys = false"_test = [] {
+      std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
+      allocated_meta obj{};
+      expect(!glz::read<glz::opts{.format = glz::binary, .error_on_unknown_keys = false, .read_allocated = true}>(obj, s));
+      expect(obj.string == "ha!");
+      expect(obj.integer == 400);
+   };*/
+};
+
 int main()
 {
    glz::trace_begin("binary_test");

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -1826,17 +1826,12 @@ struct partial_struct
    int32_t integer{};
 };
 
-struct partial_meta
+struct full_struct
 {
+   std::string skip_me{};
    std::string string{};
    int32_t integer{};
-};
-
-template <>
-struct glz::meta<partial_meta>
-{
-   using T = partial_meta;
-   static constexpr auto value = object("string", partial_read<&T::string>, "integer", partial_read<&T::integer>);
+   std::vector<int> more_data_to_ignore{};
 };
 
 suite read_allocated_tests = [] {
@@ -1881,29 +1876,14 @@ suite read_allocated_tests = [] {
       expect(obj.at("2") = 2);
     };
     
-    /*"partial_read partial_struct"_test = [] {
-       std::string s = R"({"integer":400,"string":"ha!",ignore})";
-       partial_struct obj{};
-       expect(!glz::read<glz::opts{.format = glz::binary, .partial_read = true}>(obj, s));
-       expect(obj.string == "ha!");
-       expect(obj.integer == 400);
-    };
-    
-    "partial_read partial_struct, error_on_unknown_keys = false"_test = [] {
-       std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
+    "partial_read partial_struct"_test = [] {
+       full_struct input{"garbage", "ha!", 400, {1,2,3}};
+       auto s = glz::write_binary(input);
        partial_struct obj{};
        expect(!glz::read<glz::opts{.format = glz::binary, .error_on_unknown_keys = false, .partial_read = true}>(obj, s));
        expect(obj.string == "ha!");
        expect(obj.integer == 400);
     };
-    
-    "partial_read partial_meta, error_on_unknown_keys = false"_test = [] {
-       std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
-       partial_meta obj{};
-       expect(!glz::read<glz::opts{.format = glz::binary, .error_on_unknown_keys = false, .partial_read = true}>(obj, s));
-       expect(obj.string == "ha!");
-       expect(obj.integer == 400);
-    };*/
 };
    
 struct hide_struct

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -1836,70 +1836,70 @@ template <>
 struct glz::meta<allocated_meta>
 {
    using T = allocated_meta;
-   static constexpr auto value = object("string", read_allocated<&T::string>, "integer", read_allocated<&T::integer>);
+   static constexpr auto value = object("string", partial_read<&T::string>, "integer", partial_read<&T::integer>);
 };
 
 suite read_allocated_tests = [] {
-   static constexpr glz::opts allocated{.format = glz::binary, .read_allocated = true};
+   static constexpr glz::opts partial{.format = glz::binary, .partial_read = true};
    
-   "read_allocated tuple"_test = [] {
+   "partial_read tuple"_test = [] {
       std::tuple<std::string, int, std::string> input{"hello", 88, "a string we don't care about"};
       auto s = glz::write_binary(input);
       std::tuple<std::string, int> obj{};
-      auto ec = glz::read<allocated>(obj, s);
+      auto ec = glz::read<partial>(obj, s);
       expect(!ec) << glz::format_error(ec, s);
       expect(std::get<0>(obj) == "hello");
       expect(std::get<1>(obj) == 88);
    };
    
-   "read_allocated vector<int>"_test = [] {
+   "partial_read vector<int>"_test = [] {
       std::vector<int> input{1,2,3,4,5};
       auto s = glz::write_binary(input);
       std::vector<int> v(2);
-      expect(!glz::read<allocated>(v, s));
+      expect(!glz::read<partial>(v, s));
       expect(v.size() == 2);
       expect(v[0] == 1);
       expect(v[1] == 2);
    };
    
-   "read_allocated vector<string>"_test = [] {
+   "partial_read vector<string>"_test = [] {
       std::vector<std::string> input{"1","2","3","4","5"};
       auto s = glz::write_binary(input);
       std::vector<std::string> v(2);
-      expect(!glz::read<allocated>(v, s));
+      expect(!glz::read<partial>(v, s));
       expect(v.size() == 2);
       expect(v[0] == "1");
       expect(v[1] == "2");
    };
    
-   /*"read_allocated map"_test = [] {
+   /*"partial_read map"_test = [] {
     std::string s = R"({"1":1,"2":2,"3":3})";
     std::map<std::string, int> obj{{"2", 0}};
-    expect(!glz::read<allocated>(obj, s));
+    expect(!glz::read<partial>(obj, s));
     expect(obj.size() == 1);
     expect(obj.at("2") = 2);
     };
     
-    "read_allocated allocated_struct"_test = [] {
+    "partial_read allocated_struct"_test = [] {
     std::string s = R"({"integer":400,"string":"ha!",ignore})";
     allocated_struct obj{};
-    expect(!glz::read<glz::opts{.format = glz::binary, .read_allocated = true}>(obj, s));
+    expect(!glz::read<glz::opts{.format = glz::binary, .partial_read = true}>(obj, s));
     expect(obj.string == "ha!");
     expect(obj.integer == 400);
     };
     
-    "read_allocated allocated_struct, error_on_unknown_keys = false"_test = [] {
+    "partial_read allocated_struct, error_on_unknown_keys = false"_test = [] {
     std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
     allocated_struct obj{};
-    expect(!glz::read<glz::opts{.format = glz::binary, .error_on_unknown_keys = false, .read_allocated = true}>(obj, s));
+    expect(!glz::read<glz::opts{.format = glz::binary, .error_on_unknown_keys = false, .partial_read = true}>(obj, s));
     expect(obj.string == "ha!");
     expect(obj.integer == 400);
     };
     
-    "read_allocated allocated_meta, error_on_unknown_keys = false"_test = [] {
+    "partial_read allocated_meta, error_on_unknown_keys = false"_test = [] {
     std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
     allocated_meta obj{};
-    expect(!glz::read<glz::opts{.format = glz::binary, .error_on_unknown_keys = false, .read_allocated = true}>(obj, s));
+    expect(!glz::read<glz::opts{.format = glz::binary, .error_on_unknown_keys = false, .partial_read = true}>(obj, s));
     expect(obj.string == "ha!");
     expect(obj.integer == 400);
     };*/

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -1820,22 +1820,22 @@ suite error_outputs = [] {
    };
 };
 
-struct allocated_struct
+struct partial_struct
 {
    std::string string{};
    int32_t integer{};
 };
 
-struct allocated_meta
+struct partial_meta
 {
    std::string string{};
    int32_t integer{};
 };
 
 template <>
-struct glz::meta<allocated_meta>
+struct glz::meta<partial_meta>
 {
-   using T = allocated_meta;
+   using T = partial_meta;
    static constexpr auto value = object("string", partial_read<&T::string>, "integer", partial_read<&T::integer>);
 };
 
@@ -1880,25 +1880,25 @@ suite read_allocated_tests = [] {
     expect(obj.at("2") = 2);
     };
     
-    "partial_read allocated_struct"_test = [] {
+    "partial_read partial_struct"_test = [] {
     std::string s = R"({"integer":400,"string":"ha!",ignore})";
-    allocated_struct obj{};
+    partial_struct obj{};
     expect(!glz::read<glz::opts{.format = glz::binary, .partial_read = true}>(obj, s));
     expect(obj.string == "ha!");
     expect(obj.integer == 400);
     };
     
-    "partial_read allocated_struct, error_on_unknown_keys = false"_test = [] {
+    "partial_read partial_struct, error_on_unknown_keys = false"_test = [] {
     std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
-    allocated_struct obj{};
+    partial_struct obj{};
     expect(!glz::read<glz::opts{.format = glz::binary, .error_on_unknown_keys = false, .partial_read = true}>(obj, s));
     expect(obj.string == "ha!");
     expect(obj.integer == 400);
     };
     
-    "partial_read allocated_meta, error_on_unknown_keys = false"_test = [] {
+    "partial_read partial_meta, error_on_unknown_keys = false"_test = [] {
     std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
-    allocated_meta obj{};
+    partial_meta obj{};
     expect(!glz::read<glz::opts{.format = glz::binary, .error_on_unknown_keys = false, .partial_read = true}>(obj, s));
     expect(obj.string == "ha!");
     expect(obj.integer == 400);

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -1841,7 +1841,7 @@ struct glz::meta<allocated_meta>
 
 suite read_allocated_tests = [] {
    static constexpr glz::opts allocated{.format = glz::binary, .read_allocated = true};
-
+   
    "read_allocated tuple"_test = [] {
       std::tuple<std::string, int, std::string> input{"hello", 88, "a string we don't care about"};
       auto s = glz::write_binary(input);
@@ -1851,7 +1851,7 @@ suite read_allocated_tests = [] {
       expect(std::get<0>(obj) == "hello");
       expect(std::get<1>(obj) == 88);
    };
-
+   
    "read_allocated vector<int>"_test = [] {
       std::vector<int> input{1,2,3,4,5};
       auto s = glz::write_binary(input);
@@ -1871,38 +1871,40 @@ suite read_allocated_tests = [] {
       expect(v[0] == "1");
       expect(v[1] == "2");
    };
-
-   /*"read_allocated map"_test = [] {
-      std::string s = R"({"1":1,"2":2,"3":3})";
-      std::map<std::string, int> obj{{"2", 0}};
-      expect(!glz::read<allocated>(obj, s));
-      expect(obj.size() == 1);
-      expect(obj.at("2") = 2);
-   };
-
-   "read_allocated allocated_struct"_test = [] {
-      std::string s = R"({"integer":400,"string":"ha!",ignore})";
-      allocated_struct obj{};
-      expect(!glz::read<glz::opts{.format = glz::binary, .read_allocated = true}>(obj, s));
-      expect(obj.string == "ha!");
-      expect(obj.integer == 400);
-   };
-
-   "read_allocated allocated_struct, error_on_unknown_keys = false"_test = [] {
-      std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
-      allocated_struct obj{};
-      expect(!glz::read<glz::opts{.format = glz::binary, .error_on_unknown_keys = false, .read_allocated = true}>(obj, s));
-      expect(obj.string == "ha!");
-      expect(obj.integer == 400);
-   };
    
-   "read_allocated allocated_meta, error_on_unknown_keys = false"_test = [] {
-      std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
-      allocated_meta obj{};
-      expect(!glz::read<glz::opts{.format = glz::binary, .error_on_unknown_keys = false, .read_allocated = true}>(obj, s));
-      expect(obj.string == "ha!");
-      expect(obj.integer == 400);
-   };*/
+   /*"read_allocated map"_test = [] {
+    std::string s = R"({"1":1,"2":2,"3":3})";
+    std::map<std::string, int> obj{{"2", 0}};
+    expect(!glz::read<allocated>(obj, s));
+    expect(obj.size() == 1);
+    expect(obj.at("2") = 2);
+    };
+    
+    "read_allocated allocated_struct"_test = [] {
+    std::string s = R"({"integer":400,"string":"ha!",ignore})";
+    allocated_struct obj{};
+    expect(!glz::read<glz::opts{.format = glz::binary, .read_allocated = true}>(obj, s));
+    expect(obj.string == "ha!");
+    expect(obj.integer == 400);
+    };
+    
+    "read_allocated allocated_struct, error_on_unknown_keys = false"_test = [] {
+    std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
+    allocated_struct obj{};
+    expect(!glz::read<glz::opts{.format = glz::binary, .error_on_unknown_keys = false, .read_allocated = true}>(obj, s));
+    expect(obj.string == "ha!");
+    expect(obj.integer == 400);
+    };
+    
+    "read_allocated allocated_meta, error_on_unknown_keys = false"_test = [] {
+    std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
+    allocated_meta obj{};
+    expect(!glz::read<glz::opts{.format = glz::binary, .error_on_unknown_keys = false, .read_allocated = true}>(obj, s));
+    expect(obj.string == "ha!");
+    expect(obj.integer == 400);
+    };*/
+};
+   
 struct hide_struct
 {
    int i = 287;

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -8068,57 +8068,57 @@ template <>
 struct glz::meta<allocated_meta>
 {
    using T = allocated_meta;
-   static constexpr auto value = object("string", read_allocated<&T::string>, "integer", read_allocated<&T::integer>);
+   static constexpr auto value = object("string", partial_read<&T::string>, "integer", partial_read<&T::integer>);
 };
 
 suite read_allocated_tests = [] {
-   static constexpr glz::opts allocated{.read_allocated = true};
+   static constexpr glz::opts partial{.partial_read = true};
 
-   "read_allocated tuple"_test = [] {
+   "partial_read tuple"_test = [] {
       std::string s = R"(["hello",88,"a string we don't care about"])";
       std::tuple<std::string, int> obj{};
-      expect(!glz::read<allocated>(obj, s));
+      expect(!glz::read<partial>(obj, s));
       expect(std::get<0>(obj) == "hello");
       expect(std::get<1>(obj) == 88);
    };
 
-   "read_allocated vector"_test = [] {
+   "partial_read vector"_test = [] {
       std::string s = R"([1,2,3,4,5])";
       std::vector<int> v(2);
-      expect(!glz::read<allocated>(v, s));
+      expect(!glz::read<partial>(v, s));
       expect(v.size() == 2);
       expect(v[0] == 1);
       expect(v[1] == 2);
    };
 
-   "read_allocated map"_test = [] {
+   "partial_read map"_test = [] {
       std::string s = R"({"1":1,"2":2,"3":3})";
       std::map<std::string, int> obj{{"2", 0}};
-      expect(!glz::read<allocated>(obj, s));
+      expect(!glz::read<partial>(obj, s));
       expect(obj.size() == 1);
       expect(obj.at("2") == 2);
    };
 
-   "read_allocated allocated_struct"_test = [] {
+   "partial_read allocated_struct"_test = [] {
       std::string s = R"({"integer":400,"string":"ha!",ignore})";
       allocated_struct obj{};
-      expect(!glz::read<glz::opts{.read_allocated = true}>(obj, s));
+      expect(!glz::read<glz::opts{.partial_read = true}>(obj, s));
       expect(obj.string == "ha!");
       expect(obj.integer == 400);
    };
 
-   "read_allocated allocated_struct, error_on_unknown_keys = false"_test = [] {
+   "partial_read allocated_struct, error_on_unknown_keys = false"_test = [] {
       std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
       allocated_struct obj{};
-      expect(!glz::read<glz::opts{.error_on_unknown_keys = false, .read_allocated = true}>(obj, s));
+      expect(!glz::read<glz::opts{.error_on_unknown_keys = false, .partial_read = true}>(obj, s));
       expect(obj.string == "ha!");
       expect(obj.integer == 400);
    };
    
-   "read_allocated allocated_meta, error_on_unknown_keys = false"_test = [] {
+   "partial_read allocated_meta, error_on_unknown_keys = false"_test = [] {
       std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
       allocated_meta obj{};
-      expect(!glz::read<glz::opts{.error_on_unknown_keys = false, .read_allocated = true}>(obj, s));
+      expect(!glz::read<glz::opts{.error_on_unknown_keys = false, .partial_read = true}>(obj, s));
       expect(obj.string == "ha!");
       expect(obj.integer == 400);
    };

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -8087,8 +8087,8 @@ suite read_allocated_tests = [] {
       std::vector<int> v(2);
       expect(!glz::read<allocated>(v, s));
       expect(v.size() == 2);
-      expect(v[0] = 1);
-      expect(v[1] = 2);
+      expect(v[0] == 1);
+      expect(v[1] == 2);
    };
 
    "read_allocated map"_test = [] {
@@ -8096,7 +8096,7 @@ suite read_allocated_tests = [] {
       std::map<std::string, int> obj{{"2", 0}};
       expect(!glz::read<allocated>(obj, s));
       expect(obj.size() == 1);
-      expect(obj.at("2") = 2);
+      expect(obj.at("2") == 2);
    };
 
    "read_allocated allocated_struct"_test = [] {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -8058,6 +8058,19 @@ struct allocated_struct
    int32_t integer{};
 };
 
+struct allocated_meta
+{
+   std::string string{};
+   int32_t integer{};
+};
+
+template <>
+struct glz::meta<allocated_meta>
+{
+   using T = allocated_meta;
+   static constexpr auto value = object("string", read_allocated<&T::string>, "integer", read_allocated<&T::integer>);
+};
+
 suite read_allocated_tests = [] {
    static constexpr glz::opts allocated{.read_allocated = true};
 
@@ -8097,6 +8110,14 @@ suite read_allocated_tests = [] {
    "read_allocated allocated_struct, error_on_unknown_keys = false"_test = [] {
       std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
       allocated_struct obj{};
+      expect(!glz::read<glz::opts{.error_on_unknown_keys = false, .read_allocated = true}>(obj, s));
+      expect(obj.string == "ha!");
+      expect(obj.integer == 400);
+   };
+   
+   "read_allocated allocated_meta, error_on_unknown_keys = false"_test = [] {
+      std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
+      allocated_meta obj{};
       expect(!glz::read<glz::opts{.error_on_unknown_keys = false, .read_allocated = true}>(obj, s));
       expect(obj.string == "ha!");
       expect(obj.integer == 400);

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -8052,22 +8052,22 @@ suite bools_as_numbers_test = [] {
    };
 };
 
-struct allocated_struct
+struct partial_struct
 {
    std::string string{};
    int32_t integer{};
 };
 
-struct allocated_meta
+struct partial_meta
 {
    std::string string{};
    int32_t integer{};
 };
 
 template <>
-struct glz::meta<allocated_meta>
+struct glz::meta<partial_meta>
 {
-   using T = allocated_meta;
+   using T = partial_meta;
    static constexpr auto value = object("string", partial_read<&T::string>, "integer", partial_read<&T::integer>);
 };
 
@@ -8099,25 +8099,25 @@ suite read_allocated_tests = [] {
       expect(obj.at("2") == 2);
    };
 
-   "partial_read allocated_struct"_test = [] {
+   "partial_read partial_struct"_test = [] {
       std::string s = R"({"integer":400,"string":"ha!",ignore})";
-      allocated_struct obj{};
+      partial_struct obj{};
       expect(!glz::read<glz::opts{.partial_read = true}>(obj, s));
       expect(obj.string == "ha!");
       expect(obj.integer == 400);
    };
 
-   "partial_read allocated_struct, error_on_unknown_keys = false"_test = [] {
+   "partial_read partial_struct, error_on_unknown_keys = false"_test = [] {
       std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
-      allocated_struct obj{};
+      partial_struct obj{};
       expect(!glz::read<glz::opts{.error_on_unknown_keys = false, .partial_read = true}>(obj, s));
       expect(obj.string == "ha!");
       expect(obj.integer == 400);
    };
    
-   "partial_read allocated_meta, error_on_unknown_keys = false"_test = [] {
+   "partial_read partial_meta, error_on_unknown_keys = false"_test = [] {
       std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
-      allocated_meta obj{};
+      partial_meta obj{};
       expect(!glz::read<glz::opts{.error_on_unknown_keys = false, .partial_read = true}>(obj, s));
       expect(obj.string == "ha!");
       expect(obj.integer == 400);

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -8058,19 +8058,6 @@ struct partial_struct
    int32_t integer{};
 };
 
-struct partial_meta
-{
-   std::string string{};
-   int32_t integer{};
-};
-
-template <>
-struct glz::meta<partial_meta>
-{
-   using T = partial_meta;
-   static constexpr auto value = object("string", partial_read<&T::string>, "integer", partial_read<&T::integer>);
-};
-
 suite read_allocated_tests = [] {
    static constexpr glz::opts partial{.partial_read = true};
 
@@ -8110,14 +8097,6 @@ suite read_allocated_tests = [] {
    "partial_read partial_struct, error_on_unknown_keys = false"_test = [] {
       std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
       partial_struct obj{};
-      expect(!glz::read<glz::opts{.error_on_unknown_keys = false, .partial_read = true}>(obj, s));
-      expect(obj.string == "ha!");
-      expect(obj.integer == 400);
-   };
-   
-   "partial_read partial_meta, error_on_unknown_keys = false"_test = [] {
-      std::string s = R"({"skip":null,"integer":400,"string":"ha!",ignore})";
-      partial_meta obj{};
       expect(!glz::read<glz::opts{.error_on_unknown_keys = false, .partial_read = true}>(obj, s));
       expect(obj.string == "ha!");
       expect(obj.integer == 400);


### PR DESCRIPTION
The new `read_allocated` option was confusing in its name. It has been renamed to `partial_read`.
`read_allocated` would imply that you only read allocated memory, but this is confusing for strings, which we read in completely. We only want partial reading of objects are array types.

- Adds `partial_read` support to binary