### PR TITLE
add fuzzing

### DIFF
--- a/.github/workflows/exhaustive.yml
+++ b/.github/workflows/exhaustive.yml
@@ -1,0 +1,59 @@
+name: exhaustive json tests
+
+on:
+  push:
+    branches:
+    - main
+    - feature/*
+    paths-ignore:
+    - '**.md'
+  pull_request:
+    branches: [main]
+    paths-ignore:
+    - '**.md'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        clang: [18]
+        build_type: [Release]
+        std: [23]
+
+    env:
+      CC: clang-${{matrix.clang}}
+      CXX: clang++-${{matrix.clang}}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Configure CMake
+      run: |
+        cmake -B ${{github.workspace}}/build \
+          -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
+          -DCMAKE_CXX_STANDARD=${{matrix.std}} \
+          -DCMAKE_C_COMPILER=${{env.CC}} \
+          -DCMAKE_CXX_COMPILER=${{env.CXX}} \
+          -DBUILD_TESTING=Off
+
+    - name: Build
+      run: cmake --build build -j $(nproc)
+
+    - name: Test
+      working-directory: build
+      run: |
+        set -e
+        fuzzing/json_exhaustive_roundtrip_int
+
+        echo all is OK!
+
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: fuzzing-artifacts
+        path: build/artifacts/
+

--- a/.github/workflows/quickfuzz.yml
+++ b/.github/workflows/quickfuzz.yml
@@ -1,0 +1,70 @@
+name: quickfuzz
+
+on:
+  push:
+    branches:
+    - main
+    - feature/*
+    paths-ignore:
+    - '**.md'
+  pull_request:
+    branches: [main]
+    paths-ignore:
+    - '**.md'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        clang: [18]
+        build_type: [Debug]
+        std: [23]
+
+    env:
+      CC: clang-${{matrix.clang}}
+      CXX: clang++-${{matrix.clang}}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo echo apt-get update
+        sudo echo apt-get install -y libc++-dev libc++abi-dev
+
+    - name: Configure CMake
+      run: |
+        cmake -B ${{github.workspace}}/build \
+          -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
+          -DCMAKE_CXX_STANDARD=${{matrix.std}} \
+          -DCMAKE_C_COMPILER=${{env.CC}} \
+          -DCMAKE_CXX_COMPILER=${{env.CXX}} \
+          -DBUILD_TESTING=Off
+
+    - name: Build
+      run: cmake --build build -j $(nproc)
+
+    - name: Test
+      working-directory: build
+      run: |        
+        set -e
+        mkdir -p corpus
+
+        echo number of cpus: $(nproc)
+        echo amount of ram:
+        free -h
+
+        ../fuzzing/quickfuzz/run_all.sh
+
+        echo all is OK!
+
+    - uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
+      with:
+        name: fuzzing-artifacts
+        path: build/artifacts/
+

--- a/cmake/dev-mode.cmake
+++ b/cmake/dev-mode.cmake
@@ -12,6 +12,10 @@ if(BUILD_TESTING)
   add_subdirectory(tests)
 endif()
 
+if (glaze_ENABLE_FUZZING)
+  add_subdirectory(fuzzing)
+endif()
+
 # Done in developer mode only, so users won't be bothered by this :)
 file(GLOB_RECURSE headers CONFIGURE_DEPENDS "${PROJECT_SOURCE_DIR}/include/glaze/*.hpp")
 source_group(TREE "${PROJECT_SOURCE_DIR}/include" PREFIX headers FILES ${headers})

--- a/cmake/variables.cmake
+++ b/cmake/variables.cmake
@@ -11,6 +11,10 @@ if(PROJECT_IS_TOP_LEVEL)
     glaze_DEVELOPER_MODE "Enable developer mode" ON
     "PROJECT_IS_TOP_LEVEL" OFF
   )
+  cmake_dependent_option(
+    glaze_ENABLE_FUZZING "Enable building fuzzers" ON
+    "PROJECT_IS_TOP_LEVEL" OFF
+  )
 endif()
 
 # ---- Warning guard ----

--- a/fuzzing/CMakeLists.txt
+++ b/fuzzing/CMakeLists.txt
@@ -1,0 +1,64 @@
+
+# this library provides main() for compilers that do not have libfuzzer (everyone except clang)
+# so the source code is compiled regardless of compiler, which prevents code rot.
+# also, the library provides a way to invoke the fuzzer on external data which is
+# useful to run the fuzz corpus through code also when not using clang.
+add_library(main STATIC main.cpp)
+target_compile_features(main PRIVATE cxx_std_23)
+
+# see if libfuzzer is supported - this gets more complicated than just checking
+# for clang, because apple clang does not seem to support it and windows also
+# support clang nowadays (and perhaps libfuzzer)
+
+include(CheckSourceCompiles)
+set(CMAKE_REQUIRED_LINK_OPTIONS -fsanitize=fuzzer)
+check_source_compiles(CXX "
+    #include <cstddef>
+    #include <cstdint>
+    extern \"C\" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+    { return 0;}
+    " haslibfuzzer)
+
+
+macro(create_fuzztest testname)
+    add_executable(fuzz_${testname} ${testname}.cpp)
+    target_link_libraries(fuzz_${testname} PRIVATE glaze::glaze)
+
+    if(haslibfuzzer)
+        target_compile_options(fuzz_${testname} PUBLIC -fsanitize=fuzzer)
+        target_link_options(fuzz_${testname} PUBLIC -fsanitize=fuzzer)
+    else()
+        # supply a separate main
+        target_link_libraries(fuzz_${testname} PRIVATE main)
+    endif()
+
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+        target_compile_options(fuzz_${testname} PUBLIC -fsanitize=address,undefined -fno-sanitize-recover=all )
+        target_link_options(fuzz_${testname} PUBLIC -fsanitize=address,undefined -fno-sanitize-recover=all )
+    else()
+        target_link_libraries(fuzz_${testname} PRIVATE main)
+    endif()
+endmacro()
+
+create_fuzztest(json_generic)
+create_fuzztest(json_minify)
+create_fuzztest(json_prettify)
+create_fuzztest(json_reflection)
+create_fuzztest(json_roundtrip_floating)
+create_fuzztest(json_roundtrip_int)
+create_fuzztest(json_roundtrip_string)
+create_fuzztest(json_with_comments)
+
+macro(create_exhaustive_test testname)
+    add_executable(${testname} ${testname}.cpp)
+    target_link_libraries(${testname} PRIVATE glaze::glaze)
+    # do not set sanitizers here - CI needs to run as fast as possible,
+    # manual running may want sanitizers and debug.
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        #target_compile_options(${testname} PRIVATE -O2)
+        #target_compile_options(${testname} PRIVATE -fsanitize=address,undefined  -fno-sanitize-recover=all )
+        #target_link_options(${testname} PRIVATE -fsanitize=address,undefined  -fno-sanitize-recover=all )
+    endif()
+endmacro()
+
+create_exhaustive_test(json_exhaustive_roundtrip_int)

--- a/fuzzing/build_and_run_fuzzers.sh
+++ b/fuzzing/build_and_run_fuzzers.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# builds and runs the fuzzers for a short while.
+#
+# intended to be run manually during development. gitlab CI has it's own
+# script.
+#
+
+set -eu
+
+SCRIPTDIR=$(dirname "$0")
+
+builddir=build-fuzzer-clang
+
+cmake -B "$builddir" -S "$SCRIPTDIR/.." -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=Off -GNinja -DCMAKE_CXX_COMPILER=/usr/bin/clang++-17
+cmake --build "$builddir"
+
+cd "$builddir"
+mkdir -p corpus
+
+fuzzers=$(ls fuzzing/fuzz_*|sort --random-sort)
+
+export UBSAN_OPTIONS=halt_on_error=1
+export ASAN_OPTS=halt_on_error=1
+
+for fuzzer in $fuzzers ; do
+  echo looking at $fuzzer
+  shortname=$(basename $fuzzer)
+  mkdir -p corpus/$shortname
+  $fuzzer -max_total_time=60 corpus/$shortname
+done

--- a/fuzzing/json_exhaustive_roundtrip_int.cpp
+++ b/fuzzing/json_exhaustive_roundtrip_int.cpp
@@ -1,0 +1,97 @@
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <future>
+#include <glaze/glaze.hpp>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+// must be outside test(), compilation fails on gcc 13 otherwise
+template <typename T>
+struct Value
+{
+   T value{};
+};
+
+template <typename T>
+void test()
+{
+   using S = Value<T>;
+   using UT = std::make_unsigned_t<T>;
+
+   auto testone = [](const UT loopvar, auto& outbuf) {
+      S s;
+      std::memcpy(&s.value, &loopvar, sizeof(T));
+
+      outbuf.clear();
+      const auto writeec = glz::write_json(s, outbuf);
+
+      if (writeec) [[unlikely]] {
+         std::cerr << "failed writing " << s.value << " to json\n";
+         std::abort();
+      }
+
+      auto restored = glz::read_json<S>(outbuf);
+      if (!restored) [[unlikely]] {
+         std::cerr << "failed parsing " << outbuf << '\n';
+         std::abort();
+      }
+
+      if (const auto r = restored.value().value; r != s.value) [[unlikely]] {
+         std::cerr << "failed roundtrip, got " << r << " instead of " << s.value << //
+            " (diff is " << r - s.value << ") when parsing " << outbuf << '\n';
+         std::abort();
+      }
+   };
+
+   auto testrange = [&](const UT start, const UT stop) {
+      std::string outbuf;
+      for (UT i = start; i < stop; ++i) {
+         testone(i, outbuf);
+      }
+   };
+
+   const auto nthreads = std::thread::hardware_concurrency();
+   const UT step = std::numeric_limits<UT>::max() / nthreads;
+
+   std::vector<std::future<void>> futures;
+   futures.reserve(nthreads);
+   for (int threadi = 0; threadi < nthreads; ++threadi) {
+      const UT start = threadi * step;
+      const UT stop = (threadi == nthreads - 1) ? std::numeric_limits<UT>::max() : start + step;
+      // std::cout << "thread i=" << threadi << " goes from " << start << " to " << stop << '\n';
+      futures.emplace_back(std::async(testrange, start, stop));
+   }
+   // test the last value here.
+   {
+      std::string buf;
+      testone(std::numeric_limits<UT>::max(), buf);
+   }
+
+   std::cout << "started testing in " << nthreads << " threads." << std::endl;
+   futures.clear();
+   std::cout << "tested " << std::numeric_limits<UT>::max() << " values of " << (std::is_unsigned_v<T> ? "un" : "")
+             << "signed type of size " << sizeof(T) << std::endl;
+}
+
+void testonetype(int bits)
+{
+   switch (bits) {
+   case 16:
+      test<std::int16_t>();
+      test<std::uint16_t>();
+      break;
+   case 32:
+      test<std::int32_t>();
+      test<std::uint32_t>();
+      break;
+   }
+}
+
+int main(int argc, char* argv[])
+{
+   testonetype(16);
+   testonetype(32);
+}

--- a/fuzzing/json_generic.cpp
+++ b/fuzzing/json_generic.cpp
@@ -1,0 +1,19 @@
+#include <cstddef>
+#include <cstdint>
+#include <glaze/glaze.hpp>
+#include <vector>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+   // use a vector with null termination instead of a std::string to avoid
+   // small string optimization to hide bounds problems
+   std::vector<char> buffer{Data, Data + Size};
+   buffer.push_back('\0');
+
+   glz::json_t json{};
+   auto ec = glz::read_json(json, buffer);
+   if (!ec) {
+      [[maybe_unused]] auto s = json.size();
+   }
+   return 0;
+}

--- a/fuzzing/json_minify.cpp
+++ b/fuzzing/json_minify.cpp
@@ -1,0 +1,16 @@
+#include <cstddef>
+#include <cstdint>
+#include <glaze/glaze.hpp>
+#include <vector>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+   // use a vector with null termination instead of a std::string to avoid
+   // small string optimization to hide bounds problems
+   std::vector<char> buffer{Data, Data + Size};
+   buffer.push_back('\0');
+
+   auto maybe_smaller = glz::minify_json(buffer);
+
+   return 0;
+}

--- a/fuzzing/json_prettify.cpp
+++ b/fuzzing/json_prettify.cpp
@@ -1,0 +1,16 @@
+#include <cstddef>
+#include <cstdint>
+#include <glaze/glaze.hpp>
+#include <vector>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+   // use a vector with null termination instead of a std::string to avoid
+   // small string optimization to hide bounds problems
+   std::vector<char> buffer{Data, Data + Size};
+   buffer.push_back('\0');
+
+   auto beautiful = glz::prettify_json(buffer);
+
+   return 0;
+}

--- a/fuzzing/json_reflection.cpp
+++ b/fuzzing/json_reflection.cpp
@@ -1,0 +1,27 @@
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <glaze/glaze.hpp>
+#include <vector>
+
+struct my_struct
+{
+   int i = 287;
+   double d = 3.14;
+   std::string hello = "Hello World";
+   std::array<uint64_t, 3> arr = {1, 2, 3};
+};
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+   // use a vector with null termination instead of a std::string to avoid
+   // small string optimization to hide bounds problems
+   std::vector<char> buffer{Data, Data + Size};
+   buffer.push_back('\0');
+
+   [[maybe_unused]] auto s = glz::read_json<my_struct>(std::string_view{buffer.data(), Size});
+   if (s) {
+      // hooray! valid json found
+   }
+   return 0;
+}

--- a/fuzzing/json_roundtrip_floating.cpp
+++ b/fuzzing/json_roundtrip_floating.cpp
@@ -1,0 +1,62 @@
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <glaze/glaze.hpp>
+#include <vector>
+
+// must be outside test() to work in gcc<14
+template <typename T>
+struct Value
+{
+   T value{};
+};
+
+template <typename T>
+void test(const uint8_t* Data, size_t Size)
+{
+   using S = Value<T>;
+   S s{};
+
+   if (Size >= sizeof(T)) {
+      std::memcpy(&s.value, Data, sizeof(T));
+   }
+   else {
+      return;
+   }
+   if (std::isfinite(s.value)) {
+      auto str = glz::write_json(s).value_or(std::string{});
+      auto restored = glz::read_json<S>(str);
+      assert(restored);
+
+      if (std::abs(s.value) < std::numeric_limits<T>::min()) {
+         // a denormalized value - check that it is close enough to zero.
+         assert(std::abs(restored.value().value) < std::numeric_limits<T>::min());
+      }
+      else {
+         assert(restored.value().value == s.value);
+      }
+   }
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+   if (Size < 1 + sizeof(float)) {
+      return 0;
+   }
+   const auto action = Data[0];
+   ++Data;
+   --Size;
+
+   switch (action & 0b1) {
+   case 0:
+      test<float>(Data, Size);
+      break;
+   case 1:
+      test<double>(Data, Size);
+      break;
+   }
+
+   return 0;
+}

--- a/fuzzing/json_roundtrip_int.cpp
+++ b/fuzzing/json_roundtrip_int.cpp
@@ -1,0 +1,62 @@
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <glaze/glaze.hpp>
+#include <vector>
+
+// must be outside test() to work in gcc<14
+template <typename T>
+struct Value
+{
+   T value{};
+};
+
+template <typename T>
+void test(const uint8_t* Data, size_t Size)
+{
+   using S = Value<T>;
+   S s{};
+
+   if (Size >= sizeof(T)) {
+      std::memcpy(&s.value, Data, sizeof(T));
+   }
+   else {
+      return;
+   }
+   auto str = glz::write_json(s).value_or(std::string{});
+   auto restored = glz::read_json<S>(str);
+   assert(restored);
+   assert(restored.value().value == s.value);
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+   if (Size < 2) {
+      return 0;
+   }
+   const auto action = Data[0];
+   ++Data;
+   --Size;
+
+   switch (action & 0b11) {
+   case 0:
+      test<short>(Data, Size);
+      test<unsigned short>(Data, Size);
+      break;
+   case 1:
+      test<int>(Data, Size);
+      test<unsigned int>(Data, Size);
+      break;
+   case 2:
+      test<long>(Data, Size);
+      test<unsigned long>(Data, Size);
+      break;
+   case 3:
+      test<long long>(Data, Size);
+      test<unsigned long long>(Data, Size);
+      break;
+   }
+
+   return 0;
+}

--- a/fuzzing/json_roundtrip_string.cpp
+++ b/fuzzing/json_roundtrip_string.cpp
@@ -1,0 +1,38 @@
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <glaze/glaze.hpp>
+#include <vector>
+
+struct S
+{
+   std::string value{};
+};
+
+void test(const uint8_t* Data, size_t Size)
+{
+   S s{{Data, Data + Size}};
+
+   // note - glaze does not escape control characters. see https://github.com/stephenberry/glaze/issues/812
+
+   // replace control characters with space
+   for (auto& c : s.value) {
+      if (std::iscntrl(c) && c != '\b' && c != '\f' && c != '\n' && c != '\r' && c != '\t') {
+         c = ' ';
+      }
+   }
+
+   auto str = glz::write_json(s).value_or(std::string{});
+   auto restored = glz::read_json<S>(str);
+   assert(restored);
+
+   assert(restored.value().value == s.value);
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+   test(Data, Size);
+   return 0;
+}

--- a/fuzzing/json_with_comments.cpp
+++ b/fuzzing/json_with_comments.cpp
@@ -1,0 +1,27 @@
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <glaze/glaze.hpp>
+#include <vector>
+
+struct my_struct
+{
+   int i = 287;
+   double d = 3.14;
+   std::string hello = "Hello World";
+   std::array<uint64_t, 3> arr = {1, 2, 3};
+};
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+   // use a vector with null termination instead of a std::string to avoid
+   // small string optimization to hide bounds problems
+   std::vector<char> buffer{Data, Data + Size};
+   buffer.push_back('\0');
+
+   [[maybe_unused]] auto s = glz::read_jsonc<my_struct>(std::string_view{buffer.data(), Size});
+   if (s) {
+      // hooray! valid json found
+   }
+   return 0;
+}

--- a/fuzzing/main.cpp
+++ b/fuzzing/main.cpp
@@ -1,0 +1,75 @@
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+/*
+ * this provides a way to run garbage data through glaze even on platforms
+ * that do not have libFuzzer. data can be taken from a fuzzing session
+ * and feeding it to a program with this main function.
+ */
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size);
+
+void handle_file(std::filesystem::path file)
+{
+   std::vector<char> data;
+
+   const auto Nbytes = file_size(file);
+   data.resize(Nbytes);
+
+   std::ifstream filestream(file);
+   filestream.read(data.data(), data.size());
+   if (filestream.gcount() != Nbytes) {
+      std::cerr << "failed reading from file " << file << '\n';
+      return;
+   }
+
+   std::cout << "invoking fuzzer on data from file " << file << '\n';
+
+   LLVMFuzzerTestOneInput(reinterpret_cast<const uint8_t*>(data.data()), data.size());
+}
+
+void handle_directory(std::filesystem::path directory)
+{
+   for (const auto& entry : std::filesystem::recursive_directory_iterator(
+           directory, std::filesystem::directory_options::follow_directory_symlink)) {
+      if (entry.is_regular_file()) {
+         handle_file(entry.path());
+      }
+      else if (entry.is_symlink()) {
+         auto resolved = read_symlink(entry);
+         if (is_regular_file(resolved)) {
+            handle_file(resolved);
+         }
+      }
+   }
+}
+
+void handle_possible_file(std::filesystem::path possible_file)
+{
+   if (std::filesystem::is_directory(possible_file)) {
+      handle_directory(possible_file);
+   }
+   else if (is_regular_file(possible_file)) {
+      handle_file(possible_file);
+   }
+   else if (is_symlink(possible_file)) {
+      auto resolved = read_symlink(possible_file);
+      handle_possible_file(resolved);
+   }
+   else {
+      std::cerr << "not a directory, regular file or symlink: " << possible_file << '\n';
+   }
+}
+
+void handle_arg(const char* path) { return handle_possible_file(std::filesystem::path(path)); }
+
+int main(int argc, char* argv[])
+{
+   for (int i = 1; i < argc; ++i) {
+      handle_arg(argv[i]);
+   }
+}

