### PR TITLE
Fix json parsing from arrays to set like types with custom structs

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1250,6 +1250,7 @@ namespace glz
                   return;
                }
                GLZ_MATCH_COMMA;
+               GLZ_SKIP_WS();
             }
          }
       };
@@ -2011,7 +2012,7 @@ namespace glz
             GLZ_SKIP_WS();
             const size_t ws_size = size_t(it - ws_start);
 
-            if constexpr ((glaze_object_t<T> || reflectable<T>)&&num_members == 0 && Opts.error_on_unknown_keys) {
+            if constexpr ((glaze_object_t<T> || reflectable<T>) && num_members == 0 && Opts.error_on_unknown_keys) {
                if (*it == '}') [[likely]] {
                   GLZ_SUB_LEVEL;
                   ++it;
@@ -2023,8 +2024,8 @@ namespace glz
             }
             else {
                decltype(auto) fields = [&]() -> decltype(auto) {
-                  if constexpr ((glaze_object_t<T> || reflectable<T>)&&(Opts.error_on_missing_keys ||
-                                                                        is_partial_read<T> || Opts.partial_read)) {
+                  if constexpr ((glaze_object_t<T> || reflectable<T>) &&
+                                (Opts.error_on_missing_keys || is_partial_read<T> || Opts.partial_read)) {
                      return bit_array<num_members>{};
                   }
                   else {
@@ -2065,7 +2066,7 @@ namespace glz
 
                bool first = true;
                while (true) {
-                  if constexpr ((glaze_object_t<T> || reflectable<T>)&&(is_partial_read<T> || Opts.partial_read)) {
+                  if constexpr ((glaze_object_t<T> || reflectable<T>) && (is_partial_read<T> || Opts.partial_read)) {
                      static constexpr bit_array<num_members> all_fields = [] {
                         bit_array<num_members> arr{};
                         for (size_t i = 0; i < num_members; ++i) {
@@ -2084,14 +2085,14 @@ namespace glz
 
                   if (*it == '}') {
                      GLZ_SUB_LEVEL;
-                     if constexpr ((glaze_object_t<T> || reflectable<T>)&&((is_partial_read<T> || Opts.partial_read) &&
-                                                                           Opts.error_on_missing_keys)) {
+                     if constexpr ((glaze_object_t<T> || reflectable<T>) &&
+                                   ((is_partial_read<T> || Opts.partial_read) && Opts.error_on_missing_keys)) {
                         ctx.error = error_code::missing_key;
                         return;
                      }
                      else {
                         ++it;
-                        if constexpr ((glaze_object_t<T> || reflectable<T>)&&Opts.error_on_missing_keys) {
+                        if constexpr ((glaze_object_t<T> || reflectable<T>) && Opts.error_on_missing_keys) {
                            constexpr auto req_fields = required_fields<T, Opts>();
                            if ((req_fields & fields) != req_fields) {
                               ctx.error = error_code::missing_key;
@@ -2118,10 +2119,11 @@ namespace glz
                      GLZ_SKIP_WS();
                   }
 
-                  if constexpr ((glaze_object_t<T> || reflectable<T>)&&num_members == 0 && Opts.error_on_unknown_keys) {
+                  if constexpr ((glaze_object_t<T> || reflectable<T>) && num_members == 0 &&
+                                Opts.error_on_unknown_keys) {
                      static_assert(false_v<T>, "This should be unreachable");
                   }
-                  else if constexpr ((glaze_object_t<T> || reflectable<T>)&&num_members == 0) {
+                  else if constexpr ((glaze_object_t<T> || reflectable<T>) && num_members == 0) {
                      GLZ_MATCH_QUOTE;
                      GLZ_INVALID_END();
 

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -8331,6 +8331,13 @@ namespace glz::detail
          value.str += "write";
          write<JSON>::op<Opts>(value.str, args...);
       }
+      
+      // For std::set testing, because iterators are const
+      template <auto Opts>
+      static void op(const custom_struct& value, auto&&... args) noexcept
+      {
+         write<JSON>::op<Opts>(value.str, args...);
+      }
    };
 }
 
@@ -8346,15 +8353,12 @@ suite custom_struct_tests = [] {
 
       using custom_struct_set = std::set<custom_struct>;
 
-      // TODO: below commented code does not compile
-      // custom_struct_set obj_set{custom_struct{"hello"}, custom_struct{"world"}};
+      custom_struct_set obj_set{custom_struct{"hello"}, custom_struct{"world"}};
 
-      // expect(not glz::write_json(obj_set, s));
-      // expect(s == R"(["hellowrite","worldwrite"])");
+      expect(not glz::write_json(obj_set, s));
+      expect(s == R"(["hello","world"])");
 
-      // obj_set.clear();
-
-      custom_struct_set obj_set;
+      obj_set.clear();
 
       std::string_view withSpaces = R"(
       [


### PR DESCRIPTION
Hello,

Several things in this PR:

 - I noticed a bug in the parsing of json arrays towards set like types. It seems that a skip of whitespaces is needed (`GLZ_SKIP_WS();`). It is done correctly for `vector` like types below. I tested the fix on my custom struct and it works fine. I could not figure it out with a unit test though (I don't know how new tests pass without the fix in `read.json`).
 - Could you please help me figuring out why the commented code added in this PR (in `json_test.cpp` does not compile? It seems that the `to` JSON custom function excepts this signature instead (it works with below code, however, `value` is const so it's not possible to apped anything to it):
 
 ```
      template <auto Opts, is_context Ctx, class B, class IX>
      static void op(auto&& value, Ctx&& c, B&& b, IX&& ix)
      {
         write<JSON>::op<Opts>(value.str, c, b, ix);
      }
```
Thanks a lot in advance.