### PR TITLE
Custom error messages

### DIFF
--- a/include/glaze/core/context.hpp
+++ b/include/glaze/core/context.hpp
@@ -37,20 +37,26 @@ namespace glz
             invalid_variant_string, //
             no_matching_variant_type, //
             expected_true_or_false, //
+            // Key errors
             unknown_key, //
+            missing_key, //
+            // Other errors
             invalid_flag_input, //
             invalid_escape, //
             u_requires_hex_digits, //
-            file_extension_not_supported, //
             could_not_determine_extension, //
             seek_failure, //
             unicode_escape_conversion_failure, //
+            dump_int_error, //
+            // File errors
             file_open_failure, //
             file_close_failure, //
             file_include_error, //
-            dump_int_error, //
+            file_extension_not_supported, //
+            // JSON pointer access errors
             get_nonexistent_json_ptr, //
             get_wrong_type, //
+            // Other errors
             cannot_be_referenced, //
             invalid_get, //
             invalid_get_fn, //
@@ -61,7 +67,6 @@ namespace glz
             elements_not_convertible_to_design, //
             unknown_distribution, //
             invalid_distribution_elements, //
-            missing_key, //
             hostname_failure, //
             includer_error //
    );
@@ -69,6 +74,8 @@ namespace glz
    struct error_ctx final
    {
       error_code ec{};
+      std::string_view custom_error_message{}; // for custom error messages
+      // INTERNAL USE:
       size_t location{};
       std::string_view includer_error{}; // error from a nested file includer
 
@@ -81,11 +88,12 @@ namespace glz
    // We do not template the context on iterators so that it can be easily shared across buffer implementations
    struct context final
    {
-      // INTERNAL USE
+      error_code error{};
+      std::string_view custom_error_message{}; // for custom error messages
+      // INTERNAL USE:
       uint32_t indentation_level{};
       std::string current_file; // top level file path
       std::string_view includer_error{}; // error from a nested file includer
-      error_code error{};
    };
 
    template <class T>

--- a/include/glaze/core/context.hpp
+++ b/include/glaze/core/context.hpp
@@ -26,7 +26,6 @@ namespace glz
             unexpected_end, //
             expected_end_comment, //
             syntax_error, //
-            key_not_found, //
             unexpected_enum, //
             attempt_const_read, //
             attempt_member_func_read, //
@@ -38,14 +37,13 @@ namespace glz
             no_matching_variant_type, //
             expected_true_or_false, //
             // Key errors
+            key_not_found, //
             unknown_key, //
             missing_key, //
             // Other errors
             invalid_flag_input, //
             invalid_escape, //
             u_requires_hex_digits, //
-            could_not_determine_extension, //
-            seek_failure, //
             unicode_escape_conversion_failure, //
             dump_int_error, //
             // File errors
@@ -53,9 +51,11 @@ namespace glz
             file_close_failure, //
             file_include_error, //
             file_extension_not_supported, //
+            could_not_determine_extension, //
             // JSON pointer access errors
             get_nonexistent_json_ptr, //
             get_wrong_type, //
+            seek_failure, //
             // Other errors
             cannot_be_referenced, //
             invalid_get, //
@@ -74,7 +74,7 @@ namespace glz
    struct error_ctx final
    {
       error_code ec{};
-      std::string_view custom_error_message{}; // for custom error messages
+      std::string_view custom_error_message{};
       // INTERNAL USE:
       size_t location{};
       std::string_view includer_error{}; // error from a nested file includer
@@ -89,7 +89,7 @@ namespace glz
    struct context final
    {
       error_code error{};
-      std::string_view custom_error_message{}; // for custom error messages
+      std::string_view custom_error_message{};
       // INTERNAL USE:
       uint32_t indentation_level{};
       std::string current_file; // top level file path

--- a/include/glaze/core/read.hpp
+++ b/include/glaze/core/read.hpp
@@ -57,7 +57,7 @@ namespace glz
 
       if (buffer.empty()) [[unlikely]] {
          ctx.error = error_code::no_read_input;
-         return {ctx.error, 0, ctx.includer_error};
+         return {ctx.error, ctx.custom_error_message, 0, ctx.includer_error};
       }
 
       constexpr bool use_padded = resizable<Buffer> && non_const_buffer<Buffer> && !has_disable_padding(Opts);
@@ -103,7 +103,7 @@ namespace glz
          buffer.resize(buffer.size() - padding_bytes);
       }
 
-      return {ctx.error, size_t(it - start), ctx.includer_error};
+      return {ctx.error, ctx.custom_error_message, size_t(it - start), ctx.includer_error};
    }
 
    template <opts Opts, class T>
@@ -124,7 +124,7 @@ namespace glz
    {
       const auto str = std::string_view{std::forward<Buffer>(buffer)};
       if (str.empty()) {
-         return {error_code::no_read_input, 0};
+         return {error_code::no_read_input};
       }
       return read<Opts>(value, str, ctx);
    }

--- a/include/glaze/core/write.hpp
+++ b/include/glaze/core/write.hpp
@@ -26,7 +26,7 @@ namespace glz
          buffer.resize(ix);
       }
 
