### PR TITLE
Guard against quotes in sized hashes and requiring escaped keys

### DIFF
--- a/include/glaze/core/refl.hpp
+++ b/include/glaze/core/refl.hpp
@@ -932,6 +932,10 @@ namespace glz::detail
 
       size_t min_length = (std::numeric_limits<size_t>::max)();
       for (auto& s : strings) {
+         if (s.contains('"')) {
+            return {}; // Sized hashing requires looking for terminating quote
+         }
+         
          const auto n = s.size();
          if (n < min_length) {
             min_length = n;

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1135,7 +1135,7 @@ namespace glz
 
                auto write_key = [&] {
                   // MSVC requires get<I> rather than keys[I]
-                  static constexpr sv key = get<I>(refl<T>.keys);
+                  static constexpr sv key = get<I>(refl_info<T>::keys);
                   static constexpr auto quoted_key = join_v < chars<"\"">, key,
                                         Opts.prettify ? chars<"\": "> : chars < "\":" >>
                      ;

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1133,8 +1133,8 @@ namespace glz
                   }
                };
                
-               static constexpr sv key = get<I>(refl<T>.keys);
                // MSVC requires get<I> rather than keys[I]
+               static constexpr auto key = get<I>(refl<T>.keys);
                static constexpr auto quoted_key = join_v < chars<"\"">, key,
                                      Opts.prettify ? chars<"\": "> : chars < "\":" >>
                   ;

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1132,14 +1132,14 @@ namespace glz
                      return get<I>(refl<T>.values);
                   }
                };
+               
+               // MSVC requires get<I> rather than keys[I]
+               static constexpr auto key = get<I>(refl<T>.keys);
+               static constexpr auto quoted_key = join_v < chars<"\"">, key,
+                                     Opts.prettify ? chars<"\": "> : chars < "\":" >>
+                  ;
 
                auto write_key = [&] {
-                  // MSVC requires get<I> rather than keys[I]
-                  static constexpr auto key = get<I>(refl<T>.keys); // GCC 14 requires auto here
-                  static constexpr auto quoted_key = join_v < chars<"\"">, key,
-                                        Opts.prettify ? chars<"\": "> : chars < "\":" >>
-                     ;
-                  
                   if constexpr (quoted_key.size() < 128) {
                      // Using the same padding constant alows the compiler
                      // to not need to load different lengths into the register

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1135,7 +1135,8 @@ namespace glz
 
                auto write_key = [&] {
                   // MSVC requires get<I> rather than keys[I]
-                  static constexpr sv key = get<I>(refl_info<T>::keys);
+                  static constexpr sv k = get<I>(refl<T>.keys);
+                  static constexpr sv key = join_v<k>; // Intermediate added for GCC 14
                   static constexpr auto quoted_key = join_v < chars<"\"">, key,
                                         Opts.prettify ? chars<"\": "> : chars < "\":" >>
                      ;

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1134,7 +1134,8 @@ namespace glz
                };
                
                // MSVC requires get<I> rather than keys[I]
-               static constexpr auto key = get<I>(refl<T>.keys);
+               // GCC 14 requires this to exist outside the write_key lambda
+               static constexpr auto key = get<I>(refl<T>.keys); // GCC 14 requires auto here
                static constexpr auto quoted_key = join_v < chars<"\"">, key,
                                      Opts.prettify ? chars<"\": "> : chars < "\":" >>
                   ;

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1132,14 +1132,14 @@ namespace glz
                      return get<I>(refl<T>.values);
                   }
                };
+               
+               static constexpr sv key = get<I>(refl<T>.keys);
+               // MSVC requires get<I> rather than keys[I]
+               static constexpr auto quoted_key = join_v < chars<"\"">, key,
+                                     Opts.prettify ? chars<"\": "> : chars < "\":" >>
+                  ;
 
                auto write_key = [&] {
-                  // MSVC requires get<I> rather than keys[I]
-                  static constexpr sv k = get<I>(refl<T>.keys);
-                  static constexpr sv key = join_v<k>; // Intermediate added for GCC 14
-                  static constexpr auto quoted_key = join_v < chars<"\"">, key,
-                                        Opts.prettify ? chars<"\": "> : chars < "\":" >>
-                     ;
                   if constexpr (quoted_key.size() < 128) {
                      // Using the same padding constant alows the compiler
                      // to not need to load different lengths into the register

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1132,14 +1132,14 @@ namespace glz
                      return get<I>(refl<T>.values);
                   }
                };
-               
-               // MSVC requires get<I> rather than keys[I]
-               static constexpr auto key = get<I>(refl<T>.keys);
-               static constexpr auto quoted_key = join_v < chars<"\"">, key,
-                                     Opts.prettify ? chars<"\": "> : chars < "\":" >>
-                  ;
 
                auto write_key = [&] {
+                  // MSVC requires get<I> rather than keys[I]
+                  static constexpr auto key = get<I>(refl<T>.keys); // GCC 14 requires auto here
+                  static constexpr auto quoted_key = join_v < chars<"\"">, key,
+                                        Opts.prettify ? chars<"\": "> : chars < "\":" >>
+                     ;
+                  
                   if constexpr (quoted_key.size() < 128) {
                      // Using the same padding constant alows the compiler
                      // to not need to load different lengths into the register

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -300,8 +300,8 @@ struct glz::meta<Escaped>
 {
    static constexpr std::string_view name = "Escaped";
    using T = Escaped;
-   static constexpr auto value = object(R"(escaped"key)", &T::escaped_key, //
-                                        R"(escaped""key2)", &T::escaped_key2, R"(escape_chars)", &T::escape_chars);
+   static constexpr auto value = object(R"(escaped\"key)", &T::escaped_key, //
+                                        R"(escaped\"\"key2)", &T::escaped_key2, R"(escape_chars)", &T::escape_chars);
 };
 
 suite escaping_tests = [] {
@@ -4034,7 +4034,7 @@ suite unicode_tests = [] {
    };
 
    "unicode_escaped"_test = [] {
-      std::string str = R"({"\u11FF":"\u11FF"})";
+      std::string str = R"({"ᇿ":"\u11FF"})";
       question_t obj{};
       expect(glz::read_json(obj, str) == glz::error_code::none);
 


### PR DESCRIPTION
This code removes automatically escaping quotes for compile time known keys. This was adding runtime overhead for both reading and writing and was a corner case. Users must now escape these keys in the meta description. See #597 for discussion.