### PR TITLE
Support for reading json_t value as the source

### DIFF
--- a/include/glaze/core/read.hpp
+++ b/include/glaze/core/read.hpp
@@ -117,6 +117,9 @@ namespace glz
 
    template <class T>
    concept c_style_char_buffer = std::convertible_to<std::remove_cvref_t<T>, std::string_view> && !has_data<T>;
+   
+   template <class T>
+   concept is_buffer = c_style_char_buffer<T> || contiguous<T>;
 
    // for char array input
    template <opts Opts, class T, c_style_char_buffer Buffer>

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -3149,7 +3149,7 @@ namespace glz
       };
    } // namespace detail
 
-   template <class Buffer>
+   template <is_buffer Buffer>
    [[nodiscard]] error_ctx validate_json(Buffer&& buffer) noexcept
    {
       context ctx{};
@@ -3158,7 +3158,7 @@ namespace glz
          skip_value, std::forward<Buffer>(buffer), ctx);
    }
 
-   template <class Buffer>
+   template <is_buffer Buffer>
    [[nodiscard]] error_ctx validate_jsonc(Buffer&& buffer) noexcept
    {
       context ctx{};
@@ -3166,14 +3166,14 @@ namespace glz
       return read<opts{.validate_trailing_whitespace = true}>(skip_value, std::forward<Buffer>(buffer), ctx);
    }
 
-   template <read_json_supported T, class Buffer>
+   template <read_json_supported T, is_buffer Buffer>
    [[nodiscard]] error_ctx read_json(T& value, Buffer&& buffer) noexcept
    {
       context ctx{};
       return read<opts{}>(value, std::forward<Buffer>(buffer), ctx);
    }
 
-   template <read_json_supported T, class Buffer>
+   template <read_json_supported T, is_buffer Buffer>
    [[nodiscard]] expected<T, error_ctx> read_json(Buffer&& buffer) noexcept
    {
       T value{};
@@ -3185,14 +3185,14 @@ namespace glz
       return value;
    }
 
-   template <read_json_supported T, class Buffer>
+   template <read_json_supported T, is_buffer Buffer>
    [[nodiscard]] error_ctx read_jsonc(T& value, Buffer&& buffer) noexcept
    {
       context ctx{};
       return read<opts{.comments = true}>(value, std::forward<Buffer>(buffer), ctx);
    }
 
-   template <read_json_supported T, class Buffer>
+   template <read_json_supported T, is_buffer Buffer>
    [[nodiscard]] expected<T, error_ctx> read_jsonc(Buffer&& buffer) noexcept
    {
       T value{};
@@ -3204,8 +3204,8 @@ namespace glz
       return value;
    }
 
-   template <auto Opts = opts{}, read_json_supported T>
-   [[nodiscard]] error_ctx read_file_json(T& value, const sv file_name, auto&& buffer) noexcept
+   template <auto Opts = opts{}, read_json_supported T, is_buffer Buffer>
+   [[nodiscard]] error_ctx read_file_json(T& value, const sv file_name, Buffer&& buffer) noexcept
    {
       context ctx{};
       ctx.current_file = file_name;
@@ -3219,8 +3219,8 @@ namespace glz
       return read<set_json<Opts>()>(value, buffer, ctx);
    }
 
-   template <auto Opts = opts{}, read_json_supported T>
-   [[nodiscard]] error_ctx read_file_jsonc(T& value, const sv file_name, auto&& buffer) noexcept
+   template <auto Opts = opts{}, read_json_supported T, is_buffer Buffer>
+   [[nodiscard]] error_ctx read_file_jsonc(T& value, const sv file_name, Buffer&& buffer) noexcept
    {
       context ctx{};
       ctx.current_file = file_name;

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -3500,6 +3500,11 @@ suite generic_json_tests = [] {
       glz::json_t json = {{"s", "hello world"}};
       expect(foo(json) == "hello world");
       expect(json.dump().value() == R"({"s":"hello world"})");
+      
+      std::map<std::string, std::string> obj{};
+      expect(not glz::read_json(obj, json));
+      expect(obj.contains("s"));
+      expect(obj.at("s") == "hello world");
    };
 
    "generic_json_int"_test = [] {
@@ -3538,8 +3543,13 @@ suite generic_json_tests = [] {
 
    "json_t_contains"_test = [] {
       auto json = glz::read_json<glz::json_t>(R"({"foo":"bar"})");
+      expect(bool(json));
       expect(!json->contains("id"));
       expect(json->contains("foo"));
+      auto obj = glz::read_json<std::map<std::string, std::string>>(json.value());
+      expect(bool(obj));
+      expect(obj->contains("foo"));
+      expect(obj->at("foo") == "bar");
    };
 
    "buffer underrun"_test = [] {
@@ -3592,6 +3602,9 @@ suite generic_json_tests = [] {
       expect(not json.empty());
       expect(json.size() == 3);
       expect(json.get_array().size() == 3);
+      std::array<int, 3> v{};
+      expect(not glz::read<glz::opts{}>(v, json));
+      expect(v == std::array{1,2,3});
    };
 
    "json_t is_string"_test = [] {
@@ -3612,6 +3625,9 @@ suite generic_json_tests = [] {
       expect(not json.empty());
       expect(json.size() == 19);
       expect(json.get_string() == "Beautiful beginning");
+      std::string v{};
+      expect(not glz::read<glz::opts{}>(v, json));
+      expect(v == "Beautiful beginning");
    };
 
    "json_t is_number"_test = [] {
@@ -3622,6 +3638,9 @@ suite generic_json_tests = [] {
       expect(not json.empty());
       expect(json.size() == 0);
       expect(json.get_number() == 3.882e2);
+      double v{};
+      expect(not glz::read<glz::opts{}>(v, json));
+      expect(v == 3.882e2);
    };
 
    "json_t is_boolean"_test = [] {
@@ -3632,6 +3651,9 @@ suite generic_json_tests = [] {
       expect(not json.empty());
       expect(json.size() == 0);
       expect(json.get_boolean());
+      bool v{};
+      expect(not glz::read<glz::opts{}>(v, json));
+      expect(v);
    };
 
    "json_t is_null"_test = [] {


### PR DESCRIPTION
This support for using `glz::json_t` as the source uses a buffer as an intermediate. This is not as optimal as it could be, because we often have the decoded value, however it provides the initial API and removes extra typing for users who perform these operations. A fully optimized version that avoids the intermediate buffer would required thousands of lines of code and a massive suite of unit tests.

This approach also has the benefit of being able to define parsing options for the translation of the `json_t` value into the target value and it automatically supports all meta wrappers on the target type.

Example:
```c++
glz::json_t json{};
expect(not glz::read_json(json, "[1,2,3]"));
std::array<int, 3> v{};
expect(not glz::read<glz::opts{}>(v, json));
expect(v == std::array{1,2,3});
```

Another Example:
```c++
glz::json_t json = {{"s", "hello world"}};
std::map<std::string, std::string> obj{};
expect(not glz::read_json(obj, json));
expect(obj.contains("s"));
expect(obj.at("s") == "hello world");
```

## Possible optimization
An optimization may be to serialize and parse through the BEVE format. This would speed up this intermediate translation and not require any specialized code. It still has the overhead of an intermediary format, but it will be faster than JSON being the intermediary.