### PR TITLE
add integration with oss fuzz

### DIFF
--- a/fuzzing/ossfuzz.sh
+++ b/fuzzing/ossfuzz.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# this is the entry point for build.sh on oss fuzz, so that changes in how to
+# build the fuzzers does not require changes in oss fuzz but instead can
+# be done in the glaze repository.
+
+set -eux
+
+$CXX --version
+
+for SRCFILE in $(ls fuzzing/*.cpp |grep -v -E '(exhaustive|main\.cpp)'); do
+    NAME=$(basename $SRCFILE .cpp)
+    $CXX $CXXFLAGS -std=c++23 -g -Iinclude \
+         $SRCFILE -o $OUT/$NAME \
+         $LIB_FUZZING_ENGINE
+done


### PR DESCRIPTION
[oss fuzz](https://google.github.io/oss-fuzz/ ) is a great project. They fuzz with different sanitizers and fuzzers with a lot of cpu power. Also, their automated handling of minimization and bug filing is very helpful.

I added integration to it mostly to be able to easily run memory sanitizer. That is useful on it's own.

If you agree, I will make a request on oss fuzz to accept glaze.

Here is a [draft branch](https://github.com/pauldreik/oss-fuzz/tree/glaze) I speculatively put your email there, let me know if you want any changes.

There is not much more work to be expected, once it works (and I expect it to, since this is header only) it  usually just runs.