### PR TITLE
[Custom json read] - Fix string_t concept (it is not based on push_back in practice)

### DIFF
--- a/include/glaze/concepts/container_concepts.hpp
+++ b/include/glaze/concepts/container_concepts.hpp
@@ -25,9 +25,7 @@ namespace glz
 
    template <class T>
    concept has_empty = requires(T v) {
-      {
-         v.empty()
-      } -> std::convertible_to<bool>;
+      { v.empty() } -> std::convertible_to<bool>;
    };
 
    template <class T>
@@ -38,9 +36,7 @@ namespace glz
 
    template <class T>
    concept has_capacity = requires(T t) {
-      {
-         t.capacity()
-      } -> std::integral;
+      { t.capacity() } -> std::integral;
    };
 
    template <class T>
@@ -78,70 +74,50 @@ namespace glz::detail
 
    template <typename T>
    concept complex_t = requires(T a, T b) {
-      {
-         a.real()
-      } -> std::convertible_to<typename T::value_type>;
-      {
-         a.imag()
-      } -> std::convertible_to<typename T::value_type>;
-      {
-         T(a.real(), a.imag())
-      } -> std::same_as<T>;
-      {
-         a + b
-      } -> std::same_as<T>;
-      {
-         a - b
-      } -> std::same_as<T>;
-      {
-         a* b
-      } -> std::same_as<T>;
-      {
-         a / b
-      } -> std::same_as<T>;
+      { a.real() } -> std::convertible_to<typename T::value_type>;
+      { a.imag() } -> std::convertible_to<typename T::value_type>;
+      { T(a.real(), a.imag()) } -> std::same_as<T>;
+      { a + b } -> std::same_as<T>;
+      { a - b } -> std::same_as<T>;
+      { a* b } -> std::same_as<T>;
+      { a / b } -> std::same_as<T>;
    };
 
    template <class T>
    concept pair_t = requires(T pair) {
       typename std::decay_t<T>::first_type;
       typename std::decay_t<T>::second_type;
-      {
-         pair.first
-      };
-      {
-         pair.second
-      };
+      { pair.first };
+      { pair.second };
    };
 
    template <class T>
    concept emplaceable = requires(T container) {
-      {
-         container.emplace(std::declval<typename T::value_type>())
-      };
+      { container.emplace(std::declval<typename T::value_type>()) };
    };
 
    template <class T>
    concept push_backable = requires(T container) {
-      {
-         container.push_back(std::declval<typename T::value_type>())
-      };
+      { container.push_back(std::declval<typename T::value_type>()) };
    };
 
    template <class T>
    concept emplace_backable = requires(T container) {
-      {
-         container.emplace_back()
-      } -> std::same_as<typename T::reference>;
+      { container.emplace_back() } -> std::same_as<typename T::reference>;
    };
 
    template <class T>
-   concept has_push_back = requires(T t, typename T::value_type v) { t.push_back(v); };
+   concept has_resize = requires(T t, typename T::size_type sz) { t.resize(sz); };
+
+   template <class T>
+   concept has_append = requires(T t, typename T::const_iterator it) { t.append(it, it); };
+
+   template <class T>
+   concept has_assign = requires(T t, const typename T::value_type* v, typename T::size_type sz) { t.assign(v, sz); };
 
    template <class T>
    concept accessible = requires(T container) {
-      {
-         container[size_t{}]
-      } -> std::same_as<typename T::reference>;
+      { container[size_t{}] } -> std::same_as<typename T::reference>;
    };
 
    template <class T>
@@ -150,25 +126,15 @@ namespace glz::detail
 
    template <class T>
    concept map_subscriptable = requires(T container) {
-      {
-         container[std::declval<typename T::key_type>()]
-      } -> std::same_as<typename T::mapped_type&>;
+      { container[std::declval<typename T::key_type>()] } -> std::same_as<typename T::mapped_type&>;
    };
 
    template <typename T>
    concept string_like = requires(T s) {
-      {
-         s.size()
-      } -> std::integral;
-      {
-         s.data()
-      };
-      {
-         s.empty()
-      } -> std::convertible_to<bool>;
-      {
-         s.substr(0, 1)
-      };
+      { s.size() } -> std::integral;
+      { s.data() };
+      { s.empty() } -> std::convertible_to<bool>;
+      { s.substr(0, 1) };
    };
 
    template <typename T>
