### PR TITLE
Removed data_ptr function

### DIFF
--- a/include/glaze/core/write_chars.hpp
+++ b/include/glaze/core/write_chars.hpp
@@ -69,13 +69,13 @@ namespace glz::detail
                // we cast to a lower precision floating point value before writing out
                if constexpr (uint8_t(Opts.float_max_write_precision) == 8) {
                   const auto reduced = static_cast<double>(value);
-                  const auto start = data_ptr(b) + ix;
+                  const auto start = reinterpret_cast<char*>(&b[ix]);
                   const auto end = glz::to_chars(start, reduced);
                   ix += size_t(end - start);
                }
                else if constexpr (uint8_t(Opts.float_max_write_precision) == 4) {
                   const auto reduced = static_cast<float>(value);
-                  const auto start = data_ptr(b) + ix;
+                  const auto start = reinterpret_cast<char*>(&b[ix]);
                   const auto end = glz::to_chars(start, reduced);
                   ix += size_t(end - start);
                }
@@ -84,13 +84,13 @@ namespace glz::detail
                }
             }
             else if constexpr (is_any_of<V, float, double>) {
-               const auto start = reinterpret_cast<char*>(data_ptr(b) + ix);
+               const auto start = reinterpret_cast<char*>(&b[ix]);
                const auto end = glz::to_chars(start, value);
                ix += size_t(end - start);
             }
             else if constexpr (is_float128<V>) {
-               const auto start = data_ptr(b) + ix;
-               const auto [ptr, ec] = std::to_chars(start, data_ptr(b) + b.size(), value, std::chars_format::general);
+               const auto start = reinterpret_cast<char*>(&b[ix]);
+               const auto [ptr, ec] = std::to_chars(start, &b[0] + b.size(), value, std::chars_format::general);
                if (ec != std::errc()) {
                   // TODO: Do we need to handle this error state?
                }
@@ -101,13 +101,13 @@ namespace glz::detail
             }
          }
          else if constexpr (is_any_of<V, int32_t, uint32_t, int64_t, uint64_t>) {
-            const auto start = data_ptr(b) + ix;
+            const auto start = reinterpret_cast<char*>(&b[ix]);
             const auto end = glz::to_chars(start, value);
             ix += size_t(end - start);
          }
          else if constexpr (std::integral<V>) {
             using X = std::decay_t<decltype(sized_integer_conversion<V>())>;
-            const auto start = data_ptr(b) + ix;
+            const auto start = reinterpret_cast<char*>(&b[ix]);
             const auto end = glz::to_chars(start, static_cast<X>(value));
             ix += size_t(end - start);
          }

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -262,7 +262,7 @@ namespace glz
 
                   dump<'"', false>(b, ix);
                   if (const auto escaped = char_escape_table[uint8_t(value)]; escaped) {
-                     std::memcpy(data_ptr(b) + ix, &escaped, 2);
+                     std::memcpy(&b[ix], &escaped, 2);
                      ix += 2;
                   }
                   else if (value == '\0') {
@@ -334,7 +334,7 @@ namespace glz
 
                      const auto* c = str.data();
                      const auto* const e = c + n;
-                     const auto start = data_ptr(b) + ix;
+                     const auto start = &b[ix];
                      auto data = start;
 
                      // We don't check for writing out invalid characters as this can be tested by the user if

--- a/include/glaze/util/dump.hpp
+++ b/include/glaze/util/dump.hpp
@@ -18,22 +18,6 @@ namespace glz::detail
    template <class T, class V = std::remove_cvref_t<T>>
    concept byte_sized = sizeof(T) == 1 && (std::same_as<V, char> || std::same_as<V, std::byte>);
 
-   template <class T>
-   [[nodiscard]] GLZ_ALWAYS_INLINE auto data_ptr(T& buffer) noexcept
-   {
-      if constexpr (has_data<T>) {
-         if constexpr (std::same_as<std::decay_t<typename T::value_type>, std::byte>) {
-            return reinterpret_cast<char*>(buffer.data());
-         }
-         else {
-            return buffer.data();
-         }
-      }
-      else {
-         return buffer;
-      }
-   }
-
    template <uint32_t N, class B>
    GLZ_ALWAYS_INLINE void maybe_pad(B& b, size_t& ix) noexcept
    {


### PR DESCRIPTION
Removes the `data_ptr` wrapper function, which hid a reinterpret cast and was unnecessary.