### PR TITLE
Fix nested includer buffer issue

### DIFF
--- a/include/glaze/file/hostname_include.hpp
+++ b/include/glaze/file/hostname_include.hpp
@@ -89,7 +89,7 @@ namespace glz
          static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
             constexpr auto Opts = ws_handled_off<Options>();
-            std::string& buffer = string_buffer();
+            std::string buffer{};
             read<json>::op<Opts>(buffer, ctx, it, end);
             if (bool(ctx.error)) [[unlikely]]
                return;

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -35,6 +35,7 @@ namespace glz
    {
       // Unless we can mutate the input buffer we need somewhere to store escaped strings for key lookup, etc.
       // We don't put this in the context because we don't want to continually reallocate.
+      // IMPORTANT: Do not call use this when nested calls may be made that need additional buffers on the same thread.
       inline std::string& string_buffer() noexcept
       {
          static thread_local std::string buffer(256, '\0');
@@ -1700,7 +1701,7 @@ namespace glz
          static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
          {
             constexpr auto Opts = ws_handled_off<Options>();
-            std::string& buffer = string_buffer();
+            std::string buffer{};
             read<json>::op<Opts>(buffer, ctx, it, end);
             if (bool(ctx.error)) [[unlikely]]
                return;

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -7219,6 +7219,43 @@ suite hostname_include_test = [] {
    };
 };
 
+struct core_struct
+{
+   glz::file_include include{};
+   float number{3.14f};
+};
+
+struct nested_include_struct
+{
+   glz::hostname_include hostname_include{};
+   std::string str = "Hello";
+   int integer = 55;
+   core_struct core{};
+};
+
+suite nested_include_tests = [] {
+   "nested_include"_test = [] {
+      expect(glz::error_code::none == glz::buffer_to_file(std::string_view{R"({"number":3.5})"}, "./core.jsonc"));
+      
+      glz::context ctx{};
+      const auto hostname = glz::detail::get_hostname(ctx);
+
+      std::string file_name = "./{}_include_test.jsonc";
+      glz::detail::replace_first_braces(file_name, hostname);
+      expect(glz::error_code::none == glz::buffer_to_file(std::string_view{R"({"core":{"include": "./core.jsonc"}})"}, file_name));
+
+      expect(glz::error_code::none == glz::buffer_to_file(std::string_view{R"({"str":"goodbye","integer":4,"hostname_include":"./{}_include_test.jsonc"})"}, "./start.jsonc"));
+      
+      nested_include_struct obj{};
+      std::string buffer{};
+      auto ec = glz::read_file_jsonc(obj, "./start.jsonc", buffer);
+      expect(not ec) << glz::format_error(ec, buffer);
+      expect(obj.str == "goodbye");
+      expect(obj.integer = 4);
+      expect(obj.core.number == 3.5f);
+   };
+};
+
 enum class some_enum {
    first,
    second,


### PR DESCRIPTION
If includers were nested then the `string_buffer` would be manipulated by nested calls to includers while parsing higher level includes. This corrupted memory and could result in all kinds of bugs. This has been fixed to allocate a std::string for includers to allow nesting.