-      return {ctx.error};
+      return {ctx.error, ctx.custom_error_message};
    }
 
    template <auto& Partial, opts Opts, class T, output_buffer Buffer>
@@ -44,7 +44,7 @@ namespace glz
       if constexpr (resizable<Buffer>) {
          buffer.resize(ix);
       }
-      return {ctx.error};
+      return {ctx.error, ctx.custom_error_message};
    }
 
    template <auto& Partial, opts Opts, class T, raw_buffer Buffer>
@@ -55,7 +55,7 @@ namespace glz
       size_t ix = 0;
       detail::write_partial<Opts.format>::template op<Partial, Opts>(std::forward<T>(value), ctx, buffer, ix);
       if (bool(ctx.error)) [[unlikely]] {
-         return glz::unexpected(error_ctx{ctx.error});
+         return glz::unexpected(error_ctx{.ec = ctx.error, .custom_error_message = ctx.custom_error_message});
       }
       return {ix};
    }

--- a/include/glaze/json/json_ptr.hpp
+++ b/include/glaze/json/json_ptr.hpp
@@ -41,7 +41,7 @@ namespace glz
       auto start = it;
 
       if (bool(ctx.error)) [[unlikely]] {
-         return result_t{unexpected(error_ctx{ctx.error, 0})};
+         return result_t{unexpected(error_ctx{ctx.error})};
       }
 
       if constexpr (N == 0) {
@@ -160,7 +160,7 @@ namespace glz
          });
 
          if (bool(ctx.error)) [[unlikely]] {
-            return result_t{unexpected(error_ctx{ctx.error, size_t(it - start)})};
+            return result_t{unexpected(error_ctx{ctx.error, "", size_t(it - start)})};
          }
 
          return ret;

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -153,10 +153,6 @@ namespace glz
             (void)tuple;
          }
 
-         if constexpr (Opts.error_on_unknown_keys) {
-            (void)value;
-         }
-
          constexpr auto type = HashInfo.type;
          constexpr auto N = refl<T>.N;
 

--- a/include/glaze/mustache/mustache.hpp
+++ b/include/glaze/mustache/mustache.hpp
@@ -18,7 +18,7 @@ namespace glz
 
       if (tmp.empty()) [[unlikely]] {
          ctx.error = error_code::no_read_input;
-         return unexpected(error_ctx{ctx.error, 0, ctx.includer_error});
+         return unexpected(error_ctx{ctx.error, ctx.custom_error_message, 0, ctx.includer_error});
       }
 
       auto [it, end] = read_iterators<Opts, false>(ctx, tmp);
@@ -78,11 +78,11 @@ namespace glz
                         },
                         member_it->second);
                      if (bool(ctx.error)) [[unlikely]]
-                        return unexpected(error_ctx{ctx.error, size_t(it - start), ctx.includer_error});
+                        return unexpected(error_ctx{ctx.error, ctx.custom_error_message, size_t(it - start), ctx.includer_error});
                   }
                   else {
                      ctx.error = error_code::unknown_key;
-                     return unexpected(error_ctx{ctx.error, size_t(it - start), ctx.includer_error});
+                     return unexpected(error_ctx{ctx.error, ctx.custom_error_message, size_t(it - start), ctx.includer_error});
                   }
 
                   skip_whitespace();
@@ -114,7 +114,7 @@ namespace glz
       }
 
       if (bool(ctx.error)) [[unlikely]] {
-         return unexpected(error_ctx{ctx.error, size_t(it - start), ctx.includer_error});
+         return unexpected(error_ctx{ctx.error, ctx.custom_error_message, size_t(it - start), ctx.includer_error});
       }
 
       return {result};

--- a/include/glaze/mustache/stencilcount.hpp
+++ b/include/glaze/mustache/stencilcount.hpp
@@ -19,7 +19,7 @@ namespace glz
 
       if (tmp.empty()) [[unlikely]] {
          ctx.error = error_code::no_read_input;
-         return unexpected(error_ctx{ctx.error, 0, ctx.includer_error});
+         return unexpected(error_ctx{ctx.error, ctx.custom_error_message, 0, ctx.includer_error});
       }
 
       auto [it, end] = read_iterators<Opts, false>(ctx, tmp);
@@ -127,7 +127,7 @@ namespace glz
                         },
                         member_it->second);
                      if (bool(ctx.error)) [[unlikely]]
