### PR TITLE
Fix handle_unicode_code_point for null character out of buffer read

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -751,7 +751,7 @@ namespace glz
                         ++start;
                         p += next;
                         const auto mark = start;
-                        const auto offset = handle_unicode_code_point(start, p);
+                        const auto offset = handle_unicode_code_point(start, p, end);
                         if (offset == 0) [[unlikely]] {
                            ctx.error = error_code::unicode_escape_conversion_failure;
                            return;
@@ -908,7 +908,7 @@ namespace glz
                               ++start;
                               p += next;
                               const auto mark = start;
-                              const auto offset = handle_unicode_code_point(start, p);
+                              const auto offset = handle_unicode_code_point(start, p, end);
                               if (offset == 0) [[unlikely]] {
                                  ctx.error = error_code::unicode_escape_conversion_failure;
                                  return;

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -7370,6 +7370,13 @@ suite address_sanitizer_test = [] {
       auto r = glz::read_json(json, data);
       expect(r);
    };
+   
+   "invalid json_t 4"_test = []() {
+         glz::json_t json{};
+         std::string data = "\"\\uDBDD\" DDDD";
+         auto r = glz::read_json(json, data);
+         expect(r);
+      };
 };
 
 struct Sinks


### PR DESCRIPTION
I hadn't considered how null values would be valid hex digits, and thus we must check against the `end` iterator.