### PR TITLE
Hash specialization

### DIFF
--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -1253,6 +1253,10 @@ namespace glz
                   if (bool(ctx.error)) [[unlikely]] {
                      return;
                   }
+                  if (uint64_t(end - it) < n) [[unlikely]] {
+                     ctx.error = error_code::unexpected_end;
+                     return;
+                  }
 
                   const auto index =
                      decode_hash_with_size<beve, T, HashInfo, HashInfo.type>::op(it, end, n);

--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -1253,7 +1253,7 @@ namespace glz
                   if (bool(ctx.error)) [[unlikely]] {
                      return;
                   }
-                  if (uint64_t(end - it) <= n) [[unlikely]] {
+                  if (uint64_t(end - it) < n) [[unlikely]] {
                      ctx.error = error_code::unexpected_end;
                      return;
                   }
@@ -1272,8 +1272,8 @@ namespace glz
                      jump_table<N>(
                         [&]<size_t I>() {
                            static constexpr auto TargetKey = get<I>(refl<T>.keys);
-                           static constexpr auto Length = TargetKey.size();
-                           if (compare<Length>(TargetKey.data(), key.data())) [[likely]] {
+                           static constexpr auto Length = TargetKey.size();                           
+                           if ((Length == n) && compare<Length>(TargetKey.data(), key.data())) [[likely]] {
                               if constexpr (detail::reflectable<T>) {
                                  read<binary>::op<Opts>(get_member(value, get<I>(detail::to_tuple(value))), ctx, it, end);
                               }

--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -1266,9 +1266,8 @@ namespace glz
                         fields[index] = true;
                      }
                      
-                     auto start = it;
+                     const sv key{it, n};
                      it += n;
-                     const sv key{start, size_t(it - start)};
 
                      jump_table<N>(
                         [&]<size_t I>() {

--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -1239,23 +1239,6 @@ namespace glz
                return;
             }
 
-            decltype(auto) storage = [&]() -> decltype(auto) {
-               using V = decay_keep_volatile_t<decltype(value)>;
-               if constexpr (reflectable<T>) {
-#if ((defined _MSC_VER) && (!defined __clang__))
-                  static thread_local auto cmap = make_map<V, Opts.use_hash_comparison>();
-#else
-                  static thread_local constinit auto cmap = make_map<V, Opts.use_hash_comparison>();
-#endif
-                  populate_map(value, cmap); // Function required for MSVC to build
-                  return cmap;
-               }
-               else {
-                  static constexpr auto cmap = make_map<T, Opts.use_hash_comparison>();
-                  return cmap;
-               }
-            }();
-
             for (size_t i = 0; i < n_keys; ++i) {
                if constexpr (is_partial_read<T> || Opts.partial_read) {
                   if ((all_fields & fields) == all_fields) {
@@ -1277,17 +1260,33 @@ namespace glz
                it += length;
 
                if constexpr (N > 0) {
-                  if (const auto& p = storage.find(key); p != storage.end()) [[likely]] {
+                  static constexpr auto HashInfo = hash_info<T>;
+
+                  const auto index =
+                     decode_hash<T, HashInfo, HashInfo.type>::op(key.data(), key.data() + key.size());
+
+                  if (index < N) [[likely]] {
                      if constexpr (is_partial_read<T> || Opts.partial_read) {
-                        auto index = p - storage.begin();
                         fields[index] = true;
                      }
 
-                     std::visit(
-                        [&](auto&& element) { //
-                           read<binary>::op<Opts>(get_member(value, element), ctx, it, end);
+                     jump_table<N>(
+                        [&]<size_t I>() {
+                           static constexpr auto TargetKey = get<I>(refl<T>.keys);
+                           static constexpr auto Length = TargetKey.size();
+                           if (compare<Length>(TargetKey.data(), key.data())) [[likely]] {
+                              if constexpr (detail::reflectable<T>) {
+                                 read<binary>::op<Opts>(get_member(value, get<I>(detail::to_tuple(value))), ctx, it, end);
+                              }
+                              else {
+                                 read<binary>::op<Opts>(get_member(value, get<I>(refl<T>.values)), ctx, it, end);
+                              }
+                           }
+                           else {
+                              ctx.error = error_code::unknown_key;
+                           }
                         },
-                        p->second);
+                        index);
 
                      if (bool(ctx.error)) [[unlikely]] {
                         return;

--- a/include/glaze/binary/read.hpp
+++ b/include/glaze/binary/read.hpp
@@ -1253,7 +1253,7 @@ namespace glz
                   if (bool(ctx.error)) [[unlikely]] {
                      return;
                   }
-                  if (uint64_t(end - it) < n) [[unlikely]] {
+                  if (uint64_t(end - it) <= n) [[unlikely]] {
                      ctx.error = error_code::unexpected_end;
                      return;
                   }

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -10,9 +10,11 @@
 namespace glz
 {
    // format
-   inline constexpr uint32_t binary = 0;
+   inline constexpr uint32_t binary = 0; // same as BEVE format
+   inline constexpr uint32_t beve = 0;
    inline constexpr uint32_t json = 10;
    inline constexpr uint32_t ndjson = 100; // new line delimited JSON
+   inline constexpr uint32_t MUSTACHE = 500;
    inline constexpr uint32_t csv = 10000;
 
    // layout

--- a/include/glaze/core/refl.hpp
+++ b/include/glaze/core/refl.hpp
@@ -1843,14 +1843,8 @@ namespace glz::detail
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::single_element>
    {
-      static constexpr auto N = refl<T>.N;
-      
-      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
+      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&&, auto&&, const size_t) noexcept
       {
-         if (uint64_t(end - it) < n) [[unlikely]] {
-            return N; // error
-         }
-         
          return 0;
       }
    };
@@ -1864,10 +1858,6 @@ namespace glz::detail
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
       {
-         if (uint64_t(end - it) < n) [[unlikely]] {
-            return N; // error
-         }
-         
          if constexpr (HashInfo.sized_hash) {
             if (n == 0 || n > HashInfo.max_length) {
                return N; // error
@@ -1911,12 +1901,8 @@ namespace glz::detail
       static constexpr auto N = refl<T>.N;
       static constexpr auto uindex = HashInfo.unique_index;
 
-      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
+      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t) noexcept
       {
-         if (uint64_t(end - it) < n) [[unlikely]] {
-            return N; // error
-         }
-         
          if constexpr (uindex > 0) {
             if ((it + uindex) >= end) [[unlikely]] {
                return N; // error
@@ -1940,12 +1926,8 @@ namespace glz::detail
       static constexpr auto N = refl<T>.N;
       static constexpr auto bsize = bucket_size(hash_type::front_hash, N);
 
-      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
+      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&&, const size_t) noexcept
       {
-         if (uint64_t(end - it) < n) [[unlikely]] {
-            return N; // error
-         }
-         
          if constexpr (HashInfo.front_hash_bytes == 2) {
             uint16_t h;
             if (std::is_constant_evaluated()) {
@@ -1999,10 +1981,6 @@ namespace glz::detail
       
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
       {
-         if (uint64_t(end - it) < n) [[unlikely]] {
-            return N; // error
-         }
-         
          const auto pos = per_length_info<T>.unique_index[n];
          if ((it + pos) >= end) [[unlikely]] {
             return N; // error
@@ -2018,12 +1996,8 @@ namespace glz::detail
       static constexpr auto N = refl<T>.N;
       static constexpr auto bsize = bucket_size(hash_type::full_flat, N);
       
-      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
+      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&&, const size_t n) noexcept
       {
-         if (uint64_t(end - it) < n) [[unlikely]] {
-            return N; // error
-         }
-         
          const auto h = full_hash<HashInfo.min_length, HashInfo.max_length, HashInfo.seed>(it, n);
          return HashInfo.table[h % bsize];
       }

--- a/include/glaze/core/refl.hpp
+++ b/include/glaze/core/refl.hpp
@@ -1642,6 +1642,15 @@ namespace glz::detail
 
    template <class T, auto HashInfo, hash_type Type>
    struct decode_hash;
+   
+   template <class T, auto HashInfo>
+   struct decode_hash<T, HashInfo, hash_type::single_element>
+   {
+      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&&, auto&&) noexcept
+      {
+         return 0;
+      }
+   };
 
    template <class T, auto HashInfo>
    struct decode_hash<T, HashInfo, hash_type::unique_index>

--- a/include/glaze/core/refl.hpp
+++ b/include/glaze/core/refl.hpp
@@ -1981,7 +1981,7 @@ namespace glz::detail
       
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
       {
-         const auto pos = per_length_info<T>.unique_index[n];
+         const auto pos = per_length_info<T>.unique_index[uint8_t(n)];
          if ((it + pos) >= end) [[unlikely]] {
             return N; // error
          }

--- a/include/glaze/core/refl.hpp
+++ b/include/glaze/core/refl.hpp
@@ -1868,10 +1868,8 @@ namespace glz::detail
          }
          else {
             if constexpr (N == 2) {
-               if constexpr (uindex > 0) {
-                  if ((it + uindex) >= end) [[unlikely]] {
-                     return N; // error
-                  }
+               if ((it + uindex) >= end) [[unlikely]] {
+                  return N; // error
                }
                // Avoids using a hash table
                if (std::is_constant_evaluated()) {
@@ -1884,10 +1882,8 @@ namespace glz::detail
                }
             }
             else {
-               if constexpr (uindex > 0) {
-                  if ((it + uindex) >= end) [[unlikely]] {
-                     return N; // error
-                  }
+               if ((it + uindex) >= end) [[unlikely]] {
+                  return N; // error
                }
                return HashInfo.table[uint8_t(it[uindex])];
             }

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -274,7 +274,7 @@ namespace glz
             decode_index<Opts, T, 0>(func, tuple, value, ctx, it, end);
          }
          else {
-            const auto index = decode_hash<T, HashInfo, HashInfo.type>::op(it, end);
+            const auto index = decode_hash<json, T, HashInfo, HashInfo.type>::op(it, end);
 
             if (index >= N) [[unlikely]] {
                if constexpr (Opts.error_on_unknown_keys) {
@@ -1241,7 +1241,7 @@ namespace glz
             else {
                static constexpr auto HashInfo = hash_info<T>;
 
-               const auto index = decode_hash<T, HashInfo, HashInfo.type>::op(it, end);
+               const auto index = decode_hash<json, T, HashInfo, HashInfo.type>::op(it, end);
 
                if (index >= N) [[unlikely]] {
                   ctx.error = error_code::unexpected_enum;

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1561,7 +1561,7 @@ namespace glz
 
                   static constexpr auto sub_partial = get<1>(group);
                   static constexpr auto index =
-                     decode_hash<T, HashInfo, HashInfo.type>::op(key.data(), key.data() + key.size());
+                     decode_hash<json, T, HashInfo, HashInfo.type>::op(key.data(), key.data() + key.size());
                   static_assert(index < num_members, "Invalid key passed to partial write");
                   if constexpr (glaze_object_t<T>) {
                      static constexpr auto member = get<index>(refl<T>.values);

--- a/include/glaze/mustache/mustache.hpp
+++ b/include/glaze/mustache/mustache.hpp
@@ -72,7 +72,7 @@ namespace glz
                         [&]<size_t I>() {
                            static constexpr auto TargetKey = get<I>(refl<T>.keys);
                            static constexpr auto Length = TargetKey.size();
-                           if (((start + Length) < end) && compare<Length>(TargetKey.data(), start)) [[likely]] {
+                           if ((Length == key.size()) && compare<Length>(TargetKey.data(), start)) [[likely]] {
                               if constexpr (detail::reflectable<T> && N > 0) {
                                  std::ignore = write<opt_true<Opts, &opts::raw>>(
                                     detail::get_member(value, get<I>(detail::to_tuple(value))), temp, ctx);

--- a/include/glaze/mustache/mustache.hpp
+++ b/include/glaze/mustache/mustache.hpp
@@ -44,6 +44,11 @@ namespace glz
                   while (it != end && *it != '}' && *it != ' ' && *it != '\t') {
                      ++it;
                   }
+                  
+                  if (it == end) {
+                     ctx.error = error_code::unexpected_end;
+                     return;
+                  }
 
                   const sv key{start, size_t(it - start)};
                   

--- a/include/glaze/mustache/mustache.hpp
+++ b/include/glaze/mustache/mustache.hpp
@@ -47,7 +47,8 @@ namespace glz
                   
                   if (it == end) {
                      ctx.error = error_code::unexpected_end;
-                     return;
+                     return unexpected(
+                        error_ctx{ctx.error, ctx.custom_error_message, size_t(it - start), ctx.includer_error});
                   }
 
                   const sv key{start, size_t(it - start)};

--- a/include/glaze/mustache/stencilcount.hpp
+++ b/include/glaze/mustache/stencilcount.hpp
@@ -88,11 +88,13 @@ namespace glz
                   }
 
                   auto s = it;
-                  while (it != end && *it != '}') {
+                  while (it != end && *it != '}' && *it != ' ' && *it != '\t') {
                      ++it;
                   }
 
-                  sv key{s, size_t(it - s)};
+                  const sv key{s, size_t(it - s)};
+                  
+                  skip_whitespace();
 
                   static constexpr auto num_members = refl<T>.N;
 

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -2258,6 +2258,20 @@ inline std::vector<unsigned char> base64_decode(const std::string_view input)
    return decoded_data;
 }
 
+suite base64_decode_tests = [] {
+   "hello world"_test = [] {
+      std::string_view b64 = "aGVsbG8gd29ybGQ=";
+      std::vector<uint8_t> decoded = base64_decode(b64);
+      expect(std::string_view{(char*)decoded.data(), decoded.size()} == "hello world");
+   };
+   
+   "{\"key\":42}"_test = [] {
+      std::string_view b64 = "eyJrZXkiOjQyfQ==";
+      std::vector<uint8_t> decoded = base64_decode(b64);
+      expect(std::string_view{(char*)decoded.data(), decoded.size()} == "{\"key\":42}");
+   };
+};
+
 suite past_fuzzing_issues = [] {
    "fuzz0"_test = [] {
       std::string_view base64 =

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -2393,6 +2393,17 @@ suite past_fuzzing_issues = [] {
       expect(glz::read_binary<my_struct>(input).error());
       expect(glz::beve_to_json(input, json));
    };
+   
+   "fuzz12"_test = [] {
+      std::string_view base64 = "AzwAaGho";
+      std::vector<uint8_t> input = base64_decode(base64);
+      expect(glz::read_binary<my_struct>(input).error());
+      std::string json{};
+      expect(glz::beve_to_json(input, json));
+      input.push_back('\0');
+      expect(glz::read_binary<my_struct>(input).error());
+      expect(glz::beve_to_json(input, json));
+   };
 };
 
 int main()

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -2356,6 +2356,14 @@ suite past_fuzzing_issues = [] {
       std::string json{};
       expect(glz::beve_to_json(input, json));
    };
+   
+   "fuzz9"_test = [] {
+      std::string_view base64 = "A10sAA==";
+      std::vector<uint8_t> input = base64_decode(base64);
+      expect(glz::read_binary<my_struct>(input).error());
+      std::string json{};
+      expect(glz::beve_to_json(input, json));
+   };
 };
 
 int main()

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -2429,6 +2429,17 @@ suite past_fuzzing_issues = [] {
       expect(glz::read_binary<my_struct>(input).error());
       expect(glz::beve_to_json(input, json));
    };
+   
+   "fuzz14"_test = [] {
+      std::string_view base64 = "A5AAaGgAbg==";
+      std::vector<uint8_t> input = base64_decode(base64);
+      expect(glz::read_binary<my_struct>(input).error());
+      std::string json{};
+      expect(glz::beve_to_json(input, json));
+      input.push_back('\0');
+      expect(glz::read_binary<my_struct>(input).error());
+      expect(glz::beve_to_json(input, json));
+   };
 };
 
 int main()

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -2363,6 +2363,9 @@ suite past_fuzzing_issues = [] {
       expect(glz::read_binary<my_struct>(input).error());
       std::string json{};
       expect(glz::beve_to_json(input, json));
+      input.push_back('\0');
+      expect(glz::read_binary<my_struct>(input).error());
+      expect(glz::beve_to_json(input, json));
    };
    
    "fuzz10"_test = [] {
@@ -2370,6 +2373,20 @@ suite past_fuzzing_issues = [] {
       std::vector<uint8_t> input = base64_decode(base64);
       expect(glz::read_binary<my_struct>(input).error());
       std::string json{};
+      expect(glz::beve_to_json(input, json));
+      input.push_back('\0');
+      expect(glz::read_binary<my_struct>(input).error());
+      expect(glz::beve_to_json(input, json));
+   };
+   
+   "fuzz11"_test = [] {
+      std::string_view base64 = "AxQA";
+      std::vector<uint8_t> input = base64_decode(base64);
+      expect(glz::read_binary<my_struct>(input).error());
+      std::string json{};
+      expect(glz::beve_to_json(input, json));
+      input.push_back('\0');
+      expect(glz::read_binary<my_struct>(input).error());
       expect(glz::beve_to_json(input, json));
    };
 };

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -2404,6 +2404,17 @@ suite past_fuzzing_issues = [] {
       expect(glz::read_binary<my_struct>(input).error());
       expect(glz::beve_to_json(input, json));
    };
+   
+   "fuzz13"_test = [] {
+      std::string_view base64 = "AzAAYQ==";
+      std::vector<uint8_t> input = base64_decode(base64);
+      expect(glz::read_binary<my_struct>(input).error());
+      std::string json{};
+      expect(glz::beve_to_json(input, json));
+      input.push_back('\0');
+      expect(glz::read_binary<my_struct>(input).error());
+      expect(glz::beve_to_json(input, json));
+   };
 };
 
 int main()

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -2226,19 +2226,23 @@ suite early_end = [] {
    };
 };
 
-std::vector<unsigned char> base64_decode(const std::string_view input)
+inline std::vector<unsigned char> base64_decode(const std::string_view input)
 {
-   static const std::string base64_chars =
+   static constexpr std::string_view base64_chars =
       "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
       "abcdefghijklmnopqrstuvwxyz"
       "0123456789+/";
 
    std::vector<unsigned char> decoded_data;
-   std::vector<int> decode_table(256, -1);
-
-   for (int i = 0; i < 64; i++) {
-      decode_table[base64_chars[i]] = i;
-   }
+   static constexpr std::array<int, 256> decode_table = [] {
+      std::array<int, 256> t;
+      t.fill(-1);
+      
+      for (int i = 0; i < 64; ++i) {
+         t[base64_chars[i]] = i;
+      }
+      return t;
+   }();
 
    int val = 0, valb = -8;
    for (unsigned char c : input) {

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -2364,6 +2364,14 @@ suite past_fuzzing_issues = [] {
       std::string json{};
       expect(glz::beve_to_json(input, json));
    };
+   
+   "fuzz10"_test = [] {
+      std::string_view base64 = "A4wA";
+      std::vector<uint8_t> input = base64_decode(base64);
+      expect(glz::read_binary<my_struct>(input).error());
+      std::string json{};
+      expect(glz::beve_to_json(input, json));
+   };
 };
 
 int main()

--- a/tests/binary_test/binary_test.cpp
+++ b/tests/binary_test/binary_test.cpp
@@ -2375,71 +2375,31 @@ suite past_fuzzing_issues = [] {
       expect(glz::beve_to_json(input, json));
    };
    
-   "fuzz9"_test = [] {
-      std::string_view base64 = "A10sAA==";
-      std::vector<uint8_t> input = base64_decode(base64);
-      expect(glz::read_binary<my_struct>(input).error());
-      std::string json{};
-      expect(glz::beve_to_json(input, json));
-      input.push_back('\0');
-      expect(glz::read_binary<my_struct>(input).error());
-      expect(glz::beve_to_json(input, json));
+   auto test_base64 = [](std::string_view base64) {
+      return [base64] {
+         std::vector<uint8_t> input = base64_decode(base64);
+         expect(glz::read_binary<my_struct>(input).error());
+         std::string json{};
+         expect(glz::beve_to_json(input, json));
+         input.push_back('\0');
+         expect(glz::read_binary<my_struct>(input).error());
+         expect(glz::beve_to_json(input, json));
+      };
    };
    
-   "fuzz10"_test = [] {
-      std::string_view base64 = "A4wA";
-      std::vector<uint8_t> input = base64_decode(base64);
-      expect(glz::read_binary<my_struct>(input).error());
-      std::string json{};
-      expect(glz::beve_to_json(input, json));
-      input.push_back('\0');
-      expect(glz::read_binary<my_struct>(input).error());
-      expect(glz::beve_to_json(input, json));
-   };
+   "fuzz9"_test = test_base64("A10sAA==");
    
-   "fuzz11"_test = [] {
-      std::string_view base64 = "AxQA";
-      std::vector<uint8_t> input = base64_decode(base64);
-      expect(glz::read_binary<my_struct>(input).error());
-      std::string json{};
-      expect(glz::beve_to_json(input, json));
-      input.push_back('\0');
-      expect(glz::read_binary<my_struct>(input).error());
-      expect(glz::beve_to_json(input, json));
-   };
+   "fuzz10"_test = test_base64("A4wA");
    
-   "fuzz12"_test = [] {
-      std::string_view base64 = "AzwAaGho";
-      std::vector<uint8_t> input = base64_decode(base64);
-      expect(glz::read_binary<my_struct>(input).error());
-      std::string json{};
-      expect(glz::beve_to_json(input, json));
-      input.push_back('\0');
-      expect(glz::read_binary<my_struct>(input).error());
-      expect(glz::beve_to_json(input, json));
-   };
+   "fuzz11"_test = test_base64("AxQA");
    
-   "fuzz13"_test = [] {
-      std::string_view base64 = "AzAAYQ==";
-      std::vector<uint8_t> input = base64_decode(base64);
-      expect(glz::read_binary<my_struct>(input).error());
-      std::string json{};
-      expect(glz::beve_to_json(input, json));
-      input.push_back('\0');
-      expect(glz::read_binary<my_struct>(input).error());
-      expect(glz::beve_to_json(input, json));
-   };
+   "fuzz12"_test = test_base64("AzwAaGho");
    
-   "fuzz14"_test = [] {
-      std::string_view base64 = "A5AAaGgAbg==";
-      std::vector<uint8_t> input = base64_decode(base64);
-      expect(glz::read_binary<my_struct>(input).error());
-      std::string json{};
-      expect(glz::beve_to_json(input, json));
-      input.push_back('\0');
-      expect(glz::read_binary<my_struct>(input).error());
-      expect(glz::beve_to_json(input, json));
-   };
+   "fuzz13"_test = test_base64("AzAAYQ==");
+   
+   "fuzz14"_test = test_base64("A5AAaGgAbg==");
+   
+   "fuzz15"_test = test_base64("AzEyAA==");
 };
 
 int main()


### PR DESCRIPTION
This update introduces specialization on decoding hashes. This enables BEVE to use the new hashing approach, but it also fixes issues with hashing for other formats like mustache (which can't search for a quote).

Introduces `decode_hash_with_size` for formats like BEVE and mustache.