### PR TITLE
get_[JSON type] methods for json_t and binary support

### DIFF
--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -58,16 +58,17 @@ namespace glz
             }
          }
       };
-
-      template <glaze_value_t T>
+      
+      template <class T>
+         requires(glaze_value_t<T> && !custom_read<T>)
       struct from_binary<T>
       {
-         template <auto Opts, is_context Ctx, class It0, class It1>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end)
+         template <auto Opts, class Value, is_context Ctx, class It0, class It1>
+         GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
          {
-            using V = decltype(get_member(std::declval<T>(), meta_wrapper_v<T>));
-            from_binary<V>::template op<Opts>(get_member(value, meta_wrapper_v<T>), std::forward<Ctx>(ctx),
-                                              std::forward<It0>(it), std::forward<It1>(end));
+            using V = std::decay_t<decltype(get_member(std::declval<Value>(), meta_wrapper_v<T>))>;
+            from_binary<V>::template op<Opts>(get_member(std::forward<Value>(value), meta_wrapper_v<T>),
+                                            std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
          }
       };
 

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -104,15 +104,17 @@ namespace glz
                                                                         std::forward<B>(b), std::forward<IX>(ix));
          }
       };
-
-      template <glaze_value_t T>
+      
+      template <class T>
+         requires(glaze_value_t<T> && !custom_write<T>)
       struct to_binary<T>
       {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args) noexcept
+         template <auto Opts, class Value, is_context Ctx, class B, class IX>
+         GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, B&& b, IX&& ix) noexcept
          {
-            using V = decltype(get_member(std::declval<T>(), meta_wrapper_v<T>));
-            to_binary<V>::template op<Opts>(get_member(value, meta_wrapper_v<T>), std::forward<Args>(args)...);
+            using V = std::remove_cvref_t<decltype(get_member(std::declval<Value>(), meta_wrapper_v<T>))>;
+            to_binary<V>::template op<Opts>(get_member(std::forward<Value>(value), meta_wrapper_v<T>),
+                                          std::forward<Ctx>(ctx), std::forward<B>(b), std::forward<IX>(ix));
          }
       };
 

--- a/include/glaze/json/json_t.hpp
+++ b/include/glaze/json/json_t.hpp
@@ -174,8 +174,25 @@ namespace glz
       [[nodiscard]] bool is_number() const noexcept { return holds<double>(); }
 
       [[nodiscard]] bool is_string() const noexcept { return holds<std::string>(); }
+      
+      [[nodiscard]] bool is_boolean() const noexcept { return holds<bool>(); }
 
       [[nodiscard]] bool is_null() const noexcept { return holds<std::nullptr_t>(); }
+      
+      [[nodiscard]] array_t& get_array() noexcept { return get<array_t>(); }
+      [[nodiscard]] const array_t& get_array() const noexcept { return get<array_t>(); }
+      
+      [[nodiscard]] object_t& get_object() noexcept { return get<object_t>(); }
+      [[nodiscard]] const object_t& get_object() const noexcept { return get<object_t>(); }
+      
+      [[nodiscard]] double& get_number() noexcept { return get<double>(); }
+      [[nodiscard]] const double& get_number() const noexcept { return get<double>(); }
+      
+      [[nodiscard]] std::string& get_string() noexcept { return get<std::string>(); }
+      [[nodiscard]] const std::string& get_string() const noexcept { return get<std::string>(); }
+      
+      [[nodiscard]] bool& get_boolean() noexcept { return get<bool>(); }
+      [[nodiscard]] const bool& get_boolean() const noexcept { return get<bool>(); }
 
       // empty() returns true if the value is an empty JSON object, array, or string, or a null value
       // otherwise returns false
@@ -223,6 +240,8 @@ namespace glz
    [[nodiscard]] inline bool is_number(const json_t& value) { return value.is_number(); }
 
    [[nodiscard]] inline bool is_string(const json_t& value) { return value.is_string(); }
+   
+   [[nodiscard]] inline bool is_boolean(const json_t& value) { return value.is_boolean(); }
 
    [[nodiscard]] inline bool is_null(const json_t& value) { return value.is_null(); }
 }

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -2125,6 +2125,18 @@ suite volatile_tests = [] {
    };
 };
 
