### PR TITLE
REPE registry thread safety

### DIFF
--- a/docs/rpc/repe-rpc.md
+++ b/docs/rpc/repe-rpc.md
@@ -1,12 +1,30 @@
 # REPE RPC
 
+> [!WARNING]
+>
 > **The `glz::asio_server`, `glz::asio_client`, and `glz::repe::registry`, are all under active development and should not be considered stable.**
 
 Glaze provides support for the [REPE](https://github.com/stephenberry/repe) RPC format along with client/server implementations (currently [asio](http://think-async.com/Asio/)).
 
 - [REPE specification](https://github.com/stephenberry/repe)
 
-// TODO: Expand documentation
+JSON Pointer syntax is used to refer to fields in C++ structures.
+
+## REPE registry locking and thread safety
+
+The `glz::repe::registry` allows users to expose C++ classes directly to the registry as an interface for network RPC calls and POST/GET calls.
+
+The registry attempts to handle the thread safety required to directly manipulate C++ memory and read/write from JSON or BEVE messages. In most cases unlimited clients can read and write from your registered structures in a thread-safe manner than reduces locks, permits asynchronous reads, and non-blocking writes where valid.
+
+Locking is performed on JSON pointer path chains to allow multiple clients to read/write from the same object at the same time.
+
+Locking is based on depth in the object tree. A chain of shared mutexes are locked, using shared locks until the actual write point, which uses a unique lock. When reading from C++ memory, only shared locks are used.
+
+An invoke lock is also used for invoking functions. Unlike variable access, the invocation lock also locks everything at the same depth as the function, which allows member functions to safely manipulate member variables from the same class.
+
+> [!IMPORTANT]
+>
+> Pointers to parent members or functions that manipulate shallower depth members are not thread safe and safety has to be added by the developer.
 
 ## asio
 

--- a/docs/rpc/repe-rpc.md
+++ b/docs/rpc/repe-rpc.md
@@ -10,21 +10,49 @@ Glaze provides support for the [REPE](https://github.com/stephenberry/repe) RPC 
 
 JSON Pointer syntax is used to refer to fields in C++ structures.
 
+## REPE Registry
+
+The `glz::repe::registry` produces an API for function invocation and variable access for server implementations.
+
+> The registry does not currently support adding methods from RPC calls or adding methods once RPC calls can be made.
+
 ## REPE registry locking and thread safety
 
 The `glz::repe::registry` allows users to expose C++ classes directly to the registry as an interface for network RPC calls and POST/GET calls.
 
-The registry attempts to handle the thread safety required to directly manipulate C++ memory and read/write from JSON or BEVE messages. In most cases unlimited clients can read and write from your registered structures in a thread-safe manner than reduces locks, permits asynchronous reads, and non-blocking writes where valid.
+The registry handles the thread safety required to directly manipulate C++ memory and read/write from JSON or BEVE messages. In most cases unlimited clients can read and write from your registered structures in a thread-safe manner that reduces locks, permits asynchronous reads, and non-blocking writes where valid.
 
 Locking is performed on JSON pointer path chains to allow multiple clients to read/write from the same object at the same time.
 
-Locking is based on depth in the object tree. A chain of shared mutexes are locked, using shared locks until the actual write point, which uses a unique lock. When reading from C++ memory, only shared locks are used.
+Locking is based on depth in the object tree. A chain of shared mutexes are locked, locking does the path to the write point. When reading from C++ memory, only shared locks are used at the read location.
 
 An invoke lock is also used for invoking functions. Unlike variable access, the invocation lock also locks everything at the same depth as the function, which allows member functions to safely manipulate member variables from the same class.
 
 > [!IMPORTANT]
 >
 > Pointers to parent members or functions that manipulate shallower depth members are not thread safe and safety has to be added by the developer.
+
+### Locking Example
+
+Suppose we have the following C++ structs:
+
+```c++
+struct person
+{
+  uint8_t age{};
+  std::string name{};
+};
+
+struct family
+{
+  person father{};
+  person mother{};
+};
+```
+
+The registry will allow non-conflicting paths to simultaneously read and write. `/family/father/age` and `/family/mother/age` can be asynchronously read/written by two different clients. If the same path is attempted to be read by multiple clients a lock is shared between them. Only writes and invocations require unique locks.
+
+If `/family/father/age` is written to, this will also block a shared lock on `/family`, which prevents reading from memory that has child fields being manipulated.
 
 ## asio
 

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -852,13 +852,13 @@ namespace glz
 
                   static constexpr auto group = glz::get<I>(groups);
 
-                  static constexpr auto key = std::get<0>(group);
-                  static constexpr auto sub_partial = std::get<1>(group);
+                  static constexpr auto key = get<0>(group);
+                  static constexpr auto sub_partial = get<1>(group);
                   static constexpr auto frozen_map = detail::make_map<T>();
                   static constexpr auto member_it = frozen_map.find(key);
                   static_assert(member_it != frozen_map.end(), "Invalid key passed to partial write");
                   static constexpr auto index = member_it->second.index();
-                  static constexpr decltype(auto) member_ptr = std::get<index>(member_it->second);
+                  static constexpr decltype(auto) member_ptr = get<index>(member_it->second);
 
                   detail::write<binary>::no_header<Opts>(key, ctx, b, ix);
                   we = write_partial<binary>::op<sub_partial, Opts>(glz::detail::get_member(value, member_ptr), ctx, b,
@@ -873,8 +873,8 @@ namespace glz
 
                   static constexpr auto group = glz::get<I>(groups);
 
-                  static constexpr auto key_value = std::get<0>(group);
-                  static constexpr auto sub_partial = std::get<1>(group);
+                  static constexpr auto key_value = get<0>(group);
+                  static constexpr auto sub_partial = get<1>(group);
                   if constexpr (findable<std::decay_t<T>, decltype(key_value)>) {
                      detail::write<binary>::no_header<Opts>(key_value, ctx, b, ix);
                      auto it = value.find(key_value);

--- a/include/glaze/concepts/container_concepts.hpp
+++ b/include/glaze/concepts/container_concepts.hpp
@@ -101,12 +101,8 @@ namespace glz::detail
 
    template <class T>
    concept pair_t = requires(T pair) {
-      {
-         pair.first
-      } -> std::same_as<typename T::first_type&>;
-      {
-         pair.second
-      } -> std::same_as<typename T::second_type&>;
+      { pair.first };
+      { pair.second };
    };
 
    template <class T>

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -606,7 +606,7 @@ namespace glz
          constexpr auto N = glz::tuple_size_v<meta_t<T>>;
          return [&]<size_t... I>(std::index_sequence<I...>) {
             return normal_map<sv, size_t, glz::tuple_size_v<meta_t<T>>>(
-                                                                        {pair<sv, size_t>{get_enum_key<T, I>(), I}...});
+                                                                        pair<sv, size_t>{get_enum_key<T, I>(), I}...);
          }(std::make_index_sequence<N>{});
       }
 
@@ -617,7 +617,7 @@ namespace glz
          return [&]<size_t... I>(std::index_sequence<I...>) {
             using key_t = std::underlying_type_t<T>;
             return normal_map<key_t, sv, N>(
-                                            {pair<key_t, sv>{static_cast<key_t>(get_enum_value<T, I>()), get_enum_key<T, I>()}...});
+                                            std::array<pair<key_t, sv>, N>{pair<key_t, sv>{static_cast<key_t>(get_enum_value<T, I>()), get_enum_key<T, I>()}...});
          }(std::make_index_sequence<N>{});
       }
 
@@ -635,7 +635,7 @@ namespace glz
       {
          constexpr auto N = glz::tuple_size_v<meta_t<T>>;
          return [&]<size_t... I>(std::index_sequence<I...>) {
-            return normal_map<sv, T, N>({pair<sv, T>{get_enum_key<T, I>(), T(get_enum_value<T, I>())}...});
+            return normal_map<sv, T, N>(std::array<pair<sv, T>, N>{pair<sv, T>{get_enum_key<T, I>(), T(get_enum_value<T, I>())}...});
          }(std::make_index_sequence<N>{});
       }
 
@@ -708,7 +708,7 @@ namespace glz
       consteval auto make_variant_deduction_base_map(std::index_sequence<I...>, auto&& keys)
       {
          using V = bit_array<std::variant_size_v<T>>;
-         return normal_map<sv, V, sizeof...(I)>({pair<sv, V>{sv(std::get<I>(keys)), V{}}...});
+         return normal_map<sv, V, sizeof...(I)>(std::array<pair<sv, V>, sizeof...(I)>{pair<sv, V>{sv(std::get<I>(keys)), V{}}...});
       }
 
       template <class T>
@@ -749,7 +749,7 @@ namespace glz
       template <is_variant T, size_t... I>
       constexpr auto make_variant_id_map_impl(std::index_sequence<I...>, auto&& variant_ids)
       {
-         return normal_map<sv, size_t, std::variant_size_v<T>>({pair<sv, size_t>{sv(variant_ids[I]), I}...});
+         return normal_map<sv, size_t, std::variant_size_v<T>>(std::array{pair<sv, size_t>{sv(variant_ids[I]), I}...});
       }
 
       template <is_variant T>
@@ -876,7 +876,7 @@ namespace glz
    constexpr auto enumerate_no_reflect(auto&&... args) noexcept
    {
       return [t = glz::tuplet::tuple{args...}]<size_t... I>(std::index_sequence<I...>) noexcept {
-         return glz::detail::Enum{std::array{std::pair{conv_sv(get<2 * I>(t)), get<2 * I + 1>(t)}...}};
+         return glz::detail::Enum{std::array{pair{conv_sv(get<2 * I>(t)), get<2 * I + 1>(t)}...}};
       }(std::make_index_sequence<sizeof...(args) / 2>{});
    }
 

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -581,7 +581,7 @@ namespace glz
                         return glz::detail::make_naive_map<value_t, naive_desc>({key_value<T, I>()...});
                      }
                      else {
-                        return glz::detail::normal_map<sv, value_t, n, use_hash_comparison>({key_value<T, I>()...});
+                        return glz::detail::normal_map<sv, value_t, n, use_hash_comparison>(std::array{key_value<T, I>()...});
                      }
                   }
                }

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -485,10 +485,10 @@ namespace glz
          constexpr auto first = get<0>(get<I>(meta_v<T>));
          using T0 = std::decay_t<decltype(first)>;
          if constexpr (std::is_member_pointer_v<T0>) {
-            return std::pair<sv, value_t>{get_name<first>(), first};
+            return pair<sv, value_t>{get_name<first>(), first};
          }
          else {
-            return std::pair<sv, value_t>{sv(first), get<1>(get<I>(meta_v<T>))};
+            return pair<sv, value_t>{sv(first), get<1>(get<I>(meta_v<T>))};
          }
       }
 
