### PR TITLE
Improve 32-bit support

### DIFF
--- a/.github/workflows/gcc-x86.yml
+++ b/.github/workflows/gcc-x86.yml
@@ -1,0 +1,45 @@
+name: gcc-x86
+
+on:
+   push:
+      branches:
+         - main
+         - feature/*
+      paths-ignore:
+         - "**.md"
+   pull_request:
+      branches: [main]
+      paths-ignore:
+         - "**.md"
+   workflow_dispatch:
+
+jobs:
+   build:
+      runs-on: ubuntu-24.04
+
+      strategy:
+         fail-fast: false
+         matrix:
+            gcc: [12, 13, 14]
+            build_type: [Debug]
+            std: [23]
+
+      env:
+         CC: gcc-${{matrix.gcc}}
+         CXX: g++-${{matrix.gcc}}
+
+      steps:
+         - uses: actions/checkout@v4
+
+         - name: Setup environment
+           run: |
+              sudo apt update
+              sudo apt-get install -y gcc-${{matrix.gcc}}-multilib g++-${{matrix.gcc}}-multilib libc6-dev-i386
+         - name: Configure CMake
+           run: |
+              CXXFLAGS="-g3 -m32" cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DCMAKE_CXX_STANDARD=${{matrix.std}}
+         - name: Build
+           run: cmake --build build -j $(nproc)
+
+         - name: Test
+           run: ctest --output-on-failure --test-dir ${{github.workspace}}/build

--- a/include/glaze/core/refl.hpp
+++ b/include/glaze/core/refl.hpp
@@ -1077,8 +1077,8 @@ namespace glz::detail
    }
 
    // Do not call this at runtime, it is assumes the key lies within min_length and max_length
-   inline constexpr size_t full_hash_impl(const sv key, const uint64_t seed, const auto min_length,
-                                          const auto max_length) noexcept
+   inline constexpr uint64_t full_hash_impl(const sv key, const uint64_t seed, const auto min_length,
+                                            const auto max_length) noexcept
    {
       if (max_length < 8) {
          return bitmix(to_uint64_n_below_8(key.data(), key.size()), seed);
@@ -1113,8 +1113,8 @@ namespace glz::detail
    }
 
    // runtime full hash algorithm
-   template <size_t min_length, size_t max_length, size_t seed>
-   inline constexpr size_t full_hash(const auto* it, const size_t n) noexcept
+   template <uint64_t min_length, uint64_t max_length, uint64_t seed>
+   inline constexpr uint64_t full_hash(const auto* it, const size_t n) noexcept
    {
       if constexpr (max_length < 8) {
          if (n > 7) {

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -204,7 +204,12 @@ void tests()
 
    "span type name"_test = [] {
       std::string_view s = glz::name_v<std::span<double>>;
-      expect(s == "std::span<double,18446744073709551615>");
+      if constexpr (sizeof(size_t) == sizeof(uint64_t)) {
+         expect(s == "std::span<double,18446744073709551615>");
+      }
+      else if constexpr (sizeof(size_t) == sizeof(uint32_t)) {
+         expect(s == "std::span<double,4294967295>");
+      }
    };
 
    "tuple type name"_test = [] {

--- a/tests/lib_test/lib_test.cpp
+++ b/tests/lib_test/lib_test.cpp
@@ -81,7 +81,12 @@ void tests()
 
    "span type name"_test = [] {
       std::string_view s = glz::name_v<std::span<double>>;
-      expect(s == "std::span<double,18446744073709551615>");
+      if constexpr (sizeof(size_t) == sizeof(uint64_t)) {
+         expect(s == "std::span<double,18446744073709551615>");
+      }
+      else if constexpr (sizeof(size_t) == sizeof(uint32_t)) {
+         expect(s == "std::span<double,4294967295>");
+      }
    };
 
    "my_api type io"_test = [&] {


### PR DESCRIPTION
- Added x86 GCC runner. It's based on existing GCC runner with minor changes, so it runs for GCC versions supported by glaze (12, 13, 14)
- Minor fixes were made to allow building 32-bit version of glaze, which includes small tests adjustments and some minor changes like disabled decompression of large (`> size_t`) integers

These changes may potentially affect users of binary json with 32-bit systems (because of change in `int_from_compressed`, which otherwise caused compilation errors). Other than that, no one should be hurt :)

Fixes #1277 