### PR TITLE
Reflection API

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ struct glz::meta<my_struct> {
 > Names are required for:
 >
 > - static constexpr member variables
-> - Wrappers
+> - [Wrappers](./docs/wrappers.md)
 > - Lambda functions
 
 ## Custom Read/Write

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Custom reading and writing can be achieved through the powerful `to`/`from` spec
 
 For common use cases or cases where a specific member variable should have special reading and writing, you can use `glz::custom` to register read/write member functions, std::functions, or lambda functions.
 
-<details><summary>**See example:**</summary>
+<details><summary>See example:</summary>
 
 ```c++
 struct custom_encoding

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ struct glz::meta<my_struct> {
 
 ## Local Glaze Meta
 
-<details><summary>Glaze also supports metadata provided within its associated class:</summary>
+<details><summary>Glaze also supports metadata within its associated class:</summary>
 
 ```c++
 struct my_struct

--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ struct glz::meta<my_struct> {
 
 Glaze also supports metadata provided within its associated class:
 
+<details><summary>See example:</summary>
+
 ```c++
 struct my_struct
 {
@@ -270,6 +272,8 @@ struct my_struct
   };
 };
 ```
+
+</details>
 
 ## Custom Key Names or Unnamed Types
 

--- a/README.md
+++ b/README.md
@@ -778,6 +778,8 @@ By default Glaze is strictly conformant with the latest JSON standard except in 
 
 It can be useful to acknowledge a keys existence in an object to prevent errors, and yet the value may not be needed or exist in C++. These cases are handled by registering a `glz::skip` type with the meta data.
 
+<details><summary>See example:</summary>
+
 ```c++
 struct S {
   int i{};
@@ -797,11 +799,15 @@ glz::read_json(s, buffer);
 expect(s.i == 7); // only the value i will be read into
 ```
 
+</details>
+
 ## Hide
 
 Glaze is designed to help with building generic APIs. Sometimes a value needs to be exposed to the API, but it is not desirable to read in or write out the value in JSON. This is the use case for `glz::hide`.
 
 `glz::hide` hides the value from JSON output while still allowing API (and JSON pointer) access.
+
+<details><summary>See example:</summary>
 
 ```c++
 struct hide_struct {
@@ -824,6 +830,8 @@ hide_struct s{};
 auto b = glz::write_json(s);
 expect(b == R"({"i":287,"d":3.14})"); // notice that "hello" is hidden from the output
 ```
+
+</details>
 
 ## Quoted Numbers
 

--- a/README.md
+++ b/README.md
@@ -247,9 +247,7 @@ struct glz::meta<my_struct> {
 
 ## Local Glaze Meta
 
-Glaze also supports metadata provided within its associated class:
-
-<details><summary>See example:</summary>
+<details><summary>Glaze also supports metadata provided within its associated class:</summary>
 
 ```c++
 struct my_struct

--- a/README.md
+++ b/README.md
@@ -299,6 +299,15 @@ struct glz::meta<my_struct> {
 > - [Wrappers](./docs/wrappers.md)
 > - Lambda functions
 
+# Reflection API
+
+Glaze provides a compile time reflection API that can be modified via `glz::meta` specializations. This reflection API uses pure reflection unless a `glz::meta` specialization is provided, in which case the default behavior is overridden by the developer.
+
+```c++
+static_assert(glz::refl<my_struct>::size == 5); // Number of fields
+static_assert(glz::refl<my_struct>::keys[0] == "i"); // Access keys
+```
+
 # Custom Read/Write
 
 Custom reading and writing can be achieved through the powerful `to`/`from` specialization approach, which is described here: [custom-serialization.md](https://github.com/stephenberry/glaze/blob/main/docs/custom-serialization.md). However, this only works for user defined types.

--- a/README.md
+++ b/README.md
@@ -299,13 +299,13 @@ struct glz::meta<my_struct> {
 > - [Wrappers](./docs/wrappers.md)
 > - Lambda functions
 
-## Custom Read/Write
+# Custom Read/Write
 
 Custom reading and writing can be achieved through the powerful `to`/`from` specialization approach, which is described here: [custom-serialization.md](https://github.com/stephenberry/glaze/blob/main/docs/custom-serialization.md). However, this only works for user defined types.
 
 For common use cases or cases where a specific member variable should have special reading and writing, you can use `glz::custom` to register read/write member functions, std::functions, or lambda functions.
 
-See an example:
+<details><summary>See example:</summary>
 
 ```c++
 struct custom_encoding
@@ -362,7 +362,9 @@ suite custom_encoding_test = [] {
 };
 ```
 
-## Object Mapping
+</details>
+
+# Object Mapping
 
 When using member pointers (e.g. `&T::a`) the C++ class structures must match the JSON interface. It may be desirable to map C++ classes with differing layouts to the same object interface. This is accomplished through registering lambda functions instead of member pointers.
 
@@ -381,7 +383,7 @@ Lambda functions by default copy returns, therefore the `auto&` return type is t
 
 > Note that remapping can also be achieved through pointers/references, as glaze treats values, pointers, and references in the same manner when writing/reading.
 
-## Value Types
+# Value Types
 
 A class can be treated as an underlying value as follows:
 

--- a/README.md
+++ b/README.md
@@ -306,8 +306,8 @@ struct glz::meta<my_struct> {
 Glaze provides a compile time reflection API that can be modified via `glz::meta` specializations. This reflection API uses pure reflection unless a `glz::meta` specialization is provided, in which case the default behavior is overridden by the developer.
 
 ```c++
-static_assert(glz::refl<my_struct>::size == 5); // Number of fields
-static_assert(glz::refl<my_struct>::keys[0] == "i"); // Access keys
+static_assert(glz::reflect<my_struct>::size == 5); // Number of fields
+static_assert(glz::reflect<my_struct>::keys[0] == "i"); // Access keys
 ```
 
 # Custom Read/Write

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Custom reading and writing can be achieved through the powerful `to`/`from` spec
 
 For common use cases or cases where a specific member variable should have special reading and writing, you can use `glz::custom` to register read/write member functions, std::functions, or lambda functions.
 
-<details><summary>See example:</summary>
+<details><summary>**See example:**</summary>
 
 ```c++
 struct custom_encoding

--- a/docs/reflection.md
+++ b/docs/reflection.md
@@ -10,7 +10,7 @@ struct T
   std::array<float, 3> arr{};
 };
 
-static_assert(glz::refl<T>::size == 3);
-static_assert(glz::refl<T>::)
+static_assert(glz::reflect<T>::size == 3);
+static_assert(glz::reflect<T>::keys[0] == "a");
 ```
 

--- a/docs/reflection.md
+++ b/docs/reflection.md
@@ -10,7 +10,7 @@ struct T
   std::array<float, 3> arr{};
 };
 
-static_assert(glz::reflect<T>::size == 3);
-static_assert(glz::reflect<T>::keys[0] == "a");
+static_assert(glz::refl<T>::size == 3);
+static_assert(glz::refl<T>::keys[0] == "a");
 ```
 

--- a/docs/reflection.md
+++ b/docs/reflection.md
@@ -1,0 +1,16 @@
+# Reflection in Glaze
+
+Glaze provides compile time reflection utilities for C++.
+
+```c++
+struct T
+{
+  int a{};
+  std::string str{};
+  std::array<float, 3> arr{};
+};
+
+static_assert(glz::refl<T>::size == 3);
+static_assert(glz::refl<T>::)
+```
+

--- a/include/glaze/api/trait.hpp
+++ b/include/glaze/api/trait.hpp
@@ -8,7 +8,7 @@
 #include "glaze/api/hash.hpp"
 #include "glaze/core/common.hpp"
 #include "glaze/core/meta.hpp"
-#include "glaze/core/refl.hpp"
+#include "glaze/core/reflect.hpp"
 #include "glaze/util/string_literal.hpp"
 
 namespace glz

--- a/include/glaze/base64/base64.hpp
+++ b/include/glaze/base64/base64.hpp
@@ -9,18 +9,17 @@
 
 namespace glz
 {
-   inline std::vector<unsigned char> base64_decode(const std::string_view input)
+   inline constexpr std::string_view base64_chars =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      "abcdefghijklmnopqrstuvwxyz"
+      "0123456789+/";
+   
+   inline std::string read_base64(const std::string_view input)
    {
-      static constexpr std::string_view base64_chars =
-         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-         "abcdefghijklmnopqrstuvwxyz"
-         "0123456789+/";
-
-      std::vector<unsigned char> decoded_data;
+      std::string decoded_data;
       static constexpr std::array<int, 256> decode_table = [] {
          std::array<int, 256> t;
          t.fill(-1);
-
          for (int i = 0; i < 64; ++i) {
             t[base64_chars[i]] = i;
          }
@@ -39,5 +38,27 @@ namespace glz
       }
 
       return decoded_data;
+   }
+   
+   inline std::string write_base64(const std::string_view input)
+   {
+       std::string encoded_data;
+
+       int val = 0, valb = -6;
+       for (unsigned char c : input) {
+           val = (val << 8) + c;
+           valb += 8;
+           while (valb >= 0) {
+               encoded_data.push_back(base64_chars[(val >> valb) & 0x3F]);
+               valb -= 6;
+           }
+       }
+       if (valb > -6) {
+           encoded_data.push_back(base64_chars[((val << 8) >> (valb + 8)) & 0x3F]);
+       }
+       while (encoded_data.size() % 4) {
+           encoded_data.push_back('=');
+       }
+       return encoded_data;
    }
 }

--- a/include/glaze/base64/base64.hpp
+++ b/include/glaze/base64/base64.hpp
@@ -1,0 +1,43 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include <array>
+#include <string_view>
+#include <vector>
+
+namespace glz
+{
+   inline std::vector<unsigned char> base64_decode(const std::string_view input)
+   {
+      static constexpr std::string_view base64_chars =
+         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+         "abcdefghijklmnopqrstuvwxyz"
+         "0123456789+/";
+
+      std::vector<unsigned char> decoded_data;
+      static constexpr std::array<int, 256> decode_table = [] {
+         std::array<int, 256> t;
+         t.fill(-1);
+
+         for (int i = 0; i < 64; ++i) {
+            t[base64_chars[i]] = i;
+         }
+         return t;
+      }();
+
+      int val = 0, valb = -8;
+      for (unsigned char c : input) {
+         if (decode_table[c] == -1) break; // Stop decoding at padding '=' or invalid characters
+         val = (val << 6) + decode_table[c];
+         valb += 6;
+         if (valb >= 0) {
+            decoded_data.push_back((val >> valb) & 0xFF);
+            valb -= 8;
+         }
+      }
+
+      return decoded_data;
+   }
+}

--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -7,7 +7,7 @@
 #include "glaze/beve/skip.hpp"
 #include "glaze/core/opts.hpp"
 #include "glaze/core/read.hpp"
-#include "glaze/core/refl.hpp"
+#include "glaze/core/reflect.hpp"
 #include "glaze/file/file_ops.hpp"
 #include "glaze/util/dump.hpp"
 
@@ -153,7 +153,7 @@ namespace glz
          template <auto Opts, is_context Ctx, class It0, class It1>
          static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end)
          {
-            constexpr auto N = refl<T>::size;
+            constexpr auto N = reflect<T>::size;
 
             constexpr auto Length = byte_length<T>();
             uint8_t data[Length];
@@ -166,7 +166,7 @@ namespace glz
             it += Length;
 
             invoke_table<N>([&]<size_t I>() {
-               get_member(value, get<I>(refl<T>::values)) = data[I / 8] & (uint8_t{1} << (7 - (I % 8)));
+               get_member(value, get<I>(reflect<T>::values)) = data[I / 8] & (uint8_t{1} << (7 - (I % 8)));
             });
          }
       };
@@ -1184,7 +1184,7 @@ namespace glz
                }
                ++it;
                using V = std::decay_t<T>;
-               constexpr auto N = refl<V>::size;
+               constexpr auto N = reflect<V>::size;
                const auto n = int_from_compressed(ctx, it, end);
                if (bool(ctx.error)) [[unlikely]] {
                   return;
@@ -1195,7 +1195,7 @@ namespace glz
                }
 
                invoke_table<N>(
-                  [&]<size_t I>() { read<BEVE>::op<Opts>(get_member(value, get<I>(refl<V>::values)), ctx, it, end); });
+                  [&]<size_t I>() { read<BEVE>::op<Opts>(get_member(value, get<I>(reflect<V>::values)), ctx, it, end); });
             }
          }
 
@@ -1215,7 +1215,7 @@ namespace glz
 
             ++it;
 
-            static constexpr auto N = refl<T>::size;
+            static constexpr auto N = reflect<T>::size;
 
             static constexpr bit_array<N> all_fields = [] {
                bit_array<N> arr{};
@@ -1270,14 +1270,14 @@ namespace glz
 
                      jump_table<N>(
                         [&]<size_t I>() {
-                           static constexpr auto TargetKey = get<I>(refl<T>::keys);
+                           static constexpr auto TargetKey = get<I>(reflect<T>::keys);
                            static constexpr auto Length = TargetKey.size();
                            if ((Length == n) && compare<Length>(TargetKey.data(), key.data())) [[likely]] {
                               if constexpr (detail::reflectable<T>) {
                                  read<BEVE>::op<Opts>(get_member(value, get<I>(detail::to_tuple(value))), ctx, it, end);
                               }
                               else {
-                                 read<BEVE>::op<Opts>(get_member(value, get<I>(refl<T>::values)), ctx, it, end);
+                                 read<BEVE>::op<Opts>(get_member(value, get<I>(reflect<T>::values)), ctx, it, end);
                               }
                            }
                            else {
@@ -1339,7 +1339,7 @@ namespace glz
             }
             ++it;
 
-            constexpr auto N = refl<T>::size;
+            constexpr auto N = reflect<T>::size;
             const auto n = int_from_compressed(ctx, it, end);
             if (bool(ctx.error)) [[unlikely]] {
                return;
@@ -1350,7 +1350,7 @@ namespace glz
             }
 
             invoke_table<N>(
-               [&]<size_t I>() { read<BEVE>::op<Opts>(get_member(value, get<I>(refl<T>::values)), ctx, it, end); });
+               [&]<size_t I>() { read<BEVE>::op<Opts>(get_member(value, get<I>(reflect<T>::values)), ctx, it, end); });
          }
       };
 

--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -153,7 +153,7 @@ namespace glz
          template <auto Opts, is_context Ctx, class It0, class It1>
          static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end)
          {
-            constexpr auto N = refl<T>.N;
+            constexpr auto N = refl<T>::N;
 
             constexpr auto Length = byte_length<T>();
             uint8_t data[Length];
@@ -166,7 +166,7 @@ namespace glz
             it += Length;
 
             invoke_table<N>([&]<size_t I>() {
-               get_member(value, get<I>(refl<T>.values)) = data[I / 8] & (uint8_t{1} << (7 - (I % 8)));
+               get_member(value, get<I>(refl<T>::values)) = data[I / 8] & (uint8_t{1} << (7 - (I % 8)));
             });
          }
       };
@@ -1184,7 +1184,7 @@ namespace glz
                }
                ++it;
                using V = std::decay_t<T>;
-               constexpr auto N = refl<V>.N;
+               constexpr auto N = refl<V>::N;
                const auto n = int_from_compressed(ctx, it, end);
                if (bool(ctx.error)) [[unlikely]] {
                   return;
@@ -1195,7 +1195,7 @@ namespace glz
                }
 
                invoke_table<N>(
-                  [&]<size_t I>() { read<BEVE>::op<Opts>(get_member(value, get<I>(refl<V>.values)), ctx, it, end); });
+                  [&]<size_t I>() { read<BEVE>::op<Opts>(get_member(value, get<I>(refl<V>::values)), ctx, it, end); });
             }
          }
 
@@ -1215,7 +1215,7 @@ namespace glz
 
             ++it;
 
-            static constexpr auto N = refl<T>.N;
+            static constexpr auto N = refl<T>::N;
 
             static constexpr bit_array<N> all_fields = [] {
                bit_array<N> arr{};
@@ -1270,14 +1270,14 @@ namespace glz
 
                      jump_table<N>(
                         [&]<size_t I>() {
-                           static constexpr auto TargetKey = get<I>(refl<T>.keys);
+                           static constexpr auto TargetKey = get<I>(refl<T>::keys);
                            static constexpr auto Length = TargetKey.size();
                            if ((Length == n) && compare<Length>(TargetKey.data(), key.data())) [[likely]] {
                               if constexpr (detail::reflectable<T>) {
                                  read<BEVE>::op<Opts>(get_member(value, get<I>(detail::to_tuple(value))), ctx, it, end);
                               }
                               else {
-                                 read<BEVE>::op<Opts>(get_member(value, get<I>(refl<T>.values)), ctx, it, end);
+                                 read<BEVE>::op<Opts>(get_member(value, get<I>(refl<T>::values)), ctx, it, end);
                               }
                            }
                            else {
@@ -1339,7 +1339,7 @@ namespace glz
             }
             ++it;
 
-            constexpr auto N = refl<T>.N;
+            constexpr auto N = refl<T>::N;
             const auto n = int_from_compressed(ctx, it, end);
             if (bool(ctx.error)) [[unlikely]] {
                return;
@@ -1350,7 +1350,7 @@ namespace glz
             }
 
             invoke_table<N>(
-               [&]<size_t I>() { read<BEVE>::op<Opts>(get_member(value, get<I>(refl<T>.values)), ctx, it, end); });
+               [&]<size_t I>() { read<BEVE>::op<Opts>(get_member(value, get<I>(refl<T>::values)), ctx, it, end); });
          }
       };
 

--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -153,7 +153,7 @@ namespace glz
          template <auto Opts, is_context Ctx, class It0, class It1>
          static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end)
          {
-            constexpr auto N = refl<T>::N;
+            constexpr auto N = refl<T>::size;
 
             constexpr auto Length = byte_length<T>();
             uint8_t data[Length];
@@ -1184,7 +1184,7 @@ namespace glz
                }
                ++it;
                using V = std::decay_t<T>;
