### PR TITLE
Support for write_at with JSON

### DIFF
--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -4788,6 +4788,22 @@ suite get_sv = [] {
          expect(bomb->data.y == 200);
       }
    };
+   
+   "write_at"_test = [] {
+      std::string buffer = R"( { "action": "DELETE", "data": { "x": 10, "y": 200 }})";
+
+      auto ec = glz::write_at<"/action">(R"("GO!")", buffer);
+      expect(not ec);
+      expect(buffer == R"( { "action": "GO!", "data": { "x": 10, "y": 200 }})");
+   };
+   
+   "write_at"_test = [] {
+      std::string buffer = R"({"str":"hello","number":3.14,"sub":{"target":"X"}})";
+
+      auto ec = glz::write_at<"/sub/target">("42", buffer);
+      expect(not ec);
+      expect(buffer == R"({"str":"hello","number":3.14,"sub":{"target":42}})");
+   };
 };
 
 suite no_except_tests = [] {


### PR DESCRIPTION
New `glz::write_at` function, which allows raw text to be written to a specific JSON value pointed at via JSON Pointer syntax.

Example:
```c++
std::string buffer = R"( { "action": "DELETE", "data": { "x": 10, "y": 200 }})";
auto ec = glz::write_at<"/action">(R"("GO!")", buffer);
expect(not ec);
expect(buffer == R"( { "action": "GO!", "data": { "x": 10, "y": 200 }})");
```

Another example:
```c++
std::string buffer = R"({"str":"hello","number":3.14,"sub":{"target":"X"}})";
auto ec = glz::write_at<"/sub/target">("42", buffer);
expect(not ec);
expect(buffer == R"({"str":"hello","number":3.14,"sub":{"target":42}})");
```