--- a/fuzzing/minimize_and_cleanse.sh
+++ b/fuzzing/minimize_and_cleanse.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+#
+# minimizes and cleanses a crash.
+# arg1 is the fuzzer
+# arg2 is the crash case
+
+usage() {
+  echo "$0 fuzzer crashcase"
+}
+if [ $# -ne 2 ] ; then
+usage
+exit 1
+fi
+
+if [ ! -x "$1" ] ; then
+echo "fuzzer should be passes as arg 1"
+exit 1
+fi
+
+if [ ! -e "$2" ] ; then
+echo "crash case should be passes as arg 2"
+exit 1
+fi
+
+"$1" "$2" -minimize_crash=1 -exact_artifact_path=minimized_crash -max_total_time=30
+
+"$1" minimized_crash -cleanse_crash=1 -exact_artifact_path=cleaned_crash
+
+

--- a/fuzzing/quickfuzz/run_all.sh
+++ b/fuzzing/quickfuzz/run_all.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# invoked from github action.
+# runs all fuzzers using all cores for a limited time
+
+set -eu
+
+SCRIPTDIR=$(dirname "$0")
+
+ls fuzzing/fuzz_*|sort --random-sort | \
+   xargs --verbose --max-procs $(nproc) -n 1 "$SCRIPTDIR"/run_single.sh

--- a/fuzzing/quickfuzz/run_single.sh
+++ b/fuzzing/quickfuzz/run_single.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# invoked from run_all.sh
+#
+# runs a single fuzzer a limited time.
+# if no problems are found, the results are removed.
+# problems are found, logs and artifacts are left and the exit
+# status is nonzero.
+
+set -eu
+
+fuzzer="$1"
+
+if [ ! -x "$fuzzer" ] ; then
+ exit 1
+fi
+
+shortname=$(basename "$fuzzer")
+
+ARTIFACTS=artifacts/$shortname
+CORPUS=$ARTIFACTS/corpus
+LOG=$ARTIFACTS/$shortname.log
+
+mkdir -p $ARTIFACTS $CORPUS
+
+export UBSAN_OPTIONS=halt_on_error=1
+export ASAN_OPTS=halt_on_error=1
+
+if ! $fuzzer -max_total_time=40 -artifact_prefix=$ARTIFACTS/ $CORPUS >$LOG 2>&1 ; then
+  echo FAIL - fuzzer $shortname failed - see $LOG
+  exit 1
+fi
+
+echo OK - fuzzer $shortname ran without problems
+rm -rf $ARTIFACTS/

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -132,7 +132,7 @@ namespace glz::detail
    [[nodiscard]] GLZ_ALWAYS_INLINE uint32_t hex_to_u32(const char* c) noexcept
    {
       const auto& t = digit_hex_table;
-      const uint8_t arr[4]{t[c[3]], t[c[2]], t[c[1]], t[c[0]]};
+      const uint8_t arr[4]{t[uint8_t(c[3])], t[uint8_t(c[2])], t[uint8_t(c[1])], t[uint8_t(c[0])]};
       uint32_t chunk;
       std::memcpy(&chunk, arr, 4);
       // check that all hex characters are valid

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -7350,11 +7350,11 @@ suite address_sanitizer_test = [] {
       expect(glz::read_json(json, blah));
    };
    
-   "invalid json_t read"_test = [] {
-      std::string buffer = R"({\"      \\\\\\\\\\\\[\\\\\\\\\\uuu\365uuu     \\\\\\\\\\\\[\\\\\\\\\\uuuuuuuuuuuuuuuuPuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu\\\\\\\"  @\000\000\\\\\"\"    $\000)";
-      glz::json_t json{};
-      expect(glz::read_json(json, buffer));
-   };
+   "invalid json_t read3"_test = [] {
+       glz::json_t json{};
+       auto blah = std::vector<char>{0x22, 0x5c, 0x75,char(0xff), 0x22, 0x00};
+       expect(glz::read_json(json, blah));
+    };
 };
 
 struct Sinks

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -7349,6 +7349,12 @@ suite address_sanitizer_test = [] {
       auto blah = std::vector<char>{0x22, 0x5c, char(0xff), 0x22, 0x00};
       expect(glz::read_json(json, blah));
    };
+   
+   "invalid json_t read"_test = [] {
+      std::string buffer = R"({\"      \\\\\\\\\\\\[\\\\\\\\\\uuu\365uuu     \\\\\\\\\\\\[\\\\\\\\\\uuuuuuuuuuuuuuuuPuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu\\\\\\\"  @\000\000\\\\\"\"    $\000)";
+      glz::json_t json{};
+      expect(glz::read_json(json, buffer));
+   };
 };
 
 struct Sinks


