### PR TITLE
max_recursive_depth_limit for variants

### DIFF
--- a/include/glaze/core/context.hpp
+++ b/include/glaze/core/context.hpp
@@ -12,6 +12,8 @@
 
 namespace glz
 {
+   constexpr size_t max_recursive_depth_limit = 256;
+   
    GLZ_ENUM(error_code,
             none, //
             no_read_input, //
@@ -23,6 +25,7 @@ namespace glz
             expected_comma, //
             expected_colon, //
             exceeded_static_array_size, //
+            exceeded_max_recursive_depth, //
             unexpected_end, //
             expected_end_comment, //
             syntax_error, //
@@ -91,7 +94,9 @@ namespace glz
       error_code error{};
       std::string_view custom_error_message{};
       // INTERNAL USE:
-      uint32_t indentation_level{};
+      uint32_t indentation_level{}; // When writing this is the number of indent character to serialize
+      // When reading indentation_level is used to track the depth of structures to prevent stack overflows
+      // From massive depths due to untrusted inputs or attacks
       std::string current_file; // top level file path
       std::string_view includer_error{}; // error from a nested file includer
    };

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2538,6 +2538,12 @@ namespace glz
                   ctx.error = error_code::unexpected_end;
                   return;
                case '{':
+                     if (ctx.indentation_level >= max_recursive_depth_limit) {
+                        ctx.error = error_code::exceeded_max_recursive_depth;
+                        return;
+                     }
+                     ++ctx.indentation_level;
+                     
                   ++it;
                   using object_types = typename variant_types<T>::object_types;
                   if constexpr (glz::tuple_size_v<object_types> < 1) {
@@ -2598,6 +2604,8 @@ namespace glz
                                           }
                                        },
                                        value);
+                                    
+                                    --ctx.indentation_level;
                                     return; // we've decoded our target type
                                  }
                                  else {
@@ -2671,7 +2679,9 @@ namespace glz
                                  }
                               },
                               value);
-                           return;
+                           
+                           --ctx.indentation_level;
+                           return; // we've decoded our target type
                         }
                         parse_object_entry_sep<Opts>(ctx, it, end);
                         if (bool(ctx.error)) [[unlikely]]
@@ -2687,7 +2697,14 @@ namespace glz
                   break;
                case '[':
                   using array_types = typename variant_types<T>::array_types;
+                     
+                  if (ctx.indentation_level >= max_recursive_depth_limit) {
+                     ctx.error = error_code::exceeded_max_recursive_depth;
+                     return;
+                  }
+                  ++ctx.indentation_level;
                   process_arithmetic_boolean_string_or_array<array_types>::template op<Opts>(value, ctx, it, end);
+                  --ctx.indentation_level;
                   break;
                case '"': {
                   using string_types = typename variant_types<T>::string_types;

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -8896,6 +8896,25 @@ suite TestSettingsData_test = [] {
    };
 };
 
+suite depth_limits_test = [] {
+   // test to check for guard against stack overflow
+   "massive [ depth"_test = [] {
+      std::string buffer{};
+      buffer.insert(0, 4096, '[');
+      glz::json_t json{};
+      auto ec = glz::read_json(json, buffer);
+      expect(ec);
+   };
+   
+   "massive { depth"_test = [] {
+      std::string buffer{};
+      buffer.insert(0, 4096, '{');
+      glz::json_t json{};
+      auto ec = glz::read_json(json, buffer);
+      expect(ec);
+   };
+};
+
 int main()
 {
    trace.end("json_test");


### PR DESCRIPTION
This prevents stack overflows due to long chains of opening array and object characters when parsing `json_t`. It also prevents similar issues from nested `std::variant`. This would likely only occur from untrusted input and an intentional attack, but is now safely guarded.