### PR TITLE
Support for nullable value types

### DIFF
--- a/docs/nullable-types.md
+++ b/docs/nullable-types.md
@@ -1,0 +1,32 @@
+# Nullable Types
+
+Glaze provides concepts to support custom nullable types. In order to serialize and parse your custom nullable type it should conform to the `nullable_t` concept:
+
+```c++
+template <class T>
+concept nullable_t = !meta_value_t<T> && !str_t<T> && requires(T t) {
+   bool(t);
+   {
+      *t
+   };
+};
+```
+
+> [!NOTE]
+>
+> If you want to read into a nullable type then you must have a `.reset()` method or your type must be assignable from empty braces: `value = {}`. This allows Glaze to reset the value if `"null"` is parsed.
+
+## Nullable Value Types
+
+In some cases a type may be like a `std::optional`, but also require an `operator bool()` that converts to the internal boolean. In these cases you can instead conform to the `nullable_value_t` concept:
+
+```c++
+// For optional like types that cannot overload `operator bool()`
+template <class T>
+concept nullable_value_t = !meta_value_t<T> && requires(T t) {
+   t.value();
+   {
+      t.has_value()
+   } -> std::convertible_to<bool>;
+};
+```

--- a/include/glaze/concepts/container_concepts.hpp
+++ b/include/glaze/concepts/container_concepts.hpp
@@ -9,6 +9,12 @@
 #include <utility>
 #include <vector>
 
+// Over time we want most concepts to use the nomenclature:
+// is_
+// has_
+// _like
+// Avoid the use of _t as that makes it seem like a type and not a concept
+
 namespace glz
 {
    template <class T, class... U>
@@ -99,6 +105,17 @@ namespace glz::detail
       {
          a / b
       } -> std::same_as<T>;
+   };
+   
+   template <class T>
+   concept optional_like = requires(T t, typename T::value_type v) {
+       { T() } -> std::same_as<T>;
+       { T(v) } -> std::same_as<T>;
+       { t.has_value() } -> std::convertible_to<bool>;
+      { t.value() };
+      { t = v };
+      { t.reset() };
+      { t.emplace() };
    };
 
    template <class T>

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -339,12 +339,12 @@ namespace glz
          std::same_as<T, std::nullptr_t> || std::convertible_to<T, std::monostate> || std::same_as<T, std::nullopt_t>;
 
       template <class T>
-      concept nullable_t = (!meta_value_t<T> && !str_t<T> && requires(T t) {
+      concept nullable_t = !meta_value_t<T> && !str_t<T> && requires(T t) {
          bool(t);
          {
             *t
          };
-      });
+      };
       
       // For optional like types that cannot overload `operator bool()`
       template <class T>

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -339,18 +339,27 @@ namespace glz
          std::same_as<T, std::nullptr_t> || std::convertible_to<T, std::monostate> || std::same_as<T, std::nullopt_t>;
 
       template <class T>
-      concept nullable_t = !meta_value_t<T> && !str_t<T> && requires(T t) {
+      concept nullable_t = (!meta_value_t<T> && !str_t<T> && requires(T t) {
          bool(t);
          {
             *t
          };
+      });
+      
+      // For optional like types that cannot overload `operator bool()`
+      template <class T>
+      concept nullable_value_t = !meta_value_t<T> && requires(T t) {
+         t.value();
+         {
+            t.has_value()
+         } -> std::convertible_to<bool>;
       };
 
       template <class T>
       concept nullable_wrapper = glaze_wrapper<T> && nullable_t<typename T::value_type>;
 
       template <class T>
-      concept null_t = nullable_t<T> || always_null_t<T> || nullable_wrapper<T>;
+      concept null_t = nullable_t<T> || nullable_value_t<T> || always_null_t<T> || nullable_wrapper<T>;
 
       template <class T>
       concept func_t = requires(T t) {

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2648,7 +2648,7 @@ namespace glz
       };
 
       template <class T>
-         requires((nullable_t<T> || nullable_value_t<T>) && not is_expected<T> && not std::is_array_v<T>)
+         requires((nullable_t<T> || nullable_value_t<T>) && not is_expected<T> && not std::is_array_v<T> && not custom_read<T>)
       struct from<JSON, T>
       {
          template <auto Options>

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1450,6 +1450,9 @@ namespace glz
                                  if constexpr (nullable_wrapper<val_t>) {
                                     return !bool(element()(value).val);
                                  }
+                                 else if constexpr (nullable_value_t<val_t>) {
+                                    return !get_member(value, element()).has_value();
+                                 }
                                  else {
                                     return !bool(get_member(value, element()));
                                  }

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -984,6 +984,22 @@ namespace glz
             }
          }
       };
