### PR TITLE
glz::read_directory and glz::write_directory

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 

--- a/docs/directory-io.md
+++ b/docs/directory-io.md
@@ -2,6 +2,8 @@
 
 Glaze supports reading and writing from an entire directory of files into a map like object.
 
+`#include "glaze/glaze.hpp"` or specifically include: 
+
 - `#include "glaze/file/read_directory.hpp"` for read support
 - `#include "glaze/file/write_directory.hpp"` for write support
 

--- a/docs/directory-io.md
+++ b/docs/directory-io.md
@@ -1,0 +1,22 @@
+# Directory Serialization and Deserialization
+
+Glaze supports reading and writing from an entire directory of files into a map like object.
+
+- `#include "glaze/file/read_directory.hpp"` for read support
+- `#include "glaze/file/write_directory.hpp"` for write support
+
+The key to the map is the path to the individual file and the value is any C++ type.
+
+The code below demonstrates writing out a map of two file paths and associated structs to two separate files. We then read the created directory into a default structure of the same form.
+
+```c++
+std::map<std::filesystem::path, my_struct> files{{"./dir/alpha.json", {}}, {"./dir/beta.json", {.i = 0}}};
+expect(not glz::write_directory(files, "./dir"));
+
+std::map<std::filesystem::path, my_struct> input{};
+expect(not glz::read_directory(input, "./dir"));
+expect(input.size() == 2);
+expect(input.contains("./dir/alpha.json"));
+expect(input.contains("./dir/beta.json"));
+expect(input["./dir/beta.json"].i == 0);
+```

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -239,7 +239,7 @@ namespace glz
 
       template <class T>
       concept readable_map_t = !custom_read<T> && !meta_value_t<T> && !str_t<T> && range<T> &&
-                               pair_t<range_value_t<T>> && map_subscriptable<T>;
+                               pair_t<range_value_t<T>> && map_subscriptable<std::decay_t<T>>;
 
       template <class T>
       concept writable_map_t =

--- a/include/glaze/core/seek.hpp
+++ b/include/glaze/core/seek.hpp
@@ -25,7 +25,7 @@ namespace glz::detail
    bool seek_impl(F&& func, T&& value, sv json_ptr) noexcept;
 
    template <class F, class T>
-      requires readable_map_t<std::decay_t<T>> || glaze_object_t<T> || reflectable<T>
+      requires readable_map_t<T> || glaze_object_t<T> || reflectable<T>
    bool seek_impl(F&& func, T&& value, sv json_ptr) noexcept;
 
    template <class F, class T>
@@ -40,7 +40,7 @@ namespace glz::detail
 
    // TODO: compile time search for `~` and optimize if escape does not exist
    template <class F, class T>
