### PR TITLE
[Concept update] string_t with resize also needs to have .data()

### DIFF
--- a/include/glaze/concepts/container_concepts.hpp
+++ b/include/glaze/concepts/container_concepts.hpp
@@ -25,9 +25,7 @@ namespace glz
 
    template <class T>
    concept has_empty = requires(T v) {
-      {
-         v.empty()
-      } -> std::convertible_to<bool>;
+      { v.empty() } -> std::convertible_to<bool>;
    };
 
    template <class T>
@@ -38,9 +36,7 @@ namespace glz
 
    template <class T>
    concept has_capacity = requires(T t) {
-      {
-         t.capacity()
-      } -> std::integral;
+      { t.capacity() } -> std::integral;
    };
 
    template <class T>
@@ -78,60 +74,36 @@ namespace glz::detail
 
    template <typename T>
    concept complex_t = requires(T a, T b) {
-      {
-         a.real()
-      } -> std::convertible_to<typename T::value_type>;
-      {
-         a.imag()
-      } -> std::convertible_to<typename T::value_type>;
-      {
-         T(a.real(), a.imag())
-      } -> std::same_as<T>;
-      {
-         a + b
-      } -> std::same_as<T>;
-      {
-         a - b
-      } -> std::same_as<T>;
-      {
-         a* b
-      } -> std::same_as<T>;
-      {
-         a / b
-      } -> std::same_as<T>;
+      { a.real() } -> std::convertible_to<typename T::value_type>;
+      { a.imag() } -> std::convertible_to<typename T::value_type>;
+      { T(a.real(), a.imag()) } -> std::same_as<T>;
+      { a + b } -> std::same_as<T>;
+      { a - b } -> std::same_as<T>;
+      { a* b } -> std::same_as<T>;
+      { a / b } -> std::same_as<T>;
    };
 
    template <class T>
    concept pair_t = requires(T pair) {
       typename std::decay_t<T>::first_type;
       typename std::decay_t<T>::second_type;
-      {
-         pair.first
-      };
-      {
-         pair.second
-      };
+      { pair.first };
+      { pair.second };
    };
 
    template <class T>
    concept emplaceable = requires(T container) {
-      {
-         container.emplace(std::declval<typename T::value_type>())
-      };
+      { container.emplace(std::declval<typename T::value_type>()) };
    };
 
    template <class T>
    concept push_backable = requires(T container) {
-      {
-         container.push_back(std::declval<typename T::value_type>())
-      };
+      { container.push_back(std::declval<typename T::value_type>()) };
    };
 
    template <class T>
    concept emplace_backable = requires(T container) {
-      {
-         container.emplace_back()
-      } -> std::same_as<typename T::reference>;
+      { container.emplace_back() } -> std::same_as<typename T::reference>;
    };
 
    template <class T>
@@ -142,9 +114,7 @@ namespace glz::detail
 
    template <class T>
    concept accessible = requires(T container) {
-      {
-         container[size_t{}]
-      } -> std::same_as<typename T::reference>;
+      { container[size_t{}] } -> std::same_as<typename T::reference>;
    };
 
    template <class T>
@@ -153,25 +123,15 @@ namespace glz::detail
 
    template <class T>
    concept map_subscriptable = requires(T container) {
-      {
-         container[std::declval<typename T::key_type>()]
-      } -> std::same_as<typename T::mapped_type&>;
+      { container[std::declval<typename T::key_type>()] } -> std::same_as<typename T::mapped_type&>;
    };
 
    template <typename T>
    concept string_like = requires(T s) {
-      {
-         s.size()
-      } -> std::integral;
-      {
-         s.data()
-      };
-      {
-         s.empty()
-      } -> std::convertible_to<bool>;
-      {
-         s.substr(0, 1)
-      };
+      { s.size() } -> std::integral;
+      { s.data() };
+      { s.empty() } -> std::convertible_to<bool>;
+      { s.substr(0, 1) };
    };
 
    template <typename T>
@@ -179,9 +139,7 @@ namespace glz::detail
       bitset.flip();
       bitset.set(0);
       requires string_like<decltype(bitset.to_string())>;
-      {
-         bitset.count()
-      } -> std::same_as<size_t>;
+      { bitset.count() } -> std::same_as<size_t>;
    };
 
    template <class T>
@@ -203,12 +161,8 @@ namespace glz::detail
       path.filename();
       path.extension();
       path.parent_path();
