### PR TITLE
Remove redundant read iterator checks & support empty input NDJSON

### DIFF
--- a/include/glaze/json/json_ptr.hpp
+++ b/include/glaze/json/json_ptr.hpp
@@ -29,7 +29,7 @@ namespace glz
       static constexpr auto N = tokens.size();
 
       context ctx{};
-      auto p = read_iterators<Opts>(ctx, buffer);
+      auto p = read_iterators<Opts>(buffer);
 
       auto it = p.first;
       auto end = p.second;
@@ -40,6 +40,10 @@ namespace glz
       using result_t = expected<span_t, error_ctx>;
 
       auto start = it;
+      
+      if (buffer.empty()) [[unlikely]] {
+         ctx.error = error_code::no_read_input;
+      }
 
       if (bool(ctx.error)) [[unlikely]] {
          return result_t{unexpected(error_ctx{ctx.error})};

--- a/include/glaze/json/minify.hpp
+++ b/include/glaze/json/minify.hpp
@@ -167,7 +167,7 @@ namespace glz
             out.resize(in.size() + padding_bytes);
          }
          size_t ix = 0;
-         auto [it, end] = read_iterators<Opts, true>(ctx, in);
+         auto [it, end] = read_iterators<Opts, true>(in);
          if (bool(ctx.error)) [[unlikely]] {
             return;
          }

--- a/include/glaze/json/prettify.hpp
+++ b/include/glaze/json/prettify.hpp
@@ -182,7 +182,7 @@ namespace glz
             out.resize(in.size() * 2);
          }
          size_t ix = 0;
-         auto [it, end] = read_iterators<Opts>(ctx, in);
+         auto [it, end] = read_iterators<Opts>(in);
          if (bool(ctx.error)) [[unlikely]] {
             return;
          }

--- a/include/glaze/mustache/mustache.hpp
+++ b/include/glaze/mustache/mustache.hpp
@@ -25,7 +25,7 @@ namespace glz
       auto it = p.first;
       auto end = p.second;
       auto start = it;
-      if (buffer.empty()) [[unlikely]] {
+      if (tmp.empty()) [[unlikely]] {
          ctx.error = error_code::no_read_input;
       }
       if (not bool(ctx.error)) [[likely]] {

--- a/include/glaze/mustache/mustache.hpp
+++ b/include/glaze/mustache/mustache.hpp
@@ -21,10 +21,13 @@ namespace glz
          return unexpected(error_ctx{ctx.error, ctx.custom_error_message, 0, ctx.includer_error});
       }
 
-      auto p = read_iterators<Opts, false>(ctx, tmp);
+      auto p = read_iterators<Opts, false>(tmp);
       auto it = p.first;
       auto end = p.second;
       auto start = it;
+      if (buffer.empty()) [[unlikely]] {
+         ctx.error = error_code::no_read_input;
+      }
       if (not bool(ctx.error)) [[likely]] {
          auto skip_whitespace = [&] {
             while (detail::whitespace_table[uint8_t(*it)]) {

--- a/include/glaze/mustache/stencilcount.hpp
+++ b/include/glaze/mustache/stencilcount.hpp
@@ -24,7 +24,7 @@ namespace glz
 
       auto [it, end] = read_iterators<Opts, false>(tmp);
       auto start = it;
-      if (buffer.empty()) [[unlikely]] {
+      if (tmp.empty()) [[unlikely]] {
          ctx.error = error_code::no_read_input;
       }
       if (not bool(ctx.error)) [[likely]] {

--- a/include/glaze/mustache/stencilcount.hpp
+++ b/include/glaze/mustache/stencilcount.hpp
@@ -22,8 +22,11 @@ namespace glz
          return unexpected(error_ctx{ctx.error, ctx.custom_error_message, 0, ctx.includer_error});
       }
 
-      auto [it, end] = read_iterators<Opts, false>(ctx, tmp);
+      auto [it, end] = read_iterators<Opts, false>(tmp);
       auto start = it;
+      if (buffer.empty()) [[unlikely]] {
+         ctx.error = error_code::no_read_input;
+      }
       if (not bool(ctx.error)) [[likely]] {
          auto skip_whitespace = [&] {
             while (detail::whitespace_table[uint8_t(*it)]) {

--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -153,7 +153,10 @@ namespace glz::repe
    size_t read_params(Value&& value, auto&& state, auto&& response)
    {
       glz::context ctx{};
-      auto [b, e] = read_iterators<Opts>(ctx, state.message);
+      auto [b, e] = read_iterators<Opts>(state.message);
+      if (state.message.empty()) [[unlikely]] {
+         ctx.error = error_code::no_read_input;
+      }
       if (bool(ctx.error)) [[unlikely]] {
          return 0;
       }
@@ -212,7 +215,10 @@ namespace glz::repe
    {
       repe::header h;
       context ctx{};
-      auto [b, e] = read_iterators<Opts>(ctx, buffer);
+      auto [b, e] = read_iterators<Opts>(buffer);
+      if (buffer.empty()) [[unlikely]] {
+         ctx.error = error_code::no_read_input;
+      }
       if (bool(ctx.error)) [[unlikely]] {
          return error_t{error_e::parse_error};
       }
@@ -1084,6 +1090,9 @@ namespace glz::repe
          context ctx{};
          auto [b, e] = read_iterators<Opts>(ctx, msg);
          auto start = b;
+         if (msg.empty()) [[unlikely]] {
+            ctx.error = error_code::no_read_input;
+         }
 
          auto handle_error = [&](auto& it) {
             ctx.error = error_code::syntax_error;

--- a/include/glaze/rpc/repe.hpp
+++ b/include/glaze/rpc/repe.hpp
@@ -1088,7 +1088,7 @@ namespace glz::repe
          auto& response = *(u_buffer->ptr);
 
          context ctx{};
-         auto [b, e] = read_iterators<Opts>(ctx, msg);
+         auto [b, e] = read_iterators<Opts>(msg);
          auto start = b;
          if (msg.empty()) [[unlikely]] {
             ctx.error = error_code::no_read_input;

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -4052,6 +4052,15 @@ suite ndjson_test = [] {
       auto out = glz::write_ndjson(x).value_or("error");
       expect(out == buffer) << out;
    };
+   
+   "empty json lines input"_test = [] {
+      std::vector<int> foo;
+      const auto json = glz::write_ndjson(foo).value();
+      expect(json == R"()");
+      std::vector<int> v{1, 2, 3};
+      expect(not glz::read_ndjson<>(v, json));
+      expect(v.size() == 0);
+   };
 };
 
 suite std_function_handling = [] {


### PR DESCRIPTION
`read_iterators` should be a low level function that doesn't check for empty input. Empty input should be checked when reading with certain inputs. This removes the check for NDJSON to allow empty inputs, as the specification requires.