### PR TITLE
Type conversions with BEVE

### DIFF
--- a/.github/workflows/clang-linux.yml
+++ b/.github/workflows/clang-linux.yml
@@ -47,8 +47,8 @@ jobs:
           -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++ -lc++abi"
 
     - name: Build
-      run: cmake --build build -j $(nproc)
+      run: cmake --build build -j 4
 
     - name: Test
       working-directory: build
-      run: ctest -j $(nproc) --output-on-failure
+      run: ctest -j 4 --output-on-failure

--- a/include/glaze/binary/header.hpp
+++ b/include/glaze/binary/header.hpp
@@ -26,6 +26,24 @@ namespace glz::tag
 
    constexpr uint8_t bool_false = 0b000'01'000;
    constexpr uint8_t bool_true = 0b000'11'000;
+   
+   constexpr uint8_t i8 = 0b000'01'001;
+   constexpr uint8_t i16 = 0b001'01'001;
+   constexpr uint8_t i32 = 0b010'01'001;
+   constexpr uint8_t i64 = 0b011'01'001;
+   constexpr uint8_t i128 = 0b100'01'001;
+   
+   constexpr uint8_t u8 = 0b000'10'001;
+   constexpr uint8_t u16 = 0b001'10'001;
+   constexpr uint8_t u32 = 0b010'10'001;
+   constexpr uint8_t u64 = 0b011'10'001;
+   constexpr uint8_t u128 = 0b100'10'001;
+   
+   constexpr uint8_t bf16 = 0b000'00'001; // brain float
+   constexpr uint8_t f16 = 0b001'00'001;
+   constexpr uint8_t f32 = 0b010'00'001;
+   constexpr uint8_t f64 = 0b011'00'001;
+   constexpr uint8_t f128 = 0b100'00'001;
 }
 
 namespace glz::detail

