### PR TITLE
Using GLZ_ macro prefix for third party dependencies

### DIFF
--- a/include/glaze/util/atoi.hpp
+++ b/include/glaze/util/atoi.hpp
@@ -163,9 +163,9 @@ namespace glz::detail
       // But MinGW on ARM64 doesn't have native support for 64-bit multiplications
       answer.high = __umulh(a, b);
       answer.low = a * b;
-#elif defined(FASTFLOAT_32BIT) || (defined(_WIN64) && !defined(__clang__))
+#elif defined(GLZ_FASTFLOAT_32BIT) || (defined(_WIN64) && !defined(__clang__))
       answer.low = _umul128(a, b, &answer.high); // _umul128 not available on ARM64
-#elif defined(FASTFLOAT_64BIT) && defined(__SIZEOF_INT128__)
+#elif defined(GLZ_FASTFLOAT_64BIT) && defined(__SIZEOF_INT128__)
       __uint128_t r = ((__uint128_t)a) * b;
       answer.low = uint64_t(r);
       answer.high = uint64_t(r >> 64);

--- a/include/glaze/util/dragonbox.hpp
+++ b/include/glaze/util/dragonbox.hpp
@@ -15,23 +15,23 @@
 // is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied.
 
-#ifndef JKJ_HEADER_DRAGONBOX
-#define JKJ_HEADER_DRAGONBOX
+#ifndef GLZ_JKJ_HEADER_DRAGONBOX
+#define GLZ_JKJ_HEADER_DRAGONBOX
 
 // Attribute for storing static data into a dedicated place, e.g. flash memory. Every ODR-used
 // static data declaration will be decorated with this macro. The users may define this macro,
 // before including the library headers, into whatever they want.
-#ifndef JKJ_STATIC_DATA_SECTION
-#define JKJ_STATIC_DATA_SECTION
+#ifndef GLZ_JKJ_STATIC_DATA_SECTION
+#define GLZ_JKJ_STATIC_DATA_SECTION
 #else
-#define JKJ_STATIC_DATA_SECTION_DEFINED 1
+#define GLZ_JKJ_STATIC_DATA_SECTION_DEFINED 1
 #endif
 
 // To use the library with toolchains without standard C++ headers, the users may define this macro
 // into their custom namespace which contains the defintions of all the standard C++ library
 // features used in this header. (The list can be found below.)
-#ifndef JKJ_STD_REPLACEMENT_NAMESPACE
-#define JKJ_STD_REPLACEMENT_NAMESPACE std
+#ifndef GLZ_JKJ_STD_REPLACEMENT_NAMESPACE
+#define GLZ_JKJ_STD_REPLACEMENT_NAMESPACE std
 #include <cassert>
 #include <cstdint>
 #include <cstring>
@@ -44,7 +44,7 @@
 #endif
 #endif
 #else
-#define JKJ_STD_REPLACEMENT_NAMESPACE_DEFINED 1
+#define GLZ_JKJ_STD_REPLACEMENT_NAMESPACE_DEFINED 1
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -53,146 +53,146 @@
 
 // C++14 constexpr
 #if defined(__cpp_constexpr) && __cpp_constexpr >= 201304L
-#define JKJ_HAS_CONSTEXPR14 1
+#define GLZ_JKJ_HAS_CONSTEXPR14 1
 #elif __cplusplus >= 201402L
-#define JKJ_HAS_CONSTEXPR14 1
+#define GLZ_JKJ_HAS_CONSTEXPR14 1
 #elif defined(_MSC_VER) && _MSC_VER >= 1910 && _MSVC_LANG >= 201402L
-#define JKJ_HAS_CONSTEXPR14 1
+#define GLZ_JKJ_HAS_CONSTEXPR14 1
 #else
-#define JKJ_HAS_CONSTEXPR14 0
+#define GLZ_JKJ_HAS_CONSTEXPR14 0
 #endif
 
-#if JKJ_HAS_CONSTEXPR14
-#define JKJ_CONSTEXPR14 constexpr
+#if GLZ_JKJ_HAS_CONSTEXPR14
+#define GLZ_JKJ_CONSTEXPR14 constexpr
 #else
-#define JKJ_CONSTEXPR14
+#define GLZ_JKJ_CONSTEXPR14
 #endif
 
 // C++17 constexpr lambdas
 #if defined(__cpp_constexpr) && __cpp_constexpr >= 201603L
-#define JKJ_HAS_CONSTEXPR17 1
+#define GLZ_JKJ_HAS_CONSTEXPR17 1
 #elif __cplusplus >= 201703L
-#define JKJ_HAS_CONSTEXPR17 1
+#define GLZ_JKJ_HAS_CONSTEXPR17 1
 #elif defined(_MSC_VER) && _MSC_VER >= 1911 && _MSVC_LANG >= 201703L
-#define JKJ_HAS_CONSTEXPR17 1
+#define GLZ_JKJ_HAS_CONSTEXPR17 1
 #else
-#define JKJ_HAS_CONSTEXPR17 0
+#define GLZ_JKJ_HAS_CONSTEXPR17 0
 #endif
 
 // C++17 inline variables
 #if defined(__cpp_inline_variables) && __cpp_inline_variables >= 201606L
-#define JKJ_HAS_INLINE_VARIABLE 1
+#define GLZ_JKJ_HAS_INLINE_VARIABLE 1
 #elif __cplusplus >= 201703L
-#define JKJ_HAS_INLINE_VARIABLE 1
+#define GLZ_JKJ_HAS_INLINE_VARIABLE 1
 #elif defined(_MSC_VER) && _MSC_VER >= 1912 && _MSVC_LANG >= 201703L
-#define JKJ_HAS_INLINE_VARIABLE 1
+#define GLZ_JKJ_HAS_INLINE_VARIABLE 1
 #else
-#define JKJ_HAS_INLINE_VARIABLE 0
+#define GLZ_JKJ_HAS_INLINE_VARIABLE 0
 #endif
 
-#if JKJ_HAS_INLINE_VARIABLE
-#define JKJ_INLINE_VARIABLE inline constexpr
+#if GLZ_JKJ_HAS_INLINE_VARIABLE
+#define GLZ_JKJ_INLINE_VARIABLE inline constexpr
 #else
-#define JKJ_INLINE_VARIABLE static constexpr
+#define GLZ_JKJ_INLINE_VARIABLE static constexpr
 #endif
 
 // C++17 if constexpr
 #if defined(__cpp_if_constexpr) && __cpp_if_constexpr >= 201606L
-#define JKJ_HAS_IF_CONSTEXPR 1
+#define GLZ_JKJ_HAS_IF_CONSTEXPR 1
 #elif __cplusplus >= 201703L
-#define JKJ_HAS_IF_CONSTEXPR 1
+#define GLZ_JKJ_HAS_IF_CONSTEXPR 1
 #elif defined(_MSC_VER) && _MSC_VER >= 1911 && _MSVC_LANG >= 201703L
-#define JKJ_HAS_IF_CONSTEXPR 1
+#define GLZ_JKJ_HAS_IF_CONSTEXPR 1
 #else
-#define JKJ_HAS_IF_CONSTEXPR 0
+#define GLZ_JKJ_HAS_IF_CONSTEXPR 0
 #endif
 
-#if JKJ_HAS_IF_CONSTEXPR
-#define JKJ_IF_CONSTEXPR if constexpr
+#if GLZ_JKJ_HAS_IF_CONSTEXPR
+#define GLZ_JKJ_IF_CONSTEXPR if constexpr
 #else
-#define JKJ_IF_CONSTEXPR if
+#define GLZ_JKJ_IF_CONSTEXPR if
 #endif
 
 // C++20 std::bit_cast
-#if JKJ_STD_REPLACEMENT_NAMESPACE_DEFINED
-#if JKJ_STD_REPLACEMENT_HAS_BIT_CAST
-#define JKJ_HAS_BIT_CAST 1
+#if GLZ_JKJ_STD_REPLACEMENT_NAMESPACE_DEFINED
+#if GLZ_JKJ_STD_REPLACEMENT_HAS_BIT_CAST
+#define GLZ_JKJ_HAS_BIT_CAST 1
 #else
-#define JKJ_HAS_BIT_CAST 0
+#define GLZ_JKJ_HAS_BIT_CAST 0
 #endif
 #elif defined(__cpp_lib_bit_cast) && __cpp_lib_bit_cast >= 201806L
 #include <bit>
-#define JKJ_HAS_BIT_CAST 1
+#define GLZ_JKJ_HAS_BIT_CAST 1
 #else
-#define JKJ_HAS_BIT_CAST 0
+#define GLZ_JKJ_HAS_BIT_CAST 0
 #endif
 
 // C++23 if consteval or C++20 std::is_constant_evaluated
 #if defined(__cpp_if_consteval) && __cpp_is_consteval >= 202106L
-#define JKJ_IF_CONSTEVAL if consteval
-#define JKJ_IF_NOT_CONSTEVAL if !consteval
-#define JKJ_CAN_BRANCH_ON_CONSTEVAL 1
-#define JKJ_USE_IS_CONSTANT_EVALUATED 0
-#elif JKJ_STD_REPLACEMENT_NAMESPACE_DEFINED
-#if JKJ_STD_REPLACEMENT_HAS_IS_CONSTANT_EVALUATED
-#define JKJ_IF_CONSTEVAL if (stdr::is_constant_evaluated())
-#define JKJ_IF_NOT_CONSTEVAL if (!stdr::is_constant_evaluated())
-#define JKJ_CAN_BRANCH_ON_CONSTEVAL 1
-#define JKJ_USE_IS_CONSTANT_EVALUATED 1
-#elif JKJ_HAS_IF_CONSTEXPR
-#define JKJ_IF_CONSTEVAL if constexpr (false)
-#define JKJ_IF_NOT_CONSTEVAL if constexpr (true)
-#define JKJ_CAN_BRANCH_ON_CONSTEVAL 0
-#define JKJ_USE_IS_CONSTANT_EVALUATED 0
+#define GLZ_JKJ_IF_CONSTEVAL if consteval
+#define GLZ_JKJ_IF_NOT_CONSTEVAL if !consteval
+#define GLZ_JKJ_CAN_BRANCH_ON_CONSTEVAL 1
+#define GLZ_JKJ_USE_IS_CONSTANT_EVALUATED 0
+#elif GLZ_JKJ_STD_REPLACEMENT_NAMESPACE_DEFINED
+#if GLZ_JKJ_STD_REPLACEMENT_HAS_IS_CONSTANT_EVALUATED
+#define GLZ_JKJ_IF_CONSTEVAL if (stdr::is_constant_evaluated())
+#define GLZ_JKJ_IF_NOT_CONSTEVAL if (!stdr::is_constant_evaluated())
+#define GLZ_JKJ_CAN_BRANCH_ON_CONSTEVAL 1
+#define GLZ_JKJ_USE_IS_CONSTANT_EVALUATED 1
+#elif GLZ_JKJ_HAS_IF_CONSTEXPR
+#define GLZ_JKJ_IF_CONSTEVAL if constexpr (false)
+#define GLZ_JKJ_IF_NOT_CONSTEVAL if constexpr (true)
+#define GLZ_JKJ_CAN_BRANCH_ON_CONSTEVAL 0
+#define GLZ_JKJ_USE_IS_CONSTANT_EVALUATED 0
 #else
-#define JKJ_IF_CONSTEVAL if (false)
-#define JKJ_IF_NOT_CONSTEVAL if (true)
-#define JKJ_CAN_BRANCH_ON_CONSTEVAL 0
-#define JKJ_USE_IS_CONSTANT_EVALUATED 0
+#define GLZ_JKJ_IF_CONSTEVAL if (false)
+#define GLZ_JKJ_IF_NOT_CONSTEVAL if (true)
+#define GLZ_JKJ_CAN_BRANCH_ON_CONSTEVAL 0
+#define GLZ_JKJ_USE_IS_CONSTANT_EVALUATED 0
 #endif
 #else
 #if defined(__cpp_lib_is_constant_evaluated) && __cpp_lib_is_constant_evaluated >= 201811L
-#define JKJ_IF_CONSTEVAL if (stdr::is_constant_evaluated())
-#define JKJ_IF_NOT_CONSTEVAL if (!stdr::is_constant_evaluated())
-#define JKJ_CAN_BRANCH_ON_CONSTEVAL 1
-#define JKJ_USE_IS_CONSTANT_EVALUATED 1
-#elif JKJ_HAS_IF_CONSTEXPR
-#define JKJ_IF_CONSTEVAL if constexpr (false)
-#define JKJ_IF_NOT_CONSTEVAL if constexpr (true)
-#define JKJ_CAN_BRANCH_ON_CONSTEVAL 0
-#define JKJ_USE_IS_CONSTANT_EVALUATED 0
+#define GLZ_JKJ_IF_CONSTEVAL if (stdr::is_constant_evaluated())
+#define GLZ_JKJ_IF_NOT_CONSTEVAL if (!stdr::is_constant_evaluated())
+#define GLZ_JKJ_CAN_BRANCH_ON_CONSTEVAL 1
+#define GLZ_JKJ_USE_IS_CONSTANT_EVALUATED 1
+#elif GLZ_JKJ_HAS_IF_CONSTEXPR
+#define GLZ_JKJ_IF_CONSTEVAL if constexpr (false)
+#define GLZ_JKJ_IF_NOT_CONSTEVAL if constexpr (true)
+#define GLZ_JKJ_CAN_BRANCH_ON_CONSTEVAL 0
+#define GLZ_JKJ_USE_IS_CONSTANT_EVALUATED 0
 #else
-#define JKJ_IF_CONSTEVAL if (false)
-#define JKJ_IF_NOT_CONSTEVAL if (true)
-#define JKJ_CAN_BRANCH_ON_CONSTEVAL 0
-#define JKJ_USE_IS_CONSTANT_EVALUATED 0
+#define GLZ_JKJ_IF_CONSTEVAL if (false)
+#define GLZ_JKJ_IF_NOT_CONSTEVAL if (true)
+#define GLZ_JKJ_CAN_BRANCH_ON_CONSTEVAL 0
+#define GLZ_JKJ_USE_IS_CONSTANT_EVALUATED 0
 #endif
 #endif
 
-#if JKJ_CAN_BRANCH_ON_CONSTEVAL && JKJ_HAS_BIT_CAST
-#define JKJ_CONSTEXPR20 constexpr
+#if GLZ_JKJ_CAN_BRANCH_ON_CONSTEVAL && GLZ_JKJ_HAS_BIT_CAST
+#define GLZ_JKJ_CONSTEXPR20 constexpr
 #else
-#define JKJ_CONSTEXPR20
+#define GLZ_JKJ_CONSTEXPR20
 #endif
 
 // Suppress additional buffer overrun check.
 // I have no idea why MSVC thinks some functions here are vulnerable to the buffer overrun
 // attacks. No, they aren't.
 #if defined(__GNUC__) || defined(__clang__)
-#define JKJ_SAFEBUFFERS
-#define JKJ_FORCEINLINE inline __attribute__((always_inline))
+#define GLZ_JKJ_SAFEBUFFERS
+#define GLZ_JKJ_FORCEINLINE inline __attribute__((always_inline))
 #elif defined(_MSC_VER)
-#define JKJ_SAFEBUFFERS __declspec(safebuffers)
-#define JKJ_FORCEINLINE __forceinline
+#define GLZ_JKJ_SAFEBUFFERS __declspec(safebuffers)
+#define GLZ_JKJ_FORCEINLINE __forceinline
 #else
-#define JKJ_SAFEBUFFERS
-#define JKJ_FORCEINLINE inline
+#define GLZ_JKJ_SAFEBUFFERS
+#define GLZ_JKJ_FORCEINLINE inline
 #endif
 
 #if defined(__has_builtin)
-#define JKJ_HAS_BUILTIN(x) __has_builtin(x)
+#define GLZ_JKJ_HAS_BUILTIN(x) __has_builtin(x)
 #else
-#define JKJ_HAS_BUILTIN(x) false
+#define GLZ_JKJ_HAS_BUILTIN(x) false
 #endif
 
 #if defined(_MSC_VER)
@@ -213,60 +213,60 @@ namespace glz::jkj
          namespace stdr
          {
             // <bit>
-#if JKJ_HAS_BIT_CAST
-            using JKJ_STD_REPLACEMENT_NAMESPACE::bit_cast;
+#if GLZ_JKJ_HAS_BIT_CAST
+            using GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::bit_cast;
 #endif
 
             // <cassert>
             // We need assert() macro, but it is not namespaced anyway, so nothing to do here.
 
             // <cstdint>
-            using JKJ_STD_REPLACEMENT_NAMESPACE::int_fast16_t;
-            using JKJ_STD_REPLACEMENT_NAMESPACE::int_fast32_t;
-            using JKJ_STD_REPLACEMENT_NAMESPACE::int_fast8_t;
-            using JKJ_STD_REPLACEMENT_NAMESPACE::int_least16_t;
-            using JKJ_STD_REPLACEMENT_NAMESPACE::int_least32_t;
-            using JKJ_STD_REPLACEMENT_NAMESPACE::int_least8_t;
-            using JKJ_STD_REPLACEMENT_NAMESPACE::uint_fast16_t;
-            using JKJ_STD_REPLACEMENT_NAMESPACE::uint_fast32_t;
-            using JKJ_STD_REPLACEMENT_NAMESPACE::uint_fast8_t;
-            using JKJ_STD_REPLACEMENT_NAMESPACE::uint_least16_t;
-            using JKJ_STD_REPLACEMENT_NAMESPACE::uint_least32_t;
-            using JKJ_STD_REPLACEMENT_NAMESPACE::uint_least64_t;
-            using JKJ_STD_REPLACEMENT_NAMESPACE::uint_least8_t;
+            using GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::int_fast16_t;
+            using GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::int_fast32_t;
+            using GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::int_fast8_t;
+            using GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::int_least16_t;
+            using GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::int_least32_t;
+            using GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::int_least8_t;
+            using GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::uint_fast16_t;
+            using GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::uint_fast32_t;
+            using GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::uint_fast8_t;
+            using GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::uint_least16_t;
+            using GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::uint_least32_t;
+            using GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::uint_least64_t;
+            using GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::uint_least8_t;
             // We need INT32_C, UINT32_C and UINT64_C macros too, but again there is nothing to do
             // here.
 
             // <cstring>
-            using JKJ_STD_REPLACEMENT_NAMESPACE::memcpy;
-            using JKJ_STD_REPLACEMENT_NAMESPACE::size_t;
+            using GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::memcpy;
+            using GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::size_t;
 
             // <limits>
             template <class T>
-            using numeric_limits = JKJ_STD_REPLACEMENT_NAMESPACE::numeric_limits<T>;
+            using numeric_limits = GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::numeric_limits<T>;
 
             // <type_traits>
             template <bool cond, class T = void>
-            using enable_if = JKJ_STD_REPLACEMENT_NAMESPACE::enable_if<cond, T>;
+            using enable_if = GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::enable_if<cond, T>;
             template <class T>
-            using add_rvalue_reference = JKJ_STD_REPLACEMENT_NAMESPACE::add_rvalue_reference<T>;
+            using add_rvalue_reference = GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::add_rvalue_reference<T>;
             template <bool cond, class T_true, class T_false>
-            using conditional = JKJ_STD_REPLACEMENT_NAMESPACE::conditional<cond, T_true, T_false>;
-#if JKJ_USE_IS_CONSTANT_EVALUATED
-            using JKJ_STD_REPLACEMENT_NAMESPACE::is_constant_evaluated;
+            using conditional = GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::conditional<cond, T_true, T_false>;
+#if GLZ_JKJ_USE_IS_CONSTANT_EVALUATED
+            using GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::is_constant_evaluated;
 #endif
             template <class T1, class T2>
-            using is_same = JKJ_STD_REPLACEMENT_NAMESPACE::is_same<T1, T2>;
-#if !JKJ_HAS_BIT_CAST
+            using is_same = GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::is_same<T1, T2>;
+#if !GLZ_JKJ_HAS_BIT_CAST
             template <class T>
-            using is_trivially_copyable = JKJ_STD_REPLACEMENT_NAMESPACE::is_trivially_copyable<T>;
+            using is_trivially_copyable = GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::is_trivially_copyable<T>;
 #endif
             template <class T>
-            using is_integral = JKJ_STD_REPLACEMENT_NAMESPACE::is_integral<T>;
+            using is_integral = GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::is_integral<T>;
             template <class T>
-            using is_signed = JKJ_STD_REPLACEMENT_NAMESPACE::is_signed<T>;
+            using is_signed = GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::is_signed<T>;
             template <class T>
-            using is_unsigned = JKJ_STD_REPLACEMENT_NAMESPACE::is_unsigned<T>;
+            using is_unsigned = GLZ_JKJ_STD_REPLACEMENT_NAMESPACE::is_unsigned<T>;
          }
       }
 
