### PR TITLE
Roundtrip support for vector<pair>, better concatenate option support, and BEVE support for these

### DIFF
--- a/include/glaze/beve/beve_to_json.hpp
+++ b/include/glaze/beve/beve_to_json.hpp
@@ -208,6 +208,39 @@ namespace glz
                }
                break;
             }
+               case 1: [[fallthrough]]; // signed integer key
+               case 2: {
+                  // unsigned integer key
+                  const auto n_fields = detail::int_from_compressed(ctx, it, end);
+                  if (bool(ctx.error)) {
+                     return;
+                  }
+                  for (size_t i = 0; i < n_fields; ++i) {
+                     // convert the key
+                     dump<'"'>(out, ix);
+                     beve_to_json_number<Opts>(tag, ctx, it, end, out, ix);
+                     if (bool(ctx.error)) [[unlikely]] {
+                        return;
+                     }
+                     dump<'"'>(out, ix);
+                     if constexpr (Opts.prettify) {
+                        dump<": ">(out, ix);
+                     }
+                     else {
+                        dump<':'>(out, ix);
+                     }
+                     // convert the value
+                     beve_to_json_value<Opts>(ctx, it, end, out, ix);
+                     if (i != n_fields - 1) {
+                        dump<','>(out, ix);
+                        if constexpr (Opts.prettify) {
+                           dump<'\n'>(out, ix);
+                           dumpn<Opts.indentation_char>(ctx.indentation_level, out, ix);
+                        }
+                     }
+                  }
+                  break;
+               }
             default: {
                ctx.error = error_code::syntax_error;
                return;

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -243,6 +243,10 @@ namespace glz
       template <class T>
       concept readable_map_t = !custom_read<T> && !meta_value_t<T> && !str_t<T> && range<T> &&
                                pair_t<range_value_t<T>> && map_subscriptable<std::decay_t<T>>;
+      
+      template <class T>
+      concept unaccessible_map_t = !custom_read<T> && !meta_value_t<T> && !str_t<T> && range<T> &&
+                               pair_t<range_value_t<T>> && !map_subscriptable<std::decay_t<T>>;
 
       template <class T>
       concept writable_map_t =
@@ -261,7 +265,7 @@ namespace glz
 
       template <class T>
       concept readable_array_t =
-         (range<T> && !custom_read<T> && !meta_value_t<T> && !str_t<T> && !readable_map_t<T> && !filesystem_path<T>);
+         (range<T> && !custom_read<T> && !meta_value_t<T> && !str_t<T> && !readable_map_t<T> && !unaccessible_map_t<T> && !filesystem_path<T>);
 
       template <class T>
       concept writable_array_t =

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -243,10 +243,6 @@ namespace glz
       template <class T>
       concept readable_map_t = !custom_read<T> && !meta_value_t<T> && !str_t<T> && range<T> &&
                                pair_t<range_value_t<T>> && map_subscriptable<std::decay_t<T>>;
-      
-      template <class T>
-      concept unaccessible_map_t = !custom_read<T> && !meta_value_t<T> && !str_t<T> && range<T> &&
-                               pair_t<range_value_t<T>> && !map_subscriptable<std::decay_t<T>>;
 
       template <class T>
       concept writable_map_t =
@@ -265,7 +261,7 @@ namespace glz
 
       template <class T>
       concept readable_array_t =
-         (range<T> && !custom_read<T> && !meta_value_t<T> && !str_t<T> && !readable_map_t<T> && !unaccessible_map_t<T> && !filesystem_path<T>);
+         (range<T> && !custom_read<T> && !meta_value_t<T> && !str_t<T> && !readable_map_t<T> && !filesystem_path<T>);
 
       template <class T>
       concept writable_array_t =

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -246,7 +246,7 @@ namespace glz
 
       template <class T>
       concept writable_map_t =
-         !custom_write<T> && !meta_value_t<T> && !str_t<T> && range<T> && pair_t<range_value_t<T>>;
+         !custom_write<T> && !meta_value_t<T> && !str_t<T> && range<T> && pair_t<range_value_t<T>> && map_subscriptable<std::decay_t<T>>;
 
       template <class Map>
       concept heterogeneous_map = requires {

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1366,6 +1366,83 @@ namespace glz
                }
             }
          }
