### PR TITLE
Removing repe::registry locking

### DIFF
--- a/docs/rpc/repe-rpc.md
+++ b/docs/rpc/repe-rpc.md
@@ -26,7 +26,7 @@ The `glz::repe::registry` allows users to expose C++ classes directly to the reg
 
 ## Thread Safe Classes
 
-- `glz::safe_string` in `glaze/thread/safe_string.hpp`
+- `glz::async_string` in `glaze/thread/async_string.hpp`
   - Provides a thread safe `std::string` wrapper, which Glaze can read/write from safely in asynchronous calls.
 
 ## asio

--- a/docs/rpc/repe-rpc.md
+++ b/docs/rpc/repe-rpc.md
@@ -20,41 +20,14 @@ The `glz::repe::registry` produces an API for function invocation and variable a
 
 The `glz::repe::registry` allows users to expose C++ classes directly to the registry as an interface for network RPC calls and POST/GET calls.
 
-The registry handles the thread safety required to directly manipulate C++ memory and read/write from JSON or BEVE messages. In most cases unlimited clients can read and write from your registered structures in a thread-safe manner that reduces locks, permits asynchronous reads, and non-blocking writes where valid.
-
-Locking is performed on JSON pointer path chains to allow multiple clients to read/write from the same object at the same time.
-
-Locking is based on depth in the object tree. A chain of shared mutexes are locked, locking does the path to the write point. When reading from C++ memory, only shared locks are used at the read location.
-
 > [!IMPORTANT]
 >
-> Functions that are registered are not locked when invoked. Thread safety when invoking functions must be handled by the user.
+> Like most registry implementations, no locks are acquired for reading/writing to the registry and all thread safety must be managed by the user. This allows flexible, performant interfaces to be developed on top of the registry. It is recommended to register safe types, such as `std::atomic<int>`. Glaze provides some higher level thread safe classes to be used in these asynchronous interfaces.
 
-> [!IMPORTANT]
->
-> Pointers to parent members or functions that manipulate shallower depth members are not thread safe and safety has to be added by the developer.
+## Thread Safe Classes
 
-### Locking Example
-
-Suppose we have the following C++ structs:
-
-```c++
-struct person
-{
-  uint8_t age{};
-  std::string name{};
-};
-
-struct family
-{
-  person father{};
-  person mother{};
-};
-```
-
-The registry will allow non-conflicting paths to simultaneously read and write. `/family/father/age` and `/family/mother/age` can be asynchronously read/written by two different clients. If the same path is attempted to be read by multiple clients a lock is shared between them. Only writes and invocations require unique locks.
-
-If `/family/father/age` is written to, this will also block a shared lock on `/family`, which prevents reading from memory that has child fields being manipulated.
+- `glz::safe_string` in `glaze/thread/safe_string.hpp`
+  - Provides a thread safe `std::string` wrapper, which Glaze can read/write from safely in asynchronous calls.
 
 ## asio
 

--- a/include/glaze/json/json_t.hpp
+++ b/include/glaze/json/json_t.hpp
@@ -314,6 +314,8 @@ struct glz::meta<glz::json_t>
 
 namespace glz
 {
+   // These functions allow a json_t value to be read/written to a C++ struct
+   
    template <opts Opts, class T>
       requires read_supported<Opts.format, T>
    [[nodiscard]] error_ctx read(T& value, const json_t& source) noexcept

--- a/include/glaze/rpc/repe/registry.hpp
+++ b/include/glaze/rpc/repe/registry.hpp
@@ -167,6 +167,7 @@ namespace glz::repe
 
       void clear() { methods.clear(); }
 
+      // Register a C++ type that stores pointers to the value, so be sure to keep the registered value alive
       template <const std::string_view& root = detail::empty_path, class T, const std::string_view& parent = root>
          requires(glz::detail::glaze_object_t<T> || glz::detail::reflectable<T>)
       void on(T& value)

--- a/include/glaze/rpc/repe/registry.hpp
+++ b/include/glaze/rpc/repe/registry.hpp
@@ -3,10 +3,6 @@
 
 #pragma once
 
-#include <mutex>
-#include <shared_mutex>
-#include <thread>
-
 #include "glaze/glaze.hpp"
 #include "glaze/rpc/repe/header.hpp"
 
@@ -19,14 +15,6 @@ namespace glz::repe
 
       operator bool() const noexcept { return bool(code); }
    };
