### PR TITLE
Binary (BEVE) support for non-null terminated buffers

### DIFF
--- a/include/glaze/binary/beve_to_json.hpp
+++ b/include/glaze/binary/beve_to_json.hpp
@@ -130,6 +130,7 @@ namespace glz
          case tag::string: {
             ++it;
             const auto n = detail::int_from_compressed(ctx, it, end);
+            GLZ_N_CHECK();
             const sv value{reinterpret_cast<const char*>(it), n};
             to_json<sv>::template op<Opts>(value, ctx, out, ix);
             it += n;
@@ -150,9 +151,14 @@ namespace glz
             case 0: {
                // string key
                const auto n_fields = detail::int_from_compressed(ctx, it, end);
+               if (n_fields == std::numeric_limits<uint64_t>::max()) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
                for (size_t i = 0; i < n_fields; ++i) {
                   // convert the key
                   const auto n = detail::int_from_compressed(ctx, it, end);
+                  GLZ_N_CHECK();
                   const sv key{reinterpret_cast<const char*>(it), n};
                   to_json<sv>::template op<Opts>(key, ctx, out, ix);
                   if constexpr (Opts.prettify) {

--- a/include/glaze/binary/header.hpp
+++ b/include/glaze/binary/header.hpp
@@ -13,6 +13,18 @@
 #include "glaze/core/context.hpp"
 #include "glaze/util/inline.hpp"
 
+#define GLZ_END_CHECK(RETURN) \
+if (it >= end) [[unlikely]] { \
+   ctx.error = error_code::unexpected_end; \
+   return RETURN; \
+}
+
+#define GLZ_N_CHECK(RETURN) \
+if ((it + n) >= end) [[unlikely]] { \
+   ctx.error = error_code::unexpected_end; \
+   return RETURN; \
+}
+
 namespace glz::tag
 {
    constexpr uint8_t null = 0;
@@ -51,18 +63,25 @@ namespace glz::detail
    template <class T>
    constexpr uint8_t byte_count = uint8_t(std::bit_width(sizeof(T)) - 1);
 
-   constexpr std::array<uint8_t, 8> byte_count_lookup{1, 2, 4, 8, 16, 32, 64, 128};
+   inline constexpr std::array<uint8_t, 8> byte_count_lookup{1, 2, 4, 8, 16, 32, 64, 128};
+   
+   inline constexpr uint64_t beve_invalid = (std::numeric_limits<uint64_t>::max)();
 
-   [[nodiscard]] GLZ_ALWAYS_INLINE constexpr size_t int_from_compressed(is_context auto&& ctx, auto&& it,
+   // Instead of setting an error context, which would require us to both check the context and if
+   // our increment would go beyond the end, we instead return the max uint64_t as the error condition
+   [[nodiscard]] GLZ_ALWAYS_INLINE constexpr uint64_t int_from_compressed(auto&& it,
                                                                         auto&& end) noexcept
    {
+      if (it >= end) [[unlikely]] {
+         return beve_invalid;
+      }
+      
       uint8_t header;
       std::memcpy(&header, it, 1);
       const uint8_t config = header & 0b000000'11;
 
       if ((it + byte_count_lookup[config]) > end) [[unlikely]] {
-         ctx.error = error_code::unexpected_end;
-         return 0;
+         return beve_invalid;
       }
 
       switch (config) {
@@ -94,6 +113,8 @@ namespace glz::detail
 
    GLZ_ALWAYS_INLINE constexpr void skip_compressed_int(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
+      GLZ_END_CHECK();
+      
       uint8_t header;
       std::memcpy(&header, it, 1);
       const uint8_t config = header & 0b000000'11;

--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -158,7 +158,7 @@ namespace glz
             constexpr auto Length = byte_length<T>();
             uint8_t data[Length];
 
-            if ((it + Length) >= end) [[unlikely]] {
+            if ((it + Length) > end) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return;
             }
@@ -199,7 +199,7 @@ namespace glz
                      }
 
                      auto decode = [&](auto&& i) {
-                        if ((it + sizeof(i)) >= end) [[unlikely]] {
+                        if ((it + sizeof(i)) > end) [[unlikely]] {
                            ctx.error = error_code::unexpected_end;
                            return;
                         }
@@ -266,7 +266,7 @@ namespace glz
                }
             }
             
-            if ((it + sizeof(V)) >= end) [[unlikely]] {
+            if ((it + sizeof(V)) > end) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return;
             }
@@ -303,7 +303,7 @@ namespace glz
             using V = std::underlying_type_t<std::decay_t<T>>;
 
             if constexpr (has_no_header(Opts)) {
-               if ((it + sizeof(V)) >= end) [[unlikely]] {
+               if ((it + sizeof(V)) > end) [[unlikely]] {
                   ctx.error = error_code::unexpected_end;
                   return;
                }
@@ -324,7 +324,7 @@ namespace glz
                }
 
                ++it;
-               if ((it + sizeof(V)) >= end) [[unlikely]] {
+               if ((it + sizeof(V)) > end) [[unlikely]] {
                   ctx.error = error_code::unexpected_end;
                   return;
                }
@@ -344,7 +344,7 @@ namespace glz
          {
             if constexpr (has_no_header(Opts)) {
                using V = std::decay_t<T>;
-               if ((it + sizeof(V)) >= end) [[unlikely]] {
+               if ((it + sizeof(V)) > end) [[unlikely]] {
                   ctx.error = error_code::unexpected_end;
                   return;
                }
@@ -377,7 +377,7 @@ namespace glz
                }
                ++it;
                
-               if ((it + 2 * sizeof(V)) >= end) [[unlikely]] {
+               if ((it + 2 * sizeof(V)) > end) [[unlikely]] {
                   ctx.error = error_code::unexpected_end;
                   return;
                }
@@ -590,7 +590,7 @@ namespace glz
                value.clear();
 
                for (size_t i = 0; i < n; ++i) {
-                  if ((it + sizeof(V)) >= end) [[unlikely]] {
+                  if ((it + sizeof(V)) > end) [[unlikely]] {
                      ctx.error = error_code::unexpected_end;
                      return;
                   }
@@ -789,7 +789,7 @@ namespace glz
                   if constexpr (is_volatile) {
                      V temp;
                      for (size_t i = 0; i < n; ++i) {
-                        if ((it + sizeof(V)) >= end) [[unlikely]] {
+                        if ((it + sizeof(V)) > end) [[unlikely]] {
                            ctx.error = error_code::unexpected_end;
                            return;
                         }
@@ -800,7 +800,7 @@ namespace glz
                      }
                   }
                   else {
-                     if ((it + n * sizeof(V)) >= end) [[unlikely]] {
+                     if ((it + n * sizeof(V)) > end) [[unlikely]] {
                         ctx.error = error_code::unexpected_end;
                         return;
                      }
@@ -810,7 +810,7 @@ namespace glz
                }
                else {
                   for (auto&& x : value) {
-                     if ((it + sizeof(V)) >= end) [[unlikely]] {
+                     if ((it + sizeof(V)) > end) [[unlikely]] {
                         ctx.error = error_code::unexpected_end;
                         return;
                      }

--- a/include/glaze/binary/skip.hpp
+++ b/include/glaze/binary/skip.hpp
@@ -21,32 +21,50 @@ namespace glz::detail
       if (bool(ctx.error)) [[unlikely]] {
          return;
       }
+      if (uint64_t(end - it) < n) [[unlikely]] {
+         ctx.error = error_code::unexpected_end;
+         return;
+      }
       it += n;
    }
 
-   inline void skip_number_binary(is_context auto&&, auto&& it, auto&&) noexcept
+   inline void skip_number_binary(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       const auto tag = uint8_t(*it);
       const uint8_t byte_count = byte_count_lookup[tag >> 5];
       ++it;
+      if ((it + byte_count) >= end) [[unlikely]] {
+         ctx.error = error_code::unexpected_end;
+         return;
+      }
       it += byte_count;
    }
 
    template <opts Opts>
    inline void skip_object_binary(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
+      GLZ_END_CHECK();
       const auto tag = uint8_t(*it);
       ++it;
 
       const auto n_keys = int_from_compressed(ctx, it, end);
+      if (bool(ctx.error)) [[unlikely]] {
+         return;
+      }
 
       if ((tag & 0b00000'111) == tag::string) {
          for (size_t i = 0; i < n_keys; ++i) {
             const auto string_length = int_from_compressed(ctx, it, end);
-            it += string_length;
-            if (bool(ctx.error)) [[unlikely]]
+            if (bool(ctx.error)) [[unlikely]] {
                return;
-
+            }
+            if (uint64_t(end - it) < string_length) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+            
+            it += string_length;
+            
             skip_value_binary<Opts>(ctx, it, end);
             if (bool(ctx.error)) [[unlikely]]
                return;
@@ -56,9 +74,15 @@ namespace glz::detail
          const uint8_t byte_count = byte_count_lookup[tag >> 5];
          for (size_t i = 0; i < n_keys; ++i) {
             const auto n = int_from_compressed(ctx, it, end);
-            it += byte_count * n;
-            if (bool(ctx.error)) [[unlikely]]
+            if (bool(ctx.error)) [[unlikely]] {
                return;
+            }
+            if (uint64_t(end - it) < byte_count * n) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+            
+            it += byte_count * n;
 
             skip_value_binary<Opts>(ctx, it, end);
             if (bool(ctx.error)) [[unlikely]]
@@ -82,7 +106,14 @@ namespace glz::detail
       case 2: { // unsigned integer
          ++it;
          const auto n = int_from_compressed(ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
          const uint8_t byte_count = byte_count_lookup[tag >> 5];
+         if (uint64_t(end - it) < byte_count * n) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return;
+         }
          it += byte_count * n;
          break;
       }
@@ -91,11 +122,27 @@ namespace glz::detail
          ++it;
          if (is_bool) {
             const auto n = int_from_compressed(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            
             const auto num_bytes = (n + 7) / 8;
+            if (uint64_t(end - it) < num_bytes) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
             it += num_bytes;
          }
          else {
             const auto n = int_from_compressed(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            if (uint64_t(end - it) < n) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+            
             it += n;
          }
          break;
@@ -110,6 +157,10 @@ namespace glz::detail
    {
       ++it;
       const auto n = int_from_compressed(ctx, it, end);
+      if (bool(ctx.error)) [[unlikely]] {
+         return;
+      }
+      
       for (size_t i = 0; i < n; ++i) {
          skip_value_binary<Opts>(ctx, it, end);
       }
@@ -125,6 +176,7 @@ namespace glz::detail
    template <opts Opts>
    inline void skip_value_binary(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
+      GLZ_END_CHECK();
       switch (uint8_t(*it) & 0b00000'111) {
       case tag::null: {
          ++it;

--- a/include/glaze/binary/skip.hpp
+++ b/include/glaze/binary/skip.hpp
@@ -33,7 +33,7 @@ namespace glz::detail
       const auto tag = uint8_t(*it);
       const uint8_t byte_count = byte_count_lookup[tag >> 5];
       ++it;
-      if ((it + byte_count) >= end) [[unlikely]] {
+      if ((it + byte_count) > end) [[unlikely]] {
          ctx.error = error_code::unexpected_end;
          return;
       }

--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -1160,6 +1160,9 @@ namespace glz::repe
                ++b; // skip the tag
                const auto n = glz::detail::int_from_compressed(ctx, b, e);
                if (bool(ctx.error) || (n != 2)) [[unlikely]] {
+                  if (n != 2) [[unlikely]] {
+                     ctx.error = error_code::syntax_error;
+                  }
                   handle_error(b);
                   return finish();
                }


### PR DESCRIPTION
For BEVE handling we combine our error handling with our non-null terminated handling. So, for BEVE we don't care whether a buffer is null terminated anymore, we just always handle the data as if it is not, because we wouldn't get significant performance improvements like we do with JSON, because null character is valid binary so we can't make decisions on this value.