### PR TITLE
JSON concepts

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -2,7 +2,7 @@
 
 ### What happens when the JSON input is missing objects? 
 
-The input JSON can partial. It could just include a single value. Only what is included in the JSON will be changed. JSON pointers are also supported, which can be used to change a single element in an array (not possible with normal JSON).
+The input JSON can be partial. It could include a single value. Only what is included in the JSON will be changed. JSON pointer syntax is also supported, which can be used to change a single element in an array (not possible with normal JSON).
 
 ### How are unknown keys handled?
 
@@ -21,14 +21,14 @@ struct my_struct {
 
 ### Do I need to specify the complete structure of the parsed JSON or just the parts I‘m interested in?
 
-You only need to specify the portion that you want to be serialized. You can have whatever else in your class and choose to not expose it.
+You only need to specify the portion that you want to be serialized. You can have whatever else in your struct and choose to not expose it (using `glz::meta`).
 
 ### Is the write/read API deterministic?
 
 *If I parse and serialize the same JSON string multiple times, is the output guaranteed to be the same every time?*
 
-For the most part, yes, glaze is deterministic. Structs are compile time known, so they're deterministic. The unordered map behavior just means that the input layout doesn't have to be in sequence, conforming to the JSON specification.
+Yes, Glaze is deterministic and can be round tripped, but in some cases C++ containers do not guarantee identical roundtrip behavior. Structs are compile time known, so they're deterministic.
 
 You can use std::map and std::unordered_map containers with the library. If you choose the former the sequence is deterministic, but not the latter.
 
-The library is also deterministic from a round-trippable standpoint. Floating point numbers use round-trippable algorithms.
+Floating point numbers use round-trippable algorithms.

--- a/include/glaze/json.hpp
+++ b/include/glaze/json.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "glaze/json/json_concepts.hpp"
 #include "glaze/json/custom.hpp"
 #include "glaze/json/invoke.hpp"
 #include "glaze/json/json_ptr.hpp"

--- a/include/glaze/json/json_concepts.hpp
+++ b/include/glaze/json/json_concepts.hpp
@@ -1,0 +1,30 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include "glaze/core/common.hpp"
+
+namespace glz
+{
+   template <class T>
+   concept json_object = detail::glaze_object_t<T> || detail::reflectable<T> || detail::writable_map_t<T> || detail::readable_map_t<T>;
+   
+   template <class T>
+   concept json_array = detail::array_t<T>;
+   
+   template <class T>
+   concept json_string = detail::str_t<T>;
+   
+   template <class T>
+   concept json_boolean = detail::boolean_like<T>;
+   
+   template <class T>
+   concept json_number = detail::num_t<T>;
+   
+   template <class T>
+   concept json_integer = detail::int_t<T>;
+   
+   template <class T>
+   concept json_null = detail::null_t<T>;
+}

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -8429,6 +8429,16 @@ suite threading_tests = [] {
    };
 };
 
+// JSON concepts
+static_assert(glz::json_string<std::string>);
+static_assert(glz::json_string<std::string_view>);
+static_assert(glz::json_object<my_struct>);
+static_assert(glz::json_array<std::array<float, 3>>);
+static_assert(glz::json_boolean<bool>);
+static_assert(glz::json_number<float>);
+static_assert(glz::json_integer<uint64_t>);
+static_assert(glz::json_null<std::nullptr_t>);
+
 int main()
 {
    trace.begin("json_test", "Full test suite duration.");


### PR DESCRIPTION
Adding JSON concepts for simple type checking in the user facing API:
```c++
static_assert(glz::json_string<std::string>);
static_assert(glz::json_string<std::string_view>);
static_assert(glz::json_object<my_struct>);
static_assert(glz::json_array<std::array<float, 3>>);
static_assert(glz::json_boolean<bool>);
static_assert(glz::json_number<float>);
static_assert(glz::json_integer<uint64_t>);
static_assert(glz::json_null<std::nullptr_t>);

```