### PR TITLE
Fixed asio_server threading and reworking registry lock logic

### DIFF
--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -822,12 +822,6 @@ namespace glz::repe
                if constexpr (std::same_as<Result, void>) {
                   methods[full_key] = [callback = func, chain = get_chain(full_key)](repe::state&& state) mutable {
                      {
-                        chain_invoke_lock lock{chain};
-                        if (not lock) {
-                           state.error = {error_e::timeout, std::string(full_key)};
-                           write_response<Opts>(state);
-                           return;
-                        }
                         callback();
                         if (state.header.notify) {
                            return;
@@ -839,12 +833,6 @@ namespace glz::repe
                else {
                   methods[full_key] = [callback = func, chain = get_chain(full_key)](repe::state&& state) mutable {
                      {
-                        chain_invoke_lock lock{chain};
-                        if (not lock) {
-                           state.error = {error_e::timeout, std::string(full_key)};
-                           write_response<Opts>(state);
-                           return;
-                        }
                         if (state.header.notify) {
                            std::ignore = callback();
                            return;
@@ -870,13 +858,6 @@ namespace glz::repe
                   }
 
                   {
-                     chain_invoke_lock lock{chain};
-                     if (not lock) {
-                        state.error = {error_e::timeout, std::string(full_key)};
-                        write_response<Opts>(state);
-                        return;
-                     }
-
                      if (state.header.notify) {
                         std::ignore = callback(params);
                         return;
@@ -965,12 +946,6 @@ namespace glz::repe
                      if constexpr (n_args == 0) {
                         methods[full_key] = [&value, &func, chain = get_chain(full_key)](repe::state&& state) mutable {
                            {
-                              chain_invoke_lock lock{chain};
-                              if (not lock) {
-                                 state.error = {error_e::timeout, std::string(full_key)};
-                                 write_response<Opts>(state);
-                                 return;
-                              }
                               (value.*func)();
                            }
 
@@ -993,12 +968,6 @@ namespace glz::repe
                            }
 
                            {
-                              chain_invoke_lock lock{chain};
-                              if (not lock) {
-                                 state.error = {error_e::timeout, std::string(full_key)};
-                                 write_response<Opts>(state);
-                                 return;
-                              }
                               (value.*func)(input);
                            }
 
@@ -1020,13 +989,6 @@ namespace glz::repe
                         methods[full_key] = [&value, &func, chain = get_chain(full_key)](repe::state&& state) mutable {
                            // using Result = std::decay_t<decltype((value.*func)())>;
                            {
-                              chain_invoke_lock lock{chain};
-                              if (not lock) {
-                                 state.error = {error_e::timeout, std::string(full_key)};
-                                 write_response<Opts>(state);
-                                 return;
-                              }
-
                               if (state.header.notify) {
                                  std::ignore = (value.*func)();
                                  return;
@@ -1050,13 +1012,6 @@ namespace glz::repe
 
                            // using Result = std::decay_t<decltype((value.*func)(input))>;
                            {
-                              chain_invoke_lock lock{chain};
-                              if (not lock) {
-                                 state.error = {error_e::timeout, std::string(full_key)};
-                                 write_response<Opts>(state);
-                                 return;
-                              }
-
                               if (state.header.notify) {
                                  std::ignore = (value.*func)(input);
                                  return;

--- a/tests/asio_repe/server/repe_server.cpp
+++ b/tests/asio_repe/server/repe_server.cpp
@@ -8,6 +8,7 @@
 struct api
 {
    std::function<int(std::vector<int>& vec)> sum = [](std::vector<int>& vec) {
+      std::this_thread::sleep_for(std::chrono::seconds(1));
       return std::reduce(vec.begin(), vec.end());
    };
    std::function<double(std::vector<double>& vec)> max = [](std::vector<double>& vec) { return std::ranges::max(vec); };
@@ -20,7 +21,7 @@ void run_server()
    std::cout << "Server active...\n";
 
    try {
-      glz::asio_server<> server{.port = 8080};
+      glz::asio_server<> server{.port = 8080, .concurrency = 4};
       api methods{};
       server.on(methods);
       server.run();


### PR DESCRIPTION
This makes the registry locking logic behave the same for reading and writing. This limits reading a bit more by not allowing asynchronous reads to the exact same field, but it makes asynchronous writing possible, and keeps the locking logic simpler. We can now asynchronously write to differing targets, and importantly we can call asynchronous invocations.

We are removing automatic invoke locking. With variables, there is no place for a user to put logic when it comes to locking/unlocking access. However, when it comes to functions, there is room for users to add mutexes and locks to customize lock behavior. Also, functions often have complex side effects that need to be known to the programmer. On top of this, if we don't manipulate references in an RPC, we'd like the default behavior to be able to asynchronously call these functions. For these reasons we don't automatically lock the path taken to the function call. Because we also don't want to assume that a function call would manipulate the returned state of a data, which would block reads to the data.