### PR TITLE
Partial write support for raw buffers

### DIFF
--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -808,14 +808,13 @@ namespace glz
       struct write_partial<binary>
       {
          template <auto& Partial, auto Opts, class T, is_context Ctx, class B, class IX>
-         [[nodiscard]] GLZ_ALWAYS_INLINE static error_ctx op(T&& value, Ctx&& ctx, B&& b, IX&& ix) noexcept
+         static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix) noexcept
          {
             if constexpr (std::count(Partial.begin(), Partial.end(), "") > 0) {
                detail::write<binary>::op<Opts>(value, ctx, b, ix);
-               return {};
             }
             else if constexpr (write_binary_partial_invocable<Partial, Opts, T, Ctx, B, IX>) {
-               return to_binary_partial<std::remove_cvref_t<T>>::template op<Partial, Opts>(
+               to_binary_partial<std::remove_cvref_t<T>>::template op<Partial, Opts>(
                   std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<B>(b), std::forward<IX>(ix));
             }
             else {
@@ -830,10 +829,8 @@ namespace glz
       struct to_binary_partial<T> final
       {
          template <auto& Partial, auto Opts, class... Args>
-         static error_ctx op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
          {
-            error_ctx we{};
-
             static constexpr auto sorted = sort_json_ptrs(Partial);
             static constexpr auto groups = glz::group_json_ptrs<sorted>();
             static constexpr auto N = glz::tuple_size_v<std::decay_t<decltype(groups)>>;
@@ -846,7 +843,7 @@ namespace glz
 
             if constexpr (glaze_object_t<T>) {
                for_each<N>([&](auto I) {
-                  if (we) {
+                  if (bool(ctx.error)) [[unlikely]] {
                      return;
                   }
 
@@ -861,13 +858,13 @@ namespace glz
                   static constexpr decltype(auto) member_ptr = get<index>(member_it->second);
 
                   detail::write<binary>::no_header<Opts>(key, ctx, b, ix);
-                  we = write_partial<binary>::op<sub_partial, Opts>(glz::detail::get_member(value, member_ptr), ctx, b,
+                  write_partial<binary>::op<sub_partial, Opts>(glz::detail::get_member(value, member_ptr), ctx, b,
                                                                     ix);
                });
             }
             else if constexpr (writable_map_t<T>) {
                for_each<N>([&](auto I) {
-                  if (we) {
+                  if (bool(ctx.error)) [[unlikely]] {
                      return;
                   }
 
@@ -879,10 +876,11 @@ namespace glz
                      detail::write<binary>::no_header<Opts>(key_value, ctx, b, ix);
                      auto it = value.find(key_value);
                      if (it != value.end()) {
-                        we = write_partial<binary>::op<sub_partial, Opts>(it->second, ctx, b, ix);
+                        write_partial<binary>::op<sub_partial, Opts>(it->second, ctx, b, ix);
                      }
                      else {
-                        we.ec = error_code::invalid_partial_key;
+                        ctx.error = error_code::invalid_partial_key;
+                        return;
                      }
                   }
                   else {
@@ -891,16 +889,15 @@ namespace glz
                      detail::write<binary>::no_header<Opts>(key, ctx, b, ix);
                      auto it = value.find(key);
                      if (it != value.end()) {
-                        we = write_partial<binary>::op<sub_partial, Opts>(it->second, ctx, b, ix);
+                        write_partial<binary>::op<sub_partial, Opts>(it->second, ctx, b, ix);
                      }
                      else {
-                        we.ec = error_code::invalid_partial_key;
+                        ctx.error = error_code::invalid_partial_key;
+                        return;
                      }
                   }
                });
             }
-
-            return we;
          }
       };
    }

--- a/include/glaze/core/write.hpp
+++ b/include/glaze/core/write.hpp
@@ -40,12 +40,24 @@ namespace glz
       }
       context ctx{};
       size_t ix = 0;
-      const auto error =
-         detail::write_partial<Opts.format>::template op<Partial, Opts>(std::forward<T>(value), ctx, buffer, ix);
+      detail::write_partial<Opts.format>::template op<Partial, Opts>(std::forward<T>(value), ctx, buffer, ix);
       if constexpr (resizable<Buffer>) {
          buffer.resize(ix);
       }
-      return error;
+      return {ctx.error};
+   }
+   
+   template <auto& Partial, opts Opts, class T, raw_buffer Buffer>
+      requires write_supported<Opts.format, T>
+   [[nodiscard]] glz::expected<size_t, error_ctx> write(T&& value, Buffer& buffer) noexcept
+   {
+      context ctx{};
+      size_t ix = 0;
+      detail::write_partial<Opts.format>::template op<Partial, Opts>(std::forward<T>(value), ctx, buffer, ix);
+      if (bool(ctx.error)) [[unlikely]] {
+         return glz::unexpected(error_ctx{ctx.error});
+      }
+      return {ix};
    }
 
    template <opts Opts, class T, output_buffer Buffer>

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1339,14 +1339,13 @@ namespace glz
       struct write_partial<json>
       {
          template <auto& Partial, auto Opts, class T, is_context Ctx, class B, class IX>
-         [[nodiscard]] GLZ_ALWAYS_INLINE static error_ctx op(T&& value, Ctx&& ctx, B&& b, IX&& ix) noexcept
+         static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix) noexcept
          {
             if constexpr (std::count(Partial.begin(), Partial.end(), "") > 0) {
                detail::write<json>::op<Opts>(value, ctx, b, ix);
-               return {};
             }
             else if constexpr (write_json_partial_invocable<Partial, Opts, T, Ctx, B, IX>) {
-               return to_json_partial<std::remove_cvref_t<T>>::template op<Partial, Opts>(
+               to_json_partial<std::remove_cvref_t<T>>::template op<Partial, Opts>(
                   std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<B>(b), std::forward<IX>(ix));
             }
             else {
@@ -1361,7 +1360,7 @@ namespace glz
       struct to_json_partial<T> final
       {
          template <auto& Partial, auto Opts, class... Args>
-         static error_ctx op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
          {
             if constexpr (!Opts.opening_handled) {
                dump<'{'>(b, ix);
@@ -1372,8 +1371,6 @@ namespace glz
                }
             }
 
-            error_ctx we{};
-
             static constexpr auto sorted = sort_json_ptrs(Partial);
             static constexpr auto groups = glz::group_json_ptrs<sorted>();
             static constexpr auto N = glz::tuple_size_v<std::decay_t<decltype(groups)>>;
@@ -1383,7 +1380,7 @@ namespace glz
             if constexpr ((num_members > 0) && (glaze_object_t<T> || reflectable<T>)) {
                if constexpr (glaze_object_t<T>) {
                   for_each<N>([&](auto I) {
-                     if (we) {
+                     if (bool(ctx.error)) [[unlikely]] {
                         return;
                      }
 
@@ -1402,7 +1399,7 @@ namespace glz
                      static constexpr auto index = member_it->second.index();
                      static constexpr decltype(auto) member_ptr = get<index>(member_it->second);
 
-                     we = write_partial<json>::op<sub_partial, Opts>(get_member(value, member_ptr), ctx, b, ix);
+                     write_partial<json>::op<sub_partial, Opts>(get_member(value, member_ptr), ctx, b, ix);
                      if constexpr (I != N - 1) {
                         write_entry_separator<Opts>(ctx, b, ix);
                      }
@@ -1419,7 +1416,7 @@ namespace glz
                   static constexpr auto members = member_names<T>;
 
                   for_each<N>([&](auto I) {
-                     if (we) {
+                     if (bool(ctx.error)) [[unlikely]] {
                         return;
                      }
 
@@ -1445,7 +1442,7 @@ namespace glz
                               decltype(auto) member = get_member(value, member_ptr);
                               using M = std::decay_t<decltype(member)>;
                               if constexpr (glaze_object_t<M> || writable_map_t<M> || reflectable<M>) {
-                                 we = write_partial<json>::op<sub_partial, Opts>(member, ctx, b, ix);
+                                 write_partial<json>::op<sub_partial, Opts>(member, ctx, b, ix);
                               }
                               else {
                                  detail::write<json>::op<Opts>(member, ctx, b, ix);
@@ -1461,7 +1458,7 @@ namespace glz
             }
             else if constexpr (writable_map_t<T>) {
                for_each<N>([&](auto I) {
-                  if (we) {
+                  if (bool(ctx.error)) [[unlikely]] {
                      return;
                   }
 
@@ -1477,20 +1474,22 @@ namespace glz
                   if constexpr (findable<std::decay_t<T>, decltype(key)>) {
                      auto it = value.find(key);
                      if (it != value.end()) {
-                        we = write_partial<json>::op<sub_partial, Opts>(it->second, ctx, b, ix);
+                        write_partial<json>::op<sub_partial, Opts>(it->second, ctx, b, ix);
                      }
                      else {
-                        we.ec = error_code::invalid_partial_key;
+                        ctx.error = error_code::invalid_partial_key;
+                        return;
                      }
                   }
                   else {
                      static thread_local auto k = typename std::decay_t<T>::key_type(key);
                      auto it = value.find(k);
                      if (it != value.end()) {
-                        we = write_partial<json>::op<sub_partial, Opts>(it->second, ctx, b, ix);
+                        write_partial<json>::op<sub_partial, Opts>(it->second, ctx, b, ix);
                      }
                      else {
-                        we.ec = error_code::invalid_partial_key;
+                        ctx.error = error_code::invalid_partial_key;
+                        return;
                      }
                   }
                   if constexpr (I != N - 1) {
@@ -1499,11 +1498,9 @@ namespace glz
                });
             }
 
-            if (!we) [[likely]] {
+            if (not bool(ctx.error)) [[likely]] {
                dump<'}'>(b, ix);
             }
-
-            return we;
          }
       };
    } // namespace detail
@@ -1526,8 +1523,14 @@ namespace glz
       return write<opts{}>(std::forward<T>(value));
    }
 
-   template <auto& Partial, write_json_supported T, class Buffer>
+   template <auto& Partial, write_json_supported T, output_buffer Buffer>
    [[nodiscard]] error_ctx write_json(T&& value, Buffer&& buffer) noexcept
+   {
+      return write<Partial, opts{}>(std::forward<T>(value), std::forward<Buffer>(buffer));
+   }
+   
+   template <auto& Partial, write_json_supported T, raw_buffer Buffer>
+   [[nodiscard]] glz::expected<size_t, error_ctx> write_json(T&& value, Buffer&& buffer) noexcept
    {
       return write<Partial, opts{}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }

--- a/include/glaze/util/dump.hpp
+++ b/include/glaze/util/dump.hpp
@@ -19,7 +19,7 @@ namespace glz::detail
    template <class T>
    [[nodiscard]] GLZ_ALWAYS_INLINE auto data_ptr(T& buffer) noexcept
    {
-      if constexpr (resizable<T>) {
+      if constexpr (has_data<T>) {
          return buffer.data();
       }
       else {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -7461,6 +7461,15 @@ suite partial_write_tests = [] {
       expect(!ec);
       expect(s == R"({"animals":{"tiger":"Tiger"},"name":"My Awesome Zoo"})") << s;
    };
+   
+   "partial write with raw buffer"_test = [] {
+      static constexpr auto json_ptrs = glz::json_ptrs("/name");
+      zoo_t obj{};
+      char buf[32]{};
+      const auto length = glz::write_json<json_ptrs>(obj, buf);
+      expect(length.has_value());
+      expect(std::string_view{buf} == R"({"name":"My Awesome Zoo"})");
+   };
 };
 
 struct S0


### PR DESCRIPTION
- Adds support for using partial object writing to raw `char` buffers
- Updates the internal partial write error handling to match the general write handling with `ctx.error`