### PR TITLE
Removing reflection support for C style arrays

### DIFF
--- a/include/glaze/reflection/to_tuple.hpp
+++ b/include/glaze/reflection/to_tuple.hpp
@@ -28,13 +28,6 @@ namespace glz
          template <class T>
             requires(!std::same_as<T, const char*> && !std::same_as<T, std::nullptr_t>)
          [[maybe_unused]] constexpr operator T() const;
-
-         template <class T>
-            requires(is_specialization_v<T, std::optional>)
-         [[maybe_unused]] constexpr operator T() const
-         {
-            return std::nullopt;
-         }
 #else
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-declarations"
@@ -51,11 +44,11 @@ namespace glz
          requires(std::is_aggregate_v<std::remove_cvref_t<T>>)
       inline constexpr auto count_members = [] {
          using V = std::remove_cvref_t<T>;
-         if constexpr (requires { V{Args{}..., any_t{}}; } == false) {
-            return sizeof...(Args);
+         if constexpr (requires { V{Args{}..., any_t{}}; }) {
+            return count_members<V, Args..., any_t>;
          }
          else {
-            return count_members<V, Args..., any_t>;
+            return sizeof...(Args);
          }
       }();
 

--- a/include/glaze/reflection/to_tuple.hpp
+++ b/include/glaze/reflection/to_tuple.hpp
@@ -51,7 +51,7 @@ namespace glz
          requires(std::is_aggregate_v<std::remove_cvref_t<T>>)
       inline constexpr auto count_members = [] {
          using V = std::remove_cvref_t<T>;
-         if constexpr (requires { V{{Args{}}..., {any_t{}}}; } == false) {
+         if constexpr (requires { V{Args{}..., any_t{}}; } == false) {
             return sizeof...(Args);
          }
          else {

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -1708,6 +1708,11 @@ struct struct_c_arrays
 {
    uint16_t ints[2]{1, 2};
    float floats[1]{3.14f};
+   
+   struct glaze {
+      using T = struct_c_arrays;
+      static constexpr auto value = glz::object(&T::ints, &T::floats);
+   };
 };
 
 struct struct_c_arrays_meta

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -7803,6 +7803,11 @@ struct struct_c_arrays
 {
    uint16_t ints[2]{1, 2};
    float floats[1]{3.14f};
+   
+   struct glaze {
+      using T = struct_c_arrays;
+      static constexpr auto value = glz::object(&T::ints, &T::floats);
+   };
 };
 
 struct struct_c_arrays_meta
@@ -8248,6 +8253,13 @@ struct Trade
 {
    int64_t T{};
    char s[16];
+};
+
+template <>
+struct glz::meta<Trade>
+{
+   using T = Trade;
+   static constexpr auto value = object(&T::T, &T::s);
 };
 
 suite raw_char_buffer_tests = [] {

--- a/tests/reflection_test/reflection_test.cpp
+++ b/tests/reflection_test/reflection_test.cpp
@@ -683,7 +683,7 @@ suite large_struct_tests = [] {
    };
 };
 
-/*namespace glz::detail
+namespace glz::detail
 {
    template <>
    struct from_json<std::chrono::seconds>
@@ -697,12 +697,12 @@ suite large_struct_tests = [] {
             value = std::chrono::seconds{ sec_count };
       }
    };
-} // namespace glz::detail
+}
 
 struct chrono_data
 {
    std::string  message{};
-   std::chrono::seconds seconds_duration;
+   std::chrono::seconds seconds_duration{};
 };
 
 suite custom_chrono_tests = [] {
@@ -720,6 +720,6 @@ suite custom_chrono_tests = [] {
       expect(obj.message == "Hello");
       expect(obj.seconds_duration.count() == 5458);
    };
-};*/
+};
 
 int main() { return 0; }

--- a/tests/reflection_test/reflection_test.cpp
+++ b/tests/reflection_test/reflection_test.cpp
@@ -722,4 +722,12 @@ suite custom_chrono_tests = [] {
    };
 };
 
+struct S1
+{
+   int    a{};
+   int    b{};
+   std::filesystem::path   fn{};
+};
+static_assert( glz::detail::count_members<S1> == 3 );
+
 int main() { return 0; }


### PR DESCRIPTION
## Breaking change: Removed pure reflection support for C style arrays
*This **does not** break C style array registration in `glz::meta` or the local `glaze` metadata.*

C++ allows flattening of brace initializers for C style arrays, which means that they break how we count fields in a struct. The work around was to count the number of initializer lists that we can use to construct the type. However, this approach was not consistent across MSVC, Clang, and GCC, and it restricted commonly used types with custom constructors (like `std::filesystem::path` and `std::chrono::seconds`).

After lots of experimenting, reading the C++ specification and papers, and submitting compiler bugs, it's become clear that dropping this support will make Glaze more stable for the future until we get compile time reflection into the language.

> [!TIP]
>
> Reflection still works with `std::array`, so the C style arrays can be converted to `std::array` and pure reflection in Glaze will work as before.