### PR TITLE
don't use _umul128, fallback to umul128_generic in MSYS2/MINGW32

### DIFF
--- a/include/glaze/util/atoi.hpp
+++ b/include/glaze/util/atoi.hpp
@@ -170,7 +170,7 @@ namespace glz::detail
       // But MinGW on ARM64 doesn't have native support for 64-bit multiplications
       answer.high = __umulh(a, b);
       answer.low = a * b;
-#elif defined(GLZ_FASTFLOAT_32BIT) || (defined(_WIN64) && !defined(__clang__))
+#elif defined(GLZ_FASTFLOAT_32BIT) || (defined(_WIN64) && !defined(__clang__) && !defined(__MINGW32__))
       answer.low = _umul128(a, b, &answer.high); // _umul128 not available on ARM64
 #elif defined(GLZ_FASTFLOAT_64BIT) && defined(__SIZEOF_INT128__)
       __uint128_t r = ((__uint128_t)a) * b;


### PR DESCRIPTION
Currently seeing build errors for glaze on Windows 10/11 with MSYS2, UCRT64, GCC 14.1.0 :

> C:\Users\Jalius\repos\glaze\src>g++ main.cpp --std=c++23 -I../include
> In file included from ../include/glaze/util/parse.hpp:15,
> (TRUNCATED)
>                  from main.cpp:1:
> ../include/glaze/util/atoi.hpp: In function 'constexpr glz::detail::value128 glz::detail::full_multiplication(uint64_t, uint64_t)':
> ../include/glaze/util/atoi.hpp:174:20: error: '_umul128' was not declared in this scope
>   174 |       answer.low = _umul128(a, b, &answer.high); // _umul128 not available on ARM64
>       |                    ^~~~~~~~
> 

Failling back to`umul128_generic` conditionally based on `__MINGW32__` resolves this.
