### PR TITLE
Allow NDJSON in the skip_array requires statment.

### DIFF
--- a/include/glaze/json/skip.hpp
+++ b/include/glaze/json/skip.hpp
@@ -60,7 +60,7 @@ namespace glz::detail
    }
 
    template <opts Opts>
-      requires(Opts.format == JSON)
+      requires(Opts.format == JSON || Opts.format == NDJSON)
    void skip_array(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       if constexpr (!Opts.validate_skipped) {


### PR DESCRIPTION
This hotfix fixes #1356. However I am not sure this is way to solve it, so please feel free to reject the pull request if there is a better solution.