### PR TITLE
Remove parse_ints_as_type_cast_doubles

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,6 @@ Glaze also supports:
 > - Decimal values and negative exponents will by default be rejected for safety and performance. It will still be possible through various approaches to parse decimal values into integers, but it won't be the default behavior.
 > - `std::array<char, ...>` is now handled as a JSON string `"abc"` rather than an array of characters `["a", "b", "c"]`
 >
-> ### Version 3.5
->
-> Glaze [v3.5.0](https://github.com/stephenberry/glaze/releases/tag/v3.5.0) renamed the format specifier from `json` to `JSON`. Also, `glz::detail::to_json` and `glz::detail::from_json` specializations change to `glz::detail::to<JSON` and `glz::detail::from<JSON`. [See release notes](https://github.com/stephenberry/glaze/releases/tag/v3.5.0) for more information.
->
-> `glz::read_binary` and `glz::write_binary` were also renamed to `glz::read_beve` and `glz::write_beve`
 
 ## With compile time reflection for MSVC, Clang, and GCC!
 

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -77,11 +77,6 @@ namespace glz
 
       // The maximum precision type used for writing floats, higher precision floats will be cast down to this precision
       float_precision float_max_write_precision{};
-      bool_t parse_ints_as_type_cast_doubles{}; // By default Glaze rejects decimals and negative exponents when parsing
-                                                // integers
-      // Turn on this option to read JSON integers with double precision that is cast to the integer type
-      // Note: it is not recommended to use this option generally, instead use a floating point type if necessary or
-      // use glz::custom to define your desired conversion precision and approach (truncation vs rounding)
 
       bool_t bools_as_numbers = false; // Read and write booleans with 1's and 0's
 

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -562,28 +562,16 @@ namespace glz
             if constexpr (int_t<V>) {
                static_assert(sizeof(*it) == sizeof(char));
 
-               if constexpr (Opts.parse_ints_as_type_cast_doubles) {
-                  double d{};
-                  auto [ptr, ec] = glz::from_chars<Opts.null_terminated>(it, end, d);
-                  if (ec != std::errc()) [[unlikely]] {
+               if constexpr (Opts.null_terminated) {
+                  if (not glz::detail::atoi(value, it)) [[unlikely]] {
                      ctx.error = error_code::parse_number_failure;
                      return;
                   }
-                  it = ptr;
-                  value = static_cast<V>(d);
                }
                else {
-                  if constexpr (Opts.null_terminated) {
-                     if (not glz::detail::atoi(value, it)) [[unlikely]] {
-                        ctx.error = error_code::parse_number_failure;
-                        return;
-                     }
-                  }
-                  else {
-                     if (not glz::detail::atoi(value, it, end)) [[unlikely]] {
-                        ctx.error = error_code::parse_number_failure;
-                        return;
-                     }
+                  if (not glz::detail::atoi(value, it, end)) [[unlikely]] {
+                     ctx.error = error_code::parse_number_failure;
+                     return;
                   }
                }
             }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -9701,18 +9701,6 @@ suite ndjson_options = [] {
    };
 };
 
-suite parse_ints_as_type_cast_doubles_test = [] {
-   "multiple int from double"_test = [] {
-      std::vector<int> v;
-      std::string buffer = "[1.66, 3.24, 5.555]";
-      expect(not glz::read<glz::opts{.parse_ints_as_type_cast_doubles = true}>(v, buffer));
-      expect(v.size() == 3);
-      expect(v[0] == 1);
-      expect(v[1] == 3);
-      expect(v[2] == 5);
-   };
-};
-
 suite atomics = [] {
    "atomics"_test = [] {
       std::atomic<int> i{};


### PR DESCRIPTION
glz::custom is a better solution for custom transformation, as this was adding a global option that would not be recommended.