### PR TITLE
Thread pool improvements and study tests

### DIFF
--- a/include/glaze/thread/threadpool.hpp
+++ b/include/glaze/thread/threadpool.hpp
@@ -148,6 +148,8 @@ namespace glz
             closed = true;
             work_cv.notify_all();
          }
+         
+         wait(); // wait for work to finish
 
          for (auto& t : threads) {
             if (t.joinable()) t.join();
@@ -159,7 +161,7 @@ namespace glz
          while (true) {
             // Wait for work
             std::unique_lock lock(mtx);
-            work_cv.wait(lock, [this]() { return closed || !queue.empty(); });
+            work_cv.wait(lock, [this] { return closed || !queue.empty(); });
             if (queue.empty()) {
                if (closed) {
                   return;

--- a/include/glaze/thread/threadpool.hpp
+++ b/include/glaze/thread/threadpool.hpp
@@ -47,7 +47,7 @@ namespace glz
 
          auto promise = std::make_shared<std::promise<result_type>>();
          
-         queue.emplace_back() = std::make_shared<callable_t>([promise, f = std::move(func)](const size_t /*thread_number*/) {
+         queue.emplace_back() = std::make_shared<callable_t>([promise, f = std::forward<F>(func)](const size_t /*thread_number*/) {
 #if __cpp_exceptions
             try {
                if constexpr (std::is_void_v<result_type>) {
@@ -86,7 +86,7 @@ namespace glz
 
          auto promise = std::make_shared<std::promise<result_type>>();
          
-         queue.emplace_back() = std::make_shared<callable_t>([promise, f = std::move(func)](const size_t thread_number) {
+         queue.emplace_back() = std::make_shared<callable_t>([promise, f = std::forward<F>(func)](const size_t thread_number) {
 #if __cpp_exceptions
             try {
                if constexpr (std::is_void_v<result_type>) {

--- a/include/glaze/thread/threadpool.hpp
+++ b/include/glaze/thread/threadpool.hpp
@@ -41,9 +41,9 @@ namespace glz
       using callable_t = std::function<void(const size_t)>;
 
       template <class F>
-      std::future<std::invoke_result_t<std::decay_t<F>>> emplace_back(F&& func)
+      std::future<std::invoke_result_t<F>> emplace_back(F&& func)
       {
-         using result_type = std::invoke_result_t<std::decay_t<F>>;
+         using result_type = std::invoke_result_t<F>;
 
          std::lock_guard lock(mtx);
 
@@ -79,10 +79,10 @@ namespace glz
 
       // Takes a function whose input is the thread number (size_t)
       template <class F>
-         requires std::invocable<std::decay_t<F>, size_t>
-      std::future<std::invoke_result_t<std::decay_t<F>, size_t>> emplace_back(F&& func)
+         requires std::invocable<F, size_t>
+      std::future<std::invoke_result_t<F, size_t>> emplace_back(F&& func)
       {
-         using result_type = std::invoke_result_t<std::decay_t<F>, size_t>;
+         using result_type = std::invoke_result_t<F, size_t>;
 
          std::lock_guard lock(mtx);
 

--- a/include/glaze/thread/threadpool.hpp
+++ b/include/glaze/thread/threadpool.hpp
@@ -128,14 +128,14 @@ namespace glz
       ~pool() { finish_work(); }
 
      private:
-      std::vector<std::thread> threads;
+      std::vector<std::thread> threads{};
       // using std::deque for the queue causes random function call issues
-      std::list<std::function<void(const size_t)>> queue;
+      std::list<std::function<void(const size_t)>> queue{};
       std::atomic<uint32_t> working = 0;
       std::atomic<bool> closed = false;
-      std::mutex mtx;
-      std::condition_variable work_cv;
-      std::condition_variable done_cv;
+      std::mutex mtx{};
+      std::condition_variable work_cv{};
+      std::condition_variable done_cv{};
 
       void finish_work()
       {

--- a/include/glaze/thread/threadpool.hpp
+++ b/include/glaze/thread/threadpool.hpp
@@ -62,6 +62,7 @@ namespace glz
       using callable_t = std::function<void(const size_t)>;
 
       template <class F>
+       requires (not std::invocable<F, size_t>)
       auto emplace_back(F&& func)
       {
          using result_t = std::invoke_result_t<F>;
@@ -75,6 +76,7 @@ namespace glz
             try {
                if constexpr (std::is_void_v<result_t>) {
                   f();
+                  promise->set_value();
                }
                else {
                   promise->set_value(f());
@@ -86,6 +88,7 @@ namespace glz
 #else
             if constexpr (std::is_void_v<result_t>) {
                f();
+               promise->set_value();
             }
             else {
                promise->set_value(f());
@@ -114,6 +117,7 @@ namespace glz
             try {
                if constexpr (std::is_void_v<result_t>) {
                   f(thread_number);
+                  promise->set_value();
                }
                else {
                   promise->set_value(f(thread_number));
@@ -125,6 +129,7 @@ namespace glz
 #else
             if constexpr (std::is_void_v<result_t>) {
                f(thread_number);
+               promise->set_value();
             }
             else {
                promise->set_value(f(thread_number));

--- a/include/glaze/thread/threadpool.hpp
+++ b/include/glaze/thread/threadpool.hpp
@@ -30,7 +30,9 @@ namespace glz
          threads.clear();
          threads.reserve(n);
          for (size_t i = 0; i < n; ++i) {
-            threads.emplace_back(std::thread(&pool::worker, this, i));
+            threads.emplace_back([this, i]{
+               worker(i);
+            });
          }
       }
 

--- a/include/glaze/thread/threadpool.hpp
+++ b/include/glaze/thread/threadpool.hpp
@@ -49,8 +49,6 @@ namespace glz
 
                      (*work)(thread_number);
 
-                     lock.lock();
-
                      // Notify that work is finished
                      --working;
                      done_cv.notify_all();

--- a/include/glaze/thread/threadpool.hpp
+++ b/include/glaze/thread/threadpool.hpp
@@ -62,7 +62,7 @@ namespace glz
       using callable_t = std::function<void(const size_t)>;
 
       template <class F>
-      std::future<std::invoke_result_t<F>> emplace_back(F&& func)
+      auto emplace_back(F&& func)
       {
          using result_t = std::invoke_result_t<F>;
 
@@ -101,7 +101,7 @@ namespace glz
       // Takes a function whose input is the thread number (size_t)
       template <class F>
          requires std::invocable<F, size_t>
-      std::future<std::invoke_result_t<F, size_t>> emplace_back(F&& func)
+      auto emplace_back(F&& func)
       {
          using result_t = std::invoke_result_t<F, size_t>;
 

--- a/include/glaze/thread/threadpool.hpp
+++ b/include/glaze/thread/threadpool.hpp
@@ -64,16 +64,16 @@ namespace glz
       template <class F>
       std::future<std::invoke_result_t<F>> emplace_back(F&& func)
       {
-         using result_type = std::invoke_result_t<F>;
+         using result_t = std::invoke_result_t<F>;
 
          std::lock_guard lock(mtx);
 
-         auto promise = std::make_shared<std::promise<result_type>>();
+         auto promise = std::make_shared<std::promise<result_t>>();
          
          queue.emplace_back() = std::make_shared<callable_t>([promise, f = std::forward<F>(func)](const size_t /*thread_number*/) {
 #if __cpp_exceptions
             try {
-               if constexpr (std::is_void_v<result_type>) {
+               if constexpr (std::is_void_v<result_t>) {
                   f();
                }
                else {
@@ -84,7 +84,7 @@ namespace glz
                promise->set_exception(std::current_exception());
             }
 #else
-            if constexpr (std::is_void_v<result_type>) {
+            if constexpr (std::is_void_v<result_t>) {
                f();
             }
             else {
@@ -103,16 +103,16 @@ namespace glz
          requires std::invocable<F, size_t>
       std::future<std::invoke_result_t<F, size_t>> emplace_back(F&& func)
       {
-         using result_type = std::invoke_result_t<F, size_t>;
+         using result_t = std::invoke_result_t<F, size_t>;
 
          std::lock_guard lock(mtx);
 
-         auto promise = std::make_shared<std::promise<result_type>>();
+         auto promise = std::make_shared<std::promise<result_t>>();
          
          queue.emplace_back() = std::make_shared<callable_t>([promise, f = std::forward<F>(func)](const size_t thread_number) {
 #if __cpp_exceptions
             try {
-               if constexpr (std::is_void_v<result_type>) {
+               if constexpr (std::is_void_v<result_t>) {
                   f(thread_number);
                }
                else {
@@ -123,7 +123,7 @@ namespace glz
                promise->set_exception(std::current_exception());
             }
 #else
-            if constexpr (std::is_void_v<result_type>) {
+            if constexpr (std::is_void_v<result_t>) {
                f(thread_number);
             }
             else {

--- a/include/glaze/thread/threadpool.hpp
+++ b/include/glaze/thread/threadpool.hpp
@@ -32,9 +32,8 @@ namespace glz
          for (size_t i = 0; i < n; ++i) {
             threads.emplace_back([this, thread_number = i]{
                while (true) {
-                  // Wait for work
                   std::unique_lock lock(mtx);
-                  work_cv.wait(lock, [this] { return closed || !queue.empty(); });
+                  work_cv.wait(lock, [this] { return closed || !queue.empty(); }); // Wait for work
                   if (queue.empty()) {
                      if (closed) {
                         return;

--- a/include/glaze/thread/threadpool.hpp
+++ b/include/glaze/thread/threadpool.hpp
@@ -143,10 +143,11 @@ namespace glz
       void finish_work()
       {
          // Close the queue and finish all the remaining work
-         std::unique_lock lock(mtx);
-         closed = true;
-         work_cv.notify_all();
-         lock.unlock();
+         {
+            std::unique_lock lock(mtx);
+            closed = true;
+            work_cv.notify_all();
+         }
 
          for (auto& t : threads) {
             if (t.joinable()) t.join();

--- a/tests/exceptions_test/exceptions_test.cpp
+++ b/tests/exceptions_test/exceptions_test.cpp
@@ -181,8 +181,7 @@ suite read_file_test = [] {
    };
 };
 
-// TODO: Is Clang right to complain about: AddressSanitizer: alloc-dealloc-mismatch (operator new vs free)
-/*suite thread_pool = [] {
+suite thread_pool = [] {
    "thread pool throw"_test = [] {
       glz::pool pool{1};
 
@@ -197,6 +196,6 @@ suite read_file_test = [] {
          future.get();
       }));
    };
-};*/
+};
 
 int main() { return 0; }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -2522,8 +2522,7 @@ struct glz::meta<study_obj>
    static constexpr auto value = object("x", &T::x, "y", &T::y);
 };
 
-// TODO: Is Clang right to complain about: AddressSanitizer: alloc-dealloc-mismatch (operator new vs free)
-/*suite study_tests = [] {
+suite study_tests = [] {
    "study"_test = [] {
       glz::study::design design;
       design.params = {{.ptr = "/x", .distribution = "linspace", .range = {"0", "1", "10"}}};
@@ -2568,10 +2567,9 @@ struct glz::meta<study_obj>
 
       expect(results == results2);
    };
-};*/
+};
 
-// TODO: Is Clang right to complain about: AddressSanitizer: alloc-dealloc-mismatch (operator new vs free)
-/*suite thread_pool = [] {
+suite thread_pool = [] {
    "thread pool"_test = [] {
       glz::pool pool(2);
 
@@ -2624,7 +2622,7 @@ struct glz::meta<study_obj>
 
       expect(numbers.size() == 1000);
    };
-};*/
+};
 
 suite progress_bar_tests = [] {
    "progress bar 30%"_test = [] {


### PR DESCRIPTION
- Clang address sanitizer was rightly complaining that `std::promise<void>` was never being set.
- Cleaned up internal threading code to use perfect forwarding and a `std::deque` of shared pointers to function calls