### PR TITLE
Fixed error propagation in beve_to_json

### DIFF
--- a/include/glaze/binary/beve_to_json.hpp
+++ b/include/glaze/binary/beve_to_json.hpp
@@ -370,6 +370,9 @@ namespace glz
             dump<'['>(out, ix);
             for (size_t i = 0; i < n; ++i) {
                beve_to_json_value<Opts>(ctx, it, end, out, ix);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
                if (i != n - 1) {
                   dump<','>(out, ix);
                }

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -2304,6 +2304,14 @@ suite past_fuzzing_issues = [] {
       std::string json{};
       expect(glz::beve_to_json(input, json));
    };
+   
+   "fuzz7"_test = [] {
+      std::string_view base64 = "VSYAAGUAPdJVPdI=";
+      std::vector<uint8_t> input = base64_decode(base64);
+      expect(glz::read_binary<my_struct>(input).error());
+      std::string json{};
+      expect(glz::beve_to_json(input, json));
+   };
 };
 
 int main()


### PR DESCRIPTION
Errors in array parsing were not properly short-circuiting and propagating up.