@@ -176,9 +142,7 @@ namespace glz::detail
       bitset.flip();
       bitset.set(0);
       requires string_like<decltype(bitset.to_string())>;
-      {
-         bitset.count()
-      } -> std::same_as<size_t>;
+      { bitset.count() } -> std::same_as<size_t>;
    };
 
    template <class T>
@@ -200,12 +164,8 @@ namespace glz::detail
       path.filename();
       path.extension();
       path.parent_path();
-      {
-         path.has_filename()
-      } -> std::convertible_to<bool>;
-      {
-         path.has_extension()
-      } -> std::convertible_to<bool>;
+      { path.has_filename() } -> std::convertible_to<bool>;
+      { path.has_extension() } -> std::convertible_to<bool>;
    };
 }
 
@@ -233,16 +193,12 @@ namespace glz
 #else
       // in lieu of std::ranges::empty
       if constexpr (requires() {
-                       {
-                          rng.empty()
-                       } -> std::convertible_to<bool>;
+                       { rng.empty() } -> std::convertible_to<bool>;
                     }) {
          return rng.empty();
       }
       else if constexpr (requires() {
-                            {
-                               rng.size()
-                            } -> std::same_as<std::size_t>;
+                            { rng.size() } -> std::same_as<std::size_t>;
                          }) {
          return rng.size() == std::size_t{0};
       }

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -223,9 +223,10 @@ namespace glz
       template <class T>
       concept str_t = !std::same_as<std::nullptr_t, T> && std::convertible_to<std::decay_t<T>, std::string_view>;
 
-      // this concept requires that T is string and copies the string in json
+      // this concept requires that T is a writeable string. It can be resized, appended to, or assigned to
       template <class T>
-      concept string_t = str_t<T> && !std::same_as<std::decay_t<T>, std::string_view> && has_push_back<T>;
+      concept string_t = str_t<T> && !std::same_as<std::decay_t<T>, std::string_view> &&
+                         (has_assign<T> || has_resize<T> || has_append<T>);
 
       template <class T>
       concept char_array_t = str_t<T> && std::is_array_v<std::remove_pointer_t<std::remove_reference_t<T>>>;
@@ -251,7 +252,7 @@ namespace glz
       };
 
       template <class T>
-      concept array_t = (!meta_value_t<T> && !str_t<T> && !(readable_map_t<T> || writable_map_t<T>)&&range<T>);
+      concept array_t = (!meta_value_t<T> && !str_t<T> && !(readable_map_t<T> || writable_map_t<T>) && range<T>);
 
       template <class T>
       concept readable_array_t =
@@ -335,9 +336,7 @@ namespace glz
       template <class T>
       concept nullable_t = !meta_value_t<T> && !str_t<T> && requires(T t) {
          bool(t);
-         {
-            *t
-         };
+         { *t };
       };
 
       template <class T>


### PR DESCRIPTION
Test PR to attempt to fix [this issue](https://github.com/stephenberry/glaze/issues/1348).

Basically this PR changes the `string_t` concept previously based on `has_push_back` with the methods actually used:

```cpp
// this concept requires that T is string and copies the string in json
template <class T>
concept string_t = str_t<T> && !std::same_as<std::decay_t<T>, std::string_view> && has_push_back<T>;
```
becomes:

```cpp
template <class T>
concept has_resize = requires(T t, typename T::size_type sz) { t.resize(sz); };

template <class T>
concept has_append = requires(T t, typename T::const_iterator it) { t.append(it, it); };

template <class T>
concept has_assign = requires(T t, const typename T::value_type* v, typename T::size_type sz) { t.assign(v, sz); };
   
template <class T>
concept string_t = str_t<T> && !std::same_as<std::decay_t<T>, std::string_view> &&
                                 (has_assign<T> || has_resize<T> || has_append<T>);
```