### PR TITLE
Put fast_float and dragonbox into glz namespace

### DIFF
--- a/include/glaze/util/dragonbox.hpp
+++ b/include/glaze/util/dragonbox.hpp
@@ -201,7 +201,7 @@
 #include <immintrin.h>
 #endif
 
-namespace jkj
+namespace glz::jkj
 {
    namespace dragonbox
    {

--- a/include/glaze/util/dtoa.hpp
+++ b/include/glaze/util/dtoa.hpp
@@ -176,12 +176,12 @@ namespace glz
          return buf + 1;
       }
 
-      using Conversion = jkj::dragonbox::default_float_bit_carrier_conversion_traits<T>;
+      using Conversion = glz::jkj::dragonbox::default_float_bit_carrier_conversion_traits<T>;
       using FormatTraits =
-         jkj::dragonbox::ieee754_binary_traits<typename Conversion::format, typename Conversion::carrier_uint>;
+         glz::jkj::dragonbox::ieee754_binary_traits<typename Conversion::format, typename Conversion::carrier_uint>;
       static constexpr uint32_t exp_bits_count =
          numbits(std::numeric_limits<T>::max_exponent - std::numeric_limits<T>::min_exponent + 1);
-      const auto float_bits = jkj::dragonbox::make_float_bits<T, Conversion, FormatTraits>(val);
+      const auto float_bits = glz::jkj::dragonbox::make_float_bits<T, Conversion, FormatTraits>(val);
       const auto exp_bits = float_bits.extract_exponent_bits();
       const auto s = float_bits.remove_exponent_bits();
 
@@ -196,8 +196,8 @@ namespace glz
       buf += (val < zero);
 
       if constexpr (is_float) {
-         const auto v = jkj::dragonbox::to_decimal_ex(s, exp_bits, jkj::dragonbox::policy::sign::ignore,
-                                                      jkj::dragonbox::policy::trailing_zero::remove);
+         const auto v = glz::jkj::dragonbox::to_decimal_ex(s, exp_bits, glz::jkj::dragonbox::policy::sign::ignore,
+                                                           glz::jkj::dragonbox::policy::trailing_zero::remove);
 
          uint32_t sig_dec = uint32_t(v.significand);
          int32_t exp_dec = v.exponent;
@@ -256,8 +256,8 @@ namespace glz
          }
       }
       else {
-         const auto v = jkj::dragonbox::to_decimal_ex(s, exp_bits, jkj::dragonbox::policy::sign::ignore,
-                                                      jkj::dragonbox::policy::trailing_zero::ignore);
+         const auto v = glz::jkj::dragonbox::to_decimal_ex(s, exp_bits, glz::jkj::dragonbox::policy::sign::ignore,
+                                                           glz::jkj::dragonbox::policy::trailing_zero::ignore);
 
          uint64_t sig_dec = v.significand;
          int32_t exp_dec = v.exponent;

--- a/include/glaze/util/fast_float.hpp
+++ b/include/glaze/util/fast_float.hpp
@@ -149,7 +149,7 @@
   #endif
 #endif
 
-namespace fast_float {
+namespace glz::fast_float {
 
 #define FASTFLOAT_JSONFMT (1 << 5)
 #define FASTFLOAT_FORTRANFMT (1 << 6)
@@ -315,7 +315,7 @@ using parse_options = parse_options_t<char>;
 #define FASTFLOAT_ENABLE_IF(...) typename std::enable_if<(__VA_ARGS__), int>::type
 
 
-namespace fast_float {
+namespace glz::fast_float {
 
 fastfloat_really_inline constexpr bool cpp20_and_in_constexpr() {
 #if FASTFLOAT_HAS_IS_CONSTANT_EVALUATED
@@ -897,7 +897,7 @@ constexpr size_t max_digits_u64(int base) { return int_luts<>::maxdigits_u64[bas
 fastfloat_really_inline
 constexpr uint64_t min_safe_u64(int base) { return int_luts<>::min_safe_u64[base - 2]; }
 
-} // namespace fast_float
+} // namespace glz::fast_float
 
 #endif
 
@@ -906,7 +906,7 @@ constexpr uint64_t min_safe_u64(int base) { return int_luts<>::min_safe_u64[base
 #define FASTFLOAT_FAST_FLOAT_H
 
 
-namespace fast_float {
+namespace glz::fast_float {
 /**
  * This function parses the character sequence [first,last) for a number. It parses floating-point numbers expecting
  * a locale-indepent format equivalent to what is used by std::strtod in the default ("C") locale.
@@ -945,7 +945,7 @@ template <typename T, typename UC = char, typename = FASTFLOAT_ENABLE_IF(!is_sup
 FASTFLOAT_CONSTEXPR20
 from_chars_result_t<UC> from_chars(UC const * first, UC const * last, T& value, int base = 10) noexcept;
 
-} // namespace fast_float
+} // namespace glz::fast_float
 #endif // FASTFLOAT_FAST_FLOAT_H
 
 #ifndef FASTFLOAT_ASCII_NUMBER_H
@@ -967,7 +967,7 @@ from_chars_result_t<UC> from_chars(UC const * first, UC const * last, T& value, 
 #include <arm_neon.h>
 #endif
 
-namespace fast_float {
+namespace glz::fast_float {
 
 template <typename UC>
 fastfloat_really_inline constexpr bool has_simd_opt() {
@@ -1472,7 +1472,7 @@ from_chars_result_t<UC> parse_int_string(UC const* p, UC const* pend, T& value, 
   return answer;
 }
 
-} // namespace fast_float
+} // namespace glz::fast_float
 
 #endif
 
@@ -1481,7 +1481,7 @@ from_chars_result_t<UC> parse_int_string(UC const* p, UC const* pend, T& value, 
 
 #include <cstdint>
 
-namespace fast_float {
+namespace glz::fast_float {
 
 /**
  * When mapping numbers from decimal to binary,
@@ -2173,7 +2173,7 @@ constexpr uint64_t powers_template<unused>::power_of_five_128[number_of_entries]
 
 using powers = powers_template<>;
 
-} // namespace fast_float
+} // namespace glz::fast_float
 
 #endif
 
@@ -2187,7 +2187,7 @@ using powers = powers_template<>;
 #include <cstdlib>
 #include <cstring>
 
-namespace fast_float {
+namespace glz::fast_float {
 
 // This will compute or rather approximate w * 5**q and return a pair of 64-bit words approximating
 // the result, with the "high" part corresponding to the most significant bits and the
@@ -2362,7 +2362,7 @@ adjusted_mantissa compute_float(int64_t q, uint64_t w)  noexcept  {
   return answer;
 }
 
-} // namespace fast_float
+} // namespace glz::fast_float
 
 #endif
 
@@ -2375,7 +2375,7 @@ adjusted_mantissa compute_float(int64_t q, uint64_t w)  noexcept  {
 #include <cstring>
 
 
-namespace fast_float {
+namespace glz::fast_float {
 
 // the limb width: we want efficient multiplication of double the bits in
 // limb, or for 64-bit limbs, at least 64-bit multiplication where we can
@@ -2979,7 +2979,7 @@ struct bigint : pow5_tables<> {
   }
 };
 
-} // namespace fast_float
+} // namespace glz::fast_float
 
 #endif
 
@@ -2992,7 +2992,7 @@ struct bigint : pow5_tables<> {
 #include <iterator>
 
 
-namespace fast_float {
+namespace glz::fast_float {
 
 // 1e0 to 1e19
 constexpr static uint64_t powers_of_ten_uint64[] = {
@@ -3403,7 +3403,7 @@ adjusted_mantissa digit_comp(parsed_number_string_t<UC>& num, adjusted_mantissa 
   }
 }
 
-} // namespace fast_float
+} // namespace glz::fast_float
 
 #endif
 
@@ -3415,7 +3415,7 @@ adjusted_mantissa digit_comp(parsed_number_string_t<UC>& num, adjusted_mantissa 
 #include <cstring>
 #include <limits>
 #include <system_error>
-namespace fast_float {
+namespace glz::fast_float {
 
 
 namespace detail {
@@ -3676,7 +3676,7 @@ from_chars_result_t<UC> from_chars_advanced(UC const * first, UC const * last,
 
   from_chars_result_t<UC> answer;
 #ifdef FASTFLOAT_SKIP_WHITE_SPACE  // disabled by default
-  while ((first != last) && fast_float::is_space(uint8_t(*first))) {
+  while ((first != last) && glz::fast_float::is_space(uint8_t(*first))) {
     first++;
   }
 #endif
@@ -3708,7 +3708,7 @@ from_chars_result_t<UC> from_chars(UC const* first, UC const* last, T& value, in
 
   from_chars_result_t<UC> answer;
 #ifdef FASTFLOAT_SKIP_WHITE_SPACE  // disabled by default
-  while ((first != last) && fast_float::is_space(uint8_t(*first))) {
+  while ((first != last) && glz::fast_float::is_space(uint8_t(*first))) {
     first++;
   }
 #endif
@@ -3720,7 +3720,7 @@ from_chars_result_t<UC> from_chars(UC const* first, UC const* last, T& value, in
   return parse_int_string(first, last, value, base);
 }
 
-} // namespace fast_float
+} // namespace glz::fast_float
 
 #endif
 

--- a/include/glaze/util/glaze_fast_float.hpp
+++ b/include/glaze/util/glaze_fast_float.hpp
@@ -13,10 +13,9 @@ namespace glz
    // Assuming that you use no more than 19 digits, this will
    // parse an ASCII string.
    template <bool null_terminated, class UC>
-   GLZ_ALWAYS_INLINE constexpr fast_float::parsed_number_string_t<UC> parse_number_string(UC const* p,
-                                                                                          UC const* pend) noexcept
+   GLZ_ALWAYS_INLINE constexpr glz::fast_float::parsed_number_string_t<UC> parse_number_string(UC const* p, UC const* pend) noexcept
    {
-      using namespace fast_float;
+      using namespace glz::fast_float;
       static constexpr UC decimal_point = '.';
 
       parsed_number_string_t<UC> answer;
@@ -32,7 +31,7 @@ namespace glz
             }
          }
 
-         if (!is_integer(*p)) [[unlikely]] { // a sign must be followed by an integer
+         if (!glz::fast_float::is_integer(*p)) [[unlikely]] { // a sign must be followed by an integer
             return answer;
          }
       }
@@ -41,7 +40,7 @@ namespace glz
       uint64_t i = 0; // an unsigned int avoids signed overflows (which are bad)
 
       if constexpr (null_terminated) {
-         while (is_integer(*p)) {
+         while (glz::fast_float::is_integer(*p)) {
             // a multiplication by 10 is cheaper than an arbitrary integer
             // multiplication
             i = 10 * i + uint64_t(*p - UC('0')); // might overflow, we will handle the overflow later
@@ -49,7 +48,7 @@ namespace glz
          }
       }
       else {
-         while ((p != pend) && is_integer(*p)) {
+         while ((p != pend) && glz::fast_float::is_integer(*p)) {
             // a multiplication by 10 is cheaper than an arbitrary integer
             // multiplication
             i = 10 * i + uint64_t(*p - UC('0')); // might overflow, we will handle the overflow later
@@ -59,7 +58,7 @@ namespace glz
 
       UC const* const end_of_integer_part = p;
       int64_t digit_count = int64_t(end_of_integer_part - start_digits);
-      answer.integer = fast_float::span<const UC>(start_digits, size_t(digit_count));
+      answer.integer = glz::fast_float::span<const UC>(start_digits, size_t(digit_count));
 
       // at least 1 digit in integer part, without leading zeros
       if (digit_count == 0 || (start_digits[0] == UC('0') && digit_count > 1)) {
@@ -83,21 +82,21 @@ namespace glz
          loop_parse_if_eight_digits(p, pend, i);
 
          if constexpr (null_terminated) {
-            while (is_integer(*p)) {
+            while (glz::fast_float::is_integer(*p)) {
                uint8_t digit = uint8_t(*p - UC('0'));
                ++p;
                i = i * 10 + digit; // in rare cases, this will overflow, but that's ok
             }
          }
          else {
-            while ((p != pend) && is_integer(*p)) {
+            while ((p != pend) && glz::fast_float::is_integer(*p)) {
                uint8_t digit = uint8_t(*p - UC('0'));
                ++p;
                i = i * 10 + digit; // in rare cases, this will overflow, but that's ok
             }
          }
          exponent = before - p;
-         answer.fraction = fast_float::span<const UC>(before, size_t(p - before));
+         answer.fraction = glz::fast_float::span<const UC>(before, size_t(p - before));
          digit_count -= exponent;
       }
       // at least 1 digit in fractional part
@@ -119,12 +118,12 @@ namespace glz
             else if (UC('+') == *p) { // '+' on exponent is allowed by C++17 20.19.3.(7.1)
                ++p;
             }
-            if (!is_integer(*p)) {
+            if (!glz::fast_float::is_integer(*p)) {
                // Otherwise, we will be ignoring the 'e'.
                p = location_of_e;
             }
             else {
-               while (is_integer(*p)) {
+               while (glz::fast_float::is_integer(*p)) {
                   uint8_t digit = uint8_t(*p - UC('0'));
                   if (exp_number < 0x10000000) {
                      exp_number = 10 * exp_number + digit;
@@ -150,12 +149,12 @@ namespace glz
             else if ((p != pend) && (UC('+') == *p)) { // '+' on exponent is allowed by C++17 20.19.3.(7.1)
                ++p;
             }
-            if ((p == pend) || !is_integer(*p)) {
+            if ((p == pend) || !glz::fast_float::is_integer(*p)) {
                // Otherwise, we will be ignoring the 'e'.
                p = location_of_e;
             }
             else {
-               while ((p != pend) && is_integer(*p)) {
+               while ((p != pend) && glz::fast_float::is_integer(*p)) {
                   uint8_t digit = uint8_t(*p - UC('0'));
                   if (exp_number < 0x10000000) {
                      exp_number = 10 * exp_number + digit;
@@ -235,9 +234,9 @@ namespace glz
    }
 
    template <bool null_terminated, class T, class UC>
-   constexpr fast_float::from_chars_result_t<UC> from_chars(UC const* first, UC const* last, T& value) noexcept
+   constexpr glz::fast_float::from_chars_result_t<UC> from_chars(UC const* first, UC const* last, T& value) noexcept
    {
-      using namespace fast_float;
+      using namespace glz::fast_float;
       static_assert(is_supported_float_type<T>(), "only some floating-point types are supported");
       static_assert(is_supported_char_type<UC>(), "only char, wchar_t, char16_t and char32_t are supported");
 


### PR DESCRIPTION
Move fast_float and dragonbox libraries under glz namespace to prevent version conflicts when projects using different versions of these dependencies are linked together. This change improves compatibility and reduces potential linking issues.