### PR TITLE
Improve compilation performance and cleanup

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -372,7 +372,7 @@ namespace glz
       concept glaze_array_t = glaze_t<T> && is_specialization_v<meta_wrapper_t<T>, Array>;
 
       template <class T>
-      concept glaze_object_t = glaze_t<T> && is_specialization_v<meta_wrapper_t<T>, Object>;
+      concept glaze_object_t = glaze_t<T> && (is_specialization_v<meta_wrapper_t<T>, Object> || (not std::is_enum_v<std::decay_t<T>> && meta_keys<T>));
 
       template <class T>
       concept glaze_enum_t = glaze_t<T> && is_specialization_v<meta_wrapper_t<T>, Enum>;
@@ -387,7 +387,7 @@ namespace glz
       template <class T>
       concept reflectable = std::is_aggregate_v<std::remove_cvref_t<T>> && std::is_class_v<std::remove_cvref_t<T>> &&
                             !(is_no_reflect<T> || glaze_value_t<T> || glaze_object_t<T> || glaze_array_t<T> ||
-                              glaze_flags_t<T> || range<T> || pair_t<T> || null_t<T>);
+                              glaze_flags_t<T> || range<T> || pair_t<T> || null_t<T> || meta_keys<T>);
 
       template <class T>
       concept is_memory_object = is_memory_type<T> && (glaze_object_t<memory_type<T>> || reflectable<memory_type<T>>);

