### PR TITLE
Cleaning and reducing reflected string binary size

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -92,9 +92,6 @@ namespace glz
    {
       using T::operator()...;
    };
-   // explicit deduction guide (not needed as of C++20)
-   template <class... T>
-   overload(T...) -> overload<T...>;
 
    struct hidden
    {};

--- a/include/glaze/core/refl.hpp
+++ b/include/glaze/core/refl.hpp
@@ -92,6 +92,18 @@ namespace glz
 
    template <class T>
    using not_object_key_type = std::bool_constant<not is_object_key_type<T>>;
+   
+   namespace detail {
+      // The purpose of this is to allocate a new string_view to only the portion of memory
+      // that we are concerned with. This lets the compiler reduce the binary on
+      // reflected names;
+      template <size_t I, class V>
+      struct get_name_alloc
+      {
+         static constexpr auto alias = get_name<get<I>(meta_v<V>)>();
+         static constexpr auto value = join_v<alias>;
+      };
+   }
 
    template <class T, size_t I>
    consteval sv get_key_element()
@@ -102,14 +114,16 @@ namespace glz
             return get<0>(meta_v<V>);
          }
          else {
-            return get_name<get<0>(meta_v<V>)>();
+            return detail::get_name_alloc<0, V>::value;
+            //return get_name<get<0>(meta_v<V>)>();
          }
       }
       else if constexpr (is_object_key_type<decltype(get<I - 1>(meta_v<V>))>) {
          return get<I - 1>(meta_v<V>);
       }
       else {
-         return get_name<get<I>(meta_v<V>)>();
+         return detail::get_name_alloc<I, V>::value;
+         //return get_name<get<I>(meta_v<V>)>();
       }
    };
 


### PR DESCRIPTION
Addresses #1118, which allocates and copies the portion of interest of the reflected prettified function string so that the resulting binary is smaller.