### PR TITLE
Eliminated out-of-line definition of constexpr static data member

### DIFF
--- a/include/glaze/api/hash.hpp
+++ b/include/glaze/api/hash.hpp
@@ -77,10 +77,6 @@ namespace glz
          static constexpr type value{};
          static constexpr const std::string_view get() { return {value.data, num_digits(x)}; }
       };
-
-      /* instantiate numeric_string::value as needed for different numbers */
-      template <uint64_t x>
-      constexpr typename numeric_string<x>::type numeric_string<x>::value;
    }
 
    template <class T, T Value>


### PR DESCRIPTION
For the benefit of #1197 

fast_float is the primary culprit for this issue. I've raised an issue in that repository.