### PR TITLE
to_json_schema nullable_t throws instead of segfault

### DIFF
--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -434,7 +434,8 @@ namespace glz
          {
             using V = std::decay_t<decltype(*std::declval<std::decay_t<T>>())>;
             to_json_schema<V>::template op<Opts>(s, defs);
-            auto& type = *s.type;
+            // to_json_schema above should populate the correct type, let's throw it wasn't set
+            auto& type = s.type.value();
             auto it = std::find_if(type.begin(), type.end(), [&](const auto& str) { return str == "null"; });
             if (it == type.end()) {
                type.emplace_back("null");

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -434,7 +434,7 @@ namespace glz
          {
             using V = std::decay_t<decltype(*std::declval<std::decay_t<T>>())>;
             to_json_schema<V>::template op<Opts>(s, defs);
-            // to_json_schema above should populate the correct type, let's throw it wasn't set
+            // to_json_schema above should populate the correct type, let's throw if it wasn't set
             auto& type = s.type.value();
             auto it = std::find_if(type.begin(), type.end(), [&](const auto& str) { return str == "null"; });
             if (it == type.end()) {


### PR DESCRIPTION
this can occur in special cases when user has it's own to_json_schema for custom type, where the user forgets to assign type to the schematic