### PR TITLE
escaped_unicode_key_conversion

### DIFF
--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -50,7 +50,6 @@ namespace glz
       bool_t force_conformance = false; // Do not allow invalid json normally accepted such as nan, inf.
       bool_t error_on_missing_keys = false; // Require all non nullable keys to be present in the object. Use
                                             // skip_null_members = false to require nullable members
-
       bool_t error_on_const_read =
          false; // Error if attempt is made to read into a const value, by default the value is skipped without error
 
@@ -60,6 +59,9 @@ namespace glz
       float_precision float_max_write_precision{};
 
       bool_t bools_as_numbers = false; // Read and write booleans with 1's and 0's
+      
+      bool_t escaped_unicode_key_conversion = false; // JSON does not require escaped unicode keys to match with unescaped UTF-8
+      // This enables automatic escaped unicode unescaping and matching for keys in glz::object, but it comes at a performance cost.
 
       bool_t quoted_num = false; // treat numbers as quoted or array-like types as having quoted numbers
       bool_t number = false; // read numbers as strings and write these string as numbers

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -27,13 +27,14 @@ namespace glz
 
    // Write padding bytes simplifies our dump calculations by making sure we have significant excess
    constexpr uint32_t write_padding_bytes = 256;
+   
+   // We use a alias to a uint8_t for booleans so that compiler errors will print "0" or "1" rather than "true" or
+   // "false" This shortens compiler error printouts significantly.
+   // We use a macro rather than an alias because some compilers print out alias definitions, extending length.
+#define bool_t uint8_t
 
    struct opts
    {
-      // We use a alias to a uint8_t for booleans so that compiler errors will print "0" or "1" rather than "true" or
-      // "false" This shortens compiler error printouts significantly
-      using bool_t = uint8_t;
-
       // USER CONFIGURABLE
       uint32_t format = json;
       bool_t comments = false; // Support reading in JSONC style comments
@@ -101,6 +102,8 @@ namespace glz
 
       [[nodiscard]] constexpr bool operator==(const opts&) const noexcept = default;
    };
+   
+#undef bool_t
 
    consteval bool has_opening_handled(opts o) { return o.internal & uint32_t(opts::internal::opening_handled); }
 

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -4034,9 +4034,9 @@ suite unicode_tests = [] {
    };
 
    "unicode_escaped"_test = [] {
-      std::string str = R"({"ᇿ":"\u11FF"})";
+      std::string str = R"({"\u11FF":"\u11FF"})";
       question_t obj{};
-      expect(glz::read_json(obj, str) == glz::error_code::none);
+      expect(glz::read<glz::opts{.escaped_unicode_key_conversion = true}>(obj, str) == glz::error_code::none);
 
       expect(obj.text == "ᇿ");
    };


### PR DESCRIPTION
Adding `escaped_unicode_key_conversion` option:

> JSON does not require escaped unicode keys to match with unescaped UTF-8
This enables automatic escaped unicode unescaping and matching for keys in glz::object, but it comes at a performance cost.