-               constexpr auto N = refl<V>::N;
+               constexpr auto N = refl<V>::size;
                const auto n = int_from_compressed(ctx, it, end);
                if (bool(ctx.error)) [[unlikely]] {
                   return;
@@ -1215,7 +1215,7 @@ namespace glz
 
             ++it;
 
-            static constexpr auto N = refl<T>::N;
+            static constexpr auto N = refl<T>::size;
 
             static constexpr bit_array<N> all_fields = [] {
                bit_array<N> arr{};
@@ -1339,7 +1339,7 @@ namespace glz
             }
             ++it;
 
-            constexpr auto N = refl<T>::N;
+            constexpr auto N = refl<T>::size;
             const auto n = int_from_compressed(ctx, it, end);
             if (bool(ctx.error)) [[unlikely]] {
                return;

--- a/include/glaze/beve/write.hpp
+++ b/include/glaze/beve/write.hpp
@@ -168,12 +168,12 @@ namespace glz
          template <auto Opts>
          static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix)
          {
-            static constexpr auto N = refl<T>.N;
+            static constexpr auto N = refl<T>::N;
 
             std::array<uint8_t, byte_length<T>()> data{};
 
             invoke_table<N>([&]<size_t I>() {
-               data[I / 8] |= static_cast<uint8_t>(get_member(value, get<I>(refl<T>.values))) << (7 - (I % 8));
+               data[I / 8] |= static_cast<uint8_t>(get_member(value, get<I>(refl<T>::values))) << (7 - (I % 8));
             });
 
             dump(data, b, ix);
@@ -620,7 +620,7 @@ namespace glz
                count += glz::tuple_size_v<decltype(std::declval<Value>().value)> / 2;
             }
             else {
-               count += refl<Value>.N;
+               count += refl<Value>::N;
             }
          });
          return count;
@@ -651,7 +651,7 @@ namespace glz
          requires(glaze_object_t<T> || reflectable<T>)
       struct to<BEVE, T> final
       {
-         static constexpr auto N = refl<T>.N;
+         static constexpr auto N = refl<T>::N;
          static constexpr size_t count_to_write = [] {
             size_t count{};
             invoke_table<N>([&]<size_t I>() {
@@ -695,7 +695,7 @@ namespace glz
                      write<BEVE>::op<Opts>(get_member(value, get<I>(t)), ctx, args...);
                   }
                   else {
-                     write<BEVE>::op<Opts>(get_member(value, get<I>(refl<T>.values)), ctx, args...);
+                     write<BEVE>::op<Opts>(get_member(value, get<I>(refl<T>::values)), ctx, args...);
                   }
                }
             });
@@ -729,7 +729,7 @@ namespace glz
                   return;
                }
                else {
-                  static constexpr sv key = refl<T>.keys[I];
+                  static constexpr sv key = refl<T>::keys[I];
                   write<BEVE>::no_header<Opts>(key, ctx, args...);
 
                   decltype(auto) member = [&]() -> decltype(auto) {
@@ -737,7 +737,7 @@ namespace glz
                         return get<I>(t);
                      }
                      else {
-                        return get<I>(refl<T>.values);
+                        return get<I>(refl<T>::values);
                      }
                   }();
 
@@ -756,11 +756,11 @@ namespace glz
          {
             dump<tag::generic_array>(args...);
 
-            static constexpr auto N = refl<T>.N;
+            static constexpr auto N = refl<T>::N;
             dump_compressed_int<N>(args...);
 
-            invoke_table<refl<T>.N>(
-               [&]<size_t I>() { write<BEVE>::op<Opts>(get_member(value, get<I>(refl<T>.values)), ctx, args...); });
+            invoke_table<refl<T>::N>(
+               [&]<size_t I>() { write<BEVE>::op<Opts>(get_member(value, get<I>(refl<T>::values)), ctx, args...); });
          }
       };
 

--- a/include/glaze/beve/write.hpp
+++ b/include/glaze/beve/write.hpp
@@ -168,7 +168,7 @@ namespace glz
          template <auto Opts>
          static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix)
          {
-            static constexpr auto N = refl<T>::N;
+            static constexpr auto N = refl<T>::size;
 
             std::array<uint8_t, byte_length<T>()> data{};
 
@@ -651,7 +651,7 @@ namespace glz
          requires(glaze_object_t<T> || reflectable<T>)
       struct to<BEVE, T> final
       {
-         static constexpr auto N = refl<T>::N;
+         static constexpr auto N = refl<T>::size;
          static constexpr size_t count_to_write = [] {
             size_t count{};
             invoke_table<N>([&]<size_t I>() {
@@ -756,10 +756,10 @@ namespace glz
          {
             dump<tag::generic_array>(args...);
 
-            static constexpr auto N = refl<T>::N;
+            static constexpr auto N = refl<T>::size;
             dump_compressed_int<N>(args...);
 
-            invoke_table<refl<T>::N>(
+            invoke_table<refl<T>::size>(
                [&]<size_t I>() { write<BEVE>::op<Opts>(get_member(value, get<I>(refl<T>::values)), ctx, args...); });
          }
       };

--- a/include/glaze/beve/write.hpp
+++ b/include/glaze/beve/write.hpp
@@ -7,7 +7,7 @@
 
 #include "glaze/beve/header.hpp"
 #include "glaze/core/opts.hpp"
-#include "glaze/core/refl.hpp"
+#include "glaze/core/reflect.hpp"
 #include "glaze/core/seek.hpp"
 #include "glaze/core/write.hpp"
 #include "glaze/util/dump.hpp"
@@ -168,12 +168,12 @@ namespace glz
          template <auto Opts>
          static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix)
          {
-            static constexpr auto N = refl<T>::size;
+            static constexpr auto N = reflect<T>::size;
 
             std::array<uint8_t, byte_length<T>()> data{};
 
             invoke_table<N>([&]<size_t I>() {
-               data[I / 8] |= static_cast<uint8_t>(get_member(value, get<I>(refl<T>::values))) << (7 - (I % 8));
+               data[I / 8] |= static_cast<uint8_t>(get_member(value, get<I>(reflect<T>::values))) << (7 - (I % 8));
             });
 
             dump(data, b, ix);
@@ -620,7 +620,7 @@ namespace glz
                count += glz::tuple_size_v<decltype(std::declval<Value>().value)> / 2;
             }
             else {
-               count += refl<Value>::N;
+               count += reflect<Value>::N;
             }
          });
          return count;
@@ -651,7 +651,7 @@ namespace glz
          requires(glaze_object_t<T> || reflectable<T>)
       struct to<BEVE, T> final
       {
-         static constexpr auto N = refl<T>::size;
+         static constexpr auto N = reflect<T>::size;
          static constexpr size_t count_to_write = [] {
             size_t count{};
             invoke_table<N>([&]<size_t I>() {
@@ -695,7 +695,7 @@ namespace glz
                      write<BEVE>::op<Opts>(get_member(value, get<I>(t)), ctx, args...);
                   }
                   else {
-                     write<BEVE>::op<Opts>(get_member(value, get<I>(refl<T>::values)), ctx, args...);
+                     write<BEVE>::op<Opts>(get_member(value, get<I>(reflect<T>::values)), ctx, args...);
                   }
                }
             });
@@ -729,7 +729,7 @@ namespace glz
                   return;
                }
                else {
-                  static constexpr sv key = refl<T>::keys[I];
+                  static constexpr sv key = reflect<T>::keys[I];
                   write<BEVE>::no_header<Opts>(key, ctx, args...);
 
                   decltype(auto) member = [&]() -> decltype(auto) {
@@ -737,7 +737,7 @@ namespace glz
                         return get<I>(t);
                      }
                      else {
-                        return get<I>(refl<T>::values);
+                        return get<I>(reflect<T>::values);
                      }
                   }();
 
@@ -756,11 +756,11 @@ namespace glz
          {
             dump<tag::generic_array>(args...);
 
-            static constexpr auto N = refl<T>::size;
+            static constexpr auto N = reflect<T>::size;
             dump_compressed_int<N>(args...);
 
-            invoke_table<refl<T>::size>(
-               [&]<size_t I>() { write<BEVE>::op<Opts>(get_member(value, get<I>(refl<T>::values)), ctx, args...); });
+            invoke_table<reflect<T>::size>(
+               [&]<size_t I>() { write<BEVE>::op<Opts>(get_member(value, get<I>(reflect<T>::values)), ctx, args...); });
          }
       };
 

--- a/include/glaze/compare/approx.hpp
+++ b/include/glaze/compare/approx.hpp
@@ -14,7 +14,7 @@ namespace glz
       template <detail::glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