@@ -275,7 +275,7 @@ namespace glz::jkj
       ////////////////////////////////////////////////////////////////////////////////////////
       namespace detail
       {
-#if !JKJ_HAS_CONSTEXPR17
+#if !GLZ_JKJ_HAS_CONSTEXPR17
          template <stdr::size_t... indices>
          struct index_sequence
          {};
@@ -306,7 +306,7 @@ namespace glz::jkj
          {
             T data_[N];
             constexpr T operator[](stdr::size_t idx) const noexcept { return data_[idx]; }
-            JKJ_CONSTEXPR14 T& operator[](stdr::size_t idx) noexcept { return data_[idx]; }
+            GLZ_JKJ_CONSTEXPR14 T& operator[](stdr::size_t idx) noexcept { return data_[idx]; }
          };
       }
 
@@ -328,9 +328,9 @@ namespace glz::jkj
          };
 
          template <typename To, typename From>
-         JKJ_CONSTEXPR20 To bit_cast(const From& from)
+         GLZ_JKJ_CONSTEXPR20 To bit_cast(const From& from)
          {
-#if JKJ_HAS_BIT_CAST
+#if GLZ_JKJ_HAS_BIT_CAST
             return stdr::bit_cast<To>(from);
 #else
             static_assert(sizeof(From) == sizeof(To), "");
@@ -492,13 +492,13 @@ namespace glz::jkj
                                                            ieee754_binary64>::type;
 
          // Converts the floating-point type into the bit-carrier unsigned integer type.
-         static JKJ_CONSTEXPR20 carrier_uint float_to_carrier(Float x) noexcept
+         static GLZ_JKJ_CONSTEXPR20 carrier_uint float_to_carrier(Float x) noexcept
          {
             return detail::bit_cast<carrier_uint>(x);
          }
 
          // Converts the bit-carrier unsigned integer type into the floating-point type.
-         static JKJ_CONSTEXPR20 Float carrier_to_float(carrier_uint x) noexcept { return detail::bit_cast<Float>(x); }
+         static GLZ_JKJ_CONSTEXPR20 Float carrier_to_float(carrier_uint x) noexcept { return detail::bit_cast<Float>(x); }
       };
 
       // Convenient wrappers for floating-point traits classes.
@@ -605,7 +605,7 @@ namespace glz::jkj
       template <class Float, class ConversionTraits = default_float_bit_carrier_conversion_traits<Float>,
                 class FormatTraits =
                    ieee754_binary_traits<typename ConversionTraits::format, typename ConversionTraits::carrier_uint>>
-      JKJ_CONSTEXPR20 float_bits<FormatTraits> make_float_bits(Float x) noexcept
+      GLZ_JKJ_CONSTEXPR20 float_bits<FormatTraits> make_float_bits(Float x) noexcept
       {
          return float_bits<FormatTraits>(ConversionTraits::float_to_carrier(x));
       }
@@ -621,7 +621,7 @@ namespace glz::jkj
             // Most compilers should be able to optimize this into the ROR instruction.
             // n is assumed to be at most of bit_width bits.
             template <stdr::size_t bit_width, class UInt>