### PR DESCRIPTION
This adds fuzzing for selected parts of the json functionality.

# Motivation
## Security and untrusted input
Json parsing is often used on external and/or untrusted input. It is therefore important to make sure there are bugs such as out of bounds reads/writes, signed integer overflow or other kinds of UB that can be triggered. 
For this purpose, fuzzing is an excellent tool.

While developing this, a number of bugs have been revealed and promptly fixed.
- #1173 stack overflow
- #1189 out of bounds read
- #1185 out of bounds write
- #1176  out of bounds read
- #1172  out of bounds read
- #1170 out of bounds read
- #1167 out of bounds read
- #1175 memcpy on nullptr which is UB


## Correctness
This PR also adds roundtrip fuzzers, making sure data can be serialized and deserialized without change. 
While developing this several problems were found:
- #1183 roundrip failure for double
- #1178 incorrect conversion of float

# What this PR adds
## Json parser fuzzers
These are intended to cover the supposedly most common use cases and were
based on the examples in the README.
## Roundtrip fuzzers
These are for checking conversions do roundtrip.
## Exhaustive tests
For 32 bit types it is feasible to test all possible values. Such a test for conversion of integers has been added.
In a future extension, it would be good to also do this for 32 bit floating point.
## CI jobs
### Short-fuzz
A CI job is added that runs all the fuzzers for a short while. This is often sufficient to cover shallow bugs. Most of the problems uncovered while working with this took less than ten seconds to find. The job does not store the corpus between runs, that could be improved later if desired (using github action cache).
The output is only saved in case a fuzzer fails.
### Exhaustive
This CI job compiles without sanitizers and with full optimization, so it goes quick enough to run in CI. It uses all cores.

# Preventing code rot
The fuzzers have been arranged so they compile also on compilers not supporting libFuzzer. For those, a separate main function is provided. The fuzzers build by default, meaning api changes in glaze that break the fuzzers will not go undetected.

# What comes next
This could be improved in a number of ways, it is intended to be a small start in the spirit of having something usable now rather than perfect never. But here are possible improvements:
 - An oss-fuzz build script would make it possible to easily run with memory sanitizer.
 - Fuzz also the binary formats
 - replay fuzzdata on platforms not supporting libFuzzer.
 - storing the fuzz corpus between runs
 - adding a nightly fuzz job which allows to take longer time