--- a/include/glaze/core/meta.hpp
+++ b/include/glaze/core/meta.hpp
@@ -16,23 +16,23 @@ namespace glz
 {
    template <class T>
    struct meta;
-   
+
    template <>
    struct meta<std::string_view>
    {
       static constexpr std::string_view name = "std::string_view";
    };
-   
+
    template <>
    struct meta<const std::string_view>
    {
       static constexpr std::string_view name = "const std::string_view";
    };
-   
+
    template <class T>
    struct json_schema
    {};
-   
+
    namespace detail
    {
       template <class T>
@@ -40,79 +40,79 @@ namespace glz
       {
          T value;
       };
-      
+
       template <class T>
       Array(T) -> Array<T>;
-      
+
       template <class T>
       struct Object
       {
          T value;
       };
-      
+
       template <class T>
       Object(T) -> Object<T>;
-      
+
       template <class T>
       struct Enum
       {
          T value;
       };
-      
+
       template <class T>
       Enum(T) -> Enum<T>;
-      
+
       template <class T>
       struct Flags
       {
          T value;
       };
-      
+
       template <class T>
       Flags(T) -> Flags<T>;
-      
+
       template <class T>
       concept local_construct_t = requires { T::glaze::construct; };
-      
+
       template <class T>
       concept global_construct_t = requires { meta<T>::construct; };
-      
+
       template <class T>
       concept local_meta_t = requires { T::glaze::value; };
-      
+
       template <class T>
       concept local_keys_t = requires { T::glaze::keys; };
-      
+
       template <class T>
       concept global_meta_t = requires { meta<T>::value; };
-      
+
       template <class T>
       concept glaze_t = requires { meta<std::decay_t<T>>::value; } || local_meta_t<std::decay_t<T>>;
-      
+
       template <class T>
       concept meta_keys = requires { meta<std::decay_t<T>>::keys; } || local_keys_t<std::decay_t<T>>;
-      
+
       template <class T>
       concept has_unknown_writer = requires { meta<T>::unknown_write; } || requires { T::glaze::unknown_write; };
-      
+
       template <class T>
       concept has_unknown_reader = requires { meta<T>::unknown_read; } || requires { T::glaze::unknown_read; };
-      
+
       template <class T>
       concept local_json_schema_t = requires { typename std::decay_t<T>::glaze_json_schema; };
-      
+
       template <class T>
       concept global_json_schema_t = requires { is_specialization_v<std::decay_t<T>, json_schema>; };
-      
+
       template <class T>
       concept json_schema_t = local_json_schema_t<T> || global_json_schema_t<T>;
    }
-   
+
    struct empty
    {
       static constexpr glz::tuplet::tuple<> value{};
    };
-   
+
    template <class T>
    inline constexpr decltype(auto) meta_wrapper_v = [] {
       if constexpr (detail::local_meta_t<T>) {
@@ -125,7 +125,7 @@ namespace glz
          return empty{};
       }
    }();
-   
+
    template <class T>
    inline constexpr auto meta_construct_v = [] {
       if constexpr (detail::local_construct_t<T>) {
@@ -138,7 +138,7 @@ namespace glz
          return empty{};
       }
    }();
-   
+
    template <class T>
    inline constexpr auto meta_v = []() -> decltype(auto) {
       if constexpr (detail::meta_keys<T>) {

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -789,22 +789,18 @@ namespace glz::detail
       std::array<uint8_t, 256> unique_index{};
    };
 
-   template <size_t N>
    inline constexpr unique_per_length_t unique_per_length_info(const auto& input_strings)
    {
       // TODO: MSVC fixed the related compiler bug, but GitHub Actions has not caught up yet
 #if !defined(_MSC_VER)
-      if constexpr (N == 0) {
-         return {};
-      }
-      
-      if (input_strings.size() != N) {
+      const auto N = input_strings.size();
+      if (N == 0) {
          return {};
       }
 
-      std::array<std::string_view, N> strings{};
+      std::vector<std::string_view> strings{};
       for (size_t i = 0; i < N; ++i) {
-         strings[i] = input_strings[i];
+         strings.emplace_back(input_strings[i]);
       }
 
       std::ranges::sort(strings, [](const auto& a, const auto& b) { return a.size() < b.size(); });
@@ -864,7 +860,7 @@ namespace glz::detail
    }
 
    template <class T>
-   inline constexpr auto per_length_info = unique_per_length_info<reflect<T>::size>(reflect<T>::keys);
+   inline constexpr auto per_length_info = unique_per_length_info(reflect<T>::keys);
 
    consteval size_t bucket_size(hash_type type, size_t N)
    {
@@ -1401,7 +1397,7 @@ namespace glz::detail
       // TODO: MSVC fixed the related compiler bug, but GitHub Actions has not caught up yet
 #if !defined(_MSC_VER)
       // TODO: Use meta-programming to cache this value
-      const auto per_length_data = unique_per_length_info<N>(keys);
+      const auto per_length_data = unique_per_length_info(keys);
       if (per_length_data.valid) {
          auto sized_unique_hash = [&] {
             std::array<size_t, N> bucket_index{};

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -798,6 +798,8 @@ namespace glz::detail
          return {};
       }
 
+      // This could be a std::array, but each length N for std::array causes unique template instaniations
+      // This propagates to std::ranges::sort, so using std::vector means less template instaniations
       std::vector<std::string_view> strings{};
       strings.reserve(N);
       for (size_t i = 0; i < N; ++i) {

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -1483,7 +1483,7 @@ namespace glz::detail
 
    template <class T>
    constexpr auto hash_info = [] {
-      if constexpr ((glaze_object_t<T> || reflectable<T> ||
+      if constexpr ((glaze_object_t<T> || reflectable<T> || glaze_flags_t<T> ||
                      ((std::is_enum_v<std::remove_cvref_t<T>> && meta_keys<T>) || glaze_enum_t<T>)) &&
                     (reflect<T>::size > 0)) {
          constexpr auto& k_info = keys_info<T>;

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -785,7 +785,12 @@ namespace glz::detail
          using V = decay_keep_volatile_t<std::variant_alternative_t<I, T>>;
          if constexpr (glaze_object_t<V> || reflectable<V> || is_memory_object<V>) {
             using X = std::conditional_t<is_memory_object<V>, memory_type<V>, V>;
-            for_each<reflect<X>::size>([&](auto J) { deduction_map.find(reflect<X>::keys[J])->second[I] = true; });
+            constexpr auto Size = reflect<X>::size;
+            if constexpr (Size > 0) {
+               for (size_t J = 0; J < Size; ++J) {
+                  deduction_map.find(reflect<X>::keys[J])->second[I] = true;
+               }
+            }
          }
       });
 

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -721,6 +721,18 @@ namespace glz::detail
 
 namespace glz::detail
 {
+   template <class T>
+   consteval size_t key_index(const std::string_view key)
+   {
+      const auto n = reflect<T>::keys.size();
+      for (size_t i = 0; i < n; ++i) {
+         if (key == reflect<T>::keys[i]) {
+            return i;
+         }
+      }
+      return n;
+   }
+   
    GLZ_ALWAYS_INLINE constexpr uint64_t bitmix(uint64_t h, const uint64_t seed) noexcept
    {
       h *= seed;

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -799,6 +799,7 @@ namespace glz::detail
       }
 
       std::vector<std::string_view> strings{};
+      strings.reserve(N);
       for (size_t i = 0; i < N; ++i) {
          strings.emplace_back(input_strings[i]);
       }

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -789,18 +789,22 @@ namespace glz::detail
       std::array<uint8_t, 256> unique_index{};
    };
 
+   template <size_t N>
    inline constexpr unique_per_length_t unique_per_length_info(const auto& input_strings)
    {
       // TODO: MSVC fixed the related compiler bug, but GitHub Actions has not caught up yet
 #if !defined(_MSC_VER)
-      const auto N = input_strings.size();
-      if (N == 0) {
+      if constexpr (N == 0) {
+         return {};
+      }
+      
+      if (input_strings.size() != N) {
          return {};
       }
 
-      std::vector<std::string_view> strings{};
+      std::array<std::string_view, N> strings{};
       for (size_t i = 0; i < N; ++i) {
-         strings.emplace_back(input_strings[i]);
+         strings[i] = input_strings[i];
       }
 
       std::ranges::sort(strings, [](const auto& a, const auto& b) { return a.size() < b.size(); });
@@ -860,7 +864,7 @@ namespace glz::detail
    }
 
    template <class T>
-   inline constexpr auto per_length_info = unique_per_length_info(reflect<T>::keys);
+   inline constexpr auto per_length_info = unique_per_length_info<reflect<T>::size>(reflect<T>::keys);
 
    consteval size_t bucket_size(hash_type type, size_t N)
    {
@@ -1397,7 +1401,7 @@ namespace glz::detail
       // TODO: MSVC fixed the related compiler bug, but GitHub Actions has not caught up yet
 #if !defined(_MSC_VER)
       // TODO: Use meta-programming to cache this value
-      const auto per_length_data = unique_per_length_info(keys);
+      const auto per_length_data = unique_per_length_info<N>(keys);
       if (per_length_data.valid) {
          auto sized_unique_hash = [&] {
             std::array<size_t, N> bucket_index{};

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -470,15 +470,6 @@ namespace glz::detail
       constexpr auto indices = std::make_index_sequence<reflect<T>::size>{};
       return make_map_impl<decay_keep_volatile_t<T>, use_hash_comparison>(indices);
    }
-
-   template <class T>
-   constexpr auto make_key_int_map()
-   {
-      constexpr auto N = reflect<T>::size;
-      return [&]<size_t... I>(std::index_sequence<I...>) {
-         return normal_map<sv, size_t, reflect<T>::size>(pair<sv, size_t>{reflect<T>::keys[I], I}...);
-      }(std::make_index_sequence<N>{});
-   }
 }
 
 namespace glz
@@ -646,18 +637,6 @@ namespace glz
       {
          constexpr auto indices = std::make_index_sequence<count_members<T>>{};
          return make_reflection_map_impl<decay_keep_volatile_t<T>, use_hash_comparison>(indices);
-      }
-
-      template <reflectable T>
-      GLZ_ALWAYS_INLINE constexpr void populate_map(T&& value, auto& cmap) noexcept
-      {
-         // we have to populate the pointers in the reflection map from the structured binding
-         auto t = to_tuple(std::forward<T>(value));
-         [&]<size_t... I>(std::index_sequence<I...>) {
-            ((get<std::add_pointer_t<decay_keep_volatile_t<decltype(get<I>(t))>>>(get<I>(cmap.items).second) =
-                 &get<I>(t)),
-             ...);
-         }(std::make_index_sequence<count_members<T>>{});
       }
    }
 }

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -1262,7 +1262,7 @@ namespace glz::detail
                   break;
                }
                const auto bucket = hash % bsize;
-               if (contains(std::span{bucket_index.data(), index}, bucket)) {
+               if (contains(bucket_index.data(), index, bucket)) {
                   break;
                }
                bucket_index[index] = bucket;
@@ -1272,7 +1272,7 @@ namespace glz::detail
             if (index == N) {
                // make sure the seed does not collide with any hashes
                const auto bucket = seed % bsize;
-               if (not contains(std::span{bucket_index.data(), N}, bucket)) {
+               if (not contains(bucket_index.data(), N, bucket)) {
                   return; // found working seed
                }
             }
@@ -1421,7 +1421,7 @@ namespace glz::detail
                      break;
                   }
                   const auto bucket = hash % bsize;
-                  if (contains(std::span{bucket_index.data(), index}, bucket)) {
+                  if (contains(bucket_index.data(), index, bucket)) {
                      break;
                   }
                   bucket_index[index] = bucket;
@@ -1431,7 +1431,7 @@ namespace glz::detail
                if (index == N) {
                   // make sure the seed does not collide with any hashes
                   const auto bucket = seed % bsize;
-                  if (not contains(std::span{bucket_index.data(), N}, bucket)) {
+                  if (not contains(bucket_index.data(), N, bucket)) {
                      return; // found working seed
                   }
                }
@@ -1466,7 +1466,7 @@ namespace glz::detail
                      break;
                   }
                   const auto bucket = hash % bsize;
-                  if (contains(std::span{bucket_index.data(), index}, bucket)) {
+                  if (contains(bucket_index.data(), index, bucket)) {
                      break;
                   }
                   bucket_index[index] = bucket;
@@ -1476,7 +1476,7 @@ namespace glz::detail
                if (index == N) {
                   // make sure the seed does not collide with any hashes
                   const auto bucket = seed % bsize;
-                  if (not contains(std::span{bucket_index.data(), N}, bucket)) {
+                  if (not contains(bucket_index.data(), N, bucket)) {
                      return; // found working seed
                   }
                }
@@ -1508,7 +1508,7 @@ namespace glz::detail
                      break;
                   }
                   const auto bucket = hash % bsize;
-                  if (contains(std::span{bucket_index.data(), index}, bucket)) {
+                  if (contains(bucket_index.data(), index, bucket)) {
                      break;
                   }
                   bucket_index[index] = bucket;
@@ -1518,7 +1518,7 @@ namespace glz::detail
                if (index == N) {
                   // make sure the seed does not collide with any hashes
                   const auto bucket = seed % bsize;
-                  if (not contains(std::span{bucket_index.data(), N}, bucket)) {
+                  if (not contains(bucket_index.data(), N, bucket)) {
                      return; // found working seed
                   }
                }

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -108,7 +108,7 @@ namespace glz
                                                    "multipleOf", &T::multipleOf, //
                                                    "minProperties", &T::minProperties, //
                                                    "maxProperties", &T::maxProperties, //
-                                                   //               "dependentRequired", &T::dependent_required, //
+                                                   // "dependentRequired", &T::dependent_required, //
                                                    "required", &T::required, //
                                                    "minItems", &T::minItems, //
                                                    "maxItems", &T::maxItems, //
@@ -196,42 +196,79 @@ struct glz::meta<glz::detail::schematic>
 {
    static constexpr std::string_view name = "glz::detail::schema";
    using T = detail::schematic;
-   static constexpr auto value = glz::object(
-      "type", &T::type, //
-      "properties", &T::properties, //
-      "items", &T::items, //
-      "additionalProperties", &T::additionalProperties, //
-      "$defs", &T::defs, //
-      "oneOf", &T::oneOf, //
-      "examples", raw<&T::examples>, //
-      "required", &T::required, //
-      "title", [](auto&& self) -> auto& { return self.attributes.title; }, //
-      "description", [](auto&& self) -> auto& { return self.attributes.description; }, //
-      "default", [](auto&& self) -> auto& { return self.attributes.defaultValue; }, //
-      "deprecated", [](auto&& self) -> auto& { return self.attributes.deprecated; }, //
-      "readOnly", [](auto&& self) -> auto& { return self.attributes.readOnly; }, //
-      "writeOnly", [](auto&& self) -> auto& { return self.attributes.writeOnly; }, //
-      "const", [](auto&& self) -> auto& { return self.attributes.constant; }, //
-      "minLength", [](auto&& self) -> auto& { return self.attributes.minLength; }, //
-      "maxLength", [](auto&& self) -> auto& { return self.attributes.maxLength; }, //
-      "pattern", [](auto&& self) -> auto& { return self.attributes.pattern; }, //
-      "format", [](auto&& self) -> auto& { return self.attributes.format; }, //
-      "minimum", [](auto&& self) -> auto& { return self.attributes.minimum; }, //
-      "maximum", [](auto&& self) -> auto& { return self.attributes.maximum; }, //
-      "exclusiveMinimum", [](auto&& self) -> auto& { return self.attributes.exclusiveMinimum; }, //
-      "exclusiveMaximum", [](auto&& self) -> auto& { return self.attributes.exclusiveMaximum; }, //
-      "multipleOf", [](auto&& self) -> auto& { return self.attributes.multipleOf; }, //
-      "minProperties", [](auto&& self) -> auto& { return self.attributes.minProperties; }, //
-      "maxProperties", [](auto&& self) -> auto& { return self.attributes.maxProperties; }, //
-      //               "dependentRequired", [](auto&& self) -> auto& { return self.attributes.dependent_required; }, //
-      "minItems", [](auto&& self) -> auto& { return self.attributes.minItems; }, //
-      "maxItems", [](auto&& self) -> auto& { return self.attributes.maxItems; }, //
-      "minContains", [](auto&& self) -> auto& { return self.attributes.minContains; }, //
-      "maxContains", [](auto&& self) -> auto& { return self.attributes.maxContains; }, //
-      "uniqueItems", [](auto&& self) -> auto& { return self.attributes.uniqueItems; }, //
-      "enum", [](auto&& self) -> auto& { return self.attributes.enumeration; }, //
-      "ExtUnits", [](auto&& self) -> auto& { return self.attributes.ExtUnits; }, //
-      "ExtAdvanced", [](auto&& self) -> auto& { return self.attributes.ExtAdvanced; });
+   static constexpr std::array keys{
+      "type", //
+      "properties", //
+      "items", //
+      "additionalProperties", //
+      "$defs", //
+      "oneOf", //
+      "examples", //
+      "required", //
+      "title", //
+      "description", //
+      "default", //
+      "deprecated", //
+      "readOnly", //
+      "writeOnly", //
+      "const", //
+      "minLength", //
+      "maxLength", //
+      "pattern", //
+      "format", //
+      "minimum", //
+      "maximum", //
+      "exclusiveMinimum", //
+      "exclusiveMaximum", //
+      "multipleOf", //
+      "minProperties", //
+      "maxProperties", //
+      // "dependentRequired", //
+      "minItems", //
+      "maxItems", //
+      "minContains", //
+      "maxContains", //
+      "uniqueItems", //
+      "enum", //
+      "ExtUnits", //
+      "ExtAdvanced"};
+   
+   static constexpr glz::tuplet::tuple value{
+      &T::type, //
+      &T::properties, //
+      &T::items, //
+      &T::additionalProperties, //
+      &T::defs, //
+      &T::oneOf, //
+      raw<&T::examples>, //
+      &T::required, //
+      [](auto&& s) -> auto& { return s.attributes.title; }, //
+      [](auto&& s) -> auto& { return s.attributes.description; }, //
+      [](auto&& s) -> auto& { return s.attributes.defaultValue; }, //
+      [](auto&& s) -> auto& { return s.attributes.deprecated; }, //
+      [](auto&& s) -> auto& { return s.attributes.readOnly; }, //
+      [](auto&& s) -> auto& { return s.attributes.writeOnly; }, //
+      [](auto&& s) -> auto& { return s.attributes.constant; }, //
+      [](auto&& s) -> auto& { return s.attributes.minLength; }, //
+      [](auto&& s) -> auto& { return s.attributes.maxLength; }, //
+      [](auto&& s) -> auto& { return s.attributes.pattern; }, //
+      [](auto&& s) -> auto& { return s.attributes.format; }, //
+      [](auto&& s) -> auto& { return s.attributes.minimum; }, //
+      [](auto&& s) -> auto& { return s.attributes.maximum; }, //
+      [](auto&& s) -> auto& { return s.attributes.exclusiveMinimum; }, //
+      [](auto&& s) -> auto& { return s.attributes.exclusiveMaximum; }, //
+      [](auto&& s) -> auto& { return s.attributes.multipleOf; }, //
+      [](auto&& s) -> auto& { return s.attributes.minProperties; }, //
+      [](auto&& s) -> auto& { return s.attributes.maxProperties; }, //
+      // [](auto&& s) -> auto& { return s.attributes.dependent_required; }, //
+      [](auto&& s) -> auto& { return s.attributes.minItems; }, //
+      [](auto&& s) -> auto& { return s.attributes.maxItems; }, //
+      [](auto&& s) -> auto& { return s.attributes.minContains; }, //
+      [](auto&& s) -> auto& { return s.attributes.maxContains; }, //
+      [](auto&& s) -> auto& { return s.attributes.uniqueItems; }, //
+      [](auto&& s) -> auto& { return s.attributes.enumeration; }, //
+      [](auto&& s) -> auto& { return s.attributes.ExtUnits; }, //
+      [](auto&& s) -> auto& { return s.attributes.ExtAdvanced; }};
 };
 
 namespace glz

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1672,18 +1672,6 @@ namespace glz
          }
       };
 
-      template <class T>
-      consteval size_t key_index(const std::string_view key)
-      {
-         const auto n = reflect<T>::keys.size();
-         for (size_t i = 0; i < n; ++i) {
-            if (key == reflect<T>::keys[i]) {
-               return i;
-            }
-         }
-         return n;
-      }
-
       // Only object types are supported for partial
       template <class T>
          requires(glaze_object_t<T> || writable_map_t<T> || reflectable<T>)

--- a/include/glaze/util/hash_map.hpp
+++ b/include/glaze/util/hash_map.hpp
@@ -270,11 +270,12 @@ namespace glz::detail
          }
       }
    };
-
-   constexpr bool contains(auto&& data, auto&& val) noexcept
+   
+   // Check if a size_t value exists inside of a container like std::array<size_t, N>
+   // Using a pointer and size rather than std::span for faster compile times
+   constexpr bool contains(const size_t* data, const size_t size, const size_t val) noexcept
    {
-      const auto n = data.size();
-      for (size_t i = 0; i < n; ++i) {
+      for (size_t i = 0; i < size; ++i) {
          if (data[i] == val) {
             return true;
          }
@@ -319,7 +320,7 @@ namespace glz::detail
                   break;
                }
                const auto bucket = hash % desc.bucket_size;
-               if (contains(std::span{bucket_index.data(), index}, bucket)) {
+               if (contains(bucket_index.data(), index, bucket)) {
                   break;
                }
                bucket_index[index] = bucket;
@@ -329,7 +330,7 @@ namespace glz::detail
             if (index == N) {
                // make sure the seed does not collide with any hashes
                const auto bucket = seed % desc.bucket_size;
-               if (not contains(std::span{bucket_index.data(), N}, bucket)) {
+               if (not contains(bucket_index.data(), N, bucket)) {
                   return; // found working seed
                }
             }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -1619,20 +1619,19 @@ suite json_pointer = [] {
    };
 
    "valid"_test = [] {
-      [[maybe_unused]] constexpr bool is_valid = glz::valid<Thing, "/thing/a", double>(); // Verify constexpr
+      // Compile time JSON Pointer syntax validation
+      static_assert(glz::valid<Thing, "/thing_ptr/a", double>());
+      static_assert(glz::valid<Thing, "/thing_ptr/a", int>() == false);
+      static_assert(glz::valid<Thing, "/thing_ptr/b">());
+      static_assert(glz::valid<Thing, "/thing_ptr/z">() == false);
 
-      expect(glz::valid<Thing, "/thing_ptr/a", double>() == true);
-      expect(glz::valid<Thing, "/thing_ptr/a", int>() == false);
-      expect(glz::valid<Thing, "/thing_ptr/b">() == true);
-      expect(glz::valid<Thing, "/thing_ptr/z">() == false);
+      static_assert(glz::valid<Thing, "/vec3/2", double>());
+      static_assert(glz::valid<Thing, "/vec3/3", double>() == false);
 
-      expect(glz::valid<Thing, "/vec3/2", double>() == true);
-      expect(glz::valid<Thing, "/vec3/3", double>() == false);
-
-      expect(glz::valid<Thing, "/map/f", int>() == true);
-      expect(glz::valid<Thing, "/vector", std::vector<V3>>() == true);
-      expect(glz::valid<Thing, "/vector/1", V3>() == true);
-      expect(glz::valid<Thing, "/vector/1/0", double>() == true);
+      static_assert(glz::valid<Thing, "/map/f", int>());
+      static_assert(glz::valid<Thing, "/vector", std::vector<V3>>());
+      static_assert(glz::valid<Thing, "/vector/1", V3>());
+      static_assert(glz::valid<Thing, "/vector/1/0", double>());
    };
 
    "id bug"_test = [] {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -124,8 +124,8 @@ struct glz::meta<sub_thing2>
 {
    using T = sub_thing2;
    static constexpr std::string_view name = "sub_thing2";
-   static constexpr auto value = object("a", &T::a, "Test comment 1", //
-                                        "b", &T::b, "Test comment 2", //
+   static constexpr auto value = object("a", &T::a, //
+                                        "b", &T::b, //
                                         "c", &T::c, //
                                         "d", &T::d, //
                                         "e", &T::e, //

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -10031,6 +10031,37 @@ suite variant_tag_tests = [] {
    };
 };
 
+struct birds
+{
+   std::string crow{};
+   std::string sparrow{};
+   std::string hawk{};
+};
+
+template <>
+struct glz::meta<birds>
+{
+   using T = birds;
+   static constexpr std::array keys{"crow", "sparrow", "hawk"};
+   static constexpr glz::tuplet::tuple value{&T::crow, &T::sparrow, &T::hawk};
+};
+
+suite meta_keys_for_struct = [] {
+   "meta_keys birds"_test = [] {
+      birds obj{"caw","chirp","screech"};
+      
+      std::string buffer{};
+      expect(not glz::write_json(obj, buffer));
+      expect(buffer == R"({"crow":"caw","sparrow":"chirp","hawk":"screech"})") << buffer;
+      
+      obj = {};
+      expect(not glz::read_json(obj, buffer));
+      expect(obj.crow == "caw");
+      expect(obj.sparrow == "chirp");
+      expect(obj.hawk == "screech");
+   };
+};
+
 int main()
 {
    trace.end("json_test");


### PR DESCRIPTION
Making compile time optimizations based on #1511 

- Faster `contains` by avoiding `std::span`