-
-   inline std::string format_error(const error_t& e) noexcept
-   {
-      std::string result = "error: " + std::string(meta<error_code>::keys[uint32_t(e.code)]);
-      result += "\n";
-      result += e.message;
-      return result;
-   }
 
    struct state final
    {

--- a/include/glaze/rpc/repe/registry.hpp
+++ b/include/glaze/rpc/repe/registry.hpp
@@ -151,48 +151,24 @@ namespace glz::repe
 
    inline error_t request_beve(message& msg, const user_header& h)
    {
-      msg.header = encode(h);
-      msg.query = std::string{h.query};
-      msg.header.read(true); // because no value provided
-      std::ignore = glz::write_beve(nullptr, msg.body);
-      msg.header.body_length = msg.body.size();
-      msg.header.length = sizeof(repe::header) + msg.query.size() + msg.body.size();
-      return {};
+      return request<opts{BEVE}>(msg, h);
+   }
+   
+   template <class Value>
+   error_t request_beve(message& msg, const user_header& h, Value&& value)
+   {
+      return request<opts{BEVE}>(msg, h, std::forward<Value>(value));
    }
 
    inline error_t request_json(message& msg, const user_header& h)
    {
-      msg.header = encode(h);
-      msg.query = std::string{h.query};
-      msg.header.read(true); // because no value provided
-      std::ignore = glz::write_json(nullptr, msg.body);
-      msg.header.body_length = msg.body.size();
-      msg.header.length = sizeof(repe::header) + msg.query.size() + msg.body.size();
-      return {};
+      return request<opts{JSON}>(msg, h);
    }
-
+   
    template <class Value>
    error_t request_json(message& msg, const user_header& h, Value&& value)
    {
-      msg.header = encode(h);
-      msg.query = std::string{h.query};
-      msg.header.write(true);
-      std::ignore = glz::write_json(std::forward<Value>(value), msg.body);
-      msg.header.body_length = msg.body.size();
-      msg.header.length = sizeof(repe::header) + msg.query.size() + msg.body.size();
-      return {};
-   }
-
-   template <class Value>
-   error_t request_beve(message& msg, const user_header& h, Value&& value)
-   {
-      msg.header = encode(h);
-      msg.query = std::string{h.query};
-      msg.header.write(true);
-      std::ignore = glz::write_beve(std::forward<Value>(value), msg.body);
-      msg.header.body_length = msg.body.size();
-      msg.header.length = sizeof(repe::header) + msg.query.size() + msg.body.size();
-      return {};
+      return request<opts{JSON}>(msg, h, std::forward<Value>(value));
    }
 
    // DESIGN NOTE: It might appear that we are locking ourselves into a poor design choice by using a runtime

--- a/include/glaze/rpc/repe/registry.hpp
+++ b/include/glaze/rpc/repe/registry.hpp
@@ -98,15 +98,21 @@ namespace glz::repe
    template <opts Opts>
    void write_response(is_state auto&& state)
    {
-      state.out.header = state.in.header;
+      auto& in = state.in;
+      auto& out = state.out;
+      out.header.id = in.header.id;
       if (state.error) {
-         state.out.header.error = true;
+         out.header.error = true;
+         out.header.query_length = out.query.size();
+         out.header.body_length = out.body.size();
+         out.header.length = sizeof(repe::header) + out.query.size() + out.body.size();
       }
       else {
-         const auto ec = write<Opts>(nullptr, state.out.body);
-         if (bool(ec)) [[unlikely]] {
-            state.out.header.error = true;
-         }
+         out.body.clear();
+         out.query.clear();
+         out.header.query_length = out.query.size();
+         out.header.body_length = out.body.size();
+         out.header.length = sizeof(repe::header) + out.query.size() + out.body.size();
       }
    }
    

--- a/include/glaze/thread/async_map.hpp
+++ b/include/glaze/thread/async_map.hpp
@@ -1,0 +1,468 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+// Provides a semi-safe flat map
+// This async_map only provides thread safety when inserting/deletion
+// It is intended to store thread safe types for more efficient access
+
+#include "glaze/core/common.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <iterator>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace glz
+{
+   template <typename K, typename V>
+   class async_map {
+   private:
+       std::vector<K> keys;
+       std::vector<V> values;
+       mutable std::shared_mutex mutex;
+
+       // Helper function to perform binary search.
+       // Returns a pair of iterator and a boolean indicating if the key was found.
+       std::pair<typename std::vector<K>::const_iterator, bool>
+       binary_search_key(const K& key) const {
+           auto it = std::lower_bound(keys.cbegin(), keys.cend(), key);
+           if (it != keys.cend() && !(key < *it)) { // Equivalent to key == *it
+               return {it, true};
+           }
+           return {it, false};
+       }
+
+   public:
+       using key_type = K;
+       using mapped_type = V;
+       using value_type = std::pair<const K&, V&>;
+       using const_value_type = std::pair<const K&, const V&>;
+
+       // Forward declaration of iterator classes
+       class iterator;
+       class const_iterator;
+
+       // Iterator Class Definition
+       class iterator {
+       public:
+           using iterator_category = std::forward_iterator_tag;
+           using value_type = safe_key_map::value_type;
+           using difference_type = std::ptrdiff_t;
+           using pointer = value_type*;
+           using reference = value_type&;
+
+       private:
+           typename std::vector<K>::const_iterator key_it;
+           typename std::vector<V>::iterator value_it;
+           safe_key_map* map;
+           std::shared_ptr<std::shared_lock<std::shared_mutex>> shared_lock_ptr;
+           std::shared_ptr<std::unique_lock<std::shared_mutex>> unique_lock_ptr;
+
+       public:
+           iterator(typename std::vector<K>::const_iterator key_it,
+                    typename std::vector<V>::iterator value_it,
+                    safe_key_map* map,
+                    std::shared_ptr<std::shared_lock<std::shared_mutex>> existing_shared_lock = nullptr,
+                    std::shared_ptr<std::unique_lock<std::shared_mutex>> existing_unique_lock = nullptr)
+               : key_it(key_it),
+                 value_it(value_it),
+                 map(map),
+                 shared_lock_ptr(existing_shared_lock),
+                 unique_lock_ptr(existing_unique_lock) {
+               // Acquire a shared lock only if no lock is provided
+               if (!shared_lock_ptr && !unique_lock_ptr) {
+                   shared_lock_ptr = std::make_shared<std::shared_lock<std::shared_mutex>>(map->mutex);
+               }
+           }
+
+           // Copy Constructor
+           iterator(const iterator& other)
+               : key_it(other.key_it),
+                 value_it(other.value_it),
+                 map(other.map),
+                 shared_lock_ptr(other.shared_lock_ptr),
+                 unique_lock_ptr(other.unique_lock_ptr) {}
+
+           // Move Constructor
+           iterator(iterator&& other) noexcept
+               : key_it(std::move(other.key_it)),
+                 value_it(std::move(other.value_it)),
+                 map(other.map),
+                 shared_lock_ptr(std::move(other.shared_lock_ptr)),
+                 unique_lock_ptr(std::move(other.unique_lock_ptr)) {}
+
+           // Copy Assignment
+           iterator& operator=(const iterator& other) {
+               if (this != &other) {
+                   key_it = other.key_it;
+                   value_it = other.value_it;
+                   map = other.map;
+                   shared_lock_ptr = other.shared_lock_ptr;
+                   unique_lock_ptr = other.unique_lock_ptr;
+               }
+               return *this;
+           }
+
+           // Pre-increment
+           iterator& operator++() {
+               ++key_it;
+               ++value_it;
+               return *this;
+           }
+
+           // Post-increment
+           iterator operator++(int) {
+               iterator tmp(*this);
+               ++(*this);
+               return tmp;
+           }
+
+           // Dereference
+           value_type operator*() const { return {*key_it, *value_it}; }
+
+           // Arrow Operator
+           std::unique_ptr<value_type> operator->() const {
+               return std::make_unique<value_type>(*key_it, *value_it);
+           }
+
+           // Equality Comparison
+           bool operator==(const iterator& other) const {
+               return key_it == other.key_it;
+           }
+
+           // Inequality Comparison
+           bool operator!=(const iterator& other) const {
+               return !(*this == other);
+           }
+       };
+
+       // Const Iterator Class Definition
+       class const_iterator {
+       public:
+           using iterator_category = std::forward_iterator_tag;
+           using value_type = safe_key_map::const_value_type;
+           using difference_type = std::ptrdiff_t;
+           using pointer = const value_type*;
+           using reference = const value_type&;
+
+       private:
+           typename std::vector<K>::const_iterator key_it;
+           typename std::vector<V>::const_iterator value_it;
+           const safe_key_map* map;
+           std::shared_ptr<std::shared_lock<std::shared_mutex>> shared_lock_ptr;
+
+       public:
+           const_iterator(typename std::vector<K>::const_iterator key_it,
+                         typename std::vector<V>::const_iterator value_it,
+                         const safe_key_map* map,
+                         std::shared_ptr<std::shared_lock<std::shared_mutex>> existing_shared_lock = nullptr)
+               : key_it(key_it),
+                 value_it(value_it),
+                 map(map),
+                 shared_lock_ptr(existing_shared_lock) {
+               // Acquire a shared lock only if no lock is provided
+               if (!shared_lock_ptr) {
+                   shared_lock_ptr = std::make_shared<std::shared_lock<std::shared_mutex>>(map->mutex);
+               }
+           }
+
+           // Copy Constructor
+           const_iterator(const const_iterator& other)
+               : key_it(other.key_it),
+                 value_it(other.value_it),
+                 map(other.map),
+                 shared_lock_ptr(other.shared_lock_ptr) {}
+
+           // Move Constructor
+           const_iterator(const_iterator&& other) noexcept
+               : key_it(std::move(other.key_it)),
+                 value_it(std::move(other.value_it)),
+                 map(other.map),
+                 shared_lock_ptr(std::move(other.shared_lock_ptr)) {}
+
+           // Copy Assignment
+           const_iterator& operator=(const const_iterator& other) {
+               if (this != &other) {
+                   key_it = other.key_it;
+                   value_it = other.value_it;
+                   map = other.map;
+                   shared_lock_ptr = other.shared_lock_ptr;
+               }
+               return *this;
+           }
+
+           // Pre-increment
+           const_iterator& operator++() {
+               ++key_it;
+               ++value_it;
+               return *this;
+           }
+
+           // Post-increment
+           const_iterator operator++(int) {
+               const_iterator tmp(*this);
+               ++(*this);
+               return tmp;
+           }
+
+           // Dereference
+           value_type operator*() const { return {*key_it, *value_it}; }
+
+           // Arrow Operator
+           std::unique_ptr<value_type> operator->() const {
+               return std::make_unique<value_type>(*key_it, *value_it);
+           }
+
+           // Equality Comparison
+           bool operator==(const const_iterator& other) const {
+               return key_it == other.key_it;
+           }
+
+           // Inequality Comparison
+           bool operator!=(const const_iterator& other) const {
+               return !(*this == other);
+           }
+       };
+
+       // Value Proxy Class Definition
+       class value_proxy {
+       private:
+           V& value_ref;
+           std::shared_ptr<std::shared_lock<std::shared_mutex>> shared_lock_ptr;
+           std::shared_ptr<std::unique_lock<std::shared_mutex>> unique_lock_ptr;
+
+       public:
+           value_proxy(V& value_ref,
+                      std::shared_ptr<std::shared_lock<std::shared_mutex>> existing_shared_lock,
+                      std::shared_ptr<std::unique_lock<std::shared_mutex>> existing_unique_lock = nullptr)
+               : value_ref(value_ref),
+                 shared_lock_ptr(existing_shared_lock),
+                 unique_lock_ptr(existing_unique_lock) {
+               // Ensure that a lock is provided
+               assert(shared_lock_ptr || unique_lock_ptr);
+           }
+
+           // Disable Copy and Move
+           value_proxy(const value_proxy&) = delete;
+           value_proxy& operator=(const value_proxy&) = delete;
+           value_proxy(value_proxy&&) = delete;
+           value_proxy& operator=(value_proxy&&) = delete;
+
+           // Access the value
+           V& value() { return value_ref; }
+
+           // Arrow Operator
+           V* operator->() { return &value_ref; }
+
+           // Implicit Conversion to V&
+           operator V&() { return value_ref; }
+       };
+
+       // Const Value Proxy Class Definition
+       class const_value_proxy {
+       private:
+           const V& value_ref;
+           std::shared_ptr<std::shared_lock<std::shared_mutex>> shared_lock_ptr;
+
+       public:
+           const_value_proxy(const V& value_ref,
+                             std::shared_ptr<std::shared_lock<std::shared_mutex>> existing_shared_lock)
+               : value_ref(value_ref), shared_lock_ptr(existing_shared_lock) {
+               // Ensure that a lock is provided
+               assert(shared_lock_ptr);
+           }
+
+           // Disable Copy and Move
+           const_value_proxy(const const_value_proxy&) = delete;
+           const_value_proxy& operator=(const const_value_proxy&) = delete;
+           const_value_proxy(const_value_proxy&&) = delete;
+           const_value_proxy& operator=(const_value_proxy&&) = delete;
+
+           // Access the value
+           const V& value() const { return value_ref; }
+
+           // Arrow Operator
+           const V* operator->() const { return &value_ref; }
+
+           // Implicit Conversion to const V&
+           operator const V&() const { return value_ref; }
+       };
+
+       // Insert method behaves like std::map::insert
+       std::pair<iterator, bool> insert(const std::pair<K, V>& pair) {
+           auto unique_lock_ptr = std::make_shared<std::unique_lock<std::shared_mutex>>(mutex);
+
+           // Perform binary search to find the key
+           auto [it, found] = binary_search_key(pair.first);
+
+           if (found) {
+               auto index = std::distance(keys.cbegin(), it);
+               return {iterator(keys.cbegin() + index, values.begin() + index, this, nullptr, unique_lock_ptr),
+                       false};
+           } else {
+               // Insert while maintaining sorted order
+               auto index = std::distance(keys.cbegin(), it);
+               keys.insert(it, pair.first);
+               values.insert(values.begin() + index, pair.second);
+               return {iterator(keys.cbegin() + index, values.begin() + index, this, nullptr, unique_lock_ptr),
+                       true};
+           }
+       }
+
+       // Emplace method
+       template <typename... Args>
+       std::pair<iterator, bool> emplace(const K& key, Args&&... args) {
+           auto unique_lock_ptr = std::make_shared<std::unique_lock<std::shared_mutex>>(mutex);
+
+           // Perform binary search to find the key
+           auto [it, found] = binary_search_key(key);
+
+           if (found) {
+               auto index = std::distance(keys.cbegin(), it);
+               return {iterator(keys.cbegin() + index, values.begin() + index, this, nullptr, unique_lock_ptr),
+                       false};
+           } else {
+               // Insert while maintaining sorted order
+               auto index = std::distance(keys.cbegin(), it);
+               keys.insert(it, key);
+               values.emplace(values.begin() + index, std::forward<Args>(args)...);
+               return {iterator(keys.cbegin() + index, values.begin() + index, this, nullptr, unique_lock_ptr),
+                       true};
+           }
+       }
+
+       // Try_emplace method
+       template <typename... Args>
+       std::pair<iterator, bool> try_emplace(const K& key, Args&&... args) {
+           return emplace(key, std::forward<Args>(args)...);
+       }
+
+       // Clear all elements
+       void clear() {
+           std::unique_lock lock(mutex);
+           keys.clear();
+           values.clear();
+       }
+
+       // Erase a key
+       void erase(const K& key) {
+           std::unique_lock lock(mutex);
+
+           // Perform binary search to find the key
+           auto [it, found] = binary_search_key(key);
+
+           if (found) {
+               auto index = std::distance(keys.cbegin(), it);
+               keys.erase(it);
+               values.erase(values.begin() + index);
+           }
+       }
+
+       // Find an iterator to the key
+       iterator find(const K& key) {
+           auto shared_lock_ptr = std::make_shared<std::shared_lock<std::shared_mutex>>(mutex);
+
+           // Perform binary search to find the key
+           auto [it, found] = binary_search_key(key);
+
+           if (found) {
+               auto index = std::distance(keys.cbegin(), it);
+               return iterator(keys.cbegin() + index, values.begin() + index, this, shared_lock_ptr);
+           } else {
+               return end();
+           }
+       }
+
+       // Const version of find
+       const_iterator find(const K& key) const {
+           auto shared_lock_ptr = std::make_shared<std::shared_lock<std::shared_mutex>>(mutex);
+
+           // Perform binary search to find the key
+           auto [it, found] = binary_search_key(key);
+
+           if (found) {
+               auto index = std::distance(keys.cbegin(), it);
+               return const_iterator(keys.cbegin() + index,
+                                     values.cbegin() + index, this,
+                                     shared_lock_ptr);
+           } else {
+               return end();
+           }
+       }
+
+       // Access element with bounds checking (non-const)
+       value_proxy at(const K& key) {
+           auto shared_lock_ptr = std::make_shared<std::shared_lock<std::shared_mutex>>(mutex);
+
+           // Perform binary search to find the key
+           auto [it, found] = binary_search_key(key);
+
+           if (found) {
+               auto index = std::distance(keys.cbegin(), it);
+               return value_proxy(values[index], shared_lock_ptr);
+           } else {
+               throw std::out_of_range("Key not found");
+           }
+       }
+
+       // Access element with bounds checking (const)
+       const_value_proxy at(const K& key) const {
+           auto shared_lock_ptr = std::make_shared<std::shared_lock<std::shared_mutex>>(mutex);
+
+           // Perform binary search to find the key
+           auto [it, found] = binary_search_key(key);
+
+           if (found) {
+               auto index = std::distance(keys.cbegin(), it);
+               return const_value_proxy(values[index], shared_lock_ptr);
+           } else {
+               throw std::out_of_range("Key not found");
+           }
+       }
+
+       // Begin iterator (non-const)
+       iterator begin() {
+           auto shared_lock_ptr = std::make_shared<std::shared_lock<std::shared_mutex>>(mutex);
+           return iterator(keys.cbegin(), values.begin(), this, shared_lock_ptr);
+       }
+
+       // End iterator (non-const)
+       iterator end() {
+           auto shared_lock_ptr = std::make_shared<std::shared_lock<std::shared_mutex>>(mutex);
+           return iterator(keys.cend(), values.end(), this, shared_lock_ptr);
+       }
+
+       // Begin iterator (const)
+       const_iterator begin() const {
+           auto shared_lock_ptr = std::make_shared<std::shared_lock<std::shared_mutex>>(mutex);
+           return const_iterator(keys.cbegin(), values.cbegin(), this, shared_lock_ptr);
+       }
+
+       // End iterator (const)
+       const_iterator end() const {
+           auto shared_lock_ptr = std::make_shared<std::shared_lock<std::shared_mutex>>(mutex);
+           return const_iterator(keys.cend(), values.cend(), this, shared_lock_ptr);
+       }
+
+       // Count the number of elements with the given key (0 or 1)
+       size_t count(const K& key) const {
+           std::shared_lock lock(mutex);
+           auto [it, found] = binary_search_key(key);
+           return found ? 1 : 0;
+       }
+
+       // Check if the map contains the key
+       bool contains(const K& key) const {
+           std::shared_lock lock(mutex);
+           auto [it, found] = binary_search_key(key);
+           return found;
+       }
+   };
+}

--- a/include/glaze/thread/async_string.hpp
+++ b/include/glaze/thread/async_string.hpp
@@ -14,30 +14,30 @@
 
 namespace glz
 {
-   struct safe_string
+   struct async_string
    {
       std::string str;
       mutable std::shared_mutex mutex;
 
-      safe_string() = default;
-      safe_string(const char* s) : str(s) {}
-      safe_string(const std::string& s) : str(s) {}
-      safe_string(std::string&& s) : str(std::move(s)) {}
-      safe_string(const std::string_view& sv) : str(sv) {}
+      async_string() = default;
+      async_string(const char* s) : str(s) {}
+      async_string(const std::string& s) : str(s) {}
+      async_string(std::string&& s) : str(std::move(s)) {}
+      async_string(const std::string_view& sv) : str(sv) {}
 
-      safe_string(const safe_string& other)
+      async_string(const async_string& other)
       {
          std::shared_lock lock(other.mutex);
          str = other.str;
       }
 
-      safe_string(safe_string&& other) noexcept
+      async_string(async_string&& other) noexcept
       {
          std::unique_lock lock(other.mutex);
          str = std::move(other.str);
       }
 
-      safe_string& operator=(const safe_string& other)
+      async_string& operator=(const async_string& other)
       {
          if (this != &other) {
             std::unique_lock lock1(mutex, std::defer_lock);
@@ -48,7 +48,7 @@ namespace glz
          return *this;
       }
 
-      safe_string& operator=(safe_string&& other) noexcept
+      async_string& operator=(async_string&& other) noexcept
       {
          if (this != &other) {
             std::unique_lock lock1(mutex, std::defer_lock);
@@ -59,28 +59,28 @@ namespace glz
          return *this;
       }
 
-      safe_string& operator=(const std::string& s)
+      async_string& operator=(const std::string& s)
       {
          std::unique_lock lock(mutex);
          str = s;
          return *this;
       }
 
-      safe_string& operator=(std::string&& s)
+      async_string& operator=(std::string&& s)
       {
          std::unique_lock lock(mutex);
          str = std::move(s);
          return *this;
       }
 
-      safe_string& operator=(const char* s)
+      async_string& operator=(const char* s)
       {
          std::unique_lock lock(mutex);
          str = s;
          return *this;
       }
 
-      safe_string& operator=(const std::string_view& sv)
+      async_string& operator=(const std::string_view& sv)
       {
          std::unique_lock lock(mutex);
          str = sv;
@@ -125,34 +125,34 @@ namespace glz
          str.pop_back();
       }
 
-      safe_string& append(const std::string& s)
+      async_string& append(const std::string& s)
       {
          std::unique_lock lock(mutex);
          str.append(s);
          return *this;
       }
 
-      safe_string& append(const char* s)
+      async_string& append(const char* s)
       {
          std::unique_lock lock(mutex);
          str.append(s);
          return *this;
       }
 
-      safe_string& append(const std::string_view& sv)
+      async_string& append(const std::string_view& sv)
       {
          std::unique_lock lock(mutex);
          str.append(sv);
          return *this;
       }
 
-      safe_string& operator+=(const std::string& s) { return append(s); }
+      async_string& operator+=(const std::string& s) { return append(s); }
 
-      safe_string& operator+=(const char* s) { return append(s); }
+      async_string& operator+=(const char* s) { return append(s); }
 
-      safe_string& operator+=(const std::string_view& sv) { return append(sv); }
+      async_string& operator+=(const std::string_view& sv) { return append(sv); }
 
-      safe_string& operator+=(char c)
+      async_string& operator+=(char c)
       {
          std::unique_lock lock(mutex);
          str += c;
@@ -184,7 +184,7 @@ namespace glz
          return str.back();
       }
 
-      int compare(const safe_string& other) const
+      int compare(const async_string& other) const
       {
          std::shared_lock lock1(mutex, std::defer_lock);
          std::shared_lock lock2(other.mutex, std::defer_lock);
@@ -199,7 +199,7 @@ namespace glz
          return str;
       }
 
-      friend bool operator==(const safe_string& lhs, const safe_string& rhs)
+      friend bool operator==(const async_string& lhs, const async_string& rhs)
       {
          std::shared_lock lock1(lhs.mutex, std::defer_lock);
          std::shared_lock lock2(rhs.mutex, std::defer_lock);
@@ -207,9 +207,9 @@ namespace glz
          return lhs.str == rhs.str;
       }
 
-      friend bool operator!=(const safe_string& lhs, const safe_string& rhs) { return !(lhs == rhs); }
+      friend bool operator!=(const async_string& lhs, const async_string& rhs) { return !(lhs == rhs); }
 
-      friend bool operator<(const safe_string& lhs, const safe_string& rhs)
+      friend bool operator<(const async_string& lhs, const async_string& rhs)
       {
          std::shared_lock lock1(lhs.mutex, std::defer_lock);
          std::shared_lock lock2(rhs.mutex, std::defer_lock);
@@ -217,13 +217,13 @@ namespace glz
          return lhs.str < rhs.str;
       }
 
-      friend bool operator<=(const safe_string& lhs, const safe_string& rhs) { return !(rhs < lhs); }
+      friend bool operator<=(const async_string& lhs, const async_string& rhs) { return !(rhs < lhs); }
 
-      friend bool operator>(const safe_string& lhs, const safe_string& rhs) { return rhs < lhs; }
+      friend bool operator>(const async_string& lhs, const async_string& rhs) { return rhs < lhs; }
 
-      friend bool operator>=(const safe_string& lhs, const safe_string& rhs) { return !(lhs < rhs); }
+      friend bool operator>=(const async_string& lhs, const async_string& rhs) { return !(lhs < rhs); }
 
-      void swap(safe_string& other)
+      void swap(async_string& other)
       {
          if (this == &other) return;
          std::unique_lock lock1(mutex, std::defer_lock);
@@ -232,7 +232,7 @@ namespace glz
          str.swap(other.str);
       }
 
-      friend void swap(safe_string& lhs, safe_string& rhs) { lhs.swap(rhs); }
+      friend void swap(async_string& lhs, async_string& rhs) { lhs.swap(rhs); }
    };
 
 }
@@ -240,7 +240,7 @@ namespace glz
 namespace glz::detail
 {
    template <uint32_t Format>
-   struct from<Format, glz::safe_string>
+   struct from<Format, glz::async_string>
    {
       template <auto Opts>
       static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
@@ -251,7 +251,7 @@ namespace glz::detail
    };
 
    template <uint32_t Format>
-   struct to<Format, glz::safe_string>
+   struct to<Format, glz::async_string>
    {
       template <auto Opts>
       static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept

--- a/include/glaze/thread/async_string.hpp
+++ b/include/glaze/thread/async_string.hpp
@@ -12,6 +12,8 @@
 
 #include "glaze/core/common.hpp"
 
+// Provides a thread safe wrapper around a std::string, which Glaze knows how to serialize/deserialize safely
+
 namespace glz
 {
    struct async_string

--- a/include/glaze/thread/safe_string.hpp
+++ b/include/glaze/thread/safe_string.hpp
@@ -1,0 +1,263 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include <algorithm>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "glaze/core/common.hpp"
+
+namespace glz
+{
+   struct safe_string
+   {
+      std::string str;
+      mutable std::shared_mutex mutex;
+
+      safe_string() = default;
+      safe_string(const char* s) : str(s) {}
+      safe_string(const std::string& s) : str(s) {}
+      safe_string(std::string&& s) : str(std::move(s)) {}
+      safe_string(const std::string_view& sv) : str(sv) {}
+
+      safe_string(const safe_string& other)
+      {
+         std::shared_lock lock(other.mutex);
+         str = other.str;
+      }
+
+      safe_string(safe_string&& other) noexcept
+      {
+         std::unique_lock lock(other.mutex);
+         str = std::move(other.str);
+      }
+
+      safe_string& operator=(const safe_string& other)
+      {
+         if (this != &other) {
+            std::unique_lock lock1(mutex, std::defer_lock);
+            std::shared_lock lock2(other.mutex, std::defer_lock);
+            std::lock(lock1, lock2);
+            str = other.str;
+         }
+         return *this;
+      }
+
+      safe_string& operator=(safe_string&& other) noexcept
+      {
+         if (this != &other) {
+            std::unique_lock lock1(mutex, std::defer_lock);
+            std::unique_lock lock2(other.mutex, std::defer_lock);
+            std::lock(lock1, lock2);
+            str = std::move(other.str);
+         }
+         return *this;
+      }
+
+      safe_string& operator=(const std::string& s)
+      {
+         std::unique_lock lock(mutex);
+         str = s;
+         return *this;
+      }
+
+      safe_string& operator=(std::string&& s)
+      {
+         std::unique_lock lock(mutex);
+         str = std::move(s);
+         return *this;
+      }
+
+      safe_string& operator=(const char* s)
+      {
+         std::unique_lock lock(mutex);
+         str = s;
+         return *this;
+      }
+
+      safe_string& operator=(const std::string_view& sv)
+      {
+         std::unique_lock lock(mutex);
+         str = sv;
+         return *this;
+      }
+
+      // Capacity
+      size_t size() const noexcept
+      {
+         std::shared_lock lock(mutex);
+         return str.size();
+      }
+
+      size_t length() const noexcept
+      {
+         std::shared_lock lock(mutex);
+         return str.length();
+      }
+
+      bool empty() const noexcept
+      {
+         std::shared_lock lock(mutex);
+         return str.empty();
+      }
+
+      // Modifiers
+      void clear() noexcept
+      {
+         std::unique_lock lock(mutex);
+         str.clear();
+      }
+
+      void push_back(char c)
+      {
+         std::unique_lock lock(mutex);
+         str.push_back(c);
+      }
+
+      void pop_back()
+      {
+         std::unique_lock lock(mutex);
+         str.pop_back();
+      }
+
+      safe_string& append(const std::string& s)
+      {
+         std::unique_lock lock(mutex);
+         str.append(s);
+         return *this;
+      }
+
+      safe_string& append(const char* s)
+      {
+         std::unique_lock lock(mutex);
+         str.append(s);
+         return *this;
+      }
+
+      safe_string& append(const std::string_view& sv)
+      {
+         std::unique_lock lock(mutex);
+         str.append(sv);
+         return *this;
+      }
+
+      safe_string& operator+=(const std::string& s) { return append(s); }
+
+      safe_string& operator+=(const char* s) { return append(s); }
+
+      safe_string& operator+=(const std::string_view& sv) { return append(sv); }
+
+      safe_string& operator+=(char c)
+      {
+         std::unique_lock lock(mutex);
+         str += c;
+         return *this;
+      }
+
+      // Element access
+      char at(size_t pos) const
+      {
+         std::shared_lock lock(mutex);
+         return str.at(pos);
+      }
+
+      char operator[](size_t pos) const
+      {
+         std::shared_lock lock(mutex);
+         return str[pos];
+      }
+
+      char front() const
+      {
+         std::shared_lock lock(mutex);
+         return str.front();
+      }
+
+      char back() const
+      {
+         std::shared_lock lock(mutex);
+         return str.back();
+      }
+
+      int compare(const safe_string& other) const
+      {
+         std::shared_lock lock1(mutex, std::defer_lock);
+         std::shared_lock lock2(other.mutex, std::defer_lock);
+         std::lock(lock1, lock2);
+         return str.compare(other.str);
+      }
+
+      // Obtain a copy
+      std::string string() const
+      {
+         std::shared_lock lock(mutex);
+         return str;
+      }
+
+      friend bool operator==(const safe_string& lhs, const safe_string& rhs)
+      {
+         std::shared_lock lock1(lhs.mutex, std::defer_lock);
+         std::shared_lock lock2(rhs.mutex, std::defer_lock);
+         std::lock(lock1, lock2);
+         return lhs.str == rhs.str;
+      }
+
+      friend bool operator!=(const safe_string& lhs, const safe_string& rhs) { return !(lhs == rhs); }
+
+      friend bool operator<(const safe_string& lhs, const safe_string& rhs)
+      {
+         std::shared_lock lock1(lhs.mutex, std::defer_lock);
+         std::shared_lock lock2(rhs.mutex, std::defer_lock);
+         std::lock(lock1, lock2);
+         return lhs.str < rhs.str;
+      }
+
+      friend bool operator<=(const safe_string& lhs, const safe_string& rhs) { return !(rhs < lhs); }
+
+      friend bool operator>(const safe_string& lhs, const safe_string& rhs) { return rhs < lhs; }
+
+      friend bool operator>=(const safe_string& lhs, const safe_string& rhs) { return !(lhs < rhs); }
+
+      void swap(safe_string& other)
+      {
+         if (this == &other) return;
+         std::unique_lock lock1(mutex, std::defer_lock);
+         std::unique_lock lock2(other.mutex, std::defer_lock);
+         std::lock(lock1, lock2);
+         str.swap(other.str);
+      }
+
+      friend void swap(safe_string& lhs, safe_string& rhs) { lhs.swap(rhs); }
+   };
+
+}
+
+namespace glz::detail
+{
+   template <uint32_t Format>
+   struct from<Format, glz::safe_string>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+      {
+         std::shared_lock lock{value.mutex};
+         read<Format>::template op<Opts>(value.str, ctx, it, end);
+      }
+   };
+
+   template <uint32_t Format>
+   struct to<Format, glz::safe_string>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+      {
+         std::unique_lock lock{value.mutex};
+         write<Format>::template op<Opts>(value.str, ctx, args...);
+      }
+   };
+}

--- a/tests/asio_repe/asio_repe.cpp
+++ b/tests/asio_repe/asio_repe.cpp
@@ -1,11 +1,73 @@
 // Glaze Library
 // For the license information refer to glaze.hpp
 
+#define UT_RUN_TIME_ONLY
+
+#include "ut/ut.hpp"
+
+using namespace ut;
+
 #include <iostream>
 
 #include "glaze/ext/glaze_asio.hpp"
+#include "glaze/thread/async_string.hpp"
 
 // This test code is self-contained and spawns both the server and the client
+
+struct my_data
+{
+   glz::async_string name{};
+   std::atomic<int> age{};
+};
+
+void async_clients_test()
+{
+   static constexpr int16_t port = 8431;
+
+   glz::asio_server<> server{.port = port, .concurrency = 4};
+   
+   std::future<void> server_thread = std::async([&] {
+      std::cout << "Server active...\n";
+
+      try {
+         my_data data{};
+         server.on(data);
+         server.run();
+      }
+      catch (const std::exception& e) {
+         std::cerr << "Exception: " << e.what();
+      }
+
+      std::cout << "Server closed...\n";
+   });
+   
+   try {
+      glz::asio_client<> client{"localhost", std::to_string(port)};
+
+      const auto ec = client.init();
+      if (ec) {
+         throw std::runtime_error(ec.message());
+      }
+      
+      if (auto e_call = client.set({"/age"}, 29)) {
+         std::cerr << glz::write_json(e_call).value_or("error") << '\n';
+      }
+      
+      int age{};
+      if (auto e_call = client.get({"/age"}, age)) {
+         std::cerr << glz::write_json(e_call).value_or("error") << '\n';
+      }
+      
+      expect(age == 29);
+
+      server.stop();
+   }
+   catch (const std::exception& e) {
+      std::cerr << e.what() << '\n';
+   }
+   
+   server_thread.get();
+}
 
 struct api
 {
@@ -55,10 +117,7 @@ void asio_client_test()
          threads.emplace_back(std::async([&, i] {
             auto& client = clients[i];
             const auto ec = client.init();
-            if (!ec) {
-               std::cout << "Connected to server" << std::endl;
-            }
-            else {
+            if (ec) {
                std::cerr << "Error: " << ec.message() << std::endl;
             }
 
@@ -163,6 +222,7 @@ void async_calls()
 
 int main()
 {
+   async_clients_test();
    asio_client_test();
    async_calls();
 

--- a/tests/asio_repe/asio_repe.cpp
+++ b/tests/asio_repe/asio_repe.cpp
@@ -10,7 +10,7 @@
 struct api
 {
    std::function<int(std::vector<int>& vec)> sum = [](std::vector<int>& vec) {
-      std::this_thread::sleep_for(std::chrono::seconds(1));
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
       return std::reduce(vec.begin(), vec.end());
    };
    std::function<double(std::vector<double>& vec)> max = [](std::vector<double>& vec) { return std::ranges::max(vec); };

--- a/tests/repe_test/repe_test.cpp
+++ b/tests/repe_test/repe_test.cpp
@@ -11,7 +11,7 @@
 #include "glaze/rpc/repe/registry.hpp"
 #include "ut/ut.hpp"
 
-#include "glaze/thread/safe_string.hpp"
+#include "glaze/thread/async_string.hpp"
 
 using namespace ut;
 
@@ -427,7 +427,7 @@ struct tester
 {
    std::atomic<int> integer{};
    std::atomic<double> number{};
-   glz::safe_string str{};
+   glz::async_string str{};
 };
 
 suite multi_threading_tests = [] {

--- a/tests/repe_test/repe_test.cpp
+++ b/tests/repe_test/repe_test.cpp
@@ -83,7 +83,7 @@ suite structs_of_functions = [] {
 
       repe::request_json(request, {.query = "/i"}, 42);
       server.call(request, response);
-      expect(response.body == R"(null)") << response.body;
+      expect(response.body.empty()) << response.body;
 
       repe::request_json(request, {"/hello"});
       server.call(request, response);
@@ -106,7 +106,7 @@ suite structs_of_functions = [] {
 
       repe::request_json(request, {"/my_functions/void_func"});
       server.call(request, response);
-      expect(response.body == R"(null)") << response.body;
+      expect(response.body.empty()) << response.body;
 
       repe::request_json(request, {"/my_functions/hello"});
       server.call(request, response);
@@ -122,7 +122,7 @@ suite structs_of_functions = [] {
 
       repe::request_json(request, {"/my_string"}, "Howdy!");
       server.call(request, response);
-      expect(response.body == R"(null)");
+      expect(response.body.empty());
 
       repe::request_json(request, {"/my_string"});
       server.call(request, response);
@@ -166,7 +166,7 @@ suite structs_of_functions = [] {
 
       repe::request_json(request, {"/name"}, "Susan");
       server.call(request, response);
-      expect(response.body == R"(null)") << response.body;
+      expect(response.body.empty()) << response.body;
 
       repe::request_json(request, {"/get_name"});
       server.call(request, response);
@@ -180,12 +180,12 @@ suite structs_of_functions = [] {
       repe::request_json(request, {"/set_name"}, "Bob");
       server.call(request, response);
       expect(obj.name == "Bob");
-      expect(response.body == R"(null)") << response.body;
+      expect(response.body.empty()) << response.body;
 
       repe::request_json(request, {"/custom_name"}, "Alice");
       server.call(request, response);
       expect(obj.name == "Alice");
-      expect(response.body == R"(null)") << response.body;
+      expect(response.body.empty()) << response.body;
    };
 };
 
@@ -211,7 +211,7 @@ suite structs_of_functions_beve = [] {
       repe::request_beve(request, {.query = "/i"}, 42);
       server.call(request, response);
       expect(!glz::beve_to_json(response.body, res));
-      expect(res == R"(null)") << res;
+      expect(res.empty()) << res;
 
       repe::request_beve(request, {"/hello"});
       server.call(request, response);
@@ -239,7 +239,7 @@ suite structs_of_functions_beve = [] {
 
       std::string res{};
       expect(!glz::beve_to_json(response.body, res));
-      expect(res == R"(null)") << res;
+      expect(res.empty()) << res;
 
       repe::request_beve(request, {"/my_functions/hello"});
       server.call(request, response);
@@ -259,7 +259,7 @@ suite structs_of_functions_beve = [] {
       repe::request_beve(request, {"/my_string"}, "Howdy!");
       server.call(request, response);
       expect(!glz::beve_to_json(response.body, res));
-      expect(res == R"(null)");
+      expect(res.empty());
 
       repe::request_beve(request, {"/my_string"});
       server.call(request, response);
@@ -311,7 +311,7 @@ suite structs_of_functions_beve = [] {
 
       std::string res{};
       expect(!glz::beve_to_json(response.body, res));
-      expect(res == R"(null)") << res;
+      expect(res.empty()) << res;
 
       repe::request_beve(request, {"/get_name"});
       server.call(request, response);
@@ -331,14 +331,14 @@ suite structs_of_functions_beve = [] {
 
       expect(!glz::beve_to_json(response.body, res));
       expect(obj.name == "Bob");
-      expect(res == R"(null)") << res;
+      expect(res.empty()) << res;
 
       repe::request_beve(request, {"/custom_name"}, "Alice");
       server.call(request, response);
 
       expect(!glz::beve_to_json(response.body, res));
       expect(obj.name == "Alice");
-      expect(res == R"(null)") << res;
+      expect(res.empty()) << res;
    };
 };
 
@@ -367,7 +367,7 @@ suite wrapper_tests = [] {
 
       repe::request_json(request, {"/sub/my_functions/void_func"});
       server.call(request, response);
-      expect(response.body == R"(null)") << response.body;
+      expect(response.body.empty()) << response.body;
 
       repe::request_json(request, {"/sub/my_functions/hello"});
       server.call(request, response);
@@ -388,7 +388,7 @@ suite root_tests = [] {
 
       repe::request_json(request, {"/sub/my_functions/void_func"});
       server.call(request, response);
-      expect(response.body == R"(null)") << response.body;
+      expect(response.body.empty()) << response.body;
 
       repe::request_json(request, {"/sub/my_functions/hello"});
       server.call(request, response);
@@ -413,7 +413,7 @@ suite wrapper_tests_beve = [] {
 
       std::string res{};
       expect(!glz::beve_to_json(response.body, res));
-      expect(res == R"(null)") << res;
+      expect(res.empty()) << res;
 
       repe::request_beve(request, {"/sub/my_functions/hello"});
       server.call(request, response);

--- a/tests/repe_test/repe_test.cpp
+++ b/tests/repe_test/repe_test.cpp
@@ -11,6 +11,8 @@
 #include "glaze/rpc/repe/registry.hpp"
 #include "ut/ut.hpp"
 
+#include "glaze/thread/safe_string.hpp"
+
 using namespace ut;
 
 namespace repe = glz::repe;
@@ -423,9 +425,9 @@ suite wrapper_tests_beve = [] {
 
 struct tester
 {
-   int integer{};
-   double number{};
-   std::string str{};
+   std::atomic<int> integer{};
+   std::atomic<double> number{};
+   glz::safe_string str{};
 };
 
 suite multi_threading_tests = [] {
@@ -510,10 +512,8 @@ suite multi_threading_tests = [] {
 
       {
          latch.wait();
-         auto lock = registry.read_only_lock<"/str">();
-         expect(lock);
          bool valid = true;
-         for (char c : obj.str) {
+         for (char c : obj.str.string()) {
             if (c != 'x') {
                valid = false;
                break;


### PR DESCRIPTION
After experimenting and considering performance/flexibility it is has become clear that the registry should not impose any locking mechanisms on the data it provides access to. Rather, the data should be thread safe itself. In the JSON context this means we need thread safe types for boolean and numbers (atomics), strings (`glz::async_string`), arrays (`glz::async_vector`), and objects (`glz::async_map`).

By taking this approach we don't have to use complex chains of mutexes and can asynchronously manipulate various structures efficiently. Because the `glz::async_vector` and `glz::async_map` will store thread safe elements, these on need to lock on insertion and deleting, making asynchronous writes through complex structures feasible and extremely efficient.