### PR TITLE
implement skip writing out default

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -520,7 +520,7 @@ namespace glz::detail
    template <opts Opts, class Value>
    [[nodiscard]] GLZ_ALWAYS_INLINE constexpr bool skip_member(const Value& value) noexcept
    {
-      if constexpr (null_t<Value> && Opts.skip_null_members) {
+      if constexpr (null_t<Value> && (Opts.skip_null_members & skip_null_flag)) {
          if constexpr (always_null_t<Value>)
             return true;
          else {

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -49,6 +49,8 @@ namespace glz
 #define GLZ_NULL_TERMINATED true
 #endif
 
+   inline constexpr uint8_t skip_null_flag = 1;
+   inline constexpr uint8_t skip_default_flag = 2;
    struct opts
    {
       // USER CONFIGURABLE
@@ -56,7 +58,8 @@ namespace glz
       bool_t null_terminated = GLZ_NULL_TERMINATED; // Whether the input buffer is null terminated
       bool_t comments = false; // Support reading in JSONC style comments
       bool_t error_on_unknown_keys = true; // Error when an unknown key is encountered
-      bool_t skip_null_members = true; // Skip writing out params in an object if the value is null
+      // this might be better to be named skip_write_members, just keep for backward compatibility
+      uint8_t skip_null_members = skip_null_flag | skip_default_flag; // Skip writing out params in an object if the value is null or default
       bool_t use_hash_comparison = true; // Will replace some string equality checks with hash checks
       bool_t prettify = false; // Write out prettified JSON
       bool_t minified = false; // Require minified input for JSON, which results in faster read performance

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -277,6 +277,17 @@ namespace glz
       static constexpr bool maybe_skipped = false;
    };
 
+   template <typename T>
+   constexpr uint8_t skip_write_mask() {
+      if constexpr (detail::null_t<T>) {
+         return skip_null_flag;
+      } else if constexpr (requires { T::glaze_skip_write_mask; }) {
+         return T::glaze_skip_write_mask;
+      } else {
+         return 0;
+      }
+   }
+
    template <opts Opts, class T>
       requires(reflect<T>::size > 0)
    struct object_info<Opts, T>
@@ -288,7 +299,7 @@ namespace glz
          if constexpr (N > 0) {
             using V = std::remove_cvref_t<refl_t<T, 0>>;
 
-            if constexpr (detail::null_t<V> && Opts.skip_null_members) {
+            if constexpr (skip_write_mask<V>() & Opts.skip_null_members ) {
                return false;
             }
 
@@ -310,7 +321,7 @@ namespace glz
             for_each_short_circuit<N>([&](auto I) {
                using V = std::remove_cvref_t<refl_t<T, I>>;
 
-               if constexpr (Opts.skip_null_members && detail::null_t<V>) {
+               if constexpr (skip_write_mask<V>() & Opts.skip_null_members) {
                   found_maybe_skipped = true;
                   return true; // early exit
                }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -9876,6 +9876,58 @@ suite const_pointer_tests = [] {
    };
 };
 
+struct custom_skip_struct
+{
+   int i = 287;
+   double j = 3.14;
+   std::optional<int> k;
+};
+
+template <>
+struct glz::meta<custom_skip_struct>
+{
+   using T = custom_skip_struct;
+   static constexpr auto skip_default_i = [](const T& t) { return t.i == 287; };
+
+   static constexpr auto value =
+      object("i", glz::custom<&T::i, &T::i, skip_default_i, skip_default_flag>, "j", &T::j, "k", &T::k);
+};
+
+struct skip_write_default_struct
+{
+   int i = 287;
+   double j = 3.14;
+   std::optional<int> k;
+};
+
+template <>
+struct glz::meta<skip_write_default_struct>
+{
+   using T = skip_write_default_struct;
+
+   static constexpr auto value = object("i", glz::skip_write_default<&T::i>, "j", &T::j, "k", &T::k);
+};
+
+suite skip_struct_test = [] {
+   auto skip_test = [](auto obj) {
+      std::string buffer{};
+      expect(not glz::write_json(obj, buffer));
+      // We expect both the default "i" and the null "k" to be skipped
+      expect(buffer == R"({"j":3.14})") << buffer;
+
+      expect(not glz::write<glz::opts{.skip_null_members = glz::skip_null_flag}>(obj, buffer));
+      // We expect only the null "k" to be skipped
+      expect(buffer == R"({"i":287,"j":3.14})") << buffer;
+
+      expect(not glz::write<glz::opts{.skip_null_members = glz::skip_default_flag}>(obj, buffer));
+      // We expect only the default "i" to be skipped
+      expect(buffer == R"({"j":3.14,"k":null})") << buffer;
+   };
+
+   "custom_skip_struct"_test = [&] { skip_test(custom_skip_struct{}); };
+   "skip_write_default_struct"_test = [&] { skip_test(skip_write_default_struct{}); };
+};
+
 int main()
 {
    trace.end("json_test");


### PR DESCRIPTION
# Motivation

The primary goal of this feature is to mimic protobuf behavior, where fields with default values are omitted from the wire format. Additionally, a new printout option allows users to override this behavior if they wish to include fields with default values. To support this flexibility, the `skip_null_members flag` in Opts has been redefined as a bitmask, allowing independent control over skipping null and default values.

# Key Changes
- Conditional Skipping with `custom` Wrapper: The `custom` wrapper now enables users to define a function that determines whether a field should be omitted based on specific conditions. An associated bitmask has been introduced to allow compile-time checks, which control whether user-defined functions should be evaluated based on the `Opts::skip_null_members` setting during serialization.
- New `skip_write_default` Wrapper: A `skip_write_default` wrapper provides a concise way to skip fields with default values, streamlining the setup for this common use case.

# Note
This feature can be used to resolve IS #1410