-                        return unexpected(error_ctx{ctx.error, size_t(it - start), ctx.includer_error});
+                        return unexpected(error_ctx{ctx.error, ctx.custom_error_message, size_t(it - start), ctx.includer_error});
                   }
                   else {
                      // TODO: Is this an error?
@@ -162,7 +162,7 @@ namespace glz
       }
 
       if (bool(ctx.error)) [[unlikely]] {
-         return unexpected(error_ctx{ctx.error, size_t(it - start), ctx.includer_error});
+         return unexpected(error_ctx{ctx.error, ctx.custom_error_message, size_t(it - start), ctx.includer_error});
       }
 
       return {result};

--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -162,7 +162,7 @@ namespace glz::repe
       glz::detail::read<Opts.format>::template op<Opts>(std::forward<Value>(value), ctx, b, e);
 
       if (bool(ctx.error)) {
-         error_ctx ec{ctx.error, size_t(b - start), ctx.includer_error};
+         error_ctx ec{ctx.error, ctx.custom_error_message, size_t(b - start), ctx.includer_error};
          std::ignore =
             write<Opts>(std::forward_as_tuple(header{.error = true},
                                               error_t{error_e::parse_error, format_error(ec, state.message)}),
@@ -220,7 +220,7 @@ namespace glz::repe
 
       auto handle_error = [&](auto& it) {
          ctx.error = error_code::syntax_error;
-         error_ctx pe{ctx.error, size_t(it - start), ctx.includer_error};
+         error_ctx pe{ctx.error, ctx.custom_error_message, size_t(it - start), ctx.includer_error};
          return error_t{error_e::parse_error, format_error(pe, buffer)};
       };
 
@@ -234,7 +234,7 @@ namespace glz::repe
       glz::detail::read<Opts.format>::template op<Opts>(h, ctx, b, e);
 
       if (bool(ctx.error)) {
-         error_ctx pe{ctx.error, size_t(b - start), ctx.includer_error};
+         error_ctx pe{ctx.error, ctx.custom_error_message, size_t(b - start), ctx.includer_error};
          return {error_e::parse_error, format_error(pe, buffer)};
       }
 
@@ -255,7 +255,7 @@ namespace glz::repe
          glz::detail::read<Opts.format>::template op<Opts>(result, ctx, b, e);
 
          if (bool(ctx.error)) {
-            error_ctx pe{ctx.error, size_t(b - start), ctx.includer_error};
+            error_ctx pe{ctx.error, ctx.custom_error_message, size_t(b - start), ctx.includer_error};
             return {error_e::parse_error, format_error(pe, buffer)};
          }
       }
@@ -1124,7 +1124,7 @@ namespace glz::repe
 
          auto handle_error = [&](auto& it) {
             ctx.error = error_code::syntax_error;
-            error_ctx pe{ctx.error, size_t(it - start), ctx.includer_error};
+            error_ctx pe{ctx.error, ctx.custom_error_message, size_t(it - start), ctx.includer_error};
             std::ignore = write<Opts>(
                std::forward_as_tuple(header{.error = true}, error_t{error_e::parse_error, format_error(pe, msg)}),
                response);
@@ -1173,7 +1173,7 @@ namespace glz::repe
          glz::detail::read<Opts.format>::template op<Opts>(h, ctx, b, e);
 
          if (bool(ctx.error)) [[unlikely]] {
-            error_ctx pe{ctx.error, size_t(b - start), ctx.includer_error};
+            error_ctx pe{ctx.error, ctx.custom_error_message, size_t(b - start), ctx.includer_error};
             response = format_error(pe, msg);
             return finish();
          }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -8493,6 +8493,55 @@ suite front_16_test = [] {
    };
 };
 
+struct custom_errors_t
+{
+   uint32_t a{};
+   uint32_t alpha{};
+};
+
+template <>
+struct glz::meta<custom_errors_t>
+{
+   using T = custom_errors_t;
+   static constexpr auto value = object(&T::a, &T::alpha);
+};
+
+namespace glz::detail
+{
+   template <>
+   struct from_json<custom_errors_t>
+   {
+      template <auto Opts>
+      static void op(auto&, is_context auto& ctx, auto&&...)
+      {
+         ctx.custom_error_message = "custom_errors_t read error";
+      }
+   };
+
+   template <>
+   struct to_json<custom_errors_t>
+   {
+      template <auto Opts>
+      static void op(auto&, is_context auto& ctx, auto&&...) noexcept
+      {
+         ctx.custom_error_message = "custom_errors_t write error";
+      }
+   };
+}
+
+suite custom_error = [] {
+   "custom_errors_t"_test = [] {
+      custom_errors_t obj{};
+      
+      std::string buffer{};
+      auto ec = glz::write_json(obj, buffer);
+      expect(ec.custom_error_message == "custom_errors_t write error");
+      
+      ec = glz::read_json(obj, "{}");
+      expect(ec.custom_error_message == "custom_errors_t read error");
+   };
+};
+
 int main()
 {
    trace.end("json_test");


### PR DESCRIPTION
Adds `std::string_view custom_error_message` to `glz::context` and `glz::error_ctx` to allow custom error propagation for reading/writing.