### PR TITLE
Fix rare thread pool hanging for extremely short tasks

### DIFF
--- a/include/glaze/thread/threadpool.hpp
+++ b/include/glaze/thread/threadpool.hpp
@@ -50,7 +50,10 @@ namespace glz
 
                      // Notify that work is finished
                      --working;
-                     done_cv.notify_one();
+                     lock.lock();
+                     if (queue.empty() && (working == 0)) {
+                        done_cv.notify_one();
+                     }
                   }
                }
             });
@@ -152,7 +155,7 @@ namespace glz
       {
          std::unique_lock lock(mtx);
          if (queue.empty() && (working == 0)) return;
-         done_cv.wait(lock, [&] { return queue.empty() && (working == 0); });
+         done_cv.wait(lock);
       }
 
       size_t size() const { return threads.size(); }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -2750,7 +2750,7 @@ struct glz::meta<study_obj>
 };
 
 // TODO: Figure out why the thread pool can randomly hang, especially on Windows GitHub actions
-/*suite study_tests = [] {
+suite study_tests = [] {
    "study"_test = [] {
       glz::study::design design;
       design.params = {{.ptr = "/x", .distribution = "linspace", .range = {"0", "1", "10"}}};
@@ -2850,7 +2850,7 @@ suite thread_pool = [] {
 
       expect(numbers.size() == 1000);
    };
-};*/
+};
 
 suite progress_bar_tests = [] {
    "progress bar 30%"_test = [] {


### PR DESCRIPTION
For tasks like adding an integer the thread pool could hang on `wait` because it would check the condition while multiple notify calls to the condition variable were made. This makes the error an impossibility because now only one thread can send a notify signal at a time.