### PR TITLE
Removal of force_conformance and addition of validate_skipped

### DIFF
--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -48,11 +48,11 @@ namespace glz
       bool_t new_lines_in_arrays = true; // Whether prettified arrays should have new lines for each element
       bool_t shrink_to_fit = false; // Shrinks dynamic containers to new size to save memory
       bool_t write_type_info = true; // Write type info for meta objects in variants
-      bool_t force_conformance = false; // Do not allow invalid json normally accepted such as nan, inf.
       bool_t error_on_missing_keys = false; // Require all non nullable keys to be present in the object. Use
                                             // skip_null_members = false to require nullable members
       bool_t error_on_const_read =
          false; // Error if attempt is made to read into a const value, by default the value is skipped without error
+      bool_t validate_skipped = false; // If full validation should be performed on skipped values
       bool_t validate_trailing_whitespace =
          false; // If, after parsing a value, we want to validate the trailing whitespace
 

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2842,7 +2842,7 @@ namespace glz
    {
       context ctx{};
       glz::skip skip_value{};
-      return read<opts{.force_conformance = true, .validate_trailing_whitespace = true}>(
+      return read<opts{.validate_skipped = true, .validate_trailing_whitespace = true}>(
          skip_value, std::forward<Buffer>(buffer), ctx);
    }
 

--- a/include/glaze/json/skip.hpp
+++ b/include/glaze/json/skip.hpp
@@ -10,7 +10,7 @@ namespace glz::detail
    template <opts Opts>
    void skip_object(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
-      if constexpr (!Opts.force_conformance) {
+      if constexpr (!Opts.validate_skipped) {
          ++it;
          skip_until_closed<Opts, '{', '}'>(ctx, it, end);
       }
@@ -47,7 +47,7 @@ namespace glz::detail
    template <opts Opts>
    void skip_array(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
-      if constexpr (!Opts.force_conformance) {
+      if constexpr (!Opts.validate_skipped) {
          ++it;
          skip_until_closed<Opts, '[', ']'>(ctx, it, end);
       }
@@ -74,7 +74,7 @@ namespace glz::detail
    template <opts Opts>
    void skip_value(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
-      if constexpr (!Opts.force_conformance) {
+      if constexpr (!Opts.validate_skipped) {
          if constexpr (!has_ws_handled(Opts)) {
             GLZ_SKIP_WS();
          }

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -897,7 +897,7 @@ namespace glz::detail
          ++it;
       }
 
-      if constexpr (Opts.force_conformance) {
+      if constexpr (Opts.validate_skipped) {
          while (true) {
             if ((*it & 0b11100000) == 0) [[unlikely]] {
                ctx.error = error_code::syntax_error;
@@ -1148,7 +1148,7 @@ namespace glz::detail
    template <opts Opts>
    GLZ_ALWAYS_INLINE void skip_number(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
-      if constexpr (!Opts.force_conformance) {
+      if constexpr (!Opts.validate_skipped) {
          while (numeric_table[*it]) {
             ++it;
          }

--- a/tests/json_conformance/json_conformance.cpp
+++ b/tests/json_conformance/json_conformance.cpp
@@ -354,11 +354,6 @@ suite json_conformance = [] {
       should_pass<glz::opts{.error_on_unknown_keys = false}>();
    };
 
-   "force_conformance = true"_test = [] {
-      should_fail<glz::opts{.force_conformance = true}>();
-      should_pass<glz::opts{.force_conformance = true}>();
-   };
-
    "validate_trailing_whitespace = true"_test = [] {
       should_fail<glz::opts{.validate_trailing_whitespace = true}>();
       should_pass<glz::opts{.validate_trailing_whitespace = true}>();


### PR DESCRIPTION
Removes the `force_conformance` compile time option, which was a catch-all option for corner case JSON conformance requirements. Glaze is now strictly conformant by default except for two options:

- `validate_skipped`
This option does full JSON validation for skipped values when parsing. This is not set by default because values are typically skipped when the user is unconcerned with them, and Glaze still validates for major issues. But, this makes skipping faster by not caring if the skipped values are exactly JSON conformant.

- `validate_trailing_whitespace`
This option validates the trailing whitespace in a parsed document. Because Glaze maps C++ structs, there is typically no need to continue parsing after the object of interest has been read in. Turn on this option if you want to ensure that the rest of the document has valid whitespace, otherwise Glaze will just ignore the content after the content of interest has been parsed.