### PR TITLE
Less aggressive inlining

### DIFF
--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -1065,7 +1065,7 @@ namespace glz
       {
          template <auto Opts>
             requires(Opts.structs_as_arrays == true)
-         GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
             if constexpr (reflectable<T>) {
                auto t = to_tuple(value);
@@ -1098,7 +1098,7 @@ namespace glz
 
          template <auto Opts>
             requires(Opts.structs_as_arrays == false)
-         GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
             constexpr uint8_t type = 0; // string key
             constexpr uint8_t header = tag::object | type;

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -540,7 +540,7 @@ namespace glz
       struct to_binary<T> final
       {
          template <auto Opts, class... Args>
-         GLZ_FLATTEN static auto op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         static auto op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
          {
             using Key = typename T::key_type;
 
@@ -589,7 +589,7 @@ namespace glz
       struct to_binary<T>
       {
          template <auto Options>
-         GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
          {
             using V = std::decay_t<decltype(value.value)>;
             static constexpr auto N = glz::tuple_size_v<V> / 2;
@@ -632,7 +632,7 @@ namespace glz
       struct to_binary<T>
       {
          template <auto Opts>
-         GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
          {
             using V = std::decay_t<decltype(value.value)>;
             static constexpr auto N = glz::tuple_size_v<V>;
@@ -672,7 +672,7 @@ namespace glz
 
          template <auto Opts, class... Args>
             requires(Opts.structs_as_arrays == true)
-         GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
          {
             dump<tag::generic_array>(args...);
             dump_compressed_int<count_to_write>(args...);
@@ -702,7 +702,7 @@ namespace glz
 
          template <auto Options, class... Args>
             requires(Options.structs_as_arrays == false)
-         GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
          {
             if constexpr (!Options.opening_handled) {
                constexpr uint8_t type = 0; // string key
@@ -830,7 +830,7 @@ namespace glz
       struct to_binary_partial<T> final
       {
          template <auto& Partial, auto Opts, class... Args>
-         GLZ_FLATTEN static error_ctx op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
+         static error_ctx op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
          {
             error_ctx we{};
 

--- a/include/glaze/core/reflection_tuple.hpp
+++ b/include/glaze/core/reflection_tuple.hpp
@@ -9,7 +9,7 @@
 namespace glz::detail
 {
    template <class T>
-   GLZ_FLATTEN decltype(auto) reflection_tuple(auto&& value, auto&&...) noexcept
+   decltype(auto) reflection_tuple(auto&& value, auto&&...) noexcept
    {
       if constexpr (reflectable<T>) {
          using V = decay_keep_volatile_t<decltype(value)>;

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -469,7 +469,7 @@ namespace glz
       {
          template <auto Opts, class It, class End>
             requires(Opts.is_padded)
-         GLZ_ALWAYS_INLINE static void op(auto& value, is_context auto&& ctx, It&& it, End&& end) noexcept
+         static void op(auto& value, is_context auto&& ctx, It&& it, End&& end) noexcept
          {
             if constexpr (Opts.number) {
                auto start = it;
@@ -862,7 +862,7 @@ namespace glz
       struct from_json<T>
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
             if constexpr (!Opts.ws_handled) {
                GLZ_SKIP_WS;
@@ -902,7 +902,7 @@ namespace glz
       struct from_json<T>
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto& /*value*/, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto& /*value*/, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
             if constexpr (!Opts.ws_handled) {
                GLZ_SKIP_WS;
@@ -946,7 +946,7 @@ namespace glz
       struct from_json<T>
       {
          template <auto Options>
-         GLZ_FLATTEN static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
             constexpr auto Opts = ws_handled_off<Options>();
             if constexpr (!Options.ws_handled) {
@@ -985,7 +985,7 @@ namespace glz
       struct from_json<T>
       {
          template <auto Options>
-         GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
             constexpr auto Opts = ws_handled_off<Options>();
             if constexpr (!Options.ws_handled) {
@@ -1262,7 +1262,7 @@ namespace glz
       struct from_json<T>
       {
          template <auto Options>
-         GLZ_FLATTEN static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
             constexpr auto Opts = ws_handled_off<Options>();
             if constexpr (!Options.ws_handled) {
@@ -1295,7 +1295,7 @@ namespace glz
       struct from_json<T>
       {
          template <auto Opts>
-         GLZ_FLATTEN static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
             static constexpr auto N = []() constexpr {
                if constexpr (glaze_array_t<T>) {
@@ -1352,7 +1352,7 @@ namespace glz
       struct from_json<T>
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
             if constexpr (!Opts.ws_handled) {
                GLZ_SKIP_WS;
@@ -1466,13 +1466,13 @@ namespace glz
       }
 
       template <reflectable T>
-      inline constexpr bool keys_may_contain_escape()
+      constexpr bool keys_may_contain_escape()
       {
          return false; // escapes are not valid in C++ names
       }
 
       template <is_variant T>
-      GLZ_ALWAYS_INLINE constexpr bool keys_may_contain_escape()
+      constexpr bool keys_may_contain_escape()
       {
          bool may_escape = false;
          constexpr auto N = std::variant_size_v<T>;
@@ -1492,7 +1492,7 @@ namespace glz
       // only use this if the keys cannot contain escape characters
       template <class T, string_literal tag = "">
          requires(glaze_object_t<T> || reflectable<T>)
-      GLZ_ALWAYS_INLINE constexpr auto key_stats()
+      constexpr auto key_stats()
       {
          key_stats_t stats{};
          if constexpr (!tag.sv().empty()) {
@@ -1524,7 +1524,7 @@ namespace glz
       }
 
       template <is_variant T, string_literal tag = "">
-      GLZ_ALWAYS_INLINE constexpr auto key_stats()
+      constexpr auto key_stats()
       {
          key_stats_t stats{};
          if constexpr (!tag.sv().empty()) {
@@ -1607,7 +1607,7 @@ namespace glz
       struct from_json<T>
       {
          template <opts Options, string_literal tag = "">
-         GLZ_FLATTEN static void op(T& value, is_context auto&& ctx, auto&& it, auto&& end)
+         static void op(T& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             constexpr auto Opts = opening_handled_off<ws_handled_off<Options>()>();
             if constexpr (!Options.opening_handled) {
@@ -1662,7 +1662,7 @@ namespace glz
       struct from_json<T>
       {
          template <auto Options, string_literal tag = "">
-         GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             static constexpr auto num_members = reflection_count<T>;
             if constexpr (num_members == 0 && is_partial_read<T>) {
@@ -2110,7 +2110,7 @@ namespace glz
       struct process_arithmetic_boolean_string_or_array
       {
          template <auto Options>
-         GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             if constexpr (glz::tuple_size_v<Tuple> < 1) {
                ctx.error = error_code::no_matching_variant_type;
@@ -2158,7 +2158,7 @@ namespace glz
       {
          // Note that items in the variant are required to be default constructable for us to switch types
          template <auto Options>
-         GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             constexpr auto Opts = ws_handled_off<Options>();
             if constexpr (variant_is_auto_deducible<T>()) {
@@ -2361,7 +2361,7 @@ namespace glz
       struct from_json<array_variant_wrapper<T>>
       {
          template <auto Options>
-         GLZ_FLATTEN static void op(auto&& wrapper, is_context auto&& ctx, auto&& it, auto&& end)
+         static void op(auto&& wrapper, is_context auto&& ctx, auto&& it, auto&& end)
          {
             auto& value = wrapper.value;
 
@@ -2407,7 +2407,7 @@ namespace glz
       struct from_json<T>
       {
          template <auto Opts, class... Args>
-         GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
             if constexpr (!Opts.ws_handled) {
                GLZ_SKIP_WS;
@@ -2496,7 +2496,7 @@ namespace glz
       struct from_json<T>
       {
          template <auto Options>
-         GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
             constexpr auto Opts = ws_handled_off<Options>();
             if constexpr (!Options.ws_handled) {

--- a/include/glaze/json/skip.hpp
+++ b/include/glaze/json/skip.hpp
@@ -8,7 +8,7 @@
 namespace glz::detail
 {
    template <opts Opts>
-   GLZ_FLATTEN void skip_object(is_context auto&& ctx, auto&& it, auto&& end) noexcept
+   void skip_object(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       if constexpr (!Opts.force_conformance) {
          ++it;
@@ -45,7 +45,7 @@ namespace glz::detail
    }
 
    template <opts Opts>
-   GLZ_FLATTEN void skip_array(is_context auto&& ctx, auto&& it, auto&& end) noexcept
+   void skip_array(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       if constexpr (!Opts.force_conformance) {
          ++it;
@@ -72,7 +72,7 @@ namespace glz::detail
    }
 
    template <opts Opts>
-   GLZ_FLATTEN void skip_value(is_context auto&& ctx, auto&& it, auto&& end) noexcept
+   void skip_value(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       if constexpr (!Opts.force_conformance) {
          if constexpr (!Opts.ws_handled) {

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -249,7 +249,7 @@ namespace glz
       struct to_json<T>
       {
          template <auto Opts, class B>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, B&& b, auto&& ix) noexcept
+         static void op(auto&& value, is_context auto&&, B&& b, auto&& ix) noexcept
          {
             if constexpr (Opts.number) {
                dump_maybe_empty(value, b, ix);
@@ -588,7 +588,7 @@ namespace glz
       struct to_json<T>
       {
          template <glz::opts Opts, class B, class Ix>
-         GLZ_ALWAYS_INLINE static void op(const T& value, is_context auto&& ctx, B&& b, Ix&& ix) noexcept
+         static void op(const T& value, is_context auto&& ctx, B&& b, Ix&& ix) noexcept
          {
             const auto& [key, val] = value;
             if (skip_member<Opts>(val)) {
@@ -634,7 +634,7 @@ namespace glz
 
          template <glz::opts Opts, class... Args>
             requires(Opts.concatenate)
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
          {
             if constexpr (!Opts.opening_handled) {
                dump<'{'>(args...);
@@ -810,7 +810,7 @@ namespace glz
       struct to_json<T>
       {
          template <auto Opts, class... Args>
-         GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
          {
             std::visit(
                [&](auto&& val) {
@@ -862,7 +862,7 @@ namespace glz
       struct to_json<array_variant_wrapper<T>>
       {
          template <auto Opts, class... Args>
-         GLZ_FLATTEN static void op(auto&& wrapper, is_context auto&& ctx, Args&&... args) noexcept
+         static void op(auto&& wrapper, is_context auto&& ctx, Args&&... args) noexcept
          {
             auto& value = wrapper.value;
             dump<'['>(args...);
@@ -890,7 +890,7 @@ namespace glz
       struct to_json<T>
       {
          template <auto Opts, class... Args>
-         GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
          {
             using V = std::decay_t<decltype(value.value)>;
             static constexpr auto N = glz::tuple_size_v<V>;
@@ -925,7 +925,7 @@ namespace glz
       struct to_json<T>
       {
          template <auto Opts, class... Args>
-         GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
          {
             static constexpr auto N = []() constexpr {
                if constexpr (glaze_array_t<std::decay_t<T>>) {
@@ -997,7 +997,7 @@ namespace glz
       struct to_json<T>
       {
          template <auto Options>
-         GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
          {
             if constexpr (!Options.opening_handled) {
                dump<'{'>(b, ix);
@@ -1071,7 +1071,7 @@ namespace glz
       struct to_json<T>
       {
          template <auto Options>
-         GLZ_FLATTEN static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
          {
             if constexpr (!Options.opening_handled) {
                dump<'{'>(b, ix);
@@ -1106,7 +1106,7 @@ namespace glz
       struct to_json<T>
       {
          template <auto Options, class V>
-         GLZ_FLATTEN static void op(V&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
+         static void op(V&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
          {
             using ValueType = std::decay_t<V>;
             if constexpr (detail::has_unknown_writer<ValueType> && Options.write_unknown) {
@@ -1134,7 +1134,7 @@ namespace glz
 
          // handles glaze_object_t without extra unknown fields
          template <auto Options, class B>
-         GLZ_FLATTEN static void op_base(auto&& value, is_context auto&& ctx, B&& b, auto&& ix) noexcept
+         static void op_base(auto&& value, is_context auto&& ctx, B&& b, auto&& ix) noexcept
          {
             if constexpr (!Options.opening_handled) {
                if constexpr (Options.prettify) {
@@ -1355,7 +1355,7 @@ namespace glz
       struct to_json_partial<T> final
       {
          template <auto& Partial, auto Opts, class... Args>
-         GLZ_FLATTEN static error_ctx op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
+         static error_ctx op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
          {
             if constexpr (!Opts.opening_handled) {
                dump<'{'>(b, ix);

--- a/include/glaze/util/inline.hpp
+++ b/include/glaze/util/inline.hpp
@@ -11,17 +11,18 @@
 
 #if defined(GLZ_USE_ALWAYS_INLINE) && defined(NDEBUG)
 #ifndef GLZ_ALWAYS_INLINE
-#if defined(__clang__)
-#define GLZ_ALWAYS_INLINE inline __attribute__((always_inline)) __attribute__((flatten))
-#else
 #define GLZ_ALWAYS_INLINE inline __attribute__((always_inline))
-#endif
 #endif
 #endif
 
 #ifndef GLZ_ALWAYS_INLINE
 #define GLZ_ALWAYS_INLINE inline
 #endif
+
+// IMPORTNAT: GLZ_FLATTEN should only be used with extreme care
+// It often adds to the binary size and greatly increases compilation times.
+// It should only be applied in very specific circumstances.
+// It is best to more often rely on the compiler.
 
 #if defined(__clang__) && defined(NDEBUG)
 #ifndef GLZ_FLATTEN


### PR DESCRIPTION
Glaze was too aggressively forcing inlining, especially on Clang. By allowing the compiler to manage more of the inlining builds are faster and generate smaller binary.

For the large `json_test` in Glaze, Clang Release builds are now approximately 90% faster with a 25% binary size reduction.