### PR TITLE
Removing invalid noexcept

### DIFF
--- a/include/glaze/beve/beve_to_json.hpp
+++ b/include/glaze/beve/beve_to_json.hpp
@@ -105,7 +105,7 @@ namespace glz
       }
 
       template <glz::opts Opts, class Buffer>
-      inline void beve_to_json_value(auto&& ctx, auto&& it, auto&& end, Buffer& out, auto&& ix) noexcept
+      inline void beve_to_json_value(auto&& ctx, auto&& it, auto&& end, Buffer& out, auto&& ix)
       {
          if (it >= end) [[unlikely]] {
             ctx.error = error_code::syntax_error;
@@ -638,7 +638,7 @@ namespace glz
    }
 
    template <glz::opts Opts = glz::opts{}, class BEVEBuffer, class JSONBuffer>
-   [[nodiscard]] inline error_ctx beve_to_json(const BEVEBuffer& beve, JSONBuffer& out) noexcept
+   [[nodiscard]] inline error_ctx beve_to_json(const BEVEBuffer& beve, JSONBuffer& out)
    {
       size_t ix{}; // write index
 

--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -25,7 +25,7 @@ namespace glz
       {
          template <auto Opts, class T, class Tag, is_context Ctx, class It0, class It1>
             requires(has_no_header(Opts))
-         GLZ_ALWAYS_INLINE static void op(T&& value, Tag&& tag, Ctx&& ctx, It0&& it, It1&& end) noexcept
+         GLZ_ALWAYS_INLINE static void op(T&& value, Tag&& tag, Ctx&& ctx, It0&& it, It1&& end)
          {
             if constexpr (const_value_v<T>) {
                if constexpr (Opts.error_on_const_read) {
@@ -45,7 +45,7 @@ namespace glz
 
          template <auto Opts, class T, is_context Ctx, class It0, class It1>
             requires(not has_no_header(Opts))
-         GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
+         GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, It0&& it, It1&& end)
          {
             if constexpr (const_value_v<T>) {
                if constexpr (Opts.error_on_const_read) {
@@ -69,7 +69,7 @@ namespace glz
       struct from<BEVE, T>
       {
          template <auto Opts, class Value, is_context Ctx, class It0, class It1>
-         GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
+         GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, It0&& it, It1&& end)
          {
             using V = std::decay_t<decltype(get_member(std::declval<Value>(), meta_wrapper_v<T>))>;
             from<BEVE, V>::template op<Opts>(get_member(std::forward<Value>(value), meta_wrapper_v<T>),
@@ -441,7 +441,7 @@ namespace glz
       struct from<BEVE, basic_raw_json<T>>
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             read<BEVE>::op<Opts>(value.str, ctx, it, end);
          }
@@ -451,7 +451,7 @@ namespace glz
       struct from<BEVE, basic_text<T>>
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             read<BEVE>::op<Opts>(value.str, ctx, it, end);
          }
@@ -493,7 +493,7 @@ namespace glz
          template <auto Opts>
             requires(has_no_header(Opts))
          GLZ_ALWAYS_INLINE static void op(auto&& value, const uint8_t, is_context auto&& ctx, auto&& it,
-                                          auto&& end) noexcept
+                                          auto&& end)
          {
             const auto n = int_from_compressed(ctx, it, end);
             if (bool(ctx.error)) [[unlikely]] {
@@ -510,7 +510,7 @@ namespace glz
 
          template <auto Opts>
             requires(not has_no_header(Opts))
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             constexpr uint8_t header = tag::string;
 
@@ -548,7 +548,7 @@ namespace glz
       struct from<BEVE, T> final
       {
          template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             using V = range_value_t<std::decay_t<T>>;
 
@@ -682,7 +682,7 @@ namespace glz
       struct from<BEVE, T> final
       {
          template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             using V = range_value_t<std::decay_t<T>>;
 
@@ -1037,7 +1037,7 @@ namespace glz
       struct from<BEVE, T> final
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(T& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         GLZ_ALWAYS_INLINE static void op(T& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             using Key = typename T::first_type;
 
@@ -1073,7 +1073,7 @@ namespace glz
       struct from<BEVE, T> final
       {
          template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             using Key = typename T::key_type;
 
@@ -1167,7 +1167,7 @@ namespace glz
       struct from<BEVE, T> final
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             GLZ_END_CHECK();
             const auto tag = uint8_t(*it);
@@ -1234,7 +1234,7 @@ namespace glz
       {
          template <auto Opts>
             requires(Opts.structs_as_arrays == true)
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             if constexpr (reflectable<T>) {
                auto t = to_tuple(value);
@@ -1266,7 +1266,7 @@ namespace glz
 
          template <auto Opts>
             requires(Opts.structs_as_arrays == false)
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             constexpr uint8_t type = 0; // string key
             constexpr uint8_t header = tag::object | type;
@@ -1394,7 +1394,7 @@ namespace glz
       struct from<BEVE, T> final
       {
          template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             GLZ_END_CHECK();
             const auto tag = uint8_t(*it);
@@ -1424,7 +1424,7 @@ namespace glz
       struct from<BEVE, T> final
       {
          template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             GLZ_END_CHECK();
             const auto tag = uint8_t(*it);
@@ -1485,7 +1485,7 @@ namespace glz
       struct from<BEVE, T>
       {
          template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&&... args)
          {
             static thread_local std::string buffer{};
             read<BEVE>::op<Opts>(buffer, ctx, args...);
@@ -1498,13 +1498,13 @@ namespace glz
    }
 
    template <read_beve_supported T, class Buffer>
-   [[nodiscard]] inline error_ctx read_beve(T&& value, Buffer&& buffer) noexcept
+   [[nodiscard]] inline error_ctx read_beve(T&& value, Buffer&& buffer)
    {
       return read<opts{.format = BEVE}>(value, std::forward<Buffer>(buffer));
    }
 
    template <read_beve_supported T, class Buffer>
-   [[nodiscard]] inline expected<T, error_ctx> read_beve(Buffer&& buffer) noexcept
+   [[nodiscard]] inline expected<T, error_ctx> read_beve(Buffer&& buffer)
    {
       T value{};
       const auto pe = read<opts{.format = BEVE}>(value, std::forward<Buffer>(buffer));
@@ -1515,7 +1515,7 @@ namespace glz
    }
 
    template <opts Opts = opts{}, read_beve_supported T>
-   [[nodiscard]] inline error_ctx read_file_beve(T& value, const sv file_name, auto&& buffer) noexcept
+   [[nodiscard]] inline error_ctx read_file_beve(T& value, const sv file_name, auto&& buffer)
    {
       context ctx{};
       ctx.current_file = file_name;
@@ -1530,14 +1530,14 @@ namespace glz
    }
 
    template <read_beve_supported T, class Buffer>
-   [[nodiscard]] inline error_ctx read_binary_untagged(T&& value, Buffer&& buffer) noexcept
+   [[nodiscard]] inline error_ctx read_binary_untagged(T&& value, Buffer&& buffer)
    {
       return read<opts{.format = BEVE, .structs_as_arrays = true}>(std::forward<T>(value),
                                                                    std::forward<Buffer>(buffer));
    }
 
    template <read_beve_supported T, class Buffer>
-   [[nodiscard]] inline expected<T, error_ctx> read_binary_untagged(Buffer&& buffer) noexcept
+   [[nodiscard]] inline expected<T, error_ctx> read_binary_untagged(Buffer&& buffer)
    {
       T value{};
       const auto pe = read<opts{.format = BEVE, .structs_as_arrays = true}>(value, std::forward<Buffer>(buffer));
@@ -1549,7 +1549,7 @@ namespace glz
 
    template <opts Opts = opts{}, read_beve_supported T>
    [[nodiscard]] inline error_ctx read_file_beve_untagged(T& value, const std::string& file_name,
-                                                          auto&& buffer) noexcept
+                                                          auto&& buffer)
    {
       return read_file_beve<opt_true<Opts, &opts::structs_as_arrays>>(value, file_name, buffer);
    }

--- a/include/glaze/beve/wrappers.hpp
+++ b/include/glaze/beve/wrappers.hpp
@@ -17,7 +17,7 @@ namespace glz::detail
    struct from<BEVE, T>
    {
       template <auto Opts>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args) noexcept
+      GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args)
       {
          read<BEVE>::op<opt_true<Opts, T::opts_member>>(value.val, args...);
       }
@@ -27,7 +27,7 @@ namespace glz::detail
    struct to<BEVE, T>
    {
       template <auto Opts>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args)
       {
          write<BEVE>::op<opt_true<Opts, T::opts_member>>(value.val, ctx, args...);
       }

--- a/include/glaze/beve/write.hpp
+++ b/include/glaze/beve/write.hpp
@@ -18,7 +18,7 @@ namespace glz
 {
    namespace detail
    {
-      GLZ_ALWAYS_INLINE void dump_type(auto&& value, auto&& b, auto&& ix) noexcept
+      GLZ_ALWAYS_INLINE void dump_type(auto&& value, auto&& b, auto&& ix)
       {
          using V = std::decay_t<decltype(value)>;
          constexpr auto n = sizeof(V);
@@ -39,7 +39,7 @@ namespace glz
       }
 
       template <uint64_t i, class... Args>
-      GLZ_ALWAYS_INLINE void dump_compressed_int(Args&&... args) noexcept
+      GLZ_ALWAYS_INLINE void dump_compressed_int(Args&&... args)
       {
          if constexpr (i < 64) {
             const uint8_t c = uint8_t(i) << 2;
@@ -63,7 +63,7 @@ namespace glz
       }
 
       template <auto Opts, class... Args>
-      GLZ_ALWAYS_INLINE void dump_compressed_int(uint64_t i, Args&&... args) noexcept
+      GLZ_ALWAYS_INLINE void dump_compressed_int(uint64_t i, Args&&... args)
       {
          if (i < 64) {
             const uint8_t c = uint8_t(i) << 2;
@@ -90,14 +90,14 @@ namespace glz
       struct write<BEVE>
       {
          template <auto Opts, class T, is_context Ctx, class B, class IX>
-         GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix) noexcept
+         GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
          {
             to<BEVE, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
                                                                 std::forward<B>(b), std::forward<IX>(ix));
          }
 
          template <auto Opts, class T, is_context Ctx, class B, class IX>
-         GLZ_ALWAYS_INLINE static void no_header(T&& value, Ctx&& ctx, B&& b, IX&& ix) noexcept
+         GLZ_ALWAYS_INLINE static void no_header(T&& value, Ctx&& ctx, B&& b, IX&& ix)
          {
             to<BEVE, std::remove_cvref_t<T>>::template no_header<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
                                                                        std::forward<B>(b), std::forward<IX>(ix));
@@ -109,7 +109,7 @@ namespace glz
       struct to<BEVE, T>
       {
          template <auto Opts, class Value, is_context Ctx, class B, class IX>
-         GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, B&& b, IX&& ix) noexcept
+         GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, B&& b, IX&& ix)
          {
             using V = std::remove_cvref_t<decltype(get_member(std::declval<Value>(), meta_wrapper_v<T>))>;
             to<BEVE, V>::template op<Opts>(get_member(std::forward<Value>(value), meta_wrapper_v<T>),
@@ -121,7 +121,7 @@ namespace glz
       struct to<BEVE, T>
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, auto&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, auto&&... args)
          {
             dump_type(uint8_t{0}, args...);
          }
@@ -131,7 +131,7 @@ namespace glz
       struct to<BEVE, hidden>
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&, auto&&...) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&, auto&&...)
          {
             static_assert(false_v<decltype(value)>, "hidden type should not be written");
          }
@@ -141,7 +141,7 @@ namespace glz
       struct to<BEVE, T>
       {
          template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&&, auto&&... args) noexcept
+         static void op(auto&& value, is_context auto&&, auto&&... args)
          {
             constexpr uint8_t type = uint8_t(3) << 3;
             constexpr uint8_t tag = tag::typed_array | type;
@@ -193,7 +193,7 @@ namespace glz
       struct to<BEVE, T>
       {
          template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, Args&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, Args&&... args)
          {
             constexpr uint8_t tag = tag::string;
 
@@ -206,7 +206,7 @@ namespace glz
       struct to<BEVE, T> final
       {
          template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(const bool value, is_context auto&&, Args&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(const bool value, is_context auto&&, Args&&... args)
          {
             dump_type(value ? tag::bool_true : tag::bool_false, args...);
          }
@@ -216,7 +216,7 @@ namespace glz
       struct to<BEVE, T> final
       {
          template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
          {
             write<BEVE>::op<Opts>(name_v<std::decay_t<decltype(value)>>, ctx, args...);
          }
@@ -226,7 +226,7 @@ namespace glz
       struct to<BEVE, basic_raw_json<T>> final
       {
          template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
          {
             write<BEVE>::op<Opts>(value.str, ctx, std::forward<Args>(args)...);
          }
@@ -236,7 +236,7 @@ namespace glz
       struct to<BEVE, basic_text<T>> final
       {
          template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
          {
             write<BEVE>::op<Opts>(value.str, ctx, std::forward<Args>(args)...);
          }
@@ -251,7 +251,7 @@ namespace glz
       struct to<BEVE, T> final
       {
          template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
          {
             using Variant = std::decay_t<decltype(value)>;
 
@@ -276,7 +276,7 @@ namespace glz
       struct to<BEVE, T> final
       {
          template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, Args&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, Args&&... args)
          {
             constexpr uint8_t type = std::floating_point<T> ? 0 : (std::is_signed_v<T> ? 0b000'01'000 : 0b000'10'000);
             constexpr uint8_t tag = tag::number | type | (byte_count<T> << 5);
@@ -285,7 +285,7 @@ namespace glz
          }
 
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void no_header(auto&& value, is_context auto&&, auto&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void no_header(auto&& value, is_context auto&&, auto&&... args)
          {
             dump_type(value, args...);
          }
@@ -296,7 +296,7 @@ namespace glz
       struct to<BEVE, T> final
       {
          template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, Args&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, Args&&... args)
          {
             using V = std::underlying_type_t<std::decay_t<T>>;
 
@@ -307,7 +307,7 @@ namespace glz
          }
 
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void no_header(auto&& value, is_context auto&&, auto&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void no_header(auto&& value, is_context auto&&, auto&&... args)
          {
             dump_type(value, args...);
          }
@@ -318,7 +318,7 @@ namespace glz
       struct to<BEVE, T> final
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&&... args)
          {
             constexpr uint8_t tag = tag::extensions | 0b00011'000;
             dump_type(tag, args...);
@@ -333,7 +333,7 @@ namespace glz
          }
 
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void no_header(auto&& value, is_context auto&&, auto&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void no_header(auto&& value, is_context auto&&, auto&&... args)
          {
             dump_type(value.real(), args...);
             dump_type(value.imag(), args...);
@@ -344,7 +344,7 @@ namespace glz
       struct to<BEVE, T> final
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix)
          {
             const sv str = [&]() -> const sv {
                if constexpr (!char_array_t<T> && std::is_pointer_v<std::decay_t<T>>) {
@@ -370,7 +370,7 @@ namespace glz
          }
 
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void no_header(auto&& value, is_context auto&&, auto&& b, auto&& ix) noexcept
+         GLZ_ALWAYS_INLINE static void no_header(auto&& value, is_context auto&&, auto&& b, auto&& ix)
          {
             dump_compressed_int<Opts>(value.size(), b, ix);
 
@@ -391,7 +391,7 @@ namespace glz
 
          template <auto Opts>
             requires(map_like_array ? Opts.concatenate == false : true)
-         static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&&... args)
          {
             using V = range_value_t<std::decay_t<T>>;
 
@@ -519,7 +519,7 @@ namespace glz
 
          template <auto Opts>
             requires(map_like_array && Opts.concatenate == true)
-         static auto op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+         static auto op(auto&& value, is_context auto&& ctx, auto&&... args)
          {
             using Element = typename T::value_type;
             using Key = typename Element::first_type;
@@ -541,7 +541,7 @@ namespace glz
       struct to<BEVE, T> final
       {
          template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static auto op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         GLZ_ALWAYS_INLINE static auto op(auto&& value, is_context auto&& ctx, Args&&... args)
          {
             using Key = typename T::first_type;
 
@@ -561,7 +561,7 @@ namespace glz
       struct to<BEVE, T> final
       {
          template <auto Opts, class... Args>
-         static auto op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         static auto op(auto&& value, is_context auto&& ctx, Args&&... args)
          {
             using Key = typename T::key_type;
 
@@ -583,7 +583,7 @@ namespace glz
       struct to<BEVE, T>
       {
          template <auto Opts, class V, size_t N, class... Args>
-         GLZ_ALWAYS_INLINE static void op(const V (&value)[N], is_context auto&& ctx, Args&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(const V (&value)[N], is_context auto&& ctx, Args&&... args)
          {
             write<BEVE>::op<Opts>(std::span{value, N}, ctx, std::forward<Args>(args)...);
          }
@@ -594,7 +594,7 @@ namespace glz
       struct to<BEVE, T> final
       {
          template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
          {
             if (value) {
                write<BEVE>::op<Opts>(*value, ctx, args...);
@@ -610,7 +610,7 @@ namespace glz
       struct to<BEVE, T>
       {
          template <auto Options>
-         static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&&... args)
          {
             using V = std::decay_t<decltype(value.value)>;
             static constexpr auto N = glz::tuple_size_v<V> / 2;
@@ -653,7 +653,7 @@ namespace glz
       struct to<BEVE, T>
       {
          template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
          {
             using V = std::decay_t<decltype(value.value)>;
             static constexpr auto N = glz::tuple_size_v<V>;
@@ -692,7 +692,7 @@ namespace glz
 
          template <auto Opts, class... Args>
             requires(Opts.structs_as_arrays == true)
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
          {
             dump<tag::generic_array>(args...);
             dump_compressed_int<count_to_write>(args...);
@@ -725,7 +725,7 @@ namespace glz
 
          template <auto Options, class... Args>
             requires(Options.structs_as_arrays == false)
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
          {
             if constexpr (!has_opening_handled(Options)) {
                constexpr uint8_t type = 0; // string key
@@ -774,7 +774,7 @@ namespace glz
       struct to<BEVE, T> final
       {
          template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
          {
             dump<tag::generic_array>(args...);
 
@@ -791,7 +791,7 @@ namespace glz
       struct to<BEVE, T> final
       {
          template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
          {
             dump<tag::generic_array>(args...);
 
@@ -815,7 +815,7 @@ namespace glz
       struct to<BEVE, T>
       {
          template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args)
          {
             to<BEVE, decltype(value.string())>::template op<Opts>(value.string(), std::forward<Args>(args)...);
          }
@@ -831,7 +831,7 @@ namespace glz
       struct write_partial<BEVE>
       {
          template <auto& Partial, auto Opts, class T, is_context Ctx, class B, class IX>
-         static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix) noexcept
+         static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
          {
             if constexpr (std::count(Partial.begin(), Partial.end(), "") > 0) {
                detail::write<BEVE>::op<Opts>(value, ctx, b, ix);
@@ -852,7 +852,7 @@ namespace glz
       struct to_partial<BEVE, T> final
       {
          template <auto& Partial, auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
          {
             static constexpr auto sorted = sort_json_ptrs(Partial);
             static constexpr auto groups = glz::group_json_ptrs<sorted>();
@@ -925,26 +925,26 @@ namespace glz
    }
 
    template <write_beve_supported T, class Buffer>
-   [[nodiscard]] error_ctx write_beve(T&& value, Buffer&& buffer) noexcept
+   [[nodiscard]] error_ctx write_beve(T&& value, Buffer&& buffer)
    {
       return write<opts{.format = BEVE}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
    template <opts Opts = opts{}, write_beve_supported T>
-   [[nodiscard]] glz::expected<std::string, error_ctx> write_beve(T&& value) noexcept
+   [[nodiscard]] glz::expected<std::string, error_ctx> write_beve(T&& value)
    {
       return write<set_beve<Opts>()>(std::forward<T>(value));
    }
 
    template <auto& Partial, write_beve_supported T, class Buffer>
-   [[nodiscard]] error_ctx write_beve(T&& value, Buffer&& buffer) noexcept
+   [[nodiscard]] error_ctx write_beve(T&& value, Buffer&& buffer)
    {
       return write<Partial, opts{.format = BEVE}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
    // requires file_name to be null terminated
    template <opts Opts = opts{}, write_beve_supported T>
-   [[nodiscard]] error_ctx write_file_beve(T&& value, const sv file_name, auto&& buffer) noexcept
+   [[nodiscard]] error_ctx write_file_beve(T&& value, const sv file_name, auto&& buffer)
    {
       static_assert(sizeof(decltype(*buffer.data())) == 1);
 
@@ -966,20 +966,20 @@ namespace glz
    }
 
    template <write_beve_supported T, class Buffer>
-   [[nodiscard]] error_ctx write_beve_untagged(T&& value, Buffer&& buffer) noexcept
+   [[nodiscard]] error_ctx write_beve_untagged(T&& value, Buffer&& buffer)
    {
       return write<opts{.format = BEVE, .structs_as_arrays = true}>(std::forward<T>(value),
                                                                     std::forward<Buffer>(buffer));
    }
 
    template <write_beve_supported T>
-   [[nodiscard]] error_ctx write_beve_untagged(T&& value) noexcept
+   [[nodiscard]] error_ctx write_beve_untagged(T&& value)
    {
       return write<opts{.format = BEVE, .structs_as_arrays = true}>(std::forward<T>(value));
    }
 
    template <opts Opts = opts{}, write_beve_supported T>
-   [[nodiscard]] error_ctx write_file_beve_untagged(T&& value, const std::string& file_name, auto&& buffer) noexcept
+   [[nodiscard]] error_ctx write_file_beve_untagged(T&& value, const std::string& file_name, auto&& buffer)
    {
       return write_file_beve<opt_true<Opts, &opts::structs_as_arrays>>(std::forward<T>(value), file_name, buffer);
    }

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -410,6 +410,8 @@ namespace glz
          return make_variant_id_map_impl<T>(indices, ids_v<T>);
       }
 
+      // TODO: Should noexcept be removed and will this have performance implications?
+      // The invocations could potentially throw, though unlikely
       template <class Value, class Element>
       inline decltype(auto) get_member(Value&& value, Element&& element) noexcept
       {

--- a/include/glaze/core/custom.hpp
+++ b/include/glaze/core/custom.hpp
@@ -13,7 +13,7 @@ namespace glz::detail
    struct from<Format, T>
    {
       template <auto Opts>
-      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
       {
          using V = std::decay_t<decltype(value)>;
          using From = typename V::from_t;
@@ -134,7 +134,7 @@ namespace glz::detail
    struct to<Format, T>
    {
       template <auto Opts>
-      static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+      static void op(auto&& value, is_context auto&& ctx, auto&&... args)
       {
          using V = std::decay_t<decltype(value)>;
          using To = typename V::to_t;

--- a/include/glaze/core/read.hpp
+++ b/include/glaze/core/read.hpp
@@ -31,7 +31,7 @@ namespace glz
 
    template <opts Opts, class T>
       requires read_supported<Opts.format, T>
-   [[nodiscard]] error_ctx read(T& value, contiguous auto&& buffer, is_context auto&& ctx) noexcept
+   [[nodiscard]] error_ctx read(T& value, contiguous auto&& buffer, is_context auto&& ctx)
    {
       static_assert(sizeof(decltype(*buffer.data())) == 1);
       using Buffer = std::remove_reference_t<decltype(buffer)>;
@@ -106,7 +106,7 @@ namespace glz
 
    template <opts Opts, class T>
       requires read_supported<Opts.format, T>
-   [[nodiscard]] error_ctx read(T& value, contiguous auto&& buffer) noexcept
+   [[nodiscard]] error_ctx read(T& value, contiguous auto&& buffer)
    {
       context ctx{};
       return read<Opts>(value, buffer, ctx);
@@ -121,7 +121,7 @@ namespace glz
    // for char array input
    template <opts Opts, class T, c_style_char_buffer Buffer>
       requires read_supported<Opts.format, T>
-   [[nodiscard]] error_ctx read(T& value, Buffer&& buffer, auto&& ctx) noexcept
+   [[nodiscard]] error_ctx read(T& value, Buffer&& buffer, auto&& ctx)
    {
       const auto str = std::string_view{std::forward<Buffer>(buffer)};
       if (str.empty()) {
@@ -132,7 +132,7 @@ namespace glz
 
    template <opts Opts, class T, c_style_char_buffer Buffer>
       requires read_supported<Opts.format, T>
-   [[nodiscard]] error_ctx read(T& value, Buffer&& buffer) noexcept
+   [[nodiscard]] error_ctx read(T& value, Buffer&& buffer)
    {
       context ctx{};
       return read<Opts>(value, std::forward<Buffer>(buffer), ctx);

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -846,7 +846,7 @@ namespace glz::detail
       std::array<uint8_t, 256> unique_index{};
    };
 
-   inline constexpr unique_per_length_t unique_per_length_info(const auto& input_strings) noexcept
+   inline constexpr unique_per_length_t unique_per_length_info(const auto& input_strings)
    {
       // TODO: MSVC fixed the related compiler bug, but GitHub Actions has not caught up yet
 #if !defined(_MSC_VER)

--- a/include/glaze/core/seek.hpp
+++ b/include/glaze/core/seek.hpp
@@ -15,22 +15,22 @@ namespace glz::detail
 {
    template <class F, class T>
       requires glaze_value_t<T>
-   bool seek_impl(F&& func, T&& value, sv json_ptr) noexcept;
+   bool seek_impl(F&& func, T&& value, sv json_ptr);
 
    template <class F, class T>
       requires glaze_array_t<T> || tuple_t<std::decay_t<T>> || array_t<std::decay_t<T>> || is_std_tuple<std::decay_t<T>>
-   bool seek_impl(F&& func, T&& value, sv json_ptr) noexcept;
+   bool seek_impl(F&& func, T&& value, sv json_ptr);
 
    template <class F, class T>
       requires nullable_t<std::decay_t<T>>
-   bool seek_impl(F&& func, T&& value, sv json_ptr) noexcept;
+   bool seek_impl(F&& func, T&& value, sv json_ptr);
 
    template <class F, class T>
       requires readable_map_t<T> || glaze_object_t<T> || reflectable<T>
-   bool seek_impl(F&& func, T&& value, sv json_ptr) noexcept;
+   bool seek_impl(F&& func, T&& value, sv json_ptr);
 
    template <class F, class T>
-   bool seek_impl(F&& func, T&& value, sv json_ptr) noexcept
+   bool seek_impl(F&& func, T&& value, sv json_ptr)
    {
       if (json_ptr.empty()) {
          func(value);
@@ -42,7 +42,7 @@ namespace glz::detail
    // TODO: compile time search for `~` and optimize if escape does not exist
    template <class F, class T>
       requires readable_map_t<T> || glaze_object_t<T> || reflectable<T>
-   bool seek_impl(F&& func, T&& value, sv json_ptr) noexcept
+   bool seek_impl(F&& func, T&& value, sv json_ptr)
    {
       if (json_ptr.empty()) {
          func(value);
@@ -127,7 +127,7 @@ namespace glz::detail
 
    template <class F, class T>
       requires glaze_array_t<T> || tuple_t<std::decay_t<T>> || array_t<std::decay_t<T>> || is_std_tuple<std::decay_t<T>>
-   bool seek_impl(F&& func, T&& value, sv json_ptr) noexcept
+   bool seek_impl(F&& func, T&& value, sv json_ptr)
    {
       if (json_ptr.empty()) {
          func(value);
@@ -160,7 +160,7 @@ namespace glz::detail
 
    template <class F, class T>
       requires nullable_t<std::decay_t<T>>
-   bool seek_impl(F&& func, T&& value, sv json_ptr) noexcept
+   bool seek_impl(F&& func, T&& value, sv json_ptr)
    {
       if (json_ptr.empty()) {
          func(value);
@@ -172,7 +172,7 @@ namespace glz::detail
 
    template <class F, class T>
       requires glaze_value_t<T>
-   bool seek_impl(F&& func, T&& value, sv json_ptr) noexcept
+   bool seek_impl(F&& func, T&& value, sv json_ptr)
    {
       decltype(auto) member = get_member(value, meta_wrapper_v<std::remove_cvref_t<T>>);
       if (json_ptr.empty()) {
@@ -187,7 +187,7 @@ namespace glz
 {
    // Call a function on an value at the location of a json_ptr
    template <class F, class T>
-   bool seek(F&& func, T&& value, sv json_ptr) noexcept
+   bool seek(F&& func, T&& value, sv json_ptr)
    {
       return detail::seek_impl(std::forward<F>(func), std::forward<T>(value), json_ptr);
    }
@@ -195,7 +195,7 @@ namespace glz
    // Get a refrence to a value at the location of a json_ptr. Will error if
    // value doesnt exist or is wrong type
    template <class V, class T>
-   expected<std::reference_wrapper<V>, error_ctx> get(T&& root_value, sv json_ptr) noexcept
+   expected<std::reference_wrapper<V>, error_ctx> get(T&& root_value, sv json_ptr)
    {
       V* result{};
       error_code ec{};
@@ -303,7 +303,7 @@ namespace glz
 
    // call a member function
    template <class R, class T, class... Args>
-   call_return_t<R> call(T&& root_value, sv json_ptr, Args&&... args) noexcept
+   call_return_t<R> call(T&& root_value, sv json_ptr, Args&&... args)
    {
       call_result_t<R> result{};
 

--- a/include/glaze/core/write.hpp
+++ b/include/glaze/core/write.hpp
@@ -13,7 +13,7 @@ namespace glz
    // For writing to a std::string, std::vector<char>, std::deque<char> and the like
    template <opts Opts, class T, output_buffer Buffer>
       requires write_supported<Opts.format, T>
-   [[nodiscard]] error_ctx write(T&& value, Buffer& buffer, is_context auto&& ctx) noexcept
+   [[nodiscard]] error_ctx write(T&& value, Buffer& buffer, is_context auto&& ctx)
    {
       if constexpr (resizable<Buffer>) {
          if (buffer.empty()) {
@@ -31,7 +31,7 @@ namespace glz
 
    template <auto& Partial, opts Opts, class T, output_buffer Buffer>
       requires write_supported<Opts.format, T>
-   [[nodiscard]] error_ctx write(T&& value, Buffer& buffer) noexcept
+   [[nodiscard]] error_ctx write(T&& value, Buffer& buffer)
    {
       if constexpr (resizable<Buffer>) {
          if (buffer.empty()) {
@@ -49,7 +49,7 @@ namespace glz
 
    template <auto& Partial, opts Opts, class T, raw_buffer Buffer>
       requires write_supported<Opts.format, T>
-   [[nodiscard]] glz::expected<size_t, error_ctx> write(T&& value, Buffer& buffer) noexcept
+   [[nodiscard]] glz::expected<size_t, error_ctx> write(T&& value, Buffer& buffer)
    {
       context ctx{};
       size_t ix = 0;
@@ -62,7 +62,7 @@ namespace glz
 
    template <opts Opts, class T, output_buffer Buffer>
       requires write_supported<Opts.format, T>
-   [[nodiscard]] error_ctx write(T&& value, Buffer& buffer) noexcept
+   [[nodiscard]] error_ctx write(T&& value, Buffer& buffer)
    {
       context ctx{};
       return write<Opts>(std::forward<T>(value), buffer, ctx);
@@ -70,7 +70,7 @@ namespace glz
 
    template <opts Opts, class T>
       requires write_supported<Opts.format, T>
-   [[nodiscard]] glz::expected<std::string, error_ctx> write(T&& value) noexcept
+   [[nodiscard]] glz::expected<std::string, error_ctx> write(T&& value)
    {
       std::string buffer{};
       context ctx{};
@@ -83,7 +83,7 @@ namespace glz
 
    template <opts Opts, class T, raw_buffer Buffer>
       requires write_supported<Opts.format, T>
-   [[nodiscard]] glz::expected<size_t, error_ctx> write(T&& value, Buffer&& buffer, is_context auto&& ctx) noexcept
+   [[nodiscard]] glz::expected<size_t, error_ctx> write(T&& value, Buffer&& buffer, is_context auto&& ctx)
    {
       size_t ix = 0;
       detail::write<Opts.format>::template op<Opts>(std::forward<T>(value), ctx, buffer, ix);
@@ -95,14 +95,14 @@ namespace glz
 
    template <opts Opts, class T, raw_buffer Buffer>
       requires write_supported<Opts.format, T>
-   [[nodiscard]] glz::expected<size_t, error_ctx> write(T&& value, Buffer&& buffer) noexcept
+   [[nodiscard]] glz::expected<size_t, error_ctx> write(T&& value, Buffer&& buffer)
    {
       context ctx{};
       return write<Opts>(std::forward<T>(value), std::forward<Buffer>(buffer), ctx);
    }
 
    // requires file_name to be null terminated
-   [[nodiscard]] inline error_code buffer_to_file(auto&& buffer, const sv file_name) noexcept
+   [[nodiscard]] inline error_code buffer_to_file(auto&& buffer, const sv file_name)
    {
       auto file = std::ofstream(file_name.data(), std::ios::out);
       if (!file) {

--- a/include/glaze/csv/read.hpp
+++ b/include/glaze/csv/read.hpp
@@ -39,7 +39,7 @@ namespace glz
       struct read<CSV>
       {
          template <auto Opts, class T, is_context Ctx, class It0, class It1>
-         static void op(T&& value, Ctx&& ctx, It0&& it, It1 end) noexcept
+         static void op(T&& value, Ctx&& ctx, It0&& it, It1 end)
          {
             from<CSV, std::decay_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
                                                           std::forward<It0>(it), std::forward<It1>(end));
@@ -50,7 +50,7 @@ namespace glz
       struct from<CSV, T>
       {
          template <auto Opts, is_context Ctx, class It0, class It1>
-         static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
+         static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end)
          {
             using V = decltype(get_member(std::declval<T>(), meta_wrapper_v<T>));
             from<CSV, V>::template op<Opts>(get_member(value, meta_wrapper_v<T>), std::forward<Ctx>(ctx),
@@ -122,7 +122,7 @@ namespace glz
       struct from<CSV, T>
       {
          template <auto Opts, class It>
-         static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end)
          {
             if (bool(ctx.error)) [[unlikely]] {
                return;
@@ -181,7 +181,7 @@ namespace glz
       struct from<CSV, T>
       {
          template <auto Opts, class It>
-         static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end)
          {
             read<CSV>::op<Opts>(value.emplace_back(), ctx, it, end);
          }
@@ -616,13 +616,13 @@ namespace glz
    }
 
    template <uint32_t layout = rowwise, read_csv_supported T, class Buffer>
-   [[nodiscard]] inline auto read_csv(T&& value, Buffer&& buffer) noexcept
+   [[nodiscard]] inline auto read_csv(T&& value, Buffer&& buffer)
    {
       return read<opts{.format = CSV, .layout = layout}>(value, std::forward<Buffer>(buffer));
    }
 
    template <uint32_t layout = rowwise, read_csv_supported T, class Buffer>
-   [[nodiscard]] inline auto read_csv(Buffer&& buffer) noexcept
+   [[nodiscard]] inline auto read_csv(Buffer&& buffer)
    {
       T value{};
       read<opts{.format = CSV, .layout = layout}>(value, std::forward<Buffer>(buffer));

--- a/include/glaze/csv/write.hpp
+++ b/include/glaze/csv/write.hpp
@@ -17,7 +17,7 @@ namespace glz
       struct write<CSV>
       {
          template <auto Opts, class T, is_context Ctx, class B, class IX>
-         static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix) noexcept
+         static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
          {
             to<CSV, std::decay_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
                                                         std::forward<B>(b), std::forward<IX>(ix));
@@ -28,7 +28,7 @@ namespace glz
       struct to<CSV, T>
       {
          template <auto Opts, is_context Ctx, class B, class IX>
-         static void op(auto&& value, Ctx&& ctx, B&& b, IX&& ix) noexcept
+         static void op(auto&& value, Ctx&& ctx, B&& b, IX&& ix)
          {
             using V = decltype(get_member(std::declval<T>(), meta_wrapper_v<T>));
             to<CSV, V>::template op<Opts>(get_member(value, meta_wrapper_v<T>), std::forward<Ctx>(ctx),
@@ -40,7 +40,7 @@ namespace glz
       struct to<CSV, T>
       {
          template <auto Opts, class B>
-         static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix) noexcept
+         static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
          {
             write_chars::op<Opts>(value, ctx, b, ix);
          }
@@ -50,7 +50,7 @@ namespace glz
       struct to<CSV, T>
       {
          template <auto Opts, class B>
-         static void op(auto&& value, is_context auto&&, B&& b, auto&& ix) noexcept
+         static void op(auto&& value, is_context auto&&, B&& b, auto&& ix)
          {
             if (value) {
                dump<'1'>(b, ix);
@@ -65,7 +65,7 @@ namespace glz
       struct to<CSV, T>
       {
          template <auto Opts, class B>
-         static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix) noexcept
+         static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
          {
             if constexpr (resizable<T>) {
                if constexpr (Opts.layout == rowwise) {
@@ -100,7 +100,7 @@ namespace glz
       struct to<CSV, T>
       {
          template <auto Opts, class B>
-         static void op(auto&& value, is_context auto&&, B&& b, auto&& ix) noexcept
+         static void op(auto&& value, is_context auto&&, B&& b, auto&& ix)
          {
             dump_maybe_empty(value, b, ix);
          }
@@ -110,7 +110,7 @@ namespace glz
       struct to<CSV, T>
       {
          template <auto Opts, class B>
-         static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix) noexcept
+         static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
          {
             if constexpr (Opts.layout == rowwise) {
                for (auto& [name, data] : value) {
@@ -174,7 +174,7 @@ namespace glz
       struct to<CSV, T>
       {
          template <auto Opts, class B>
-         static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix) noexcept
+         static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
          {
             static constexpr auto N = reflect<T>::size;
 
@@ -332,19 +332,19 @@ namespace glz
    }
 
    template <uint32_t layout = rowwise, write_csv_supported T, class Buffer>
-   [[nodiscard]] auto write_csv(T&& value, Buffer&& buffer) noexcept
+   [[nodiscard]] auto write_csv(T&& value, Buffer&& buffer)
    {
       return write<opts{.format = CSV, .layout = layout}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
    template <uint32_t layout = rowwise, write_csv_supported T>
-   [[nodiscard]] expected<std::string, error_ctx> write_csv(T&& value) noexcept
+   [[nodiscard]] expected<std::string, error_ctx> write_csv(T&& value)
    {
       return write<opts{.format = CSV, .layout = layout}>(std::forward<T>(value));
    }
 
    template <uint32_t layout = rowwise, write_csv_supported T>
-   [[nodiscard]] error_ctx write_file_csv(T&& value, const std::string& file_name, auto&& buffer) noexcept
+   [[nodiscard]] error_ctx write_file_csv(T&& value, const std::string& file_name, auto&& buffer)
    {
       const auto ec = write<opts{.format = CSV, .layout = layout}>(std::forward<T>(value), buffer);
       if (bool(ec)) [[unlikely]] {

--- a/include/glaze/exceptions/binary_exceptions.hpp
+++ b/include/glaze/exceptions/binary_exceptions.hpp
@@ -20,7 +20,7 @@ namespace glz::ex
    }
 
    template <class T, class Buffer>
-   [[nodiscard]] T read_beve(Buffer&& buffer) noexcept
+   [[nodiscard]] T read_beve(Buffer&& buffer)
    {
       const auto ex = glz::read_beve<T>(std::forward<Buffer>(buffer));
       if (ex) {

--- a/include/glaze/ext/eigen.hpp
+++ b/include/glaze/ext/eigen.hpp
@@ -86,7 +86,7 @@ namespace glz
       struct to<BEVE, T>
       {
          template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&&... args)
          {
             constexpr uint8_t matrix = 0b00010'000;
             constexpr uint8_t tag = tag::extensions | matrix;
@@ -108,7 +108,7 @@ namespace glz
       struct to<BEVE, T>
       {
          template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&&... args)
          {
             constexpr uint8_t matrix = 0b00010'000;
             constexpr uint8_t tag = tag::extensions | matrix;
@@ -142,7 +142,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
          {
             std::span<typename T::Scalar, T::RowsAtCompileTime * T::ColsAtCompileTime> view(value.data(), value.size());
             detail::write<JSON>::op<Opts>(view, ctx, b, ix);

--- a/include/glaze/file/file_ops.hpp
+++ b/include/glaze/file/file_ops.hpp
@@ -18,7 +18,7 @@
 namespace glz
 {
    template <class T>
-   [[nodiscard]] error_code file_to_buffer(T& buffer, auto* file, const std::string_view path) noexcept
+   [[nodiscard]] error_code file_to_buffer(T& buffer, auto* file, const std::string_view path)
    {
       if (!file) {
          return error_code::file_open_failure;
@@ -45,14 +45,14 @@ namespace glz
    }
 
    template <class T>
-   [[nodiscard]] error_code file_to_buffer(T& buffer, const std::string_view file_name) noexcept
+   [[nodiscard]] error_code file_to_buffer(T& buffer, const std::string_view file_name)
    {
       auto* file = std::fopen(file_name.data(), "rb");
       return file_to_buffer(buffer, file, file_name);
    }
 
    template <class T>
-   std::string file_to_buffer(T&& file_name) noexcept
+   std::string file_to_buffer(T&& file_name)
    {
       std::string buffer{};
       file_to_buffer(buffer, std::forward<T>(file_name));
@@ -60,7 +60,7 @@ namespace glz
    }
 
    inline std::filesystem::path relativize_if_not_absolute(const std::filesystem::path& working_directory,
-                                                           const std::filesystem::path& filepath) noexcept
+                                                           const std::filesystem::path& filepath)
    {
       if (filepath.is_absolute()) {
          return filepath;

--- a/include/glaze/file/hostname_include.hpp
+++ b/include/glaze/file/hostname_include.hpp
@@ -58,7 +58,7 @@ namespace glz
          }
       }
 
-      inline std::string get_hostname(context& ctx) noexcept
+      inline std::string get_hostname(context& ctx)
       {
          char hostname[256]{};
 
@@ -86,7 +86,7 @@ namespace glz
       struct from<JSON, hostname_includer<T>>
       {
          template <auto Options>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             constexpr auto Opts = ws_handled_off<Options>();
             std::string buffer{};

--- a/include/glaze/file/raw_or_file.hpp
+++ b/include/glaze/file/raw_or_file.hpp
@@ -23,7 +23,7 @@ namespace glz
       struct from<JSON, raw_or_file>
       {
          template <auto Options>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             constexpr auto Opts = ws_handled_off<Options>();
             auto& v = value;
@@ -78,7 +78,7 @@ namespace glz
       struct to<JSON, raw_or_file>
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix)
          {
             dump_maybe_empty(value.str, b, ix);
          }

--- a/include/glaze/format/format_to.hpp
+++ b/include/glaze/format/format_to.hpp
@@ -10,7 +10,7 @@
 namespace glz
 {
    template <detail::num_t T>
-   void format_to(std::string& buffer, T&& value) noexcept
+   void format_to(std::string& buffer, T&& value)
    {
       auto ix = buffer.size();
       buffer.resize((std::max)(buffer.size() * 2, ix + 64));

--- a/include/glaze/json/invoke.hpp
+++ b/include/glaze/json/invoke.hpp
@@ -36,7 +36,7 @@ namespace glz
       struct from<JSON, invoke_t<T>>
       {
          template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             using V = std::decay_t<decltype(value.val)>;
 
@@ -99,7 +99,7 @@ namespace glz
       struct to<JSON, invoke_t<T>>
       {
          template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&&... args)
          {
             using V = std::decay_t<decltype(value.val)>;
             dump<'['>(args...);
@@ -120,7 +120,7 @@ namespace glz
       };
 
       template <auto MemPtr>
-      inline constexpr decltype(auto) invoke_impl() noexcept
+      inline constexpr decltype(auto) invoke_impl()
       {
          using V = decltype(MemPtr);
          if constexpr (std::is_member_function_pointer_v<V>) {
@@ -172,7 +172,7 @@ namespace glz
       struct from<JSON, T>
       {
          template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             using V = std::decay_t<decltype(value.func)>;
 
@@ -221,7 +221,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&&... args)
          {
             using V = std::decay_t<decltype(value.val)>;
             dump<'['>(args...);

--- a/include/glaze/json/json_t.hpp
+++ b/include/glaze/json/json_t.hpp
@@ -237,20 +237,20 @@ namespace glz
 
       [[nodiscard]] bool is_null() const noexcept { return holds<std::nullptr_t>(); }
 
-      [[nodiscard]] array_t& get_array() noexcept { return get<array_t>(); }
-      [[nodiscard]] const array_t& get_array() const noexcept { return get<array_t>(); }
+      [[nodiscard]] array_t& get_array() { return get<array_t>(); }
+      [[nodiscard]] const array_t& get_array() const { return get<array_t>(); }
 
-      [[nodiscard]] object_t& get_object() noexcept { return get<object_t>(); }
-      [[nodiscard]] const object_t& get_object() const noexcept { return get<object_t>(); }
+      [[nodiscard]] object_t& get_object() { return get<object_t>(); }
+      [[nodiscard]] const object_t& get_object() const { return get<object_t>(); }
 
-      [[nodiscard]] double& get_number() noexcept { return get<double>(); }
-      [[nodiscard]] const double& get_number() const noexcept { return get<double>(); }
+      [[nodiscard]] double& get_number() { return get<double>(); }
+      [[nodiscard]] const double& get_number() const { return get<double>(); }
 
-      [[nodiscard]] std::string& get_string() noexcept { return get<std::string>(); }
-      [[nodiscard]] const std::string& get_string() const noexcept { return get<std::string>(); }
+      [[nodiscard]] std::string& get_string() { return get<std::string>(); }
+      [[nodiscard]] const std::string& get_string() const { return get<std::string>(); }
 
-      [[nodiscard]] bool& get_boolean() noexcept { return get<bool>(); }
-      [[nodiscard]] const bool& get_boolean() const noexcept { return get<bool>(); }
+      [[nodiscard]] bool& get_boolean() { return get<bool>(); }
+      [[nodiscard]] const bool& get_boolean() const { return get<bool>(); }
 
       // empty() returns true if the value is an empty JSON object, array, or string, or a null value
       // otherwise returns false
@@ -291,17 +291,17 @@ namespace glz
       }
    };
 
-   [[nodiscard]] inline bool is_array(const json_t& value) { return value.is_array(); }
+   [[nodiscard]] inline bool is_array(const json_t& value) noexcept { return value.is_array(); }
 
-   [[nodiscard]] inline bool is_object(const json_t& value) { return value.is_object(); }
+   [[nodiscard]] inline bool is_object(const json_t& value) noexcept { return value.is_object(); }
 
-   [[nodiscard]] inline bool is_number(const json_t& value) { return value.is_number(); }
+   [[nodiscard]] inline bool is_number(const json_t& value) noexcept { return value.is_number(); }
 
-   [[nodiscard]] inline bool is_string(const json_t& value) { return value.is_string(); }
+   [[nodiscard]] inline bool is_string(const json_t& value) noexcept { return value.is_string(); }
 
-   [[nodiscard]] inline bool is_boolean(const json_t& value) { return value.is_boolean(); }
+   [[nodiscard]] inline bool is_boolean(const json_t& value) noexcept { return value.is_boolean(); }
 
-   [[nodiscard]] inline bool is_null(const json_t& value) { return value.is_null(); }
+   [[nodiscard]] inline bool is_null(const json_t& value) noexcept { return value.is_null(); }
 }
 
 template <>
@@ -318,7 +318,7 @@ namespace glz
 
    template <opts Opts, class T>
       requires read_supported<Opts.format, T>
-   [[nodiscard]] error_ctx read(T& value, const json_t& source) noexcept
+   [[nodiscard]] error_ctx read(T& value, const json_t& source)
    {
       auto buffer = source.dump();
       if (buffer) {
@@ -331,7 +331,7 @@ namespace glz
    }
 
    template <read_json_supported T>
-   [[nodiscard]] error_ctx read_json(T& value, const json_t& source) noexcept
+   [[nodiscard]] error_ctx read_json(T& value, const json_t& source)
    {
       auto buffer = source.dump();
       if (buffer) {
@@ -343,7 +343,7 @@ namespace glz
    }
 
    template <read_json_supported T>
-   [[nodiscard]] expected<T, error_ctx> read_json(const json_t& source) noexcept
+   [[nodiscard]] expected<T, error_ctx> read_json(const json_t& source)
    {
       auto buffer = source.dump();
       if (buffer) {

--- a/include/glaze/json/json_t.hpp
+++ b/include/glaze/json/json_t.hpp
@@ -32,7 +32,7 @@ namespace glz
       val_t data{};
 
       // Dump the value to JSON, returns an expected that will contain a std::string if valid
-      expected<std::string, error_ctx> dump() const noexcept { return write_json(data); }
+      expected<std::string, error_ctx> dump() const { return write_json(data); }
 
       template <class T>
       [[nodiscard]] T& get()

--- a/include/glaze/json/manage.hpp
+++ b/include/glaze/json/manage.hpp
@@ -32,7 +32,7 @@ namespace glz
       struct from<JSON, T>
       {
          template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             using V = std::decay_t<decltype(value)>;
             using From = typename V::from_t;
@@ -77,7 +77,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&&... args)
          {
             using V = std::decay_t<decltype(value)>;
             using To = typename V::to_t;
@@ -118,7 +118,7 @@ namespace glz
       };
 
       template <auto Member, auto From, auto To>
-      inline constexpr decltype(auto) manage_impl() noexcept
+      inline constexpr decltype(auto) manage_impl()
       {
          return [](auto&& v) { return manage_t{v, Member, From, To}; };
       }

--- a/include/glaze/json/minify.hpp
+++ b/include/glaze/json/minify.hpp
@@ -156,7 +156,7 @@ namespace glz
 
       template <opts Opts, class In, output_buffer Out>
          requires(contiguous<In> && resizable<In>)
-      inline void minify_json(is_context auto&& ctx, In&& in, Out&& out) noexcept
+      inline void minify_json(is_context auto&& ctx, In&& in, Out&& out)
       {
          if (in.empty()) {
             return;
@@ -192,14 +192,14 @@ namespace glz
    // The detail version can be used if error context is needed
 
    template <opts Opts = opts{}>
-   inline void minify_json(resizable auto& in, auto& out) noexcept
+   inline void minify_json(resizable auto& in, auto& out)
    {
       context ctx{};
       detail::minify_json<Opts>(ctx, in, out);
    }
 
    template <opts Opts = opts{}>
-   inline std::string minify_json(resizable auto& in) noexcept
+   inline std::string minify_json(resizable auto& in)
    {
       context ctx{};
       std::string out{};
@@ -208,14 +208,14 @@ namespace glz
    }
 
    template <opts Opts = opts{}>
-   inline void minify_jsonc(const auto& in, auto& out) noexcept
+   inline void minify_jsonc(const auto& in, auto& out)
    {
       context ctx{};
       detail::minify_json<opt_true<Opts, &opts::comments>>(ctx, in, out);
    }
 
    template <opts Opts = opts{}>
-   inline std::string minify_jsonc(resizable auto& in) noexcept
+   inline std::string minify_jsonc(resizable auto& in)
    {
       context ctx{};
       std::string out{};

--- a/include/glaze/json/ndjson.hpp
+++ b/include/glaze/json/ndjson.hpp
@@ -167,7 +167,7 @@ namespace glz
       struct to<NDJSON, T>
       {
          template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
          {
             const auto is_empty = [&]() -> bool {
                if constexpr (has_size<T>) {
@@ -196,7 +196,7 @@ namespace glz
       struct to<NDJSON, T>
       {
          template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
          {
             static constexpr auto N = []() constexpr {
                if constexpr (glaze_array_t<std::decay_t<T>>) {
@@ -228,7 +228,7 @@ namespace glz
       struct to<NDJSON, T>
       {
          template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
          {
             static constexpr auto N = []() constexpr {
                if constexpr (glaze_array_t<std::decay_t<T>>) {
@@ -257,7 +257,7 @@ namespace glz
    } // namespace detail
 
    template <read_ndjson_supported T, class Buffer>
-   [[nodiscard]] auto read_ndjson(T& value, Buffer&& buffer) noexcept
+   [[nodiscard]] auto read_ndjson(T& value, Buffer&& buffer)
    {
       context ctx{};
       return read<opts{.format = NDJSON}>(value, std::forward<Buffer>(buffer), ctx);
@@ -276,7 +276,7 @@ namespace glz
    }
 
    template <auto Opts = opts{.format = NDJSON}, read_ndjson_supported T>
-   [[nodiscard]] error_ctx read_file_ndjson(T& value, const sv file_name) noexcept
+   [[nodiscard]] error_ctx read_file_ndjson(T& value, const sv file_name)
    {
       context ctx{};
       ctx.current_file = file_name;
@@ -293,19 +293,19 @@ namespace glz
    }
 
    template <write_ndjson_supported T, class Buffer>
-   [[nodiscard]] error_ctx write_ndjson(T&& value, Buffer&& buffer) noexcept
+   [[nodiscard]] error_ctx write_ndjson(T&& value, Buffer&& buffer)
    {
       return write<opts{.format = NDJSON}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
    template <write_ndjson_supported T>
-   [[nodiscard]] expected<std::string, error_ctx> write_ndjson(T&& value) noexcept
+   [[nodiscard]] expected<std::string, error_ctx> write_ndjson(T&& value)
    {
       return write<opts{.format = NDJSON}>(std::forward<T>(value));
    }
 
    template <write_ndjson_supported T>
-   [[nodiscard]] error_ctx write_file_ndjson(T&& value, const std::string& file_name, auto&& buffer) noexcept
+   [[nodiscard]] error_ctx write_file_ndjson(T&& value, const std::string& file_name, auto&& buffer)
    {
       write<opts{.format = NDJSON}>(std::forward<T>(value), buffer);
       return {buffer_to_file(buffer, file_name)};

--- a/include/glaze/json/prettify.hpp
+++ b/include/glaze/json/prettify.hpp
@@ -12,7 +12,7 @@ namespace glz
    namespace detail
    {
       template <opts Opts>
-      inline void prettify_json(is_context auto&& ctx, auto&& it, auto&& end, auto&& b, auto&& ix) noexcept
+      inline void prettify_json(is_context auto&& ctx, auto&& it, auto&& end, auto&& b, auto&& ix)
       {
          constexpr bool use_tabs = Opts.indentation_char == '\t';
          constexpr auto indent_width = Opts.indentation_width;
@@ -172,7 +172,7 @@ namespace glz
       }
 
       template <opts Opts, contiguous In, output_buffer Out>
-      inline void prettify_json(is_context auto&& ctx, In&& in, Out&& out) noexcept
+      inline void prettify_json(is_context auto&& ctx, In&& in, Out&& out)
       {
          if constexpr (resizable<Out>) {
             if (in.empty()) {
@@ -205,7 +205,7 @@ namespace glz
    // The detail version can be used if error context is needed
 
    template <opts Opts = opts{}>
-   inline void prettify_json(const auto& in, auto& out) noexcept
+   inline void prettify_json(const auto& in, auto& out)
    {
       context ctx{};
       detail::prettify_json<Opts>(ctx, in, out);
@@ -215,7 +215,7 @@ namespace glz
    /// allocating version of prettify
    /// </summary>
    template <opts Opts = opts{}>
-   inline std::string prettify_json(const auto& in) noexcept
+   inline std::string prettify_json(const auto& in)
    {
       context ctx{};
       std::string out{};
@@ -224,7 +224,7 @@ namespace glz
    }
 
    template <opts Opts = opts{}>
-   inline void prettify_jsonc(const auto& in, auto& out) noexcept
+   inline void prettify_jsonc(const auto& in, auto& out)
    {
       context ctx{};
       detail::prettify_json<opt_true<Opts, &opts::comments>>(ctx, in, out);
@@ -234,7 +234,7 @@ namespace glz
    /// allocating version of prettify
    /// </summary>
    template <opts Opts = opts{}>
-   inline std::string prettify_jsonc(const auto& in) noexcept
+   inline std::string prettify_jsonc(const auto& in)
    {
       context ctx{};
       std::string out{};

--- a/include/glaze/json/raw_string.hpp
+++ b/include/glaze/json/raw_string.hpp
@@ -31,7 +31,7 @@ namespace glz
       struct from<JSON, raw_string_t<T>>
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args)
          {
             read<JSON>::op<opt_true<Opts, &opts::raw_string>>(value.val, args...);
          }
@@ -41,7 +41,7 @@ namespace glz
       struct to<JSON, raw_string_t<T>>
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args)
          {
             using val_t = std::remove_cvref_t<decltype(value.val)>;
             to<JSON, val_t>::template op<opt_true<Opts, &opts::raw_string>>(value.val, ctx, args...);
@@ -52,7 +52,7 @@ namespace glz
       struct from<JSON, escaped_t<T>>
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args)
          {
             read<JSON>::op<opt_false<Opts, &opts::raw_string>>(value.val, args...);
          }
@@ -62,7 +62,7 @@ namespace glz
       struct to<JSON, escaped_t<T>>
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args)
          {
             using val_t = std::remove_cvref_t<decltype(value.val)>;
             to<JSON, val_t>::template op<opt_false<Opts, &opts::raw_string>>(value.val, ctx, args...);

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -52,7 +52,7 @@ namespace glz
       struct read<JSON>
       {
          template <auto Opts, class T, is_context Ctx, class It0, class It1>
-         GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
+         GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, It0&& it, It1&& end)
          {
             if constexpr (const_value_v<T>) {
                if constexpr (Opts.error_on_const_read) {
@@ -72,7 +72,7 @@ namespace glz
 
          // This unknown key handler should not be given unescaped keys, that is for the user to handle.
          template <auto Opts, class T, is_context Ctx, class It0, class It1>
-         static void handle_unknown(const sv& key, T&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
+         static void handle_unknown(const sv& key, T&& value, Ctx&& ctx, It0&& it, It1&& end)
          {
             using ValueType = std::decay_t<decltype(value)>;
             if constexpr (detail::has_unknown_reader<ValueType>) {
@@ -121,7 +121,7 @@ namespace glz
       struct from<JSON, T>
       {
          template <auto Opts, class Value, is_context Ctx, class It0, class It1>
-         GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
+         GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, It0&& it, It1&& end)
          {
             using V = std::decay_t<decltype(get_member(std::declval<Value>(), meta_wrapper_v<T>))>;
             from<JSON, V>::template op<Opts>(get_member(std::forward<Value>(value), meta_wrapper_v<T>),
@@ -137,7 +137,7 @@ namespace glz
       template <opts Opts, class T, size_t I, class Func, class Tuple, class Value>
          requires(glaze_object_t<T> || reflectable<T>)
       void decode_index(Func&& func, Tuple&& tuple, Value&& value, is_context auto&& ctx, auto&& it,
-                        auto&& end) noexcept
+                        auto&& end)
       {
          static constexpr auto TargetKey = glz::get<I>(reflect<T>::keys);
          static constexpr auto Length = TargetKey.size();
@@ -256,7 +256,7 @@ namespace glz
       template <opts Opts, class T, auto HashInfo, class Func, class Value>
          requires(glaze_object_t<T> || reflectable<T>)
       GLZ_ALWAYS_INLINE constexpr void parse_and_invoke(Func&& func, Value&& value, is_context auto&& ctx, auto&& it,
-                                                        auto&& end) noexcept
+                                                        auto&& end)
       {
          constexpr auto type = HashInfo.type;
          constexpr auto N = reflect<T>::size;
@@ -384,7 +384,7 @@ namespace glz
       struct from<JSON, T>
       {
          template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args)
          {
             using V = std::decay_t<decltype(value.get())>;
             from<JSON, V>::template op<Opts>(value.get(), std::forward<Args>(args)...);
@@ -624,7 +624,7 @@ namespace glz
       {
          template <auto Opts, class It, class End>
             requires(has_is_padded(Opts))
-         static void op(auto& value, is_context auto&& ctx, It&& it, End&& end) noexcept
+         static void op(auto& value, is_context auto&& ctx, It&& it, End&& end)
          {
             if constexpr (Opts.number) {
                auto start = it;
@@ -756,7 +756,7 @@ namespace glz
 
          template <auto Opts, class It, class End>
             requires(not has_is_padded(Opts))
-         static void op(auto& value, is_context auto&& ctx, It&& it, End&& end) noexcept
+         static void op(auto& value, is_context auto&& ctx, It&& it, End&& end)
          {
             if constexpr (Opts.number) {
                auto start = it;
@@ -1172,7 +1172,7 @@ namespace glz
       struct from<JSON, T>
       {
          template <auto Opts>
-         static void op(auto& /*value*/, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto& /*value*/, is_context auto&& ctx, auto&& it, auto&& end)
          {
             if constexpr (!has_ws_handled(Opts)) {
                GLZ_SKIP_WS();
@@ -1191,7 +1191,7 @@ namespace glz
       struct from<JSON, basic_raw_json<T>>
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             auto it_start = it;
             skip_value<JSON>::op<Opts>(ctx, it, end);
@@ -1205,7 +1205,7 @@ namespace glz
       struct from<JSON, basic_text<T>>
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&& it, auto&& end) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&& it, auto&& end)
          {
             value.str = {it, static_cast<size_t>(end - it)}; // read entire contents as string
             it = end;
@@ -1218,7 +1218,7 @@ namespace glz
       struct from<JSON, T>
       {
          template <auto Options>
-         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             constexpr auto Opts = ws_handled_off<Options>();
             if constexpr (!has_ws_handled(Options)) {
@@ -1261,7 +1261,7 @@ namespace glz
       struct from<JSON, T>
       {
          template <auto Options>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             constexpr auto Opts = ws_handled_off<Options>();
             if constexpr (!has_ws_handled(Options)) {
@@ -1510,7 +1510,7 @@ namespace glz
       struct from<JSON, T>
       {
          template <auto Options>
-         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             constexpr auto Opts = ws_handled_off<Options>();
             if constexpr (!has_ws_handled(Options)) {
@@ -1545,7 +1545,7 @@ namespace glz
       struct from<JSON, T>
       {
          template <auto Opts>
-         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             static constexpr auto N = []() constexpr {
                if constexpr (glaze_array_t<T>) {
@@ -1611,7 +1611,7 @@ namespace glz
       struct from<JSON, T>
       {
          template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             if constexpr (!has_ws_handled(Opts)) {
                GLZ_SKIP_WS();
@@ -1654,7 +1654,7 @@ namespace glz
       struct from<JSON, includer<T>>
       {
          template <auto Options>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             constexpr auto Opts = ws_handled_off<Options>();
             std::string buffer{};
@@ -1930,7 +1930,7 @@ namespace glz
       };
 
       template <opts Opts>
-      GLZ_ALWAYS_INLINE void read_json_visitor(auto&& value, auto&& variant, auto&& ctx, auto&& it, auto&& end) noexcept
+      GLZ_ALWAYS_INLINE void read_json_visitor(auto&& value, auto&& variant, auto&& ctx, auto&& it, auto&& end)
       {
          constexpr auto variant_size = std::variant_size_v<std::decay_t<decltype(variant)>>;
          jump_table<variant_size>(
@@ -2852,7 +2852,7 @@ namespace glz
       struct from<JSON, T>
       {
          template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             if constexpr (!has_ws_handled(Opts)) {
                GLZ_SKIP_WS();
@@ -2944,7 +2944,7 @@ namespace glz
       struct from<JSON, T>
       {
          template <auto Options>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             constexpr auto Opts = ws_handled_off<Options>();
             if constexpr (!has_ws_handled(Options)) {
@@ -2994,7 +2994,7 @@ namespace glz
       struct from<JSON, T>
       {
          template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             std::string& buffer = string_buffer();
             read<JSON>::op<Opts>(buffer, ctx, it, end);
@@ -3030,14 +3030,14 @@ namespace glz
    }
 
    template <read_json_supported T, is_buffer Buffer>
-   [[nodiscard]] error_ctx read_json(T& value, Buffer&& buffer) noexcept
+   [[nodiscard]] error_ctx read_json(T& value, Buffer&& buffer)
    {
       context ctx{};
       return read<opts{}>(value, std::forward<Buffer>(buffer), ctx);
    }
 
    template <read_json_supported T, is_buffer Buffer>
-   [[nodiscard]] expected<T, error_ctx> read_json(Buffer&& buffer) noexcept
+   [[nodiscard]] expected<T, error_ctx> read_json(Buffer&& buffer)
    {
       T value{};
       context ctx{};
@@ -3049,14 +3049,14 @@ namespace glz
    }
 
    template <read_json_supported T, is_buffer Buffer>
-   [[nodiscard]] error_ctx read_jsonc(T& value, Buffer&& buffer) noexcept
+   [[nodiscard]] error_ctx read_jsonc(T& value, Buffer&& buffer)
    {
       context ctx{};
       return read<opts{.comments = true}>(value, std::forward<Buffer>(buffer), ctx);
    }
 
    template <read_json_supported T, is_buffer Buffer>
-   [[nodiscard]] expected<T, error_ctx> read_jsonc(Buffer&& buffer) noexcept
+   [[nodiscard]] expected<T, error_ctx> read_jsonc(Buffer&& buffer)
    {
       T value{};
       context ctx{};
@@ -3068,7 +3068,7 @@ namespace glz
    }
 
    template <auto Opts = opts{}, read_json_supported T, is_buffer Buffer>
-   [[nodiscard]] error_ctx read_file_json(T& value, const sv file_name, Buffer&& buffer) noexcept
+   [[nodiscard]] error_ctx read_file_json(T& value, const sv file_name, Buffer&& buffer)
    {
       context ctx{};
       ctx.current_file = file_name;
@@ -3083,7 +3083,7 @@ namespace glz
    }
 
    template <auto Opts = opts{}, read_json_supported T, is_buffer Buffer>
-   [[nodiscard]] error_ctx read_file_jsonc(T& value, const sv file_name, Buffer&& buffer) noexcept
+   [[nodiscard]] error_ctx read_file_jsonc(T& value, const sv file_name, Buffer&& buffer)
    {
       context ctx{};
       ctx.current_file = file_name;

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -263,7 +263,7 @@ namespace glz
       struct to_json_schema
       {
          template <auto Opts>
-         static void op(auto& s, auto& defs) noexcept
+         static void op(auto& s, auto& defs)
          {
             // &T::member
             if constexpr (glaze_t<T> && std::is_member_object_pointer_v<meta_wrapper_t<T>>) {
@@ -294,7 +294,7 @@ namespace glz
       struct to_json_schema<T>
       {
          template <auto Opts>
-         static void op(auto& s, auto&) noexcept
+         static void op(auto& s, auto&)
          {
             s.type = {"boolean"};
          }
@@ -304,7 +304,7 @@ namespace glz
       struct to_json_schema<T>
       {
          template <auto Opts>
-         static void op(auto& s, auto&) noexcept
+         static void op(auto& s, auto&)
          {
             using V = std::decay_t<T>;
             if constexpr (std::integral<V>) {
@@ -325,7 +325,7 @@ namespace glz
       struct to_json_schema<T>
       {
          template <auto Opts>
-         static void op(auto& s, auto&) noexcept
+         static void op(auto& s, auto&)
          {
             s.type = {"string"};
          }
@@ -335,7 +335,7 @@ namespace glz
       struct to_json_schema<T>
       {
          template <auto Opts>
-         static void op(auto& s, auto&) noexcept
+         static void op(auto& s, auto&)
          {
             s.type = {"null"};
             s.attributes.constant = std::monostate{};
@@ -346,7 +346,7 @@ namespace glz
       struct to_json_schema<T>
       {
          template <auto Opts>
-         static void op(auto& s, auto&) noexcept
+         static void op(auto& s, auto&)
          {
             s.type = {"string"};
 
@@ -375,7 +375,7 @@ namespace glz
       struct to_json_schema<basic_raw_json<T>>
       {
          template <auto Opts>
-         static void op(auto& s, auto&) noexcept
+         static void op(auto& s, auto&)
          {
             s.type = {"number", "string", "boolean", "object", "array", "null"};
          }
@@ -385,7 +385,7 @@ namespace glz
       struct to_json_schema<T>
       {
          template <auto Opts>
-         static void op(auto& s, auto& defs) noexcept
+         static void op(auto& s, auto& defs)
          {
             using V = std::decay_t<range_value_t<std::decay_t<T>>>;
             s.type = {"array"};
@@ -405,7 +405,7 @@ namespace glz
       struct to_json_schema<T>
       {
          template <auto Opts>
-         static void op(auto& s, auto& defs) noexcept
+         static void op(auto& s, auto& defs)
          {
             using V = std::decay_t<glz::tuple_element_t<1, range_value_t<std::decay_t<T>>>>;
             s.type = {"object"};
@@ -421,7 +421,7 @@ namespace glz
       struct to_json_schema<T>
       {
          template <auto Opts>
-         static void op(auto& s, auto& defs) noexcept
+         static void op(auto& s, auto& defs)
          {
             using V = std::decay_t<decltype(*std::declval<std::decay_t<T>>())>;
             to_json_schema<V>::template op<Opts>(s, defs);
@@ -438,7 +438,7 @@ namespace glz
       struct to_json_schema<T>
       {
          template <auto Opts>
-         static void op(auto& s, auto& defs) noexcept
+         static void op(auto& s, auto& defs)
          {
             static constexpr auto N = std::variant_size_v<T>;
             using type_counts = variant_type_count<T>;
@@ -484,7 +484,7 @@ namespace glz
       struct to_json_schema<T>
       {
          template <auto Opts>
-         static void op(auto& s, auto&) noexcept
+         static void op(auto& s, auto&)
          {
             // TODO: Actually handle this. We can specify a schema per item in items
             //      We can also do size restrictions on static arrays
@@ -540,7 +540,7 @@ namespace glz
       struct to_json_schema<T>
       {
          template <auto Opts>
-         static void op(auto& s, auto& defs) noexcept
+         static void op(auto& s, auto& defs)
          {
             static_assert(json_schema_matches_object_keys<T>());
 
@@ -603,7 +603,7 @@ namespace glz
    }
 
    template <class T, opts Opts = opts{}, class Buffer>
-   [[nodiscard]] error_ctx write_json_schema(Buffer&& buffer) noexcept
+   [[nodiscard]] error_ctx write_json_schema(Buffer&& buffer)
    {
       detail::schematic s{};
       s.defs.emplace();
@@ -612,7 +612,7 @@ namespace glz
    }
 
    template <class T, opts Opts = opts{}>
-   [[nodiscard]] glz::expected<std::string, error_ctx> write_json_schema() noexcept
+   [[nodiscard]] glz::expected<std::string, error_ctx> write_json_schema()
    {
       std::string buffer{};
       const error_ctx ec = write_json_schema<T, Opts>(buffer);

--- a/include/glaze/json/study.hpp
+++ b/include/glaze/json/study.hpp
@@ -106,7 +106,7 @@ namespace glz
 
          std::size_t size() const { return max_index; }
 
-         [[nodiscard]] expected<State, error_code> generate(const size_t i) noexcept
+         [[nodiscard]] expected<State, error_code> generate(const size_t i)
          {
             size_t deconst_index = i;
             for (auto& param_set : param_sets) {

--- a/include/glaze/json/wrappers.hpp
+++ b/include/glaze/json/wrappers.hpp
@@ -28,7 +28,7 @@ namespace glz
       struct from<JSON, quoted_t<T>>
       {
          template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&&... args)
          {
             static thread_local std::string s{};
             read<JSON>::op<Opts>(s, ctx, args...);
@@ -43,7 +43,7 @@ namespace glz
       struct to<JSON, quoted_t<T>>
       {
          template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&&... args)
          {
             static thread_local std::string s(128, ' ');
             size_t ix = 0; // overwrite index
@@ -57,7 +57,7 @@ namespace glz
       struct from<JSON, T>
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args)
          {
             read<JSON>::op<opt_true<Opts, T::opts_member>>(value.val, args...);
          }
@@ -67,7 +67,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args)
          {
             write<JSON>::op<opt_true<Opts, T::opts_member>>(value.val, ctx, args...);
          }

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -32,7 +32,7 @@ namespace glz
       struct write<JSON>
       {
          template <auto Opts, class T, is_context Ctx, class B, class IX>
-         GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix) noexcept
+         GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
          {
             to<JSON, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
                                                                 std::forward<B>(b), std::forward<IX>(ix));
@@ -44,7 +44,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts, class Value, is_context Ctx, class B, class IX>
-         GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, B&& b, IX&& ix) noexcept
+         GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, B&& b, IX&& ix)
          {
             using V = std::remove_cvref_t<decltype(get_member(std::declval<Value>(), meta_wrapper_v<T>))>;
             to<JSON, V>::template op<Opts>(get_member(std::forward<Value>(value), meta_wrapper_v<T>),
@@ -90,7 +90,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts>
-         static void op(auto&& value, auto&&, auto&& b, auto&& ix) noexcept
+         static void op(auto&& value, auto&&, auto&& b, auto&& ix)
          {
             dump<'"'>(b, ix);
             for (size_t i = value.size(); i > 0; --i) {
@@ -104,7 +104,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts>
-         static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix) noexcept
+         static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix)
          {
             static constexpr auto N = reflect<T>::size;
 
@@ -131,7 +131,7 @@ namespace glz
       struct to<JSON, hidden>
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, auto&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, auto&&... args)
          {
             dump(R"("hidden type should not have been written")", args...);
          }
@@ -159,7 +159,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args)
          {
             using V = std::remove_cvref_t<decltype(value.get())>;
             to<JSON, V>::template op<Opts>(value.get(), std::forward<Args>(args)...);
@@ -170,7 +170,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts, class B>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
          {
             dump<'['>(b, ix);
             write<JSON>::op<Opts>(value.real(), ctx, b, ix);
@@ -184,7 +184,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts, class B>
-         GLZ_ALWAYS_INLINE static void op(const bool value, is_context auto&&, B&& b, auto&& ix) noexcept
+         GLZ_ALWAYS_INLINE static void op(const bool value, is_context auto&&, B&& b, auto&& ix)
          {
             static constexpr auto checked = not has_write_unchecked(Opts);
             if constexpr (checked && vector_like<B>) {
@@ -218,7 +218,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts, class B>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
          {
             constexpr auto checked = not has_write_unchecked(Opts);
             if constexpr (Opts.quoted_num) {
@@ -250,7 +250,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts, class B>
-         static void op(auto&& value, is_context auto&&, B&& b, auto&& ix) noexcept
+         static void op(auto&& value, is_context auto&&, B&& b, auto&& ix)
          {
             if constexpr (Opts.number) {
                dump_maybe_empty(value, b, ix);
@@ -533,7 +533,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
          {
             to<JSON, decltype(value.string())>::template op<Opts>(value.string(), ctx, args...);
          }
@@ -544,7 +544,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
          {
             // TODO: Use new hashing approach for better performance
             // TODO: Check if sequenced and use the value as the index if so
@@ -575,7 +575,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
          {
             // serialize as underlying number
             write<JSON>::op<Opts>(static_cast<std::underlying_type_t<std::decay_t<T>>>(value), ctx,
@@ -587,7 +587,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, Args&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, Args&&... args)
          {
             dump<'"'>(args...);
             dump_maybe_empty(name_v<std::decay_t<decltype(value)>>, args...);
@@ -599,7 +599,7 @@ namespace glz
       struct to<JSON, basic_raw_json<T>>
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix)
          {
             dump_maybe_empty(value.str, b, ix);
          }
@@ -609,14 +609,14 @@ namespace glz
       struct to<JSON, basic_text<T>>
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix)
          {
             dump_maybe_empty(value.str, b, ix);
          }
       };
 
       template <opts Opts, bool minified_check = true, class B>
-      GLZ_ALWAYS_INLINE void write_array_entry_separator(is_context auto&& ctx, B&& b, auto&& ix) noexcept
+      GLZ_ALWAYS_INLINE void write_array_entry_separator(is_context auto&& ctx, B&& b, auto&& ix)
       {
          if constexpr (Opts.prettify) {
             if constexpr (vector_like<B>) {
@@ -646,7 +646,7 @@ namespace glz
       }
 
       template <opts Opts, bool minified_check = true, class B>
-      GLZ_ALWAYS_INLINE void write_object_entry_separator(is_context auto&& ctx, B&& b, auto&& ix) noexcept
+      GLZ_ALWAYS_INLINE void write_object_entry_separator(is_context auto&& ctx, B&& b, auto&& ix)
       {
          if constexpr (Opts.prettify) {
             if constexpr (vector_like<B>) {
@@ -671,7 +671,7 @@ namespace glz
       }
 
       template <opts Opts, class Key, class Value, is_context Ctx>
-      GLZ_ALWAYS_INLINE void write_pair_content(const Key& key, Value&& value, Ctx& ctx, auto&&... args) noexcept
+      GLZ_ALWAYS_INLINE void write_pair_content(const Key& key, Value&& value, Ctx& ctx, auto&&... args)
       {
          if constexpr (str_t<Key> || char_t<Key> || glaze_enum_t<Key> || Opts.quoted_num) {
             write<JSON>::op<Opts>(key, ctx, args...);
@@ -697,7 +697,7 @@ namespace glz
 
          template <auto Opts, class B>
             requires(writable_array_t<T> && (map_like_array ? Opts.concatenate == false : true))
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
          {
             if (empty_range(value)) {
                dump<"[]">(b, ix);
@@ -795,7 +795,7 @@ namespace glz
 
          template <auto Opts>
             requires(writable_map_t<T> || (map_like_array && Opts.concatenate == true))
-         static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&&... args)
          {
             if constexpr (!has_opening_handled(Opts)) {
                dump<'{'>(args...);
@@ -902,7 +902,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <glz::opts Opts, class B, class Ix>
-         static void op(const T& value, is_context auto&& ctx, B&& b, Ix&& ix) noexcept
+         static void op(const T& value, is_context auto&& ctx, B&& b, Ix&& ix)
          {
             const auto& [key, val] = value;
             if (skip_member<Opts>(val)) {
@@ -940,7 +940,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
          {
             if (value) {
                write<JSON>::op<Opts>(*value, ctx, std::forward<Args>(args)...);
@@ -957,7 +957,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts, class V, size_t N, class... Args>
-         GLZ_ALWAYS_INLINE static void op(const V (&value)[N], is_context auto&& ctx, Args&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(const V (&value)[N], is_context auto&& ctx, Args&&... args)
          {
             write<JSON>::op<Opts>(std::span{value, N}, ctx, std::forward<Args>(args)...);
          }
@@ -967,7 +967,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
          {
             if (value) {
                if constexpr (
@@ -989,7 +989,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts, class B>
-         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, B&& b, auto&& ix) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, B&& b, auto&& ix)
          {
             if constexpr (not has_write_unchecked(Opts)) {
                if (ix + 4 > b.size()) [[unlikely]] {
@@ -1006,7 +1006,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
          {
             std::visit(
                [&](auto&& val) {
@@ -1058,7 +1058,7 @@ namespace glz
       struct to<JSON, array_variant_wrapper<T>>
       {
          template <auto Opts, class... Args>
-         static void op(auto&& wrapper, is_context auto&& ctx, Args&&... args) noexcept
+         static void op(auto&& wrapper, is_context auto&& ctx, Args&&... args)
          {
             auto& value = wrapper.value;
             dump<'['>(args...);
@@ -1086,7 +1086,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
          {
             using V = std::decay_t<decltype(value.value)>;
             static constexpr auto N = glz::tuple_size_v<V>;
@@ -1125,7 +1125,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
          {
             static constexpr auto N = []() constexpr {
                if constexpr (glaze_array_t<std::decay_t<T>>) {
@@ -1173,7 +1173,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, Args&&... args) noexcept
+         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, Args&&... args)
          {
             dump<R"("")">(args...); // dump an empty string
          }
@@ -1193,7 +1193,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Options>
-         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
          {
             if constexpr (!has_opening_handled(Options)) {
                dump<'{'>(b, ix);
@@ -1267,7 +1267,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Options>
-         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
          {
             if constexpr (!has_opening_handled(Options)) {
                dump<'{'>(b, ix);
@@ -1355,7 +1355,7 @@ namespace glz
       {
          template <auto Options, class V, class B>
             requires(not std::is_pointer_v<std::remove_cvref_t<V>>)
-         static void op(V&& value, is_context auto&& ctx, B&& b, auto&& ix) noexcept
+         static void op(V&& value, is_context auto&& ctx, B&& b, auto&& ix)
          {
             using ValueType = std::decay_t<V>;
             if constexpr (detail::has_unknown_writer<ValueType> && not has_disable_write_unknown(Options)) {
@@ -1624,7 +1624,7 @@ namespace glz
       struct write_partial<JSON>
       {
          template <auto& Partial, auto Opts, class T, is_context Ctx, class B, class IX>
-         static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix) noexcept
+         static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
          {
             if constexpr (std::count(Partial.begin(), Partial.end(), "") > 0) {
                detail::write<JSON>::op<Opts>(value, ctx, b, ix);
@@ -1645,7 +1645,7 @@ namespace glz
       struct to_partial<JSON, T> final
       {
          template <auto& Partial, auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
          {
             if constexpr (!has_opening_handled(Opts)) {
                dump<'{'>(b, ix);
@@ -1749,49 +1749,49 @@ namespace glz
    } // namespace detail
 
    template <write_json_supported T, output_buffer Buffer>
-   [[nodiscard]] error_ctx write_json(T&& value, Buffer&& buffer) noexcept
+   [[nodiscard]] error_ctx write_json(T&& value, Buffer&& buffer)
    {
       return write<opts{}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
    template <write_json_supported T, raw_buffer Buffer>
-   [[nodiscard]] glz::expected<size_t, error_ctx> write_json(T&& value, Buffer&& buffer) noexcept
+   [[nodiscard]] glz::expected<size_t, error_ctx> write_json(T&& value, Buffer&& buffer)
    {
       return write<opts{}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
    template <write_json_supported T>
-   [[nodiscard]] glz::expected<std::string, error_ctx> write_json(T&& value) noexcept
+   [[nodiscard]] glz::expected<std::string, error_ctx> write_json(T&& value)
    {
       return write<opts{}>(std::forward<T>(value));
    }
 
    template <auto& Partial, write_json_supported T, output_buffer Buffer>
-   [[nodiscard]] error_ctx write_json(T&& value, Buffer&& buffer) noexcept
+   [[nodiscard]] error_ctx write_json(T&& value, Buffer&& buffer)
    {
       return write<Partial, opts{}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
    template <auto& Partial, write_json_supported T, raw_buffer Buffer>
-   [[nodiscard]] glz::expected<size_t, error_ctx> write_json(T&& value, Buffer&& buffer) noexcept
+   [[nodiscard]] glz::expected<size_t, error_ctx> write_json(T&& value, Buffer&& buffer)
    {
       return write<Partial, opts{}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
    template <write_json_supported T, class Buffer>
-   [[nodiscard]] error_ctx write_jsonc(T&& value, Buffer&& buffer) noexcept
+   [[nodiscard]] error_ctx write_jsonc(T&& value, Buffer&& buffer)
    {
       return write<opts{.comments = true}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
    template <write_json_supported T>
-   [[nodiscard]] glz::expected<std::string, error_ctx> write_jsonc(T&& value) noexcept
+   [[nodiscard]] glz::expected<std::string, error_ctx> write_jsonc(T&& value)
    {
       return write<opts{.comments = true}>(std::forward<T>(value));
    }
 
    template <opts Opts = opts{}, write_json_supported T>
-   [[nodiscard]] error_ctx write_file_json(T&& value, const sv file_name, auto&& buffer) noexcept
+   [[nodiscard]] error_ctx write_file_json(T&& value, const sv file_name, auto&& buffer)
    {
       const auto ec = write<set_json<Opts>()>(std::forward<T>(value), buffer);
       if (bool(ec)) [[unlikely]] {

--- a/include/glaze/mustache/mustache.hpp
+++ b/include/glaze/mustache/mustache.hpp
@@ -10,7 +10,7 @@
 namespace glz
 {
    template <opts Opts = opts{}, class T, class Template>
-   expected<std::string, error_ctx> mustache(T&& value, Template&& tmp) noexcept
+   expected<std::string, error_ctx> mustache(T&& value, Template&& tmp)
    {
       std::string result{};
 
@@ -136,7 +136,7 @@ namespace glz
 
    template <opts Opts = opts{}, class T>
       requires(requires { std::decay_t<T>::glaze_mustache; })
-   expected<std::string, error_ctx> mustache(T&& value) noexcept
+   expected<std::string, error_ctx> mustache(T&& value)
    {
       return mustache(std::forward<T>(value), sv{std::decay_t<T>::glaze_mustache});
    }

--- a/include/glaze/mustache/stencilcount.hpp
+++ b/include/glaze/mustache/stencilcount.hpp
@@ -11,7 +11,7 @@
 namespace glz
 {
    template <opts Opts = opts{}, class T, class Template>
-   expected<std::string, error_ctx> stencilcount(T&& value, Template&& tmp) noexcept
+   expected<std::string, error_ctx> stencilcount(T&& value, Template&& tmp)
    {
       std::string result{};
 

--- a/include/glaze/record/recorder.hpp
+++ b/include/glaze/record/recorder.hpp
@@ -71,7 +71,7 @@ namespace glz
       struct to<JSON, T>
       {
          template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
          {
             dump<'{'>(std::forward<Args>(args)...);
 
@@ -115,7 +115,7 @@ namespace glz
       struct from<JSON, T>
       {
          template <auto Options>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             if (bool(ctx.error)) [[unlikely]] {
                return;
@@ -169,7 +169,7 @@ namespace glz
       struct to<CSV, T>
       {
          template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+         static void op(auto&& value, is_context auto&& ctx, auto&&... args)
          {
             if constexpr (Opts.layout == rowwise) {
                const size_t n = value.data.size();

--- a/include/glaze/rpc/repe/registry.hpp
+++ b/include/glaze/rpc/repe/registry.hpp
@@ -245,6 +245,7 @@ namespace glz::repe
                   methods[full_key] = [&func](repe::state&& state) mutable {
                      func();
                      if (state.notify()) {
+                        state.out.header.notify(true);
                         return;
                      }
                      write_response<Opts>(state);
@@ -254,6 +255,7 @@ namespace glz::repe
                   methods[full_key] = [&func](repe::state&& state) mutable {
                      if (state.notify()) {
                         std::ignore = func();
+                        state.out.header.notify(true);
                         return;
                      }
                      write_response<Opts>(func(), state);
@@ -276,6 +278,7 @@ namespace glz::repe
 
                   if (state.notify()) {
                      std::ignore = func(params);
+                     state.out.header.notify(true);
                      return;
                   }
                   auto ret = func(params);
@@ -315,6 +318,7 @@ namespace glz::repe
                   }
 
                   if (state.notify()) {
+                     state.out.header.notify(true);
                      return;
                   }
 
@@ -342,6 +346,7 @@ namespace glz::repe
                            }
 
                            if (state.notify()) {
+                              state.out.header.notify(true);
                               return;
                            }
 
@@ -361,6 +366,7 @@ namespace glz::repe
                            (value.*func)(input);
 
                            if (state.notify()) {
+                              state.out.header.notify(true);
                               return;
                            }
 
@@ -396,6 +402,7 @@ namespace glz::repe
 
                            if (state.notify()) {
                               std::ignore = (value.*func)(input);
+                              state.out.header.notify(true);
                               return;
                            }
 
@@ -417,6 +424,7 @@ namespace glz::repe
                      }
 
                      if (state.notify()) {
+                        state.out.header.notify(true);
                         return;
                      }
 

--- a/include/glaze/util/dump.hpp
+++ b/include/glaze/util/dump.hpp
@@ -19,7 +19,7 @@ namespace glz::detail
    concept byte_sized = sizeof(T) == 1 && (std::same_as<V, char> || std::same_as<V, std::byte>);
 
    template <uint32_t N, class B>
-   GLZ_ALWAYS_INLINE void maybe_pad(B& b, size_t& ix) noexcept
+   GLZ_ALWAYS_INLINE void maybe_pad(B& b, size_t& ix) noexcept(not vector_like<B>)
    {
       if constexpr (vector_like<B>) {
          if (const auto k = ix + N; k > b.size()) [[unlikely]] {
@@ -29,7 +29,7 @@ namespace glz::detail
    }
 
    template <class B>
-   GLZ_ALWAYS_INLINE void maybe_pad(const size_t n, B& b, size_t& ix) noexcept
+   GLZ_ALWAYS_INLINE void maybe_pad(const size_t n, B& b, size_t& ix) noexcept(not vector_like<B>)
    {
       if constexpr (vector_like<B>) {
          if (const auto k = ix + n; k > b.size()) [[unlikely]] {
@@ -64,7 +64,7 @@ namespace glz::detail
    }
 
    template <bool Checked = true, class B>
-   GLZ_ALWAYS_INLINE void dump(const byte_sized auto c, B& b, size_t& ix) noexcept
+   GLZ_ALWAYS_INLINE void dump(const byte_sized auto c, B& b, size_t& ix) noexcept(not vector_like<B>)
    {
       if constexpr (Checked && vector_like<B>) {
          if (ix == b.size()) [[unlikely]] {
@@ -76,7 +76,7 @@ namespace glz::detail
    }
 
    template <auto c, bool Checked = true, class B>
-   GLZ_ALWAYS_INLINE void dump(B& b, size_t& ix) noexcept
+   GLZ_ALWAYS_INLINE void dump(B& b, size_t& ix) noexcept(not vector_like<B>)
    {
       if constexpr (Checked && vector_like<B>) {
          if (ix == b.size()) [[unlikely]] {
@@ -88,7 +88,7 @@ namespace glz::detail
    }
 
    template <string_literal str, bool Checked = true, class B>
-   GLZ_ALWAYS_INLINE void dump(B& b, size_t& ix) noexcept
+   GLZ_ALWAYS_INLINE void dump(B& b, size_t& ix) noexcept(not vector_like<B>)
    {
       static constexpr auto s = str.sv();
       static constexpr auto n = s.size();
@@ -105,7 +105,7 @@ namespace glz::detail
    }
 
    template <bool Checked = true, class B>
-   GLZ_ALWAYS_INLINE void dump(const sv str, B& b, size_t& ix) noexcept
+   GLZ_ALWAYS_INLINE void dump(const sv str, B& b, size_t& ix) noexcept(not vector_like<B>)
    {
       const auto n = str.size();
       if constexpr (vector_like<B>) {
@@ -120,7 +120,7 @@ namespace glz::detail
    }
 
    template <auto c, class B>
-   GLZ_ALWAYS_INLINE void dumpn(size_t n, B& b, size_t& ix) noexcept
+   GLZ_ALWAYS_INLINE void dumpn(size_t n, B& b, size_t& ix) noexcept(not vector_like<B>)
    {
       if constexpr (vector_like<B>) {
          if (ix + n > b.size()) [[unlikely]] {
@@ -139,7 +139,7 @@ namespace glz::detail
    }
 
    template <char IndentChar, class B>
-   GLZ_ALWAYS_INLINE void dump_newline_indent(size_t n, B& b, size_t& ix) noexcept
+   GLZ_ALWAYS_INLINE void dump_newline_indent(size_t n, B& b, size_t& ix) noexcept(not vector_like<B>)
    {
       if constexpr (vector_like<B>) {
          if (const auto k = ix + n + write_padding_bytes; k > b.size()) [[unlikely]] {
@@ -154,7 +154,7 @@ namespace glz::detail
    }
 
    template <const sv& str, bool Checked = true, class B>
-   GLZ_ALWAYS_INLINE void dump(B& b, size_t& ix) noexcept
+   GLZ_ALWAYS_INLINE void dump(B& b, size_t& ix) noexcept(not vector_like<B> && not Checked)
    {
       static constexpr auto s = str;
       static constexpr auto n = s.size();
@@ -171,7 +171,7 @@ namespace glz::detail
    }
 
    template <bool Checked = true, class B>
-   GLZ_ALWAYS_INLINE void dump_not_empty(const sv str, B& b, size_t& ix) noexcept
+   GLZ_ALWAYS_INLINE void dump_not_empty(const sv str, B& b, size_t& ix) noexcept(not vector_like<B> && not Checked)
    {
       const auto n = str.size();
       if constexpr (vector_like<B>) {
@@ -186,7 +186,7 @@ namespace glz::detail
    }
 
    template <bool Checked = true, class B>
-   GLZ_ALWAYS_INLINE void dump_maybe_empty(const sv str, B& b, size_t& ix) noexcept
+   GLZ_ALWAYS_INLINE void dump_maybe_empty(const sv str, B& b, size_t& ix) noexcept(not vector_like<B> && not Checked)
    {
       const auto n = str.size();
       if (n) {
@@ -203,7 +203,7 @@ namespace glz::detail
    }
 
    template <class B>
-   GLZ_ALWAYS_INLINE void dump(const vector_like auto& bytes, B& b, size_t& ix) noexcept
+   GLZ_ALWAYS_INLINE void dump(const vector_like auto& bytes, B& b, size_t& ix) noexcept(not vector_like<B>)
    {
       const auto n = bytes.size();
       if constexpr (vector_like<B>) {
@@ -216,7 +216,7 @@ namespace glz::detail
    }
 
    template <size_t N, class B>
-   GLZ_ALWAYS_INLINE void dump(const std::array<uint8_t, N>& bytes, B& b, size_t& ix) noexcept
+   GLZ_ALWAYS_INLINE void dump(const std::array<uint8_t, N>& bytes, B& b, size_t& ix) noexcept(not vector_like<B>)
    {
       if constexpr (vector_like<B>) {
          if (ix + N > b.size()) [[unlikely]] {

--- a/include/glaze/util/for_each.hpp
+++ b/include/glaze/util/for_each.hpp
@@ -97,7 +97,7 @@ namespace glz::detail
 #define GLZ_60 GLZ_50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60
 
    template <size_t N, class Lambda>
-   GLZ_ALWAYS_INLINE constexpr void jump_table(Lambda&& lambda, size_t index) noexcept
+   GLZ_ALWAYS_INLINE constexpr void jump_table(Lambda&& lambda, size_t index)
    {
       if constexpr (N == 0) {
          return;
@@ -189,7 +189,7 @@ namespace glz::detail
    }
 
    template <size_t N, class Lambda>
-   GLZ_ALWAYS_INLINE constexpr void invoke_table(Lambda&& lambda) noexcept
+   GLZ_ALWAYS_INLINE constexpr void invoke_table(Lambda&& lambda)
    {
       if constexpr (N == 0) {
          return;


### PR DESCRIPTION
Glaze has been too aggressive in marking things `noexcept` for use in exception contexts. This merge culls a lot of those excessive use cases.