### PR TITLE
Add missing include inside of threadpool.hpp

### DIFF
--- a/include/glaze/thread/threadpool.hpp
+++ b/include/glaze/thread/threadpool.hpp
@@ -5,9 +5,9 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <deque>
 #include <functional>
 #include <future>
-#include <deque>
 #include <mutex>
 #include <thread>
 #include <vector>

--- a/include/glaze/thread/threadpool.hpp
+++ b/include/glaze/thread/threadpool.hpp
@@ -8,6 +8,7 @@
 #include <functional>
 #include <future>
 #include <list>
+#include <deque>
 #include <mutex>
 #include <thread>
 #include <vector>

--- a/include/glaze/thread/threadpool.hpp
+++ b/include/glaze/thread/threadpool.hpp
@@ -7,7 +7,6 @@
 #include <condition_variable>
 #include <functional>
 #include <future>
-#include <list>
 #include <deque>
 #include <mutex>
 #include <thread>


### PR DESCRIPTION
After updating glaze I encountered a missing include inside of threadpool.hpp which was introduced in commit: 544da7a. I've added the deque include and removed an unused list include.

This issue can also be seen on compiler explorer with the current main branch version of glaze: https://godbolt.org/z/TWW7G318T