### PR TITLE
Fix normal_map constructor

### DIFF
--- a/include/glaze/reflection/reflect.hpp
+++ b/include/glaze/reflection/reflect.hpp
@@ -86,7 +86,7 @@ namespace glz
                      }
                      else {
                         return glz::detail::normal_map<sv, value_t, n, use_hash_comparison>(
-                           {pair<sv, value_t>{get<I>(members), std::add_pointer_t<glz::tuple_element_t<I, V>>{}}...});
+                                                                                            std::array{pair<sv, value_t>{get<I>(members), std::add_pointer_t<glz::tuple_element_t<I, V>>{}}...});
                      }
                   }
                }
@@ -94,7 +94,7 @@ namespace glz
          }
          else {
             return glz::detail::normal_map<sv, value_t, n, use_hash_comparison>(
-               {pair<sv, value_t>{get<I>(members), std::add_pointer_t<glz::tuple_element_t<I, V>>{}}...});
+                                                                                std::array{pair<sv, value_t>{get<I>(members), std::add_pointer_t<glz::tuple_element_t<I, V>>{}}...});
          }
       }
 

--- a/include/glaze/util/hash_map.hpp
+++ b/include/glaze/util/hash_map.hpp
@@ -506,8 +506,7 @@ namespace glz::detail
          return items.begin() + index;
       }
 
-      template <class... Args>
-      constexpr normal_map(Args&&... args) : items(std::forward<Args>(args)...)
+      constexpr normal_map(const std::array<pair<Key, Value>, N>& pairs) : items(pairs)
       {
          find_perfect_hash();
       }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -8272,6 +8272,60 @@ suite error_on_missing_keys_symbols_tests = [] {
    };
 };
 
+struct large_struct_t
+{
+   bool a = false;
+   bool b = false;
+   bool c = false;
+   bool d = false;
+   bool e = false;
+   bool f = false;
+   bool g = false;
+   bool h = false;
+   bool i = false;
+   bool j = false;
+   bool k = false;
+   bool l = false;
+   bool m = false;
+   bool n = false;
+   bool o = false;
+   bool p = false;
+   bool q = false;
+   bool r = false;
+   bool s = false;
+   bool t = false;
+   bool u = false;
+   bool v = false;
+   bool w = false;
+   bool x = false;
+   bool y = false;
+   bool z = false;
+   bool one = false;
+   bool two = false;
+   bool three = false;
+   bool four = false;
+   bool five = false;
+   bool six = false;
+   bool seven = false;
+};
+
+template <>
+struct glz::meta<large_struct_t>
+{
+   using T = large_struct_t;
+   static constexpr auto value = object(&T::a, &T::b, &T::c, &T::d, &T::e, &T::f, &T::g, &T::h, &T::i, &T::j, &T::k, &T::l, &T::m, &T::n, &T::o, &T::p, &T::q, &T::r, &T::s, &T::t, &T::u, &T::v, &T::w, &T::x, &T::y, &T::z, &T::one, &T::two, &T::three, &T::four, &T::five, &T::six, &T::seven);
+};
+
+suite large_struct_tests = []
+{
+   "large_struct"_test = [] {
+      large_struct_t obj{};
+      std::string s = glz::write_json(obj).value_or("error");
+      expect(s == R"({"a":false,"b":false,"c":false,"d":false,"e":false,"f":false,"g":false,"h":false,"i":false,"j":false,"k":false,"l":false,"m":false,"n":false,"o":false,"p":false,"q":false,"r":false,"s":false,"t":false,"u":false,"v":false,"w":false,"x":false,"y":false,"z":false,"one":false,"two":false,"three":false,"four":false,"five":false,"six":false,"seven":false})") << s;
+      expect(not glz::read_json(obj, s));
+   };
+};
+
 int main()
 {
    trace.begin("json_test", "Full test suite duration.");

--- a/tests/reflection_test/reflection_test.cpp
+++ b/tests/reflection_test/reflection_test.cpp
@@ -634,6 +634,53 @@ suite nested_target_tests = [] {
    };
 };
 
+struct large_struct_t
+{
+   bool a = false;
+   bool b = false;
+   bool c = false;
+   bool d = false;
+   bool e = false;
+   bool f = false;
+   bool g = false;
+   bool h = false;
+   bool i = false;
+   bool j = false;
+   bool k = false;
+   bool l = false;
+   bool m = false;
+   bool n = false;
+   bool o = false;
+   bool p = false;
+   bool q = false;
+   bool r = false;
+   bool s = false;
+   bool t = false;
+   bool u = false;
+   bool v = false;
+   bool w = false;
+   bool x = false;
+   bool y = false;
+   bool z = false;
+   bool one = false;
+   bool two = false;
+   bool three = false;
+   bool four = false;
+   bool five = false;
+   bool six = false;
+   bool seven = false;
+};
+
+suite large_struct_tests = []
+{
+   "large_struct"_test = [] {
+      large_struct_t obj{};
+      std::string s = glz::write_json(obj).value_or("error");
+      expect(s == R"({"a":false,"b":false,"c":false,"d":false,"e":false,"f":false,"g":false,"h":false,"i":false,"j":false,"k":false,"l":false,"m":false,"n":false,"o":false,"p":false,"q":false,"r":false,"s":false,"t":false,"u":false,"v":false,"w":false,"x":false,"y":false,"z":false,"one":false,"two":false,"three":false,"four":false,"five":false,"six":false,"seven":false})") << s;
+      expect(not glz::read_json(obj, s));
+   };
+};
+
 /*namespace glz::detail
 {
    template <>


### PR DESCRIPTION
I had worked on cleaning up hash map constructors for faster compilation times, but broke the normal_map when trying to use perfect forwarding.