### PR TITLE
Add exhaustive float testing and tighten float fuzzer for denormals

### DIFF
--- a/.github/workflows/exhaustive_float.yml
+++ b/.github/workflows/exhaustive_float.yml
@@ -1,0 +1,52 @@
+name: exhaustive float json tests
+
+on:
+  push:
+    branches:
+    - main
+    - feature/*
+    paths-ignore:
+    - '**.md'
+  pull_request:
+    branches: [main]
+    paths-ignore:
+    - '**.md'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        clang: [18]
+        build_type: [Release]
+        std: [23]
+
+    env:
+      CC: clang-${{matrix.clang}}
+      CXX: clang++-${{matrix.clang}}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Configure CMake
+      run: |
+        cmake -B ${{github.workspace}}/build \
+          -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
+          -DCMAKE_CXX_STANDARD=${{matrix.std}} \
+          -DCMAKE_C_COMPILER=${{env.CC}} \
+          -DCMAKE_CXX_COMPILER=${{env.CXX}} \
+          -DBUILD_TESTING=Off
+
+    - name: Build
+      run: cmake --build build -j $(nproc)
+
+    - name: Test
+      working-directory: build
+      run: |
+        set -e
+        fuzzing/json_exhaustive_roundtrip_float
+
+        echo all is OK!

--- a/.github/workflows/exhaustive_int.yml
+++ b/.github/workflows/exhaustive_int.yml
@@ -1,4 +1,4 @@
-name: exhaustive json tests
+name: exhaustive integer json tests
 
 on:
   push:
@@ -50,10 +50,4 @@ jobs:
         fuzzing/json_exhaustive_roundtrip_int
 
         echo all is OK!
-
-    - uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: fuzzing-artifacts
-        path: build/artifacts/
 

--- a/fuzzing/CMakeLists.txt
+++ b/fuzzing/CMakeLists.txt
@@ -62,3 +62,4 @@ macro(create_exhaustive_test testname)
 endmacro()
 
 create_exhaustive_test(json_exhaustive_roundtrip_int)
+create_exhaustive_test(json_exhaustive_roundtrip_float)

--- a/fuzzing/json_exhaustive_roundtrip_float.cpp
+++ b/fuzzing/json_exhaustive_roundtrip_float.cpp
@@ -1,0 +1,83 @@
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <future>
+#include <glaze/glaze.hpp>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+// must be outside test(), compilation fails on gcc 13 otherwise
+struct Value
+{
+   // use a short name to reduce the number of characters written
+   float v;
+};
+
+void test()
+{
+   using UT = std::uint32_t;
+   static_assert(sizeof(float) == sizeof(UT));
+
+   auto test_one_value = [](const UT loopvar, auto& outbuf) {
+      Value s;
+      std::memcpy(&s.v, &loopvar, sizeof(float));
+
+      if (!std::isfinite(s.v)) {
+         return;
+      }
+
+      outbuf.clear();
+      const auto writeec = glz::write_json(s, outbuf);
+
+      if (writeec) [[unlikely]] {
+         std::cerr << "failed writing " << s.v << " to json\n";
+         std::abort();
+      }
+
+      auto restored = glz::read_json<Value>(outbuf);
+      if (!restored) [[unlikely]] {
+         std::cerr << "failed parsing " << outbuf << '\n';
+         std::abort();
+      }
+
+      if (const auto r = restored.value().v; r != s.v) [[unlikely]] {
+         std::cerr << "failed roundtrip, got " << r << " instead of " << s.v << //
+            " (diff is " << r - s.v << ") when parsing " << outbuf << '\n';
+         std::abort();
+      }
+   };
+
+   auto test_all_in_range = [&](const UT start, const UT stop) {
+      std::string outbuf;
+      for (UT i = start; i < stop; ++i) {
+         test_one_value(i, outbuf);
+      }
+   };
+
+   const auto nthreads = std::thread::hardware_concurrency();
+   const UT step = std::numeric_limits<UT>::max() / nthreads;
+
+   std::vector<std::thread> threads;
+   threads.reserve(nthreads);
+   for (int threadi = 0; threadi < nthreads; ++threadi) {
+      const UT start = threadi * step;
+      const UT stop = (threadi == nthreads - 1) ? std::numeric_limits<UT>::max() : start + step;
+      // std::cout << "thread i=" << threadi << " goes from " << start << " to " << stop << '\n';
+      threads.emplace_back(test_all_in_range, start, stop);
+   }
+   // test the last value here.
+   {
+      std::string buf;
+      test_one_value(std::numeric_limits<UT>::max(), buf);
+   }
+
+   std::cout << "started testing in " << nthreads << " threads." << std::endl;
+   for (auto& t : threads) {
+      t.join();
+   }
+   std::cout << "tested " << std::numeric_limits<UT>::max() << " values of float" << std::endl;
+}
+
+int main(int argc, char* argv[]) { test(); }

--- a/fuzzing/json_exhaustive_roundtrip_int.cpp
+++ b/fuzzing/json_exhaustive_roundtrip_int.cpp
@@ -2,7 +2,6 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
-#include <future>
 #include <glaze/glaze.hpp>
 #include <iostream>
 #include <thread>
@@ -56,13 +55,14 @@ void test()
    const auto nthreads = std::thread::hardware_concurrency();
    const UT step = std::numeric_limits<UT>::max() / nthreads;
 
-   std::vector<std::future<void>> futures;
-   futures.reserve(nthreads);
+   // can't use jthread, does not exist in all stdlibs.
+   std::vector<std::thread> threads;
+   threads.reserve(nthreads);
    for (int threadi = 0; threadi < nthreads; ++threadi) {
       const UT start = threadi * step;
       const UT stop = (threadi == nthreads - 1) ? std::numeric_limits<UT>::max() : start + step;
       // std::cout << "thread i=" << threadi << " goes from " << start << " to " << stop << '\n';
-      futures.emplace_back(std::async(testrange, start, stop));
+      threads.emplace_back(testrange, start, stop);
    }
    // test the last value here.
    {
@@ -71,7 +71,9 @@ void test()
    }
 
    std::cout << "started testing in " << nthreads << " threads." << std::endl;
-   futures.clear();
+   for (auto& t : threads) {
+      t.join();
+   }
    std::cout << "tested " << std::numeric_limits<UT>::max() << " values of " << (std::is_unsigned_v<T> ? "un" : "")
              << "signed type of size " << sizeof(T) << std::endl;
 }

--- a/fuzzing/json_roundtrip_floating.cpp
+++ b/fuzzing/json_roundtrip_floating.cpp
@@ -29,14 +29,7 @@ void test(const uint8_t* Data, size_t Size)
       auto str = glz::write_json(s).value_or(std::string{});
       auto restored = glz::read_json<S>(str);
       assert(restored);
-
-      if (std::abs(s.value) < std::numeric_limits<T>::min()) {
-         // a denormalized value - check that it is close enough to zero.
-         assert(std::abs(restored.value().value) < std::numeric_limits<T>::min());
-      }
-      else {
-         assert(restored.value().value == s.value);
-      }
+      assert(restored.value().value == s.value);
    }
 }
 

--- a/include/glaze/util/inline.hpp
+++ b/include/glaze/util/inline.hpp
@@ -19,7 +19,7 @@
 #define GLZ_ALWAYS_INLINE inline
 #endif
 
-// IMPORTNAT: GLZ_FLATTEN should only be used with extreme care
+// IMPORTANT: GLZ_FLATTEN should only be used with extreme care
 // It often adds to the binary size and greatly increases compilation times.
 // It should only be applied in very specific circumstances.
 // It is best to more often rely on the compiler.


### PR DESCRIPTION
This adds an exhaustive test for roundtripping floats.
It takes around one cpu hour running with sanitizers, about five cpu minutes without. CI runners have four cores, so it takes a minute or two to run.

Since the floating point serializer was changed to one that roundtrips denormal numbers, I tightened the check in the existing fuzzer. It is good to lock in that improvement.

I also fixed a tiny spelling error and changed std::async to std::thread since async did not behave well on one of my machines, it got stuck for a minute or so without any reason.