-         constexpr auto N = refl<T>::N;
+         constexpr auto N = refl<T>::size;
 
          bool equal = true;
          for_each_short_circuit<N>([&](auto I) {

--- a/include/glaze/compare/approx.hpp
+++ b/include/glaze/compare/approx.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "glaze/core/common.hpp"
-#include "glaze/core/refl.hpp"
+#include "glaze/core/reflect.hpp"
 
 namespace glz
 {
@@ -14,12 +14,12 @@ namespace glz
       template <detail::glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
-         constexpr auto N = refl<T>::size;
+         constexpr auto N = reflect<T>::size;
 
          bool equal = true;
          for_each_short_circuit<N>([&](auto I) {
-            auto& l = detail::get_member(lhs, get<I>(refl<T>::values));
-            auto& r = detail::get_member(rhs, get<I>(refl<T>::values));
+            auto& l = detail::get_member(lhs, get<I>(reflect<T>::values));
+            auto& r = detail::get_member(rhs, get<I>(reflect<T>::values));
             using V = std::decay_t<decltype(l)>;
             if constexpr (std::floating_point<V> && requires { meta<std::decay_t<T>>::compare_epsilon; }) {
                if (std::abs(l - r) >= meta<std::decay_t<T>>::compare_epsilon) {

--- a/include/glaze/compare/approx.hpp
+++ b/include/glaze/compare/approx.hpp
@@ -14,12 +14,12 @@ namespace glz
       template <detail::glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
-         constexpr auto N = refl<T>.N;
+         constexpr auto N = refl<T>::N;
 
          bool equal = true;
          for_each_short_circuit<N>([&](auto I) {
-            auto& l = detail::get_member(lhs, get<I>(refl<T>.values));
-            auto& r = detail::get_member(rhs, get<I>(refl<T>.values));
+            auto& l = detail::get_member(lhs, get<I>(refl<T>::values));
+            auto& r = detail::get_member(rhs, get<I>(refl<T>::values));
             using V = std::decay_t<decltype(l)>;
             if constexpr (std::floating_point<V> && requires { meta<std::decay_t<T>>::compare_epsilon; }) {
                if (std::abs(l - r) >= meta<std::decay_t<T>>::compare_epsilon) {

--- a/include/glaze/compare/compare.hpp
+++ b/include/glaze/compare/compare.hpp
@@ -6,7 +6,7 @@
 #include <functional>
 
 #include "glaze/core/common.hpp"
-#include "glaze/core/refl.hpp"
+#include "glaze/core/reflect.hpp"
 
 namespace glz
 {
@@ -19,12 +19,12 @@ namespace glz
             return lhs == rhs;
          }
          else {
-            constexpr auto N = refl<T>::size;
+            constexpr auto N = reflect<T>::size;
 
             bool equal = true;
             for_each_short_circuit<N>([&](auto I) {
-               auto& l = detail::get_member(lhs, get<I>(refl<T>::values));
-               auto& r = detail::get_member(rhs, get<I>(refl<T>::values));
+               auto& l = detail::get_member(lhs, get<I>(reflect<T>::values));
+               auto& r = detail::get_member(rhs, get<I>(reflect<T>::values));
                if (!std::equal_to{}(l, r)) {
                   equal = false;
                   return true; // exit
@@ -42,12 +42,12 @@ namespace glz
       template <detail::glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
-         constexpr auto N = refl<T>::size;
+         constexpr auto N = reflect<T>::size;
 
          bool less_than = true;
          for_each_short_circuit<N>([&](auto I) {
-            auto& l = detail::get_member(lhs, get<I>(refl<T>::values));
-            auto& r = detail::get_member(rhs, get<I>(refl<T>::values));
+            auto& l = detail::get_member(lhs, get<I>(reflect<T>::values));
+            auto& r = detail::get_member(rhs, get<I>(reflect<T>::values));
             if (!std::less{}(l, r)) {
                less_than = false;
                return true; // exit
@@ -64,12 +64,12 @@ namespace glz
       template <detail::glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
-         constexpr auto N = refl<T>::size;
+         constexpr auto N = reflect<T>::size;
 
          bool less_than = true;
          for_each_short_circuit<N>([&](auto I) {
-            auto& l = detail::get_member(lhs, get<I>(refl<T>::values));
-            auto& r = detail::get_member(rhs, get<I>(refl<T>::values));
+            auto& l = detail::get_member(lhs, get<I>(reflect<T>::values));
+            auto& r = detail::get_member(rhs, get<I>(reflect<T>::values));
             if (!std::less_equal{}(l, r)) {
                less_than = false;
                return true; // exit
@@ -86,12 +86,12 @@ namespace glz
       template <detail::glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
-         constexpr auto N = refl<T>::size;
+         constexpr auto N = reflect<T>::size;
 
          bool greater_than = true;
          for_each_short_circuit<N>([&](auto I) {
-            auto& l = detail::get_member(lhs, get<I>(refl<T>::values));
-            auto& r = detail::get_member(rhs, get<I>(refl<T>::values));
+            auto& l = detail::get_member(lhs, get<I>(reflect<T>::values));
+            auto& r = detail::get_member(rhs, get<I>(reflect<T>::values));
             if (!std::greater{}(l, r)) {
                greater_than = false;
                return true; // exit
@@ -108,12 +108,12 @@ namespace glz
       template <detail::glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
-         constexpr auto N = refl<T>::size;
+         constexpr auto N = reflect<T>::size;
 
          bool greater_than = true;
          for_each_short_circuit<N>([&](auto I) {
-            auto& l = detail::get_member(lhs, get<I>(refl<T>::values));
-            auto& r = detail::get_member(rhs, get<I>(refl<T>::values));
+            auto& l = detail::get_member(lhs, get<I>(reflect<T>::values));
+            auto& r = detail::get_member(rhs, get<I>(reflect<T>::values));
             if (!std::greater_equal{}(l, r)) {
                greater_than = false;
                return true; // exit

--- a/include/glaze/compare/compare.hpp
+++ b/include/glaze/compare/compare.hpp
@@ -19,7 +19,7 @@ namespace glz
             return lhs == rhs;
          }
          else {
-            constexpr auto N = refl<T>::N;
+            constexpr auto N = refl<T>::size;
 
             bool equal = true;
             for_each_short_circuit<N>([&](auto I) {
@@ -42,7 +42,7 @@ namespace glz
       template <detail::glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
-         constexpr auto N = refl<T>::N;
+         constexpr auto N = refl<T>::size;
 
          bool less_than = true;
          for_each_short_circuit<N>([&](auto I) {
@@ -64,7 +64,7 @@ namespace glz
       template <detail::glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
-         constexpr auto N = refl<T>::N;
+         constexpr auto N = refl<T>::size;
 
          bool less_than = true;
          for_each_short_circuit<N>([&](auto I) {
@@ -86,7 +86,7 @@ namespace glz
       template <detail::glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
-         constexpr auto N = refl<T>::N;
+         constexpr auto N = refl<T>::size;
 
          bool greater_than = true;
          for_each_short_circuit<N>([&](auto I) {
@@ -108,7 +108,7 @@ namespace glz
       template <detail::glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
-         constexpr auto N = refl<T>::N;
+         constexpr auto N = refl<T>::size;
 
          bool greater_than = true;
          for_each_short_circuit<N>([&](auto I) {

--- a/include/glaze/compare/compare.hpp
+++ b/include/glaze/compare/compare.hpp
@@ -19,12 +19,12 @@ namespace glz
             return lhs == rhs;
          }
          else {
-            constexpr auto N = refl<T>.N;
+            constexpr auto N = refl<T>::N;
 
             bool equal = true;
             for_each_short_circuit<N>([&](auto I) {
-               auto& l = detail::get_member(lhs, get<I>(refl<T>.values));
-               auto& r = detail::get_member(rhs, get<I>(refl<T>.values));
+               auto& l = detail::get_member(lhs, get<I>(refl<T>::values));
+               auto& r = detail::get_member(rhs, get<I>(refl<T>::values));
                if (!std::equal_to{}(l, r)) {
                   equal = false;
                   return true; // exit
@@ -42,12 +42,12 @@ namespace glz
       template <detail::glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
-         constexpr auto N = refl<T>.N;
+         constexpr auto N = refl<T>::N;
 
          bool less_than = true;
          for_each_short_circuit<N>([&](auto I) {
-            auto& l = detail::get_member(lhs, get<I>(refl<T>.values));
-            auto& r = detail::get_member(rhs, get<I>(refl<T>.values));
+            auto& l = detail::get_member(lhs, get<I>(refl<T>::values));
+            auto& r = detail::get_member(rhs, get<I>(refl<T>::values));
             if (!std::less{}(l, r)) {
                less_than = false;
                return true; // exit
@@ -64,12 +64,12 @@ namespace glz
       template <detail::glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
-         constexpr auto N = refl<T>.N;
+         constexpr auto N = refl<T>::N;
 
          bool less_than = true;
          for_each_short_circuit<N>([&](auto I) {
-            auto& l = detail::get_member(lhs, get<I>(refl<T>.values));
-            auto& r = detail::get_member(rhs, get<I>(refl<T>.values));
+            auto& l = detail::get_member(lhs, get<I>(refl<T>::values));
+            auto& r = detail::get_member(rhs, get<I>(refl<T>::values));
             if (!std::less_equal{}(l, r)) {
                less_than = false;
                return true; // exit
@@ -86,12 +86,12 @@ namespace glz
       template <detail::glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
-         constexpr auto N = refl<T>.N;
+         constexpr auto N = refl<T>::N;
 
          bool greater_than = true;
          for_each_short_circuit<N>([&](auto I) {
-            auto& l = detail::get_member(lhs, get<I>(refl<T>.values));
-            auto& r = detail::get_member(rhs, get<I>(refl<T>.values));
+            auto& l = detail::get_member(lhs, get<I>(refl<T>::values));
+            auto& r = detail::get_member(rhs, get<I>(refl<T>::values));
             if (!std::greater{}(l, r)) {
                greater_than = false;
                return true; // exit
@@ -108,12 +108,12 @@ namespace glz
       template <detail::glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
-         constexpr auto N = refl<T>.N;
+         constexpr auto N = refl<T>::N;
 
          bool greater_than = true;
          for_each_short_circuit<N>([&](auto I) {
-            auto& l = detail::get_member(lhs, get<I>(refl<T>.values));
-            auto& r = detail::get_member(rhs, get<I>(refl<T>.values));
+            auto& l = detail::get_member(lhs, get<I>(refl<T>::values));
+            auto& r = detail::get_member(rhs, get<I>(refl<T>::values));
             if (!std::greater_equal{}(l, r)) {
                greater_than = false;
                return true; // exit

--- a/include/glaze/core/feature_test.hpp
+++ b/include/glaze/core/feature_test.hpp
@@ -4,9 +4,9 @@
 #pragma once
 
 // Feature test macros
-#define glaze_v3_refl_info // Version 3.0.0 refl_info metadata
+#define glaze_v3_6_0_refl // Version 3.6.0 refl metadata
 
 namespace glz::features
 {
-   static constexpr auto v3_refl_info = true;
+   static constexpr auto v3_refl = true;
 }

--- a/include/glaze/core/feature_test.hpp
+++ b/include/glaze/core/feature_test.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 // Feature test macros
-#define glaze_v3_6_0_refl // Version 3.6.0 refl metadata
+#define glaze_v3_6_0_refl // Version 3.6.0 reflect metadata
 
 namespace glz::features
 {

--- a/include/glaze/core/refl.hpp
+++ b/include/glaze/core/refl.hpp
@@ -131,14 +131,14 @@ namespace glz
    };
 
    template <class T>
-   struct refl_info;
+   struct refl;
 
    // MSVC requires this template specialization for when the tuple size if zero,
    // otherwise MSVC tries to instantiate calls of get<0> in invalid branches
    template <class T>
       requires((detail::glaze_object_t<T> || detail::glaze_flags_t<T> || detail::glaze_enum_t<T>) &&
                (tuple_size_v<meta_t<T>> == 0))
-   struct refl_info<T>
+   struct refl<T>
    {
       static constexpr auto N = 0;
       static constexpr auto values = tuplet::tuple{};
@@ -152,7 +152,7 @@ namespace glz
       requires(!detail::meta_keys<T> &&
                (detail::glaze_object_t<T> || detail::glaze_flags_t<T> || detail::glaze_enum_t<T>) &&
                (tuple_size_v<meta_t<T>> != 0))
-   struct refl_info<T>
+   struct refl<T>
    {
       using V = std::remove_cvref_t<T>;
       static constexpr auto value_indices = filter_indices<meta_t<V>, not_object_key_type>();
@@ -195,7 +195,7 @@ namespace glz
 
    template <class T>
       requires(detail::meta_keys<T> && detail::glaze_t<T>)
-   struct refl_info<T>
+   struct refl<T>
    {
       using V = std::remove_cvref_t<T>;
       static constexpr auto N = tuple_size_v<meta_keys_t<T>>;
@@ -213,12 +213,12 @@ namespace glz
 
    template <class T>
       requires(detail::is_memory_object<T>)
-   struct refl_info<T> : refl_info<memory_type<T>>
+   struct refl<T> : refl<memory_type<T>>
    {};
 
    template <class T>
       requires(detail::glaze_array_t<T>)
-   struct refl_info<T>
+   struct refl<T>
    {
       using V = std::remove_cvref_t<T>;
 
@@ -235,7 +235,7 @@ namespace glz
 
    template <class T>
       requires detail::reflectable<T>
-   struct refl_info<T>
+   struct refl<T>
    {
       using V = std::remove_cvref_t<T>;
       using tuple = decay_keep_volatile_t<decltype(detail::to_tuple(std::declval<T>()))>;
@@ -254,26 +254,23 @@ namespace glz
 
    template <class T>
       requires detail::readable_map_t<T>
-   struct refl_info<T>
+   struct refl<T>
    {
       static constexpr auto N = 0;
    };
 
-   template <class T>
-   constexpr auto refl = refl_info<T>{};
+   template <class T, size_t I>
+   using elem_t = refl<T>::template elem<I>;
 
    template <class T, size_t I>
-   using elem_t = refl_info<T>::template elem<I>;
-
-   template <class T, size_t I>
-   using refl_t = refl_info<T>::template type<I>;
+   using refl_t = refl<T>::template type<I>;
 
    // MSVC requires this specialization, otherwise it will try to instatiate dead `if constexpr` branches for N == 0
    template <opts Opts, class T>
    struct object_info;
 
    template <opts Opts, class T>
-      requires(refl<T>.N == 0)
+      requires(refl<T>::N == 0)
    struct object_info<Opts, T>
    {
       static constexpr bool first_will_be_written = false;
@@ -281,10 +278,10 @@ namespace glz
    };
 
    template <opts Opts, class T>
-      requires(refl<T>.N > 0)
+      requires(refl<T>::N > 0)
    struct object_info<Opts, T>
    {
-      static constexpr auto N = refl<T>.N;
+      static constexpr auto N = refl<T>::N;
 
       // Allows us to remove a branch if the first item will always be written
       static constexpr bool first_will_be_written = [] {
@@ -341,14 +338,14 @@ namespace glz::detail
          return get<I>(member_names<T>);
       }
       else {
-         return refl<T>.keys[I];
+         return refl<T>::keys[I];
       }
    }();
 
    template <class T, auto Opts>
    constexpr auto required_fields()
    {
-      constexpr auto N = refl<T>.N;
+      constexpr auto N = refl<T>::N;
 
       bit_array<N> fields{};
       if constexpr (Opts.error_on_missing_keys) {
@@ -394,7 +391,7 @@ namespace glz::detail
    struct tuple_ptr_variant<std::pair<Ts...>> : unique<std::variant<>, std::add_pointer_t<Ts>...>
    {};
 
-   template <class T, class = std::make_index_sequence<refl<T>.N>>
+   template <class T, class = std::make_index_sequence<refl<T>::N>>
    struct member_tuple_type;
 
    template <class T, size_t... I>
@@ -407,7 +404,7 @@ namespace glz::detail
    template <class T>
    using member_tuple_t = typename member_tuple_type<T>::type;
 
-   template <class T, class = std::make_index_sequence<refl<T>.N>>
+   template <class T, class = std::make_index_sequence<refl<T>::N>>
    struct value_variant;
 
    template <class T, size_t... I>
@@ -424,8 +421,8 @@ namespace glz::detail
    {
       return []<size_t... I>(std::index_sequence<I...>) {
          using value_t = value_variant_t<T>;
-         return std::array<value_t, refl<T>.N>{get<I>(refl<T>.values)...};
-      }(std::make_index_sequence<refl<T>.N>{});
+         return std::array<value_t, refl<T>::N>{get<I>(refl<T>::values)...};
+      }(std::make_index_sequence<refl<T>::N>{});
    }
 
    template <class Tuple, std::size_t... Is>
@@ -457,16 +454,16 @@ namespace glz::detail
 namespace glz::detail
 {
    template <class T, size_t I>
-   constexpr auto key_value = pair<sv, value_variant_t<T>>{refl<T>.keys[I], get<I>(refl<T>.values)};
+   constexpr auto key_value = pair<sv, value_variant_t<T>>{refl<T>::keys[I], get<I>(refl<T>::values)};
 
    template <class T, size_t I>
-   constexpr sv key_v = refl<T>.keys[I];
+   constexpr sv key_v = refl<T>::keys[I];
 
    template <class T, bool use_hash_comparison, size_t... I>
    constexpr auto make_map_impl(std::index_sequence<I...>)
    {
       using value_t = value_variant_t<T>;
-      constexpr auto n = refl<T>.N;
+      constexpr auto n = refl<T>::N;
 
       if constexpr (n == 0) {
          return nullptr; // Hack to fix MSVC
@@ -480,7 +477,7 @@ namespace glz::detail
       }
       else if constexpr (n < 64) // don't even attempt a first character hash if we have too many keys
       {
-         constexpr auto& keys = refl<T>.keys;
+         constexpr auto& keys = refl<T>::keys;
          constexpr auto front_desc = single_char_hash<n>(keys);
 
          if constexpr (front_desc.valid) {
@@ -522,16 +519,16 @@ namespace glz::detail
       requires(!reflectable<T>)
    constexpr auto make_map()
    {
-      constexpr auto indices = std::make_index_sequence<refl<T>.N>{};
+      constexpr auto indices = std::make_index_sequence<refl<T>::N>{};
       return make_map_impl<decay_keep_volatile_t<T>, use_hash_comparison>(indices);
    }
 
    template <class T>
    constexpr auto make_key_int_map()
    {
-      constexpr auto N = refl<T>.N;
+      constexpr auto N = refl<T>::N;
       return [&]<size_t... I>(std::index_sequence<I...>) {
-         return normal_map<sv, size_t, refl<T>.N>(pair<sv, size_t>{refl<T>.keys[I], I}...);
+         return normal_map<sv, size_t, refl<T>::N>(pair<sv, size_t>{refl<T>::keys[I], I}...);
       }(std::make_index_sequence<N>{});
    }
 }
@@ -545,7 +542,7 @@ namespace glz
 
       if constexpr (detail::glaze_t<T>) {
          using U = std::underlying_type_t<T>;
-         return refl<T>.keys[static_cast<U>(Enum)];
+         return refl<T>::keys[static_cast<U>(Enum)];
       }
       else {
          static_assert(false_v<decltype(Enum)>, "Enum requires glaze metadata for name");
@@ -558,11 +555,11 @@ namespace glz::detail
    template <class T>
    constexpr auto make_enum_to_string_map()
    {
-      constexpr auto N = refl<T>.N;
+      constexpr auto N = refl<T>::N;
       return [&]<size_t... I>(std::index_sequence<I...>) {
          using key_t = std::underlying_type_t<T>;
          return normal_map<key_t, sv, N>(std::array<pair<key_t, sv>, N>{
-            pair<key_t, sv>{static_cast<key_t>(glz::get<I>(refl<T>.values)), refl<T>.keys[I]}...});
+            pair<key_t, sv>{static_cast<key_t>(glz::get<I>(refl<T>::values)), refl<T>::keys[I]}...});
       }(std::make_index_sequence<N>{});
    }
 
@@ -571,17 +568,17 @@ namespace glz::detail
    constexpr auto make_enum_to_string_array() noexcept
    {
       return []<size_t... I>(std::index_sequence<I...>) {
-         return std::array<sv, sizeof...(I)>{refl<T>.keys[I]...};
-      }(std::make_index_sequence<refl<T>.N>{});
+         return std::array<sv, sizeof...(I)>{refl<T>::keys[I]...};
+      }(std::make_index_sequence<refl<T>::N>{});
    }
 
    template <class T>
    constexpr auto make_string_to_enum_map() noexcept
    {
-      constexpr auto N = refl<T>.N;
+      constexpr auto N = refl<T>::N;
       return [&]<size_t... I>(std::index_sequence<I...>) {
          return normal_map<sv, T, N>(
-            std::array<pair<sv, T>, N>{pair<sv, T>{refl<T>.keys[I], T(glz::get<I>(refl<T>.values))}...});
+            std::array<pair<sv, T>, N>{pair<sv, T>{refl<T>::keys[I], T(glz::get<I>(refl<T>::values))}...});
       }(std::make_index_sequence<N>{});
    }
 
@@ -599,7 +596,7 @@ namespace glz::detail
    template <detail::glaze_flags_t T>
    consteval auto byte_length() noexcept
    {
-      constexpr auto N = refl<T>.N;
+      constexpr auto N = refl<T>::N;
 
       if constexpr (N % 8 == 0) {
          return N / 8;
@@ -736,10 +733,10 @@ namespace glz::detail
       for_each<N>([&](auto I) {
          using V = std::decay_t<std::variant_alternative_t<I, T>>;
          if constexpr (glaze_object_t<V> || reflectable<V>) {
-            res += refl<V>.N;
+            res += refl<V>::N;
          }
          else if constexpr (is_memory_object<V>) {
-            res += refl<memory_type<V>>.N;
+            res += refl<memory_type<V>>::N;
          }
       });
       return res;
@@ -758,8 +755,8 @@ namespace glz::detail
          using V = std::decay_t<std::variant_alternative_t<I, T>>;
          if constexpr (glaze_object_t<V> || reflectable<V> || is_memory_object<V>) {
             using X = std::conditional_t<is_memory_object<V>, memory_type<V>, V>;
-            for (size_t i = 0; i < refl<X>.N; ++i) {
-               (*data_ptr)[index++] = refl<X>.keys[i];
+            for (size_t i = 0; i < refl<X>::N; ++i) {
+               (*data_ptr)[index++] = refl<X>::keys[i];
             }
          }
       });
@@ -792,7 +789,7 @@ namespace glz::detail
          using V = decay_keep_volatile_t<std::variant_alternative_t<I, T>>;
          if constexpr (glaze_object_t<V> || reflectable<V> || is_memory_object<V>) {
             using X = std::conditional_t<is_memory_object<V>, memory_type<V>, V>;
-            for_each<refl<X>.N>([&](auto J) { deduction_map.find(refl<X>.keys[J])->second[I] = true; });
+            for_each<refl<X>::N>([&](auto J) { deduction_map.find(refl<X>::keys[J])->second[I] = true; });
          }
       });
 
@@ -920,7 +917,7 @@ namespace glz::detail
    }
 
    template <class T>
-   inline constexpr auto per_length_info = unique_per_length_info(refl<T>.keys);
+   inline constexpr auto per_length_info = unique_per_length_info(refl<T>::keys);
 
    consteval size_t bucket_size(hash_type type, size_t N)
    {
@@ -983,7 +980,7 @@ namespace glz::detail
    {
       hash_type type{};
 
-      static constexpr auto N = refl<T>.N;
+      static constexpr auto N = refl<T>::N;
       using V = bucket_value_t<N>;
       static constexpr auto invalid = static_cast<V>(N);
 
@@ -1545,17 +1542,17 @@ namespace glz::detail
    }
 
    template <class T>
-   constexpr auto keys_info = make_keys_info(refl<T>.keys);
+   constexpr auto keys_info = make_keys_info(refl<T>::keys);
 
    template <class T>
    constexpr auto hash_info = [] {
       if constexpr ((glaze_object_t<T> || reflectable<T> ||
                      ((std::is_enum_v<std::remove_cvref_t<T>> && meta_keys<T>) || glaze_enum_t<T>)) &&
-                    (refl<T>.N > 0)) {
+                    (refl<T>::N > 0)) {
          constexpr auto& k_info = keys_info<T>;
          constexpr auto& type = k_info.type;
-         constexpr auto& N = refl<T>.N;
-         constexpr auto& keys = refl<T>.keys;
+         constexpr auto& N = refl<T>::N;
+         constexpr auto& keys = refl<T>::keys;
 
          using enum hash_type;
          if constexpr (type == single_element) {
@@ -1734,7 +1731,7 @@ namespace glz::detail
    template <class T, auto HashInfo>
    struct decode_hash<JSON, T, HashInfo, hash_type::xor_mod4>
    {
-      static constexpr auto first_key_char = refl<T>.keys[0][0];
+      static constexpr auto first_key_char = refl<T>::keys[0][0];
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& /*end*/) noexcept
       {
@@ -1745,7 +1742,7 @@ namespace glz::detail
    template <class T, auto HashInfo>
    struct decode_hash<JSON, T, HashInfo, hash_type::minus_mod4>
    {
-      static constexpr auto first_key_char = refl<T>.keys[0][0];
+      static constexpr auto first_key_char = refl<T>::keys[0][0];
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& /*end*/) noexcept
       {
@@ -1756,7 +1753,7 @@ namespace glz::detail
    template <class T, auto HashInfo>
    struct decode_hash<JSON, T, HashInfo, hash_type::unique_index>
    {
-      static constexpr auto N = refl<T>.N;
+      static constexpr auto N = refl<T>::N;
       static constexpr auto bsize = bucket_size(hash_type::unique_index, N);
       static constexpr auto uindex = HashInfo.unique_index;
 
@@ -1786,11 +1783,11 @@ namespace glz::detail
                }
                // Avoids using a hash table
                if (std::is_constant_evaluated()) {
-                  constexpr auto first_key_char = refl<T>.keys[0][uindex];
+                  constexpr auto first_key_char = refl<T>::keys[0][uindex];
                   return size_t(bool(it[uindex] ^ first_key_char));
                }
                else {
-                  static constexpr auto first_key_char = refl<T>.keys[0][uindex];
+                  static constexpr auto first_key_char = refl<T>::keys[0][uindex];
                   return size_t(bool(it[uindex] ^ first_key_char));
                }
             }
@@ -1809,7 +1806,7 @@ namespace glz::detail
    template <class T, auto HashInfo>
    struct decode_hash<JSON, T, HashInfo, hash_type::three_element_unique_index>
    {
-      static constexpr auto N = refl<T>.N;
+      static constexpr auto N = refl<T>::N;
       static constexpr auto uindex = HashInfo.unique_index;
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end) noexcept
@@ -1821,11 +1818,11 @@ namespace glz::detail
          }
          // Avoids using a hash table
          if (std::is_constant_evaluated()) {
-            constexpr auto first_key_char = refl<T>.keys[0][uindex];
+            constexpr auto first_key_char = refl<T>::keys[0][uindex];
             return (uint8_t(it[uindex] ^ first_key_char) * HashInfo.seed) % 4;
          }
          else {
-            static constexpr auto first_key_char = refl<T>.keys[0][uindex];
+            static constexpr auto first_key_char = refl<T>::keys[0][uindex];
             return (uint8_t(it[uindex] ^ first_key_char) * HashInfo.seed) % 4;
          }
       }
@@ -1834,7 +1831,7 @@ namespace glz::detail
    template <class T, auto HashInfo>
    struct decode_hash<JSON, T, HashInfo, hash_type::front_hash>
    {
-      static constexpr auto N = refl<T>.N;
+      static constexpr auto N = refl<T>::N;
       static constexpr auto bsize = bucket_size(hash_type::front_hash, N);
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end) noexcept
@@ -1896,7 +1893,7 @@ namespace glz::detail
    template <class T, auto HashInfo>
    struct decode_hash<JSON, T, HashInfo, hash_type::unique_per_length>
    {
-      static constexpr auto N = refl<T>.N;
+      static constexpr auto N = refl<T>::N;
       static constexpr auto bsize = bucket_size(hash_type::unique_per_length, N);
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end) noexcept
@@ -1920,7 +1917,7 @@ namespace glz::detail
    template <class T, auto HashInfo>
    struct decode_hash<JSON, T, HashInfo, hash_type::full_flat>
    {
-      static constexpr auto N = refl<T>.N;
+      static constexpr auto N = refl<T>::N;
       static constexpr auto bsize = bucket_size(hash_type::full_flat, N);
       static constexpr auto min_length = HashInfo.min_length;
       static constexpr auto max_length = HashInfo.max_length;
@@ -1985,7 +1982,7 @@ namespace glz::detail
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::xor_mod4>
    {
-      static constexpr auto first_key_char = refl<T>.keys[0][0];
+      static constexpr auto first_key_char = refl<T>::keys[0][0];
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&&, const size_t) noexcept
       {
@@ -1996,7 +1993,7 @@ namespace glz::detail
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::minus_mod4>
    {
-      static constexpr auto first_key_char = refl<T>.keys[0][0];
+      static constexpr auto first_key_char = refl<T>::keys[0][0];
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&&, const size_t) noexcept
       {
@@ -2007,7 +2004,7 @@ namespace glz::detail
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::unique_index>
    {
-      static constexpr auto N = refl<T>.N;
+      static constexpr auto N = refl<T>::N;
       static constexpr auto bsize = bucket_size(hash_type::unique_index, N);
       static constexpr auto uindex = HashInfo.unique_index;
 
@@ -2028,11 +2025,11 @@ namespace glz::detail
                }
                // Avoids using a hash table
                if (std::is_constant_evaluated()) {
-                  constexpr auto first_key_char = refl<T>.keys[0][uindex];
+                  constexpr auto first_key_char = refl<T>::keys[0][uindex];
                   return size_t(bool(it[uindex] ^ first_key_char));
                }
                else {
-                  static constexpr auto first_key_char = refl<T>.keys[0][uindex];
+                  static constexpr auto first_key_char = refl<T>::keys[0][uindex];
                   return size_t(bool(it[uindex] ^ first_key_char));
                }
             }
@@ -2049,7 +2046,7 @@ namespace glz::detail
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::three_element_unique_index>
    {
-      static constexpr auto N = refl<T>.N;
+      static constexpr auto N = refl<T>::N;
       static constexpr auto uindex = HashInfo.unique_index;
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t) noexcept
@@ -2061,11 +2058,11 @@ namespace glz::detail
          }
          // Avoids using a hash table
          if (std::is_constant_evaluated()) {
-            constexpr auto first_key_char = refl<T>.keys[0][uindex];
+            constexpr auto first_key_char = refl<T>::keys[0][uindex];
             return (uint8_t(it[uindex] ^ first_key_char) * HashInfo.seed) % 4;
          }
          else {
-            static constexpr auto first_key_char = refl<T>.keys[0][uindex];
+            static constexpr auto first_key_char = refl<T>::keys[0][uindex];
             return (uint8_t(it[uindex] ^ first_key_char) * HashInfo.seed) % 4;
          }
       }
@@ -2074,7 +2071,7 @@ namespace glz::detail
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::front_hash>
    {
-      static constexpr auto N = refl<T>.N;
+      static constexpr auto N = refl<T>::N;
       static constexpr auto bsize = bucket_size(hash_type::front_hash, N);
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&&, const size_t) noexcept
@@ -2127,7 +2124,7 @@ namespace glz::detail
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::unique_per_length>
    {
-      static constexpr auto N = refl<T>.N;
+      static constexpr auto N = refl<T>::N;
       static constexpr auto bsize = bucket_size(hash_type::unique_per_length, N);
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
@@ -2144,7 +2141,7 @@ namespace glz::detail
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::full_flat>
    {
-      static constexpr auto N = refl<T>.N;
+      static constexpr auto N = refl<T>::N;
       static constexpr auto bsize = bucket_size(hash_type::full_flat, N);
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&&, const size_t n) noexcept

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -131,14 +131,14 @@ namespace glz
    };
 
    template <class T>
-   struct refl;
+   struct reflect;
 
    // MSVC requires this template specialization for when the tuple size if zero,
    // otherwise MSVC tries to instantiate calls of get<0> in invalid branches
    template <class T>
       requires((detail::glaze_object_t<T> || detail::glaze_flags_t<T> || detail::glaze_enum_t<T>) &&
                (tuple_size_v<meta_t<T>> == 0))
-   struct refl<T>
+   struct reflect<T>
    {
       static constexpr auto size = 0;
       static constexpr auto values = tuplet::tuple{};
@@ -152,7 +152,7 @@ namespace glz
       requires(!detail::meta_keys<T> &&
                (detail::glaze_object_t<T> || detail::glaze_flags_t<T> || detail::glaze_enum_t<T>) &&
                (tuple_size_v<meta_t<T>> != 0))
-   struct refl<T>
+   struct reflect<T>
    {
       using V = std::remove_cvref_t<T>;
       static constexpr auto value_indices = filter_indices<meta_t<V>, not_object_key_type>();
@@ -195,7 +195,7 @@ namespace glz
 
    template <class T>
       requires(detail::meta_keys<T> && detail::glaze_t<T>)
-   struct refl<T>
+   struct reflect<T>
    {
       using V = std::remove_cvref_t<T>;
       static constexpr auto size = tuple_size_v<meta_keys_t<T>>;
@@ -213,12 +213,12 @@ namespace glz
 
    template <class T>
       requires(detail::is_memory_object<T>)
-   struct refl<T> : refl<memory_type<T>>
+   struct reflect<T> : reflect<memory_type<T>>
    {};
 
    template <class T>
       requires(detail::glaze_array_t<T>)
-   struct refl<T>
+   struct reflect<T>
    {
       using V = std::remove_cvref_t<T>;
 
@@ -235,7 +235,7 @@ namespace glz
 
    template <class T>
       requires detail::reflectable<T>
-   struct refl<T>
+   struct reflect<T>
    {
       using V = std::remove_cvref_t<T>;
       using tuple = decay_keep_volatile_t<decltype(detail::to_tuple(std::declval<T>()))>;
@@ -254,23 +254,23 @@ namespace glz
 
    template <class T>
       requires detail::readable_map_t<T>
-   struct refl<T>
+   struct reflect<T>
    {
       static constexpr auto size = 0;
    };
 
    template <class T, size_t I>
-   using elem_t = refl<T>::template elem<I>;
+   using elem_t = reflect<T>::template elem<I>;
 
    template <class T, size_t I>
-   using refl_t = refl<T>::template type<I>;
+   using refl_t = reflect<T>::template type<I>;
 
    // MSVC requires this specialization, otherwise it will try to instatiate dead `if constexpr` branches for N == 0
    template <opts Opts, class T>
    struct object_info;
 
    template <opts Opts, class T>
-      requires(refl<T>::size == 0)
+      requires(reflect<T>::size == 0)
    struct object_info<Opts, T>
    {
       static constexpr bool first_will_be_written = false;
@@ -278,10 +278,10 @@ namespace glz
    };
 
    template <opts Opts, class T>
-      requires(refl<T>::size > 0)
+      requires(reflect<T>::size > 0)
    struct object_info<Opts, T>
    {
-      static constexpr auto N = refl<T>::size;
+      static constexpr auto N = reflect<T>::size;
 
       // Allows us to remove a branch if the first item will always be written
       static constexpr bool first_will_be_written = [] {
@@ -338,14 +338,14 @@ namespace glz::detail
          return get<I>(member_names<T>);
       }
       else {
-         return refl<T>::keys[I];
+         return reflect<T>::keys[I];
       }
    }();
 
    template <class T, auto Opts>
    constexpr auto required_fields()
    {
-      constexpr auto N = refl<T>::size;
+      constexpr auto N = reflect<T>::size;
 
       bit_array<N> fields{};
       if constexpr (Opts.error_on_missing_keys) {
@@ -391,7 +391,7 @@ namespace glz::detail
    struct tuple_ptr_variant<std::pair<Ts...>> : unique<std::variant<>, std::add_pointer_t<Ts>...>
    {};
 
-   template <class T, class = std::make_index_sequence<refl<T>::size>>
+   template <class T, class = std::make_index_sequence<reflect<T>::size>>
    struct member_tuple_type;
 
    template <class T, size_t... I>
@@ -404,7 +404,7 @@ namespace glz::detail
    template <class T>
    using member_tuple_t = typename member_tuple_type<T>::type;
 
-   template <class T, class = std::make_index_sequence<refl<T>::size>>
+   template <class T, class = std::make_index_sequence<reflect<T>::size>>
    struct value_variant;
 
    template <class T, size_t... I>
@@ -421,8 +421,8 @@ namespace glz::detail
    {
       return []<size_t... I>(std::index_sequence<I...>) {
          using value_t = value_variant_t<T>;
-         return std::array<value_t, refl<T>::size>{get<I>(refl<T>::values)...};
-      }(std::make_index_sequence<refl<T>::size>{});
+         return std::array<value_t, reflect<T>::size>{get<I>(reflect<T>::values)...};
+      }(std::make_index_sequence<reflect<T>::size>{});
    }
 
    template <class Tuple, std::size_t... Is>
@@ -454,16 +454,16 @@ namespace glz::detail
 namespace glz::detail
 {
    template <class T, size_t I>
-   constexpr auto key_value = pair<sv, value_variant_t<T>>{refl<T>::keys[I], get<I>(refl<T>::values)};
+   constexpr auto key_value = pair<sv, value_variant_t<T>>{reflect<T>::keys[I], get<I>(reflect<T>::values)};
 
    template <class T, size_t I>
-   constexpr sv key_v = refl<T>::keys[I];
+   constexpr sv key_v = reflect<T>::keys[I];
 
    template <class T, bool use_hash_comparison, size_t... I>
    constexpr auto make_map_impl(std::index_sequence<I...>)
    {
       using value_t = value_variant_t<T>;
-      constexpr auto n = refl<T>::size;
+      constexpr auto n = reflect<T>::size;
 
       if constexpr (n == 0) {
          return nullptr; // Hack to fix MSVC
@@ -477,7 +477,7 @@ namespace glz::detail
       }
       else if constexpr (n < 64) // don't even attempt a first character hash if we have too many keys
       {
-         constexpr auto& keys = refl<T>::keys;
+         constexpr auto& keys = reflect<T>::keys;
          constexpr auto front_desc = single_char_hash<n>(keys);
 
          if constexpr (front_desc.valid) {
@@ -519,16 +519,16 @@ namespace glz::detail
       requires(!reflectable<T>)
    constexpr auto make_map()
    {
-      constexpr auto indices = std::make_index_sequence<refl<T>::size>{};
+      constexpr auto indices = std::make_index_sequence<reflect<T>::size>{};
       return make_map_impl<decay_keep_volatile_t<T>, use_hash_comparison>(indices);
    }
 
    template <class T>
    constexpr auto make_key_int_map()
    {
-      constexpr auto N = refl<T>::size;
+      constexpr auto N = reflect<T>::size;
       return [&]<size_t... I>(std::index_sequence<I...>) {
-         return normal_map<sv, size_t, refl<T>::size>(pair<sv, size_t>{refl<T>::keys[I], I}...);
+         return normal_map<sv, size_t, reflect<T>::size>(pair<sv, size_t>{reflect<T>::keys[I], I}...);
       }(std::make_index_sequence<N>{});
    }
 }
@@ -542,7 +542,7 @@ namespace glz
 
       if constexpr (detail::glaze_t<T>) {
          using U = std::underlying_type_t<T>;
-         return refl<T>::keys[static_cast<U>(Enum)];
+         return reflect<T>::keys[static_cast<U>(Enum)];
       }
       else {
          static_assert(false_v<decltype(Enum)>, "Enum requires glaze metadata for name");
@@ -555,11 +555,11 @@ namespace glz::detail
    template <class T>
    constexpr auto make_enum_to_string_map()
    {
-      constexpr auto N = refl<T>::size;
+      constexpr auto N = reflect<T>::size;
       return [&]<size_t... I>(std::index_sequence<I...>) {
          using key_t = std::underlying_type_t<T>;
          return normal_map<key_t, sv, N>(std::array<pair<key_t, sv>, N>{
-            pair<key_t, sv>{static_cast<key_t>(glz::get<I>(refl<T>::values)), refl<T>::keys[I]}...});
+            pair<key_t, sv>{static_cast<key_t>(glz::get<I>(reflect<T>::values)), reflect<T>::keys[I]}...});
       }(std::make_index_sequence<N>{});
    }
 
@@ -568,17 +568,17 @@ namespace glz::detail
    constexpr auto make_enum_to_string_array() noexcept
    {
       return []<size_t... I>(std::index_sequence<I...>) {
-         return std::array<sv, sizeof...(I)>{refl<T>::keys[I]...};
-      }(std::make_index_sequence<refl<T>::size>{});
+         return std::array<sv, sizeof...(I)>{reflect<T>::keys[I]...};
+      }(std::make_index_sequence<reflect<T>::size>{});
    }
 
    template <class T>
    constexpr auto make_string_to_enum_map() noexcept
    {
-      constexpr auto N = refl<T>::size;
+      constexpr auto N = reflect<T>::size;
       return [&]<size_t... I>(std::index_sequence<I...>) {
          return normal_map<sv, T, N>(
-            std::array<pair<sv, T>, N>{pair<sv, T>{refl<T>::keys[I], T(glz::get<I>(refl<T>::values))}...});
+            std::array<pair<sv, T>, N>{pair<sv, T>{reflect<T>::keys[I], T(glz::get<I>(reflect<T>::values))}...});
       }(std::make_index_sequence<N>{});
    }
 
@@ -596,7 +596,7 @@ namespace glz::detail
    template <detail::glaze_flags_t T>
    consteval auto byte_length() noexcept
    {
-      constexpr auto N = refl<T>::size;
+      constexpr auto N = reflect<T>::size;
 
       if constexpr (N % 8 == 0) {
          return N / 8;
@@ -733,10 +733,10 @@ namespace glz::detail
       for_each<N>([&](auto I) {
          using V = std::decay_t<std::variant_alternative_t<I, T>>;
          if constexpr (glaze_object_t<V> || reflectable<V>) {
-            res += refl<V>::size;
+            res += reflect<V>::size;
          }
          else if constexpr (is_memory_object<V>) {
-            res += refl<memory_type<V>>::size;
+            res += reflect<memory_type<V>>::size;
          }
       });
       return res;
@@ -755,8 +755,8 @@ namespace glz::detail
          using V = std::decay_t<std::variant_alternative_t<I, T>>;
          if constexpr (glaze_object_t<V> || reflectable<V> || is_memory_object<V>) {
             using X = std::conditional_t<is_memory_object<V>, memory_type<V>, V>;
-            for (size_t i = 0; i < refl<X>::size; ++i) {
-               (*data_ptr)[index++] = refl<X>::keys[i];
+            for (size_t i = 0; i < reflect<X>::size; ++i) {
+               (*data_ptr)[index++] = reflect<X>::keys[i];
             }
          }
       });
@@ -789,7 +789,7 @@ namespace glz::detail
          using V = decay_keep_volatile_t<std::variant_alternative_t<I, T>>;
          if constexpr (glaze_object_t<V> || reflectable<V> || is_memory_object<V>) {
             using X = std::conditional_t<is_memory_object<V>, memory_type<V>, V>;
-            for_each<refl<X>::size>([&](auto J) { deduction_map.find(refl<X>::keys[J])->second[I] = true; });
+            for_each<reflect<X>::size>([&](auto J) { deduction_map.find(reflect<X>::keys[J])->second[I] = true; });
          }
       });
 
@@ -917,7 +917,7 @@ namespace glz::detail
    }
 
    template <class T>
-   inline constexpr auto per_length_info = unique_per_length_info(refl<T>::keys);
+   inline constexpr auto per_length_info = unique_per_length_info(reflect<T>::keys);
 
    consteval size_t bucket_size(hash_type type, size_t N)
    {
@@ -980,7 +980,7 @@ namespace glz::detail
    {
       hash_type type{};
 
-      static constexpr auto N = refl<T>::size;
+      static constexpr auto N = reflect<T>::size;
       using V = bucket_value_t<N>;
       static constexpr auto invalid = static_cast<V>(N);
 
@@ -1542,17 +1542,17 @@ namespace glz::detail
    }
 
    template <class T>
-   constexpr auto keys_info = make_keys_info(refl<T>::keys);
+   constexpr auto keys_info = make_keys_info(reflect<T>::keys);
 
    template <class T>
    constexpr auto hash_info = [] {
       if constexpr ((glaze_object_t<T> || reflectable<T> ||
                      ((std::is_enum_v<std::remove_cvref_t<T>> && meta_keys<T>) || glaze_enum_t<T>)) &&
-                    (refl<T>::size > 0)) {
+                    (reflect<T>::size > 0)) {
          constexpr auto& k_info = keys_info<T>;
          constexpr auto& type = k_info.type;
-         constexpr auto& N = refl<T>::size;
-         constexpr auto& keys = refl<T>::keys;
+         constexpr auto& N = reflect<T>::size;
+         constexpr auto& keys = reflect<T>::keys;
 
          using enum hash_type;
          if constexpr (type == single_element) {
@@ -1731,7 +1731,7 @@ namespace glz::detail
    template <class T, auto HashInfo>
    struct decode_hash<JSON, T, HashInfo, hash_type::xor_mod4>
    {
-      static constexpr auto first_key_char = refl<T>::keys[0][0];
+      static constexpr auto first_key_char = reflect<T>::keys[0][0];
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& /*end*/) noexcept
       {
@@ -1742,7 +1742,7 @@ namespace glz::detail
    template <class T, auto HashInfo>
    struct decode_hash<JSON, T, HashInfo, hash_type::minus_mod4>
    {
-      static constexpr auto first_key_char = refl<T>::keys[0][0];
+      static constexpr auto first_key_char = reflect<T>::keys[0][0];
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& /*end*/) noexcept
       {
@@ -1753,7 +1753,7 @@ namespace glz::detail
    template <class T, auto HashInfo>
    struct decode_hash<JSON, T, HashInfo, hash_type::unique_index>
    {
-      static constexpr auto N = refl<T>::size;
+      static constexpr auto N = reflect<T>::size;
       static constexpr auto bsize = bucket_size(hash_type::unique_index, N);
       static constexpr auto uindex = HashInfo.unique_index;
 
@@ -1783,11 +1783,11 @@ namespace glz::detail
                }
                // Avoids using a hash table
                if (std::is_constant_evaluated()) {
-                  constexpr auto first_key_char = refl<T>::keys[0][uindex];
+                  constexpr auto first_key_char = reflect<T>::keys[0][uindex];
                   return size_t(bool(it[uindex] ^ first_key_char));
                }
                else {
-                  static constexpr auto first_key_char = refl<T>::keys[0][uindex];
+                  static constexpr auto first_key_char = reflect<T>::keys[0][uindex];
                   return size_t(bool(it[uindex] ^ first_key_char));
                }
             }
@@ -1806,7 +1806,7 @@ namespace glz::detail
    template <class T, auto HashInfo>
    struct decode_hash<JSON, T, HashInfo, hash_type::three_element_unique_index>
    {
-      static constexpr auto N = refl<T>::size;
+      static constexpr auto N = reflect<T>::size;
       static constexpr auto uindex = HashInfo.unique_index;
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end) noexcept
@@ -1818,11 +1818,11 @@ namespace glz::detail
          }
          // Avoids using a hash table
          if (std::is_constant_evaluated()) {
-            constexpr auto first_key_char = refl<T>::keys[0][uindex];
+            constexpr auto first_key_char = reflect<T>::keys[0][uindex];
             return (uint8_t(it[uindex] ^ first_key_char) * HashInfo.seed) % 4;
          }
          else {
-            static constexpr auto first_key_char = refl<T>::keys[0][uindex];
+            static constexpr auto first_key_char = reflect<T>::keys[0][uindex];
             return (uint8_t(it[uindex] ^ first_key_char) * HashInfo.seed) % 4;
          }
       }
@@ -1831,7 +1831,7 @@ namespace glz::detail
    template <class T, auto HashInfo>
    struct decode_hash<JSON, T, HashInfo, hash_type::front_hash>
    {
-      static constexpr auto N = refl<T>::size;
+      static constexpr auto N = reflect<T>::size;
       static constexpr auto bsize = bucket_size(hash_type::front_hash, N);
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end) noexcept
@@ -1893,7 +1893,7 @@ namespace glz::detail
    template <class T, auto HashInfo>
    struct decode_hash<JSON, T, HashInfo, hash_type::unique_per_length>
    {
-      static constexpr auto N = refl<T>::size;
+      static constexpr auto N = reflect<T>::size;
       static constexpr auto bsize = bucket_size(hash_type::unique_per_length, N);
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end) noexcept
@@ -1917,7 +1917,7 @@ namespace glz::detail
    template <class T, auto HashInfo>
    struct decode_hash<JSON, T, HashInfo, hash_type::full_flat>
    {
-      static constexpr auto N = refl<T>::size;
+      static constexpr auto N = reflect<T>::size;
       static constexpr auto bsize = bucket_size(hash_type::full_flat, N);
       static constexpr auto min_length = HashInfo.min_length;
       static constexpr auto max_length = HashInfo.max_length;
@@ -1982,7 +1982,7 @@ namespace glz::detail
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::xor_mod4>
    {
-      static constexpr auto first_key_char = refl<T>::keys[0][0];
+      static constexpr auto first_key_char = reflect<T>::keys[0][0];
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&&, const size_t) noexcept
       {
@@ -1993,7 +1993,7 @@ namespace glz::detail
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::minus_mod4>
    {
-      static constexpr auto first_key_char = refl<T>::keys[0][0];
+      static constexpr auto first_key_char = reflect<T>::keys[0][0];
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&&, const size_t) noexcept
       {
@@ -2004,7 +2004,7 @@ namespace glz::detail
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::unique_index>
    {
-      static constexpr auto N = refl<T>::size;
+      static constexpr auto N = reflect<T>::size;
       static constexpr auto bsize = bucket_size(hash_type::unique_index, N);
       static constexpr auto uindex = HashInfo.unique_index;
 
@@ -2025,11 +2025,11 @@ namespace glz::detail
                }
                // Avoids using a hash table
                if (std::is_constant_evaluated()) {
-                  constexpr auto first_key_char = refl<T>::keys[0][uindex];
+                  constexpr auto first_key_char = reflect<T>::keys[0][uindex];
                   return size_t(bool(it[uindex] ^ first_key_char));
                }
                else {
-                  static constexpr auto first_key_char = refl<T>::keys[0][uindex];
+                  static constexpr auto first_key_char = reflect<T>::keys[0][uindex];
                   return size_t(bool(it[uindex] ^ first_key_char));
                }
             }
@@ -2046,7 +2046,7 @@ namespace glz::detail
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::three_element_unique_index>
    {
-      static constexpr auto N = refl<T>::size;
+      static constexpr auto N = reflect<T>::size;
       static constexpr auto uindex = HashInfo.unique_index;
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t) noexcept
@@ -2058,11 +2058,11 @@ namespace glz::detail
          }
          // Avoids using a hash table
          if (std::is_constant_evaluated()) {
-            constexpr auto first_key_char = refl<T>::keys[0][uindex];
+            constexpr auto first_key_char = reflect<T>::keys[0][uindex];
             return (uint8_t(it[uindex] ^ first_key_char) * HashInfo.seed) % 4;
          }
          else {
-            static constexpr auto first_key_char = refl<T>::keys[0][uindex];
+            static constexpr auto first_key_char = reflect<T>::keys[0][uindex];
             return (uint8_t(it[uindex] ^ first_key_char) * HashInfo.seed) % 4;
          }
       }
@@ -2071,7 +2071,7 @@ namespace glz::detail
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::front_hash>
    {
-      static constexpr auto N = refl<T>::size;
+      static constexpr auto N = reflect<T>::size;
       static constexpr auto bsize = bucket_size(hash_type::front_hash, N);
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&&, const size_t) noexcept
@@ -2124,7 +2124,7 @@ namespace glz::detail
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::unique_per_length>
    {
-      static constexpr auto N = refl<T>::size;
+      static constexpr auto N = reflect<T>::size;
       static constexpr auto bsize = bucket_size(hash_type::unique_per_length, N);
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
@@ -2141,7 +2141,7 @@ namespace glz::detail
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::full_flat>
    {
-      static constexpr auto N = refl<T>::size;
+      static constexpr auto N = reflect<T>::size;
       static constexpr auto bsize = bucket_size(hash_type::full_flat, N);
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&&, const size_t n) noexcept

--- a/include/glaze/core/seek.hpp
+++ b/include/glaze/core/seek.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "glaze/core/read.hpp"
-#include "glaze/core/refl.hpp"
+#include "glaze/core/reflect.hpp"
 #include "glaze/core/write.hpp"
 #include "glaze/util/glaze_fast_float.hpp"
 
@@ -96,7 +96,7 @@ namespace glz::detail
       }
 
       if constexpr (glaze_object_t<T> || reflectable<T>) {
-         static constexpr auto N = refl<T>::size;
+         static constexpr auto N = reflect<T>::size;
          static constexpr auto HashInfo = detail::hash_info<T>;
 
          const auto index = decode_hash_with_size<JSON_PTR, T, HashInfo, HashInfo.type>::op(
@@ -110,7 +110,7 @@ namespace glz::detail
                      ret = seek_impl(std::forward<F>(func), get_member(value, get<I>(to_tuple(value))), json_ptr);
                   }
                   else {
-                     ret = seek_impl(std::forward<F>(func), get_member(value, get<I>(refl<T>::values)), json_ptr);
+                     ret = seek_impl(std::forward<F>(func), get_member(value, get<I>(reflect<T>::values)), json_ptr);
                   }
                },
                index);

--- a/include/glaze/core/seek.hpp
+++ b/include/glaze/core/seek.hpp
@@ -96,7 +96,7 @@ namespace glz::detail
       }
 
       if constexpr (glaze_object_t<T> || reflectable<T>) {
-         static constexpr auto N = refl<T>.N;
+         static constexpr auto N = refl<T>::N;
          static constexpr auto HashInfo = detail::hash_info<T>;
 
          const auto index = decode_hash_with_size<JSON_PTR, T, HashInfo, HashInfo.type>::op(
@@ -110,7 +110,7 @@ namespace glz::detail
                      ret = seek_impl(std::forward<F>(func), get_member(value, get<I>(to_tuple(value))), json_ptr);
                   }
                   else {
-                     ret = seek_impl(std::forward<F>(func), get_member(value, get<I>(refl<T>.values)), json_ptr);
+                     ret = seek_impl(std::forward<F>(func), get_member(value, get<I>(refl<T>::values)), json_ptr);
                   }
                },
                index);

--- a/include/glaze/core/seek.hpp
+++ b/include/glaze/core/seek.hpp
@@ -96,7 +96,7 @@ namespace glz::detail
       }
 
       if constexpr (glaze_object_t<T> || reflectable<T>) {
-         static constexpr auto N = refl<T>::N;
+         static constexpr auto N = refl<T>::size;
          static constexpr auto HashInfo = detail::hash_info<T>;
 
          const auto index = decode_hash_with_size<JSON_PTR, T, HashInfo, HashInfo.type>::op(

--- a/include/glaze/csv/read.hpp
+++ b/include/glaze/csv/read.hpp
@@ -7,7 +7,7 @@
 
 #include "glaze/core/opts.hpp"
 #include "glaze/core/read.hpp"
-#include "glaze/core/refl.hpp"
+#include "glaze/core/reflect.hpp"
 #include "glaze/file/file_ops.hpp"
 #include "glaze/util/glaze_fast_float.hpp"
 #include "glaze/util/parse.hpp"
@@ -412,7 +412,7 @@ namespace glz
          template <auto Opts, class It>
          static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end)
          {
-            static constexpr auto N = refl<T>::size;
+            static constexpr auto N = reflect<T>::size;
             static constexpr auto HashInfo = detail::hash_info<T>;
 
             if constexpr (Opts.layout == rowwise) {
@@ -448,7 +448,7 @@ namespace glz
                                  return get_member(value, get<I>(to_tuple(value)));
                               }
                               else {
-                                 return get_member(value, get<I>(refl<T>::values));
+                                 return get_member(value, get<I>(reflect<T>::values));
                               }
                            }();
 
@@ -565,7 +565,7 @@ namespace glz
                                        return get_member(value, get<I>(to_tuple(value)));
                                     }
                                     else {
-                                       return get_member(value, get<I>(refl<T>::values));
+                                       return get_member(value, get<I>(reflect<T>::values));
                                     }
                                  }();
 

--- a/include/glaze/csv/read.hpp
+++ b/include/glaze/csv/read.hpp
@@ -412,7 +412,7 @@ namespace glz
          template <auto Opts, class It>
          static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end)
          {
-            static constexpr auto N = refl<T>::N;
+            static constexpr auto N = refl<T>::size;
             static constexpr auto HashInfo = detail::hash_info<T>;
 
             if constexpr (Opts.layout == rowwise) {

--- a/include/glaze/csv/read.hpp
+++ b/include/glaze/csv/read.hpp
@@ -412,7 +412,7 @@ namespace glz
          template <auto Opts, class It>
          static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end)
          {
-            static constexpr auto N = refl<T>.N;
+            static constexpr auto N = refl<T>::N;
             static constexpr auto HashInfo = detail::hash_info<T>;
 
             if constexpr (Opts.layout == rowwise) {
@@ -448,7 +448,7 @@ namespace glz
                                  return get_member(value, get<I>(to_tuple(value)));
                               }
                               else {
-                                 return get_member(value, get<I>(refl<T>.values));
+                                 return get_member(value, get<I>(refl<T>::values));
                               }
                            }();
 
@@ -565,7 +565,7 @@ namespace glz
                                        return get_member(value, get<I>(to_tuple(value)));
                                     }
                                     else {
-                                       return get_member(value, get<I>(refl<T>.values));
+                                       return get_member(value, get<I>(refl<T>::values));
                                     }
                                  }();
 

--- a/include/glaze/csv/write.hpp
+++ b/include/glaze/csv/write.hpp
@@ -176,7 +176,7 @@ namespace glz
          template <auto Opts, class B>
          static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix) noexcept
          {
-            static constexpr auto N = refl<T>::N;
+            static constexpr auto N = refl<T>::size;
 
             [[maybe_unused]] decltype(auto) t = [&] {
                if constexpr (reflectable<T>) {

--- a/include/glaze/csv/write.hpp
+++ b/include/glaze/csv/write.hpp
@@ -176,7 +176,7 @@ namespace glz
          template <auto Opts, class B>
          static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix) noexcept
          {
-            static constexpr auto N = refl<T>.N;
+            static constexpr auto N = refl<T>::N;
 
             [[maybe_unused]] decltype(auto) t = [&] {
                if constexpr (reflectable<T>) {
@@ -191,14 +191,14 @@ namespace glz
                for_each<N>([&](auto I) {
                   using value_type = typename std::decay_t<refl_t<T, I>>::value_type;
 
-                  static constexpr sv key = refl<T>.keys[I];
+                  static constexpr sv key = refl<T>::keys[I];
 
                   decltype(auto) mem = [&]() -> decltype(auto) {
                      if constexpr (reflectable<T>) {
                         return get<I>(t);
                      }
                      else {
-                        return get<I>(refl<T>.values);
+                        return get<I>(refl<T>::values);
                      }
                   }();
 
@@ -238,14 +238,14 @@ namespace glz
                for_each<N>([&](auto I) {
                   using X = refl_t<T, I>;
 
-                  static constexpr sv key = refl<T>.keys[I];
+                  static constexpr sv key = refl<T>::keys[I];
 
                   decltype(auto) member = [&]() -> decltype(auto) {
                      if constexpr (reflectable<T>) {
                         return get<I>(t);
                      }
                      else {
-                        return get<I>(refl<T>.values);
+                        return get<I>(refl<T>::values);
                      }
                   }();
 
@@ -284,7 +284,7 @@ namespace glz
                            return get<I>(t);
                         }
                         else {
-                           return get<I>(refl<T>.values);
+                           return get<I>(refl<T>::values);
                         }
                      }();
 

--- a/include/glaze/csv/write.hpp
+++ b/include/glaze/csv/write.hpp
@@ -176,7 +176,7 @@ namespace glz
          template <auto Opts, class B>
          static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix) noexcept
          {
-            static constexpr auto N = refl<T>::size;
+            static constexpr auto N = reflect<T>::size;
 
             [[maybe_unused]] decltype(auto) t = [&] {
                if constexpr (reflectable<T>) {
@@ -191,14 +191,14 @@ namespace glz
                for_each<N>([&](auto I) {
                   using value_type = typename std::decay_t<refl_t<T, I>>::value_type;
 
-                  static constexpr sv key = refl<T>::keys[I];
+                  static constexpr sv key = reflect<T>::keys[I];
 
                   decltype(auto) mem = [&]() -> decltype(auto) {
                      if constexpr (reflectable<T>) {
                         return get<I>(t);
                      }
                      else {
-                        return get<I>(refl<T>::values);
+                        return get<I>(reflect<T>::values);
                      }
                   }();
 
@@ -238,14 +238,14 @@ namespace glz
                for_each<N>([&](auto I) {
                   using X = refl_t<T, I>;
 
-                  static constexpr sv key = refl<T>::keys[I];
+                  static constexpr sv key = reflect<T>::keys[I];
 
                   decltype(auto) member = [&]() -> decltype(auto) {
                      if constexpr (reflectable<T>) {
                         return get<I>(t);
                      }
                      else {
-                        return get<I>(refl<T>::values);
+                        return get<I>(reflect<T>::values);
                      }
                   }();
 
@@ -284,7 +284,7 @@ namespace glz
                            return get<I>(t);
                         }
                         else {
-                           return get<I>(refl<T>::values);
+                           return get<I>(reflect<T>::values);
                         }
                      }();
 

--- a/include/glaze/ext/cli_menu.hpp
+++ b/include/glaze/ext/cli_menu.hpp
@@ -60,7 +60,7 @@ namespace glz
    {
       using namespace detail;
 
-      static constexpr auto N = refl<T>::size;
+      static constexpr auto N = reflect<T>::size;
 
       auto execute_menu_item = [&](const auto item_number) {
          if (item_number == N + 1) {
@@ -88,7 +88,7 @@ namespace glz
                         return get_member(value, get<I>(t));
                      }
                      else {
-                        return get_member(value, get<I>(refl<T>::values));
+                        return get_member(value, get<I>(reflect<T>::values));
                      }
                   }.template operator()<I>();
 
@@ -150,7 +150,7 @@ namespace glz
                         run_cli_menu<Opts>(get<I>(t), menu_boolean);
                      }
                      else {
-                        decltype(auto) v = get_member(value, get<I>(refl<T>::values));
+                        decltype(auto) v = get_member(value, get<I>(reflect<T>::values));
                         run_cli_menu<Opts>(v, menu_boolean);
                      }
                   }
@@ -173,7 +173,7 @@ namespace glz
          std::printf("================================\n");
          for_each<N>([&](auto I) {
             using E = refl_t<T, I>;
-            constexpr sv key = refl<T>::keys[I];
+            constexpr sv key = reflect<T>::keys[I];
 
             if constexpr (glaze_object_t<E> || reflectable<E>) {
                std::printf("  %d   %.*s\n", uint32_t(I + 1), int(key.size()), key.data());
@@ -193,7 +193,7 @@ namespace glz
                      return get<I>(t);
                   }
                   else {
-                     return get_member(value, get<I>(refl<T>::values));
+                     return get_member(value, get<I>(reflect<T>::values));
                   }
                }();
 

--- a/include/glaze/ext/cli_menu.hpp
+++ b/include/glaze/ext/cli_menu.hpp
@@ -60,7 +60,7 @@ namespace glz
    {
       using namespace detail;
 
-      static constexpr auto N = refl<T>::N;
+      static constexpr auto N = refl<T>::size;
 
       auto execute_menu_item = [&](const auto item_number) {
          if (item_number == N + 1) {

--- a/include/glaze/ext/cli_menu.hpp
+++ b/include/glaze/ext/cli_menu.hpp
@@ -60,7 +60,7 @@ namespace glz
    {
       using namespace detail;
 
-      static constexpr auto N = refl<T>.N;
+      static constexpr auto N = refl<T>::N;
 
       auto execute_menu_item = [&](const auto item_number) {
          if (item_number == N + 1) {
@@ -88,7 +88,7 @@ namespace glz
                         return get_member(value, get<I>(t));
                      }
                      else {
-                        return get_member(value, get<I>(refl<T>.values));
+                        return get_member(value, get<I>(refl<T>::values));
                      }
                   }.template operator()<I>();
 
@@ -150,7 +150,7 @@ namespace glz
                         run_cli_menu<Opts>(get<I>(t), menu_boolean);
                      }
                      else {
-                        decltype(auto) v = get_member(value, get<I>(refl<T>.values));
+                        decltype(auto) v = get_member(value, get<I>(refl<T>::values));
                         run_cli_menu<Opts>(v, menu_boolean);
                      }
                   }
@@ -173,7 +173,7 @@ namespace glz
          std::printf("================================\n");
          for_each<N>([&](auto I) {
             using E = refl_t<T, I>;
-            constexpr sv key = refl<T>.keys[I];
+            constexpr sv key = refl<T>::keys[I];
 
             if constexpr (glaze_object_t<E> || reflectable<E>) {
                std::printf("  %d   %.*s\n", uint32_t(I + 1), int(key.size()), key.data());
@@ -193,7 +193,7 @@ namespace glz
                      return get<I>(t);
                   }
                   else {
-                     return get_member(value, get<I>(refl<T>.values));
+                     return get_member(value, get<I>(refl<T>::values));
                   }
                }();
 

--- a/include/glaze/json/ndjson.hpp
+++ b/include/glaze/json/ndjson.hpp
@@ -109,7 +109,7 @@ namespace glz
 
             static constexpr auto N = []() constexpr {
                if constexpr (glaze_array_t<T>) {
-                  return refl<T>::N;
+                  return refl<T>::size;
                }
                else {
                   return glz::tuple_size_v<T>;

--- a/include/glaze/json/ndjson.hpp
+++ b/include/glaze/json/ndjson.hpp
@@ -109,7 +109,7 @@ namespace glz
 
             static constexpr auto N = []() constexpr {
                if constexpr (glaze_array_t<T>) {
-                  return refl<T>.N;
+                  return refl<T>::N;
                }
                else {
                   return glz::tuple_size_v<T>;

--- a/include/glaze/json/ndjson.hpp
+++ b/include/glaze/json/ndjson.hpp
@@ -109,7 +109,7 @@ namespace glz
 
             static constexpr auto N = []() constexpr {
                if constexpr (glaze_array_t<T>) {
-                  return refl<T>::size;
+                  return reflect<T>::size;
                }
                else {
                   return glz::tuple_size_v<T>;

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -140,7 +140,7 @@ namespace glz
       void decode_index(Func&& func, Tuple&& tuple, Value&& value, is_context auto&& ctx, auto&& it,
                         auto&& end) noexcept
       {
-         static constexpr auto TargetKey = glz::get<I>(refl<T>.keys);
+         static constexpr auto TargetKey = glz::get<I>(refl<T>::keys);
          static constexpr auto Length = TargetKey.size();
          // The == end check is validating that we have space for a quote
          if ((it + Length) >= end) [[unlikely]] {
@@ -199,7 +199,7 @@ namespace glz
 
             // invoke on the value
             if constexpr (glaze_object_t<T>) {
-               std::forward<Func>(func)(get<I>(refl<T>.values), I);
+               std::forward<Func>(func)(get<I>(refl<T>::values), I);
             }
             else {
                std::forward<Func>(func)(get<I>(std::forward<Tuple>(tuple)), I);
@@ -229,7 +229,7 @@ namespace glz
          requires(glaze_enum_t<T> || (meta_keys<T> && std::is_enum_v<T>))
       void decode_index(Value&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
       {
-         static constexpr auto TargetKey = glz::get<I>(refl<T>.keys);
+         static constexpr auto TargetKey = glz::get<I>(refl<T>::keys);
          static constexpr auto Length = TargetKey.size();
          // The == end check is validating that we have space for a quote
          if ((it + Length) >= end) [[unlikely]] {
@@ -243,7 +243,7 @@ namespace glz
                ctx.error = error_code::unexpected_enum;
                return;
             }
-            value = get<I>(refl<T>.values);
+            value = get<I>(refl<T>::values);
 
             ++it;
             GLZ_VALID_END();
@@ -260,7 +260,7 @@ namespace glz
                                                         auto&& end) noexcept
       {
          constexpr auto type = HashInfo.type;
-         constexpr auto N = refl<T>.N;
+         constexpr auto N = refl<T>::N;
 
          if constexpr (not bool(type)) {
             static_assert(false_v<T>, "invalid hash algorithm");
@@ -1233,7 +1233,7 @@ namespace glz
                GLZ_SKIP_WS();
             }
 
-            constexpr auto N = refl<T>.N;
+            constexpr auto N = refl<T>::N;
 
             if (*it != '"') [[unlikely]] {
                ctx.error = error_code::expected_quote;
@@ -1687,7 +1687,7 @@ namespace glz
          {
             static constexpr auto N = []() constexpr {
                if constexpr (glaze_array_t<T>) {
-                  return refl<T>.N;
+                  return refl<T>::N;
                }
                else {
                   return glz::tuple_size_v<T>;
@@ -1845,10 +1845,10 @@ namespace glz
             stats.min_length = tag_size;
          }
 
-         constexpr auto N = refl<T>.N;
+         constexpr auto N = refl<T>::N;
 
          for_each<N>([&](auto I) {
-            constexpr sv key = refl<T>.keys[I];
+            constexpr sv key = refl<T>::keys[I];
 
             const auto n = key.size();
             if (n < stats.min_length) {
@@ -1915,9 +1915,9 @@ namespace glz
          auto is_unicode = [](const auto c) { return (uint8_t(c) >> 7) > 0; };
 
          bool may_escape = false;
-         constexpr auto N = refl<T>.N;
+         constexpr auto N = refl<T>::N;
          for_each<N>([&](auto I) {
-            constexpr auto key = refl<T>.keys[I];
+            constexpr auto key = refl<T>::keys[I];
             for (auto& c : key) {
                if (c == '\\' || c == '"' || is_unicode(c)) {
                   may_escape = true;
@@ -1970,7 +1970,7 @@ namespace glz
                return std::variant_size_v<T>;
             }
             else {
-               return refl<T>.N;
+               return refl<T>::N;
             }
          }();
 
@@ -2099,7 +2099,7 @@ namespace glz
          template <auto Options, string_literal tag = "">
          static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
-            static constexpr auto num_members = refl<T>.N;
+            static constexpr auto num_members = refl<T>::N;
             if constexpr (num_members == 0 && is_partial_read<T>) {
                static_assert(false_v<T>, "No members to read for partial read");
             }

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -260,7 +260,7 @@ namespace glz
                                                         auto&& end) noexcept
       {
          constexpr auto type = HashInfo.type;
-         constexpr auto N = refl<T>::N;
+         constexpr auto N = refl<T>::size;
 
          if constexpr (not bool(type)) {
             static_assert(false_v<T>, "invalid hash algorithm");
@@ -1233,7 +1233,7 @@ namespace glz
                GLZ_SKIP_WS();
             }
 
-            constexpr auto N = refl<T>::N;
+            constexpr auto N = refl<T>::size;
 
             if (*it != '"') [[unlikely]] {
                ctx.error = error_code::expected_quote;
@@ -1687,7 +1687,7 @@ namespace glz
          {
             static constexpr auto N = []() constexpr {
                if constexpr (glaze_array_t<T>) {
-                  return refl<T>::N;
+                  return refl<T>::size;
                }
                else {
                   return glz::tuple_size_v<T>;
@@ -1845,7 +1845,7 @@ namespace glz
             stats.min_length = tag_size;
          }
 
-         constexpr auto N = refl<T>::N;
+         constexpr auto N = refl<T>::size;
 
          for_each<N>([&](auto I) {
             constexpr sv key = refl<T>::keys[I];
@@ -1915,7 +1915,7 @@ namespace glz
          auto is_unicode = [](const auto c) { return (uint8_t(c) >> 7) > 0; };
 
          bool may_escape = false;
-         constexpr auto N = refl<T>::N;
+         constexpr auto N = refl<T>::size;
          for_each<N>([&](auto I) {
             constexpr auto key = refl<T>::keys[I];
             for (auto& c : key) {
@@ -1970,7 +1970,7 @@ namespace glz
                return std::variant_size_v<T>;
             }
             else {
-               return refl<T>::N;
+               return refl<T>::size;
             }
          }();
 
@@ -2099,7 +2099,7 @@ namespace glz
          template <auto Options, string_literal tag = "">
          static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
-            static constexpr auto num_members = refl<T>::N;
+            static constexpr auto num_members = refl<T>::size;
             if constexpr (num_members == 0 && is_partial_read<T>) {
                static_assert(false_v<T>, "No members to read for partial read");
             }

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -14,7 +14,7 @@
 #include "glaze/core/common.hpp"
 #include "glaze/core/opts.hpp"
 #include "glaze/core/read.hpp"
-#include "glaze/core/refl.hpp"
+#include "glaze/core/reflect.hpp"
 #include "glaze/file/file_ops.hpp"
 #include "glaze/json/json_concepts.hpp"
 #include "glaze/json/json_t.hpp"
@@ -140,7 +140,7 @@ namespace glz
       void decode_index(Func&& func, Tuple&& tuple, Value&& value, is_context auto&& ctx, auto&& it,
                         auto&& end) noexcept
       {
-         static constexpr auto TargetKey = glz::get<I>(refl<T>::keys);
+         static constexpr auto TargetKey = glz::get<I>(reflect<T>::keys);
          static constexpr auto Length = TargetKey.size();
          // The == end check is validating that we have space for a quote
          if ((it + Length) >= end) [[unlikely]] {
@@ -199,7 +199,7 @@ namespace glz
 
             // invoke on the value
             if constexpr (glaze_object_t<T>) {
-               std::forward<Func>(func)(get<I>(refl<T>::values), I);
+               std::forward<Func>(func)(get<I>(reflect<T>::values), I);
             }
             else {
                std::forward<Func>(func)(get<I>(std::forward<Tuple>(tuple)), I);
@@ -229,7 +229,7 @@ namespace glz
          requires(glaze_enum_t<T> || (meta_keys<T> && std::is_enum_v<T>))
       void decode_index(Value&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
       {
-         static constexpr auto TargetKey = glz::get<I>(refl<T>::keys);
+         static constexpr auto TargetKey = glz::get<I>(reflect<T>::keys);
          static constexpr auto Length = TargetKey.size();
          // The == end check is validating that we have space for a quote
          if ((it + Length) >= end) [[unlikely]] {
@@ -243,7 +243,7 @@ namespace glz
                ctx.error = error_code::unexpected_enum;
                return;
             }
-            value = get<I>(refl<T>::values);
+            value = get<I>(reflect<T>::values);
 
             ++it;
             GLZ_VALID_END();
@@ -260,7 +260,7 @@ namespace glz
                                                         auto&& end) noexcept
       {
          constexpr auto type = HashInfo.type;
-         constexpr auto N = refl<T>::size;
+         constexpr auto N = reflect<T>::size;
 
          if constexpr (not bool(type)) {
             static_assert(false_v<T>, "invalid hash algorithm");
@@ -1233,7 +1233,7 @@ namespace glz
                GLZ_SKIP_WS();
             }
 
-            constexpr auto N = refl<T>::size;
+            constexpr auto N = reflect<T>::size;
 
             if (*it != '"') [[unlikely]] {
                ctx.error = error_code::expected_quote;
@@ -1687,7 +1687,7 @@ namespace glz
          {
             static constexpr auto N = []() constexpr {
                if constexpr (glaze_array_t<T>) {
-                  return refl<T>::size;
+                  return reflect<T>::size;
                }
                else {
                   return glz::tuple_size_v<T>;
@@ -1845,10 +1845,10 @@ namespace glz
             stats.min_length = tag_size;
          }
 
-         constexpr auto N = refl<T>::size;
+         constexpr auto N = reflect<T>::size;
 
          for_each<N>([&](auto I) {
-            constexpr sv key = refl<T>::keys[I];
+            constexpr sv key = reflect<T>::keys[I];
 
             const auto n = key.size();
             if (n < stats.min_length) {
@@ -1915,9 +1915,9 @@ namespace glz
          auto is_unicode = [](const auto c) { return (uint8_t(c) >> 7) > 0; };
 
          bool may_escape = false;
-         constexpr auto N = refl<T>::size;
+         constexpr auto N = reflect<T>::size;
          for_each<N>([&](auto I) {
-            constexpr auto key = refl<T>::keys[I];
+            constexpr auto key = reflect<T>::keys[I];
             for (auto& c : key) {
                if (c == '\\' || c == '"' || is_unicode(c)) {
                   may_escape = true;
@@ -1970,7 +1970,7 @@ namespace glz
                return std::variant_size_v<T>;
             }
             else {
-               return refl<T>::size;
+               return reflect<T>::size;
             }
          }();
 
@@ -2099,7 +2099,7 @@ namespace glz
          template <auto Options, string_literal tag = "">
          static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
-            static constexpr auto num_members = refl<T>::size;
+            static constexpr auto num_members = reflect<T>::size;
             if constexpr (num_members == 0 && is_partial_read<T>) {
                static_assert(false_v<T>, "No members to read for partial read");
             }

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -351,7 +351,7 @@ namespace glz
             s.type = {"string"};
 
             // TODO use oneOf instead of enum to handle doc comments
-            static constexpr auto N = refl<T>::size;
+            static constexpr auto N = reflect<T>::size;
             // s.enumeration = std::vector<std::string_view>(N);
             // for_each<N>([&](auto I) {
             //    static constexpr auto item = std::get<I>(meta_v<V>);
@@ -362,10 +362,10 @@ namespace glz
                auto& enumeration = (*s.oneOf)[I];
                // Do not override if already set
                if (!enumeration.attributes.constant.has_value()) {
-                  enumeration.attributes.constant = refl<T>::keys[I];
+                  enumeration.attributes.constant = reflect<T>::keys[I];
                }
                if (!enumeration.attributes.title.has_value()) {
-                  enumeration.attributes.title = refl<T>::keys[I];
+                  enumeration.attributes.title = reflect<T>::keys[I];
                }
             });
          }
@@ -494,9 +494,9 @@ namespace glz
 
       template <class T>
       inline constexpr auto glaze_names = []() {
-         constexpr auto N = refl<T>::size;
+         constexpr auto N = reflect<T>::size;
          std::array<sv, N> names{};
-         for_each<N>([&](auto I) { names[I] = refl<T>::keys[I]; });
+         for_each<N>([&](auto I) { names[I] = reflect<T>::keys[I]; });
          return names;
       }();
 
@@ -566,7 +566,7 @@ namespace glz
                }
             }
 
-            static constexpr auto N = refl<T>::size;
+            static constexpr auto N = reflect<T>::size;
 
             static constexpr auto schema_map = make_reflection_schema_map<T>();
 
@@ -576,7 +576,7 @@ namespace glz
 
                auto& def = defs[name_v<val_t>];
 
-               constexpr sv key = refl<T>::keys[I];
+               constexpr sv key = reflect<T>::keys[I];
 
                schema ref_val{};
                if constexpr (schema_map.size()) {

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -351,7 +351,7 @@ namespace glz
             s.type = {"string"};
 
             // TODO use oneOf instead of enum to handle doc comments
-            static constexpr auto N = refl<T>::N;
+            static constexpr auto N = refl<T>::size;
             // s.enumeration = std::vector<std::string_view>(N);
             // for_each<N>([&](auto I) {
             //    static constexpr auto item = std::get<I>(meta_v<V>);
@@ -494,7 +494,7 @@ namespace glz
 
       template <class T>
       inline constexpr auto glaze_names = []() {
-         constexpr auto N = refl<T>::N;
+         constexpr auto N = refl<T>::size;
          std::array<sv, N> names{};
          for_each<N>([&](auto I) { names[I] = refl<T>::keys[I]; });
          return names;
@@ -566,7 +566,7 @@ namespace glz
                }
             }
 
-            static constexpr auto N = refl<T>::N;
+            static constexpr auto N = refl<T>::size;
 
             static constexpr auto schema_map = make_reflection_schema_map<T>();
 

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -351,7 +351,7 @@ namespace glz
             s.type = {"string"};
 
             // TODO use oneOf instead of enum to handle doc comments
-            static constexpr auto N = refl<T>.N;
+            static constexpr auto N = refl<T>::N;
             // s.enumeration = std::vector<std::string_view>(N);
             // for_each<N>([&](auto I) {
             //    static constexpr auto item = std::get<I>(meta_v<V>);
@@ -362,10 +362,10 @@ namespace glz
                auto& enumeration = (*s.oneOf)[I];
                // Do not override if already set
                if (!enumeration.attributes.constant.has_value()) {
-                  enumeration.attributes.constant = refl<T>.keys[I];
+                  enumeration.attributes.constant = refl<T>::keys[I];
                }
                if (!enumeration.attributes.title.has_value()) {
-                  enumeration.attributes.title = refl<T>.keys[I];
+                  enumeration.attributes.title = refl<T>::keys[I];
                }
             });
          }
@@ -494,9 +494,9 @@ namespace glz
 
       template <class T>
       inline constexpr auto glaze_names = []() {
-         constexpr auto N = refl<T>.N;
+         constexpr auto N = refl<T>::N;
          std::array<sv, N> names{};
-         for_each<N>([&](auto I) { names[I] = refl<T>.keys[I]; });
+         for_each<N>([&](auto I) { names[I] = refl<T>::keys[I]; });
          return names;
       }();
 
@@ -566,7 +566,7 @@ namespace glz
                }
             }
 
-            static constexpr auto N = refl<T>.N;
+            static constexpr auto N = refl<T>::N;
 
             static constexpr auto schema_map = make_reflection_schema_map<T>();
 
@@ -576,7 +576,7 @@ namespace glz
 
                auto& def = defs[name_v<val_t>];
 
-               constexpr sv key = refl<T>.keys[I];
+               constexpr sv key = refl<T>::keys[I];
 
                schema ref_val{};
                if constexpr (schema_map.size()) {

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -99,14 +99,14 @@ namespace glz
          template <auto Opts>
          static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix) noexcept
          {
-            static constexpr auto N = refl<T>.N;
+            static constexpr auto N = refl<T>::N;
 
             dump<'['>(b, ix);
 
             invoke_table<N>([&]<size_t I>() {
-               if (get_member(value, get<I>(refl<T>.values))) {
+               if (get_member(value, get<I>(refl<T>::values))) {
                   dump<'"'>(b, ix);
-                  dump_maybe_empty(refl<T>.keys[I], b, ix);
+                  dump_maybe_empty(refl<T>::keys[I], b, ix);
                   dump<"\",">(b, ix);
                }
             });
@@ -905,7 +905,7 @@ namespace glz
                   using V = std::decay_t<decltype(val)>;
 
                   if constexpr (Opts.write_type_info && !tag_v<T>.empty() && glaze_object_t<V>) {
-                     constexpr auto num_members = refl<V>.N;
+                     constexpr auto num_members = refl<V>::N;
 
                      // must first write out type
                      if constexpr (Opts.prettify) {
@@ -1191,11 +1191,11 @@ namespace glz
 
       template <class T>
       inline constexpr size_t maximum_key_size = [] {
-         constexpr auto N = refl<T>.N;
+         constexpr auto N = refl<T>::N;
          size_t maximum{};
          for (size_t i = 0; i < N; ++i) {
-            if (refl<T>.keys[i].size() > maximum) {
-               maximum = refl<T>.keys[i].size();
+            if (refl<T>::keys[i].size() > maximum) {
+               maximum = refl<T>::keys[i].size();
             }
          }
          return maximum + 2; // add quotes
@@ -1206,13 +1206,13 @@ namespace glz
       // Only use this if you are not prettifying
       template <class T>
       inline constexpr std::optional<size_t> fixed_padding = [] {
-         constexpr auto N = refl<T>.N;
+         constexpr auto N = refl<T>::N;
          std::optional<size_t> fixed = 2 + 16; // {} + extra padding
          for_each_short_circuit<N>([&](auto I) -> bool {
             using val_t = std::remove_cvref_t<refl_t<T, I>>;
             if constexpr (supports_unchecked_write<val_t> && required_padding<val_t>().has_value()) {
                fixed.value() += required_padding<val_t>().value();
-               fixed.value() += refl<T>.keys[I].size() + 2; // key length
+               fixed.value() += refl<T>::keys[I].size() + 2; // key length
                fixed.value() += 2; // colon and comma
                return false; // continue
             }
@@ -1277,7 +1277,7 @@ namespace glz
                   }
                }
 
-               static constexpr auto N = refl<T>.N;
+               static constexpr auto N = refl<T>::N;
 
                decltype(auto) t = [&]() -> decltype(auto) {
                   if constexpr (reflectable<T>) {
@@ -1309,7 +1309,7 @@ namespace glz
                                        return get<I>(t);
                                     }
                                     else {
-                                       return get<I>(refl<T>.values);
+                                       return get<I>(refl<T>::values);
                                     }
                                  };
 
@@ -1386,7 +1386,7 @@ namespace glz
                         }
 
                         // MSVC requires get<I> rather than keys[I]
-                        static constexpr auto key = glz::get<I>(refl<T>.keys); // GCC 14 requires auto here
+                        static constexpr auto key = glz::get<I>(refl<T>::keys); // GCC 14 requires auto here
                         static constexpr auto quoted_key = join_v < chars<"\"">, key,
                                               Opts.prettify ? chars<"\": "> : chars < "\":" >>
                            ;
@@ -1401,7 +1401,7 @@ namespace glz
                            to<JSON, val_t>::template op<check_opts>(get_member(value, get<I>(t)), ctx, b, ix);
                         }
                         else {
-                           to<JSON, val_t>::template op<check_opts>(get_member(value, get<I>(refl<T>.values)), ctx, b,
+                           to<JSON, val_t>::template op<check_opts>(get_member(value, get<I>(refl<T>::values)), ctx, b,
                                                                     ix);
                         }
                      }
@@ -1419,7 +1419,7 @@ namespace glz
                      }
 
                      // MSVC requires get<I> rather than keys[I]
-                     static constexpr auto key = glz::get<I>(refl<T>.keys); // GCC 14 requires auto here
+                     static constexpr auto key = glz::get<I>(refl<T>::keys); // GCC 14 requires auto here
                      static constexpr auto quoted_key = join_v < chars<"\"">, key,
                                            Opts.prettify ? chars<"\": "> : chars < "\":" >>
                         ;
@@ -1436,7 +1436,7 @@ namespace glz
                         to<JSON, val_t>::template op<check_opts>(get_member(value, get<I>(t)), ctx, b, ix);
                      }
                      else {
-                        to<JSON, val_t>::template op<check_opts>(get_member(value, get<I>(refl<T>.values)), ctx, b, ix);
+                        to<JSON, val_t>::template op<check_opts>(get_member(value, get<I>(refl<T>::values)), ctx, b, ix);
                      }
 
                      if constexpr (I != (N - 1)) {
@@ -1537,7 +1537,7 @@ namespace glz
             static constexpr auto groups = glz::group_json_ptrs<sorted>();
             static constexpr auto N = glz::tuple_size_v<std::decay_t<decltype(groups)>>;
 
-            static constexpr auto num_members = refl<T>.N;
+            static constexpr auto num_members = refl<T>::N;
 
             if constexpr ((num_members > 0) && (glaze_object_t<T> || reflectable<T>)) {
                static constexpr auto HashInfo = hash_info<T>;
@@ -1560,7 +1560,7 @@ namespace glz
                      decode_hash<JSON, T, HashInfo, HashInfo.type>::op(key.data(), key.data() + key.size());
                   static_assert(index < num_members, "Invalid key passed to partial write");
                   if constexpr (glaze_object_t<T>) {
-                     static constexpr auto member = get<index>(refl<T>.values);
+                     static constexpr auto member = get<index>(refl<T>::values);
 
                      write_partial<JSON>::op<sub_partial, Opts>(get_member(value, member), ctx, b, ix);
                      if constexpr (I != N - 1) {

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -99,7 +99,7 @@ namespace glz
          template <auto Opts>
          static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix) noexcept
          {
-            static constexpr auto N = refl<T>::N;
+            static constexpr auto N = refl<T>::size;
 
             dump<'['>(b, ix);
 
@@ -905,7 +905,7 @@ namespace glz
                   using V = std::decay_t<decltype(val)>;
 
                   if constexpr (Opts.write_type_info && !tag_v<T>.empty() && glaze_object_t<V>) {
-                     constexpr auto num_members = refl<V>::N;
+                     constexpr auto num_members = refl<V>::size;
 
                      // must first write out type
                      if constexpr (Opts.prettify) {
@@ -1191,7 +1191,7 @@ namespace glz
 
       template <class T>
       inline constexpr size_t maximum_key_size = [] {
-         constexpr auto N = refl<T>::N;
+         constexpr auto N = refl<T>::size;
          size_t maximum{};
          for (size_t i = 0; i < N; ++i) {
             if (refl<T>::keys[i].size() > maximum) {
@@ -1206,7 +1206,7 @@ namespace glz
       // Only use this if you are not prettifying
       template <class T>
       inline constexpr std::optional<size_t> fixed_padding = [] {
-         constexpr auto N = refl<T>::N;
+         constexpr auto N = refl<T>::size;
          std::optional<size_t> fixed = 2 + 16; // {} + extra padding
          for_each_short_circuit<N>([&](auto I) -> bool {
             using val_t = std::remove_cvref_t<refl_t<T, I>>;
@@ -1277,7 +1277,7 @@ namespace glz
                   }
                }
 
-               static constexpr auto N = refl<T>::N;
+               static constexpr auto N = refl<T>::size;
 
                decltype(auto) t = [&]() -> decltype(auto) {
                   if constexpr (reflectable<T>) {
@@ -1537,7 +1537,7 @@ namespace glz
             static constexpr auto groups = glz::group_json_ptrs<sorted>();
             static constexpr auto N = glz::tuple_size_v<std::decay_t<decltype(groups)>>;
 
-            static constexpr auto num_members = refl<T>::N;
+            static constexpr auto num_members = refl<T>::size;
 
             if constexpr ((num_members > 0) && (glaze_object_t<T> || reflectable<T>)) {
                static constexpr auto HashInfo = hash_info<T>;

--- a/include/glaze/mustache/mustache.hpp
+++ b/include/glaze/mustache/mustache.hpp
@@ -55,7 +55,7 @@ namespace glz
 
                   skip_whitespace();
 
-                  static constexpr auto N = refl<T>::N;
+                  static constexpr auto N = refl<T>::size;
                   static constexpr auto HashInfo = detail::hash_info<T>;
 
                   const auto index =

--- a/include/glaze/mustache/mustache.hpp
+++ b/include/glaze/mustache/mustache.hpp
@@ -55,7 +55,7 @@ namespace glz
 
                   skip_whitespace();
 
-                  static constexpr auto N = refl<T>.N;
+                  static constexpr auto N = refl<T>::N;
                   static constexpr auto HashInfo = detail::hash_info<T>;
 
                   const auto index =
@@ -70,7 +70,7 @@ namespace glz
                      static thread_local std::string temp{};
                      detail::jump_table<N>(
                         [&]<size_t I>() {
-                           static constexpr auto TargetKey = get<I>(refl<T>.keys);
+                           static constexpr auto TargetKey = get<I>(refl<T>::keys);
                            static constexpr auto Length = TargetKey.size();
                            if ((Length == key.size()) && compare<Length>(TargetKey.data(), start)) [[likely]] {
                               if constexpr (detail::reflectable<T> && N > 0) {
@@ -79,7 +79,7 @@ namespace glz
                               }
                               else if constexpr (detail::glaze_object_t<T> && N > 0) {
                                  std::ignore = write<opt_true<Opts, &opts::raw>>(
-                                    detail::get_member(value, get<I>(refl<T>.values)), temp, ctx);
+                                    detail::get_member(value, get<I>(refl<T>::values)), temp, ctx);
                               }
                            }
                            else {

--- a/include/glaze/mustache/mustache.hpp
+++ b/include/glaze/mustache/mustache.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "glaze/core/read.hpp"
-#include "glaze/core/refl.hpp"
+#include "glaze/core/reflect.hpp"
 #include "glaze/core/write.hpp"
 
 namespace glz
@@ -55,7 +55,7 @@ namespace glz
 
                   skip_whitespace();
 
-                  static constexpr auto N = refl<T>::size;
+                  static constexpr auto N = reflect<T>::size;
                   static constexpr auto HashInfo = detail::hash_info<T>;
 
                   const auto index =
@@ -70,7 +70,7 @@ namespace glz
                      static thread_local std::string temp{};
                      detail::jump_table<N>(
                         [&]<size_t I>() {
-                           static constexpr auto TargetKey = get<I>(refl<T>::keys);
+                           static constexpr auto TargetKey = get<I>(reflect<T>::keys);
                            static constexpr auto Length = TargetKey.size();
                            if ((Length == key.size()) && compare<Length>(TargetKey.data(), start)) [[likely]] {
                               if constexpr (detail::reflectable<T> && N > 0) {
@@ -79,7 +79,7 @@ namespace glz
                               }
                               else if constexpr (detail::glaze_object_t<T> && N > 0) {
                                  std::ignore = write<opt_true<Opts, &opts::raw>>(
-                                    detail::get_member(value, get<I>(refl<T>::values)), temp, ctx);
+                                    detail::get_member(value, get<I>(reflect<T>::values)), temp, ctx);
                               }
                            }
                            else {

--- a/include/glaze/mustache/stencilcount.hpp
+++ b/include/glaze/mustache/stencilcount.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "glaze/core/read.hpp"
-#include "glaze/core/refl.hpp"
+#include "glaze/core/reflect.hpp"
 #include "glaze/core/write.hpp"
 #include "glaze/format/format_to.hpp"
 
@@ -96,7 +96,7 @@ namespace glz
 
                   skip_whitespace();
 
-                  static constexpr auto N = refl<T>::size;
+                  static constexpr auto N = reflect<T>::size;
                   static constexpr auto HashInfo = detail::hash_info<T>;
 
                   const auto index =
@@ -106,7 +106,7 @@ namespace glz
                      static thread_local std::string temp{};
                      detail::jump_table<N>(
                         [&]<size_t I>() {
-                           static constexpr auto TargetKey = get<I>(refl<T>::keys);
+                           static constexpr auto TargetKey = get<I>(reflect<T>::keys);
                            static constexpr auto Length = TargetKey.size();
                            if ((Length == key.size()) && compare<Length>(TargetKey.data(), start)) [[likely]] {
                               if constexpr (detail::reflectable<T> && N > 0) {
@@ -115,7 +115,7 @@ namespace glz
                               }
                               else if constexpr (detail::glaze_object_t<T> && N > 0) {
                                  std::ignore = write<opt_true<Opts, &opts::raw>>(
-                                    detail::get_member(value, get<I>(refl<T>::values)), temp, ctx);
+                                    detail::get_member(value, get<I>(reflect<T>::values)), temp, ctx);
                               }
                            }
                            else {

--- a/include/glaze/mustache/stencilcount.hpp
+++ b/include/glaze/mustache/stencilcount.hpp
@@ -96,7 +96,7 @@ namespace glz
 
                   skip_whitespace();
 
-                  static constexpr auto N = refl<T>::N;
+                  static constexpr auto N = refl<T>::size;
                   static constexpr auto HashInfo = detail::hash_info<T>;
 
                   const auto index =

--- a/include/glaze/mustache/stencilcount.hpp
+++ b/include/glaze/mustache/stencilcount.hpp
@@ -96,7 +96,7 @@ namespace glz
 
                   skip_whitespace();
 
-                  static constexpr auto N = refl<T>.N;
+                  static constexpr auto N = refl<T>::N;
                   static constexpr auto HashInfo = detail::hash_info<T>;
 
                   const auto index =
@@ -106,7 +106,7 @@ namespace glz
                      static thread_local std::string temp{};
                      detail::jump_table<N>(
                         [&]<size_t I>() {
-                           static constexpr auto TargetKey = get<I>(refl<T>.keys);
+                           static constexpr auto TargetKey = get<I>(refl<T>::keys);
                            static constexpr auto Length = TargetKey.size();
                            if ((Length == key.size()) && compare<Length>(TargetKey.data(), start)) [[likely]] {
                               if constexpr (detail::reflectable<T> && N > 0) {
@@ -115,7 +115,7 @@ namespace glz
                               }
                               else if constexpr (detail::glaze_object_t<T> && N > 0) {
                                  std::ignore = write<opt_true<Opts, &opts::raw>>(
-                                    detail::get_member(value, get<I>(refl<T>.values)), temp, ctx);
+                                    detail::get_member(value, get<I>(refl<T>::values)), temp, ctx);
                               }
                            }
                            else {

--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -325,7 +325,7 @@ namespace glz::repe
    {
       using Mtx = std::mutex*;
       using namespace glz::detail;
-      constexpr auto N = refl<T>.N;
+      constexpr auto N = refl<T>::N;
       return [&]<size_t... I>(std::index_sequence<I...>) {
          return normal_map<sv, Mtx, N>(
             std::array<pair<sv, Mtx>, N>{pair<sv, Mtx>{join_v<parent, chars<"/">, key_name_v<I, T>>, Mtx{}}...});
@@ -745,7 +745,7 @@ namespace glz::repe
       void on(T& value)
       {
          using namespace glz::detail;
-         static constexpr auto N = refl<T>.N;
+         static constexpr auto N = refl<T>::N;
 
          [[maybe_unused]] decltype(auto) t = [&]() -> decltype(auto) {
             if constexpr (reflectable<T> && requires { to_tuple(value); }) {
@@ -797,11 +797,11 @@ namespace glz::repe
                   return get_member(value, get<I>(t));
                }
                else {
-                  return get_member(value, get<I>(refl<T>.values));
+                  return get_member(value, get<I>(refl<T>::values));
                }
             }.template operator()<I>();
 
-            static constexpr auto key = refl<T>.keys[I];
+            static constexpr auto key = refl<T>::keys[I];
 
             static constexpr std::string_view full_key = [&] {
                if constexpr (parent == detail::empty_path) {

--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -325,7 +325,7 @@ namespace glz::repe
    {
       using Mtx = std::mutex*;
       using namespace glz::detail;
-      constexpr auto N = refl<T>::size;
+      constexpr auto N = reflect<T>::size;
       return [&]<size_t... I>(std::index_sequence<I...>) {
          return normal_map<sv, Mtx, N>(
             std::array<pair<sv, Mtx>, N>{pair<sv, Mtx>{join_v<parent, chars<"/">, key_name_v<I, T>>, Mtx{}}...});
@@ -745,7 +745,7 @@ namespace glz::repe
       void on(T& value)
       {
          using namespace glz::detail;
-         static constexpr auto N = refl<T>::size;
+         static constexpr auto N = reflect<T>::size;
 
          [[maybe_unused]] decltype(auto) t = [&]() -> decltype(auto) {
             if constexpr (reflectable<T> && requires { to_tuple(value); }) {
@@ -797,11 +797,11 @@ namespace glz::repe
                   return get_member(value, get<I>(t));
                }
                else {
-                  return get_member(value, get<I>(refl<T>::values));
+                  return get_member(value, get<I>(reflect<T>::values));
                }
             }.template operator()<I>();
 
-            static constexpr auto key = refl<T>::keys[I];
+            static constexpr auto key = reflect<T>::keys[I];
 
             static constexpr std::string_view full_key = [&] {
                if constexpr (parent == detail::empty_path) {

--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -325,7 +325,7 @@ namespace glz::repe
    {
       using Mtx = std::mutex*;
       using namespace glz::detail;
-      constexpr auto N = refl<T>::N;
+      constexpr auto N = refl<T>::size;
       return [&]<size_t... I>(std::index_sequence<I...>) {
          return normal_map<sv, Mtx, N>(
             std::array<pair<sv, Mtx>, N>{pair<sv, Mtx>{join_v<parent, chars<"/">, key_name_v<I, T>>, Mtx{}}...});
@@ -745,7 +745,7 @@ namespace glz::repe
       void on(T& value)
       {
          using namespace glz::detail;
-         static constexpr auto N = refl<T>::N;
+         static constexpr auto N = refl<T>::size;
 
          [[maybe_unused]] decltype(auto) t = [&]() -> decltype(auto) {
             if constexpr (reflectable<T> && requires { to_tuple(value); }) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,7 @@ struct glz::meta<my_struct>
    );
 };
 
-static constexpr auto info = glz::refl<my_struct>{};
+static constexpr auto info = glz::reflect<my_struct>{};
 
 #include <iostream>
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,12 +28,12 @@ static constexpr auto info = glz::refl<my_struct>{};
 int main()
 {
    std::cout << "Field types:\n";
-   glz::for_each<info.N>([](auto I) {
+   glz::for_each<info.size>([](auto I) {
       // std::cout << glz::name_v<decltype(glz::get<I>(info.values))> << '\n';
    });
 
    std::cout << "Field keys:\n";
-   glz::for_each<info.N>([](auto I) { std::cout << info.keys[I] << '\n'; });
+   glz::for_each<info.size>([](auto I) { std::cout << info.keys[I] << '\n'; });
 
    my_struct obj{};
    std::cout << '\n' << glz::write_json(obj).value() << '\n';

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,7 @@ struct glz::meta<my_struct>
    );
 };
 
-static constexpr auto& info = glz::refl<my_struct>;
+static constexpr auto info = glz::refl<my_struct>{};
 
 #include <iostream>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,7 @@ add_subdirectory(mock_json_test)
 add_subdirectory(mustache_test)
 add_subdirectory(reflection_test)
 add_subdirectory(repe_test)
+add_subdirectory(utility_formats)
 
 # We don't run find_package_test or glaze-install_test with MSVC/Windows, because the Github action runner often chokes
 # Don't run find_package on Clang, because Linux runs with Clang try to use GCC standard library and have errors before Clang 18

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,8 +33,8 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     endif()
 
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-      target_compile_options(glz_test_common INTERFACE -fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined)
-      target_link_options(glz_test_common INTERFACE -fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined)
+      target_compile_options(glz_test_common INTERFACE -ftime-trace -fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined)
+      target_link_options(glz_test_common INTERFACE -ftime-trace -fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined)
     endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(glz_test_common INTERFACE /GR- /bigobj) #/fsanitize=address

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -2226,38 +2226,24 @@ suite early_end = [] {
    };
 };
 
-suite base64_decode_tests = [] {
-   "hello world"_test = [] {
-      std::string_view b64 = "aGVsbG8gd29ybGQ=";
-      std::vector<uint8_t> decoded = glz::base64_decode(b64);
-      expect(std::string_view{(char*)decoded.data(), decoded.size()} == "hello world");
-   };
-
-   "{\"key\":42}"_test = [] {
-      std::string_view b64 = "eyJrZXkiOjQyfQ==";
-      std::vector<uint8_t> decoded = glz::base64_decode(b64);
-      expect(std::string_view{(char*)decoded.data(), decoded.size()} == "{\"key\":42}");
-   };
-};
-
 suite past_fuzzing_issues = [] {
    "fuzz0"_test = [] {
       std::string_view base64 =
          "AwQEaWH//////////////////////////////////////////////////////////////////////////////////////////////////////"
          "////////////////////////////////////////////////////////////8A=";
-      std::vector<uint8_t> input = glz::base64_decode(base64);
+      const auto input = glz::read_base64(base64);
       expect(glz::read_beve<my_struct>(input).error());
    };
 
    "fuzz1"_test = [] {
       std::string_view base64 = "A4gEaWHw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw";
-      std::vector<uint8_t> input = glz::base64_decode(base64);
+      const auto input = glz::read_base64(base64);
       expect(glz::read_beve<my_struct>(input).error());
    };
 
    "fuzz2"_test = [] {
       std::string_view base64 = "A2AMYXJy3ANg/////////wpgDAxhcnI=";
-      std::vector<uint8_t> input = glz::base64_decode(base64);
+      const auto input = glz::read_base64(base64);
       expect(glz::read_beve<my_struct>(input).error());
    };
 
@@ -2265,27 +2251,27 @@ suite past_fuzzing_issues = [] {
       std::string_view base64 =
          "AzoxKOUMYXJydCQkKOUMYXJydCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJ"
          "CQkJCQkJCQkJCQkJCkA";
-      std::vector<uint8_t> input = glz::base64_decode(base64);
+      const auto input = glz::read_base64(base64);
       expect(glz::read_beve<my_struct>(input).error());
    };
 
    "fuzz4"_test = [] {
       std::string_view base64 = "Zew=";
-      std::vector<uint8_t> input = glz::base64_decode(base64);
+      const auto input = glz::read_base64(base64);
       std::string json{};
       expect(glz::beve_to_json(input, json));
    };
 
    "fuzz5"_test = [] {
       std::string_view base64 = "CDE=";
-      std::vector<uint8_t> input = glz::base64_decode(base64);
+      const auto input = glz::read_base64(base64);
       std::string json{};
       expect(glz::beve_to_json(input, json));
    };
 
    "fuzz6"_test = [] {
       std::string_view base64 = "HsEmAH5L";
-      std::vector<uint8_t> input = glz::base64_decode(base64);
+      const auto input = glz::read_base64(base64);
       expect(glz::read_beve<my_struct>(input).error());
       std::string json{};
       expect(glz::beve_to_json(input, json));
@@ -2293,7 +2279,7 @@ suite past_fuzzing_issues = [] {
 
    "fuzz7"_test = [] {
       std::string_view base64 = "VSYAAGUAPdJVPdI=";
-      std::vector<uint8_t> input = glz::base64_decode(base64);
+      const auto input = glz::read_base64(base64);
       expect(glz::read_beve<my_struct>(input).error());
       std::string json{};
       expect(glz::beve_to_json(input, json));
@@ -2337,7 +2323,7 @@ suite past_fuzzing_issues = [] {
          "hYWFhYWABYAABYAFgIWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFgQAFhYAFgAAFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh"
          "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWAAIAFhYWFhYWFhYWFhYWFhYWAAIAFhYWFhYWFhYWFgABBwACAAAA";
 
-      std::vector<uint8_t> input = glz::base64_decode(base64);
+      const auto input = glz::read_base64(base64);
       expect(glz::read_beve<my_struct>(input).error());
       std::string json{};
       expect(glz::beve_to_json(input, json));
@@ -2345,12 +2331,9 @@ suite past_fuzzing_issues = [] {
 
    auto test_base64 = [](std::string_view base64) {
       return [base64] {
-         std::vector<uint8_t> input = glz::base64_decode(base64);
+         const auto input = glz::read_base64(base64);
          expect(glz::read_beve<my_struct>(input).error());
          std::string json{};
-         expect(glz::beve_to_json(input, json));
-         input.push_back('\0');
-         expect(glz::read_beve<my_struct>(input).error());
          expect(glz::beve_to_json(input, json));
       };
    };

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -16,6 +16,7 @@
 #include <unordered_set>
 
 #include "glaze/api/impl.hpp"
+#include "glaze/base64/base64.hpp"
 #include "glaze/beve/beve_to_json.hpp"
 #include "glaze/beve/read.hpp"
 #include "glaze/beve/write.hpp"
@@ -2225,48 +2226,16 @@ suite early_end = [] {
    };
 };
 
-inline std::vector<unsigned char> base64_decode(const std::string_view input)
-{
-   static constexpr std::string_view base64_chars =
-      "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-      "abcdefghijklmnopqrstuvwxyz"
-      "0123456789+/";
-
-   std::vector<unsigned char> decoded_data;
-   static constexpr std::array<int, 256> decode_table = [] {
-      std::array<int, 256> t;
-      t.fill(-1);
-
-      for (int i = 0; i < 64; ++i) {
-         t[base64_chars[i]] = i;
-      }
-      return t;
-   }();
-
-   int val = 0, valb = -8;
-   for (unsigned char c : input) {
-      if (decode_table[c] == -1) break; // Stop decoding at padding '=' or invalid characters
-      val = (val << 6) + decode_table[c];
-      valb += 6;
-      if (valb >= 0) {
-         decoded_data.push_back((val >> valb) & 0xFF);
-         valb -= 8;
-      }
-   }
-
-   return decoded_data;
-}
-
 suite base64_decode_tests = [] {
    "hello world"_test = [] {
       std::string_view b64 = "aGVsbG8gd29ybGQ=";
-      std::vector<uint8_t> decoded = base64_decode(b64);
+      std::vector<uint8_t> decoded = glz::base64_decode(b64);
       expect(std::string_view{(char*)decoded.data(), decoded.size()} == "hello world");
    };
 
    "{\"key\":42}"_test = [] {
       std::string_view b64 = "eyJrZXkiOjQyfQ==";
-      std::vector<uint8_t> decoded = base64_decode(b64);
+      std::vector<uint8_t> decoded = glz::base64_decode(b64);
       expect(std::string_view{(char*)decoded.data(), decoded.size()} == "{\"key\":42}");
    };
 };
@@ -2276,19 +2245,19 @@ suite past_fuzzing_issues = [] {
       std::string_view base64 =
          "AwQEaWH//////////////////////////////////////////////////////////////////////////////////////////////////////"
          "////////////////////////////////////////////////////////////8A=";
-      std::vector<uint8_t> input = base64_decode(base64);
+      std::vector<uint8_t> input = glz::base64_decode(base64);
       expect(glz::read_beve<my_struct>(input).error());
    };
 
    "fuzz1"_test = [] {
       std::string_view base64 = "A4gEaWHw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw8PDw";
-      std::vector<uint8_t> input = base64_decode(base64);
+      std::vector<uint8_t> input = glz::base64_decode(base64);
       expect(glz::read_beve<my_struct>(input).error());
    };
 
    "fuzz2"_test = [] {
       std::string_view base64 = "A2AMYXJy3ANg/////////wpgDAxhcnI=";
-      std::vector<uint8_t> input = base64_decode(base64);
+      std::vector<uint8_t> input = glz::base64_decode(base64);
       expect(glz::read_beve<my_struct>(input).error());
    };
 
@@ -2296,27 +2265,27 @@ suite past_fuzzing_issues = [] {
       std::string_view base64 =
          "AzoxKOUMYXJydCQkKOUMYXJydCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJ"
          "CQkJCQkJCQkJCQkJCkA";
-      std::vector<uint8_t> input = base64_decode(base64);
+      std::vector<uint8_t> input = glz::base64_decode(base64);
       expect(glz::read_beve<my_struct>(input).error());
    };
 
    "fuzz4"_test = [] {
       std::string_view base64 = "Zew=";
-      std::vector<uint8_t> input = base64_decode(base64);
+      std::vector<uint8_t> input = glz::base64_decode(base64);
       std::string json{};
       expect(glz::beve_to_json(input, json));
    };
 
    "fuzz5"_test = [] {
       std::string_view base64 = "CDE=";
-      std::vector<uint8_t> input = base64_decode(base64);
+      std::vector<uint8_t> input = glz::base64_decode(base64);
       std::string json{};
       expect(glz::beve_to_json(input, json));
    };
 
    "fuzz6"_test = [] {
       std::string_view base64 = "HsEmAH5L";
-      std::vector<uint8_t> input = base64_decode(base64);
+      std::vector<uint8_t> input = glz::base64_decode(base64);
       expect(glz::read_beve<my_struct>(input).error());
       std::string json{};
       expect(glz::beve_to_json(input, json));
@@ -2324,7 +2293,7 @@ suite past_fuzzing_issues = [] {
 
    "fuzz7"_test = [] {
       std::string_view base64 = "VSYAAGUAPdJVPdI=";
-      std::vector<uint8_t> input = base64_decode(base64);
+      std::vector<uint8_t> input = glz::base64_decode(base64);
       expect(glz::read_beve<my_struct>(input).error());
       std::string json{};
       expect(glz::beve_to_json(input, json));
@@ -2368,7 +2337,7 @@ suite past_fuzzing_issues = [] {
          "hYWFhYWABYAABYAFgIWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFgQAFhYAFgAAFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFh"
          "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWAAIAFhYWFhYWFhYWFhYWFhYWAAIAFhYWFhYWFhYWFgABBwACAAAA";
 
-      std::vector<uint8_t> input = base64_decode(base64);
+      std::vector<uint8_t> input = glz::base64_decode(base64);
       expect(glz::read_beve<my_struct>(input).error());
       std::string json{};
       expect(glz::beve_to_json(input, json));
@@ -2376,7 +2345,7 @@ suite past_fuzzing_issues = [] {
 
    auto test_base64 = [](std::string_view base64) {
       return [base64] {
-         std::vector<uint8_t> input = base64_decode(base64);
+         std::vector<uint8_t> input = glz::base64_decode(base64);
          expect(glz::read_beve<my_struct>(input).error());
          std::string json{};
          expect(glz::beve_to_json(input, json));

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -289,7 +289,7 @@ suite test_data_struct_tests = [] {
             .f = 0xFFFFFFFF,
          },
       };
-      expect(glz::refl<TestData>.keys.size() == 6);
+      expect(glz::refl<TestData>::keys.size() == 6);
       std::string s = glz::write_json(test_data).value_or("error");
       expect(s != "error") << s;
       std::vector<DummyData> in_test_data;
@@ -9539,7 +9539,7 @@ struct same_length_keys
 
 suite same_length_keys_test = [] {
    "same_length_keys"_test = [] {
-      static constexpr auto info = glz::detail::make_keys_info(glz::refl<same_length_keys>.keys);
+      static constexpr auto info = glz::detail::make_keys_info(glz::refl<same_length_keys>::keys);
       static_assert(info.type == glz::detail::hash_type::full_flat);
 
       same_length_keys obj{};
@@ -9564,7 +9564,7 @@ struct offset_one
 
 suite offset_one_test = [] {
    "offset_one"_test = [] {
-      static constexpr auto info = glz::detail::make_keys_info(glz::refl<same_length_keys>.keys);
+      static constexpr auto info = glz::detail::make_keys_info(glz::refl<same_length_keys>::keys);
       static_assert(info.type == glz::detail::hash_type::full_flat);
 
       offset_one obj{};

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -195,7 +195,7 @@ struct glz::meta<Shapes>
    static constexpr std::array value{circ, sq, triangle};
 };
 
-// static_assert(glz::refl<Vehicle>::keys[uint32_t(Vehicle::Truck)] == "Truck");
+// static_assert(glz::reflect<Vehicle>::keys[uint32_t(Vehicle::Truck)] == "Truck");
 
 suite glz_enum_test = [] {
    "glz_enum"_test = [] {
@@ -289,7 +289,7 @@ suite test_data_struct_tests = [] {
             .f = 0xFFFFFFFF,
          },
       };
-      expect(glz::refl<TestData>::keys.size() == 6);
+      expect(glz::reflect<TestData>::keys.size() == 6);
       std::string s = glz::write_json(test_data).value_or("error");
       expect(s != "error") << s;
       std::vector<DummyData> in_test_data;
@@ -9539,7 +9539,7 @@ struct same_length_keys
 
 suite same_length_keys_test = [] {
    "same_length_keys"_test = [] {
-      static constexpr auto info = glz::detail::make_keys_info(glz::refl<same_length_keys>::keys);
+      static constexpr auto info = glz::detail::make_keys_info(glz::reflect<same_length_keys>::keys);
       static_assert(info.type == glz::detail::hash_type::full_flat);
 
       same_length_keys obj{};
@@ -9564,7 +9564,7 @@ struct offset_one
 
 suite offset_one_test = [] {
    "offset_one"_test = [] {
-      static constexpr auto info = glz::detail::make_keys_info(glz::refl<same_length_keys>::keys);
+      static constexpr auto info = glz::detail::make_keys_info(glz::reflect<same_length_keys>::keys);
       static_assert(info.type == glz::detail::hash_type::full_flat);
 
       offset_one obj{};

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -195,7 +195,7 @@ struct glz::meta<Shapes>
    static constexpr std::array value{circ, sq, triangle};
 };
 
-// static_assert(glz::refl<Vehicle>.keys[uint32_t(Vehicle::Truck)] == "Truck");
+// static_assert(glz::refl<Vehicle>::keys[uint32_t(Vehicle::Truck)] == "Truck");
 
 suite glz_enum_test = [] {
    "glz_enum"_test = [] {

--- a/tests/reflection_test/reflection_test.cpp
+++ b/tests/reflection_test/reflection_test.cpp
@@ -455,7 +455,7 @@ suite json_schema = [] {
 struct empty_t
 {};
 
-static_assert(glz::refl<empty_t>.N == 0);
+static_assert(glz::refl<empty_t>::size == 0);
 static_assert(not glz::object_info<glz::opts{}, empty_t>::first_will_be_written);
 static_assert(not glz::object_info<glz::opts{}, empty_t>::maybe_skipped);
 

--- a/tests/reflection_test/reflection_test.cpp
+++ b/tests/reflection_test/reflection_test.cpp
@@ -824,7 +824,7 @@ suite hash_tests = [] {
    "front_64"_test = [] {
       glz::detail::keys_info_t info{.min_length = 8, .max_length = 8};
       [[maybe_unused]] const auto valid =
-         glz::detail::front_bytes_hash_info<uint64_t>(glz::refl<front_64_t>.keys, info);
+         glz::detail::front_bytes_hash_info<uint64_t>(glz::refl<front_64_t>::keys, info);
 
       front_64_t obj{};
       std::string_view buffer = R"({"aaaaaaaa":1,"aaaaaaaz":2,"aaaaaaza":3})";

--- a/tests/reflection_test/reflection_test.cpp
+++ b/tests/reflection_test/reflection_test.cpp
@@ -455,7 +455,7 @@ suite json_schema = [] {
 struct empty_t
 {};
 
-static_assert(glz::refl<empty_t>::size == 0);
+static_assert(glz::reflect<empty_t>::size == 0);
 static_assert(not glz::object_info<glz::opts{}, empty_t>::first_will_be_written);
 static_assert(not glz::object_info<glz::opts{}, empty_t>::maybe_skipped);
 
@@ -824,7 +824,7 @@ suite hash_tests = [] {
    "front_64"_test = [] {
       glz::detail::keys_info_t info{.min_length = 8, .max_length = 8};
       [[maybe_unused]] const auto valid =
-         glz::detail::front_bytes_hash_info<uint64_t>(glz::refl<front_64_t>::keys, info);
+         glz::detail::front_bytes_hash_info<uint64_t>(glz::reflect<front_64_t>::keys, info);
 
       front_64_t obj{};
       std::string_view buffer = R"({"aaaaaaaa":1,"aaaaaaaz":2,"aaaaaaza":3})";

--- a/tests/utility_formats/CMakeLists.txt
+++ b/tests/utility_formats/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(utility_formats)
+
+add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE glz_test_common)
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
+
+target_code_coverage(${PROJECT_NAME} AUTO ALL)

--- a/tests/utility_formats/utility_formats.cpp
+++ b/tests/utility_formats/utility_formats.cpp
@@ -1,0 +1,10 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#define UT_RUN_TIME_ONLY
+
+#include <ut/ut.hpp>
+
+using namespace ut;
+
+int main() { return 0; }

--- a/tests/utility_formats/utility_formats.cpp
+++ b/tests/utility_formats/utility_formats.cpp
@@ -5,6 +5,38 @@
 
 #include <ut/ut.hpp>
 
+#include "glaze/base64/base64.hpp"
+
 using namespace ut;
+
+suite base64_read_tests = [] {
+   "hello world"_test = [] {
+      std::string_view b64 = "aGVsbG8gd29ybGQ=";
+      const auto decoded = glz::read_base64(b64);
+      expect(decoded == "hello world");
+   };
+
+   "{\"key\":42}"_test = [] {
+      std::string_view b64 = "eyJrZXkiOjQyfQ==";
+      const auto decoded = glz::read_base64(b64);
+      expect(decoded == "{\"key\":42}");
+   };
+};
+
+suite base64_roundtrip_tests = [] {
+   "hello world"_test = [] {
+      std::string_view str = "Hello World";
+      const auto b64 = glz::write_base64(str);
+      const auto decoded = glz::read_base64(b64);
+      expect(decoded == str);
+   };
+
+   "{\"key\":42}"_test = [] {
+      std::string_view str = "{\"key\":42}";
+      const auto b64 = glz::write_base64(str);
+      const auto decoded = glz::read_base64(b64);
+      expect(decoded == str);
+   };
+};
 
 int main() { return 0; }


### PR DESCRIPTION
# Breaking internal change for `glz::refl` -> `glz::reflect`

Formalizing the `glz::reflect<T>` API.
- Removes the inline definition of `refl` and renames `refl_info` to `reflect`
- Changes `N` to `size` for the number of fields