### PR TITLE
Make glz::async_map copyable and movable

### DIFF
--- a/tests/exceptions_test/exceptions_test.cpp
+++ b/tests/exceptions_test/exceptions_test.cpp
@@ -416,6 +416,11 @@ suite async_map_tests = [] {
       expect(map.size() == 2);
       expect(map.at("first").value() == 100);
       expect(map.at("third").value() == 300);
+      
+      auto other = map; // copy
+      expect(other.size() == 2);
+      expect(other.at("first").value() == 100);
+      expect(other.at("third").value() == 300);
    };
 };
 


### PR DESCRIPTION
DO NOT MERGE YET. MUST DETERMINE IF THE MAP ITSELF SHOULD BE SHARED OR JUST THE ELEMENTS.

```c++
// The async_map is copyable, but it only performs shallow copies
// This is to allow values like `std::atomic<int>` (and other thread safe types) to be held
// So, copying an async_map will result in a shared reference to the data
// In a multi-threading context this is often the desired behavior as thread safe logic
// is typically attempting to shared state across threads
```