### PR TITLE
Fixed raw c string parsing and added expected support for format_error

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -1023,6 +1023,17 @@ namespace glz
       }
       return error_str;
    }
+   
+   template <class T>
+   [[nodiscard]] std::string format_error(const expected<T, parse_error>& pe, const auto& buffer)
+   {
+      if (not pe) {
+         return format_error(pe.error(), buffer);
+      }
+      else {
+         return "";
+      }
+   }
 }
 
 namespace glz::detail

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -771,7 +771,7 @@ namespace glz
                if (bool(ctx.error)) [[unlikely]]
                   return;
                value = {start, size_t(it - start)};
-               ++it;
+               ++it; // skip closing quote
             }
             else if constexpr (char_array_t<T>) {
                skip_string_view<Opts>(ctx, it, end);
@@ -785,6 +785,7 @@ namespace glz
                }
                std::memcpy(value, start, n);
                value[n] = '\0';
+               ++it; // skip closing quote
             }
          }
       };

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -8127,6 +8127,25 @@ suite read_allocated_tests = [] {
    };
 };
 
+struct Trade {
+  int64_t T{};
+  char s[16];
+};
+
+suite raw_char_buffer_tests = [] {
+   "binance_trade"_test = [] {
+      const auto* payload = R"(
+            {
+                "T": 123456788,
+                "s": "ETHBTC"
+            }
+        )";
+      auto result = glz::read_json<Trade>(payload);
+      expect(result.has_value()) << glz::format_error(result, payload);
+   };
+};
+
+
 int main()
 {
    trace.begin("json_test", "Full test suite duration.");


### PR DESCRIPTION
- Raw C style string parsing was not iterating past the closing quote
- Added support to `glz::format_error` to support `expected<T, glz::parse_error>`