@@ -606,7 +606,7 @@ namespace glz
          constexpr auto N = glz::tuple_size_v<meta_t<T>>;
          return [&]<size_t... I>(std::index_sequence<I...>) {
             return normal_map<sv, size_t, glz::tuple_size_v<meta_t<T>>>(
-               {std::make_pair<sv, size_t>(get_enum_key<T, I>(), I)...});
+                                                                        {pair<sv, size_t>{get_enum_key<T, I>(), I}...});
          }(std::make_index_sequence<N>{});
       }
 
@@ -617,7 +617,7 @@ namespace glz
          return [&]<size_t... I>(std::index_sequence<I...>) {
             using key_t = std::underlying_type_t<T>;
             return normal_map<key_t, sv, N>(
-               {std::make_pair<key_t, sv>(static_cast<key_t>(get_enum_value<T, I>()), get_enum_key<T, I>())...});
+                                            {pair<key_t, sv>{static_cast<key_t>(get_enum_value<T, I>()), get_enum_key<T, I>()}...});
          }(std::make_index_sequence<N>{});
       }
 
@@ -635,7 +635,7 @@ namespace glz
       {
          constexpr auto N = glz::tuple_size_v<meta_t<T>>;
          return [&]<size_t... I>(std::index_sequence<I...>) {
-            return normal_map<sv, T, N>({std::pair<sv, T>{get_enum_key<T, I>(), T(get_enum_value<T, I>())}...});
+            return normal_map<sv, T, N>({pair<sv, T>{get_enum_key<T, I>(), T(get_enum_value<T, I>())}...});
          }(std::make_index_sequence<N>{});
       }
 
@@ -708,7 +708,7 @@ namespace glz
       consteval auto make_variant_deduction_base_map(std::index_sequence<I...>, auto&& keys)
       {
          using V = bit_array<std::variant_size_v<T>>;
-         return normal_map<sv, V, sizeof...(I)>({std::make_pair<sv, V>(sv(std::get<I>(keys)), V{})...});
+         return normal_map<sv, V, sizeof...(I)>({pair<sv, V>{sv(std::get<I>(keys)), V{}}...});
       }
 
       template <class T>
@@ -749,7 +749,7 @@ namespace glz
       template <is_variant T, size_t... I>
       constexpr auto make_variant_id_map_impl(std::index_sequence<I...>, auto&& variant_ids)
       {
-         return normal_map<sv, size_t, std::variant_size_v<T>>({std::make_pair<sv, size_t>(sv(variant_ids[I]), I)...});
+         return normal_map<sv, size_t, std::variant_size_v<T>>({pair<sv, size_t>{sv(variant_ids[I]), I}...});
       }
 
       template <is_variant T>
@@ -1122,13 +1122,29 @@ namespace glz::detail
    };
 
    template <size_t I, class T, bool use_reflection>