-            JKJ_CONSTEXPR14 UInt rotr(UInt n, unsigned int r) noexcept
+            GLZ_JKJ_CONSTEXPR14 UInt rotr(UInt n, unsigned int r) noexcept
             {
                static_assert(bit_width > 0, "jkj::dragonbox: rotation bit-width must be positive");
                static_assert(bit_width <= value_bits<UInt>::value, "jkj::dragonbox: rotation bit-width is too large");
@@ -665,7 +665,7 @@ namespace glz::jkj
                constexpr stdr::uint_least64_t high() const noexcept { return high_; }
                constexpr stdr::uint_least64_t low() const noexcept { return low_; }
 
-               JKJ_CONSTEXPR20 uint128& operator+=(stdr::uint_least64_t n) & noexcept
+               GLZ_JKJ_CONSTEXPR20 uint128& operator+=(stdr::uint_least64_t n) & noexcept
                {
                   const auto generic_impl = [&] {
                      auto const sum = (low_ + n) & UINT64_C(0xffffffffffffffff);
@@ -675,21 +675,21 @@ namespace glz::jkj
                   // To suppress warning.
                   static_cast<void>(generic_impl);
 
-                  JKJ_IF_CONSTEXPR(value_bits<stdr::uint_least64_t>::value > 64)
+                  GLZ_JKJ_IF_CONSTEXPR(value_bits<stdr::uint_least64_t>::value > 64)
                   {
                      generic_impl();
                      return *this;
                   }
 
-                  JKJ_IF_CONSTEVAL
+                  GLZ_JKJ_IF_CONSTEVAL
                   {
                      generic_impl();
                      return *this;
                   }
 
                   // See https://github.com/fmtlib/fmt/pull/2985.
-#if JKJ_HAS_BUILTIN(__builtin_addcll) && !defined(__ibmxl__)
-                  JKJ_IF_CONSTEXPR(stdr::is_same<stdr::uint_least64_t, unsigned long long>::value)
+#if GLZ_JKJ_HAS_BUILTIN(__builtin_addcll) && !defined(__ibmxl__)
+                  GLZ_JKJ_IF_CONSTEXPR(stdr::is_same<stdr::uint_least64_t, unsigned long long>::value)
                   {
                      unsigned long long carry{};
                      low_ = stdr::uint_least64_t(__builtin_addcll(low_, n, 0, &carry));
@@ -697,8 +697,8 @@ namespace glz::jkj
                      return *this;
                   }
 #endif
-#if JKJ_HAS_BUILTIN(__builtin_addcl) && !defined(__ibmxl__)
-                  JKJ_IF_CONSTEXPR(stdr::is_same<stdr::uint_least64_t, unsigned long>::value)
+#if GLZ_JKJ_HAS_BUILTIN(__builtin_addcl) && !defined(__ibmxl__)
+                  GLZ_JKJ_IF_CONSTEXPR(stdr::is_same<stdr::uint_least64_t, unsigned long>::value)
                   {
                      unsigned long carry{};
                      low_ = stdr::uint_least64_t(
@@ -707,8 +707,8 @@ namespace glz::jkj
                      return *this;
                   }
 #endif
-#if JKJ_HAS_BUILTIN(__builtin_addc) && !defined(__ibmxl__)
-                  JKJ_IF_CONSTEXPR(stdr::is_same<stdr::uint_least64_t, unsigned int>::value)
+#if GLZ_JKJ_HAS_BUILTIN(__builtin_addc) && !defined(__ibmxl__)
+                  GLZ_JKJ_IF_CONSTEXPR(stdr::is_same<stdr::uint_least64_t, unsigned int>::value)
                   {
                      unsigned int carry{};
                      low_ = stdr::uint_least64_t(
@@ -718,7 +718,7 @@ namespace glz::jkj
                   }
 #endif
 
-#if JKJ_HAS_BUILTIN(__builtin_ia32_addcarry_u64)
+#if GLZ_JKJ_HAS_BUILTIN(__builtin_ia32_addcarry_u64)
                   // __builtin_ia32_addcarry_u64 is not documented, but it seems it takes unsigned
                   // long long arguments.
                   unsigned long long result{};
@@ -746,16 +746,16 @@ namespace glz::jkj
                }
             };
 
-            inline JKJ_CONSTEXPR20 stdr::uint_least64_t umul64(stdr::uint_least32_t x, stdr::uint_least32_t y) noexcept
+            inline GLZ_JKJ_CONSTEXPR20 stdr::uint_least64_t umul64(stdr::uint_least32_t x, stdr::uint_least32_t y) noexcept
             {
 #if defined(_MSC_VER) && defined(_M_IX86)
-               JKJ_IF_NOT_CONSTEVAL { return __emulu(x, y); }
+               GLZ_JKJ_IF_NOT_CONSTEVAL { return __emulu(x, y); }
 #endif
                return x * stdr::uint_least64_t(y);
             }
 
             // Get 128-bit result of multiplication of two 64-bit unsigned integers.
-            JKJ_SAFEBUFFERS inline JKJ_CONSTEXPR20 uint128 umul128(stdr::uint_least64_t x,
+            GLZ_JKJ_SAFEBUFFERS inline GLZ_JKJ_CONSTEXPR20 uint128 umul128(stdr::uint_least64_t x,
                                                                    stdr::uint_least64_t y) noexcept
             {
                const auto generic_impl = [=]() -> uint128 {
@@ -781,7 +781,7 @@ namespace glz::jkj
                const auto result = builtin_uint128_t(x) * builtin_uint128_t(y);
                return {stdr::uint_least64_t(result >> 64), stdr::uint_least64_t(result)};
 #elif defined(_MSC_VER) && defined(_M_X64)
-               JKJ_IF_CONSTEVAL
+               GLZ_JKJ_IF_CONSTEVAL
                {
                   // This redundant variable is to workaround MSVC's codegen bug caused by the
                   // interaction of NRVO and intrinsics.
@@ -802,7 +802,7 @@ namespace glz::jkj
 
             // Get high half of the 128-bit result of multiplication of two 64-bit unsigned
             // integers.
-            JKJ_SAFEBUFFERS inline JKJ_CONSTEXPR20 stdr::uint_least64_t umul128_upper64(stdr::uint_least64_t x,
+            GLZ_JKJ_SAFEBUFFERS inline GLZ_JKJ_CONSTEXPR20 stdr::uint_least64_t umul128_upper64(stdr::uint_least64_t x,
                                                                                         stdr::uint_least64_t y) noexcept
             {
                const auto generic_impl = [=]() -> stdr::uint_least64_t {
@@ -827,7 +827,7 @@ namespace glz::jkj
                const auto result = builtin_uint128_t(x) * builtin_uint128_t(y);
                return stdr::uint_least64_t(result >> 64);
 #elif defined(_MSC_VER) && defined(_M_X64)
-               JKJ_IF_CONSTEVAL
+               GLZ_JKJ_IF_CONSTEVAL
                {
                   // This redundant variable is to workaround MSVC's codegen bug caused by the
                   // interaction of NRVO and intrinsics.
@@ -848,7 +848,7 @@ namespace glz::jkj
 
             // Get upper 128-bits of multiplication of a 64-bit unsigned integer and a 128-bit
             // unsigned integer.
-            JKJ_SAFEBUFFERS inline JKJ_CONSTEXPR20 uint128 umul192_upper128(stdr::uint_least64_t x, uint128 y) noexcept
+            GLZ_JKJ_SAFEBUFFERS inline GLZ_JKJ_CONSTEXPR20 uint128 umul192_upper128(stdr::uint_least64_t x, uint128 y) noexcept
             {
                auto r = umul128(x, y.high());
                r += umul128_upper64(x, y.low());
@@ -857,7 +857,7 @@ namespace glz::jkj
 
             // Get upper 64-bits of multiplication of a 32-bit unsigned integer and a 64-bit
             // unsigned integer.
-            inline JKJ_CONSTEXPR20 stdr::uint_least64_t umul96_upper64(stdr::uint_least32_t x,
+            inline GLZ_JKJ_CONSTEXPR20 stdr::uint_least64_t umul96_upper64(stdr::uint_least32_t x,
                                                                        stdr::uint_least64_t y) noexcept
             {
 #if defined(__SIZEOF_INT128__) || (defined(_MSC_VER) && defined(_M_X64))
@@ -875,7 +875,7 @@ namespace glz::jkj
 
             // Get lower 128-bits of multiplication of a 64-bit unsigned integer and a 128-bit
             // unsigned integer.
-            JKJ_SAFEBUFFERS inline JKJ_CONSTEXPR20 uint128 umul192_lower128(stdr::uint_least64_t x, uint128 y) noexcept
+            GLZ_JKJ_SAFEBUFFERS inline GLZ_JKJ_CONSTEXPR20 uint128 umul192_lower128(stdr::uint_least64_t x, uint128 y) noexcept
             {
                const auto high = x * y.high();
                const auto high_low = umul128(x, y.low());
@@ -898,7 +898,7 @@ namespace glz::jkj
          constexpr Int compute_power(Int a) noexcept
          {
             static_assert(k >= 0, "");
-#if JKJ_HAS_CONSTEXPR14
+#if GLZ_JKJ_HAS_CONSTEXPR14
             Int p = 1;
             for (int i = 0; i < k; ++i) {
                p *= a;
@@ -913,7 +913,7 @@ namespace glz::jkj
          constexpr int count_factors(UInt n) noexcept
          {
             static_assert(a > 1, "");
-#if JKJ_HAS_CONSTEXPR14
+#if GLZ_JKJ_HAS_CONSTEXPR14
             int c = 0;
             while (n % a == 0) {
                n /= a;
@@ -940,7 +940,7 @@ namespace glz::jkj
             template <class UInt>
             constexpr int floor_log2(UInt n) noexcept
             {
-#if JKJ_HAS_CONSTEXPR14
+#if GLZ_JKJ_HAS_CONSTEXPR14
                int count = -1;
                while (n != 0) {
                   ++count;
@@ -983,7 +983,7 @@ namespace glz::jkj
                template <class ReturnType, class Int>
                static constexpr ReturnType compute(Int e) noexcept
                {
-#if JKJ_HAS_CONSTEXPR14
+#if GLZ_JKJ_HAS_CONSTEXPR14
                   assert(min_exponent <= e && e <= max_exponent);
 #endif
                   // The sign is irrelevant for the mathematical validity of the formula, but
@@ -1231,7 +1231,7 @@ namespace glz::jkj
             };
 
             template <int N, class UInt>
-            JKJ_CONSTEXPR14 bool check_divisibility_and_divide_by_pow10(UInt& n) noexcept
+            GLZ_JKJ_CONSTEXPR14 bool check_divisibility_and_divide_by_pow10(UInt& n) noexcept
             {
                // Make sure the computation for max_n does not overflow.
                static_assert(N + 1 <= log::floor_log10_pow2(int(value_bits<UInt>::value)), "");
@@ -1251,7 +1251,7 @@ namespace glz::jkj
             // Compute floor(n / 10^N) for small n and N.
             // Precondition: n <= 10^(N+1)
             template <int N, class UInt>
-            JKJ_CONSTEXPR14 UInt small_division_by_pow10(UInt n) noexcept
+            GLZ_JKJ_CONSTEXPR14 UInt small_division_by_pow10(UInt n) noexcept
             {
                // Make sure the computation for max_n does not overflow.
                static_assert(N + 1 <= log::floor_log10_pow2(int(value_bits<UInt>::value)), "");
@@ -1264,7 +1264,7 @@ namespace glz::jkj
             // Compute floor(n / 10^N) for small N.
             // Precondition: n <= n_max
             template <int N, class UInt, UInt n_max>
-            JKJ_CONSTEXPR20 UInt divide_by_pow10(UInt n) noexcept
+            GLZ_JKJ_CONSTEXPR20 UInt divide_by_pow10(UInt n) noexcept
             {
                static_assert(N >= 0, "");
 
@@ -1274,7 +1274,7 @@ namespace glz::jkj
                // code for 32-bit or smaller architectures. Even for 64-bit architectures, it seems
                // compilers tend to generate mov + mul instead of a single imul for an unknown
                // reason if we just write n / 10.
-               JKJ_IF_CONSTEXPR(stdr::is_same<UInt, stdr::uint_least32_t>::value && N == 1 &&
+               GLZ_JKJ_IF_CONSTEXPR(stdr::is_same<UInt, stdr::uint_least32_t>::value && N == 1 &&
                                 n_max <= UINT32_C(1073741828))
                {
                   return UInt(wuint::umul64(n, UINT32_C(429496730)) >> 32);
@@ -1282,7 +1282,7 @@ namespace glz::jkj
                // Specialize for 64-bit division by 10.
                // Without the bound on n_max (which compilers these days never leverage), the
                // minimum needed amount of shift is larger than 64.
-               else JKJ_IF_CONSTEXPR(stdr::is_same<UInt, stdr::uint_least64_t>::value && N == 1 &&
+               else GLZ_JKJ_IF_CONSTEXPR(stdr::is_same<UInt, stdr::uint_least64_t>::value && N == 1 &&
                                      n_max <= UINT64_C(4611686018427387908))
                {
                   return UInt(wuint::umul128_upper64(n, UINT64_C(1844674407370955162)));
@@ -1290,14 +1290,14 @@ namespace glz::jkj
                // Specialize for 32-bit division by 100.
                // It seems compilers tend to generate mov + mul instead of a single imul for an
                // unknown reason if we just write n / 100.
-               else JKJ_IF_CONSTEXPR(stdr::is_same<UInt, stdr::uint_least32_t>::value && N == 2)
+               else GLZ_JKJ_IF_CONSTEXPR(stdr::is_same<UInt, stdr::uint_least32_t>::value && N == 2)
                {
                   return UInt(wuint::umul64(n, UINT32_C(1374389535)) >> 37);
                }
                // Specialize for 64-bit division by 1000.
                // Without the bound on n_max (which compilers these days never leverage), the
                // smallest magic number for this computation does not fit into 64-bits.
-               else JKJ_IF_CONSTEXPR(stdr::is_same<UInt, stdr::uint_least64_t>::value && N == 3 &&
+               else GLZ_JKJ_IF_CONSTEXPR(stdr::is_same<UInt, stdr::uint_least64_t>::value && N == 3 &&
                                      n_max <= UINT64_C(15534100272597517998))
                {
                   return UInt(wuint::umul128_upper64(n, UINT64_C(4722366482869645214)) >> 8);
@@ -1400,7 +1400,7 @@ namespace glz::jkj
          static constexpr int min_k = -31;
          static constexpr int max_k = 46;
          static constexpr detail::array<cache_entry_type, detail::stdr::size_t(max_k - min_k + 1)> cache
-            JKJ_STATIC_DATA_SECTION = {
+            GLZ_JKJ_STATIC_DATA_SECTION = {
                {UINT64_C(0x81ceb32c4b43fcf5), UINT64_C(0xa2425ff75e14fc32), UINT64_C(0xcad2f7f5359a3b3f),
                 UINT64_C(0xfd87b5f28300ca0e), UINT64_C(0x9e74d1b791e07e49), UINT64_C(0xc612062576589ddb),
                 UINT64_C(0xf79687aed3eec552), UINT64_C(0x9abe14cd44753b53), UINT64_C(0xc16d9a0095928a28),
@@ -1428,7 +1428,7 @@ namespace glz::jkj
                 UINT64_C(0x92efd1b8d0cf37bf), UINT64_C(0xb7abc627050305ae), UINT64_C(0xe596b7b0c643c71a),
                 UINT64_C(0x8f7e32ce7bea5c70), UINT64_C(0xb35dbf821ae4f38c), UINT64_C(0xe0352f62a19e306f)}};
       };
-#if !JKJ_HAS_INLINE_VARIABLE
+#if !GLZ_JKJ_HAS_INLINE_VARIABLE
       // decltype(...) should not depend on Dummy; see
       // https://stackoverflow.com/questions/76438400/decltype-on-static-variable-in-template-class.
       template <class Dummy>
@@ -1443,7 +1443,7 @@ namespace glz::jkj
          static constexpr int min_k = -292;
          static constexpr int max_k = 326;
          static constexpr detail::array<cache_entry_type, detail::stdr::size_t(max_k - min_k + 1)> cache
-            JKJ_STATIC_DATA_SECTION = {{{UINT64_C(0xff77b1fcbebcdc4f), UINT64_C(0x25e8e89c13bb0f7b)},
+            GLZ_JKJ_STATIC_DATA_SECTION = {{{UINT64_C(0xff77b1fcbebcdc4f), UINT64_C(0x25e8e89c13bb0f7b)},
                                         {UINT64_C(0x9faacf3df73609b1), UINT64_C(0x77b191618c54e9ad)},
                                         {UINT64_C(0xc795830d75038c1d), UINT64_C(0xd59df5b9ef6a2418)},
                                         {UINT64_C(0xf97ae3d0d2446f25), UINT64_C(0x4b0573286b44ad1e)},
@@ -2063,7 +2063,7 @@ namespace glz::jkj
                                         {UINT64_C(0xc5a05277621be293), UINT64_C(0xc7098b7305241886)},
                                         {UINT64_C(0xf70867153aa2db38), UINT64_C(0xb8cbee4fc66d1ea8)}}};
       };
-#if !JKJ_HAS_INLINE_VARIABLE
+#if !GLZ_JKJ_HAS_INLINE_VARIABLE
       // decltype(...) should not depend on Dummy; see
       // https://stackoverflow.com/questions/76438400/decltype-on-static-variable-in-template-class.
       template <class Dummy>
@@ -2101,15 +2101,15 @@ namespace glz::jkj
          using cache_holder_t = detail::array<cache_entry_type, compressed_table_size>;
          using pow5_holder_t = detail::array<detail::stdr::uint_least16_t, pow5_table_size>;
 
-#if JKJ_HAS_CONSTEXPR17
-         static constexpr cache_holder_t cache JKJ_STATIC_DATA_SECTION = [] {
+#if GLZ_JKJ_HAS_CONSTEXPR17
+         static constexpr cache_holder_t cache GLZ_JKJ_STATIC_DATA_SECTION = [] {
             cache_holder_t res{};
             for (detail::stdr::size_t i = 0; i < compressed_table_size; ++i) {
                res[i] = cache_holder<ieee754_binary32>::cache[i * compression_ratio];
             }
             return res;
          }();
-         static constexpr pow5_holder_t pow5_table JKJ_STATIC_DATA_SECTION = [] {
+         static constexpr pow5_holder_t pow5_table GLZ_JKJ_STATIC_DATA_SECTION = [] {
             pow5_holder_t res{};
             detail::stdr::uint_least16_t p = 1;
             for (detail::stdr::size_t i = 0; i < pow5_table_size; ++i) {
@@ -2124,7 +2124,7 @@ namespace glz::jkj
          {
             return {cache_holder<ieee754_binary32>::cache[indices * compression_ratio]...};
          }
-         static constexpr cache_holder_t cache JKJ_STATIC_DATA_SECTION =
+         static constexpr cache_holder_t cache GLZ_JKJ_STATIC_DATA_SECTION =
             make_cache(detail::make_index_sequence<compressed_table_size>{});
 
          template <detail::stdr::size_t... indices>
@@ -2132,12 +2132,12 @@ namespace glz::jkj
          {
             return {detail::compute_power<indices>(detail::stdr::uint_least16_t(5))...};
          }
-         static constexpr pow5_holder_t pow5_table JKJ_STATIC_DATA_SECTION =
+         static constexpr pow5_holder_t pow5_table GLZ_JKJ_STATIC_DATA_SECTION =
             make_pow5_table(detail::make_index_sequence<pow5_table_size>{});
 #endif
 
          template <class ShiftAmountType, class DecimalExponentType>
-         static JKJ_CONSTEXPR20 cache_entry_type get_cache(DecimalExponentType k) noexcept
+         static GLZ_JKJ_CONSTEXPR20 cache_entry_type get_cache(DecimalExponentType k) noexcept
          {
             // Compute the base index.
             // Supposed to compute (k - min_k) / compression_ratio.
@@ -2175,7 +2175,7 @@ namespace glz::jkj
             }
          }
       };
-#if !JKJ_HAS_INLINE_VARIABLE
+#if !GLZ_JKJ_HAS_INLINE_VARIABLE
       template <class Dummy>
       constexpr typename compressed_cache_holder<ieee754_binary32, Dummy>::cache_holder_t
          compressed_cache_holder<ieee754_binary32, Dummy>::cache;
@@ -2199,15 +2199,15 @@ namespace glz::jkj
          using cache_holder_t = detail::array<cache_entry_type, compressed_table_size>;
          using pow5_holder_t = detail::array<detail::stdr::uint_least64_t, pow5_table_size>;
 
-#if JKJ_HAS_CONSTEXPR17
-         static constexpr cache_holder_t cache JKJ_STATIC_DATA_SECTION = [] {
+#if GLZ_JKJ_HAS_CONSTEXPR17
+         static constexpr cache_holder_t cache GLZ_JKJ_STATIC_DATA_SECTION = [] {
             cache_holder_t res{};
             for (detail::stdr::size_t i = 0; i < compressed_table_size; ++i) {
                res[i] = cache_holder<ieee754_binary64>::cache[i * compression_ratio];
             }
             return res;
          }();
-         static constexpr pow5_holder_t pow5_table JKJ_STATIC_DATA_SECTION = [] {
+         static constexpr pow5_holder_t pow5_table GLZ_JKJ_STATIC_DATA_SECTION = [] {
             pow5_holder_t res{};
             detail::stdr::uint_least64_t p = 1;
             for (detail::stdr::size_t i = 0; i < pow5_table_size; ++i) {
@@ -2222,7 +2222,7 @@ namespace glz::jkj
          {
             return {cache_holder<ieee754_binary64>::cache[indices * compression_ratio]...};
          }
-         static constexpr cache_holder_t cache JKJ_STATIC_DATA_SECTION =
+         static constexpr cache_holder_t cache GLZ_JKJ_STATIC_DATA_SECTION =
             make_cache(detail::make_index_sequence<compressed_table_size>{});
 
          template <detail::stdr::size_t... indices>
@@ -2230,12 +2230,12 @@ namespace glz::jkj
          {
             return {detail::compute_power<indices>(detail::stdr::uint_least64_t(5))...};
          }
-         static constexpr pow5_holder_t pow5_table JKJ_STATIC_DATA_SECTION =
+         static constexpr pow5_holder_t pow5_table GLZ_JKJ_STATIC_DATA_SECTION =
             make_pow5_table(detail::make_index_sequence<pow5_table_size>{});
 #endif
 
          template <class ShiftAmountType, class DecimalExponentType>
-         static JKJ_CONSTEXPR20 cache_entry_type get_cache(DecimalExponentType k) noexcept
+         static GLZ_JKJ_CONSTEXPR20 cache_entry_type get_cache(DecimalExponentType k) noexcept
          {
             // Compute the base index.
             // Supposed to compute (k - min_k) / compression_ratio.
@@ -2280,7 +2280,7 @@ namespace glz::jkj
             }
          }
       };
-#if !JKJ_HAS_INLINE_VARIABLE
+#if !GLZ_JKJ_HAS_INLINE_VARIABLE
       template <class Dummy>
       constexpr typename compressed_cache_holder<ieee754_binary64, Dummy>::cache_holder_t
          compressed_cache_holder<ieee754_binary64, Dummy>::cache;
@@ -2342,7 +2342,7 @@ namespace glz::jkj
       {
          namespace sign
          {
-            JKJ_INLINE_VARIABLE struct ignore_t
+            GLZ_JKJ_INLINE_VARIABLE struct ignore_t
             {
                using sign_policy = ignore_t;
                static constexpr bool return_has_sign = false;
@@ -2371,7 +2371,7 @@ namespace glz::jkj
 #endif
             } ignore = {};
 
-            JKJ_INLINE_VARIABLE struct return_sign_t
+            GLZ_JKJ_INLINE_VARIABLE struct return_sign_t
             {
                using sign_policy = return_sign_t;
                static constexpr bool return_has_sign = true;
@@ -2387,7 +2387,7 @@ namespace glz::jkj
 
          namespace trailing_zero
          {
-            JKJ_INLINE_VARIABLE struct ignore_t
+            GLZ_JKJ_INLINE_VARIABLE struct ignore_t
             {
                using trailing_zero_policy = ignore_t;
                static constexpr bool report_trailing_zeros = false;
@@ -2407,13 +2407,13 @@ namespace glz::jkj
                }
             } ignore = {};
 
-            JKJ_INLINE_VARIABLE struct remove_t
+            GLZ_JKJ_INLINE_VARIABLE struct remove_t
             {
                using trailing_zero_policy = remove_t;
                static constexpr bool report_trailing_zeros = false;
 
                template <class Format, class DecimalSignificand, class DecimalExponentType>
-               JKJ_FORCEINLINE static JKJ_CONSTEXPR14
+               GLZ_JKJ_FORCEINLINE static GLZ_JKJ_CONSTEXPR14
                   unsigned_decimal_fp<DecimalSignificand, DecimalExponentType, false>
                   on_trailing_zeros(DecimalSignificand significand, DecimalExponentType exponent) noexcept
                {
@@ -2430,13 +2430,13 @@ namespace glz::jkj
                }
             } remove = {};
 
-            JKJ_INLINE_VARIABLE struct remove_compact_t
+            GLZ_JKJ_INLINE_VARIABLE struct remove_compact_t
             {
                using trailing_zero_policy = remove_compact_t;
                static constexpr bool report_trailing_zeros = false;
 
                template <class Format, class DecimalSignificand, class DecimalExponentType>
-               JKJ_FORCEINLINE static JKJ_CONSTEXPR14
+               GLZ_JKJ_FORCEINLINE static GLZ_JKJ_CONSTEXPR14
                   unsigned_decimal_fp<DecimalSignificand, DecimalExponentType, false>
                   on_trailing_zeros(DecimalSignificand significand, DecimalExponentType exponent) noexcept
                {
@@ -2453,7 +2453,7 @@ namespace glz::jkj
                }
             } remove_compact = {};
 
-            JKJ_INLINE_VARIABLE struct report_t
+            GLZ_JKJ_INLINE_VARIABLE struct report_t
             {
                using trailing_zero_policy = report_t;
                static constexpr bool report_trailing_zeros = true;
@@ -2520,14 +2520,14 @@ namespace glz::jkj
                };
             }
 
-            JKJ_INLINE_VARIABLE struct nearest_to_even_t
+            GLZ_JKJ_INLINE_VARIABLE struct nearest_to_even_t
             {
                using decimal_to_binary_rounding_policy = nearest_to_even_t;
                using interval_type_provider = nearest_to_even_t;
                static constexpr auto tag = tag_t::to_nearest;
 
                template <class SignedSignificandBits, class Func, class... Args>
-               JKJ_FORCEINLINE JKJ_SAFEBUFFERS static constexpr decltype(Func{}(
+               GLZ_JKJ_FORCEINLINE GLZ_JKJ_SAFEBUFFERS static constexpr decltype(Func{}(
                   dragonbox::detail::declval<nearest_to_even_t>(), Args{}...))
                delegate(SignedSignificandBits, Func f, Args... args) noexcept
                {
@@ -2547,14 +2547,14 @@ namespace glz::jkj
                }
             } nearest_to_even = {};
 
-            JKJ_INLINE_VARIABLE struct nearest_to_odd_t
+            GLZ_JKJ_INLINE_VARIABLE struct nearest_to_odd_t
             {
                using decimal_to_binary_rounding_policy = nearest_to_odd_t;
                using interval_type_provider = nearest_to_odd_t;
                static constexpr auto tag = tag_t::to_nearest;
 
                template <class SignedSignificandBits, class Func, class... Args>
-               JKJ_FORCEINLINE JKJ_SAFEBUFFERS static constexpr decltype(Func{}(
+               GLZ_JKJ_FORCEINLINE GLZ_JKJ_SAFEBUFFERS static constexpr decltype(Func{}(
                   dragonbox::detail::declval<nearest_to_odd_t>(), Args{}...))
                delegate(SignedSignificandBits, Func f, Args... args) noexcept
                {
@@ -2573,14 +2573,14 @@ namespace glz::jkj
                }
             } nearest_to_odd = {};
 
-            JKJ_INLINE_VARIABLE struct nearest_toward_plus_infinity_t
+            GLZ_JKJ_INLINE_VARIABLE struct nearest_toward_plus_infinity_t
             {
                using decimal_to_binary_rounding_policy = nearest_toward_plus_infinity_t;
                using interval_type_provider = nearest_toward_plus_infinity_t;
                static constexpr auto tag = tag_t::to_nearest;
 
                template <class SignedSignificandBits, class Func, class... Args>
-               JKJ_FORCEINLINE JKJ_SAFEBUFFERS static constexpr decltype(Func{}(
+               GLZ_JKJ_FORCEINLINE GLZ_JKJ_SAFEBUFFERS static constexpr decltype(Func{}(
                   dragonbox::detail::declval<nearest_toward_plus_infinity_t>(), Args{}...))
                delegate(SignedSignificandBits, Func f, Args... args) noexcept
                {
@@ -2599,14 +2599,14 @@ namespace glz::jkj
                }
             } nearest_toward_plus_infinity = {};
 
-            JKJ_INLINE_VARIABLE struct nearest_toward_minus_infinity_t
+            GLZ_JKJ_INLINE_VARIABLE struct nearest_toward_minus_infinity_t
             {
                using decimal_to_binary_rounding_policy = nearest_toward_minus_infinity_t;
                using interval_type_provider = nearest_toward_minus_infinity_t;
                static constexpr auto tag = tag_t::to_nearest;
 
                template <class SignedSignificandBits, class Func, class... Args>
-               JKJ_FORCEINLINE JKJ_SAFEBUFFERS static constexpr decltype(Func{}(
+               GLZ_JKJ_FORCEINLINE GLZ_JKJ_SAFEBUFFERS static constexpr decltype(Func{}(
                   dragonbox::detail::declval<nearest_toward_minus_infinity_t>(), Args{}...))
                delegate(SignedSignificandBits, Func f, Args... args) noexcept
                {
@@ -2625,14 +2625,14 @@ namespace glz::jkj
                }
             } nearest_toward_minus_infinity = {};
 
-            JKJ_INLINE_VARIABLE struct nearest_toward_zero_t
+            GLZ_JKJ_INLINE_VARIABLE struct nearest_toward_zero_t
             {
                using decimal_to_binary_rounding_policy = nearest_toward_zero_t;
                using interval_type_provider = nearest_toward_zero_t;
                static constexpr auto tag = tag_t::to_nearest;
 
                template <class SignedSignificandBits, class Func, class... Args>
-               JKJ_FORCEINLINE JKJ_SAFEBUFFERS static constexpr decltype(Func{}(
+               GLZ_JKJ_FORCEINLINE GLZ_JKJ_SAFEBUFFERS static constexpr decltype(Func{}(
                   dragonbox::detail::declval<nearest_toward_zero_t>(), Args{}...))
                delegate(SignedSignificandBits, Func f, Args... args) noexcept
                {
@@ -2651,14 +2651,14 @@ namespace glz::jkj
                }
             } nearest_toward_zero = {};
 
-            JKJ_INLINE_VARIABLE struct nearest_away_from_zero_t
+            GLZ_JKJ_INLINE_VARIABLE struct nearest_away_from_zero_t
             {
                using decimal_to_binary_rounding_policy = nearest_away_from_zero_t;
                using interval_type_provider = nearest_away_from_zero_t;
                static constexpr auto tag = tag_t::to_nearest;
 
                template <class SignedSignificandBits, class Func, class... Args>
-               JKJ_FORCEINLINE JKJ_SAFEBUFFERS static constexpr decltype(Func{}(
+               GLZ_JKJ_FORCEINLINE GLZ_JKJ_SAFEBUFFERS static constexpr decltype(Func{}(
                   dragonbox::detail::declval<nearest_away_from_zero_t>(), Args{}...))
                delegate(SignedSignificandBits, Func f, Args... args) noexcept
                {
@@ -2713,12 +2713,12 @@ namespace glz::jkj
                };
             }
 
-            JKJ_INLINE_VARIABLE struct nearest_to_even_static_boundary_t
+            GLZ_JKJ_INLINE_VARIABLE struct nearest_to_even_static_boundary_t
             {
                using decimal_to_binary_rounding_policy = nearest_to_even_static_boundary_t;
 
                template <class SignedSignificandBits, class Func, class... Args>
-               JKJ_FORCEINLINE JKJ_SAFEBUFFERS static constexpr decltype(Func{}(detail::nearest_always_closed_t{},
+               GLZ_JKJ_FORCEINLINE GLZ_JKJ_SAFEBUFFERS static constexpr decltype(Func{}(detail::nearest_always_closed_t{},
                                                                                 Args{}...))
                delegate(SignedSignificandBits s, Func f, Args... args) noexcept
                {
@@ -2727,12 +2727,12 @@ namespace glz::jkj
                }
             } nearest_to_even_static_boundary = {};
 
-            JKJ_INLINE_VARIABLE struct nearest_to_odd_static_boundary_t
+            GLZ_JKJ_INLINE_VARIABLE struct nearest_to_odd_static_boundary_t
             {
                using decimal_to_binary_rounding_policy = nearest_to_odd_static_boundary_t;
 
                template <class SignedSignificandBits, class Func, class... Args>
-               JKJ_FORCEINLINE JKJ_SAFEBUFFERS static constexpr decltype(Func{}(detail::nearest_always_closed_t{},
+               GLZ_JKJ_FORCEINLINE GLZ_JKJ_SAFEBUFFERS static constexpr decltype(Func{}(detail::nearest_always_closed_t{},
                                                                                 Args{}...))
                delegate(SignedSignificandBits s, Func f, Args... args) noexcept
                {
@@ -2741,24 +2741,24 @@ namespace glz::jkj
                }
             } nearest_to_odd_static_boundary = {};
 
-            JKJ_INLINE_VARIABLE struct nearest_toward_plus_infinity_static_boundary_t
+            GLZ_JKJ_INLINE_VARIABLE struct nearest_toward_plus_infinity_static_boundary_t
             {
                using decimal_to_binary_rounding_policy = nearest_toward_plus_infinity_static_boundary_t;
 
                template <class SignedSignificandBits, class Func, class... Args>
-               JKJ_FORCEINLINE JKJ_SAFEBUFFERS static constexpr decltype(Func{}(nearest_toward_zero, Args{}...))
+               GLZ_JKJ_FORCEINLINE GLZ_JKJ_SAFEBUFFERS static constexpr decltype(Func{}(nearest_toward_zero, Args{}...))
                delegate(SignedSignificandBits s, Func f, Args... args) noexcept
                {
                   return s.is_negative() ? f(nearest_toward_zero, args...) : f(nearest_away_from_zero, args...);
                }
             } nearest_toward_plus_infinity_static_boundary = {};
 
-            JKJ_INLINE_VARIABLE struct nearest_toward_minus_infinity_static_boundary_t
+            GLZ_JKJ_INLINE_VARIABLE struct nearest_toward_minus_infinity_static_boundary_t
             {
                using decimal_to_binary_rounding_policy = nearest_toward_minus_infinity_static_boundary_t;
 
                template <class SignedSignificandBits, class Func, class... Args>
-               JKJ_FORCEINLINE JKJ_SAFEBUFFERS static constexpr decltype(Func{}(nearest_toward_zero, Args{}...))
+               GLZ_JKJ_FORCEINLINE GLZ_JKJ_SAFEBUFFERS static constexpr decltype(Func{}(nearest_toward_zero, Args{}...))
                delegate(SignedSignificandBits s, Func f, Args... args) noexcept
                {
                   return s.is_negative() ? f(nearest_away_from_zero, args...) : f(nearest_toward_zero, args...);
@@ -2777,12 +2777,12 @@ namespace glz::jkj
                };
             }
 
-            JKJ_INLINE_VARIABLE struct toward_plus_infinity_t
+            GLZ_JKJ_INLINE_VARIABLE struct toward_plus_infinity_t
             {
                using decimal_to_binary_rounding_policy = toward_plus_infinity_t;
 
                template <class SignedSignificandBits, class Func, class... Args>
-               JKJ_FORCEINLINE JKJ_SAFEBUFFERS static constexpr decltype(Func{}(detail::left_closed_directed_t{},
+               GLZ_JKJ_FORCEINLINE GLZ_JKJ_SAFEBUFFERS static constexpr decltype(Func{}(detail::left_closed_directed_t{},
                                                                                 Args{}...))
                delegate(SignedSignificandBits s, Func f, Args... args) noexcept
                {
@@ -2791,12 +2791,12 @@ namespace glz::jkj
                }
             } toward_plus_infinity = {};
 
-            JKJ_INLINE_VARIABLE struct toward_minus_infinity_t
+            GLZ_JKJ_INLINE_VARIABLE struct toward_minus_infinity_t
             {
                using decimal_to_binary_rounding_policy = toward_minus_infinity_t;
 
                template <class SignedSignificandBits, class Func, class... Args>
-               JKJ_FORCEINLINE JKJ_SAFEBUFFERS static constexpr decltype(Func{}(detail::left_closed_directed_t{},
+               GLZ_JKJ_FORCEINLINE GLZ_JKJ_SAFEBUFFERS static constexpr decltype(Func{}(detail::left_closed_directed_t{},
                                                                                 Args{}...))
                delegate(SignedSignificandBits s, Func f, Args... args) noexcept
                {
@@ -2805,12 +2805,12 @@ namespace glz::jkj
                }
             } toward_minus_infinity = {};
 
-            JKJ_INLINE_VARIABLE struct toward_zero_t
+            GLZ_JKJ_INLINE_VARIABLE struct toward_zero_t
             {
                using decimal_to_binary_rounding_policy = toward_zero_t;
 
                template <class SignedSignificandBits, class Func, class... Args>
-               JKJ_FORCEINLINE JKJ_SAFEBUFFERS static constexpr decltype(Func{}(detail::left_closed_directed_t{},
+               GLZ_JKJ_FORCEINLINE GLZ_JKJ_SAFEBUFFERS static constexpr decltype(Func{}(detail::left_closed_directed_t{},
                                                                                 Args{}...))
                delegate(SignedSignificandBits, Func f, Args... args) noexcept
                {
@@ -2818,12 +2818,12 @@ namespace glz::jkj
                }
             } toward_zero = {};
 
-            JKJ_INLINE_VARIABLE struct away_from_zero_t
+            GLZ_JKJ_INLINE_VARIABLE struct away_from_zero_t
             {
                using decimal_to_binary_rounding_policy = away_from_zero_t;
 
                template <class SignedSignificandBits, class Func, class... Args>
-               JKJ_FORCEINLINE JKJ_SAFEBUFFERS static constexpr decltype(Func{}(detail::right_closed_directed_t{},
+               GLZ_JKJ_FORCEINLINE GLZ_JKJ_SAFEBUFFERS static constexpr decltype(Func{}(detail::right_closed_directed_t{},
                                                                                 Args{}...))
                delegate(SignedSignificandBits, Func f, Args... args) noexcept
                {
@@ -2840,7 +2840,7 @@ namespace glz::jkj
 
             // The parameter significand corresponds to 10\tilde{s}+t in the paper.
 
-            JKJ_INLINE_VARIABLE struct do_not_care_t
+            GLZ_JKJ_INLINE_VARIABLE struct do_not_care_t
             {
                using binary_to_decimal_rounding_policy = do_not_care_t;
                static constexpr auto tag = tag_t::do_not_care;
@@ -2852,7 +2852,7 @@ namespace glz::jkj
                }
             } do_not_care = {};
 
-            JKJ_INLINE_VARIABLE struct to_even_t
+            GLZ_JKJ_INLINE_VARIABLE struct to_even_t
             {
                using binary_to_decimal_rounding_policy = to_even_t;
                static constexpr auto tag = tag_t::to_even;
@@ -2864,7 +2864,7 @@ namespace glz::jkj
                }
             } to_even = {};
 
-            JKJ_INLINE_VARIABLE struct to_odd_t
+            GLZ_JKJ_INLINE_VARIABLE struct to_odd_t
             {
                using binary_to_decimal_rounding_policy = to_odd_t;
                static constexpr auto tag = tag_t::to_odd;
@@ -2876,7 +2876,7 @@ namespace glz::jkj
                }
             } to_odd = {};
 
-            JKJ_INLINE_VARIABLE struct away_from_zero_t
+            GLZ_JKJ_INLINE_VARIABLE struct away_from_zero_t
             {
                using binary_to_decimal_rounding_policy = away_from_zero_t;
                static constexpr auto tag = tag_t::away_from_zero;
@@ -2888,7 +2888,7 @@ namespace glz::jkj
                }
             } away_from_zero = {};
 
-            JKJ_INLINE_VARIABLE struct toward_zero_t
+            GLZ_JKJ_INLINE_VARIABLE struct toward_zero_t
             {
                using binary_to_decimal_rounding_policy = toward_zero_t;
                static constexpr auto tag = tag_t::toward_zero;
@@ -2903,7 +2903,7 @@ namespace glz::jkj
 
          namespace cache
          {
-            JKJ_INLINE_VARIABLE struct full_t
+            GLZ_JKJ_INLINE_VARIABLE struct full_t
             {
                using cache_policy = full_t;
                template <class FloatFormat>
@@ -2913,7 +2913,7 @@ namespace glz::jkj
                static constexpr typename cache_holder_type<FloatFormat>::cache_entry_type get_cache(
                   DecimalExponentType k) noexcept
                {
-#if JKJ_HAS_CONSTEXPR14
+#if GLZ_JKJ_HAS_CONSTEXPR14
                   assert(k >= cache_holder_type<FloatFormat>::min_k && k <= cache_holder_type<FloatFormat>::max_k);
 #endif
                   return cache_holder_type<FloatFormat>::cache[detail::stdr::size_t(
@@ -2921,14 +2921,14 @@ namespace glz::jkj
                }
             } full = {};
 
-            JKJ_INLINE_VARIABLE struct compact_t
+            GLZ_JKJ_INLINE_VARIABLE struct compact_t
             {
                using cache_policy = compact_t;
                template <class FloatFormat>
                using cache_holder_type = compressed_cache_holder<FloatFormat>;
 
                template <class FloatFormat, class ShiftAmountType, class DecimalExponentType>
-               static JKJ_CONSTEXPR20 typename cache_holder<FloatFormat>::cache_entry_type get_cache(
+               static GLZ_JKJ_CONSTEXPR20 typename cache_holder<FloatFormat>::cache_entry_type get_cache(
                   DecimalExponentType k) noexcept
                {
                   assert(k >= cache_holder<FloatFormat>::min_k && k <= cache_holder<FloatFormat>::max_k);
@@ -2940,7 +2940,7 @@ namespace glz::jkj
 
          namespace preferred_integer_types
          {
-            JKJ_INLINE_VARIABLE struct match_t
+            GLZ_JKJ_INLINE_VARIABLE struct match_t
             {
                using preferred_integer_types_policy = match_t;
 
@@ -2955,7 +2955,7 @@ namespace glz::jkj
                using shift_amount_type = typename FormatTraits::exponent_int;
             } match;
 
-            JKJ_INLINE_VARIABLE struct prefer_32_t
+            GLZ_JKJ_INLINE_VARIABLE struct prefer_32_t
             {
                using preferred_integer_types_policy = prefer_32_t;
 
@@ -2974,7 +2974,7 @@ namespace glz::jkj
                using shift_amount_type = detail::stdr::int_least32_t;
             } prefer_32;
 
-            JKJ_INLINE_VARIABLE struct minimal_t
+            GLZ_JKJ_INLINE_VARIABLE struct minimal_t
             {
                using preferred_integer_types_policy = minimal_t;
 
@@ -3022,7 +3022,7 @@ namespace glz::jkj
       struct remove_trailing_zeros_traits<policy::trailing_zero::remove_t, ieee754_binary32,
                                           detail::stdr::uint_least32_t, DecimalExponentType>
       {
-         JKJ_FORCEINLINE static JKJ_CONSTEXPR14 void remove_trailing_zeros(detail::stdr::uint_least32_t& significand,
+         GLZ_JKJ_FORCEINLINE static GLZ_JKJ_CONSTEXPR14 void remove_trailing_zeros(detail::stdr::uint_least32_t& significand,
                                                                            DecimalExponentType& exponent) noexcept
          {
             // See https://github.com/jk-jeon/rtz_benchmark.
@@ -3052,7 +3052,7 @@ namespace glz::jkj
       struct remove_trailing_zeros_traits<policy::trailing_zero::remove_t, ieee754_binary64,
                                           detail::stdr::uint_least64_t, DecimalExponentType>
       {
-         JKJ_FORCEINLINE static JKJ_CONSTEXPR14 void remove_trailing_zeros(detail::stdr::uint_least64_t& significand,
+         GLZ_JKJ_FORCEINLINE static GLZ_JKJ_CONSTEXPR14 void remove_trailing_zeros(detail::stdr::uint_least64_t& significand,
                                                                            DecimalExponentType& exponent) noexcept
          {
             // See https://github.com/jk-jeon/rtz_benchmark.
@@ -3087,7 +3087,7 @@ namespace glz::jkj
       struct remove_trailing_zeros_traits<policy::trailing_zero::remove_compact_t, ieee754_binary32,
                                           detail::stdr::uint_least32_t, DecimalExponentType>
       {
-         JKJ_FORCEINLINE static JKJ_CONSTEXPR14 void remove_trailing_zeros(detail::stdr::uint_least32_t& significand,
+         GLZ_JKJ_FORCEINLINE static GLZ_JKJ_CONSTEXPR14 void remove_trailing_zeros(detail::stdr::uint_least32_t& significand,
                                                                            DecimalExponentType& exponent) noexcept
          {
             // See https://github.com/jk-jeon/rtz_benchmark.
@@ -3108,7 +3108,7 @@ namespace glz::jkj
       struct remove_trailing_zeros_traits<policy::trailing_zero::remove_compact_t, ieee754_binary64,
                                           detail::stdr::uint_least64_t, DecimalExponentType>
       {
-         JKJ_FORCEINLINE static JKJ_CONSTEXPR14 void remove_trailing_zeros(detail::stdr::uint_least64_t& significand,
+         GLZ_JKJ_FORCEINLINE static GLZ_JKJ_CONSTEXPR14 void remove_trailing_zeros(detail::stdr::uint_least64_t& significand,
                                                                            DecimalExponentType& exponent) noexcept
          {
             // See https://github.com/jk-jeon/rtz_benchmark.
@@ -3131,7 +3131,7 @@ namespace glz::jkj
          : public multiplication_traits_base<ieee754_binary_traits<ieee754_binary32, detail::stdr::uint_least32_t>,
                                              detail::stdr::uint_least64_t, 64>
       {
-         static JKJ_CONSTEXPR20 compute_mul_result compute_mul(carrier_uint u, const cache_entry_type& cache) noexcept
+         static GLZ_JKJ_CONSTEXPR20 compute_mul_result compute_mul(carrier_uint u, const cache_entry_type& cache) noexcept
          {
             const auto r = detail::wuint::umul96_upper64(u, cache);
             return {carrier_uint(r >> 32), carrier_uint(r) == 0};
@@ -3145,7 +3145,7 @@ namespace glz::jkj
          }
 
          template <class ShiftAmountType>
-         static JKJ_CONSTEXPR20 compute_mul_parity_result compute_mul_parity(carrier_uint two_f,
+         static GLZ_JKJ_CONSTEXPR20 compute_mul_parity_result compute_mul_parity(carrier_uint two_f,
                                                                              const cache_entry_type& cache,
                                                                              ShiftAmountType beta) noexcept
          {
@@ -3187,7 +3187,7 @@ namespace glz::jkj
          : public multiplication_traits_base<ieee754_binary_traits<ieee754_binary64, detail::stdr::uint_least64_t>,
                                              detail::wuint::uint128, 128>
       {
-         static JKJ_CONSTEXPR20 compute_mul_result compute_mul(carrier_uint u, const cache_entry_type& cache) noexcept
+         static GLZ_JKJ_CONSTEXPR20 compute_mul_result compute_mul(carrier_uint u, const cache_entry_type& cache) noexcept
          {
             const auto r = detail::wuint::umul192_upper128(u, cache);
             return {r.high(), r.low() == 0};
@@ -3201,7 +3201,7 @@ namespace glz::jkj
          }
 
          template <class ShiftAmountType>
-         static JKJ_CONSTEXPR20 compute_mul_parity_result compute_mul_parity(carrier_uint two_f,
+         static GLZ_JKJ_CONSTEXPR20 compute_mul_parity_result compute_mul_parity(carrier_uint two_f,
                                                                              const cache_entry_type& cache,
                                                                              ShiftAmountType beta) noexcept
          {
@@ -3307,7 +3307,7 @@ namespace glz::jkj
 
             template <class SignPolicy, class TrailingZeroPolicy, class IntervalTypeProvider,
                       class BinaryToDecimalRoundingPolicy, class CachePolicy, class PreferredIntegerTypesPolicy>
-            JKJ_SAFEBUFFERS static JKJ_CONSTEXPR20
+            GLZ_JKJ_SAFEBUFFERS static GLZ_JKJ_CONSTEXPR20
                return_type<SignPolicy, TrailingZeroPolicy, PreferredIntegerTypesPolicy>
                compute_nearest(signed_significand_bits<FormatTraits> s, exponent_int exponent_bits) noexcept
             {
@@ -3485,7 +3485,7 @@ namespace glz::jkj
                      // Exclude the right endpoint if necessary.
                      if ((r | remainder_type_(!z_result.is_integer) |
                           remainder_type_(interval_type.include_right_endpoint())) == 0) {
-                        JKJ_IF_CONSTEXPR(BinaryToDecimalRoundingPolicy::tag ==
+                        GLZ_JKJ_IF_CONSTEXPR(BinaryToDecimalRoundingPolicy::tag ==
                                          policy::binary_to_decimal_rounding::tag_t::do_not_care)
                         {
                            decimal_significand *= 10;
@@ -3527,7 +3527,7 @@ namespace glz::jkj
 
                decimal_significand *= 10;
 
-               JKJ_IF_CONSTEXPR(BinaryToDecimalRoundingPolicy::tag ==
+               GLZ_JKJ_IF_CONSTEXPR(BinaryToDecimalRoundingPolicy::tag ==
                                 policy::binary_to_decimal_rounding::tag_t::do_not_care)
                {
                   // Normally, we want to compute
@@ -3589,7 +3589,7 @@ namespace glz::jkj
             }
 
             template <class SignPolicy, class TrailingZeroPolicy, class CachePolicy, class PreferredIntegerTypesPolicy>
-            JKJ_FORCEINLINE JKJ_SAFEBUFFERS static JKJ_CONSTEXPR20
+            GLZ_JKJ_FORCEINLINE GLZ_JKJ_SAFEBUFFERS static GLZ_JKJ_CONSTEXPR20
                return_type<SignPolicy, TrailingZeroPolicy, PreferredIntegerTypesPolicy>
                compute_left_closed_directed(signed_significand_bits<FormatTraits> s,
                                             exponent_int exponent_bits) noexcept
@@ -3644,7 +3644,7 @@ namespace glz::jkj
                // and 29711844 * 2^-81
                // = 1.2288530660000000001731007559513386695471126586198806762695... * 10^-17
                // for binary32.
-               JKJ_IF_CONSTEXPR(stdr::is_same<format, ieee754_binary32>::value)
+               GLZ_JKJ_IF_CONSTEXPR(stdr::is_same<format, ieee754_binary32>::value)
                {
                   if (binary_exponent <= -80) {
                      x_result.is_integer = false;
@@ -3691,7 +3691,7 @@ namespace glz::jkj
                      // case, the recovered cache is two large to make compute_mul_parity
                      // mistakenly conclude that z is not an integer, but actually z = 16384 is
                      // an integer.
-                     JKJ_IF_CONSTEXPR(
+                     GLZ_JKJ_IF_CONSTEXPR(
                         stdr::is_same<cache_holder_type, compressed_cache_holder<ieee754_binary32>>::value)
                      {
                         if (two_fc == 33554430 && binary_exponent == -10) {
@@ -3722,7 +3722,7 @@ namespace glz::jkj
             }
 
             template <class SignPolicy, class TrailingZeroPolicy, class CachePolicy, class PreferredIntegerTypesPolicy>
-            JKJ_FORCEINLINE JKJ_SAFEBUFFERS static JKJ_CONSTEXPR20
+            GLZ_JKJ_FORCEINLINE GLZ_JKJ_SAFEBUFFERS static GLZ_JKJ_CONSTEXPR20
                return_type<SignPolicy, TrailingZeroPolicy, PreferredIntegerTypesPolicy>
                compute_right_closed_directed(signed_significand_bits<FormatTraits> s,
                                              exponent_int exponent_bits) noexcept
@@ -4132,26 +4132,26 @@ namespace glz::jkj
                                                                                   preferred_integer_types_policy>;
 
             template <class IntervalTypeProvider>
-            JKJ_FORCEINLINE JKJ_SAFEBUFFERS JKJ_CONSTEXPR20 return_type
+            GLZ_JKJ_FORCEINLINE GLZ_JKJ_SAFEBUFFERS GLZ_JKJ_CONSTEXPR20 return_type
             operator()(IntervalTypeProvider, signed_significand_bits<FormatTraits> s,
                        typename FormatTraits::exponent_int exponent_bits) noexcept
             {
                constexpr auto tag = IntervalTypeProvider::tag;
 
-               JKJ_IF_CONSTEXPR(tag == policy::decimal_to_binary_rounding::tag_t::to_nearest)
+               GLZ_JKJ_IF_CONSTEXPR(tag == policy::decimal_to_binary_rounding::tag_t::to_nearest)
                {
                   return impl<FormatTraits>::template compute_nearest<
                      sign_policy, trailing_zero_policy, IntervalTypeProvider, binary_to_decimal_rounding_policy,
                      cache_policy, preferred_integer_types_policy>(s, exponent_bits);
                }
-               else JKJ_IF_CONSTEXPR(tag == policy::decimal_to_binary_rounding::tag_t::left_closed_directed)
+               else GLZ_JKJ_IF_CONSTEXPR(tag == policy::decimal_to_binary_rounding::tag_t::left_closed_directed)
                {
                   return impl<FormatTraits>::template compute_left_closed_directed<
                      sign_policy, trailing_zero_policy, cache_policy, preferred_integer_types_policy>(s, exponent_bits);
                }
                else
                {
-#if JKJ_HAS_IF_CONSTEXPR
+#if GLZ_JKJ_HAS_IF_CONSTEXPR
                   static_assert(tag == policy::decimal_to_binary_rounding::tag_t::right_closed_directed, "");
 #endif
                   return impl<FormatTraits>::template compute_right_closed_directed<
@@ -4166,7 +4166,7 @@ namespace glz::jkj
       ////////////////////////////////////////////////////////////////////////////////////////
 
       template <class FormatTraits, class ExponentBits, class... Policies>
-      JKJ_FORCEINLINE JKJ_SAFEBUFFERS JKJ_CONSTEXPR20 detail::to_decimal_return_type<FormatTraits, Policies...>
+      GLZ_JKJ_FORCEINLINE GLZ_JKJ_SAFEBUFFERS GLZ_JKJ_CONSTEXPR20 detail::to_decimal_return_type<FormatTraits, Policies...>
       to_decimal_ex(signed_significand_bits<FormatTraits> s, ExponentBits exponent_bits, Policies...) noexcept
       {
          // Build policy holder type.
@@ -4180,7 +4180,7 @@ namespace glz::jkj
                 class FormatTraits =
                    ieee754_binary_traits<typename ConversionTraits::format, typename ConversionTraits::carrier_uint>,
                 class... Policies>
-      JKJ_FORCEINLINE JKJ_SAFEBUFFERS JKJ_CONSTEXPR20 detail::to_decimal_return_type<FormatTraits, Policies...>
+      GLZ_JKJ_FORCEINLINE GLZ_JKJ_SAFEBUFFERS GLZ_JKJ_CONSTEXPR20 detail::to_decimal_return_type<FormatTraits, Policies...>
       to_decimal(Float x, Policies... policies) noexcept
       {
          const auto br = make_float_bits<Float, ConversionTraits, FormatTraits>(x);
@@ -4193,31 +4193,31 @@ namespace glz::jkj
    }
 }
 
-#undef JKJ_HAS_BUILTIN
-#undef JKJ_FORCEINLINE
-#undef JKJ_SAFEBUFFERS
-#undef JKJ_CONSTEXPR20
-#undef JKJ_USE_IS_CONSTANT_EVALUATED
-#undef JKJ_CAN_BRANCH_ON_CONSTEVAL
-#undef JKJ_IF_NOT_CONSTEVAL
-#undef JKJ_IF_CONSTEVAL
-#undef JKJ_HAS_BIT_CAST
-#undef JKJ_IF_CONSTEXPR
-#undef JKJ_HAS_IF_CONSTEXPR
-#undef JKJ_INLINE_VARIABLE
-#undef JKJ_HAS_INLINE_VARIABLE
-#undef JKJ_HAS_CONSTEXPR17
-#undef JKJ_CONSTEXPR14
-#undef JKJ_HAS_CONSTEXPR14
-#if JKJ_STD_REPLACEMENT_NAMESPACE_DEFINED
-#undef JKJ_STD_REPLACEMENT_NAMESPACE_DEFINED
+#undef GLZ_JKJ_HAS_BUILTIN
+#undef GLZ_JKJ_FORCEINLINE
+#undef GLZ_JKJ_SAFEBUFFERS
+#undef GLZ_JKJ_CONSTEXPR20
+#undef GLZ_JKJ_USE_IS_CONSTANT_EVALUATED
+#undef GLZ_JKJ_CAN_BRANCH_ON_CONSTEVAL
+#undef GLZ_JKJ_IF_NOT_CONSTEVAL
+#undef GLZ_JKJ_IF_CONSTEVAL
+#undef GLZ_JKJ_HAS_BIT_CAST
+#undef GLZ_JKJ_IF_CONSTEXPR
+#undef GLZ_JKJ_HAS_IF_CONSTEXPR
+#undef GLZ_JKJ_INLINE_VARIABLE
+#undef GLZ_JKJ_HAS_INLINE_VARIABLE
+#undef GLZ_JKJ_HAS_CONSTEXPR17
+#undef GLZ_JKJ_CONSTEXPR14
+#undef GLZ_JKJ_HAS_CONSTEXPR14
+#if GLZ_JKJ_STD_REPLACEMENT_NAMESPACE_DEFINED
+#undef GLZ_JKJ_STD_REPLACEMENT_NAMESPACE_DEFINED
 #else
-#undef JKJ_STD_REPLACEMENT_NAMESPACE
+#undef GLZ_JKJ_STD_REPLACEMENT_NAMESPACE
 #endif
-#if JKJ_STATIC_DATA_SECTION_DEFINED
-#undef JKJ_STATIC_DATA_SECTION_DEFINED
+#if GLZ_JKJ_STATIC_DATA_SECTION_DEFINED
+#undef GLZ_JKJ_STATIC_DATA_SECTION_DEFINED
 #else
-#undef JKJ_STATIC_DATA_SECTION
+#undef GLZ_JKJ_STATIC_DATA_SECTION
 #endif
 
 #endif

--- a/include/glaze/util/fast_float.hpp
+++ b/include/glaze/util/fast_float.hpp
@@ -93,8 +93,8 @@
 //    DEALINGS IN THE SOFTWARE.
 //
 
-#ifndef FASTFLOAT_CONSTEXPR_FEATURE_DETECT_H
-#define FASTFLOAT_CONSTEXPR_FEATURE_DETECT_H
+#ifndef GLZ_FASTFLOAT_CONSTEXPR_FEATURE_DETECT_H
+#define GLZ_FASTFLOAT_CONSTEXPR_FEATURE_DETECT_H
 
 #ifdef __has_include
 #if __has_include(<version>)
@@ -104,38 +104,38 @@
 
 // Testing for https://wg21.link/N3652, adopted in C++14
 #if __cpp_constexpr >= 201304
-#define FASTFLOAT_CONSTEXPR14 constexpr
+#define GLZ_FASTFLOAT_CONSTEXPR14 constexpr
 #else
-#define FASTFLOAT_CONSTEXPR14
+#define GLZ_FASTFLOAT_CONSTEXPR14
 #endif
 
 #if defined(__cpp_lib_bit_cast) && __cpp_lib_bit_cast >= 201806L
-#define FASTFLOAT_HAS_BIT_CAST 1
+#define GLZ_FASTFLOAT_HAS_BIT_CAST 1
 #else
-#define FASTFLOAT_HAS_BIT_CAST 0
+#define GLZ_FASTFLOAT_HAS_BIT_CAST 0
 #endif
 
 #if defined(__cpp_lib_is_constant_evaluated) && __cpp_lib_is_constant_evaluated >= 201811L
-#define FASTFLOAT_HAS_IS_CONSTANT_EVALUATED 1
+#define GLZ_FASTFLOAT_HAS_IS_CONSTANT_EVALUATED 1
 #else
-#define FASTFLOAT_HAS_IS_CONSTANT_EVALUATED 0
+#define GLZ_FASTFLOAT_HAS_IS_CONSTANT_EVALUATED 0
 #endif
 
 // Testing for relevant C++20 constexpr library features
-#if FASTFLOAT_HAS_IS_CONSTANT_EVALUATED \
-    && FASTFLOAT_HAS_BIT_CAST \
+#if GLZ_FASTFLOAT_HAS_IS_CONSTANT_EVALUATED \
+    && GLZ_FASTFLOAT_HAS_BIT_CAST \
     && __cpp_lib_constexpr_algorithms >= 201806L /*For std::copy and std::fill*/
-#define FASTFLOAT_CONSTEXPR20 constexpr
-#define FASTFLOAT_IS_CONSTEXPR 1
+#define GLZ_FASTFLOAT_CONSTEXPR20 constexpr
+#define GLZ_FASTFLOAT_IS_CONSTEXPR 1
 #else
-#define FASTFLOAT_CONSTEXPR20
-#define FASTFLOAT_IS_CONSTEXPR 0
+#define GLZ_FASTFLOAT_CONSTEXPR20
+#define GLZ_FASTFLOAT_IS_CONSTEXPR 0
 #endif
 
-#endif // FASTFLOAT_CONSTEXPR_FEATURE_DETECT_H
+#endif // GLZ_FASTFLOAT_CONSTEXPR_FEATURE_DETECT_H
 
-#ifndef FASTFLOAT_FLOAT_COMMON_H
-#define FASTFLOAT_FLOAT_COMMON_H
+#ifndef GLZ_FASTFLOAT_FLOAT_COMMON_H
+#define GLZ_FASTFLOAT_FLOAT_COMMON_H
 
 #include <cfloat>
 #include <cstdint>
@@ -151,8 +151,8 @@
 
 namespace glz::fast_float {
 
-#define FASTFLOAT_JSONFMT (1 << 5)
-#define FASTFLOAT_FORTRANFMT (1 << 6)
+#define GLZ_FASTFLOAT_JSONFMT (1 << 5)
+#define GLZ_FASTFLOAT_FORTRANFMT (1 << 6)
 
 enum chars_format {
   scientific = 1 << 0,
@@ -160,10 +160,10 @@ enum chars_format {
   hex = 1 << 3,
   no_infnan = 1 << 4,
   // RFC 8259: https://datatracker.ietf.org/doc/html/rfc8259#section-6
-  json = FASTFLOAT_JSONFMT | fixed | scientific | no_infnan,
+  json = GLZ_FASTFLOAT_JSONFMT | fixed | scientific | no_infnan,
   // Extension of RFC 8259 where, e.g., "inf" and "nan" are allowed.
-  json_or_infnan = FASTFLOAT_JSONFMT | fixed | scientific,
-  fortran = FASTFLOAT_FORTRANFMT | fixed | scientific,
+  json_or_infnan = GLZ_FASTFLOAT_JSONFMT | fixed | scientific,
+  fortran = GLZ_FASTFLOAT_FORTRANFMT | fixed | scientific,
   general = fixed | scientific
 };
 
@@ -189,7 +189,7 @@ using parse_options = parse_options_t<char>;
 
 }
 
-#if FASTFLOAT_HAS_BIT_CAST
+#if GLZ_FASTFLOAT_HAS_BIT_CAST
 #include <bit>
 #endif
 
@@ -199,11 +199,11 @@ using parse_options = parse_options_t<char>;
        || defined(__s390x__)                                            \
        || (defined(__ppc64__) || defined(__PPC64__) || defined(__ppc64le__) || defined(__PPC64LE__)) \
        || defined(__loongarch64) )
-#define FASTFLOAT_64BIT 1
+#define GLZ_FASTFLOAT_64BIT 1
 #elif (defined(__i386) || defined(__i386__) || defined(_M_IX86)   \
      || defined(__arm__) || defined(_M_ARM) || defined(__ppc__)   \
      || defined(__MINGW32__) || defined(__EMSCRIPTEN__))
-#define FASTFLOAT_32BIT 1
+#define GLZ_FASTFLOAT_32BIT 1
 #else
   // Need to check incrementally, since SIZE_MAX is a size_t, avoid overflow.
   // We can never tell the register width, but the SIZE_MAX is a good approximation.
@@ -211,9 +211,9 @@ using parse_options = parse_options_t<char>;
   #if SIZE_MAX == 0xffff
     #error Unknown platform (16-bit, unsupported)
   #elif SIZE_MAX == 0xffffffff
-    #define FASTFLOAT_32BIT 1
+    #define GLZ_FASTFLOAT_32BIT 1
   #elif SIZE_MAX == 0xffffffffffffffff
-    #define FASTFLOAT_64BIT 1
+    #define GLZ_FASTFLOAT_64BIT 1
   #else
     #error Unknown platform (not 32-bit, not 64-bit?)
   #endif
@@ -224,13 +224,13 @@ using parse_options = parse_options_t<char>;
 #endif
 
 #if defined(_MSC_VER) && !defined(__clang__)
-#define FASTFLOAT_VISUAL_STUDIO 1
+#define GLZ_FASTFLOAT_VISUAL_STUDIO 1
 #endif
 
 #if defined __BYTE_ORDER__ && defined __ORDER_BIG_ENDIAN__
-#define FASTFLOAT_IS_BIG_ENDIAN (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#define GLZ_FASTFLOAT_IS_BIG_ENDIAN (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
 #elif defined _WIN32
-#define FASTFLOAT_IS_BIG_ENDIAN 0
+#define GLZ_FASTFLOAT_IS_BIG_ENDIAN 0
 #else
 #if defined(__APPLE__) || defined(__FreeBSD__)
 #include <machine/endian.h>
@@ -248,77 +248,77 @@ using parse_options = parse_options_t<char>;
 #
 #ifndef __BYTE_ORDER__
 // safe choice
-#define FASTFLOAT_IS_BIG_ENDIAN 0
+#define GLZ_FASTFLOAT_IS_BIG_ENDIAN 0
 #endif
 #
 #ifndef __ORDER_LITTLE_ENDIAN__
 // safe choice
-#define FASTFLOAT_IS_BIG_ENDIAN 0
+#define GLZ_FASTFLOAT_IS_BIG_ENDIAN 0
 #endif
 #
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#define FASTFLOAT_IS_BIG_ENDIAN 0
+#define GLZ_FASTFLOAT_IS_BIG_ENDIAN 0
 #else
-#define FASTFLOAT_IS_BIG_ENDIAN 1
+#define GLZ_FASTFLOAT_IS_BIG_ENDIAN 1
 #endif
 #endif
 
 #if defined(__SSE2__) || \
-  (defined(FASTFLOAT_VISUAL_STUDIO) && \
+  (defined(GLZ_FASTFLOAT_VISUAL_STUDIO) && \
     (defined(_M_AMD64) || defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP == 2)))
-#define FASTFLOAT_SSE2 1
+#define GLZ_FASTFLOAT_SSE2 1
 #endif
 
 #if defined(__aarch64__) || defined(_M_ARM64)
-#define FASTFLOAT_NEON 1
+#define GLZ_FASTFLOAT_NEON 1
 #endif
 
-#if defined(FASTFLOAT_SSE2) || defined(FASTFLOAT_NEON)
-#define FASTFLOAT_HAS_SIMD 1
+#if defined(GLZ_FASTFLOAT_SSE2) || defined(GLZ_FASTFLOAT_NEON)
+#define GLZ_FASTFLOAT_HAS_SIMD 1
 #endif
 
 #if defined(__GNUC__)
 // disable -Wcast-align=strict (GCC only)
-#define FASTFLOAT_SIMD_DISABLE_WARNINGS \
+#define GLZ_FASTFLOAT_SIMD_DISABLE_WARNINGS \
   _Pragma("GCC diagnostic push") \
   _Pragma("GCC diagnostic ignored \"-Wcast-align\"")
 #else
-#define FASTFLOAT_SIMD_DISABLE_WARNINGS
+#define GLZ_FASTFLOAT_SIMD_DISABLE_WARNINGS
 #endif
 
 #if defined(__GNUC__)
-#define FASTFLOAT_SIMD_RESTORE_WARNINGS \
+#define GLZ_FASTFLOAT_SIMD_RESTORE_WARNINGS \
   _Pragma("GCC diagnostic pop")
 #else
-#define FASTFLOAT_SIMD_RESTORE_WARNINGS
+#define GLZ_FASTFLOAT_SIMD_RESTORE_WARNINGS
 #endif
 
 
 
-#ifdef FASTFLOAT_VISUAL_STUDIO
+#ifdef GLZ_FASTFLOAT_VISUAL_STUDIO
 #define fastfloat_really_inline __forceinline
 #else
 #define fastfloat_really_inline inline __attribute__((always_inline))
 #endif
 
-#ifndef FASTFLOAT_ASSERT
-#define FASTFLOAT_ASSERT(x)  { ((void)(x)); }
+#ifndef GLZ_FASTFLOAT_ASSERT
+#define GLZ_FASTFLOAT_ASSERT(x)  { ((void)(x)); }
 #endif
 
-#ifndef FASTFLOAT_DEBUG_ASSERT
-#define FASTFLOAT_DEBUG_ASSERT(x) { ((void)(x)); }
+#ifndef GLZ_FASTFLOAT_DEBUG_ASSERT
+#define GLZ_FASTFLOAT_DEBUG_ASSERT(x) { ((void)(x)); }
 #endif
 
 // rust style `try!()` macro, or `?` operator
-#define FASTFLOAT_TRY(x) { if (!(x)) return false; }
+#define GLZ_FASTFLOAT_TRY(x) { if (!(x)) return false; }
 
-#define FASTFLOAT_ENABLE_IF(...) typename std::enable_if<(__VA_ARGS__), int>::type
+#define GLZ_FASTFLOAT_ENABLE_IF(...) typename std::enable_if<(__VA_ARGS__), int>::type
 
 
 namespace glz::fast_float {
 
 fastfloat_really_inline constexpr bool cpp20_and_in_constexpr() {
-#if FASTFLOAT_HAS_IS_CONSTANT_EVALUATED
+#if GLZ_FASTFLOAT_HAS_IS_CONSTANT_EVALUATED
   return std::is_constant_evaluated();
 #else
   return false;
@@ -348,7 +348,7 @@ fastfloat_really_inline constexpr bool is_supported_char_type() {
 
 // Compares two ASCII strings in a case insensitive manner.
 template <typename UC>
-inline FASTFLOAT_CONSTEXPR14 bool
+inline GLZ_FASTFLOAT_CONSTEXPR14 bool
 fastfloat_strncasecmp(UC const * input1, UC const * input2, size_t length) {
   char running_diff{0};
   for (size_t i = 0; i < length; ++i) {
@@ -373,8 +373,8 @@ struct span {
     return length;
   }
 
-  FASTFLOAT_CONSTEXPR14 const T& operator[](size_t index) const noexcept {
-    FASTFLOAT_DEBUG_ASSERT(index < length);
+  GLZ_FASTFLOAT_CONSTEXPR14 const T& operator[](size_t index) const noexcept {
+    GLZ_FASTFLOAT_DEBUG_ASSERT(index < length);
     return ptr[index];
   }
 };
@@ -387,7 +387,7 @@ struct value128 {
 };
 
 /* Helper C++14 constexpr generic implementation of leading_zeroes */
-fastfloat_really_inline FASTFLOAT_CONSTEXPR14
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR14
 int leading_zeroes_generic(uint64_t input_num, int last_bit = 0) {
     if(input_num & uint64_t(0xffffffff00000000)) { input_num >>= 32; last_bit |= 32; }
     if(input_num & uint64_t(        0xffff0000)) { input_num >>= 16; last_bit |= 16; }
@@ -399,13 +399,13 @@ int leading_zeroes_generic(uint64_t input_num, int last_bit = 0) {
 }
 
 /* result might be undefined when input_num is zero */
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 int leading_zeroes(uint64_t input_num) {
   assert(input_num > 0);
   if (cpp20_and_in_constexpr()) {
     return leading_zeroes_generic(input_num);
   }
-#ifdef FASTFLOAT_VISUAL_STUDIO
+#ifdef GLZ_FASTFLOAT_VISUAL_STUDIO
   #if defined(_M_X64) || defined(_M_ARM64)
   unsigned long leading_zero = 0;
   // Search the mask data from most significant bit (MSB)
@@ -425,7 +425,7 @@ fastfloat_really_inline constexpr uint64_t emulu(uint32_t x, uint32_t y) {
     return x * (uint64_t)y;
 }
 
-fastfloat_really_inline FASTFLOAT_CONSTEXPR14
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR14
 uint64_t umul128_generic(uint64_t ab, uint64_t cd, uint64_t *hi) {
   uint64_t ad = emulu((uint32_t)(ab >> 32), (uint32_t)cd);
   uint64_t bd = emulu((uint32_t)ab, (uint32_t)cd);
@@ -437,21 +437,21 @@ uint64_t umul128_generic(uint64_t ab, uint64_t cd, uint64_t *hi) {
   return lo;
 }
 
-#ifdef FASTFLOAT_32BIT
+#ifdef GLZ_FASTFLOAT_32BIT
 
 // slow emulation routine for 32-bit
 #if !defined(__MINGW64__)
-fastfloat_really_inline FASTFLOAT_CONSTEXPR14
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR14
 uint64_t _umul128(uint64_t ab, uint64_t cd, uint64_t *hi) {
   return umul128_generic(ab, cd, hi);
 }
 #endif // !__MINGW64__
 
-#endif // FASTFLOAT_32BIT
+#endif // GLZ_FASTFLOAT_32BIT
 
 
 // compute 64-bit a*b
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 value128 full_multiplication(uint64_t a, uint64_t b) {
   if (cpp20_and_in_constexpr()) {
     value128 answer;
@@ -464,9 +464,9 @@ value128 full_multiplication(uint64_t a, uint64_t b) {
   // But MinGW on ARM64 doesn't have native support for 64-bit multiplications
   answer.high = __umulh(a, b);
   answer.low = a * b;
-#elif defined(FASTFLOAT_32BIT) || (defined(_WIN64) && !defined(__clang__))
+#elif defined(GLZ_FASTFLOAT_32BIT) || (defined(_WIN64) && !defined(__clang__))
   answer.low = _umul128(a, b, &answer.high); // _umul128 not available on ARM64
-#elif defined(FASTFLOAT_64BIT) && defined(__SIZEOF_INT128__)
+#elif defined(GLZ_FASTFLOAT_64BIT) && defined(__SIZEOF_INT128__)
   __uint128_t r = ((__uint128_t)a) * b;
   answer.low = uint64_t(r);
   answer.high = uint64_t(r >> 64);
@@ -737,20 +737,20 @@ template <> inline constexpr binary_format<double>::equiv_uint
 }
 
 template<typename T>
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 void to_float(bool negative, adjusted_mantissa am, T &value) {
   using fastfloat_uint = typename binary_format<T>::equiv_uint;
   fastfloat_uint word = (fastfloat_uint)am.mantissa;
   word |= fastfloat_uint(am.power2) << binary_format<T>::mantissa_explicit_bits();
   word |= fastfloat_uint(negative) << binary_format<T>::sign_index();
-#if FASTFLOAT_HAS_BIT_CAST
+#if GLZ_FASTFLOAT_HAS_BIT_CAST
   value = std::bit_cast<T>(word);
 #else
   ::memcpy(&value, &word, sizeof(T));
 #endif
 }
 
-#ifdef FASTFLOAT_SKIP_WHITE_SPACE // disabled by default
+#ifdef GLZ_FASTFLOAT_SKIP_WHITE_SPACE // disabled by default
 template <typename = void>
 struct space_lut {
   static constexpr bool value[] = {
@@ -902,8 +902,8 @@ constexpr uint64_t min_safe_u64(int base) { return int_luts<>::min_safe_u64[base
 #endif
 
 
-#ifndef FASTFLOAT_FAST_FLOAT_H
-#define FASTFLOAT_FAST_FLOAT_H
+#ifndef GLZ_FASTFLOAT_FAST_FLOAT_H
+#define GLZ_FASTFLOAT_FAST_FLOAT_H
 
 
 namespace glz::fast_float {
@@ -926,8 +926,8 @@ namespace glz::fast_float {
  * to determine whether we allow the fixed point and scientific notation respectively.
  * The default is  `fast_float::chars_format::general` which allows both `fixed` and `scientific`.
  */
-template<typename T, typename UC = char, typename = FASTFLOAT_ENABLE_IF(is_supported_float_type<T>())>
-FASTFLOAT_CONSTEXPR20
+template<typename T, typename UC = char, typename = GLZ_FASTFLOAT_ENABLE_IF(is_supported_float_type<T>())>
+GLZ_FASTFLOAT_CONSTEXPR20
 from_chars_result_t<UC> from_chars(UC const * first, UC const * last,
                              T &value, chars_format fmt = chars_format::general)  noexcept;
 
@@ -935,21 +935,21 @@ from_chars_result_t<UC> from_chars(UC const * first, UC const * last,
  * Like from_chars, but accepts an `options` argument to govern number parsing.
  */
 template<typename T, typename UC = char>
-FASTFLOAT_CONSTEXPR20
+GLZ_FASTFLOAT_CONSTEXPR20
 from_chars_result_t<UC> from_chars_advanced(UC const * first, UC const * last,
                                       T &value, parse_options_t<UC> options)  noexcept;
 /**
 * from_chars for integer types.
 */
-template <typename T, typename UC = char, typename = FASTFLOAT_ENABLE_IF(!is_supported_float_type<T>())>
-FASTFLOAT_CONSTEXPR20
+template <typename T, typename UC = char, typename = GLZ_FASTFLOAT_ENABLE_IF(!is_supported_float_type<T>())>
+GLZ_FASTFLOAT_CONSTEXPR20
 from_chars_result_t<UC> from_chars(UC const * first, UC const * last, T& value, int base = 10) noexcept;
 
 } // namespace glz::fast_float
-#endif // FASTFLOAT_FAST_FLOAT_H
+#endif // GLZ_FASTFLOAT_FAST_FLOAT_H
 
-#ifndef FASTFLOAT_ASCII_NUMBER_H
-#define FASTFLOAT_ASCII_NUMBER_H
+#ifndef GLZ_FASTFLOAT_ASCII_NUMBER_H
+#define GLZ_FASTFLOAT_ASCII_NUMBER_H
 
 #include <cctype>
 #include <cstdint>
@@ -959,11 +959,11 @@ from_chars_result_t<UC> from_chars(UC const * first, UC const * last, T& value, 
 #include <type_traits>
 
 
-#ifdef FASTFLOAT_SSE2
+#ifdef GLZ_FASTFLOAT_SSE2
 #include <emmintrin.h>
 #endif
 
-#ifdef FASTFLOAT_NEON
+#ifdef GLZ_FASTFLOAT_NEON
 #include <arm_neon.h>
 #endif
 
@@ -971,7 +971,7 @@ namespace glz::fast_float {
 
 template <typename UC>
 fastfloat_really_inline constexpr bool has_simd_opt() {
-#ifdef FASTFLOAT_HAS_SIMD
+#ifdef GLZ_FASTFLOAT_HAS_SIMD
   return std::is_same<UC, char16_t>::value;
 #else
   return false;
@@ -998,7 +998,7 @@ fastfloat_really_inline constexpr uint64_t byteswap(uint64_t val) {
 
 // Read 8 UC into a u64. Truncates UC if not char.
 template <typename UC>
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 uint64_t read8_to_u64(const UC *chars) {
   if (cpp20_and_in_constexpr() || !std::is_same<UC, char>::value) {
     uint64_t val = 0;
@@ -1010,20 +1010,20 @@ uint64_t read8_to_u64(const UC *chars) {
   }
   uint64_t val;
   ::memcpy(&val, chars, sizeof(uint64_t));
-#if FASTFLOAT_IS_BIG_ENDIAN == 1
+#if GLZ_FASTFLOAT_IS_BIG_ENDIAN == 1
   // Need to read as-if the number was in little-endian order.
   val = byteswap(val);
 #endif
   return val;
 }
 
-#ifdef FASTFLOAT_SSE2
+#ifdef GLZ_FASTFLOAT_SSE2
 
 fastfloat_really_inline
 uint64_t simd_read8_to_u64(const __m128i data) {
-FASTFLOAT_SIMD_DISABLE_WARNINGS
+GLZ_FASTFLOAT_SIMD_DISABLE_WARNINGS
   const __m128i packed = _mm_packus_epi16(data, data);
-#ifdef FASTFLOAT_64BIT
+#ifdef GLZ_FASTFLOAT_64BIT
   return uint64_t(_mm_cvtsi128_si64(packed));
 #else
   uint64_t value;
@@ -1031,41 +1031,41 @@ FASTFLOAT_SIMD_DISABLE_WARNINGS
   _mm_storel_epi64(reinterpret_cast<__m128i*>(&value), packed);
   return value;
 #endif
-FASTFLOAT_SIMD_RESTORE_WARNINGS
+GLZ_FASTFLOAT_SIMD_RESTORE_WARNINGS
 }
 
 fastfloat_really_inline
 uint64_t simd_read8_to_u64(const char16_t* chars) {
-FASTFLOAT_SIMD_DISABLE_WARNINGS
+GLZ_FASTFLOAT_SIMD_DISABLE_WARNINGS
   return simd_read8_to_u64(_mm_loadu_si128(reinterpret_cast<const __m128i*>(chars)));
-FASTFLOAT_SIMD_RESTORE_WARNINGS
+GLZ_FASTFLOAT_SIMD_RESTORE_WARNINGS
 }
 
-#elif defined(FASTFLOAT_NEON)
+#elif defined(GLZ_FASTFLOAT_NEON)
 
 
 fastfloat_really_inline
 uint64_t simd_read8_to_u64(const uint16x8_t data) {
-FASTFLOAT_SIMD_DISABLE_WARNINGS
+GLZ_FASTFLOAT_SIMD_DISABLE_WARNINGS
   uint8x8_t utf8_packed = vmovn_u16(data);
   return vget_lane_u64(vreinterpret_u64_u8(utf8_packed), 0);
-FASTFLOAT_SIMD_RESTORE_WARNINGS
+GLZ_FASTFLOAT_SIMD_RESTORE_WARNINGS
 }
 
 fastfloat_really_inline
 uint64_t simd_read8_to_u64(const char16_t* chars) {
-FASTFLOAT_SIMD_DISABLE_WARNINGS
+GLZ_FASTFLOAT_SIMD_DISABLE_WARNINGS
   return simd_read8_to_u64(vld1q_u16(reinterpret_cast<const uint16_t*>(chars)));
-FASTFLOAT_SIMD_RESTORE_WARNINGS
+GLZ_FASTFLOAT_SIMD_RESTORE_WARNINGS
 }
 
-#endif // FASTFLOAT_SSE2
+#endif // GLZ_FASTFLOAT_SSE2
 
 // MSVC SFINAE is broken pre-VS2017
 #if defined(_MSC_VER) && _MSC_VER <= 1900
 template <typename UC>
 #else
-template <typename UC, FASTFLOAT_ENABLE_IF(!has_simd_opt<UC>()) = 0>
+template <typename UC, GLZ_FASTFLOAT_ENABLE_IF(!has_simd_opt<UC>()) = 0>
 #endif
 // dummy for compile
 uint64_t simd_read8_to_u64(UC const*) {
@@ -1073,7 +1073,7 @@ uint64_t simd_read8_to_u64(UC const*) {
 }
 
 // credit  @aqrit
-fastfloat_really_inline FASTFLOAT_CONSTEXPR14
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR14
 uint32_t parse_eight_digits_unrolled(uint64_t val) {
   const uint64_t mask = 0x000000FF000000FF;
   const uint64_t mul1 = 0x000F424000000064; // 100 + (1000000ULL << 32)
@@ -1087,7 +1087,7 @@ uint32_t parse_eight_digits_unrolled(uint64_t val) {
 
 // Call this if chars are definitely 8 digits.
 template <typename UC>
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 uint32_t parse_eight_digits_unrolled(UC const * chars)  noexcept {
   if (cpp20_and_in_constexpr() || !has_simd_opt<UC>()) {
     return parse_eight_digits_unrolled(read8_to_u64(chars)); // truncation okay
@@ -1103,18 +1103,18 @@ fastfloat_really_inline constexpr bool is_made_of_eight_digits_fast(uint64_t val
 }
 
 
-#ifdef FASTFLOAT_HAS_SIMD
+#ifdef GLZ_FASTFLOAT_HAS_SIMD
 
 // Call this if chars might not be 8 digits.
 // Using this style (instead of is_made_of_eight_digits_fast() then parse_eight_digits_unrolled())
 // ensures we don't load SIMD registers twice.
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 bool simd_parse_if_eight_digits_unrolled(const char16_t* chars, uint64_t& i) noexcept {
   if (cpp20_and_in_constexpr()) {
     return false;
   }
-#ifdef FASTFLOAT_SSE2
-FASTFLOAT_SIMD_DISABLE_WARNINGS
+#ifdef GLZ_FASTFLOAT_SSE2
+GLZ_FASTFLOAT_SIMD_DISABLE_WARNINGS
   const __m128i data = _mm_loadu_si128(reinterpret_cast<const __m128i*>(chars));
 
   // (x - '0') <= 9
@@ -1127,9 +1127,9 @@ FASTFLOAT_SIMD_DISABLE_WARNINGS
     return true;
   }
   else return false;
-FASTFLOAT_SIMD_RESTORE_WARNINGS
-#elif defined(FASTFLOAT_NEON)
-FASTFLOAT_SIMD_DISABLE_WARNINGS
+GLZ_FASTFLOAT_SIMD_RESTORE_WARNINGS
+#elif defined(GLZ_FASTFLOAT_NEON)
+GLZ_FASTFLOAT_SIMD_DISABLE_WARNINGS
   const uint16x8_t data = vld1q_u16(reinterpret_cast<const uint16_t*>(chars));
   
   // (x - '0') <= 9
@@ -1142,20 +1142,20 @@ FASTFLOAT_SIMD_DISABLE_WARNINGS
     return true;
   }
   else return false;
-FASTFLOAT_SIMD_RESTORE_WARNINGS
+GLZ_FASTFLOAT_SIMD_RESTORE_WARNINGS
 #else
   (void)chars; (void)i;
   return false;
-#endif // FASTFLOAT_SSE2
+#endif // GLZ_FASTFLOAT_SSE2
 }
 
-#endif // FASTFLOAT_HAS_SIMD
+#endif // GLZ_FASTFLOAT_HAS_SIMD
 
 // MSVC SFINAE is broken pre-VS2017
 #if defined(_MSC_VER) && _MSC_VER <= 1900
 template <typename UC>
 #else
-template <typename UC, FASTFLOAT_ENABLE_IF(!has_simd_opt<UC>()) = 0>
+template <typename UC, GLZ_FASTFLOAT_ENABLE_IF(!has_simd_opt<UC>()) = 0>
 #endif
 // dummy for compile
 bool simd_parse_if_eight_digits_unrolled(UC const*, uint64_t&) {
@@ -1163,8 +1163,8 @@ bool simd_parse_if_eight_digits_unrolled(UC const*, uint64_t&) {
 }
 
 
-template <typename UC, FASTFLOAT_ENABLE_IF(!std::is_same<UC, char>::value) = 0>
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+template <typename UC, GLZ_FASTFLOAT_ENABLE_IF(!std::is_same<UC, char>::value) = 0>
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 void loop_parse_if_eight_digits(const UC*& p, const UC* const pend, uint64_t& i) {
   if (!has_simd_opt<UC>()) {
     return;
@@ -1174,7 +1174,7 @@ void loop_parse_if_eight_digits(const UC*& p, const UC* const pend, uint64_t& i)
   }
 }
 
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 void loop_parse_if_eight_digits(const char*& p, const char* const pend, uint64_t& i) {
   // optimizes better than parse_if_eight_digits_unrolled() for UC = char.
   while ((std::distance(p, pend) >= 8) && is_made_of_eight_digits_fast(read8_to_u64(p))) {
@@ -1202,7 +1202,7 @@ using parsed_number_string = parsed_number_string_t<char>;
 // Assuming that you use no more than 19 digits, this will
 // parse an ASCII string.
 template <typename UC>
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, parse_options_t<UC> options) noexcept {
   chars_format const fmt = options.format;
   UC const decimal_point = options.decimal_point;
@@ -1211,8 +1211,8 @@ parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, par
   answer.valid = false;
   answer.too_many_digits = false;
   answer.negative = (*p == UC('-'));
-#ifdef FASTFLOAT_ALLOWS_LEADING_PLUS // disabled by default
-  if ((*p == UC('-')) || (!(fmt & FASTFLOAT_JSONFMT) && *p == UC('+'))) {
+#ifdef GLZ_FASTFLOAT_ALLOWS_LEADING_PLUS // disabled by default
+  if ((*p == UC('-')) || (!(fmt & GLZ_FASTFLOAT_JSONFMT) && *p == UC('+'))) {
 #else
   if (*p == UC('-')) { // C++17 20.19.3.(7.1) explicitly forbids '+' sign here
 #endif
@@ -1220,7 +1220,7 @@ parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, par
     if (p == pend) {
       return answer;
     }
-    if (fmt & FASTFLOAT_JSONFMT) {
+    if (fmt & GLZ_FASTFLOAT_JSONFMT) {
       if (!is_integer(*p)) { // a sign must be followed by an integer
         return answer;
       }
@@ -1244,7 +1244,7 @@ parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, par
   UC const * const end_of_integer_part = p;
   int64_t digit_count = int64_t(end_of_integer_part - start_digits);
   answer.integer = span<const UC>(start_digits, size_t(digit_count));
-  if (fmt & FASTFLOAT_JSONFMT) {
+  if (fmt & GLZ_FASTFLOAT_JSONFMT) {
     // at least 1 digit in integer part, without leading zeros
     if (digit_count == 0 || (start_digits[0] == UC('0') && digit_count > 1)) {
       return answer;
@@ -1269,7 +1269,7 @@ parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, par
     answer.fraction = span<const UC>(before, size_t(p - before));
     digit_count -= exponent;
   }
-  if (fmt & FASTFLOAT_JSONFMT) {
+  if (fmt & GLZ_FASTFLOAT_JSONFMT) {
     // at least 1 digit in fractional part
     if (has_decimal_point && exponent == 0) {
       return answer;
@@ -1283,7 +1283,7 @@ parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, par
         (p != pend) &&
         ((UC('e') == *p) || (UC('E') == *p)))
        ||
-       ((fmt & FASTFLOAT_FORTRANFMT) &&
+       ((fmt & GLZ_FASTFLOAT_FORTRANFMT) &&
         (p != pend) &&
         ((UC('+') == *p) || (UC('-') == *p) || (UC('d') == *p) || (UC('D') == *p)))) {
     UC const * location_of_e = p;
@@ -1372,7 +1372,7 @@ parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, par
 }
 
 template <typename T, typename UC>
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 from_chars_result_t<UC> parse_int_string(UC const* p, UC const* pend, T& value, int base) {
   from_chars_result_t<UC> answer;
   
@@ -1384,7 +1384,7 @@ from_chars_result_t<UC> parse_int_string(UC const* p, UC const* pend, T& value, 
     answer.ptr = first;
     return answer;
   }
-#ifdef FASTFLOAT_ALLOWS_LEADING_PLUS // disabled by default
+#ifdef GLZ_FASTFLOAT_ALLOWS_LEADING_PLUS // disabled by default
   if ((*p == UC('-')) || (*p == UC('+'))) {
 #else
   if (*p == UC('-')) {
@@ -1453,7 +1453,7 @@ from_chars_result_t<UC> parse_int_string(UC const* p, UC const* pend, T& value, 
   }
 
   if (negative) {
-#ifdef FASTFLOAT_VISUAL_STUDIO
+#ifdef GLZ_FASTFLOAT_VISUAL_STUDIO
 #pragma warning(push)
 #pragma warning(disable: 4146)
 #endif
@@ -1462,7 +1462,7 @@ from_chars_result_t<UC> parse_int_string(UC const* p, UC const* pend, T& value, 
     // - reinterpret_casting (~i + 1) would work, but it is not constexpr
     // this is always optimized into a neg instruction (note: T is an integer type)
     value = T(-std::numeric_limits<T>::max() - T(i - uint64_t(std::numeric_limits<T>::max())));
-#ifdef FASTFLOAT_VISUAL_STUDIO
+#ifdef GLZ_FASTFLOAT_VISUAL_STUDIO
 #pragma warning(pop)
 #endif
   }
@@ -1476,8 +1476,8 @@ from_chars_result_t<UC> parse_int_string(UC const* p, UC const* pend, T& value, 
 
 #endif
 
-#ifndef FASTFLOAT_FAST_TABLE_H
-#define FASTFLOAT_FAST_TABLE_H
+#ifndef GLZ_FASTFLOAT_FAST_TABLE_H
+#define GLZ_FASTFLOAT_FAST_TABLE_H
 
 #include <cstdint>
 
@@ -2177,8 +2177,8 @@ using powers = powers_template<>;
 
 #endif
 
-#ifndef FASTFLOAT_DECIMAL_TO_BINARY_H
-#define FASTFLOAT_DECIMAL_TO_BINARY_H
+#ifndef GLZ_FASTFLOAT_DECIMAL_TO_BINARY_H
+#define GLZ_FASTFLOAT_DECIMAL_TO_BINARY_H
 
 #include <cfloat>
 #include <cinttypes>
@@ -2194,7 +2194,7 @@ namespace glz::fast_float {
 // low part corresponding to the least significant bits.
 //
 template <int bit_precision>
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 value128 compute_product_approximation(int64_t q, uint64_t w) {
   const int index = 2 * int(q - powers::smallest_power_of_five);
   // For small values of q, e.g., q in [0,27], the answer is always exact because
@@ -2240,7 +2240,7 @@ namespace detail {
 // create an adjusted mantissa, biased by the invalid power2
 // for significant digits already multiplied by 10 ** q.
 template <typename binary>
-fastfloat_really_inline FASTFLOAT_CONSTEXPR14
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR14
 adjusted_mantissa compute_error_scaled(int64_t q, uint64_t w, int lz) noexcept  {
   int hilz = int(w >> 63) ^ 1;
   adjusted_mantissa answer;
@@ -2253,7 +2253,7 @@ adjusted_mantissa compute_error_scaled(int64_t q, uint64_t w, int lz) noexcept  
 // w * 10 ** q, without rounding the representation up.
 // the power2 in the exponent will be adjusted by invalid_am_bias.
 template <typename binary>
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 adjusted_mantissa compute_error(int64_t q, uint64_t w)  noexcept  {
   int lz = leading_zeroes(w);
   w <<= lz;
@@ -2267,7 +2267,7 @@ adjusted_mantissa compute_error(int64_t q, uint64_t w)  noexcept  {
 // return an adjusted_mantissa with a negative power of 2: the caller should recompute
 // in such cases.
 template <typename binary>
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 adjusted_mantissa compute_float(int64_t q, uint64_t w)  noexcept  {
   adjusted_mantissa answer;
   if ((w == 0) || (q < binary::smallest_power_of_ten())) {
@@ -2366,8 +2366,8 @@ adjusted_mantissa compute_float(int64_t q, uint64_t w)  noexcept  {
 
 #endif
 
-#ifndef FASTFLOAT_BIGINT_H
-#define FASTFLOAT_BIGINT_H
+#ifndef GLZ_FASTFLOAT_BIGINT_H
+#define GLZ_FASTFLOAT_BIGINT_H
 
 #include <algorithm>
 #include <cstdint>
@@ -2383,12 +2383,12 @@ namespace glz::fast_float {
 // architecture except for sparc, which emulates 128-bit multiplication.
 // we might have platforms where `CHAR_BIT` is not 8, so let's avoid
 // doing `8 * sizeof(limb)`.
-#if defined(FASTFLOAT_64BIT) && !defined(__sparc)
-#define FASTFLOAT_64BIT_LIMB 1
+#if defined(GLZ_FASTFLOAT_64BIT) && !defined(__sparc)
+#define GLZ_FASTFLOAT_64BIT_LIMB 1
 typedef uint64_t limb;
 constexpr size_t limb_bits = 64;
 #else
-#define FASTFLOAT_32BIT_LIMB
+#define GLZ_FASTFLOAT_32BIT_LIMB
 typedef uint32_t limb;
 constexpr size_t limb_bits = 32;
 #endif
@@ -2417,27 +2417,27 @@ struct stackvec {
   stackvec &operator=(stackvec &&other) = delete;
 
   // create stack vector from existing limb span.
-  FASTFLOAT_CONSTEXPR20 stackvec(limb_span s) {
-    FASTFLOAT_ASSERT(try_extend(s));
+  GLZ_FASTFLOAT_CONSTEXPR20 stackvec(limb_span s) {
+    GLZ_FASTFLOAT_ASSERT(try_extend(s));
   }
 
-  FASTFLOAT_CONSTEXPR14 limb& operator[](size_t index) noexcept {
-    FASTFLOAT_DEBUG_ASSERT(index < length);
+  GLZ_FASTFLOAT_CONSTEXPR14 limb& operator[](size_t index) noexcept {
+    GLZ_FASTFLOAT_DEBUG_ASSERT(index < length);
     return data[index];
   }
-  FASTFLOAT_CONSTEXPR14 const limb& operator[](size_t index) const noexcept {
-    FASTFLOAT_DEBUG_ASSERT(index < length);
+  GLZ_FASTFLOAT_CONSTEXPR14 const limb& operator[](size_t index) const noexcept {
+    GLZ_FASTFLOAT_DEBUG_ASSERT(index < length);
     return data[index];
   }
   // index from the end of the container
-  FASTFLOAT_CONSTEXPR14 const limb& rindex(size_t index) const noexcept {
-    FASTFLOAT_DEBUG_ASSERT(index < length);
+  GLZ_FASTFLOAT_CONSTEXPR14 const limb& rindex(size_t index) const noexcept {
+    GLZ_FASTFLOAT_DEBUG_ASSERT(index < length);
     size_t rindex = length - index - 1;
     return data[rindex];
   }
 
   // set the length, without bounds checking.
-  FASTFLOAT_CONSTEXPR14 void set_len(size_t len) noexcept {
+  GLZ_FASTFLOAT_CONSTEXPR14 void set_len(size_t len) noexcept {
     length = uint16_t(len);
   }
   constexpr size_t len() const noexcept {
@@ -2450,12 +2450,12 @@ struct stackvec {
     return size;
   }
   // append item to vector, without bounds checking
-  FASTFLOAT_CONSTEXPR14 void push_unchecked(limb value) noexcept {
+  GLZ_FASTFLOAT_CONSTEXPR14 void push_unchecked(limb value) noexcept {
     data[length] = value;
     length++;
   }
   // append item to vector, returning if item was added
-  FASTFLOAT_CONSTEXPR14 bool try_push(limb value) noexcept {
+  GLZ_FASTFLOAT_CONSTEXPR14 bool try_push(limb value) noexcept {
     if (len() < capacity()) {
       push_unchecked(value);
       return true;
@@ -2464,13 +2464,13 @@ struct stackvec {
     }
   }
   // add items to the vector, from a span, without bounds checking
-  FASTFLOAT_CONSTEXPR20 void extend_unchecked(limb_span s) noexcept {
+  GLZ_FASTFLOAT_CONSTEXPR20 void extend_unchecked(limb_span s) noexcept {
     limb* ptr = data + length;
     std::copy_n(s.ptr, s.len(), ptr);
     set_len(len() + s.len());
   }
   // try to add items to the vector, returning if items were added
-  FASTFLOAT_CONSTEXPR20 bool try_extend(limb_span s) noexcept {
+  GLZ_FASTFLOAT_CONSTEXPR20 bool try_extend(limb_span s) noexcept {
     if (len() + s.len() <= capacity()) {
       extend_unchecked(s);
       return true;
@@ -2481,7 +2481,7 @@ struct stackvec {
   // resize the vector, without bounds checking
   // if the new size is longer than the vector, assign value to each
   // appended item.
-  FASTFLOAT_CONSTEXPR20
+  GLZ_FASTFLOAT_CONSTEXPR20
   void resize_unchecked(size_t new_len, limb value) noexcept {
     if (new_len > len()) {
       size_t count = new_len - len();
@@ -2494,7 +2494,7 @@ struct stackvec {
     }
   }
   // try to resize the vector, returning if the vector was resized.
-  FASTFLOAT_CONSTEXPR20 bool try_resize(size_t new_len, limb value) noexcept {
+  GLZ_FASTFLOAT_CONSTEXPR20 bool try_resize(size_t new_len, limb value) noexcept {
     if (new_len > capacity()) {
       return false;
     } else {
@@ -2505,7 +2505,7 @@ struct stackvec {
   // check if any limbs are non-zero after the given index.
   // this needs to be done in reverse order, since the index
   // is relative to the most significant limbs.
-  FASTFLOAT_CONSTEXPR14 bool nonzero(size_t index) const noexcept {
+  GLZ_FASTFLOAT_CONSTEXPR14 bool nonzero(size_t index) const noexcept {
     while (index < len()) {
       if (rindex(index) != 0) {
         return true;
@@ -2515,27 +2515,27 @@ struct stackvec {
     return false;
   }
   // normalize the big integer, so most-significant zero limbs are removed.
-  FASTFLOAT_CONSTEXPR14 void normalize() noexcept {
+  GLZ_FASTFLOAT_CONSTEXPR14 void normalize() noexcept {
     while (len() > 0 && rindex(0) == 0) {
       length--;
     }
   }
 };
 
-fastfloat_really_inline FASTFLOAT_CONSTEXPR14
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR14
 uint64_t empty_hi64(bool& truncated) noexcept {
   truncated = false;
   return 0;
 }
 
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 uint64_t uint64_hi64(uint64_t r0, bool& truncated) noexcept {
   truncated = false;
   int shl = leading_zeroes(r0);
   return r0 << shl;
 }
 
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 uint64_t uint64_hi64(uint64_t r0, uint64_t r1, bool& truncated) noexcept {
   int shl = leading_zeroes(r0);
   if (shl == 0) {
@@ -2548,19 +2548,19 @@ uint64_t uint64_hi64(uint64_t r0, uint64_t r1, bool& truncated) noexcept {
   }
 }
 
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 uint64_t uint32_hi64(uint32_t r0, bool& truncated) noexcept {
   return uint64_hi64(r0, truncated);
 }
 
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 uint64_t uint32_hi64(uint32_t r0, uint32_t r1, bool& truncated) noexcept {
   uint64_t x0 = r0;
   uint64_t x1 = r1;
   return uint64_hi64((x0 << 32) | x1, truncated);
 }
 
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 uint64_t uint32_hi64(uint32_t r0, uint32_t r1, uint32_t r2, bool& truncated) noexcept {
   uint64_t x0 = r0;
   uint64_t x1 = r1;
@@ -2572,7 +2572,7 @@ uint64_t uint32_hi64(uint32_t r0, uint32_t r1, uint32_t r2, bool& truncated) noe
 // we want an efficient operation. for msvc, where
 // we don't have built-in intrinsics, this is still
 // pretty fast.
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 limb scalar_add(limb x, limb y, bool& overflow) noexcept {
   limb z;
 // gcc and clang
@@ -2592,9 +2592,9 @@ limb scalar_add(limb x, limb y, bool& overflow) noexcept {
 }
 
 // multiply two small integers, getting both the high and low bits.
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 limb scalar_mul(limb x, limb y, limb& carry) noexcept {
-#ifdef FASTFLOAT_64BIT_LIMB
+#ifdef GLZ_FASTFLOAT_64BIT_LIMB
   #if defined(__SIZEOF_INT128__)
   // GCC and clang both define it as an extension.
   __uint128_t z = __uint128_t(x) * __uint128_t(y) + __uint128_t(carry);
@@ -2620,7 +2620,7 @@ limb scalar_mul(limb x, limb y, limb& carry) noexcept {
 // add scalar value to bigint starting from offset.
 // used in grade school multiplication
 template <uint16_t size>
-inline FASTFLOAT_CONSTEXPR20
+inline GLZ_FASTFLOAT_CONSTEXPR20
 bool small_add_from(stackvec<size>& vec, limb y, size_t start) noexcept {
   size_t index = start;
   limb carry = y;
@@ -2631,28 +2631,28 @@ bool small_add_from(stackvec<size>& vec, limb y, size_t start) noexcept {
     index += 1;
   }
   if (carry != 0) {
-    FASTFLOAT_TRY(vec.try_push(carry));
+    GLZ_FASTFLOAT_TRY(vec.try_push(carry));
   }
   return true;
 }
 
 // add scalar value to bigint.
 template <uint16_t size>
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 bool small_add(stackvec<size>& vec, limb y) noexcept {
   return small_add_from(vec, y, 0);
 }
 
 // multiply bigint by scalar value.
 template <uint16_t size>
-inline FASTFLOAT_CONSTEXPR20
+inline GLZ_FASTFLOAT_CONSTEXPR20
 bool small_mul(stackvec<size>& vec, limb y) noexcept {
   limb carry = 0;
   for (size_t index = 0; index < vec.len(); index++) {
     vec[index] = scalar_mul(vec[index], y, carry);
   }
   if (carry != 0) {
-    FASTFLOAT_TRY(vec.try_push(carry));
+    GLZ_FASTFLOAT_TRY(vec.try_push(carry));
   }
   return true;
 }
@@ -2660,12 +2660,12 @@ bool small_mul(stackvec<size>& vec, limb y) noexcept {
 // add bigint to bigint starting from index.
 // used in grade school multiplication
 template <uint16_t size>
-FASTFLOAT_CONSTEXPR20
+GLZ_FASTFLOAT_CONSTEXPR20
 bool large_add_from(stackvec<size>& x, limb_span y, size_t start) noexcept {
   // the effective x buffer is from `xstart..x.len()`, so exit early
   // if we can't get that current range.
   if (x.len() < start || y.len() > x.len() - start) {
-      FASTFLOAT_TRY(x.try_resize(y.len() + start, 0));
+      GLZ_FASTFLOAT_TRY(x.try_resize(y.len() + start, 0));
   }
 
   bool carry = false;
@@ -2684,21 +2684,21 @@ bool large_add_from(stackvec<size>& x, limb_span y, size_t start) noexcept {
 
   // handle overflow
   if (carry) {
-    FASTFLOAT_TRY(small_add_from(x, 1, y.len() + start));
+    GLZ_FASTFLOAT_TRY(small_add_from(x, 1, y.len() + start));
   }
   return true;
 }
 
 // add bigint to bigint.
 template <uint16_t size>
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 bool large_add_from(stackvec<size>& x, limb_span y) noexcept {
   return large_add_from(x, y, 0);
 }
 
 // grade-school multiplication algorithm
 template <uint16_t size>
-FASTFLOAT_CONSTEXPR20
+GLZ_FASTFLOAT_CONSTEXPR20
 bool long_mul(stackvec<size>& x, limb_span y) noexcept {
   limb_span xs = limb_span(x.data, x.len());
   stackvec<size> z(xs);
@@ -2706,17 +2706,17 @@ bool long_mul(stackvec<size>& x, limb_span y) noexcept {
 
   if (y.len() != 0) {
     limb y0 = y[0];
-    FASTFLOAT_TRY(small_mul(x, y0));
+    GLZ_FASTFLOAT_TRY(small_mul(x, y0));
     for (size_t index = 1; index < y.len(); index++) {
       limb yi = y[index];
       stackvec<size> zi;
       if (yi != 0) {
         // re-use the same buffer throughout
         zi.set_len(0);
-        FASTFLOAT_TRY(zi.try_extend(zs));
-        FASTFLOAT_TRY(small_mul(zi, yi));
+        GLZ_FASTFLOAT_TRY(zi.try_extend(zs));
+        GLZ_FASTFLOAT_TRY(small_mul(zi, yi));
         limb_span zis = limb_span(zi.data, zi.len());
-        FASTFLOAT_TRY(large_add_from(x, zis, index));
+        GLZ_FASTFLOAT_TRY(large_add_from(x, zis, index));
       }
     }
   }
@@ -2727,12 +2727,12 @@ bool long_mul(stackvec<size>& x, limb_span y) noexcept {
 
 // grade-school multiplication algorithm
 template <uint16_t size>
-FASTFLOAT_CONSTEXPR20
+GLZ_FASTFLOAT_CONSTEXPR20
 bool large_mul(stackvec<size>& x, limb_span y) noexcept {
   if (y.len() == 1) {
-    FASTFLOAT_TRY(small_mul(x, y[0]));
+    GLZ_FASTFLOAT_TRY(small_mul(x, y[0]));
   } else {
-    FASTFLOAT_TRY(long_mul(x, y));
+    GLZ_FASTFLOAT_TRY(long_mul(x, y));
   }
   return true;
 }
@@ -2748,7 +2748,7 @@ struct pow5_tables {
     2384185791015625UL, 11920928955078125UL, 59604644775390625UL,
     298023223876953125UL, 1490116119384765625UL, 7450580596923828125UL,
   };
-#ifdef FASTFLOAT_64BIT_LIMB
+#ifdef GLZ_FASTFLOAT_64BIT_LIMB
   constexpr static limb large_power_of_5[] = {
     1414648277510068013UL, 9180637584431281687UL, 4539964771860779200UL,
     10482974169319127550UL, 198276706040285095UL};
@@ -2776,14 +2776,14 @@ struct bigint : pow5_tables<> {
   // storage of the limbs, in little-endian order.
   stackvec<bigint_limbs> vec;
 
-  FASTFLOAT_CONSTEXPR20 bigint(): vec() {}
+  GLZ_FASTFLOAT_CONSTEXPR20 bigint(): vec() {}
   bigint(const bigint &) = delete;
   bigint &operator=(const bigint &) = delete;
   bigint(bigint &&) = delete;
   bigint &operator=(bigint &&other) = delete;
 
-  FASTFLOAT_CONSTEXPR20 bigint(uint64_t value): vec() {
-#ifdef FASTFLOAT_64BIT_LIMB
+  GLZ_FASTFLOAT_CONSTEXPR20 bigint(uint64_t value): vec() {
+#ifdef GLZ_FASTFLOAT_64BIT_LIMB
     vec.push_unchecked(value);
 #else
     vec.push_unchecked(uint32_t(value));
@@ -2794,8 +2794,8 @@ struct bigint : pow5_tables<> {
 
   // get the high 64 bits from the vector, and if bits were truncated.
   // this is to get the significant digits for the float.
-  FASTFLOAT_CONSTEXPR20 uint64_t hi64(bool& truncated) const noexcept {
-#ifdef FASTFLOAT_64BIT_LIMB
+  GLZ_FASTFLOAT_CONSTEXPR20 uint64_t hi64(bool& truncated) const noexcept {
+#ifdef GLZ_FASTFLOAT_64BIT_LIMB
     if (vec.len() == 0) {
       return empty_hi64(truncated);
     } else if (vec.len() == 1) {
@@ -2826,7 +2826,7 @@ struct bigint : pow5_tables<> {
   // positive, this is larger, otherwise they are equal.
   // the limbs are stored in little-endian order, so we
   // must compare the limbs in ever order.
-  FASTFLOAT_CONSTEXPR20 int compare(const bigint& other) const noexcept {
+  GLZ_FASTFLOAT_CONSTEXPR20 int compare(const bigint& other) const noexcept {
     if (vec.len() > other.vec.len()) {
       return 1;
     } else if (vec.len() < other.vec.len()) {
@@ -2847,14 +2847,14 @@ struct bigint : pow5_tables<> {
 
   // shift left each limb n bits, carrying over to the new limb
   // returns true if we were able to shift all the digits.
-  FASTFLOAT_CONSTEXPR20 bool shl_bits(size_t n) noexcept {
+  GLZ_FASTFLOAT_CONSTEXPR20 bool shl_bits(size_t n) noexcept {
     // Internally, for each item, we shift left by n, and add the previous
     // right shifted limb-bits.
     // For example, we transform (for u8) shifted left 2, to:
     //      b10100100 b01000010
     //      b10 b10010001 b00001000
-    FASTFLOAT_DEBUG_ASSERT(n != 0);
-    FASTFLOAT_DEBUG_ASSERT(n < sizeof(limb) * 8);
+    GLZ_FASTFLOAT_DEBUG_ASSERT(n != 0);
+    GLZ_FASTFLOAT_DEBUG_ASSERT(n < sizeof(limb) * 8);
 
     size_t shl = n;
     size_t shr = limb_bits - shl;
@@ -2873,8 +2873,8 @@ struct bigint : pow5_tables<> {
   }
 
   // move the limbs left by `n` limbs.
-  FASTFLOAT_CONSTEXPR20 bool shl_limbs(size_t n) noexcept {
-    FASTFLOAT_DEBUG_ASSERT(n != 0);
+  GLZ_FASTFLOAT_CONSTEXPR20 bool shl_limbs(size_t n) noexcept {
+    GLZ_FASTFLOAT_DEBUG_ASSERT(n != 0);
     if (n + vec.len() > vec.capacity()) {
       return false;
     } else if (!vec.is_empty()) {
@@ -2894,24 +2894,24 @@ struct bigint : pow5_tables<> {
   }
 
   // move the limbs left by `n` bits.
-  FASTFLOAT_CONSTEXPR20 bool shl(size_t n) noexcept {
+  GLZ_FASTFLOAT_CONSTEXPR20 bool shl(size_t n) noexcept {
     size_t rem = n % limb_bits;
     size_t div = n / limb_bits;
     if (rem != 0) {
-      FASTFLOAT_TRY(shl_bits(rem));
+      GLZ_FASTFLOAT_TRY(shl_bits(rem));
     }
     if (div != 0) {
-      FASTFLOAT_TRY(shl_limbs(div));
+      GLZ_FASTFLOAT_TRY(shl_limbs(div));
     }
     return true;
   }
 
   // get the number of leading zeros in the bigint.
-  FASTFLOAT_CONSTEXPR20 int ctlz() const noexcept {
+  GLZ_FASTFLOAT_CONSTEXPR20 int ctlz() const noexcept {
     if (vec.is_empty()) {
       return 0;
     } else {
-#ifdef FASTFLOAT_64BIT_LIMB
+#ifdef GLZ_FASTFLOAT_64BIT_LIMB
       return leading_zeroes(vec.rindex(0));
 #else
       // no use defining a specialized leading_zeroes for a 32-bit type.
@@ -2922,34 +2922,34 @@ struct bigint : pow5_tables<> {
   }
 
   // get the number of bits in the bigint.
-  FASTFLOAT_CONSTEXPR20 int bit_length() const noexcept {
+  GLZ_FASTFLOAT_CONSTEXPR20 int bit_length() const noexcept {
     int lz = ctlz();
     return int(limb_bits * vec.len()) - lz;
   }
 
-  FASTFLOAT_CONSTEXPR20 bool mul(limb y) noexcept {
+  GLZ_FASTFLOAT_CONSTEXPR20 bool mul(limb y) noexcept {
     return small_mul(vec, y);
   }
 
-  FASTFLOAT_CONSTEXPR20 bool add(limb y) noexcept {
+  GLZ_FASTFLOAT_CONSTEXPR20 bool add(limb y) noexcept {
     return small_add(vec, y);
   }
 
   // multiply as if by 2 raised to a power.
-  FASTFLOAT_CONSTEXPR20 bool pow2(uint32_t exp) noexcept {
+  GLZ_FASTFLOAT_CONSTEXPR20 bool pow2(uint32_t exp) noexcept {
     return shl(exp);
   }
 
   // multiply as if by 5 raised to a power.
-  FASTFLOAT_CONSTEXPR20 bool pow5(uint32_t exp) noexcept {
+  GLZ_FASTFLOAT_CONSTEXPR20 bool pow5(uint32_t exp) noexcept {
     // multiply by a power of 5
     size_t large_length = sizeof(large_power_of_5) / sizeof(limb);
     limb_span large = limb_span(large_power_of_5, large_length);
     while (exp >= large_step) {
-      FASTFLOAT_TRY(large_mul(vec, large));
+      GLZ_FASTFLOAT_TRY(large_mul(vec, large));
       exp -= large_step;
     }
-#ifdef FASTFLOAT_64BIT_LIMB
+#ifdef GLZ_FASTFLOAT_64BIT_LIMB
     uint32_t small_step = 27;
     limb max_native = 7450580596923828125UL;
 #else
@@ -2957,14 +2957,14 @@ struct bigint : pow5_tables<> {
     limb max_native = 1220703125U;
 #endif
     while (exp >= small_step) {
-      FASTFLOAT_TRY(small_mul(vec, max_native));
+      GLZ_FASTFLOAT_TRY(small_mul(vec, max_native));
       exp -= small_step;
     }
     if (exp != 0) {
       // Work around clang bug https://godbolt.org/z/zedh7rrhc
       // This is similar to https://github.com/llvm/llvm-project/issues/47746,
       // except the workaround described there don't work here
-      FASTFLOAT_TRY(
+      GLZ_FASTFLOAT_TRY(
         small_mul(vec, limb(((void)small_power_of_5[0], small_power_of_5[exp])))
       );
     }
@@ -2973,8 +2973,8 @@ struct bigint : pow5_tables<> {
   }
 
   // multiply as if by 10 raised to a power.
-  FASTFLOAT_CONSTEXPR20 bool pow10(uint32_t exp) noexcept {
-    FASTFLOAT_TRY(pow5(exp));
+  GLZ_FASTFLOAT_CONSTEXPR20 bool pow10(uint32_t exp) noexcept {
+    GLZ_FASTFLOAT_TRY(pow5(exp));
     return pow2(exp);
   }
 };
@@ -2983,8 +2983,8 @@ struct bigint : pow5_tables<> {
 
 #endif
 
-#ifndef FASTFLOAT_DIGIT_COMPARISON_H
-#define FASTFLOAT_DIGIT_COMPARISON_H
+#ifndef GLZ_FASTFLOAT_DIGIT_COMPARISON_H
+#define GLZ_FASTFLOAT_DIGIT_COMPARISON_H
 
 #include <algorithm>
 #include <cstdint>
@@ -3006,7 +3006,7 @@ constexpr static uint64_t powers_of_ten_uint64[] = {
 // effect on performance: in order to have a faster algorithm, we'd need
 // to slow down performance for faster algorithms, and this is still fast.
 template <typename UC>
-fastfloat_really_inline FASTFLOAT_CONSTEXPR14
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR14
 int32_t scientific_exponent(parsed_number_string_t<UC> & num) noexcept {
   uint64_t mantissa = num.mantissa;
   int32_t exponent = int32_t(num.exponent);
@@ -3027,7 +3027,7 @@ int32_t scientific_exponent(parsed_number_string_t<UC> & num) noexcept {
 
 // this converts a native floating-point number to an extended-precision float.
 template <typename T>
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 adjusted_mantissa to_extended(T value) noexcept {
   using equiv_uint = typename binary_format<T>::equiv_uint;
   constexpr equiv_uint exponent_mask = binary_format<T>::exponent_mask();
@@ -3037,7 +3037,7 @@ adjusted_mantissa to_extended(T value) noexcept {
   adjusted_mantissa am;
   int32_t bias = binary_format<T>::mantissa_explicit_bits() - binary_format<T>::minimum_exponent();
   equiv_uint bits;
-#if FASTFLOAT_HAS_BIT_CAST
+#if GLZ_FASTFLOAT_HAS_BIT_CAST
   bits = std::bit_cast<equiv_uint>(value);
 #else
   ::memcpy(&bits, &value, sizeof(T));
@@ -3060,7 +3060,7 @@ adjusted_mantissa to_extended(T value) noexcept {
 // we are given a native float that represents b, so we need to adjust it
 // halfway between b and b+u.
 template <typename T>
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 adjusted_mantissa to_extended_halfway(T value) noexcept {
   adjusted_mantissa am = to_extended(value);
   am.mantissa <<= 1;
@@ -3071,7 +3071,7 @@ adjusted_mantissa to_extended_halfway(T value) noexcept {
 
 // round an extended-precision float to the nearest machine float.
 template <typename T, typename callback>
-fastfloat_really_inline FASTFLOAT_CONSTEXPR14
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR14
 void round(adjusted_mantissa& am, callback cb) noexcept {
   int32_t mantissa_shift = 64 - binary_format<T>::mantissa_explicit_bits() - 1;
   if (-am.power2 >= mantissa_shift) {
@@ -3101,7 +3101,7 @@ void round(adjusted_mantissa& am, callback cb) noexcept {
 }
 
 template <typename callback>
-fastfloat_really_inline FASTFLOAT_CONSTEXPR14
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR14
 void round_nearest_tie_even(adjusted_mantissa& am, int32_t shift, callback cb) noexcept {
   const uint64_t mask
   = (shift == 64)
@@ -3127,7 +3127,7 @@ void round_nearest_tie_even(adjusted_mantissa& am, int32_t shift, callback cb) n
   am.mantissa += uint64_t(cb(is_odd, is_halfway, is_above));
 }
 
-fastfloat_really_inline FASTFLOAT_CONSTEXPR14
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR14
 void round_down(adjusted_mantissa& am, int32_t shift) noexcept {
   if (shift == 64) {
     am.mantissa = 0;
@@ -3137,7 +3137,7 @@ void round_down(adjusted_mantissa& am, int32_t shift) noexcept {
   am.power2 += shift;
 }
 template <typename UC>
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 void skip_zeros(UC const * & first, UC const * last) noexcept {
   uint64_t val;
   while (!cpp20_and_in_constexpr() && std::distance(first, last) >= int_cmp_len<UC>()) {
@@ -3158,7 +3158,7 @@ void skip_zeros(UC const * & first, UC const * last) noexcept {
 // determine if any non-zero digits were truncated.
 // all characters must be valid digits.
 template <typename UC>
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 bool is_truncated(UC const * first, UC const * last) noexcept {
   // do 8-bit optimizations, can just compare to 8 literal 0s.
   uint64_t val;
@@ -3178,14 +3178,14 @@ bool is_truncated(UC const * first, UC const * last) noexcept {
   return false;
 }
 template <typename UC>
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 bool is_truncated(span<const UC> s) noexcept {
   return is_truncated(s.ptr, s.ptr + s.len());
 }
 
 
 template <typename UC>
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 void parse_eight_digits(const UC*& p, limb& value, size_t& counter, size_t& count) noexcept {
   value = value * 100000000 + parse_eight_digits_unrolled(p);
   p += 8;
@@ -3194,7 +3194,7 @@ void parse_eight_digits(const UC*& p, limb& value, size_t& counter, size_t& coun
 }
 
 template <typename UC>
-fastfloat_really_inline FASTFLOAT_CONSTEXPR14
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR14
 void parse_one_digit(UC const *& p, limb& value, size_t& counter, size_t& count) noexcept {
   value = value * 10 + limb(*p - UC('0'));
   p++;
@@ -3202,13 +3202,13 @@ void parse_one_digit(UC const *& p, limb& value, size_t& counter, size_t& count)
   count++;
 }
 
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 void add_native(bigint& big, limb power, limb value) noexcept {
   big.mul(power);
   big.add(value);
 }
 
-fastfloat_really_inline FASTFLOAT_CONSTEXPR20
+fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR20
 void round_up_bigint(bigint& big, size_t& count) noexcept {
   // need to round-up the digits, but need to avoid rounding
   // ....9999 to ...10000, which could cause a false halfway point.
@@ -3218,7 +3218,7 @@ void round_up_bigint(bigint& big, size_t& count) noexcept {
 
 // parse the significant digits into a big integer
 template <typename UC>
-inline FASTFLOAT_CONSTEXPR20
+inline GLZ_FASTFLOAT_CONSTEXPR20
 void parse_mantissa(bigint& result, parsed_number_string_t<UC>& num, size_t max_digits, size_t& digits) noexcept {
   // try to minimize the number of big integer and scalar multiplication.
   // therefore, try to parse 8 digits at a time, and multiply by the largest
@@ -3226,7 +3226,7 @@ void parse_mantissa(bigint& result, parsed_number_string_t<UC>& num, size_t max_
   size_t counter = 0;
   digits = 0;
   limb value = 0;
-#ifdef FASTFLOAT_64BIT_LIMB
+#ifdef GLZ_FASTFLOAT_64BIT_LIMB
   size_t step = 19;
 #else
   size_t step = 9;
@@ -3299,9 +3299,9 @@ void parse_mantissa(bigint& result, parsed_number_string_t<UC>& num, size_t max_
 }
 
 template <typename T>
-inline FASTFLOAT_CONSTEXPR20
+inline GLZ_FASTFLOAT_CONSTEXPR20
 adjusted_mantissa positive_digit_comp(bigint& bigmant, int32_t exponent) noexcept {
-  FASTFLOAT_ASSERT(bigmant.pow10(uint32_t(exponent)));
+  GLZ_FASTFLOAT_ASSERT(bigmant.pow10(uint32_t(exponent)));
   adjusted_mantissa answer;
   bool truncated;
   answer.mantissa = bigmant.hi64(truncated);
@@ -3323,7 +3323,7 @@ adjusted_mantissa positive_digit_comp(bigint& bigmant, int32_t exponent) noexcep
 // we then need to scale by `2^(f- e)`, and then the two significant digits
 // are of the same magnitude.
 template <typename T>
-inline FASTFLOAT_CONSTEXPR20
+inline GLZ_FASTFLOAT_CONSTEXPR20
 adjusted_mantissa negative_digit_comp(bigint& bigmant, adjusted_mantissa am, int32_t exponent) noexcept {
   bigint& real_digits = bigmant;
   int32_t real_exp = exponent;
@@ -3342,12 +3342,12 @@ adjusted_mantissa negative_digit_comp(bigint& bigmant, adjusted_mantissa am, int
   int32_t pow2_exp = theor_exp - real_exp;
   uint32_t pow5_exp = uint32_t(-real_exp);
   if (pow5_exp != 0) {
-    FASTFLOAT_ASSERT(theor_digits.pow5(pow5_exp));
+    GLZ_FASTFLOAT_ASSERT(theor_digits.pow5(pow5_exp));
   }
   if (pow2_exp > 0) {
-    FASTFLOAT_ASSERT(theor_digits.pow2(uint32_t(pow2_exp)));
+    GLZ_FASTFLOAT_ASSERT(theor_digits.pow2(uint32_t(pow2_exp)));
   } else if (pow2_exp < 0) {
-    FASTFLOAT_ASSERT(real_digits.pow2(uint32_t(-pow2_exp)));
+    GLZ_FASTFLOAT_ASSERT(real_digits.pow2(uint32_t(-pow2_exp)));
   }
 
   // compare digits, and use it to director rounding
@@ -3384,7 +3384,7 @@ adjusted_mantissa negative_digit_comp(bigint& bigmant, adjusted_mantissa am, int
 // the actual digits. we then compare the big integer representations
 // of both, and use that to direct rounding.
 template <typename T, typename UC>
-inline FASTFLOAT_CONSTEXPR20
+inline GLZ_FASTFLOAT_CONSTEXPR20
 adjusted_mantissa digit_comp(parsed_number_string_t<UC>& num, adjusted_mantissa am) noexcept {
   // remove the invalid exponent bias
   am.power2 -= invalid_am_bias;
@@ -3407,8 +3407,8 @@ adjusted_mantissa digit_comp(parsed_number_string_t<UC>& num, adjusted_mantissa 
 
 #endif
 
-#ifndef FASTFLOAT_PARSE_NUMBER_H
-#define FASTFLOAT_PARSE_NUMBER_H
+#ifndef GLZ_FASTFLOAT_PARSE_NUMBER_H
+#define GLZ_FASTFLOAT_PARSE_NUMBER_H
 
 
 #include <cmath>
@@ -3425,7 +3425,7 @@ namespace detail {
  * strings a null-free and fixed.
  **/
 template <typename T, typename UC>
-from_chars_result_t<UC> FASTFLOAT_CONSTEXPR14
+from_chars_result_t<UC> GLZ_FASTFLOAT_CONSTEXPR14
 parse_infnan(UC const * first, UC const * last, T &value)  noexcept  {
   from_chars_result_t<UC> answer{};
   answer.ptr = first;
@@ -3435,7 +3435,7 @@ parse_infnan(UC const * first, UC const * last, T &value)  noexcept  {
       minusSign = true;
       ++first;
   }
-#ifdef FASTFLOAT_ALLOWS_LEADING_PLUS // disabled by default
+#ifdef GLZ_FASTFLOAT_ALLOWS_LEADING_PLUS // disabled by default
   if (*first == UC('+')) {
       ++first;
   }
@@ -3514,7 +3514,7 @@ fastfloat_really_inline bool rounds_to_nearest() noexcept {
   //
   // Note: This may fail to be accurate if fast-math has been
   // enabled, as rounding conventions may not apply.
-  #ifdef FASTFLOAT_VISUAL_STUDIO
+  #ifdef GLZ_FASTFLOAT_VISUAL_STUDIO
   #   pragma warning(push)
   //  todo: is there a VS warning?
   //  see https://stackoverflow.com/questions/46079446/is-there-a-warning-for-floating-point-equality-checking-in-visual-studio-2013
@@ -3526,7 +3526,7 @@ fastfloat_really_inline bool rounds_to_nearest() noexcept {
   #   pragma GCC diagnostic ignored "-Wfloat-equal"
   #endif
   return (fmini + 1.0f == 1.0f - fmini);
-  #ifdef FASTFLOAT_VISUAL_STUDIO
+  #ifdef GLZ_FASTFLOAT_VISUAL_STUDIO
   #   pragma warning(pop)
   #elif defined(__clang__)
   #   pragma clang diagnostic pop
@@ -3541,7 +3541,7 @@ template <typename T>
 struct from_chars_caller
 {
   template <typename UC>
-  FASTFLOAT_CONSTEXPR20
+  GLZ_FASTFLOAT_CONSTEXPR20
   static from_chars_result_t<UC> call(UC const * first, UC const * last,
                                       T &value, parse_options_t<UC> options)  noexcept {
     return from_chars_advanced(first, last, value, options);
@@ -3553,7 +3553,7 @@ template <>
 struct from_chars_caller<std::float32_t>
 {
   template <typename UC>
-  FASTFLOAT_CONSTEXPR20
+  GLZ_FASTFLOAT_CONSTEXPR20
   static from_chars_result_t<UC> call(UC const * first, UC const * last,
                                       std::float32_t &value, parse_options_t<UC> options) noexcept{
     // if std::float32_t is defined, and we are in C++23 mode; macro set for float32;
@@ -3571,7 +3571,7 @@ template <>
 struct from_chars_caller<std::float64_t>
 {
   template <typename UC>
-  FASTFLOAT_CONSTEXPR20
+  GLZ_FASTFLOAT_CONSTEXPR20
   static from_chars_result_t<UC> call(UC const * first, UC const * last,
                                       std::float64_t &value, parse_options_t<UC> options) noexcept{
     // if std::float64_t is defined, and we are in C++23 mode; macro set for float64;
@@ -3586,7 +3586,7 @@ struct from_chars_caller<std::float64_t>
 
 
 template<typename T, typename UC, typename>
-FASTFLOAT_CONSTEXPR20
+GLZ_FASTFLOAT_CONSTEXPR20
 from_chars_result_t<UC> from_chars(UC const * first, UC const * last,
                              T &value, chars_format fmt /*= chars_format::general*/)  noexcept  {
   return from_chars_caller<T>::call(first, last, value, parse_options_t<UC>(fmt));
@@ -3598,7 +3598,7 @@ from_chars_result_t<UC> from_chars(UC const * first, UC const * last,
  * or other parsing custom function implemented by user.
  */
 template<typename T, typename UC>
-FASTFLOAT_CONSTEXPR20
+GLZ_FASTFLOAT_CONSTEXPR20
 from_chars_result_t<UC> from_chars_advanced(parsed_number_string_t<UC>& pns,
                                       T &value)  noexcept  {
 
@@ -3636,7 +3636,7 @@ from_chars_result_t<UC> from_chars_advanced(parsed_number_string_t<UC>& pns,
       // We do not have that fegetround() == FE_TONEAREST.
       // Next is a modified Clinger's fast path, inspired by Jakub Jelínek's proposal
       if (pns.exponent >= 0 && pns.mantissa <=binary_format<T>::max_mantissa_fast_path(pns.exponent)) {
-#if defined(__clang__) || defined(FASTFLOAT_32BIT)
+#if defined(__clang__) || defined(GLZ_FASTFLOAT_32BIT)
         // Clang may map 0 to -0.0 when fegetround() == FE_DOWNWARD
         if(pns.mantissa == 0) {
           value = pns.negative ? T(-0.) : T(0.);
@@ -3667,7 +3667,7 @@ from_chars_result_t<UC> from_chars_advanced(parsed_number_string_t<UC>& pns,
 }
 
 template<typename T, typename UC>
-FASTFLOAT_CONSTEXPR20
+GLZ_FASTFLOAT_CONSTEXPR20
 from_chars_result_t<UC> from_chars_advanced(UC const * first, UC const * last,
                                       T &value, parse_options_t<UC> options)  noexcept  {
 
@@ -3675,7 +3675,7 @@ from_chars_result_t<UC> from_chars_advanced(UC const * first, UC const * last,
   static_assert (is_supported_char_type<UC>(), "only char, wchar_t, char16_t and char32_t are supported");
 
   from_chars_result_t<UC> answer;
-#ifdef FASTFLOAT_SKIP_WHITE_SPACE  // disabled by default
+#ifdef GLZ_FASTFLOAT_SKIP_WHITE_SPACE  // disabled by default
   while ((first != last) && glz::fast_float::is_space(uint8_t(*first))) {
     first++;
   }
@@ -3702,12 +3702,12 @@ from_chars_result_t<UC> from_chars_advanced(UC const * first, UC const * last,
 
 
 template <typename T, typename UC, typename>
-FASTFLOAT_CONSTEXPR20
+GLZ_FASTFLOAT_CONSTEXPR20
 from_chars_result_t<UC> from_chars(UC const* first, UC const* last, T& value, int base) noexcept {
   static_assert (is_supported_char_type<UC>(), "only char, wchar_t, char16_t and char32_t are supported");
 
   from_chars_result_t<UC> answer;
-#ifdef FASTFLOAT_SKIP_WHITE_SPACE  // disabled by default
+#ifdef GLZ_FASTFLOAT_SKIP_WHITE_SPACE  // disabled by default
   while ((first != last) && glz::fast_float::is_space(uint8_t(*first))) {
     first++;
   }


### PR DESCRIPTION
This avoids potential conflicts with multiple includes.