### PR TITLE
More strict JSON conformant number parsing by default

### DIFF
--- a/include/glaze/csv/read.hpp
+++ b/include/glaze/csv/read.hpp
@@ -109,7 +109,7 @@ namespace glz
                }
             }
             else {
-               auto s = parse_float<V, Opts.force_conformance>(value, it);
+               auto s = parse_float<V>(value, it);
                if (!s) [[unlikely]] {
                   ctx.error = error_code::parse_number_failure;
                   return;

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -550,7 +550,7 @@ namespace glz
                         // Hardware may interact with value changes, so we parse into a temporary and assign in one
                         // place
                         uint64_t i{};
-                        auto s = parse_int<uint64_t, Opts.force_conformance>(i, cur);
+                        auto s = parse_int<uint64_t>(i, cur);
                         if (!s) [[unlikely]] {
                            ctx.error = error_code::parse_number_failure;
                            return;
@@ -558,7 +558,7 @@ namespace glz
                         value = i;
                      }
                      else {
-                        auto s = parse_int<decay_keep_volatile_t<decltype(value)>, Opts.force_conformance>(value, cur);
+                        auto s = parse_int<decay_keep_volatile_t<decltype(value)>>(value, cur);
                         if (!s) [[unlikely]] {
                            ctx.error = error_code::parse_number_failure;
                            return;
@@ -576,7 +576,7 @@ namespace glz
 
                      const char* cur = reinterpret_cast<const char*>(it);
                      const char* beg = cur;
-                     auto s = parse_int<std::decay_t<decltype(i)>, Opts.force_conformance>(i, cur);
+                     auto s = parse_int<std::decay_t<decltype(i)>>(i, cur);
                      if (!s) [[unlikely]] {
                         ctx.error = error_code::parse_number_failure;
                         return;
@@ -600,7 +600,7 @@ namespace glz
 
                   const char* cur = reinterpret_cast<const char*>(it);
                   const char* beg = cur;
-                  auto s = parse_int<decay_keep_volatile_t<decltype(i)>, Opts.force_conformance>(i, cur);
+                  auto s = parse_int<decay_keep_volatile_t<decltype(i)>>(i, cur);
                   if (!s) [[unlikely]] {
                      ctx.error = error_code::parse_number_failure;
                      return;

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -637,7 +637,7 @@ namespace glz
                   if constexpr (std::is_volatile_v<std::remove_reference_t<decltype(value)>>) {
                      // Hardware may interact with value changes, so we parse into a temporary and assign in one place
                      V temp;
-                     auto s = parse_float<V, Opts.force_conformance>(temp, it);
+                     auto s = parse_float<V>(temp, it);
                      if (!s) [[unlikely]] {
                         ctx.error = error_code::parse_number_failure;
                         return;
@@ -645,7 +645,7 @@ namespace glz
                      value = temp;
                   }
                   else {
-                     auto s = parse_float<V, Opts.force_conformance>(value, it);
+                     auto s = parse_float<V>(value, it);
                      if (!s) [[unlikely]] {
                         ctx.error = error_code::parse_number_failure;
                         return;

--- a/include/glaze/util/stoui64.hpp
+++ b/include/glaze/util/stoui64.hpp
@@ -146,7 +146,7 @@ namespace glz::detail
       return false;
    }
 
-   template <class T, bool force_conformance, class CharType>
+   template <class T, bool json_conformance = true, class CharType>
       requires(std::is_unsigned_v<T>)
    inline bool parse_int(auto& val, const CharType*& cur) noexcept
    {
@@ -173,14 +173,14 @@ namespace glz::detail
    if ((num_tmp = cur[i] - zero) <= 9) [[likely]] \
       sig = num_tmp + sig * 10;                   \
    else {                                         \
-      if constexpr (force_conformance && i > 1) { \
+      if constexpr (json_conformance && i > 1) { \
          if (*cur == zero) return false;          \
       }                                           \
       goto digi_sepr_##i;                         \
    }
       repeat_in_1_18(expr_intg);
 #undef expr_intg
-      if constexpr (force_conformance) {
+      if constexpr (json_conformance) {
          if (*cur == zero) return false;
       }
       cur += 19; /* skip continuous 19 digits */
@@ -283,7 +283,7 @@ namespace glz::detail
    digi_frac_end:
       sig_end = cur;
       exp_sig = -int32_t((cur - dot_pos) - 1);
-      if constexpr (force_conformance) {
+      if constexpr (json_conformance) {
          if (exp_sig == 0) [[unlikely]]
             return false;
       }
@@ -303,7 +303,7 @@ namespace glz::detail
       exp_sign = (*++cur == '-');
       cur += (*cur == '+' || *cur == '-');
       if (uint8_t(*cur - zero) > 9) {
-         if constexpr (force_conformance) {
+         if constexpr (json_conformance) {
             return false;
          }
          else {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -1937,7 +1937,7 @@ suite read_tests = [] {
          std::string res = R"(1.a)";
          double d;
 
-         expect(glz::read_json(d, res) == glz::error_code::none);
+         expect(glz::read_json(d, res) != glz::error_code::none);
       }
       {
          std::string res = R"()";
@@ -1953,19 +1953,19 @@ suite read_tests = [] {
          std::string res = R"(1.)";
          double d;
 
-         expect(glz::read_json(d, res) == glz::error_code::none);
+         expect(glz::read_json(d, res) != glz::error_code::none);
       }
       {
          std::string res = R"(1.0e)";
          double d;
 
-         expect(glz::read_json(d, res) == glz::error_code::none);
+         expect(glz::read_json(d, res) != glz::error_code::none);
       }
       {
          std::string res = R"(1.0e-)";
          double d;
 
-         expect(glz::read_json(d, res) == glz::error_code::none);
+         expect(glz::read_json(d, res) != glz::error_code::none);
       }
    };
 

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -1968,6 +1968,18 @@ suite read_tests = [] {
          expect(glz::read_json(d, res) != glz::error_code::none);
       }
    };
+   
+   "random doubles"_test = [] {
+      std::mt19937_64 g{std::random_device{}()};
+      std::uniform_real_distribution<double> dist{};
+      
+      std::string buffer{};
+      for (size_t i = 0; i < 1000; ++i) {
+         double x = dist(g);
+         expect(not glz::write_json(x, buffer));
+         expect(not glz::read_json(x, buffer));
+      }
+   };
 
    "Read string"_test = [] {
       std::string in_nothrow = R"("asljl{}121231212441[]123::,,;,;,,::,Q~123\\a13dqwdwqwq")";


### PR DESCRIPTION
Previously the `force_conformance` option was necessary to have JSON conformant number parsing. This update applies the more stringent rules from the JSON specification by default, such as not allowing leading zeros.

Other rules applied now by default:
- JSON requires a digit after the decimal place in numbers.
- JSON requires a digit after an exponent `e` or `E`