-   static constexpr auto key_name = [] {
+   constexpr auto key_name = [] {
       if constexpr (reflectable<T>) {
          return get<I>(member_names<T>);
       }
       else {
          using V = std::decay_t<T>;
          if constexpr (use_reflection) {
+            return get_name<get<0>(get<I>(meta_v<V>))>();
+         }
+         else {
+            return get<0>(get<I>(meta_v<V>));
+         }
+      }
+   }();
+   
+   template <size_t I, class T>
+   constexpr auto key_name_v = [] {
+      if constexpr (reflectable<T>) {
+         return get<I>(member_names<T>);
+      }
+      else {
+         using V = std::decay_t<T>;
+         if constexpr (glaze_tuple_element<I, reflection_count<T>, T>::use_reflection) {
             return get_name<get<0>(get<I>(meta_v<V>))>();
          }
          else {

--- a/include/glaze/core/seek.hpp
+++ b/include/glaze/core/seek.hpp
@@ -434,14 +434,15 @@ namespace glz
       // Get each full JSON pointer path at increasing depth
       inline auto json_ptr_children(sv s) {
          std::vector<sv> v{};
-          const auto n = std::count(s.begin(), s.end(), '/');
+          const auto n = std::count(s.begin(), s.end(), '/') + 1; // +1 for root ""
           v.resize(n);
+         v[0] = "";
           auto* start = s.data();
-          for (auto i = 0; i < n; ++i) {
+          for (auto i = 1; i < n; ++i) {
               std::tie(v[i], s) = tokenize_json_ptr_children(s);
           }
 
-          for (auto i = 0; i < n; ++i) {
+          for (auto i = 1; i < n; ++i) {
               v[i] = sv{start, size_t((v[i].data() + v[i].size()) - start)};
           }
          return v;
@@ -451,15 +452,16 @@ namespace glz
       constexpr auto json_ptr_children()
       {
          constexpr auto str = Str;
-         constexpr auto N = std::count(str.begin(), str.end(), '/');
+         constexpr auto N = std::count(str.begin(), str.end(), '/') + 1; // +1 for root ""
          auto* start = str.data();
          std::array<sv, N> v;
+         v[0] = "";
          sv s = str;
-         for (auto i = 0; i < N; ++i) {
+         for (auto i = 1; i < N; ++i) {
             std::tie(v[i], s) = tokenize_json_ptr_children(s);
          }
          
-         for (auto i = 0; i < N; ++i) {
+         for (auto i = 1; i < N; ++i) {
              v[i] = sv{start, size_t((v[i].data() + v[i].size()) - start)};
          }
          return v;

--- a/include/glaze/core/seek.hpp
+++ b/include/glaze/core/seek.hpp
@@ -432,8 +432,7 @@ namespace glz
       };
       
       // Get each full JSON pointer path at increasing depth
-      inline auto json_ptr_children(sv s) {
-         std::vector<sv> v{};
+      inline auto json_ptr_children(sv s, std::vector<sv>& v) {
           const auto n = std::count(s.begin(), s.end(), '/');
           v.resize(n);
           auto* start = s.data();

--- a/include/glaze/core/seek.hpp
+++ b/include/glaze/core/seek.hpp
@@ -451,7 +451,7 @@ namespace glz
    template <auto Arr, std::size_t... Is>
    constexpr auto make_arrays(std::index_sequence<Is...>)
    {
-      return glz::tuplet::make_tuple(std::pair{sv{}, std::array<sv, Arr[Is]>{}}...);
+      return glz::tuplet::make_tuple(pair{sv{}, std::array<sv, Arr[Is]>{}}...);
    }
 
    template <size_t N, auto& Arr>

--- a/include/glaze/core/seek.hpp
+++ b/include/glaze/core/seek.hpp
@@ -432,7 +432,8 @@ namespace glz
       };
       
       // Get each full JSON pointer path at increasing depth
-      inline auto json_ptr_children(sv s, std::vector<sv>& v) {
+      inline auto json_ptr_children(sv s) {
+         std::vector<sv> v{};
           const auto n = std::count(s.begin(), s.end(), '/');
           v.resize(n);
           auto* start = s.data();
@@ -443,6 +444,7 @@ namespace glz
           for (auto i = 0; i < n; ++i) {
               v[i] = sv{start, size_t((v[i].data() + v[i].size()) - start)};
           }
+         return v;
       }
       
       template <auto& Str>

--- a/include/glaze/core/seek.hpp
+++ b/include/glaze/core/seek.hpp
@@ -432,7 +432,8 @@ namespace glz
       };
       
       // Get each full JSON pointer path at increasing depth
-      inline auto json_ptr_children(sv s, std::vector<sv>& v) {
+      inline auto json_ptr_children(sv s) {
+         std::vector<sv> v{};
           const auto n = std::count(s.begin(), s.end(), '/');
           v.resize(n);
           auto* start = s.data();

--- a/include/glaze/ext/glaze_asio.hpp
+++ b/include/glaze/ext/glaze_asio.hpp
@@ -141,20 +141,13 @@ namespace glz
       template <class Result = glz::raw_json>
       [[nodiscard]] glz::expected<Result, repe::error_t> get(repe::header&& header)
       {
-         header.notify = false;
-         header.empty = true; // no params
-         repe::request<Opts>(std::move(header), nullptr, buffer);
-
-         send_buffer(*socket, buffer);
-         receive_buffer(*socket, buffer);
-
          std::decay_t<Result> result{};
-         const auto error = repe::decode_response<Opts>(result, buffer);
+         const auto error = get<Result>(std::move(header), result);
          if (error) {
             return glz::unexpected(error);
          }
          else {
-            return result;
+            return {result};
          }
       }
 

--- a/include/glaze/ext/glaze_asio.hpp
+++ b/include/glaze/ext/glaze_asio.hpp
@@ -296,8 +296,9 @@ namespace glz
 
             while (true) {
                co_await co_receive_buffer(socket, buffer);
-               if (registry.call(buffer)) {
-                  co_await co_send_buffer(socket, registry.response);
+               auto response = registry.call(buffer);
+               if (response) {
+                  co_await co_send_buffer(socket, response->value());
                }
             }
          }

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -245,11 +245,11 @@ namespace glz
             constexpr auto& names = member_names<json_schema_type<T>>;
             return [&]<size_t... I>(std::index_sequence<I...>) {
                return detail::normal_map<sv, schema, N>(
-                  std::array<std::pair<sv, schema>, N>{std::pair{names[I], std::get<I>(tuple)}...});
+                  std::array<pair<sv, schema>, N>{pair{names[I], std::get<I>(tuple)}...});
             }(std::make_index_sequence<N>{});
          }
          else {
-            return detail::normal_map<sv, schema, 0>(std::array<std::pair<sv, schema>, 0>{});
+            return detail::normal_map<sv, schema, 0>(std::array<pair<sv, schema>, 0>{});
          }
       }
 

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1383,18 +1383,18 @@ namespace glz
 
                      static constexpr auto group = glz::get<I>(groups);
 
-                     static constexpr auto key = std::get<0>(group);
+                     static constexpr auto key = get<0>(group);
                      static constexpr auto quoted_key = join_v < chars<"\"">, key,
                                            Opts.prettify ? chars<"\": "> : chars < "\":" >>
                         ;
                      dump<quoted_key>(b, ix);
 
-                     static constexpr auto sub_partial = std::get<1>(group);
+                     static constexpr auto sub_partial = get<1>(group);
                      static constexpr auto frozen_map = make_map<T>();
                      static constexpr auto member_it = frozen_map.find(key);
                      static_assert(member_it != frozen_map.end(), "Invalid key passed to partial write");
                      static constexpr auto index = member_it->second.index();
-                     static constexpr decltype(auto) member_ptr = std::get<index>(member_it->second);
+                     static constexpr decltype(auto) member_ptr = get<index>(member_it->second);
 
                      we = write_partial<json>::op<sub_partial, Opts>(get_member(value, member_ptr), ctx, b, ix);
                      if constexpr (I != N - 1) {

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1419,7 +1419,7 @@ namespace glz
 
                      static constexpr auto group = glz::get<I>(groups);
 
-                     static constexpr auto key = std::get<0>(group);
+                     static constexpr auto key = get<0>(group);
                      constexpr auto mem_it = std::find(members.begin(), members.end(), key);
                      static_assert(mem_it != members.end(), "Invalid key passed to partial write");
 
@@ -1428,7 +1428,7 @@ namespace glz
                         ;
                      dump<quoted_key>(b, ix);
 
-                     static constexpr auto sub_partial = std::get<1>(group);
+                     static constexpr auto sub_partial = get<1>(group);
                      auto member_it = cmap.find(key); // we verified at compile time that this exists
                      std::visit(
                         [&](auto&& member_ptr) {

--- a/include/glaze/reflection/reflect.hpp
+++ b/include/glaze/reflection/reflect.hpp
@@ -47,11 +47,11 @@ namespace glz
          }
          else if constexpr (n == 1) {
             return micro_map1<value_t, named_member<T, I>::value...>{
-               std::pair<sv, value_t>{get<I>(members), std::add_pointer_t<glz::tuple_element_t<I, V>>{}}...};
+               pair<sv, value_t>{get<I>(members), std::add_pointer_t<glz::tuple_element_t<I, V>>{}}...};
          }
          else if constexpr (n == 2) {
             return micro_map2<value_t, named_member<T, I>::value...>{
-               std::pair<sv, value_t>{get<I>(members), std::add_pointer_t<glz::tuple_element_t<I, V>>{}}...};
+               pair<sv, value_t>{get<I>(members), std::add_pointer_t<glz::tuple_element_t<I, V>>{}}...};
          }
          else if constexpr (n < 64) // don't even attempt a first character hash if we have too many keys
          {
@@ -81,11 +81,11 @@ namespace glz
                   else {
                      if constexpr (n <= naive_map_max_size) {
                         constexpr auto naive_desc = naive_map_hash<use_hash_comparison, n>(keys);
-                        return glz::detail::make_naive_map<value_t, naive_desc>({std::pair<sv, value_t>{
+                        return glz::detail::make_naive_map<value_t, naive_desc>({pair<sv, value_t>{
                            get<I>(members), std::add_pointer_t<glz::tuple_element_t<I, V>>{}}...});
                      }
                      else {
-                        return glz::detail::normal_map<sv, value_t, n, use_hash_comparison>({std::pair<sv, value_t>{
+                        return glz::detail::normal_map<sv, value_t, n, use_hash_comparison>({pair<sv, value_t>{
                            get<I>(members), std::add_pointer_t<glz::tuple_element_t<I, V>>{}}...});
                      }
                   }
@@ -94,7 +94,7 @@ namespace glz
          }
          else {
             return glz::detail::normal_map<sv, value_t, n, use_hash_comparison>(
-               {std::pair<sv, value_t>{get<I>(members), std::add_pointer_t<glz::tuple_element_t<I, V>>{}}...});
+               {pair<sv, value_t>{get<I>(members), std::add_pointer_t<glz::tuple_element_t<I, V>>{}}...});
          }
       }
 

--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -382,15 +382,6 @@ namespace glz::repe
       return timeout_ns;
    }
    
-   struct exclusive_mutex {
-      exclusive_mutex(std::shared_mutex& mtx) : mtx_(mtx) {}
-       void lock() { mtx_.lock(); }
-       void unlock() { mtx_.unlock(); }
-      bool try_lock() { return mtx_.try_lock(); }
-   private:
-      std::shared_mutex& mtx_;
-   };
-   
    struct shared_mutex {
       shared_mutex(std::shared_mutex& mtx) : mtx_(mtx) {}
        void lock() { mtx_.lock_shared(); }
@@ -480,8 +471,7 @@ namespace glz::repe
          else {
             for (size_t i = 0; i < (n - 1); ++i) {
                shared_mutex route{chain[i]->route};
-               exclusive_mutex endpoint{chain[i]->endpoint};
-               const auto valid = try_lock_for(route, endpoint);
+               const auto valid = try_lock_for(route, chain[i]->endpoint);
                if (not valid) {
                   return false;
                }
@@ -557,14 +547,12 @@ namespace glz::repe
          }
          else if (n == 1) {
             shared_mutex route{chain[0]->route};
-            exclusive_mutex endpoint{chain[0]->endpoint};
-            return try_lock_for(route, endpoint);
+            return try_lock_for(route, chain[0]->endpoint);
          }
          else {
             for (size_t i = 0; i < (n - 2); ++i) {
                shared_mutex route{chain[i]->route};
-               exclusive_mutex endpoint{chain[i]->endpoint};
-               const bool valid = try_lock_for(route, endpoint);
+               const bool valid = try_lock_for(route, chain[i]->endpoint);
                if (not valid) {
                   return false;
                }

--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -373,8 +373,8 @@ namespace glz::repe
    
    using mutex_chain = std::vector<mutex_link*>;
    
-   struct exclusive_lock {
-      exclusive_lock(std::shared_mutex& mtx) : mtx_(mtx) {}
+   struct exclusive_mutex {
+      exclusive_mutex(std::shared_mutex& mtx) : mtx_(mtx) {}
        void lock() { mtx_.lock(); }
        void unlock() { mtx_.unlock(); }
       bool try_lock() { return mtx_.try_lock(); }
@@ -382,8 +382,8 @@ namespace glz::repe
        std::shared_mutex& mtx_;
    };
    
-   struct shared_lock {
-      shared_lock(std::shared_mutex& mtx) : mtx_(mtx) {}
+   struct shared_mutex {
+      shared_mutex(std::shared_mutex& mtx) : mtx_(mtx) {}
        void lock() { mtx_.lock_shared(); }
        void unlock() { mtx_.unlock_shared(); }
       bool try_lock() { return mtx_.try_lock_shared(); }
@@ -393,8 +393,8 @@ namespace glz::repe
    
    inline void lock_shared(auto& mtx0, auto& mtx1)
    {
-      shared_lock wrapper0{mtx0};
-      shared_lock wrapper1{mtx1};
+      shared_mutex wrapper0{mtx0};
+      shared_mutex wrapper1{mtx1};
       std::lock(wrapper0, wrapper1);
    }
    
@@ -411,8 +411,8 @@ namespace glz::repe
          }
          else {
             for (size_t i = 0; i < (n - 1); ++i) {
-               shared_lock route{chain[i]->route};
-               exclusive_lock endpoint{chain[i]->endpoint};
+               shared_mutex route{chain[i]->route};
+               exclusive_mutex endpoint{chain[i]->endpoint};
                std::lock(route, endpoint);
             }
             std::lock(chain[n - 1]->route, chain[n - 1]->endpoint);
@@ -481,14 +481,14 @@ namespace glz::repe
             return;
          }
          else if (n == 1) {
-            shared_lock route{chain[0]->route};
-            exclusive_lock endpoint{chain[0]->endpoint};
+            shared_mutex route{chain[0]->route};
+            exclusive_mutex endpoint{chain[0]->endpoint};
             std::lock(route, endpoint);
          }
          else {
             for (size_t i = 0; i < (n - 2); ++i) {
-               shared_lock route{chain[i]->route};
-               exclusive_lock endpoint{chain[i]->endpoint};
+               shared_mutex route{chain[i]->route};
+               exclusive_mutex endpoint{chain[i]->endpoint};
                std::lock(route, endpoint);
             }
             std::lock(chain[n - 2]->route, chain[n - 2]->endpoint);

--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -66,6 +66,43 @@ namespace glz::repe
       
       static constexpr int32_t timeout = -6000;
    };
+   
+   inline constexpr std::string_view error_code_to_sv(const int32_t e) noexcept {
+      switch (e)
+      {
+         case error_e::no_error: {
+            return "0 [no_error]";
+         }
+         case error_e::server_error_lower: {
+            return "-32000 [server_error_lower]";
+         }
+         case error_e::server_error_upper: {
+            return "-32099 [server_error_upper]";
+         }
+         case error_e::invalid_request: {
+            return "-32600 [invalid_request]";
+         }
+         case error_e::method_not_found: {
+            return "-32601 [method_not_found]";
+         }
+         case error_e::invalid_params: {
+            return "-32602 [invalid_params]";
+         }
+         case error_e::internal: {
+            return "-32603 [internal]";
+         }
+         case error_e::parse_error: {
+            return "-32700 [parse_error]";
+         }
+         case error_e::timeout: {
+            return "-6000 [timeout]";
+         }
+         default: {
+            return "unknown_error_code";
+            break;
+         }
+      };
+   }
 
    struct error_t final
    {
@@ -80,6 +117,14 @@ namespace glz::repe
          static constexpr auto value = glz::array(&T::code, &T::message);
       };
    };
+   
+   inline std::string format_error(const error_t& e) noexcept
+   {
+      std::string result = "error: " + std::string(error_code_to_sv(e.code));
+      result += "\n";
+      result += e.message;
+      return result;
+   }
 
    struct state final
    {
@@ -101,12 +146,6 @@ namespace glz::repe
          [[nodiscard]] size_t operator()(std::string_view txt) const { return std::hash<std::string_view>{}(txt); }
          [[nodiscard]] size_t operator()(const std::string& txt) const { return std::hash<std::string>{}(txt); }
       };
-   }
-
-   inline auto& get_shared_mutex()
-   {
-      static std::shared_mutex mtx{};
-      return mtx;
    }
 
    // returns 0 on error

--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -892,12 +892,6 @@ namespace glz::repe
          });
       }
 
-      // TODO: Implement JSON Pointer lock free path access when paths do not collide
-      /*template <class Params, class Result, class Callback>
-      void on(const sv name, Params&& params, Result&& result, Callback&& callback) {
-
-      }*/
-
       template <class Value>
       bool call(const header& header)
       {

--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -375,22 +375,24 @@ namespace glz::repe
    template <class Mutex>
    using mutex_chain = std::vector<mutex_link<Mutex>*>;
    
+   template <class Mutex>
    struct exclusive_mutex {
-      exclusive_mutex(std::shared_mutex& mtx) : mtx_(mtx) {}
+      exclusive_mutex(Mutex& mtx) : mtx_(mtx) {}
        void lock() { mtx_.lock(); }
        void unlock() { mtx_.unlock(); }
       bool try_lock() { return mtx_.try_lock(); }
    private:
-       std::shared_mutex& mtx_;
+      Mutex& mtx_;
    };
    
+   template <class Mutex>
    struct shared_mutex {
-      shared_mutex(std::shared_mutex& mtx) : mtx_(mtx) {}
+      shared_mutex(Mutex& mtx) : mtx_(mtx) {}
        void lock() { mtx_.lock_shared(); }
        void unlock() { mtx_.unlock_shared(); }
       bool try_lock() { return mtx_.try_lock_shared(); }
    private:
-       std::shared_mutex& mtx_;
+      Mutex& mtx_;
    };
    
    inline void lock_shared(auto& mtx0, auto& mtx1)
@@ -578,7 +580,7 @@ namespace glz::repe
    };
 
    // This registry does not support adding methods from RPC calls or adding methods once RPC calls can be made.
-   template <opts Opts = opts{}, class Mutex = std::shared_mutex>
+   template <opts Opts = opts{}, class Mutex = std::shared_timed_mutex>
    struct registry
    {
       using procedure = std::function<void(state&&)>; // RPC method

--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -403,14 +403,19 @@ namespace glz::repe
       }
       
       // lock writing out a value (reading from C++ memory)
-      // we only lock the access point and don't need to lock down the chain for reading from memory
       inline void lock_write(chain_t& chain) {
          const auto n = chain.size();
          if (n == 0) {
             return;
          }
+         else if (n == 1) {
+            chain[0]->lock_shared();
+         }
          else {
-            chain.back()->lock_shared();
+            for (size_t i = 0; i < (n - 1); ++i) {
+               chain[i]->lock_shared();
+            }
+            chain[n - 1]->lock_shared();
          }
       }
       
@@ -419,8 +424,14 @@ namespace glz::repe
          if (n == 0) {
             return;
          }
+         else if (n == 1) {
+            chain[0]->unlock_shared();
+         }
          else {
-            chain.back()->unlock_shared();
+            for (size_t i = 0; i < (n - 1); ++i) {
+               chain[i]->unlock_shared();
+            }
+            chain[n - 1]->unlock_shared();
          }
       }
       

--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -540,7 +540,7 @@ namespace glz::repe
       
       // used for writing to C++ memory
       template <string_literal json_ptr>
-      auto unique_lock()
+      auto lock()
       {
          // TODO: use a std::array and calculate number of path segments
          static thread_local chain_t chain = [&]{

--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -578,14 +578,14 @@ namespace glz::repe
    };
 
    // This registry does not support adding methods from RPC calls or adding methods once RPC calls can be made.
-   template <opts Opts = opts{}>
+   template <opts Opts = opts{}, class Mutex = std::shared_mutex>
    struct registry
    {
       using procedure = std::function<void(state&&)>; // RPC method
       std::unordered_map<sv, procedure, detail::string_hash, std::equal_to<>> methods;
       
-      using mutex_link_t = mutex_link<std::shared_mutex>;
-      using mutex_chain_t = mutex_chain<std::shared_mutex>;
+      using mutex_link_t = mutex_link<Mutex>;
+      using mutex_chain_t = mutex_chain<Mutex>;
       
       // TODO: replace this std::map with a std::flat_map with a std::deque (to not invalidate references)
       std::map<sv, mutex_link_t> mtxs; // only hashes during initialization

--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -298,12 +298,12 @@ namespace glz::repe
       requires(glz::detail::glaze_object_t<T> || glz::detail::reflectable<T>)
    constexpr auto make_mutex_map()
    {
-      using Mtx = std::mutex;
+      using Mtx = std::mutex*;
       using namespace glz::detail;
       constexpr auto N = reflection_count<T>;
       return [&]<size_t... I>(std::index_sequence<I...>) {
          return normal_map<sv, Mtx, N>(
-                                       {pair<sv, Mtx>{join_v<parent, chars<"/">, key_name_v<I, T>>, Mtx{}}...});
+                                       std::array<pair<sv, Mtx>, N>{pair<sv, Mtx>{join_v<parent, chars<"/">, key_name_v<I, T>>, Mtx{}}...});
       }(std::make_index_sequence<N>{});
    }
 

--- a/include/glaze/util/hash_map.hpp
+++ b/include/glaze/util/hash_map.hpp
@@ -17,6 +17,7 @@
 #include <span>
 #include <string_view>
 
+#include "glaze/concepts/container_concepts.hpp"
 #include "glaze/util/compare.hpp"
 
 #ifdef _MSC_VER
@@ -50,6 +51,20 @@ namespace glz
    
    template <class T1, class T2>
    pair(T1, T2) -> pair<T1, T2>;
+   
+   template <size_t I, detail::pair_t T>
+   constexpr decltype(auto) get(T&& p) noexcept
+   {
+      if constexpr (I == 0) {
+         return p.first;
+      }
+      else if constexpr (I == 1) {
+         return p.second;
+      }
+      else {
+         static_assert(false_v<decltype(p)>, "Invalid get for pair");
+      }
+   }
 }
 
 namespace glz::detail

--- a/include/glaze/util/poly.hpp
+++ b/include/glaze/util/poly.hpp
@@ -26,8 +26,8 @@ namespace glz
    inline constexpr auto make_mem_fn_wrapper_map_impl(std::index_sequence<I...>)
    {
       constexpr auto N = glz::tuple_size_v<meta_t<Spec>>;
-      return detail::normal_map<sv, fn_variant<Spec>, N>({std::make_pair<sv, fn_variant<Spec>>(
-         sv(get<0>(get<I>(meta_v<Spec>))), get_argument<get<1>(get<I>(meta_v<Spec>))>())...});
+      return detail::normal_map<sv, fn_variant<Spec>, N>({pair<sv, fn_variant<Spec>>{
+         sv(get<0>(get<I>(meta_v<Spec>))), get_argument<get<1>(get<I>(meta_v<Spec>))>()}...});
    }
 
    template <class Spec>

--- a/include/glaze/util/poly.hpp
+++ b/include/glaze/util/poly.hpp
@@ -26,7 +26,7 @@ namespace glz
    inline constexpr auto make_mem_fn_wrapper_map_impl(std::index_sequence<I...>)
    {
       constexpr auto N = glz::tuple_size_v<meta_t<Spec>>;
-      return detail::normal_map<sv, fn_variant<Spec>, N>({pair<sv, fn_variant<Spec>>{
+      return detail::normal_map<sv, fn_variant<Spec>, N>(std::array{pair<sv, fn_variant<Spec>>{
          sv(get<0>(get<I>(meta_v<Spec>))), get_argument<get<1>(get<I>(meta_v<Spec>))>()}...});
    }
 

--- a/tests/asio_repe/server/repe_server.cpp
+++ b/tests/asio_repe/server/repe_server.cpp
@@ -20,9 +20,9 @@ void run_server()
    std::cout << "Server active...\n";
 
    try {
-      glz::asio_server<glz::repe::registry<>> server{.port = 8080};
+      glz::asio_server<> server{.port = 8080};
       api methods{};
-      server.init_registry = [&](glz::repe::registry<>& registry) { registry.on(methods); };
+      server.on(methods);
       server.run();
    }
    catch (const std::exception& e) {

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -533,8 +533,8 @@ void test_partial()
    static constexpr auto N = glz::tuple_size_v<decltype(groups)>;
    glz::for_each<N>([&](auto I) {
       const auto group = glz::get<I>(groups);
-      std::cout << std::get<0>(group) << ": ";
-      for (auto& rest : std::get<1>(group)) {
+      std::cout << glz::get<0>(group) << ": ";
+      for (auto& rest : glz::get<1>(group)) {
          std::cout << rest << ", ";
       }
       std::cout << '\n';

--- a/tests/repe_test/repe_test.cpp
+++ b/tests/repe_test/repe_test.cpp
@@ -575,6 +575,17 @@ suite multi_threading_tests = [] {
          std::cout << "read integer response_counter: " << response_counter << '\n';
       });
       
+      auto read_full = repe::request_json({""});
+      
+      std::thread reader_full([&]{
+         size_t response_counter{};
+         for (size_t i = 0; i < N; ++i) {
+            const auto response = registry.call(read_full);
+            response_counter += response->value().size();
+         }
+         std::cout << "read full response_counter: " << response_counter << '\n';
+      });
+      
       std::latch latch{1};
       
       std::thread writer_str([&]{
@@ -618,6 +629,7 @@ suite multi_threading_tests = [] {
       
       reader_str.join();
       reader_integer.join();
+      reader_full.join();
       writer_str.join();
       writer_integer.join();
    };

--- a/tests/repe_test/repe_test.cpp
+++ b/tests/repe_test/repe_test.cpp
@@ -617,9 +617,8 @@ suite multi_threading_tests = [] {
       {
          latch.wait();
          auto lock = registry.read_only_lock<"/str">();
-         auto valid = lock.try_lock();
-         expect(valid);
-         valid = true;
+         expect(lock);
+         bool valid = true;
          for (char c : obj.str) {
               if (c != 'x') {
                   valid = false;

--- a/tests/repe_test/repe_test.cpp
+++ b/tests/repe_test/repe_test.cpp
@@ -617,7 +617,9 @@ suite multi_threading_tests = [] {
       {
          latch.wait();
          auto lock = registry.read_only_lock<"/str">();
-         bool valid = true;
+         auto valid = lock.try_lock();
+         expect(valid);
+         valid = true;
          for (char c : obj.str) {
               if (c != 'x') {
                   valid = false;

--- a/tests/repe_test/repe_test.cpp
+++ b/tests/repe_test/repe_test.cpp
@@ -69,34 +69,36 @@ suite structs_of_functions = [] {
       server.on(obj);
 
       obj.i = 55;
+      
+      glz::repe::shared_buffer response{};
 
       {
          auto request = repe::request_json({"/i"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(server.response == R"([[0,0,0,"/i",null],55])") << server.response;
+      expect(response->value() == R"([[0,0,0,"/i",null],55])") << response->value();
 
       {
          auto request = repe::request_json({.method = "/i"}, 42);
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(server.response == R"([[0,0,2,"/i",null],null])") << server.response;
+      expect(response->value() == R"([[0,0,2,"/i",null],null])") << response->value();
 
       {
          auto request = repe::request_json({"/hello"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(server.response == R"([[0,0,0,"/hello",null],"Hello"])");
+      expect(response->value() == R"([[0,0,0,"/hello",null],"Hello"])");
 
       {
          auto request = repe::request_json({"/get_number"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(server.response == R"([[0,0,0,"/get_number",null],42])");
+      expect(response->value() == R"([[0,0,0,"/get_number",null],42])");
    };
 
    "nested_structs_of_functions"_test = [] {
@@ -105,85 +107,87 @@ suite structs_of_functions = [] {
       my_nested_functions_t obj{};
 
       server.on(obj);
+      
+      glz::repe::shared_buffer response{};
 
       {
          auto request = repe::request_json({"/my_functions/void_func"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(server.response == R"([[0,0,2,"/my_functions/void_func",null],null])") << server.response;
+      expect(response->value() == R"([[0,0,2,"/my_functions/void_func",null],null])") << response->value();
 
       {
          auto request = repe::request_json({"/my_functions/hello"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(server.response == R"([[0,0,0,"/my_functions/hello",null],"Hello"])");
+      expect(response->value() == R"([[0,0,0,"/my_functions/hello",null],"Hello"])");
 
       {
          auto request = repe::request_json({"/meta_functions/hello"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(server.response == R"([[0,0,0,"/meta_functions/hello",null],"Hello"])");
+      expect(response->value() == R"([[0,0,0,"/meta_functions/hello",null],"Hello"])");
 
       {
          auto request = repe::request_json({"/append_awesome"}, "you are");
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(server.response == R"([[0,0,0,"/append_awesome",null],"you are awesome!"])");
+      expect(response->value() == R"([[0,0,0,"/append_awesome",null],"you are awesome!"])");
 
       {
          auto request = repe::request_json({"/my_string"}, "Howdy!");
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(server.response == R"([[0,0,2,"/my_string",null],null])");
+      expect(response->value() == R"([[0,0,2,"/my_string",null],null])");
 
       {
          auto request = repe::request_json({"/my_string"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(server.response == R"([[0,0,0,"/my_string",null],"Howdy!"])") << server.response;
+      expect(response->value() == R"([[0,0,0,"/my_string",null],"Howdy!"])") << response->value();
 
       obj.my_string.clear();
 
       {
          auto request = repe::request_json({"/my_string"});
-         server.call(request);
+         response = server.call(request);
       }
 
       // we expect an empty string returned because we cleared it
-      expect(server.response == R"([[0,0,0,"/my_string",null],""])");
+      expect(response->value() == R"([[0,0,0,"/my_string",null],""])");
 
       {
          auto request = repe::request_json({"/my_functions/max"}, std::vector<double>{1.1, 3.3, 2.25});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(server.response == R"([[0,0,0,"/my_functions/max",null],3.3])") << server.response;
+      expect(response->value() == R"([[0,0,0,"/my_functions/max",null],3.3])") << response->value();
 
       {
          auto request = repe::request_json({"/my_functions"});
-         server.call(request);
+         response = server.call(request);
       }
 
       expect(
-         server.response ==
+         response->value() ==
          R"([[0,0,0,"/my_functions",null],{"i":0,"hello":"std::function<std::string_view()>","world":"std::function<std::string_view()>","get_number":"std::function<int32_t()>","void_func":"std::function<void()>","max":"std::function<double(std::vector<double>&)>"}])")
-         << server.response;
+         << response->value();
 
       {
          auto request = repe::request_json({""});
-         server.call(request);
+         response = server.call(request);
       }
 
       expect(
-         server.response ==
+         response->value() ==
          R"([[0,0,0,"",null],{"my_functions":{"i":0,"hello":"std::function<std::string_view()>","world":"std::function<std::string_view()>","get_number":"std::function<int32_t()>","void_func":"std::function<void()>","max":"std::function<double(std::vector<double>&)>"},"meta_functions":{"hello":"std::function<std::string_view()>","world":"std::function<std::string_view()>","get_number":"std::function<int32_t()>"},"append_awesome":"std::function<std::string(const std::string&)>","my_string":""}])")
-         << server.response;
+         << response->value();
    };
 
    "example_functions"_test = [] {
@@ -192,44 +196,46 @@ suite structs_of_functions = [] {
       example_functions_t obj{};
 
       server.on(obj);
+      
+      glz::repe::shared_buffer response{};
 
       {
          auto request = repe::request_json({"/name"}, "Susan");
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(server.response == R"([[0,0,2,"/name",null],null])") << server.response;
+      expect(response->value() == R"([[0,0,2,"/name",null],null])") << response->value();
 
       {
          auto request = repe::request_json({"/get_name"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(server.response == R"([[0,0,0,"/get_name",null],"Susan"])") << server.response;
+      expect(response->value() == R"([[0,0,0,"/get_name",null],"Susan"])") << response->value();
 
       {
          auto request = repe::request_json({"/get_name"}, "Bob");
-         server.call(request);
+         response = server.call(request);
       }
 
       expect(obj.name == "Susan"); // we expect the name to not have changed because this function take no inputs
-      expect(server.response == R"([[0,0,2,"/get_name",null],null])") << server.response;
+      expect(response->value() == R"([[0,0,2,"/get_name",null],null])") << response->value();
 
       {
          auto request = repe::request_json({"/set_name"}, "Bob");
-         server.call(request);
+         response = server.call(request);
       }
 
       expect(obj.name == "Bob");
-      expect(server.response == R"([[0,0,2,"/set_name",null],null])") << server.response;
+      expect(response->value() == R"([[0,0,2,"/set_name",null],null])") << response->value();
 
       {
          auto request = repe::request_json({"/custom_name"}, "Alice");
-         server.call(request);
+         response = server.call(request);
       }
 
       expect(obj.name == "Alice");
-      expect(server.response == R"([[0,0,2,"/custom_name",null],null])") << server.response;
+      expect(response->value() == R"([[0,0,2,"/custom_name",null],null])") << response->value();
    };
 };
 
@@ -242,39 +248,41 @@ suite structs_of_functions_binary = [] {
       server.on(obj);
 
       obj.i = 55;
+      
+      glz::repe::shared_buffer response{};
 
       {
          auto request = repe::request_binary({"/i"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      std::string response{};
-      expect(!glz::beve_to_json(server.response, response));
-      expect(response == R"([[0,0,0,"/i",null],55])") << response;
+      std::string res{};
+      expect(!glz::beve_to_json(response->value(), res));
+      expect(res == R"([[0,0,0,"/i",null],55])") << res;
 
       {
          auto request = repe::request_binary({.method = "/i"}, 42);
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(!glz::beve_to_json(server.response, response));
-      expect(response == R"([[0,0,2,"/i",null],null])") << response;
+      expect(!glz::beve_to_json(response->value(), res));
+      expect(res == R"([[0,0,2,"/i",null],null])") << res;
 
       {
          auto request = repe::request_binary({"/hello"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(!glz::beve_to_json(server.response, response));
-      expect(response == R"([[0,0,0,"/hello",null],"Hello"])");
+      expect(!glz::beve_to_json(response->value(), res));
+      expect(res == R"([[0,0,0,"/hello",null],"Hello"])");
 
       {
          auto request = repe::request_binary({"/get_number"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(!glz::beve_to_json(server.response, response));
-      expect(response == R"([[0,0,0,"/get_number",null],42])");
+      expect(!glz::beve_to_json(response->value(), res));
+      expect(res == R"([[0,0,0,"/get_number",null],42])");
    };
 
    "nested_structs_of_functions"_test = [] {
@@ -283,96 +291,98 @@ suite structs_of_functions_binary = [] {
       my_nested_functions_t obj{};
 
       server.on(obj);
+      
+      glz::repe::shared_buffer response{};
 
       {
          auto request = repe::request_binary({"/my_functions/void_func"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      std::string response{};
-      expect(!glz::beve_to_json(server.response, response));
-      expect(response == R"([[0,0,2,"/my_functions/void_func",null],null])") << response;
+      std::string res{};
+      expect(!glz::beve_to_json(response->value(), res));
+      expect(res == R"([[0,0,2,"/my_functions/void_func",null],null])") << response;
 
       {
          auto request = repe::request_binary({"/my_functions/hello"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(!glz::beve_to_json(server.response, response));
-      expect(response == R"([[0,0,0,"/my_functions/hello",null],"Hello"])");
+      expect(!glz::beve_to_json(response->value(), res));
+      expect(res == R"([[0,0,0,"/my_functions/hello",null],"Hello"])");
 
       {
          auto request = repe::request_binary({"/meta_functions/hello"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(!glz::beve_to_json(server.response, response));
-      expect(response == R"([[0,0,0,"/meta_functions/hello",null],"Hello"])");
+      expect(!glz::beve_to_json(response->value(), res));
+      expect(res == R"([[0,0,0,"/meta_functions/hello",null],"Hello"])");
 
       {
          auto request = repe::request_binary({"/append_awesome"}, "you are");
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(!glz::beve_to_json(server.response, response));
-      expect(response == R"([[0,0,0,"/append_awesome",null],"you are awesome!"])");
+      expect(!glz::beve_to_json(response->value(), res));
+      expect(res == R"([[0,0,0,"/append_awesome",null],"you are awesome!"])");
 
       {
          auto request = repe::request_binary({"/my_string"}, "Howdy!");
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(!glz::beve_to_json(server.response, response));
-      expect(response == R"([[0,0,2,"/my_string",null],null])");
+      expect(!glz::beve_to_json(response->value(), res));
+      expect(res == R"([[0,0,2,"/my_string",null],null])");
 
       {
          auto request = repe::request_binary({"/my_string"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(!glz::beve_to_json(server.response, response));
-      expect(response == R"([[0,0,0,"/my_string",null],"Howdy!"])") << response;
+      expect(!glz::beve_to_json(response->value(), res));
+      expect(res == R"([[0,0,0,"/my_string",null],"Howdy!"])") << response;
 
       obj.my_string.clear();
 
       {
          auto request = repe::request_binary({"/my_string"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(!glz::beve_to_json(server.response, response));
+      expect(!glz::beve_to_json(response->value(), res));
       // we expect an empty string returned because we cleared it
-      expect(response == R"([[0,0,0,"/my_string",null],""])");
+      expect(res == R"([[0,0,0,"/my_string",null],""])");
 
       {
          auto request = repe::request_binary({"/my_functions/max"}, std::vector<double>{1.1, 3.3, 2.25});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(!glz::beve_to_json(server.response, response));
-      expect(response == R"([[0,0,0,"/my_functions/max",null],3.3])") << response;
+      expect(!glz::beve_to_json(response->value(), res));
+      expect(res == R"([[0,0,0,"/my_functions/max",null],3.3])") << response;
 
       {
          auto request = repe::request_binary({"/my_functions"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(!glz::beve_to_json(server.response, response));
+      expect(!glz::beve_to_json(response->value(), res));
       expect(
-         response ==
+             res ==
          R"([[0,0,0,"/my_functions",null],{"i":0,"hello":"std::function<std::string_view()>","world":"std::function<std::string_view()>","get_number":"std::function<int32_t()>","void_func":"std::function<void()>","max":"std::function<double(std::vector<double>&)>"}])")
-         << response;
+         << res;
 
       {
          auto request = repe::request_binary({""});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(!glz::beve_to_json(server.response, response));
+      expect(!glz::beve_to_json(response->value(), res));
       expect(
-         response ==
+             res ==
          R"([[0,0,0,"",null],{"my_functions":{"i":0,"hello":"std::function<std::string_view()>","world":"std::function<std::string_view()>","get_number":"std::function<int32_t()>","void_func":"std::function<void()>","max":"std::function<double(std::vector<double>&)>"},"meta_functions":{"hello":"std::function<std::string_view()>","world":"std::function<std::string_view()>","get_number":"std::function<int32_t()>"},"append_awesome":"std::function<std::string(const std::string&)>","my_string":""}])")
-         << response;
+         << res;
    };
 
    "example_functions"_test = [] {
@@ -381,50 +391,52 @@ suite structs_of_functions_binary = [] {
       example_functions_t obj{};
 
       server.on(obj);
+      
+      glz::repe::shared_buffer response{};
 
       {
          auto request = repe::request_binary({"/name"}, "Susan");
-         server.call(request);
+         response = server.call(request);
       }
 
-      std::string response{};
-      expect(!glz::beve_to_json(server.response, response));
-      expect(response == R"([[0,0,2,"/name",null],null])") << response;
+      std::string res{};
+      expect(!glz::beve_to_json(response->value(), res));
+      expect(res == R"([[0,0,2,"/name",null],null])") << response;
 
       {
          auto request = repe::request_binary({"/get_name"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(!glz::beve_to_json(server.response, response));
-      expect(response == R"([[0,0,0,"/get_name",null],"Susan"])") << response;
+      expect(!glz::beve_to_json(response->value(), res));
+      expect(res == R"([[0,0,0,"/get_name",null],"Susan"])") << response;
 
       {
          auto request = repe::request_binary({"/get_name"}, "Bob");
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(!glz::beve_to_json(server.response, response));
+      expect(!glz::beve_to_json(response->value(), res));
       expect(obj.name == "Susan"); // we expect the name to not have changed because this function take no inputs
-      expect(response == R"([[0,0,2,"/get_name",null],null])") << response;
+      expect(res == R"([[0,0,2,"/get_name",null],null])") << response;
 
       {
          auto request = repe::request_binary({"/set_name"}, "Bob");
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(!glz::beve_to_json(server.response, response));
+      expect(!glz::beve_to_json(response->value(), res));
       expect(obj.name == "Bob");
-      expect(response == R"([[0,0,2,"/set_name",null],null])") << response;
+      expect(res == R"([[0,0,2,"/set_name",null],null])") << response;
 
       {
          auto request = repe::request_binary({"/custom_name"}, "Alice");
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(!glz::beve_to_json(server.response, response));
+      expect(!glz::beve_to_json(response->value(), res));
       expect(obj.name == "Alice");
-      expect(response == R"([[0,0,2,"/custom_name",null],null])") << response;
+      expect(res == R"([[0,0,2,"/custom_name",null],null])") << response;
    };
 };
 
@@ -434,9 +446,9 @@ struct wrapper_t
    T* sub{};
 
    // TODO: support meta wrappers and not only reflectable wrappers (I don't know why this isn't working)
-   /*struct glaze {
-      static constexpr auto value = glz::object(&wrapper_t::sub);
-   };*/
+   //struct glaze {
+   //   static constexpr auto value = glz::object(&wrapper_t::sub);
+   //};
 };
 
 suite wrapper_tests = [] {
@@ -447,20 +459,22 @@ suite wrapper_tests = [] {
       wrapper_t<my_nested_functions_t> obj{&instance};
 
       server.on(obj);
+      
+      glz::repe::shared_buffer response{};
 
       {
          auto request = repe::request_json({"/sub/my_functions/void_func"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(server.response == R"([[0,0,2,"/sub/my_functions/void_func",null],null])") << server.response;
+      expect(response->value() == R"([[0,0,2,"/sub/my_functions/void_func",null],null])") << response->value();
 
       {
          auto request = repe::request_json({"/sub/my_functions/hello"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(server.response == R"([[0,0,0,"/sub/my_functions/hello",null],"Hello"])");
+      expect(response->value() == R"([[0,0,0,"/sub/my_functions/hello",null],"Hello"])");
    };
 };
 
@@ -471,20 +485,22 @@ suite root_tests = [] {
       my_nested_functions_t obj{};
 
       server.on<glz::root<"/sub">>(obj);
+      
+      glz::repe::shared_buffer response{};
 
       {
          auto request = repe::request_json({"/sub/my_functions/void_func"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(server.response == R"([[0,0,2,"/sub/my_functions/void_func",null],null])") << server.response;
+      expect(response->value() == R"([[0,0,2,"/sub/my_functions/void_func",null],null])") << response->value();
 
       {
          auto request = repe::request_json({"/sub/my_functions/hello"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(server.response == R"([[0,0,0,"/sub/my_functions/hello",null],"Hello"])");
+      expect(response->value() == R"([[0,0,0,"/sub/my_functions/hello",null],"Hello"])");
    };
 };
 
@@ -496,23 +512,25 @@ suite wrapper_tests_binary = [] {
       wrapper_t<my_nested_functions_t> obj{&instance};
 
       server.on(obj);
+      
+      glz::repe::shared_buffer response{};
 
       {
          auto request = repe::request_binary({"/sub/my_functions/void_func"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      std::string response{};
-      expect(!glz::beve_to_json(server.response, response));
-      expect(response == R"([[0,0,2,"/sub/my_functions/void_func",null],null])") << response;
+      std::string res{};
+      expect(!glz::beve_to_json(response->value(), res));
+      expect(res == R"([[0,0,2,"/sub/my_functions/void_func",null],null])") << response;
 
       {
          auto request = repe::request_binary({"/sub/my_functions/hello"});
-         server.call(request);
+         response = server.call(request);
       }
 
-      expect(!glz::beve_to_json(server.response, response));
-      expect(response == R"([[0,0,0,"/sub/my_functions/hello",null],"Hello"])");
+      expect(!glz::beve_to_json(response->value(), res));
+      expect(res == R"([[0,0,0,"/sub/my_functions/hello",null],"Hello"])");
    };
 };
 

--- a/tests/repe_test/repe_test.cpp
+++ b/tests/repe_test/repe_test.cpp
@@ -616,7 +616,7 @@ suite multi_threading_tests = [] {
       
       {
          latch.wait();
-         auto lock = registry.shared_lock<"/str">();
+         auto lock = registry.read_only_lock<"/str">();
          bool valid = true;
          for (char c : obj.str) {
               if (c != 'x') {


### PR DESCRIPTION
# Breaking `glz::repe::registry` changes

## REPE registry locking and thread safety
Rather than designing the registry to be duplicated per client, this rework allows the registry to be used for all clients and adds thread locking based on JSON pointer paths to allow multiple clients to read/write from the same object at the same time.

Locking is based on depth in the object tree. A chain of shared mutexes are locked. When reading from C++ memory, only shared locks are used at the read location.

An invoke lock is also used for invoking functions. Unlike variable access, the invocation lock also locks everything at the same depth as the function, which allows member functions to safely manipulate member variables from the same class.

> [!IMPORTANT]
>
> Pointers to parent members or functions that manipulate shallower depth members are not thread safe and safety has to be added by the developer.

## Other Improvements
- Perfect forwarding constructor of `normal_map`
- New, simpler `pair` type than `std::pair`, which avoids some compiler bugs (for internal use)