### PR TITLE
Reflection macro improvements

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -362,6 +362,11 @@ namespace glz
 
       template <class T>
       concept glaze_enum_t = glaze_t<T> && is_specialization_v<meta_wrapper_t<T>, Enum>;
+      
+      template <class T>
+      concept has_nameof = requires(T t) {
+          { glz::nameof(t) } -> std::convertible_to<std::string_view>;
+      };
 
       template <class T>
       concept glaze_flags_t = glaze_t<T> && is_specialization_v<meta_wrapper_t<T>, Flags>;

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -362,11 +362,6 @@ namespace glz
 
       template <class T>
       concept glaze_enum_t = glaze_t<T> && is_specialization_v<meta_wrapper_t<T>, Enum>;
-      
-      template <class T>
-      concept has_nameof = requires(T t) {
-          { glz::nameof(t) } -> std::convertible_to<std::string_view>;
-      };
 
       template <class T>
       concept glaze_flags_t = glaze_t<T> && is_specialization_v<meta_wrapper_t<T>, Flags>;

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -906,7 +906,25 @@ namespace glz
          {
             if constexpr (has_nameof<T>)
             {
-               //static constexpr auto N = enum_count<T>();
+               if constexpr (!Opts.ws_handled) {
+                  GLZ_SKIP_WS;
+               }
+
+               const auto key = parse_key(ctx, it, end); // TODO: Use more optimal enum key parsing
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
+               
+               // TODO: use a compile time hash map
+               constexpr auto& names = enum_names(T{});
+               for (size_t i = 0; i < names.size(); ++i) {
+                  if (key == names[i]) {
+                     value = static_cast<std::decay_t<T>>(i);
+                     return;
+                  }
+               }
+               
+               ctx.error = error_code::unexpected_enum;
+               return;
             }
             else {
                // TODO: use std::bit_cast???

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -904,11 +904,16 @@ namespace glz
          template <auto Opts>
          GLZ_ALWAYS_INLINE static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
-            // read<json>::op<Opts>(*reinterpret_cast<std::underlying_type_t<std::decay_t<decltype(value)>>*>(&value),
-            // ctx, it, end);
-            std::underlying_type_t<std::decay_t<T>> x{};
-            read<json>::op<Opts>(x, ctx, it, end);
-            value = static_cast<std::decay_t<T>>(x);
+            if constexpr (has_nameof<T>)
+            {
+               //static constexpr auto N = enum_count<T>();
+            }
+            else {
+               // TODO: use std::bit_cast???
+               std::underlying_type_t<std::decay_t<T>> x{};
+               read<json>::op<Opts>(x, ctx, it, end);
+               value = static_cast<std::decay_t<T>>(x);
+            }
          }
       };
 

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -25,7 +25,7 @@ namespace glz
 {
    namespace detail
    {
-      enum struct defined_formats : std::uint8_t;
+      enum struct defined_formats : uint32_t;
       struct ExtUnits final
       {
          std::optional<std::string_view> unitAscii{}; // ascii representation of the unit, e.g. "m^2" for square meters
@@ -135,27 +135,27 @@ namespace glz
          std::optional<std::vector<std::string_view>> examples{};
          schema attributes{};
       };
-      enum struct defined_formats : std::uint8_t {
-         datetime,
-         date,
-         time,
-         duration,
-         email,
-         idn_email,
-         hostname,
-         idn_hostname,
-         ipv4,
-         ipv6,
-         uri,
-         uri_reference,
-         iri,
-         iri_reference,
-         uuid,
-         uri_template,
-         json_pointer,
-         relative_json_pointer,
-         regex
-      };
+      
+      GLZ_ENUM_MAP(defined_formats, //
+                   "date-time", datetime, //
+                  "date", date, //
+                  "time", time, //
+                  "duration", duration, //
+                  "email", email, //
+                  "idn-email", idn_email, //
+                  "hostname", hostname, //
+                  "idn-hostname", idn_hostname, //
+                  "ipv4", ipv4, //
+                  "ipv6", ipv6, //
+                  "uri", uri, //
+                  "uri-reference", uri_reference, //
+                  "iri", iri, //
+                  "iri-reference", iri_reference, //
+                  "uuid", uuid, //
+                  "uri-template", uri_template, //
+                  "json-pointer", json_pointer, //
+                  "relative-json-pointer", relative_json_pointer, //
+                  "regex", regex);
    }
 }
 