+      
+      template <class T>
+         requires (nullable_value_t<T> && not optional_like<T> && not is_expected<T>)
+      struct to<JSON, T>
+      {
+         template <auto Opts>
+         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
+         {
+            if (value.has_value()) {
+               write<JSON>::op<Opts>(value.value(), ctx, b, ix);
+            }
+            else {
+               dump<"null">(b, ix);
+            }
+         }
+      };
 
       template <always_null_t T>
       struct to<JSON, T>

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -53,10 +53,10 @@ namespace glz
       };
 
       template <class T>
-      concept optional_like = nullable_t<T> && (!is_expected<T> && !std::is_array_v<T>);
+      concept nullable_like = nullable_t<T> && (!is_expected<T> && !std::is_array_v<T>);
 
       template <class T>
-      concept supports_unchecked_write = boolean_like<T> || num_t<T> || optional_like<T> || always_null_t<T>;
+      concept supports_unchecked_write = boolean_like<T> || num_t<T> || nullable_like<T> || always_null_t<T>;
 
       template <class T>
       inline constexpr std::optional<size_t> required_padding()
@@ -67,7 +67,7 @@ namespace glz
          else if constexpr (num_t<T>) {
             return 64;
          }
-         else if constexpr (optional_like<T> &&
+         else if constexpr (nullable_like<T> &&
                             (
                                requires { requires supports_unchecked_write<typename T::value_type>; } ||
                                requires { requires supports_unchecked_write<typename T::element_type>; })) {
@@ -963,7 +963,7 @@ namespace glz
          }
       };
 
-      template <optional_like T>
+      template <nullable_like T>
       struct to<JSON, T>
       {
          template <auto Opts>
@@ -986,7 +986,7 @@ namespace glz
       };
       
       template <class T>
-         requires (nullable_value_t<T> && not optional_like<T> && not is_expected<T>)
+         requires (nullable_value_t<T> && not nullable_like<T> && not is_expected<T>)
       struct to<JSON, T>
       {
          template <auto Opts>

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -9896,22 +9896,16 @@ struct custom_nullable_t
    std::optional<T> val{};
 
    bool has_value() const { return val.has_value(); }
+   
+   T& value() { return *val; }
 
    const T& value() const { return *val; }
+   
+   template <class... Args>
+   void emplace(Args&&... args) {
+      val.emplace(std::forward<Args>(args)...);
+   }
 };
-
-namespace glz::detail
-{
-   template <class T>
-   struct from<JSON, custom_nullable_t<T>>
-   {
-      template <auto Opts>
-      static void op(auto& value, auto&&... args)
-      {
-         read<JSON>::op<Opts>(value.val, args...);
-      }
-   };
-}
 
 struct custom_nullable_container_t
 {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -9911,16 +9911,6 @@ namespace glz::detail
          read<JSON>::op<Opts>(value.val, args...);
       }
    };
-
-   template <class T>
-   struct to<JSON, custom_nullable_t<T>>
-   {
-      template <auto Opts>
-      static void op(auto& value, auto&&... args)
-      {
-         write<JSON>::op<Opts>(value.val, args...);
-      }
-   };
 }
 
 struct custom_nullable_container_t


### PR DESCRIPTION
This adds support for optional like types that cannot provide an `operator bool()` because that operator is reserved for some other action. This adds a `nullable_value_t` concept that only checks for `value()` and `has_value()`.