+         
+         // for types like std::vector<std::pair...> that can't look up with operator[]
+         // Intead of hashing or linear searching, we just clear the input and overwrite the entire contents
+         template <auto Options>
+            requires (pair_t<range_value_t<T>> && Options.concatenate == true)
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+         {
+            static constexpr auto Opts = opening_handled_off<ws_handled_off<Options>()>();
+            if constexpr (!has_opening_handled(Options)) {
+               if constexpr (!has_ws_handled(Options)) {
+                  GLZ_SKIP_WS();
+               }
+               GLZ_MATCH_OPEN_BRACE;
+               GLZ_INVALID_END();
+               GLZ_ADD_LEVEL;
+            }
+            
+            // clear all contents and repopulate
+            value.clear();
+            
+            while (it < end)
+            {
+               GLZ_SKIP_WS();
+               
+               if (*it == '}') {
+                  ++it;
+                  GLZ_SUB_LEVEL;
+                  GLZ_VALID_END();
+                  return;
+               }
+               
+               auto& item = value.emplace_back();
+               
+               using V = std::decay_t<decltype(item)>;
+
+               if constexpr (str_t<typename V::first_type>) {
+                  read<JSON>::op<Opts>(item.first, ctx, it, end);
+                  if (bool(ctx.error)) [[unlikely]]
+                     return;
+               }
+               else {
+                  std::string_view key;
+                  read<JSON>::op<Opts>(key, ctx, it, end);
+                  if (bool(ctx.error)) [[unlikely]]
+                     return;
+                  if constexpr (Opts.null_terminated) {
+                     read<JSON>::op<Opts>(item.first, ctx, key.data(), key.data() + key.size());
+                  }
+                  else {
+                     if (size_t(end - it) == key.size()) [[unlikely]] {
+                        ctx.error = error_code::unexpected_end;
+                        return;
+                     }
+                     // For the non-null terminated case we just want one more character so that we don't parse
+                     // until the end of the buffer and create an end_reached code (unless there is an error).
+                     read<JSON>::op<Opts>(item.first, ctx, key.data(), key.data() + key.size() + 1);
+                  }
+                  if (bool(ctx.error)) [[unlikely]]
+                     return;
+               }
+
+               GLZ_PARSE_WS_COLON;
+               
+               read<JSON>::op<Opts>(item.second, ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
+               
+               GLZ_SKIP_WS();
+               
+               if (*it == ',') {
+                  ++it;
+                  GLZ_INVALID_END();
+               }
+            }
+            
+            ctx.error = error_code::unexpected_end;
+         }
       };
 
       // counts the number of JSON array elements
@@ -1850,88 +1927,6 @@ namespace glz
             match<'}'>(ctx, it);
             GLZ_SUB_LEVEL;
             GLZ_VALID_END();
