### PR TITLE
Default behavior no longer reads comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,9 @@ expect(buffer == "\"Red\"");
 
 Comments are supported with the specification defined here: [JSONC](https://github.com/stephenberry/JSONC)
 
-Comments may also be included in the `glz::meta` description for your types. These comments can be written out to provide a description of your JSON interface. Calling `write_jsonc` as opposed to `write_json` will write out any comments included in the `meta` description.
+Read support for comments is provided with `glz::read_jsonc` or `glz::read<glz::opts{.comments = true}>(...)`.
+
+Comments may be included in the `glz::meta` description for your types. These comments can be written out to provide a description of your JSON interface. Calling `write_jsonc` as opposed to `write_json` will write out any comments included in the `meta` description.
 
 ```c++
 struct thing {
@@ -697,7 +699,7 @@ The struct below shows the available options and the default behavior.
 ```c++
 struct opts {
   uint32_t format = json;
-  bool comments = false; // Write out comments
+  bool comments = false; // Write out or support reading in JSONC style comments
   bool error_on_unknown_keys = true; // Error when an unknown key is encountered
   bool skip_null_members = true; // Skip writing out params in an object if the value is null
   bool use_hash_comparison = true; // Will replace some string equality checks with hash checks
@@ -708,7 +710,7 @@ struct opts {
   bool new_lines_in_arrays = true; // Whether prettified arrays should have new lines for each element
   bool shrink_to_fit = false; // Shrinks dynamic containers to new size to save memory
   bool write_type_info = true; // Write type info for meta objects in variants
-  bool force_conformance = false; // Do not allow invalid json normally accepted such as comments, nan, inf.
+  bool force_conformance = false; // Do not allow invalid json normally accepted such as nan, inf.
   bool error_on_missing_keys = false; // Require all non nullable keys to be present in the object. Use
                                       // skip_null_members = false to require nullable members
 

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -32,7 +32,7 @@ namespace glz
    {
       // USER CONFIGURABLE
       uint32_t format = json;
-      bool comments = false; // Write out comments
+      bool comments = false; // Write out or support reading in JSONC style comments
       bool error_on_unknown_keys = true; // Error when an unknown key is encountered
       bool skip_null_members = true; // Skip writing out params in an object if the value is null
       bool use_hash_comparison = true; // Will replace some string equality checks with hash checks
@@ -43,7 +43,7 @@ namespace glz
       bool new_lines_in_arrays = true; // Whether prettified arrays should have new lines for each element
       bool shrink_to_fit = false; // Shrinks dynamic containers to new size to save memory
       bool write_type_info = true; // Write type info for meta objects in variants
-      bool force_conformance = false; // Do not allow invalid json normally accepted such as comments, nan, inf.
+      bool force_conformance = false; // Do not allow invalid json normally accepted such as nan, inf.
       bool error_on_missing_keys = false; // Require all non nullable keys to be present in the object. Use
                                           // skip_null_members = false to require nullable members
 

--- a/include/glaze/exceptions/json_exceptions.hpp
+++ b/include/glaze/exceptions/json_exceptions.hpp
@@ -45,11 +45,42 @@ namespace glz::ex
       }
       return ex.value();
    }
+   
+   template <class T, class Buffer>
+   void read_jsonc(T& value, Buffer&& buffer)
+   {
+      const auto ec = glz::read_jsonc(value, std::forward<Buffer>(buffer));
+      if (ec) {
+         throw std::runtime_error("read_json error: " + glz::format_error(ec, buffer));
+      }
+   }
+
+   template <class T, class Buffer>
+   [[nodiscard]] T read_jsonc(Buffer&& buffer)
+   {
+      const auto ex = glz::read_jsonc<T>(std::forward<Buffer>(buffer));
+      if (!ex) {
+         throw std::runtime_error("read_json error: " + glz::format_error(ex.error(), buffer));
+      }
+      return ex.value();
+   }
 
    template <auto Opts = opts{}, class T>
    void read_file_json(T& value, const sv file_name, auto&& buffer)
    {
       const auto ec = glz::read_file_json<Opts, T>(value, file_name, buffer);
+      if (ec == glz::error_code::file_open_failure) {
+         throw std::runtime_error("file failed to open: " + std::string(file_name));
+      }
+      else if (ec) {
+         throw std::runtime_error("read_file_json error: " + glz::format_error(ec, buffer));
+      }
+   }
+   
+   template <auto Opts = opts{}, class T>
+   void read_file_jsonc(T& value, const sv file_name, auto&& buffer)
+   {
+      const auto ec = glz::read_file_jsonc<Opts, T>(value, file_name, buffer);
       if (ec == glz::error_code::file_open_failure) {
          throw std::runtime_error("file failed to open: " + std::string(file_name));
       }

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -523,7 +523,7 @@ namespace glz::detail
 
 #define GLZ_SKIP_WS                                \
    if constexpr (!Opts.minified) {                 \
-      if constexpr (!Opts.force_conformance) {     \
+      if constexpr (Opts.comments) {         \
          while (whitespace_comment_table[*it]) {   \
             if (*it == '/') [[unlikely]] {         \
                skip_comment(ctx, it, end);         \
@@ -548,7 +548,7 @@ namespace glz::detail
    GLZ_ALWAYS_INLINE void skip_ws(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       if constexpr (!Opts.minified) {
-         if constexpr (!Opts.force_conformance) {
+         if constexpr (Opts.comments) {
             while (whitespace_comment_table[*it]) {
                if (*it == '/') [[unlikely]] {
                   skip_comment(ctx, it, end);

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -794,7 +794,7 @@ suite user_types = [] {
 
       // Should skip invalid keys
       // glaze::read_json(obj,"{/**/ \"b\":\"fox\", \"c\":7.7/**/, \"d\": {\"a\": \"}\"} //\n   /**/, \"a\":322}");
-      expect(glz::read<glz::opts{.error_on_unknown_keys = false, .comments = true}>(obj,
+      expect(glz::read<glz::opts{.comments = true, .error_on_unknown_keys = false}>(obj,
                                                                   R"({/**/ "b":"fox", "c":7.7/**/, "d": {"a": "}"} //
 /**/, "a":322})") == glz::error_code::none);
 

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -794,12 +794,12 @@ suite user_types = [] {
 
       // Should skip invalid keys
       // glaze::read_json(obj,"{/**/ \"b\":\"fox\", \"c\":7.7/**/, \"d\": {\"a\": \"}\"} //\n   /**/, \"a\":322}");
-      expect(glz::read<glz::opts{.error_on_unknown_keys = false}>(obj,
+      expect(glz::read<glz::opts{.error_on_unknown_keys = false, .comments = true}>(obj,
                                                                   R"({/**/ "b":"fox", "c":7.7/**/, "d": {"a": "}"} //
 /**/, "a":322})") == glz::error_code::none);
 
       // glaze::read_json(obj,"{/**/ \"b\":\"fox\", \"c\":7.7/**/, \"d\": {\"a\": \"}\"} //\n   /**/, \"a\":322}");
-      auto ec = glz::read_json(obj,
+      auto ec = glz::read<glz::opts{.comments = true}>(obj,
                                R"({/**/ "b":"fox", "c":7.7/**/, "d": {"a": "}"} //
    /**/, "a":322})");
       expect(ec != glz::error_code::none);
@@ -830,7 +830,7 @@ suite user_types = [] {
          buffer ==
          R"({"thing":{"a":3.14/*Test comment 1*/,"b":"stuff"/*Test comment 2*/},"thing2array":[{"a":3.14/*Test comment 1*/,"b":"stuff"/*Test comment 2*/,"c":999.342494903,"d":1E-12,"e":203082348402.1,"f":89.089,"g":12380.00000013,"h":1000000.000001}],"vec3":[3.14,2.7,6.5],"list":[6,7,8,2],"deque":[9,6.7,3.1],"vector":[[9,6.7,3.1],[3.14,2.7,6.5]],"i":8,"d":2/*double is the best type*/,"b":false,"c":"W","v":{"x":0},"color":"Green","vb":[true,false,false,true,true,true,true],"sptr":{"a":3.14/*Test comment 1*/,"b":"stuff"/*Test comment 2*/},"array":["as\"df\\ghjkl","pie","42","foo"],"map":{"a":4,"b":12,"f":7},"mapi":{"2":9.63,"5":3.14,"7":7.42},"thing_ptr":{"a":3.14/*Test comment 1*/,"b":"stuff"/*Test comment 2*/}})")
          << buffer;
-      expect(glz::read_json(obj, buffer) == glz::error_code::none);
+      expect(glz::read_jsonc(obj, buffer) == glz::error_code::none);
    };
 
    "complex user obect opts prettify"_test = [] {
@@ -1125,10 +1125,10 @@ suite user_types = [] {
 })";
 
       expect(thing_pretty == buffer);
-      expect(!glz::read_json(obj, buffer));
+      expect(!glz::read_jsonc(obj, buffer));
       const auto minified = glz::minify_jsonc(thing_pretty);
       expect(json == minified);
-      expect(!glz::read_json(obj, minified));
+      expect(!glz::read_jsonc(obj, minified));
    };
 
    "complex user obect roundtrip"_test = [] {
@@ -1568,14 +1568,14 @@ suite read_tests = [] {
       {
          std::string b = "1/*a comment*/00";
          int a{};
-         expect(glz::read_json(a, b) == glz::error_code::none);
+         expect(glz::read_jsonc(a, b) == glz::error_code::none);
          expect(a == 1);
       }
       {
          std::string b = R"([100, // a comment
 20])";
          std::vector<int> a{};
-         expect(glz::read_json(a, b) == glz::error_code::none);
+         expect(glz::read_jsonc(a, b) == glz::error_code::none);
          expect(a[0] == 100);
          expect(a[1] == 20);
       }
@@ -6916,7 +6916,7 @@ suite hostname_include_test = [] {
       std::string_view s = R"(
 // testing opening whitespace and comment
 {"hostname_include": "../{}_config.json", "i": 100})";
-      const auto ec = glz::read_json(obj, s);
+      const auto ec = glz::read_jsonc(obj, s);
       expect(ec == glz::error_code::none) << glz::format_error(ec, s);
 
       expect(obj.str == "Hello") << obj.str;
@@ -6925,12 +6925,12 @@ suite hostname_include_test = [] {
       obj.str = "";
 
       std::string buffer{};
-      expect(!glz::read_file_json(obj, file_name, buffer));
+      expect(!glz::read_file_jsonc(obj, file_name, buffer));
       expect(obj.str == "Hello") << obj.str;
       expect(obj.i == 55) << obj.i;
 
       s = R"({"i": 100, "hostname_include": "../{}_config.json"})";
-      expect(!glz::read_json(obj, s));
+      expect(!glz::read_jsonc(obj, s));
 
       expect(obj.str == "Hello") << obj.str;
       expect(obj.i == 55) << obj.i;


### PR DESCRIPTION
# Breaking change: comment reading is no longer default for `glz::read_json`
Previously, JSONC style comments were automatically handled in `glz::read_json`. But, this was inconsistent with writing JSON and added overhead for users who don't require JSONC support. It also is outside the JSON specification. For these reasons the default behavior no longer accepts JSONC comments, but you can still opt-in to this behavior.

- `glz::read_jsonc` has been added, which pairs with `glz::write_jsonc`.
- The compile time option `comments` can be set to true for reading JSONC style comments, previously this option only worked for writing out comments. `glz::read<glz::opts{.comments = true}>(...)`