+suite json_t_tests = [] {
+   "json_t"_test = [] {
+      glz::json_t json("Hello World");
+      auto b = glz::write_binary(json).value_or("error");
+      
+      json = nullptr;
+      expect(not glz::read_binary(json, b));
+      expect(json.is_string());
+      expect(json.get_string() == "Hello World");
+   };
+};
+
 int main()
 {
    glz::trace_begin("binary_test");

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -2135,6 +2135,40 @@ suite json_t_tests = [] {
       expect(json.is_string());
       expect(json.get_string() == "Hello World");
    };
+   
+   "json_t"_test = [] {
+      glz::json_t json{{"i", 42}};
+      auto b = glz::write_binary(json).value_or("error");
+      
+      json = nullptr;
+      expect(not glz::read_binary(json, b));
+      expect(json.is_object());
+      expect(json.get_object().size() == 1);
+      expect(json["i"].get_number() == 42);
+   };
+   
+   "json_t"_test = [] {
+      glz::json_t json{{"str", "somewhere"}, {"arr", {1,2,3}}};
+      auto b = glz::write_binary(json).value_or("error");
+      
+      json = nullptr;
+      expect(not glz::read_binary(json, b));
+      expect(json.is_object());
+      expect(json.get_object().size() == 2);
+      expect(json["str"].get_string() == "somewhere");
+      expect(json["arr"].get_array().size() == 3);
+   };
+   
+   "json_t"_test = [] {
+      glz::json_t json{1, 2, 3};
+      auto b = glz::write_binary(json).value_or("error");
+      
+      json = nullptr;
+      expect(not glz::read_binary(json, b));
+      expect(json.is_array());
+      expect(json.get_array().size() == 3);
+      expect(json[0].get_number() == 1);
+   };
 };
 
 int main()

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -3120,6 +3120,7 @@ suite generic_json_tests = [] {
       expect(glz::is_object(json));
       expect(json.empty());
       expect(json.size() == 0);
+      expect(json.get_object().size() == 0);
    };
 
    "json_t is_object"_test = [] {
@@ -3129,6 +3130,7 @@ suite generic_json_tests = [] {
       expect(glz::is_object(json));
       expect(not json.empty());
       expect(json.size() == 2);
+      expect(json.get_object().size() == 2);
    };
 
    "json_t is_array"_test = [] {
@@ -3138,6 +3140,7 @@ suite generic_json_tests = [] {
       expect(glz::is_array(json));
       expect(json.empty());
       expect(json.size() == 0);
+      expect(json.get_array().size() == 0);
    };
 
    "json_t is_array"_test = [] {
@@ -3147,6 +3150,7 @@ suite generic_json_tests = [] {
       expect(glz::is_array(json));
       expect(not json.empty());
       expect(json.size() == 3);
+      expect(json.get_array().size() == 3);
    };
 
    "json_t is_string"_test = [] {
@@ -3156,6 +3160,7 @@ suite generic_json_tests = [] {
       expect(glz::is_string(json));
       expect(json.empty());
       expect(json.size() == 0);
+      expect(json.get_string() == "");
    };
 
    "json_t is_string"_test = [] {
@@ -3165,6 +3170,7 @@ suite generic_json_tests = [] {
       expect(glz::is_string(json));
       expect(not json.empty());
       expect(json.size() == 19);
+      expect(json.get_string() == "Beautiful beginning");
    };
 
    "json_t is_number"_test = [] {
@@ -3174,6 +3180,17 @@ suite generic_json_tests = [] {
       expect(glz::is_number(json));
       expect(not json.empty());
       expect(json.size() == 0);
+      expect(json.get_number() == 3.882e2);
+   };
+   
+   "json_t is_boolean"_test = [] {
+      glz::json_t json{};
+      expect(not glz::read_json(json, "true"));
+      expect(json.is_boolean());
+      expect(glz::is_boolean(json));
+      expect(not json.empty());
+      expect(json.size() == 0);
+      expect(json.get_boolean());
    };
 
    "json_t is_null"_test = [] {


### PR DESCRIPTION
- Adds `.get_string()`, `.get_boolean()`, `.get_number()`, etc. to `json_t`
- Adds missing `is_boolean()`
- Adds binary BEVE support for `json_t`