-         }
-      };
-      
-      // for types like std::vector<std::pair...> that can't look up with operator[]
-      // Intead of hashing or linear searching, we just clear the input and overwrite the entire contents
-      template <class T>
-         requires unaccessible_map_t<T>
-      struct from<JSON, T>
-      {
-         template <auto Options>
-            requires (Options.concatenate == true)
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            static constexpr auto Opts = opening_handled_off<ws_handled_off<Options>()>();
-            if constexpr (!has_opening_handled(Options)) {
-               if constexpr (!has_ws_handled(Options)) {
-                  GLZ_SKIP_WS();
-               }
-               GLZ_MATCH_OPEN_BRACE;
-               GLZ_INVALID_END();
-               GLZ_ADD_LEVEL;
-            }
-            
-            // clear all contents and repopulate
-            value.clear();
-            
-            while (it < end)
-            {
-               GLZ_SKIP_WS();
-               
-               if (*it == '}') {
-                  ++it;
-                  GLZ_SUB_LEVEL;
-                  GLZ_VALID_END();
-                  return;
-               }
-               
-               auto& item = value.emplace_back();
-               
-               using V = std::decay_t<decltype(item)>;
-
-               if constexpr (str_t<typename V::first_type>) {
-                  read<JSON>::op<Opts>(item.first, ctx, it, end);
-                  if (bool(ctx.error)) [[unlikely]]
-                     return;
-               }
-               else {
-                  std::string_view key;
-                  read<JSON>::op<Opts>(key, ctx, it, end);
-                  if (bool(ctx.error)) [[unlikely]]
-                     return;
-                  if constexpr (Opts.null_terminated) {
-                     read<JSON>::op<Opts>(item.first, ctx, key.data(), key.data() + key.size());
-                  }
-                  else {
-                     if (size_t(end - it) == key.size()) [[unlikely]] {
-                        ctx.error = error_code::unexpected_end;
-                        return;
-                     }
-                     // For the non-null terminated case we just want one more character so that we don't parse
-                     // until the end of the buffer and create an end_reached code (unless there is an error).
-                     read<JSON>::op<Opts>(item.first, ctx, key.data(), key.data() + key.size() + 1);
-                  }
-                  if (bool(ctx.error)) [[unlikely]]
-                     return;
-               }
-
-               GLZ_PARSE_WS_COLON;
-               
-               read<JSON>::op<Opts>(item.second, ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]]
-                  return;
-               
-               GLZ_SKIP_WS();
-               
-               if (*it == ',') {
-                  ++it;
-                  GLZ_INVALID_END();
-               }
-            }
-            
-            ctx.error = error_code::unexpected_end;
          }
       };
 

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -2378,7 +2378,7 @@ suite custom_load_test = [] {
    };
 };
 
-/*suite pair_ranges_tests = [] {
+suite pair_ranges_tests = [] {
    static constexpr glz::opts concatenate_off{.format = glz::BEVE, .concatenate = false};
    
    "vector pair"_test = [] {
@@ -2401,7 +2401,7 @@ suite custom_load_test = [] {
       expect(!glz::read_beve(x, s));
       expect(x == v);
    };
-};*/
+};
 
 int main()
 {

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -2378,6 +2378,31 @@ suite custom_load_test = [] {
    };
 };
 
