### PR TITLE
Statically sized string decode buffer

### DIFF
--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -158,7 +158,7 @@ namespace glz
             std::memcpy(data, it, Length);
             it += Length;
 
-            for_each<N>([&](auto I) {
+            for_each_flatten<N>([&](auto I) {
                get_member(value, get<I>(refl<T>.values)) = data[I / 8] & (uint8_t{1} << (7 - (I % 8)));
             });
          }
@@ -1085,7 +1085,7 @@ namespace glz
                   return;
                }
 
-               for_each<N>(
+               for_each_flatten<N>(
                   [&](auto I) { read<binary>::op<Opts>(get_member(value, get<I>(refl<V>.values)), ctx, it, end); });
             }
          }
@@ -1222,7 +1222,7 @@ namespace glz
                return;
             }
 
-            for_each<N>(
+            for_each_flatten<N>(
                [&](auto I) { read<binary>::op<Opts>(get_member(value, get<I>(refl<T>.values)), ctx, it, end); });
          }
       };
@@ -1247,7 +1247,7 @@ namespace glz
                const auto n = int_from_compressed(ctx, it, end);
 
                if constexpr (is_std_tuple<T>) {
-                  for_each_short_circuit<N>([&](auto I) {
+                  for_each_short_circuit_flatten<N>([&](auto I) {
                      if (I < n) {
                         read<binary>::op<Opts>(std::get<I>(value), ctx, it, end);
                         return false; // continue
@@ -1256,7 +1256,7 @@ namespace glz
                   });
                }
                else {
-                  for_each_short_circuit<N>([&](auto I) {
+                  for_each_short_circuit_flatten<N>([&](auto I) {
                      if (I < n) {
                         read<binary>::op<Opts>(glz::get<I>(value), ctx, it, end);
                         return false; // continue
@@ -1272,10 +1272,10 @@ namespace glz
                }
 
                if constexpr (is_std_tuple<T>) {
-                  for_each<N>([&](auto I) { read<binary>::op<Opts>(std::get<I>(value), ctx, it, end); });
+                  for_each_flatten<N>([&](auto I) { read<binary>::op<Opts>(std::get<I>(value), ctx, it, end); });
                }
                else {
-                  for_each<N>([&](auto I) { read<binary>::op<Opts>(glz::get<I>(value), ctx, it, end); });
+                  for_each_flatten<N>([&](auto I) { read<binary>::op<Opts>(glz::get<I>(value), ctx, it, end); });
                }
             }
          }

--- a/include/glaze/binary/write.hpp
+++ b/include/glaze/binary/write.hpp
@@ -172,7 +172,7 @@ namespace glz
 
             std::array<uint8_t, byte_length<T>()> data{};
 
-            for_each<N>([&](auto I) {
+            for_each_flatten<N>([&](auto I) {
                data[I / 8] |= static_cast<uint8_t>(get_member(value, get<I>(refl<T>.values))) << (7 - (I % 8));
             });
 
@@ -600,7 +600,7 @@ namespace glz
                dump_compressed_int<N>(args...);
             }
 
-            for_each<N>([&](auto I) {
+            for_each_flatten<N>([&](auto I) {
                constexpr auto Opts = opening_handled_off<Options>();
                write<binary>::no_header<Opts>(get<2 * I>(value.value), ctx, args...);
                write<binary>::op<Opts>(get<2 * I + 1>(value.value), ctx, args...);
@@ -654,7 +654,7 @@ namespace glz
          static constexpr auto N = refl<T>.N;
          static constexpr size_t count_to_write = [] {
             size_t count{};
-            for_each<N>([&](auto I) {
+            for_each_flatten<N>([&](auto I) {
                using V = std::remove_cvref_t<refl_t<T, I>>;
 
                if constexpr (std::same_as<V, hidden> || std::same_as<V, skip>) {
@@ -684,7 +684,7 @@ namespace glz
                }
             }();
 
-            for_each<N>([&](auto I) {
+            for_each_flatten<N>([&](auto I) {
                using val_t = std::remove_cvref_t<refl_t<T, I>>;
 
                if constexpr (std::same_as<val_t, hidden> || std::same_as<val_t, skip>) {
@@ -722,7 +722,7 @@ namespace glz
                }
             }();
 
-            for_each<N>([&](auto I) {
+            for_each_flatten<N>([&](auto I) {
                using val_t = std::remove_cvref_t<refl_t<T, I>>;
 
                if constexpr (std::same_as<val_t, hidden> || std::same_as<val_t, skip>) {
@@ -759,7 +759,7 @@ namespace glz
             static constexpr auto N = refl<T>.N;
             dump_compressed_int<N>(args...);
 
-            for_each<refl<T>.N>(
+            for_each_flatten<refl<T>.N>(
                [&](auto I) { write<binary>::op<Opts>(get_member(value, get<I>(refl<T>.values)), ctx, args...); });
          }
       };

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -221,7 +221,7 @@ namespace glz
                }
             }
 
-            for_each_short_circuit<N>([&](auto I) {
+            for_each_short_circuit_flatten<N>([&](auto I) {
                if (I == index) {
                   static constexpr auto TargetKey = get<I>(refl<T>.keys);
                   static constexpr auto Length = TargetKey.size();
@@ -1533,7 +1533,7 @@ namespace glz
             GLZ_MATCH_OPEN_BRACKET;
             GLZ_SKIP_WS();
 
-            for_each<N>([&](auto I) {
+            for_each_flatten<N>([&](auto I) {
                if (*it == ']') {
                   return;
                }
@@ -1870,7 +1870,7 @@ namespace glz
       GLZ_ALWAYS_INLINE void read_json_visitor(auto&& value, auto&& variant, auto&& ctx, auto&& it, auto&& end) noexcept
       {
          constexpr auto variant_size = std::variant_size_v<std::decay_t<decltype(variant)>>;
-         for_each_short_circuit<variant_size>([&](auto I) {
+         for_each_short_circuit_flatten<variant_size>([&](auto I) {
             if (I == variant.index()) {
                using V = decltype(get_member(value, std::get<I>(variant)));
 

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -247,8 +247,7 @@ namespace glz
                      }
                   }
 
-                  const sv key{it, Length};
-                  if (cx_string_cmp<TargetKey>(key)) [[likely]] {
+                  if (compare<Length>(TargetKey.data(), it)) [[likely]] {
                      it += Length;
                      if (*it != '"') [[unlikely]] {
                         if constexpr (Opts.error_on_unknown_keys) {
@@ -2046,7 +2045,7 @@ namespace glz
                   }
                   else if constexpr (direct_maps) {
                      if (*it != '"') [[unlikely]] {
-                        ctx.error = error_code::unknown_key;
+                        ctx.error = error_code::expected_quote;
                         return;
                      }
                      ++it;

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -40,8 +40,8 @@ namespace glz
          return buffer;
       }
 
-      // The string_buffer() often gets resized, but we want our decode buffer to
-      // only ever grow on resizing. So, we make it its own buffer.
+      // The string_decode_buffer() is statically sized to
+      // reduce memory usage.
       GLZ_ALWAYS_INLINE auto& string_decode_buffer() noexcept
       {
          static thread_local std::array<char, 512> buffer{};

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -76,7 +76,7 @@ namespace glz
 
             dump<'['>(b, ix);
 
-            for_each<N>([&](auto I) {
+            for_each_flatten<N>([&](auto I) {
                if (get_member(value, get<I>(refl<T>.values))) {
                   dump<'"'>(b, ix);
                   dump_maybe_empty(refl<T>.keys[I], b, ix);
@@ -861,7 +861,7 @@ namespace glz
                ctx.indentation_level += Opts.indentation_width;
                dump_newline_indent<Opts.indentation_char>(ctx.indentation_level, args...);
             }
-            for_each<N>([&](auto I) {
+            for_each_flatten<N>([&](auto I) {
                if constexpr (glaze_array_t<V>) {
                   write<json>::op<Opts>(get_member(value.value, glz::get<I>(meta_v<T>)), ctx, args...);
                }
@@ -903,7 +903,7 @@ namespace glz
                dump_newline_indent<Opts.indentation_char>(ctx.indentation_level, args...);
             }
             using V = std::decay_t<T>;
-            for_each<N>([&](auto I) {
+            for_each_flatten<N>([&](auto I) {
                if constexpr (glaze_array_t<V>) {
                   write<json>::op<Opts>(get_member(value, glz::get<I>(meta_v<T>)), ctx, args...);
                }
@@ -965,7 +965,7 @@ namespace glz
             static constexpr auto N = glz::tuple_size_v<V> / 2;
 
             bool first = true;
-            for_each<N>([&](auto I) {
+            for_each_flatten<N>([&](auto I) {
                constexpr auto Opts = opening_and_closing_handled_off<ws_handled_off<Options>()>();
                decltype(auto) item = glz::get<2 * I + 1>(value.value);
                using val_t = std::decay_t<decltype(item)>;
@@ -1038,7 +1038,7 @@ namespace glz
             using V = std::decay_t<decltype(value.value)>;
             static constexpr auto N = glz::tuple_size_v<V>;
 
-            for_each<N>([&](auto I) {
+            for_each_flatten<N>([&](auto I) {
                write<json>::op<opening_and_closing_handled<Options>()>(glz::get<I>(value.value), ctx, b, ix);
                if constexpr (I < N - 1) {
                   dump<','>(b, ix);
@@ -1119,7 +1119,7 @@ namespace glz
 
             [[maybe_unused]] bool first = true;
             static constexpr auto first_is_written = object_info<Options, T>::first_will_be_written;
-            for_each<N>([&](auto I) {
+            for_each_flatten<N>([&](auto I) {
                constexpr auto Opts = opening_and_closing_handled_off<ws_handled_off<Options>()>();
 
                using val_t = std::remove_cvref_t<refl_t<T, I>>;
@@ -1285,7 +1285,7 @@ namespace glz
 
             if constexpr ((num_members > 0) && (glaze_object_t<T> || reflectable<T>)) {
                if constexpr (glaze_object_t<T>) {
-                  for_each<N>([&](auto I) {
+                  for_each_flatten<N>([&](auto I) {
                      if (bool(ctx.error)) [[unlikely]] {
                         return;
                      }
@@ -1321,7 +1321,7 @@ namespace glz
 
                   static constexpr auto members = member_names<T>;
 
-                  for_each<N>([&](auto I) {
+                  for_each_flatten<N>([&](auto I) {
                      if (bool(ctx.error)) [[unlikely]] {
                         return;
                      }
@@ -1363,7 +1363,7 @@ namespace glz
                }
             }
             else if constexpr (writable_map_t<T>) {
-               for_each<N>([&](auto I) {
+               for_each_flatten<N>([&](auto I) {
                   if (bool(ctx.error)) [[unlikely]] {
                      return;
                   }

--- a/include/glaze/util/for_each.hpp
+++ b/include/glaze/util/for_each.hpp
@@ -5,6 +5,8 @@
 
 #include <utility>
 
+#include "glaze/util/inline.hpp"
+
 namespace glz
 {
    // Compile time iterate over I indices
@@ -16,10 +18,26 @@ namespace glz
          (f(std::integral_constant<std::size_t, I>{}), ...);
       }(std::make_index_sequence<N>{});
    }
+   
+   template <std::size_t N, class Func>
+   GLZ_FLATTEN constexpr void for_each_flatten(Func&& f)
+   {
+      [&]<std::size_t... I>(std::index_sequence<I...>) constexpr {
+         (f(std::integral_constant<std::size_t, I>{}), ...);
+      }(std::make_index_sequence<N>{});
+   }
 
    // Runtime short circuiting if function returns true, return false to continue evaluation
    template <std::size_t N, class Func>
    constexpr void for_each_short_circuit(Func&& f)
+   {
+      [&]<std::size_t... I>(std::index_sequence<I...>) constexpr {
+         (f(std::integral_constant<std::size_t, I>{}) || ...);
+      }(std::make_index_sequence<N>{});
+   }
+   
+   template <std::size_t N, class Func>
+   GLZ_FLATTEN constexpr void for_each_short_circuit_flatten(Func&& f)
    {
       [&]<std::size_t... I>(std::index_sequence<I...>) constexpr {
          (f(std::integral_constant<std::size_t, I>{}) || ...);

--- a/include/glaze/util/inline.hpp
+++ b/include/glaze/util/inline.hpp
@@ -41,3 +41,11 @@
 #ifndef GLZ_FLATTEN_NO_INLINE
 #define GLZ_FLATTEN_NO_INLINE
 #endif
+
+#ifndef GLZ_NO_INLINE
+#if defined(__clang__) || defined(__GNUC__)
+#define GLZ_NO_INLINE __attribute__((noinline))
+#elif defined(_MSC_VER)
+#define GLZ_NO_INLINE __declspec((noinline))
+#endif
+#endif

--- a/include/glaze/util/inline.hpp
+++ b/include/glaze/util/inline.hpp
@@ -24,7 +24,7 @@
 // It should only be applied in very specific circumstances.
 // It is best to more often rely on the compiler.
 
-#if defined(__clang__) && defined(NDEBUG)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(NDEBUG)
 #ifndef GLZ_FLATTEN
 #define GLZ_FLATTEN inline __attribute__((flatten))
 #endif

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -208,7 +208,7 @@ namespace glz::detail
    }
 
    template <class Char>
-   [[nodiscard]] GLZ_ALWAYS_INLINE bool handle_unicode_code_point(const Char*& it, Char*& dst)
+   [[nodiscard]] GLZ_ALWAYS_INLINE bool handle_unicode_code_point(const Char*& it, Char*& dst) noexcept
    {
       using namespace unicode;
 
@@ -234,7 +234,7 @@ namespace glz::detail
          }
          it += 4;
 
-         if ((low & surrogate_mask) != low_surrogate_value) {
+         if ((low & surrogate_mask) != low_surrogate_value) [[unlikely]] {
             return false;
          }
 
@@ -251,7 +251,7 @@ namespace glz::detail
    }
 
    template <class Char>
-   [[nodiscard]] GLZ_ALWAYS_INLINE bool handle_unicode_code_point(const Char*& it, Char*& dst, const Char* end)
+   [[nodiscard]] GLZ_ALWAYS_INLINE bool handle_unicode_code_point(const Char*& it, Char*& dst, const Char* end) noexcept
    {
       using namespace unicode;
 
@@ -283,7 +283,7 @@ namespace glz::detail
          }
          it += 4;
 
-         if ((low & surrogate_mask) != low_surrogate_value) {
+         if ((low & surrogate_mask) != low_surrogate_value) [[unlikely]] {
             return false;
          }
 
@@ -300,7 +300,7 @@ namespace glz::detail
    }
 
    template <class Char>
-   [[nodiscard]] GLZ_ALWAYS_INLINE bool skip_unicode_code_point(const Char*& it, const Char* end)
+   [[nodiscard]] GLZ_ALWAYS_INLINE bool skip_unicode_code_point(const Char*& it, const Char* end) noexcept
    {
       using namespace unicode;
       if (it + 4 >= end) [[unlikely]] {
@@ -317,7 +317,7 @@ namespace glz::detail
 
       if ((high & generic_surrogate_mask) == generic_surrogate_value) {
          // surrogate pair code points
-         if ((high & surrogate_mask) != high_surrogate_value) {
+         if ((high & surrogate_mask) != high_surrogate_value) [[unlikely]] {
             return false;
          }
 
@@ -332,7 +332,7 @@ namespace glz::detail
          }
          it += 4;
 
-         if ((low & surrogate_mask) != low_surrogate_value) {
+         if ((low & surrogate_mask) != low_surrogate_value) [[unlikely]] {
             return false;
          }
 


### PR DESCRIPTION
Uses a statically sized string decode buffer for significant memory savings when JSON documents have long strings.