-      requires readable_map_t<std::decay_t<T>> || glaze_object_t<T> || reflectable<T>
+      requires readable_map_t<T> || glaze_object_t<T> || reflectable<T>
    bool seek_impl(F&& func, T&& value, sv json_ptr) noexcept
    {
       if (json_ptr.empty()) {

--- a/include/glaze/file/read_directory.hpp
+++ b/include/glaze/file/read_directory.hpp
@@ -21,8 +21,7 @@ namespace glz
       return {};
    }
    
-   template <opts Opts = opts{}, class T>
-      requires detail::readable_map_t<std::decay_t<T>>
+   template <opts Opts = opts{}, detail::readable_map_t T>
    [[nodiscard]] error_ctx read_directory(T& value, const sv directory_path) {
       std::unordered_map<std::filesystem::path, std::string> files{};
       if (auto ec = directory_to_buffers(files, directory_path)) {

--- a/include/glaze/file/read_directory.hpp
+++ b/include/glaze/file/read_directory.hpp
@@ -25,8 +25,8 @@ namespace glz
       requires detail::readable_map_t<std::decay_t<T>>
    [[nodiscard]] error_ctx read_directory(T& value, const sv directory_path) {
       std::unordered_map<std::filesystem::path, std::string> files{};
-      if (auto ec = directory_to_buffers(files, directory_path); bool(ec)) {
-         return {ec};
+      if (auto ec = directory_to_buffers(files, directory_path)) {
+         return ec;
       }
       
       for (auto&[path, content] : files) {

--- a/include/glaze/file/read_directory.hpp
+++ b/include/glaze/file/read_directory.hpp
@@ -23,7 +23,7 @@ namespace glz
    
    template <opts Opts = opts{}, class T>
       requires detail::readable_map_t<std::decay_t<T>>
-   [[nodiscard]] error_ctx read_directory(T&& value, const sv directory_path) {
+   [[nodiscard]] error_ctx read_directory(T& value, const sv directory_path) {
       std::unordered_map<std::filesystem::path, std::string> files{};
       if (auto ec = directory_to_buffers(files, directory_path); bool(ec)) {
          return {ec};

--- a/include/glaze/file/read_directory.hpp
+++ b/include/glaze/file/read_directory.hpp
@@ -1,0 +1,40 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include <filesystem>
+
+#include "glaze/core/read.hpp"
+#include "glaze/file/file_ops.hpp"
+
+namespace glz
+{
+   [[nodiscard]] error_ctx directory_to_buffers(std::unordered_map<std::filesystem::path, std::string>& files, const sv directory_path) {
+       for (const auto& entry : std::filesystem::directory_iterator(directory_path)) {
+           if (entry.is_regular_file()) {
+              if (auto ec = file_to_buffer(files[entry.path()], entry.path().string()); bool(ec)) {
+                 return {ec};
+              }
+           }
+       }
+      return {};
+   }
+   
+   template <opts Opts = opts{}, class T>
+      requires detail::readable_map_t<std::decay_t<T>>
+   [[nodiscard]] error_ctx read_directory(T&& value, const sv directory_path) {
+      std::unordered_map<std::filesystem::path, std::string> files{};
+      if (auto ec = directory_to_buffers(files, directory_path); bool(ec)) {
+         return {ec};
+      }
+      
+      for (auto&[path, content] : files) {
+         if (auto ec = read<Opts>(value[path], content)) {
+            return ec;
+         }
+      }
+      
+      return {};
+   }
+}

--- a/include/glaze/file/write_directory.hpp
+++ b/include/glaze/file/write_directory.hpp
@@ -1,0 +1,53 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include <filesystem>
+
+#include "glaze/core/write.hpp"
+#include "glaze/file/file_ops.hpp"
+
+namespace glz
+{   
+   [[nodiscard]] error_ctx buffers_to_directory(const std::unordered_map<std::filesystem::path, std::string>& buffers, const sv directory) {
+      namespace fs = std::filesystem;
+       if (not fs::exists(directory)) {
+           fs::create_directory(directory);
+       }
+      
+      for (auto&[path, content] : buffers) {
+         return {buffer_to_file(content, path.string())};
+      }
+      
+      return {};
+   }
+   
+   template <opts Opts = opts{}, detail::writable_map_t T>
+   [[nodiscard]] error_ctx write_directory(T&& value, const sv directory_path) {
+      namespace fs = std::filesystem;
+      if (not fs::exists(directory_path)) {
+          fs::create_directory(directory_path);
+      }
+      
+      for (auto&[path, content] : value) {
+         using Path = std::decay_t<decltype(path)>;
+         std::string buffer{};
+         if constexpr (std::same_as<std::filesystem::path, Path>) {
+            if (auto ec = glz::write_json(content, buffer)) {
+               return ec;
+            }
+            if (auto ec = buffer_to_file(buffer, path.string()); bool(ec)) {
+               return {ec};
+            }
+         }
+         else {
+            if (auto ec = buffer_to_file(content, path); bool(ec)) {
+               return {ec};
+            }
+         }
+      }
+      
+      return {};
+   }
+}

--- a/include/glaze/glaze.hpp
+++ b/include/glaze/glaze.hpp
@@ -36,5 +36,7 @@
 #include "glaze/binary/beve_to_json.hpp"
 #include "glaze/csv.hpp"
 #include "glaze/file/file_ops.hpp"
+#include "glaze/file/read_directory.hpp"
+#include "glaze/file/write_directory.hpp"
 #include "glaze/json.hpp"
 #include "glaze/record/recorder.hpp"

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -58,7 +58,7 @@ struct glz::meta<my_struct>
    static constexpr std::string_view name = "my_struct";
    using T = my_struct;
    static constexpr auto value = object(
-      "i", [](auto&& v) { return v.i; }, //
+      "i", [](auto&& v) -> auto& { return v.i; }, //
       "d", &T::d, //
       "hello", &T::hello, //
       "arr", &T::arr //

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -26,8 +26,6 @@
 #include "glaze/api/impl.hpp"
 #include "glaze/file/hostname_include.hpp"
 #include "glaze/file/raw_or_file.hpp"
-#include "glaze/file/read_directory.hpp"
-#include "glaze/file/write_directory.hpp"
 #include "glaze/hardware/volatile_array.hpp"
 #include "glaze/json.hpp"
 #include "glaze/json/study.hpp"

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -8454,6 +8454,7 @@ suite directory_tests = [] {
       expect(input.size() == 2);
       expect(input.contains("./dir/alpha.json"));
       expect(input.contains("./dir/beta.json"));
+      expect(input["./dir/beta.json"].i == 0);
    };
 };
 


### PR DESCRIPTION
Adds the ability to read and write maps as directories of files.

```c++
std::map<std::filesystem::path, my_struct> files{{"./dir/alpha.json", {}}, {"./dir/beta.json", {.i = 0}}};
expect(not glz::write_directory(files, "./dir"));

std::map<std::filesystem::path, my_struct> input{};
expect(not glz::read_directory(input, "./dir"));
expect(input.size() == 2);
expect(input.contains("./dir/alpha.json"));
expect(input.contains("./dir/beta.json"));
expect(input["./dir/beta.json"].i == 0);
```