+/*suite pair_ranges_tests = [] {
+   static constexpr glz::opts concatenate_off{.format = glz::BEVE, .concatenate = false};
+   
+   "vector pair"_test = [] {
+      std::vector<std::pair<int, int>> v{{1,2},{3,4}};
+      auto s = glz::write<concatenate_off>(v).value_or("error");
+      std::string json{};
+      expect(not glz::beve_to_json(s, json));
+      expect(json == R"([{"1":2},{"3":4}])");
+      std::vector<std::pair<int, int>> x;
+      expect(!glz::read<concatenate_off>(x, s));
+      expect(x == v);
+   };
+   "vector pair roundtrip"_test = [] {
+      std::vector<std::pair<int, int>> v{{1,2},{3,4}};
+      auto s = glz::write_beve(v).value_or("error");
+      std::string json{};
+      expect(not glz::beve_to_json(s, json));
+      expect(json == R"({"1":2,"3":4})");
+      std::vector<std::pair<int, int>> x;
+      expect(!glz::read_beve(x, s));
+      expect(x == v);
+   };
+};*/
+
 int main()
 {
    glz::trace_begin("binary_test");

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -834,14 +834,14 @@ suite container_types = [] {
    };
    "vector pair"_test = [] {
       std::vector<std::pair<int, int>> v;
-      expect(!glz::read_json(v, R"([{"1":2},{"3":4}])"));
+      expect(!glz::read<glz::opts{.concatenate = false}>(v, R"([{"1":2},{"3":4}])"));
       static_assert(glz::detail::writable_map_t<decltype(v)>);
       const auto s = glz::write_json(v).value_or("error");
       expect(s == R"({"1":2,"3":4})") << s;
    };
    "vector pair"_test = [] {
       std::vector<std::pair<int, int>> v;
-      expect(!glz::read_json(v, R"([{"1":2},{"3":4}])"));
+      expect(!glz::read<glz::opts{.concatenate = false}>(v, R"([{"1":2},{"3":4}])"));
       const auto s = glz::write<glz::opts{.prettify = true}>(v).value_or("error");
       expect(s == R"({
    "1": 2,

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -836,27 +836,12 @@ suite container_types = [] {
       std::vector<std::pair<int, int>> v;
       expect(!glz::read<glz::opts{.concatenate = false}>(v, R"([{"1":2},{"3":4}])"));
       static_assert(glz::detail::writable_map_t<decltype(v)>);
-      const auto s = glz::write_json(v).value_or("error");
-      expect(s == R"({"1":2,"3":4})") << s;
+      const auto s = glz::write<glz::opts{.concatenate = false}>(v).value_or("error");
+      expect(s == R"([{"1":2},{"3":4}])") << s;
    };
    "vector pair"_test = [] {
       std::vector<std::pair<int, int>> v;
       expect(!glz::read<glz::opts{.concatenate = false}>(v, R"([{"1":2},{"3":4}])"));
-      const auto s = glz::write<glz::opts{.prettify = true}>(v).value_or("error");
-      expect(s == R"({
-   "1": 2,
-   "3": 4
-})") << s;
-   };
-   "vector pair roundtrip"_test = [] {
-      std::vector<std::pair<int, int>> v;
-      expect(!glz::read_json(v, R"([{"1":2},{"3":4}])"));
-      const auto s = glz::write<glz::opts{.concatenate = false}>(v).value_or("error");
-      expect(s == R"([{"1":2},{"3":4}])") << s;
-   };
-   "vector pair roundtrip"_test = [] {
-      std::vector<std::pair<int, int>> v;
-      expect(!glz::read_json(v, R"([{"1":2},{"3":4}])"));
       const auto s = glz::write<glz::opts{.prettify = true, .concatenate = false}>(v).value_or("error");
       expect(s == R"([
    {
@@ -866,6 +851,21 @@ suite container_types = [] {
       "3": 4
    }
 ])") << s;
+   };
+   "vector pair roundtrip"_test = [] {
+      std::vector<std::pair<int, int>> v;
+      expect(!glz::read_json(v, R"({"1":2,"3":4})"));
+      const auto s = glz::write_json(v).value_or("error");
+      expect(s == R"({"1":2,"3":4})") << s;
+   };
+   "vector pair roundtrip"_test = [] {
+      std::vector<std::pair<int, int>> v;
+      expect(!glz::read_json(v, R"({"1":2,"3":4})"));
+      const auto s = glz::write<glz::opts{.prettify = true}>(v).value_or("error");
+      expect(s == R"({
+   "1": 2,
+   "3": 4
+})") << s;
    };
    "deque roundtrip"_test = [] {
       std::vector<int> deq(100);

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -835,7 +835,6 @@ suite container_types = [] {
    "vector pair"_test = [] {
       std::vector<std::pair<int, int>> v;
       expect(!glz::read<glz::opts{.concatenate = false}>(v, R"([{"1":2},{"3":4}])"));
-      static_assert(glz::detail::writable_map_t<decltype(v)>);
       const auto s = glz::write<glz::opts{.concatenate = false}>(v).value_or("error");
       expect(s == R"([{"1":2},{"3":4}])") << s;
    };
@@ -904,6 +903,7 @@ suite container_types = [] {
       }
       std::string buffer{};
       std::map<std::string, int> map2{};
+      static_assert(glz::detail::writable_map_t<decltype(map2)>);
       expect(not glz::write_json(map, buffer));
       expect(glz::read_json(map2, buffer) == glz::error_code::none);
       // expect(map == map2);


### PR DESCRIPTION
Roundtrip support for vector<pair>, better concatenate option support, and BEVE support for these.