--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -18,7 +18,27 @@ namespace glz
       template <>
       struct read<binary>
       {
+         template <auto Opts, class T, class Tag, is_context Ctx, class It0, class It1>
+            requires (Opts.no_header)
+         GLZ_ALWAYS_INLINE static void op(T&& value, Tag&& tag, Ctx&& ctx, It0&& it, It1&& end) noexcept
+         {
+            if constexpr (std::is_const_v<std::remove_reference_t<T>>) {
+               if constexpr (Opts.error_on_const_read) {
+                  ctx.error = error_code::attempt_const_read;
+               }
+               else {
+                  // do not read anything into the const value
+                  skip_value_binary<Opts>(std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
+               }
+            }
+            else {
+               using V = std::remove_cvref_t<T>;
+               from_binary<V>::template op<Opts>(std::forward<T>(value), std::forward<Tag>(tag), std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
+            }
+         }
+         
          template <auto Opts, class T, is_context Ctx, class It0, class It1>
+            requires (not Opts.no_header)
          GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
          {
             if constexpr (std::is_const_v<std::remove_reference_t<T>>) {
@@ -134,99 +154,100 @@ namespace glz
          requires(num_t<T> || char_t<T> || glaze_enum_t<T>)
       struct from_binary<T>
       {
+         static constexpr uint8_t type =
+            std::floating_point<T> ? 0 : (std::is_signed_v<T> ? 0b000'01'000 : 0b000'10'000);
+         static constexpr uint8_t header = tag::number | type | (byte_count<T> << 5);
+         
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&&) noexcept
+            requires (Opts.no_header)
+         GLZ_ALWAYS_INLINE static void op(auto&& value, const uint8_t tag, is_context auto&& ctx, auto&& it, auto&&) noexcept
          {
             using V = std::decay_t<decltype(value)>;
-            if constexpr (Opts.no_header) {
-               std::memcpy(&value, it, sizeof(V));
-               it += sizeof(V);
-            }
-            else {
-               constexpr uint8_t type =
-                  std::floating_point<T> ? 0 : (std::is_signed_v<T> ? 0b000'01'000 : 0b000'10'000);
-               constexpr uint8_t header = tag::number | type | (byte_count<T> << 5);
+            
+            if (tag != header) {
+               if constexpr (Opts.allow_conversions) {
+                  if constexpr (num_t<T>) {
+                     if ((tag & 0b00000111) != tag::number) {
+                        ctx.error = error_code::syntax_error;
+                        return;
+                     }
+                     
+                     auto decode = [&](auto&& i) {
+                        std::memcpy(&i, it, sizeof(i));
+                        value = static_cast<V>(i);
+                        it += sizeof(i);
+                     };
 
-               const auto tag = uint8_t(*it);
-               if (tag != header) {
-                  if constexpr (Opts.allow_conversions) {
-                     if constexpr (num_t<T>) {
-                        if ((tag & 0b00000111) != tag::number) {
+                     switch (tag)
+                     {
+                        case tag::f32: {
+                           static_assert(sizeof(float) == 4);
+                           // TODO: use float32_t in C++23
+                           decode(float{});
+                           return;
+                        }
+                        case tag::f64: {
+                           static_assert(sizeof(double) == 8);
+                           // TODO: use float64_t in C++23
+                           decode(double{});
+                           return;
+                        }
+                        case tag::i8: {
+                           decode(int8_t{});
+                           return;
+                        }
+                        case tag::i16: {
+                           decode(int16_t{});
+                           return;
+                        }
+                        case tag::i32: {
+                           decode(int32_t{});
+                           return;
+                        }
+                        case tag::i64: {
+                           decode(int64_t{});
+                           return;
+                        }
+                        case tag::u8: {
+                           decode(uint8_t{});
+                           return;
+                        }
+                        case tag::u16: {
+                           decode(uint16_t{});
+                           return;
+                        }
+                        case tag::u32: {
+                           decode(uint32_t{});
+                           return;
+                        }
+                        case tag::u64: {
+                           decode(uint64_t{});
+                           return;
+                        }
+                        default: {
                            ctx.error = error_code::syntax_error;
                            return;
                         }
-                        
-                        ++it;
-                        
-                        auto decode = [&](auto&& i) {
-                           std::memcpy(&i, it, sizeof(i));
-                           value = static_cast<V>(i);
-                           it += sizeof(i);
-                        };
-
-                        switch (tag)
-                        {
-                           case tag::f32: {
-                              static_assert(sizeof(float) == 4);
-                              // TODO: use float32_t in C++23
-                              decode(float{});
-                              return;
-                           }
-                           case tag::f64: {
-                              static_assert(sizeof(double) == 8);
-                              // TODO: use float64_t in C++23
-                              decode(double{});
-                              return;
-                           }
-                           case tag::i8: {
-                              decode(int8_t{});
-                              return;
-                           }
-                           case tag::i16: {
-                              decode(int16_t{});
-                              return;
-                           }
-                           case tag::i32: {
-                              decode(int32_t{});
-                              return;
-                           }
-                           case tag::i64: {
-                              decode(int64_t{});
-                              return;
-                           }
-                           case tag::u8: {
-                              decode(uint8_t{});
-                              return;
-                           }
-                           case tag::u16: {
-                              decode(uint16_t{});
-                              return;
-                           }
-                           case tag::u32: {
-                              decode(uint32_t{});
-                              return;
-                           }
-                           case tag::u64: {
-                              decode(uint64_t{});
-                              return;
-                           }
-                           default: {
-                              ctx.error = error_code::syntax_error;
-                              return;
-                           }
-                        }
                      }
                   }
-                  else {
-                     ctx.error = error_code::syntax_error;
-                     return;
-                  }
                }
-
-               ++it;
-               std::memcpy(&value, it, sizeof(V));
-               it += sizeof(V);
+               else {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
             }
+
+            std::memcpy(&value, it, sizeof(V));
+            it += sizeof(V);
+         }
+         
+         template <auto Opts>
+            requires (not Opts.no_header)
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         {
+            const auto tag = uint8_t(*it);
+            ++it;
+            op<opt_true<Opts, &opts::no_header>>(value, tag, ctx, it, end);
          }
       };
 
@@ -383,42 +404,45 @@ namespace glz
       template <str_t T>
       struct from_binary<T> final
       {
+         using V = typename std::decay_t<T>::value_type;
+         static_assert(sizeof(V) == 1);
+         
          template <auto Opts>
+            requires (Opts.no_header)
+         GLZ_ALWAYS_INLINE static void op(auto&& value, const uint8_t, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         {
+            const auto n = int_from_compressed(ctx, it, end);
+            if ((it + n) > end) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+            value.resize(n);
+            std::memcpy(value.data(), it, n);
+            it += n;
+         }
+         
+         template <auto Opts>
+            requires (not Opts.no_header)
          GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
-            using V = typename std::decay_t<T>::value_type;
-            static_assert(sizeof(V) == 1);
+            constexpr uint8_t header = tag::string;
 
-            if constexpr (Opts.no_header) {
-               const auto n = int_from_compressed(ctx, it, end);
-               if ((it + n) > end) [[unlikely]] {
-                  ctx.error = error_code::unexpected_end;
-                  return;
-               }
-               value.resize(n);
-               std::memcpy(value.data(), it, n);
-               it += n;
+            const auto tag = uint8_t(*it);
+            if (tag != header) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
             }
-            else {
-               constexpr uint8_t header = tag::string;
 
-               const auto tag = uint8_t(*it);
-               if (tag != header) [[unlikely]] {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
+            ++it;
 
-               ++it;
-
-               const auto n = int_from_compressed(ctx, it, end);
-               if ((it + n) > end) [[unlikely]] {
-                  ctx.error = error_code::unexpected_end;
-                  return;
-               }
-               value.resize(n);
-               std::memcpy(value.data(), it, n);
-               it += n;
+            const auto n = int_from_compressed(ctx, it, end);
+            if ((it + n) > end) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
             }
+            value.resize(n);
+            std::memcpy(value.data(), it, n);
+            it += n;
          }
       };
 
@@ -591,34 +615,71 @@ namespace glz
                constexpr uint8_t type =
                   std::floating_point<V> ? 0 : (std::is_signed_v<V> ? 0b000'01'000 : 0b000'10'000);
                constexpr uint8_t header = tag::typed_array | type | (byte_count<V> << 5);
+               
+               auto prepare = [&](const size_t element_size) -> size_t {
+                  ++it;
 
-               if (tag != header) [[unlikely]] {
-                  ctx.error = error_code::syntax_error;
-                  return;
+                  std::conditional_t<Opts.partial_read, size_t, const size_t> n = int_from_compressed(ctx, it, end);
+                  if (bool(ctx.error)) [[unlikely]] {
+                     return 0;
+                  }
+
+                  if constexpr (Opts.partial_read) {
+                     n = value.size();
+                  }
+
+                  if ((it + n * element_size) > end) [[unlikely]] {
+                     ctx.error = error_code::unexpected_end;
+                     return 0;
+                  }
+
+                  if constexpr (resizable<T>) {
+                     value.resize(n);
+
+                     if constexpr (Opts.shrink_to_fit) {
+                        value.shrink_to_fit();
+                     }
+                  }
+                  
+                  return n;
+               };
+
+               if (tag != header) {
+                  if constexpr (Opts.allow_conversions) {
+                     if (tag != header) [[unlikely]] {
+                        if constexpr (Opts.allow_conversions) {
+                           if ((tag & 0b00000111) != tag::typed_array) {
+                              ctx.error = error_code::syntax_error;
+                              return;
+                           }
+                           
+                           const uint8_t byte_count = byte_count_lookup[tag >> 5];
+                           prepare(byte_count);
+                           if (bool(ctx.error)) [[unlikely]] {
+                              return;
+                           }
+                           
+                           for (auto&& x : value) {
+                              const auto number_tag = tag::number | (tag & 0b11111000);
+                              read<binary>::op<opt_true<Opts, &opts::no_header>>(x, number_tag, ctx, it, end);
+                           }
+                           return;
+                        }
+                        else {
+                           ctx.error = error_code::syntax_error;
+                           return;
+                        }
+                     }
+                  }
+                  else {
+                     ctx.error = error_code::syntax_error;
+                     return;
+                  }
                }
 
-               ++it;
-
-               std::conditional_t<Opts.partial_read, size_t, const size_t> n = int_from_compressed(ctx, it, end);
+               const auto n = prepare(sizeof(V));
                if (bool(ctx.error)) [[unlikely]] {
                   return;
-               }
-
-               if constexpr (Opts.partial_read) {
-                  n = value.size();
-               }
-
-               if ((it + n * sizeof(V)) > end) [[unlikely]] {
-                  ctx.error = error_code::unexpected_end;
-                  return;
-               }
-
-               if constexpr (resizable<T>) {
-                  value.resize(n);
-
-                  if constexpr (Opts.shrink_to_fit) {
-                     value.shrink_to_fit();
-                  }
                }
 
                if constexpr (contiguous<T>) {
@@ -789,7 +850,8 @@ namespace glz
                return;
             }
 
-            read<binary>::op<opt_true<Opts, &opts::no_header>>(value.first, ctx, it, end);
+            constexpr auto key_tag = type == 0 ? tag::string : (tag::number | (byte_cnt << 5));
+            read<binary>::op<opt_true<Opts, &opts::no_header>>(value.first, key_tag, ctx, it, end);
             read<binary>::op<Opts>(value.second, ctx, it, end);
          }
       };
@@ -824,31 +886,34 @@ namespace glz
             }
 
             if constexpr (std::is_arithmetic_v<std::decay_t<Key>>) {
+               constexpr auto key_tag = tag::number | type | (byte_cnt << 5);
                Key key;
                for (size_t i = 0; i < n; ++i) {
                   if constexpr (Opts.partial_read) {
-                     read<binary>::op<opt_true<Opts, &opts::no_header>>(key, ctx, it, end);
+                     read<binary>::op<opt_true<Opts, &opts::no_header>>(key, key_tag, ctx, it, end);
                      if (auto element = value.find(key); element != value.end()) {
                         read<binary>::op<Opts>(element->second, ctx, it, end);
                      }
                   }
                   else {
-                     read<binary>::op<opt_true<Opts, &opts::no_header>>(key, ctx, it, end);
+                     // convert the object tag to the key type tag
+                     read<binary>::op<opt_true<Opts, &opts::no_header>>(key, key_tag, ctx, it, end);
                      read<binary>::op<Opts>(value[key], ctx, it, end);
                   }
                }
             }
             else {
+               constexpr auto key_tag = tag::string;
                static thread_local Key key;
                for (size_t i = 0; i < n; ++i) {
                   if constexpr (Opts.partial_read) {
-                     read<binary>::op<opt_true<Opts, &opts::no_header>>(key, ctx, it, end);
+                     read<binary>::op<opt_true<Opts, &opts::no_header>>(key, key_tag, ctx, it, end);
                      if (auto element = value.find(key); element != value.end()) {
                         read<binary>::op<Opts>(element->second, ctx, it, end);
                      }
                   }
                   else {
-                     read<binary>::op<opt_true<Opts, &opts::no_header>>(key, ctx, it, end);
+                     read<binary>::op<opt_true<Opts, &opts::no_header>>(key, key_tag, ctx, it, end);
                      read<binary>::op<Opts>(value[key], ctx, it, end);
                   }
                }

--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -870,8 +870,25 @@ namespace glz
 
             const auto tag = uint8_t(*it);
             if (tag != header) [[unlikely]] {
-               ctx.error = error_code::syntax_error;
-               return;
+               if constexpr (Opts.allow_conversions) {
+                  const auto key_type = tag & 0b000'11'000;
+                  if constexpr (str_t<Key>) {
+                     if (key_type != 0) {
+                        ctx.error = error_code::syntax_error;
+                        return;
+                     }
+                  }
+                  else {
+                     if (key_type == 0) {
+                        ctx.error = error_code::syntax_error;
+                        return;
+                     }
+                  }
+               }
+               else {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
             }
 
             ++it;

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -61,7 +61,9 @@ namespace glz
       bool number = false; // read numbers as strings and write these string as numbers
       bool raw = false; // write out string like values without quotes
       bool raw_string = false; // do not decode/encode escaped characters for strings (improves read/write performance)
-      bool structs_as_arrays = false; // Handle structs (reading/writing) without keys, which applies to reflectable and
+      bool structs_as_arrays = false; // Handle structs (reading/writing) without keys, which applies
+      bool allow_conversions = true; // Whether conversions between convertible types are
+      // allowed in binary, e.g. double -> float
 
       bool partial_read =
          false; // Reads into only existing fields and elements and then exits without parsing the rest of the input

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -1986,6 +1986,22 @@ suite type_conversions = [] {
       expect(!glz::read_binary(v, b));
       expect(v == std::vector{1.0, 2.0, 3.0});
    };
+   
+   "vector<double> -> vector<int>"_test = [] {
+      std::vector<double> input{1.1, 2.2, 3.3};
+      auto b = glz::write_binary(input);
+      std::vector<int> v{};
+      expect(!glz::read_binary(v, b));
+      expect(v == std::vector{1, 2, 3});
+   };
+   
+   "map<int32_t, double> -> map<uint32_t, float>"_test = [] {
+      std::map<int32_t, double> input{{1, 1.1}, {2, 2.2}, {3, 3.3}};
+      auto b = glz::write_binary(input);
+      std::map<uint32_t, float> v{};
+      expect(!glz::read_binary(v, b));
+      expect(v == std::map<uint32_t, float>{{1, 1.1f}, {2, 2.2f}, {3, 3.3f}});
+   };
 };
 
 int main()

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -1835,6 +1835,18 @@ struct full_struct
    std::vector<int> more_data_to_ignore{};
 };
 
+struct Header
+{
+   std::string id{};
+   std::string type{};
+};
+
+template <>
+struct glz::meta<Header>
+{
+   static constexpr auto partial_read = true;
+};
+
 suite read_allocated_tests = [] {
    static constexpr glz::opts partial{.format = glz::binary, .partial_read = true};
 
@@ -1885,6 +1897,24 @@ suite read_allocated_tests = [] {
          !glz::read<glz::opts{.format = glz::binary, .error_on_unknown_keys = false, .partial_read = true}>(obj, s));
       expect(obj.string == "ha!");
       expect(obj.integer == 400);
+   };
+   
+   "partial_read"_test = [] {
+      Header input{"51e2affb", "message_type"};
+      auto buf = glz::write_binary(input);
+      Header h{};
+      expect(!glz::read_binary(h, buf));
+      expect(h.id == "51e2affb");
+      expect(h.type == "message_type");
+   };
+   
+   "partial read unknown key 2"_test = [] {
+      Header input{"51e2affb", "message_type"};
+      auto buf = glz::write_binary(input);
+      Header h{};
+      expect(!glz::read<glz::opts{.format = glz::binary, .error_on_unknown_keys = false}>(h, buf));
+      expect(h.id == "51e2affb");
+      expect(h.type == "message_type");
    };
 };
 

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -10,6 +10,7 @@
 #include <deque>
 #include <list>
 #include <map>
+#include <numbers>
 #include <random>
 #include <set>
 #include <unordered_set>
@@ -1932,6 +1933,42 @@ suite skip_tests = [] {
       auto buffer = glz::write_binary(data);
       skip_obj obj{};
       expect(!glz::read_binary(obj, buffer));
+   };
+};
+
+suite type_conversions = [] {
+   "double -> float"_test = [] {
+      constexpr double pi64 = std::numbers::pi_v<double>;
+      auto b = glz::write_binary(pi64);
+      float pi32{};
+      expect(!glz::read_binary(pi32, b));
+      expect(pi32 == std::numbers::pi_v<float>);
+   };
+   
+   "float -> double"_test = [] {
+      constexpr float pi32 = std::numbers::pi_v<float>;
+      auto b = glz::write_binary(pi32);
+      double pi64{};
+      expect(!glz::read_binary(pi64, b));
+      expect(pi64 == std::numbers::pi_v<float>);
+   };
+   
+   "int8_t -> uint8_t"_test = [] {
+      auto b = glz::write_binary(int8_t{45});
+      uint8_t i{};
+      expect(!glz::read_binary(i, b));
+      expect(i == 45);
+      
+      b = glz::write_binary(int8_t{-1});
+      expect(!glz::read_binary(i, b));
+      expect(i == 255);
+   };
+   
+   "int8_t -> int32_t"_test = [] {
+      auto b = glz::write_binary(int8_t{127});
+      int32_t i{};
+      expect(!glz::read_binary(i, b));
+      expect(i == 127);
    };
 };
 

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -1970,6 +1970,22 @@ suite type_conversions = [] {
       expect(!glz::read_binary(i, b));
       expect(i == 127);
    };
+   
+   "vector<double> -> vector<float>"_test = [] {
+      std::vector<double> input{1.1, 2.2, 3.3};
+      auto b = glz::write_binary(input);
+      std::vector<float> v{};
+      expect(!glz::read_binary(v, b));
+      expect(v == std::vector{1.1f, 2.2f, 3.3f});
+   };
+   
+   "vector<float> -> vector<double>"_test = [] {
+      std::vector<float> input{1.f, 2.f, 3.f};
+      auto b = glz::write_binary(input);
+      std::vector<double> v{};
+      expect(!glz::read_binary(v, b));
+      expect(v == std::vector{1.0, 2.0, 3.0});
+   };
 };
 
 int main()


### PR DESCRIPTION
Introduces a new `allow_conversions` option for BEVE parsing. This allows convertible types to be cast upon parsing instead of resulting in a parsing error.