### PR TITLE
Added missing check for surrogate unicode pair parsing

### DIFF
--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -241,6 +241,10 @@ namespace glz::detail
       dst += offset;
       return offset;
    }
+   
+   consteval uint16_t to_uint16_t(const char chars[2]) {
+      return uint16_t(chars[0]) | (uint16_t(chars[1]) << 8);
+   }
 
    template <class Char>
    [[nodiscard]] GLZ_ALWAYS_INLINE uint32_t handle_unicode_code_point(const Char*& it, Char*& dst,
@@ -266,6 +270,12 @@ namespace glz::detail
          }
 
          if (it + 6 >= end) [[unlikely]] {
+            return false;
+         }
+         // The next two characters must be `\u`
+         uint16_t u;
+         std::memcpy(&u, it, 2);
+         if (u != to_uint16_t(R"(\u)")) [[unlikely]] {
             return false;
          }
          it += 2;

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -7355,6 +7355,13 @@ struct glz::meta<string_tester>
    static constexpr auto value = object("val1", &T::val1);
 };
 
+template <size_t N>
+std::vector<char> make_vector(const char (&literal)[N])
+{
+   // include the null
+   return {literal, literal + N};
+};
+
 // Former address santizer issues
 suite address_sanitizer_test = [] {
    "address_sanitizer"_test = [] {
@@ -7398,9 +7405,16 @@ suite address_sanitizer_test = [] {
       expect(r);
    };
 
-   "invalid json_t 4"_test = []() {
+   "json_t 4"_test = []() {
       glz::json_t json{};
       std::string data = "\"\\uDBDD\" DDDD";
+      auto r = glz::read_json(json, data);
+      expect(r);
+   };
+   
+   "json_t 5"_test = []() {
+      glz::json_t json{};
+      auto data = make_vector("\"\\udb0f \"df33 ");
       auto r = glz::read_json(json, data);
       expect(r);
    };


### PR DESCRIPTION
There was a missing check for `\u` in the unicode surrogate pair parsing logic.