### PR TITLE
Unknown fields fix with all null first object

### DIFF
--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1292,9 +1292,23 @@ namespace glz
             static constexpr auto N = glz::tuple_size_v<V>;
 
             invoke_table<N>([&]<size_t I>() {
-               write<JSON>::op<opening_and_closing_handled<Options>()>(glz::get<I>(value.value), ctx, b, ix);
-               if constexpr (I < N - 1) {
-                  dump<','>(b, ix);
+               if constexpr (Options.skip_null_members) {
+                  // It is possible that all fields were skipped if skip_null_members is true
+                  // In this case we don't want to dump a comma
+                  const auto ix_start = ix;
+                  write<JSON>::op<opening_and_closing_handled<Options>()>(glz::get<I>(value.value), ctx, b, ix);
+                  if constexpr (I < N - 1) {
+                     if (ix > ix_start) // we wrote something
+                     {
+                        dump<','>(b, ix);
+                     }
+                  }
+               }
+               else {
+                  write<JSON>::op<opening_and_closing_handled<Options>()>(glz::get<I>(value.value), ctx, b, ix);
+                  if constexpr (I < N - 1) {
+                     dump<','>(b, ix);
+                  }
                }
             });
 


### PR DESCRIPTION
This fixes the issue where the first object in the unknown key writer might have all null values that are skipped when `skip_null_values` is true.