### PR TITLE
Packing internal options for shorter compile time errors

### DIFF
--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -596,7 +596,7 @@ namespace glz
             using V = std::decay_t<decltype(value.value)>;
             static constexpr auto N = glz::tuple_size_v<V> / 2;
 
-            if constexpr (!Options.opening_handled) {
+            if constexpr (!has_opening_handled(Options)) {
                constexpr uint8_t type = 0; // string key
                constexpr uint8_t tag = tag::object | type;
                dump_type(tag, args...);
@@ -706,7 +706,7 @@ namespace glz
             requires(Options.structs_as_arrays == false)
          static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
          {
-            if constexpr (!Options.opening_handled) {
+            if constexpr (!has_opening_handled(Options)) {
                constexpr uint8_t type = 0; // string key
                constexpr uint8_t tag = tag::object | type;
                dump_type(tag, args...);

--- a/include/glaze/core/read.hpp
+++ b/include/glaze/core/read.hpp
@@ -60,7 +60,7 @@ namespace glz
          return {ctx.error, 0, ctx.includer_error};
       }
 
-      constexpr bool use_padded = resizable<Buffer> && non_const_buffer<Buffer> && !Opts.disable_padding;
+      constexpr bool use_padded = resizable<Buffer> && non_const_buffer<Buffer> && !has_disable_padding(Opts);
 
       if constexpr (use_padded) {
          // Pad the buffer for SWAR
@@ -74,10 +74,10 @@ namespace glz
       }
 
       if constexpr (use_padded) {
-         detail::read<Opts.format>::template op<opt_true<Opts, &opts::is_padded>>(value, ctx, it, end);
+         detail::read<Opts.format>::template op<is_padded_on<Opts>()>(value, ctx, it, end);
       }
       else {
-         detail::read<Opts.format>::template op<opt_false<Opts, &opts::is_padded>>(value, ctx, it, end);
+         detail::read<Opts.format>::template op<is_padded_off<Opts>()>(value, ctx, it, end);
       }
 
       if (bool(ctx.error)) [[unlikely]] {

--- a/include/glaze/core/write_chars.hpp
+++ b/include/glaze/core/write_chars.hpp
@@ -55,7 +55,7 @@ namespace glz::detail
 
          // https://stackoverflow.com/questions/1701055/what-is-the-maximum-length-in-chars-needed-to-represent-any-double-value
          // maximum length for a double should be 24 chars, we use 64 to be sufficient for float128_t
-         if constexpr (resizable<B> && not Opts.write_unchecked) {
+         if constexpr (resizable<B> && not has_write_unchecked(Opts)) {
             if (ix + 64 > b.size()) [[unlikely]] {
                b.resize((std::max)(b.size() * 2, ix + 64));
             }

--- a/include/glaze/json/json_format.hpp
+++ b/include/glaze/json/json_format.hpp
@@ -66,7 +66,7 @@ namespace glz::detail
    };
 
    template <opts Opts>
-      requires(Opts.is_padded)
+      requires(has_is_padded(Opts))
    sv read_json_string(auto&& it, auto&& end) noexcept
    {
       auto start = it;
@@ -97,7 +97,7 @@ namespace glz::detail
    }
 
    template <opts Opts>
-      requires(!Opts.is_padded)
+      requires(!has_is_padded(Opts))
    sv read_json_string(auto&& it, auto&& end) noexcept
    {
       auto start = it;

--- a/include/glaze/json/minify.hpp
+++ b/include/glaze/json/minify.hpp
@@ -148,7 +148,7 @@ namespace glz
          if (bool(ctx.error)) [[unlikely]] {
             return;
          }
-         minify_json<opt_true<Opts, &opts::is_padded>>(ctx, it, end, out, ix);
+         minify_json<is_padded_on<Opts>()>(ctx, it, end, out, ix);
          if constexpr (resizable<Out>) {
             out.resize(ix);
          }

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -152,7 +152,7 @@ namespace glz
          template <auto Opts, class... Args>
          static void op(auto&&, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
-            if constexpr (!Opts.ws_handled) {
+            if constexpr (!has_ws_handled(Opts)) {
                GLZ_SKIP_WS;
             }
 
@@ -234,7 +234,7 @@ namespace glz
          static void op(auto&& v, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
             constexpr auto Opts = ws_handled_off<Options>();
-            if constexpr (!Options.ws_handled) {
+            if constexpr (!has_ws_handled(Options)) {
                GLZ_SKIP_WS;
             }
             GLZ_MATCH_OPEN_BRACKET;
@@ -264,7 +264,7 @@ namespace glz
          template <auto Opts>
          GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
-            if constexpr (!Opts.ws_handled) {
+            if constexpr (!has_ws_handled(Opts)) {
                GLZ_SKIP_WS;
             }
             match<"null", Opts>(ctx, it, end);
@@ -282,7 +282,7 @@ namespace glz
                GLZ_MATCH_QUOTE;
             }
 
-            if constexpr (!Opts.ws_handled) {
+            if constexpr (!has_ws_handled(Opts)) {
                GLZ_SKIP_WS;
             }
 
@@ -301,7 +301,7 @@ namespace glz
                }
             }
             else {
-               if constexpr (not Opts.is_padded) {
+               if constexpr (not has_is_padded(Opts)) {
                   if (size_t(end - it) < 4) [[unlikely]] {
                      ctx.error = error_code::expected_true_or_false;
                      return;
@@ -345,7 +345,7 @@ namespace glz
                GLZ_MATCH_QUOTE;
             }
 
-            if constexpr (!Opts.ws_handled) {
+            if constexpr (!has_ws_handled(Opts)) {
                GLZ_SKIP_WS;
             }
 
@@ -482,7 +482,7 @@ namespace glz
       struct from_json<T>
       {
          template <auto Opts, class It, class End>
-            requires(Opts.is_padded)
+            requires(has_is_padded(Opts))
          static void op(auto& value, is_context auto&& ctx, It&& it, End&& end) noexcept
          {
             if constexpr (Opts.number) {
@@ -494,8 +494,8 @@ namespace glz
                value.append(start, size_t(it - start));
             }
             else {
-               if constexpr (!Opts.opening_handled) {
-                  if constexpr (!Opts.ws_handled) {
+               if constexpr (!has_opening_handled(Opts)) {
+                  if constexpr (!has_ws_handled(Opts)) {
                      GLZ_SKIP_WS;
                   }
 
@@ -597,7 +597,7 @@ namespace glz
          }
 
          template <auto Opts, class It, class End>
-            requires(not Opts.is_padded)
+            requires(not has_is_padded(Opts))
          GLZ_ALWAYS_INLINE static void op(auto& value, is_context auto&& ctx, It&& it, End&& end) noexcept
          {
             if constexpr (Opts.number) {
@@ -609,8 +609,8 @@ namespace glz
                value.append(start, size_t(it - start));
             }
             else {
-               if constexpr (!Opts.opening_handled) {
-                  if constexpr (!Opts.ws_handled) {
+               if constexpr (!has_opening_handled(Opts)) {
+                  if constexpr (!has_ws_handled(Opts)) {
                      GLZ_SKIP_WS;
                   }
 
@@ -770,8 +770,8 @@ namespace glz
          template <auto Opts, class It, class End>
          GLZ_ALWAYS_INLINE static void op(auto& value, is_context auto&& ctx, It&& it, End&& end) noexcept
          {
-            if constexpr (!Opts.opening_handled) {
-               if constexpr (!Opts.ws_handled) {
+            if constexpr (!has_opening_handled(Opts)) {
+               if constexpr (!has_ws_handled(Opts)) {
                   GLZ_SKIP_WS;
                }
 
@@ -810,8 +810,8 @@ namespace glz
          template <auto Opts>
          GLZ_ALWAYS_INLINE static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
-            if constexpr (!Opts.opening_handled) {
-               if constexpr (!Opts.ws_handled) {
+            if constexpr (!has_opening_handled(Opts)) {
+               if constexpr (!has_ws_handled(Opts)) {
                   GLZ_SKIP_WS;
                }
 
@@ -878,7 +878,7 @@ namespace glz
          template <auto Opts>
          static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
-            if constexpr (!Opts.ws_handled) {
+            if constexpr (!has_ws_handled(Opts)) {
                GLZ_SKIP_WS;
             }
 
@@ -905,7 +905,7 @@ namespace glz
          GLZ_ALWAYS_INLINE static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
             if constexpr (has_nameof<T>) {
-               if constexpr (!Opts.ws_handled) {
+               if constexpr (!has_ws_handled(Opts)) {
                   GLZ_SKIP_WS;
                }
 
@@ -940,7 +940,7 @@ namespace glz
          template <auto Opts>
          static void op(auto& /*value*/, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
-            if constexpr (!Opts.ws_handled) {
+            if constexpr (!has_ws_handled(Opts)) {
                GLZ_SKIP_WS;
             }
             GLZ_MATCH_QUOTE;
@@ -985,7 +985,7 @@ namespace glz
          static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
             constexpr auto Opts = ws_handled_off<Options>();
-            if constexpr (!Options.ws_handled) {
+            if constexpr (!has_ws_handled(Options)) {
                GLZ_SKIP_WS;
             }
 
@@ -1024,7 +1024,7 @@ namespace glz
          static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
             constexpr auto Opts = ws_handled_off<Options>();
-            if constexpr (!Options.ws_handled) {
+            if constexpr (!has_ws_handled(Options)) {
                GLZ_SKIP_WS;
             }
 
@@ -1301,7 +1301,7 @@ namespace glz
          static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
             constexpr auto Opts = ws_handled_off<Options>();
-            if constexpr (!Options.ws_handled) {
+            if constexpr (!has_ws_handled(Options)) {
                GLZ_SKIP_WS;
             }
 
@@ -1342,7 +1342,7 @@ namespace glz
                }
             }();
 
-            if constexpr (!Opts.ws_handled) {
+            if constexpr (!has_ws_handled(Opts)) {
                GLZ_SKIP_WS;
             }
 
@@ -1390,7 +1390,7 @@ namespace glz
          template <auto Opts>
          static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
-            if constexpr (!Opts.ws_handled) {
+            if constexpr (!has_ws_handled(Opts)) {
                GLZ_SKIP_WS;
             }
 
@@ -1455,7 +1455,7 @@ namespace glz
 
             // We need to allocate a new buffer here because we could call another includer that uses buffer
             std::string nested_buffer = buffer;
-            const auto ecode = glz::read<opt_true<Opts, &opts::disable_padding>>(value.value, nested_buffer, ctx);
+            const auto ecode = glz::read<disable_padding_on<Opts>()>(value.value, nested_buffer, ctx);
             if (bool(ctx.error)) [[unlikely]] {
                ctx.error = error_code::includer_error;
                auto& error_msg = error_buffer();
@@ -1604,7 +1604,7 @@ namespace glz
       GLZ_ALWAYS_INLINE std::string_view parse_object_key(is_context auto&& ctx, auto&& it, auto&& end)
       {
          // skip white space and escape characters and find the string
-         if constexpr (!Opts.ws_handled) {
+         if constexpr (!has_ws_handled(Opts)) {
             skip_ws<Opts>(ctx, it, end);
             if (bool(ctx.error)) [[unlikely]]
                return {};
@@ -1646,8 +1646,8 @@ namespace glz
          static void op(T& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             constexpr auto Opts = opening_handled_off<ws_handled_off<Options>()>();
-            if constexpr (!Options.opening_handled) {
-               if constexpr (!Options.ws_handled) {
+            if constexpr (!has_opening_handled(Options)) {
+               if constexpr (!has_ws_handled(Options)) {
                   GLZ_SKIP_WS;
                }
                GLZ_MATCH_OPEN_BRACE;
@@ -1719,8 +1719,8 @@ namespace glz
             }
 
             constexpr auto Opts = opening_handled_off<ws_handled_off<Options>()>();
-            if constexpr (!Options.opening_handled) {
-               if constexpr (!Options.ws_handled) {
+            if constexpr (!has_opening_handled(Options)) {
+               if constexpr (!has_ws_handled(Options)) {
                   GLZ_SKIP_WS;
                }
                GLZ_MATCH_OPEN_BRACE;
@@ -2205,7 +2205,7 @@ namespace glz
          {
             constexpr auto Opts = ws_handled_off<Options>();
             if constexpr (variant_is_auto_deducible<T>()) {
-               if constexpr (!Options.ws_handled) {
+               if constexpr (!has_ws_handled(Options)) {
                   GLZ_SKIP_WS;
                }
 
@@ -2409,7 +2409,7 @@ namespace glz
             auto& value = wrapper.value;
 
             constexpr auto Opts = ws_handled_off<Options>();
-            if constexpr (!Options.ws_handled) {
+            if constexpr (!has_ws_handled(Options)) {
                GLZ_SKIP_WS;
             }
 
@@ -2452,7 +2452,7 @@ namespace glz
          template <auto Opts, class... Args>
          static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
-            if constexpr (!Opts.ws_handled) {
+            if constexpr (!has_ws_handled(Opts)) {
                GLZ_SKIP_WS;
             }
 
@@ -2542,7 +2542,7 @@ namespace glz
          static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
             constexpr auto Opts = ws_handled_off<Options>();
-            if constexpr (!Options.ws_handled) {
+            if constexpr (!has_ws_handled(Options)) {
                GLZ_SKIP_WS;
             }
 

--- a/include/glaze/json/skip.hpp
+++ b/include/glaze/json/skip.hpp
@@ -75,7 +75,7 @@ namespace glz::detail
    void skip_value(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       if constexpr (!Opts.force_conformance) {
-         if constexpr (!Opts.ws_handled) {
+         if constexpr (!has_ws_handled(Opts)) {
             GLZ_SKIP_WS;
          }
          while (true) {
@@ -119,7 +119,7 @@ namespace glz::detail
          }
       }
       else {
-         if constexpr (!Opts.ws_handled) {
+         if constexpr (!has_ws_handled(Opts)) {
             GLZ_SKIP_WS;
          }
          switch (*it) {

--- a/include/glaze/record/recorder.hpp
+++ b/include/glaze/record/recorder.hpp
@@ -123,7 +123,7 @@ namespace glz
 
             constexpr auto Opts = opening_handled_off<ws_handled_off<Options>()>();
 
-            if constexpr (!Options.opening_handled) {
+            if constexpr (!has_opening_handled(Options)) {
                GLZ_SKIP_WS;
                GLZ_MATCH_OPEN_BRACE;
             }

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -434,7 +434,7 @@ namespace glz::detail
    }
 
    template <string_literal str, opts Opts>
-      requires(Opts.is_padded && str.size() <= padding_bytes)
+      requires(has_is_padded(Opts) && str.size() <= padding_bytes)
    GLZ_ALWAYS_INLINE void match(is_context auto&& ctx, auto&& it, auto&&) noexcept
    {
       if (!compare<str.size()>(it, str.value)) [[unlikely]] {
@@ -446,7 +446,7 @@ namespace glz::detail
    }
 
    template <string_literal str, opts Opts>
-      requires(!Opts.is_padded)
+      requires(!has_is_padded(Opts))
    GLZ_ALWAYS_INLINE void match(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       const auto n = size_t(end - it);
@@ -655,7 +655,7 @@ namespace glz::detail
    }
 
    template <opts Opts>
-      requires(Opts.is_padded)
+      requires(has_is_padded(Opts))
    GLZ_ALWAYS_INLINE void skip_string_view(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       static_assert(std::contiguous_iterator<std::decay_t<decltype(it)>>);
@@ -685,7 +685,7 @@ namespace glz::detail
    }
 
    template <opts Opts>
-      requires(!Opts.is_padded)
+      requires(!has_is_padded(Opts))
    GLZ_ALWAYS_INLINE void skip_string_view(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       static_assert(std::contiguous_iterator<std::decay_t<decltype(it)>>);
@@ -893,7 +893,7 @@ namespace glz::detail
    template <opts Opts>
    GLZ_ALWAYS_INLINE void skip_string(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
-      if constexpr (!Opts.opening_handled) {
+      if constexpr (!has_opening_handled(Opts)) {
          ++it;
       }
 
@@ -942,7 +942,7 @@ namespace glz::detail
    }
 
    template <opts Opts, char open, char close, size_t Depth = 1>
-      requires(Opts.is_padded)
+      requires(has_is_padded(Opts))
    GLZ_ALWAYS_INLINE void skip_until_closed(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       size_t depth = Depth;
@@ -997,7 +997,7 @@ namespace glz::detail
    }
 
    template <opts Opts, char open, char close, size_t Depth = 1>
-      requires(!Opts.is_padded)
+      requires(!has_is_padded(Opts))
    GLZ_ALWAYS_INLINE void skip_until_closed(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       size_t depth = Depth;


### PR DESCRIPTION
This packs glz::opts that are for internal use into a `uint32_t` associated with a bit aligned enumeration. This reduces the length of compile time errors by seven fields and will let us expand internal options without lengthening compiler error outputs much.