@@ -205,27 +205,7 @@ struct glz::meta<glz::detail::schematic>
 template <>
 struct glz::meta<glz::detail::defined_formats>
 {
-   using enum detail::defined_formats;
    static constexpr std::string_view name = "defined_formats";
-   static constexpr auto value = enumerate_no_reflect("date-time", datetime, //
-                                                      "date", date, //
-                                                      "time", time, //
-                                                      "duration", duration, //
-                                                      "email", email, //
-                                                      "idn-email", idn_email, //
-                                                      "hostname", hostname, //
-                                                      "idn-hostname", idn_hostname, //
-                                                      "ipv4", ipv4, //
-                                                      "ipv6", ipv6, //
-                                                      "uri", uri, //
-                                                      "uri-reference", uri_reference, //
-                                                      "iri", iri, //
-                                                      "iri-reference", iri_reference, //
-                                                      "uuid", uuid, //
-                                                      "uri-template", uri_template, //
-                                                      "json-pointer", json_pointer, //
-                                                      "relative-json-pointer", relative_json_pointer, //
-                                                      "regex", regex);
 };
 
 namespace glz

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -465,7 +465,7 @@ namespace glz
          {
             if constexpr (has_nameof<T>)
             {
-               write<json>::op<Opts>(glz::nameof(value), ctx,
+               write<json>::op<Opts>(nameof(value), ctx,
                                      std::forward<Args>(args)...);
             }
             else {

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -463,8 +463,16 @@ namespace glz
          template <auto Opts, class... Args>
          GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
          {
-            write<json>::op<Opts>(static_cast<std::underlying_type_t<std::decay_t<T>>>(value), ctx,
-                                  std::forward<Args>(args)...);
+            if constexpr (has_nameof<T>)
+            {
+               write<json>::op<Opts>(glz::nameof(value), ctx,
+                                     std::forward<Args>(args)...);
+            }
+            else {
+               // serialize as underlying number
+               write<json>::op<Opts>(static_cast<std::underlying_type_t<std::decay_t<T>>>(value), ctx,
+                                     std::forward<Args>(args)...);
+            }
          }
       };
 

--- a/include/glaze/reflection/enum_macro.hpp
+++ b/include/glaze/reflection/enum_macro.hpp
@@ -22,7 +22,32 @@
 
 #define GLZ_STRINGIFY(a) #a
 
+// For pairs of arguments
+#define GLZ_FOR_EACH2(macro, ...)                                    \
+  __VA_OPT__(GLZ_EXPAND(GLZ_FOR_EACH_HELPER2(macro, __VA_ARGS__)))
+#define GLZ_FOR_EACH_HELPER2(macro, a1, a2, ...)                     \
+  macro(a1, a2)                                                 \
+  __VA_OPT__(, GLZ_FOR_EACH_AGAIN2 GLZ_PARENS (macro, __VA_ARGS__))
+#define GLZ_FOR_EACH_AGAIN2() GLZ_FOR_EACH_HELPER2
+
+#define GLZ_EXTRACT_FIRST(x, y) x
+#define GLZ_EXTRACT_SECOND(x, y) y
+
+// Create an enum with the provided fields. A nameof reflection function made.
+// Example: GLZ_ENUM(color, red, green blue)
+// nameof(color::red) == "red"
 #define GLZ_ENUM(EnumType, ...)                                                              \
    enum struct EnumType : uint32_t { __VA_ARGS__ };                                          \
-   constexpr std::string_view EnumType_names[] = {GLZ_FOR_EACH(GLZ_STRINGIFY, __VA_ARGS__)}; \
-   constexpr std::string_view nameof(EnumType value) noexcept { return EnumType_names[size_t(value)]; };
+constexpr std::string_view (EnumType ## _names)[] = {GLZ_FOR_EACH(GLZ_STRINGIFY, __VA_ARGS__)}; \
+   constexpr std::string_view nameof(EnumType value) noexcept { return (EnumType ## _names)[size_t(value)]; };
+
+// Create an enum with the provided fields and names. A nameof reflection function is made.
+// Example: GLZ_ENUM_MAP(color, "Red", red, "Green", green, "Blue", blue);
+// nameof(color::red) == "Red"
+#define GLZ_ENUM_MAP(EnumType, ...)                                  \
+    enum struct EnumType { GLZ_FOR_EACH2(GLZ_EXTRACT_SECOND, __VA_ARGS__) };                        \
+    constexpr std::string_view (EnumType ## _names)[] = {              \
+        GLZ_FOR_EACH2(GLZ_EXTRACT_FIRST, __VA_ARGS__)};               \
+    constexpr std::string_view nameof(EnumType value) noexcept { \
+        return (EnumType ## _names)[size_t(value)];                    \
+    };

--- a/include/glaze/reflection/enum_macro.hpp
+++ b/include/glaze/reflection/enum_macro.hpp
@@ -12,6 +12,11 @@ namespace glz
    concept has_nameof = requires {
       { nameof(T{}) } -> std::convertible_to<std::string_view>;
    };
+   
+   template <class... Args>
+   constexpr size_t number_of_args(Args&&...) {
+        return sizeof...(Args);
+   }
 }
 
 // Macros for GLZ_ENUM
@@ -46,16 +51,24 @@ namespace glz
 // nameof(color::red) == "red"
 #define GLZ_ENUM(EnumType, ...)                                                              \
    enum struct EnumType : uint32_t { __VA_ARGS__ };                                          \
-constexpr std::string_view (EnumType ## _names)[] = {GLZ_FOR_EACH(GLZ_STRINGIFY, __VA_ARGS__)}; \
-   constexpr std::string_view nameof(EnumType value) noexcept { return (EnumType ## _names)[size_t(value)]; };
+constexpr auto (EnumType ## _names) = std::array{GLZ_FOR_EACH(GLZ_STRINGIFY, __VA_ARGS__)}; \
+   constexpr std::string_view nameof(EnumType value) noexcept { return (EnumType ## _names)[size_t(value)]; }; \
+template <class T> requires (std::same_as<std::decay_t<T>, EnumType>) \
+constexpr decltype(auto) enum_names() noexcept { \
+   return (EnumType ## _names); \
+}
 
 // Create an enum with the provided fields and names. A nameof reflection function is made.
 // Example: GLZ_ENUM_MAP(color, "Red", red, "Green", green, "Blue", blue);
 // nameof(color::red) == "Red"
 #define GLZ_ENUM_MAP(EnumType, ...)                                  \
     enum struct EnumType { GLZ_FOR_EACH2(GLZ_EXTRACT_SECOND, __VA_ARGS__) };                        \
-    constexpr std::string_view (EnumType ## _names)[] = {              \
+    constexpr auto (EnumType ## _names) = std::array{              \
         GLZ_FOR_EACH2(GLZ_EXTRACT_FIRST, __VA_ARGS__)};               \
     constexpr std::string_view nameof(EnumType value) noexcept { \
         return (EnumType ## _names)[size_t(value)];                    \
-    };
+    }; \
+template <class T> requires (std::same_as<std::decay_t<T>, EnumType>) \
+constexpr decltype(auto) enum_names() noexcept { \
+   return (EnumType ## _names); \
+}

--- a/include/glaze/reflection/enum_macro.hpp
+++ b/include/glaze/reflection/enum_macro.hpp
@@ -62,7 +62,7 @@ constexpr decltype(auto) enum_names(T&&) noexcept { \
 // Example: GLZ_ENUM_MAP(color, "Red", red, "Green", green, "Blue", blue);
 // nameof(color::red) == "Red"
 #define GLZ_ENUM_MAP(EnumType, ...)                                  \
-    enum struct EnumType { GLZ_FOR_EACH2(GLZ_EXTRACT_SECOND, __VA_ARGS__) };                        \
+    enum struct EnumType : uint32_t { GLZ_FOR_EACH2(GLZ_EXTRACT_SECOND, __VA_ARGS__) };                        \
     constexpr auto (EnumType ## _names) = std::array{              \
         GLZ_FOR_EACH2(GLZ_EXTRACT_FIRST, __VA_ARGS__)};               \
     constexpr std::string_view nameof(EnumType value) noexcept { \

--- a/include/glaze/reflection/enum_macro.hpp
+++ b/include/glaze/reflection/enum_macro.hpp
@@ -6,6 +6,14 @@
 #include <array>
 #include <string_view>
 
+namespace glz
+{
+   template <class T>
+   concept has_nameof = requires {
+      { nameof(T{}) } -> std::convertible_to<std::string_view>;
+   };
+}
+
 // Macros for GLZ_ENUM
 #define GLZ_PARENS ()
 

--- a/include/glaze/reflection/enum_macro.hpp
+++ b/include/glaze/reflection/enum_macro.hpp
@@ -33,7 +33,7 @@ namespace glz
    macro(a) __VA_OPT__(, ) __VA_OPT__(GLZ_FOR_EACH_AGAIN GLZ_PARENS(macro, __VA_ARGS__))
 #define GLZ_FOR_EACH_AGAIN() GLZ_FOR_EACH_HELPER
 
-#define GLZ_STRINGIFY(a) #a
+#define GLZ_STRINGIFY(a) std::string_view{#a}
 
 // For pairs of arguments
 #define GLZ_FOR_EACH2(macro, ...)                                    \
@@ -54,7 +54,7 @@ namespace glz
 constexpr auto (EnumType ## _names) = std::array{GLZ_FOR_EACH(GLZ_STRINGIFY, __VA_ARGS__)}; \
    constexpr std::string_view nameof(EnumType value) noexcept { return (EnumType ## _names)[size_t(value)]; }; \
 template <class T> requires (std::same_as<std::decay_t<T>, EnumType>) \
-constexpr decltype(auto) enum_names() noexcept { \
+constexpr decltype(auto) enum_names(T&&) noexcept { \
    return (EnumType ## _names); \
 }
 
@@ -69,6 +69,6 @@ constexpr decltype(auto) enum_names() noexcept { \
         return (EnumType ## _names)[size_t(value)];                    \
     }; \
 template <class T> requires (std::same_as<std::decay_t<T>, EnumType>) \
-constexpr decltype(auto) enum_names() noexcept { \
+constexpr decltype(auto) enum_names(T&&) noexcept { \
    return (EnumType ## _names); \
 }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -178,9 +178,11 @@ suite get_enum_name_tests = [] {
 namespace glz
 {
    GLZ_ENUM(Vehicle, Car, Truck, Plane);
+   
+   GLZ_ENUM_MAP(Shapes, "Circle", circ, "Square", sq, "Triangle", triangle);
 }
-
-static_assert(glz::detail::has_nameof<glz::Vehicle>);
+static_assert(glz::nameof(glz::Vehicle::Truck) == "Truck");
+static_assert(glz::has_nameof<glz::Vehicle>);
 
 suite glz_enum_test = [] {
    "glz_enum"_test = [] {
@@ -188,6 +190,13 @@ suite glz_enum_test = [] {
       
       auto name = glz::write_json(glz::Vehicle::Plane).value();
       expect(name == R"("Plane")") << name;
+   };
+   
+   "glz_enum_map"_test = [] {
+      expect(glz::nameof(glz::Shapes::circ) == "Circle");
+      
+      auto name = glz::write_json(glz::Shapes::sq).value();
+      expect(name == R"("Square")") << name;
    };
 };
 

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -190,6 +190,10 @@ suite glz_enum_test = [] {
       
       auto name = glz::write_json(glz::Vehicle::Plane).value();
       expect(name == R"("Plane")") << name;
+      
+      glz::Vehicle vehicle{};
+      expect(not glz::read_json(vehicle, name));
+      expect(vehicle == glz::Vehicle::Plane);
    };
    
    "glz_enum_map"_test = [] {
@@ -197,6 +201,10 @@ suite glz_enum_test = [] {
       
       auto name = glz::write_json(glz::Shapes::sq).value();
       expect(name == R"("Square")") << name;
+      
+      glz::Shapes shape{};
+      expect(not glz::read_json(shape, name));
+      expect(shape == glz::Shapes::sq);
    };
 };
 

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -175,6 +175,22 @@ suite get_enum_name_tests = [] {
    };
 };
 
+namespace glz
+{
+   GLZ_ENUM(Vehicle, Car, Truck, Plane);
+}
+
+static_assert(glz::detail::has_nameof<glz::Vehicle>);
+
+suite glz_enum_test = [] {
+   "glz_enum"_test = [] {
+      expect(glz::nameof(glz::Vehicle::Plane) == "Plane");
+      
+      auto name = glz::write_json(glz::Vehicle::Plane).value();
+      expect(name == R"("Plane")") << name;
+   };
+};
+
 struct var1_t
 {
    double x{};

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -192,7 +192,8 @@ suite glz_enum_test = [] {
       expect(name == R"("Plane")") << name;
       
       glz::Vehicle vehicle{};
-      expect(not glz::read_json(vehicle, name));
+      auto ec = glz::read_json(vehicle, name);
+      expect(not ec) << glz::format_error(ec, name);
       expect(vehicle == glz::Vehicle::Plane);
    };
    


### PR DESCRIPTION
Create an enum with the provided fields and names. A nameof reflection function is made.
Example: GLZ_ENUM_MAP(color, "Red", red, "Green", green, "Blue", blue);
nameof(color::red) == "Red"