### PR TITLE
Fix JSON RPC documentation link to json-rpc.cpp source

### DIFF
--- a/docs/rpc/json-rpc.md
+++ b/docs/rpc/json-rpc.md
@@ -6,7 +6,7 @@ Compile time specification of JSON-RPC methods making it unnecessary to convert 
 
 ### Example
 
-full working example can be seen in source code [examples/json-rpc.cc](examples/json-rpc.cc)
+full working example can be seen in source code [examples/json-rpc.cpp](../../examples/json-rpc.cpp)
 
 ```C++
 struct foo_params


### PR DESCRIPTION
Fix broken link to json-rpc.cpp example in the docs.