### PR TITLE
change internal linkage on header constants to external

### DIFF
--- a/docs/rpc/json-rpc.md
+++ b/docs/rpc/json-rpc.md
@@ -74,7 +74,7 @@ int main() {
     // you can assign timeout for the request in your event loop
     auto timeout = [uuid, &client]() {
         decltype(auto) map = client.get_request_map<"foo">();
-        if (map.contains(uuid));
+        if (map.contains(uuid))
             map.erase(uuid);
     };
     timeout();

--- a/examples/json-rpc.cpp
+++ b/examples/json-rpc.cpp
@@ -70,8 +70,7 @@ int main()
    auto timeout = [uuid, &client]() {
       decltype(auto) map = client.get_request_map<"foo">();
       if (map.contains(uuid))
-         ;
-      map.erase(uuid);
+         map.erase(uuid);
    };
 #if 0
    // caling timeout would cause to not process response

--- a/include/glaze/reflection/get_name.hpp
+++ b/include/glaze/reflection/get_name.hpp
@@ -90,7 +90,7 @@ namespace glz
    };
 
    template <auto N, class T>
-   constexpr auto member_nameof = []() constexpr { return member_nameof_impl<N, T>::stripped_literal; }();
+   inline constexpr auto member_nameof = []() constexpr { return member_nameof_impl<N, T>::stripped_literal; }();
 
    template <class T>
    constexpr auto type_name = [] {

--- a/include/glaze/util/string_literal.hpp
+++ b/include/glaze/util/string_literal.hpp
@@ -46,10 +46,10 @@ namespace glz
    }
 
    template <string_literal Str>
-   constexpr std::string_view chars = Str.sv();
+   inline constexpr std::string_view chars = Str.sv();
 
    template <string_literal Str>
-   constexpr std::string_view root = Str.sv();
+   inline constexpr std::string_view root = Str.sv();
 
    namespace detail
    {
@@ -79,5 +79,5 @@ namespace glz
 
    // Helper to get the value out
    template <const std::string_view&... Strs>
-   constexpr auto join_v = detail::join<Strs...>();
+   inline constexpr auto join_v = detail::join<Strs...>();
 }


### PR DESCRIPTION
- changing linkage on header constants to external as internal causes warnings
- also fix invalid comma in example