-      {
-         path.has_filename()
-      } -> std::convertible_to<bool>;
-      {
-         path.has_extension()
-      } -> std::convertible_to<bool>;
+      { path.has_filename() } -> std::convertible_to<bool>;
+      { path.has_extension() } -> std::convertible_to<bool>;
    };
 }
 
@@ -236,16 +190,12 @@ namespace glz
 #else
       // in lieu of std::ranges::empty
       if constexpr (requires() {
-                       {
-                          rng.empty()
-                       } -> std::convertible_to<bool>;
+                       { rng.empty() } -> std::convertible_to<bool>;
                     }) {
          return rng.empty();
       }
       else if constexpr (requires() {
-                            {
-                               rng.size()
-                            } -> std::same_as<std::size_t>;
+                            { rng.size() } -> std::same_as<std::size_t>;
                          }) {
          return rng.size() == std::size_t{0};
       }

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2023,7 +2023,7 @@ namespace glz
             GLZ_SKIP_WS();
             const size_t ws_size = size_t(it - ws_start);
 
-            if constexpr ((glaze_object_t<T> || reflectable<T>)&&num_members == 0 && Opts.error_on_unknown_keys) {
+            if constexpr ((glaze_object_t<T> || reflectable<T>) && num_members == 0 && Opts.error_on_unknown_keys) {
                if (*it == '}') [[likely]] {
                   GLZ_SUB_LEVEL;
                   ++it;
@@ -2035,8 +2035,8 @@ namespace glz
             }
             else {
                decltype(auto) fields = [&]() -> decltype(auto) {
-                  if constexpr ((glaze_object_t<T> || reflectable<T>)&&(Opts.error_on_missing_keys ||
-                                                                        is_partial_read<T> || Opts.partial_read)) {
+                  if constexpr ((glaze_object_t<T> || reflectable<T>) &&
+                                (Opts.error_on_missing_keys || is_partial_read<T> || Opts.partial_read)) {
                      return bit_array<num_members>{};
                   }
                   else {
@@ -2077,7 +2077,7 @@ namespace glz
 
                bool first = true;
                while (true) {
-                  if constexpr ((glaze_object_t<T> || reflectable<T>)&&(is_partial_read<T> || Opts.partial_read)) {
+                  if constexpr ((glaze_object_t<T> || reflectable<T>) && (is_partial_read<T> || Opts.partial_read)) {
                      static constexpr bit_array<num_members> all_fields = [] {
                         bit_array<num_members> arr{};
                         for (size_t i = 0; i < num_members; ++i) {
@@ -2096,14 +2096,14 @@ namespace glz
 
                   if (*it == '}') {
                      GLZ_SUB_LEVEL;
-                     if constexpr ((glaze_object_t<T> || reflectable<T>)&&((is_partial_read<T> || Opts.partial_read) &&
-                                                                           Opts.error_on_missing_keys)) {
+                     if constexpr ((glaze_object_t<T> || reflectable<T>) &&
+                                   ((is_partial_read<T> || Opts.partial_read) && Opts.error_on_missing_keys)) {
                         ctx.error = error_code::missing_key;
                         return;
                      }
                      else {
                         ++it;
-                        if constexpr ((glaze_object_t<T> || reflectable<T>)&&Opts.error_on_missing_keys) {
+                        if constexpr ((glaze_object_t<T> || reflectable<T>) && Opts.error_on_missing_keys) {
                            constexpr auto req_fields = required_fields<T, Opts>();
                            if ((req_fields & fields) != req_fields) {
                               ctx.error = error_code::missing_key;
@@ -2130,10 +2130,11 @@ namespace glz
                      GLZ_SKIP_WS();
                   }
 
-                  if constexpr ((glaze_object_t<T> || reflectable<T>)&&num_members == 0 && Opts.error_on_unknown_keys) {
+                  if constexpr ((glaze_object_t<T> || reflectable<T>) && num_members == 0 &&
+                                Opts.error_on_unknown_keys) {
                      static_assert(false_v<T>, "This should be unreachable");
                   }
-                  else if constexpr ((glaze_object_t<T> || reflectable<T>)&&num_members == 0) {
+                  else if constexpr ((glaze_object_t<T> || reflectable<T>) && num_members == 0) {
                      GLZ_MATCH_QUOTE;
                      GLZ_INVALID_END();
 


### PR DESCRIPTION
`resize()` is used with `data()`. Update the concept requirements for `string_t`.
Also clang-formatted the code according to the `.clang-format` file