### PR TITLE
glz::for_each_field

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ import libs = libglaze%lib{glaze}
 
 # Explicit Metadata
 
-If you want to specialize your reflection then you can optionally write the code below:
+If you want to specialize your reflection then you can **optionally** write the code below:
 
 > This metadata is also necessary for non-aggregate initializable structs.
 

--- a/README.md
+++ b/README.md
@@ -322,7 +322,25 @@ static_assert(glz::reflect<my_struct>::keys[0] == "i"); // Access keys
 
 > [!WARNING]
 >
-> The `glz::reflect` fields described above have been formalized and are unlikely to change. Other fields within the `glz::reflect` struct may evolve as we continue to formalize the spec. Therefore, breaking changes may occur for undocumented fields in the future.
+> The `glz::reflect` fields described above have been formalized and are unlikely to change. Other fields may evolve as we continue to formalize the spec.
+
+## glz::for_each_field
+
+```c++
+struct test_type {
+   int32_t int1{};
+   int64_t int2{};
+};
+
+test_type var{42, 43};
+
+glz::for_each_field(var, [](auto& field) {
+    field += 1;
+});
+
+expect(var.int1 == 43);
+expect(var.int2 == 44);
+```
 
 # Custom Read/Write
 

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -2203,6 +2203,8 @@ namespace glz
 
 namespace glz
 {
+   // The Callable comes second as ranges::for_each puts the callable at the end
+   
    template <class Callable, detail::reflectable T>
    void for_each_field(T&& value, Callable&& callable)
    {

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -2201,6 +2201,31 @@ namespace glz
    }
 }
 
+namespace glz
+{
+   template <class Callable, detail::reflectable T>
+   void for_each_field(T&& value, Callable&& callable)
+   {
+      constexpr auto N = reflect<T>::size;
+      if constexpr (N > 0) {
+         [&]<size_t... I>(std::index_sequence<I...>) constexpr {
+            (callable(get_member(value, get<I>(to_tuple(value)))), ...);
+         }(std::make_index_sequence<N>{});
+      }
+   }
+   
+   template <class Callable, detail::glaze_object_t T>
+   void for_each_field(T&& value, Callable&& callable)
+   {
+      constexpr auto N = reflect<T>::size;
+      if constexpr (N > 0) {
+         [&]<size_t... I>(std::index_sequence<I...>) constexpr {
+            (callable(get_member(value, get<I>(reflect<T>::values))), ...);
+         }(std::make_index_sequence<N>{});
+      }
+   }
+}
+
 #ifdef _MSC_VER
 // restore disabled warnings
 #pragma warning(pop)

--- a/tests/reflection/reflection.cpp
+++ b/tests/reflection/reflection.cpp
@@ -7,6 +7,55 @@
 
 using namespace ut;
 
+struct test_type {
+   int32_t int1{};
+   int64_t int2{};
+};
+
+suite reflect_test_type = [] {
+   static_assert(glz::reflect<test_type>::size == 2);
+   static_assert(glz::reflect<test_type>::keys[0] == "int1");
+   
+   "for_each_field"_test = [] {
+      test_type var{42, 43};
+      
+      glz::for_each_field(var, [](auto& field) {
+          field += 1;
+      });
+      
+      expect(var.int1 == 43);
+      expect(var.int2 == 44);
+   };
+};
+
+struct test_type_meta {
+   int32_t int1{};
+   int64_t int2{};
+};
+
+template <>
+struct glz::meta<test_type_meta>
+{
+   using T = test_type_meta;
+   static constexpr auto value = object(&T::int1, &T::int2);
+};
+
+suite meta_reflect_test_type = [] {
+   static_assert(glz::reflect<test_type_meta>::size == 2);
+   static_assert(glz::reflect<test_type_meta>::keys[0] == "int1");
+   
+   "for_each_field"_test = [] {
+      test_type_meta var{42, 43};
+      
+      glz::for_each_field(var, [](auto& field) {
+          field += 1;
+      });
+      
+      expect(var.int1 == 43);
+      expect(var.int2 == 44);
+   };
+};
+
 struct a_type
 {
    float fluff = 1.1f;


### PR DESCRIPTION
Adds `glz::for_each_field` for reflected and meta types.

```c++
struct test_type {
   int32_t int1{};
   int64_t int2{};
};

suite reflect_test_type = [] {
   static_assert(glz::reflect<test_type>::size == 2);
   static_assert(glz::reflect<test_type>::keys[0] == "int1");
   
   "for_each_field"_test = [] {
      test_type var{42, 43};
      
      glz::for_each_field(var, [](auto& field) {
          field += 1;
      });
      
      expect(var.int1 == 43);
      expect(var.int2 == 44);
   };
};
```