### PR TITLE
glz::tuplet::tuple -> glz::tuple

### DIFF
--- a/include/glaze/api/tuplet.hpp
+++ b/include/glaze/api/tuplet.hpp
@@ -9,10 +9,10 @@
 namespace glz
 {
    template <class... T>
-   struct meta<glz::tuplet::tuple<T...>>
+   struct meta<glz::tuple<T...>>
    {
       static constexpr std::string_view name = []<size_t... I>(std::index_sequence<I...>) {
-         return join_v<chars<"glz::tuplet::tuple<">,
+         return join_v<chars<"glz::tuple<">,
                        ((I != sizeof...(T) - 1) ? join_v<name_v<T>, chars<",">> : join_v<name_v<T>>)..., chars<">">>;
       }(std::make_index_sequence<sizeof...(T)>{});
    };

--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -1236,7 +1236,7 @@ namespace glz
          static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             if constexpr (reflectable<T>) {
-               auto t = to_tuple(value);
+               auto t = to_tie(value);
                read<BEVE>::op<Opts>(t, ctx, it, end);
             }
             else {
@@ -1338,7 +1338,7 @@ namespace glz
                            static constexpr auto Length = TargetKey.size();
                            if ((Length == n) && compare<Length>(TargetKey.data(), key.data())) [[likely]] {
                               if constexpr (detail::reflectable<T>) {
-                                 read<BEVE>::op<Opts>(get_member(value, get<I>(to_tuple(value))), ctx, it, end);
+                                 read<BEVE>::op<Opts>(get_member(value, get<I>(to_tie(value))), ctx, it, end);
                               }
                               else {
                                  read<BEVE>::op<Opts>(get_member(value, get<I>(reflect<T>::values)), ctx, it, end);

--- a/include/glaze/beve/write.hpp
+++ b/include/glaze/beve/write.hpp
@@ -699,7 +699,7 @@ namespace glz
 
             [[maybe_unused]] decltype(auto) t = [&]() -> decltype(auto) {
                if constexpr (reflectable<T>) {
-                  return to_tuple(value);
+                  return to_tie(value);
                }
                else {
                   return nullptr;
@@ -737,7 +737,7 @@ namespace glz
 
             [[maybe_unused]] decltype(auto) t = [&]() -> decltype(auto) {
                if constexpr (reflectable<T>) {
-                  return to_tuple(value);
+                  return to_tie(value);
                }
                else {
                   return nullptr;
@@ -884,7 +884,7 @@ namespace glz
                   }
                   else {
                      detail::write<BEVE>::no_header<Opts>(key, ctx, b, ix);
-                     write_partial<BEVE>::op<sub_partial, Opts>(get_member(value, get<index>(to_tuple(value))), ctx, b,
+                     write_partial<BEVE>::op<sub_partial, Opts>(get_member(value, get<index>(to_tie(value))), ctx, b,
                                                                 ix);
                   }
                });

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -41,7 +41,7 @@ namespace glz
    template <class... T>
    struct obj final
    {
-      glz::tuplet::tuple<std::conditional_t<std::is_convertible_v<std::decay_t<T>, sv>, sv, T>...> value;
+      glz::tuple<std::conditional_t<std::is_convertible_v<std::decay_t<T>, sv>, sv, T>...> value;
       static constexpr auto glaze_reflect = false;
    };
 
@@ -51,7 +51,7 @@ namespace glz
    template <class... T>
    struct obj_copy final
    {
-      glz::tuplet::tuple<T...> value;
+      glz::tuple<T...> value;
       static constexpr auto glaze_reflect = false;
    };
 
@@ -61,7 +61,7 @@ namespace glz
    template <class... T>
    struct arr final
    {
-      glz::tuplet::tuple<std::conditional_t<std::is_convertible_v<std::decay_t<T>, sv>, sv, T>...> value;
+      glz::tuple<std::conditional_t<std::is_convertible_v<std::decay_t<T>, sv>, sv, T>...> value;
       static constexpr auto glaze_reflect = false;
    };
 
@@ -71,7 +71,7 @@ namespace glz
    template <class... T>
    struct arr_copy final
    {
-      glz::tuplet::tuple<T...> value;
+      glz::tuple<T...> value;
    };
 
    template <class... T>
@@ -81,7 +81,7 @@ namespace glz
    template <class... T>
    struct merge final
    {
-      glz::tuplet::tuple<std::conditional_t<std::is_convertible_v<std::decay_t<T>, sv>, sv, T>...> value;
+      glz::tuple<std::conditional_t<std::is_convertible_v<std::decay_t<T>, sv>, sv, T>...> value;
       static constexpr auto glaze_reflect = false;
    };
 
@@ -521,17 +521,17 @@ namespace glz
       }
    }
 
-   constexpr auto array(auto&&... args) noexcept { return detail::Array{glz::tuplet::tuple{conv_sv(args)...}}; }
+   constexpr auto array(auto&&... args) noexcept { return detail::Array{glz::tuple{conv_sv(args)...}}; }
 
    template <class... Args>
    constexpr auto object(Args&&... args) noexcept
    {
-      return detail::Object{tuplet::tuple{std::forward<Args>(args)...}};
+      return detail::Object{tuple{std::forward<Args>(args)...}};
    }
 
-   constexpr auto enumerate(auto&&... args) noexcept { return detail::Enum{tuplet::tuple{args...}}; }
+   constexpr auto enumerate(auto&&... args) noexcept { return detail::Enum{tuple{args...}}; }
 
-   constexpr auto flags(auto&&... args) noexcept { return detail::Flags{tuplet::tuple{args...}}; }
+   constexpr auto flags(auto&&... args) noexcept { return detail::Flags{tuple{args...}}; }
 }
 
 namespace glz

--- a/include/glaze/core/convert_struct.hpp
+++ b/include/glaze/core/convert_struct.hpp
@@ -22,8 +22,8 @@ namespace glz
    template <class In, class Out>
    void convert_struct(In&& in, Out&& out)
    {
-      auto in_tuple = to_tuple(std::forward<In>(in));
-      auto out_tuple = to_tuple(std::forward<Out>(out));
+      auto in_tuple = to_tie(std::forward<In>(in));
+      auto out_tuple = to_tie(std::forward<Out>(out));
 
       constexpr auto N = tuple_size_v<std::decay_t<decltype(in_tuple)>>;
       static_assert(N == tuple_size_v<std::decay_t<decltype(out_tuple)>>);

--- a/include/glaze/core/meta.hpp
+++ b/include/glaze/core/meta.hpp
@@ -110,7 +110,7 @@ namespace glz
 
    struct empty
    {
-      static constexpr glz::tuplet::tuple<> value{};
+      static constexpr glz::tuple<> value{};
    };
 
    template <class T>

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -91,7 +91,7 @@ namespace glz
    struct reflect<T>
    {
       static constexpr auto size = 0;
-      static constexpr auto values = tuplet::tuple{};
+      static constexpr auto values = tuple{};
       static constexpr std::array<sv, 0> keys{};
 
       template <size_t I>
@@ -109,7 +109,7 @@ namespace glz
 
       static constexpr auto values = [] {
          return [&]<size_t... I>(std::index_sequence<I...>) { //
-            return tuplet::tuple{get<value_indices[I]>(meta_v<T>)...}; //
+            return tuple{get<value_indices[I]>(meta_v<T>)...}; //
          }(std::make_index_sequence<value_indices.size()>{}); //
       }();
 
@@ -328,7 +328,7 @@ namespace glz::detail
    struct tuple_ptr_variant;
 
    template <class... Ts>
-   struct tuple_ptr_variant<glz::tuplet::tuple<Ts...>> : unique<std::variant<>, std::add_pointer_t<Ts>...>
+   struct tuple_ptr_variant<glz::tuple<Ts...>> : unique<std::variant<>, std::add_pointer_t<Ts>...>
    {};
 
    template <class... Ts>
@@ -345,8 +345,8 @@ namespace glz::detail
    template <class T, size_t... I>
    struct member_tuple_type<T, std::index_sequence<I...>>
    {
-      using type = std::conditional_t<sizeof...(I) == 0, tuplet::tuple<>,
-                                      tuplet::tuple<std::remove_cvref_t<member_t<T, refl_t<T, I>>>...>>;
+      using type = std::conditional_t<sizeof...(I) == 0, tuple<>,
+                                      tuple<std::remove_cvref_t<member_t<T, refl_t<T, I>>>...>>;
    };
 
    template <class T>

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -188,16 +188,16 @@ namespace glz
    struct reflect<T>
    {
       using V = std::remove_cvref_t<T>;
-      using tuple = decay_keep_volatile_t<decltype(to_tie(std::declval<T>()))>;
+      using tie_type = decltype(to_tie(std::declval<T&>()));
 
       static constexpr auto keys = member_names<V>;
       static constexpr auto size = keys.size();
 
       template <size_t I>
-      using elem = decltype(get<I>(std::declval<tuple>()));
+      using elem = decltype(get<I>(std::declval<tie_type>()));
 
       template <size_t I>
-      using type = member_t<V, decltype(get<I>(std::declval<tuple>()))>;
+      using type = member_t<V, decltype(get<I>(std::declval<tie_type>()))>;
    };
 
    template <class T>

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -188,7 +188,7 @@ namespace glz
    struct reflect<T>
    {
       using V = std::remove_cvref_t<T>;
-      using tuple = decay_keep_volatile_t<decltype(to_tuple(std::declval<T>()))>;
+      using tuple = decay_keep_volatile_t<decltype(to_tie(std::declval<T>()))>;
 
       static constexpr auto keys = member_names<V>;
       static constexpr auto size = keys.size();
@@ -1992,7 +1992,7 @@ namespace glz
       constexpr auto N = reflect<T>::size;
       if constexpr (N > 0) {
          [&]<size_t... I>(std::index_sequence<I...>) constexpr {
-            (callable(get_member(value, get<I>(to_tuple(value)))), ...);
+            (callable(get_member(value, get<I>(to_tie(value)))), ...);
          }(std::make_index_sequence<N>{});
       }
    }

--- a/include/glaze/core/seek.hpp
+++ b/include/glaze/core/seek.hpp
@@ -494,7 +494,7 @@ namespace glz
          n_items_per_group[i] = std::count(first_keys.begin(), first_keys.end(), unique_keys[i]);
       }
 
-      return glz::tuplet::tuple{n_items_per_group, n_unique, unique_keys};
+      return glz::tuple{n_items_per_group, n_unique, unique_keys};
    }
 
    template <auto Arr, std::size_t... Is>

--- a/include/glaze/core/seek.hpp
+++ b/include/glaze/core/seek.hpp
@@ -107,7 +107,7 @@ namespace glz::detail
             jump_table<N>(
                [&]<size_t I>() {
                   if constexpr (reflectable<T>) {
-                     ret = seek_impl(std::forward<F>(func), get_member(value, get<I>(to_tuple(value))), json_ptr);
+                     ret = seek_impl(std::forward<F>(func), get_member(value, get<I>(to_tie(value))), json_ptr);
                   }
                   else {
                      ret = seek_impl(std::forward<F>(func), get_member(value, get<I>(reflect<T>::values)), json_ptr);

--- a/include/glaze/csv/read.hpp
+++ b/include/glaze/csv/read.hpp
@@ -464,7 +464,7 @@ namespace glz
                         [&]<size_t I>() {
                            decltype(auto) member = [&]() -> decltype(auto) {
                               if constexpr (reflectable<T>) {
-                                 return get_member(value, get<I>(to_tuple(value)));
+                                 return get_member(value, get<I>(to_tie(value)));
                               }
                               else {
                                  return get_member(value, get<I>(reflect<T>::values));
@@ -581,7 +581,7 @@ namespace glz
                               [&]<size_t I>() {
                                  decltype(auto) member = [&]() -> decltype(auto) {
                                     if constexpr (reflectable<T>) {
-                                       return get_member(value, get<I>(to_tuple(value)));
+                                       return get_member(value, get<I>(to_tie(value)));
                                     }
                                     else {
                                        return get_member(value, get<I>(reflect<T>::values));

--- a/include/glaze/csv/write.hpp
+++ b/include/glaze/csv/write.hpp
@@ -180,7 +180,7 @@ namespace glz
 
             [[maybe_unused]] decltype(auto) t = [&] {
                if constexpr (reflectable<T>) {
-                  return to_tuple(value);
+                  return to_tie(value);
                }
                else {
                   return nullptr;

--- a/include/glaze/ext/cli_menu.hpp
+++ b/include/glaze/ext/cli_menu.hpp
@@ -70,7 +70,7 @@ namespace glz
 
          [[maybe_unused]] decltype(auto) t = [&] {
             if constexpr (reflectable<T>) {
-               return to_tuple(value);
+               return to_tie(value);
             }
             else {
                return nullptr;
@@ -181,7 +181,7 @@ namespace glz
             else {
                [[maybe_unused]] decltype(auto) t = [&] {
                   if constexpr (reflectable<T>) {
-                     return to_tuple(value);
+                     return to_tie(value);
                   }
                   else {
                      return nullptr;

--- a/include/glaze/ext/jsonrpc.hpp
+++ b/include/glaze/ext/jsonrpc.hpp
@@ -198,7 +198,7 @@ namespace glz::rpc
    namespace detail
    {
       template <string_literal name, class... Method>
-      inline constexpr void set_callback(glz::tuplet::tuple<Method...>& methods, const auto& callback)
+      inline constexpr void set_callback(glz::tuple<Method...>& methods, const auto& callback)
       {
          constexpr bool method_found = ((Method::name_v == name) || ...);
          static_assert(method_found, "Method not settable in given tuple.");
@@ -257,7 +257,7 @@ namespace glz::rpc
       };
 
       template <class Map, string_literal Name, class... Method>
-      auto get_request_map(glz::tuplet::tuple<Method...>& methods) -> Map&
+      auto get_request_map(glz::tuple<Method...>& methods) -> Map&
       {
          constexpr bool method_found = ((Method::name_v == Name) || ...);
          static_assert(method_found, "Method not declared in client.");
@@ -284,7 +284,7 @@ namespace glz::rpc
    {
       using raw_response_t = response_t<glz::raw_json>;
 
-      glz::tuplet::tuple<server_method_t<Method>...> methods{};
+      glz::tuple<server_method_t<Method>...> methods{};
 
       template <string_literal name>
       constexpr void on(const auto& callback) // std::function<expected<result_t, rpc::error>(params_t const&)>
@@ -411,7 +411,7 @@ namespace glz::rpc
    template <concepts::method_type... Method>
    struct client
    {
-      glz::tuplet::tuple<client_method_t<Method>...> methods{};
+      glz::tuple<client_method_t<Method>...> methods{};
 
       rpc::error call(std::string_view json_response)
       {

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2065,23 +2065,23 @@ namespace glz
       {
          // TODO: this way of filtering types is compile time intensive.
          using bool_types = decltype(tuplet::tuple_cat(
-            std::conditional_t<bool_t<remove_meta_wrapper_t<Ts>>, tuplet::tuple<Ts>, tuplet::tuple<>>{}...));
+            std::conditional_t<bool_t<remove_meta_wrapper_t<Ts>>, tuple<Ts>, tuple<>>{}...));
          using number_types = decltype(tuplet::tuple_cat(
-            std::conditional_t<num_t<remove_meta_wrapper_t<Ts>>, tuplet::tuple<Ts>, tuplet::tuple<>>{}...));
+            std::conditional_t<num_t<remove_meta_wrapper_t<Ts>>, tuple<Ts>, tuple<>>{}...));
          using string_types = decltype(tuplet::tuple_cat( // glaze_enum_t remove_meta_wrapper_t supports constexpr
                                                           // types while the other supports non const
             std::conditional_t < str_t<remove_meta_wrapper_t<Ts>> || glaze_enum_t<remove_meta_wrapper_t<Ts>> ||
                glaze_enum_t<Ts>,
-            tuplet::tuple<Ts>, tuplet::tuple < >> {}...));
+            tuple<Ts>, tuple < >> {}...));
          using object_types =
-            decltype(tuplet::tuple_cat(std::conditional_t<json_object<Ts>, tuplet::tuple<Ts>, tuplet::tuple<>>{}...));
+            decltype(tuplet::tuple_cat(std::conditional_t<json_object<Ts>, tuple<Ts>, tuple<>>{}...));
          using array_types =
             decltype(tuplet::tuple_cat(std::conditional_t < array_t<remove_meta_wrapper_t<Ts>> || glaze_array_t<Ts>,
-                                       tuplet::tuple<Ts>, tuplet::tuple < >> {}...));
+                                       tuple<Ts>, tuple < >> {}...));
          using nullable_types =
-            decltype(tuplet::tuple_cat(std::conditional_t<null_t<Ts>, tuplet::tuple<Ts>, tuplet::tuple<>>{}...));
+            decltype(tuplet::tuple_cat(std::conditional_t<null_t<Ts>, tuple<Ts>, tuple<>>{}...));
          using nullable_objects = decltype(tuplet::tuple_cat(
-            std::conditional_t<is_memory_object<Ts>, tuplet::tuple<Ts>, tuplet::tuple<>>{}...));
+            std::conditional_t<is_memory_object<Ts>, tuple<Ts>, tuple<>>{}...));
       };
 
       // post process output of variant_types
@@ -2089,12 +2089,12 @@ namespace glz
       struct tuple_types;
 
       template <class... Ts>
-      struct tuple_types<tuplet::tuple<Ts...>>
+      struct tuple_types<tuple<Ts...>>
       {
          using glaze_const_types = decltype(tuplet::tuple_cat(
-            std::conditional_t<glaze_const_value_t<Ts>, tuplet::tuple<Ts>, tuplet::tuple<>>{}...));
+            std::conditional_t<glaze_const_value_t<Ts>, tuple<Ts>, tuple<>>{}...));
          using glaze_non_const_types = decltype(tuplet::tuple_cat(
-            std::conditional_t<!glaze_const_value_t<Ts>, tuplet::tuple<Ts>, tuplet::tuple<>>{}...));
+            std::conditional_t<!glaze_const_value_t<Ts>, tuple<Ts>, tuple<>>{}...));
       };
 
       template <class>

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -174,7 +174,7 @@ namespace glz
                }
                else {
                   from<JSON, std::remove_cvref_t<V>>::template op<ws_handled<Opts>()>(
-                     get_member(value, get<I>(to_tuple(value))), ctx, it, end);
+                     get_member(value, get<I>(to_tie(value))), ctx, it, end);
                }
             }
 

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -279,7 +279,7 @@ namespace glz
       consteval auto make_reflection_schema_map()
       {
          auto schema_instance = json_schema_v<T>;
-         auto tuple = to_tuple(schema_instance);
+         auto tuple = to_tie(schema_instance);
          using V = std::decay_t<decltype(tuple)>;
          constexpr auto N = glz::tuple_size_v<V>;
          if constexpr (N > 0) {

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -65,7 +65,7 @@ namespace glz
       // object only keywords
       std::optional<std::uint64_t> minProperties{};
       std::optional<std::uint64_t> maxProperties{};
-      //      std::optional<std::map<std::string_view, std::vector<std::string_view>>> dependent_required{};
+      // std::optional<std::map<std::string_view, std::vector<std::string_view>>> dependent_required{};
       std::optional<std::span<const std::string_view>> required{};
       // array only keywords
       std::optional<std::uint64_t> minItems{};
@@ -88,36 +88,67 @@ namespace glz
       struct glaze
       {
          using T = schema;
-         static constexpr auto value = glz::object("$ref", &T::ref, //
-                                                   "title", &T::title, //
-                                                   "description", &T::description, //
-                                                   "default", &T::defaultValue, //
-                                                   "deprecated", &T::deprecated, //
-                                                   "examples", raw<&T::examples>, //
-                                                   "readOnly", &T::readOnly, //
-                                                   "writeOnly", &T::writeOnly, //
-                                                   "const", &T::constant, //
-                                                   "minLength", &T::minLength, //
-                                                   "maxLength", &T::maxLength, //
-                                                   "pattern", &T::pattern, //
-                                                   "format", &T::format, //
-                                                   "minimum", &T::minimum, //
-                                                   "maximum", &T::maximum, //
-                                                   "exclusiveMinimum", &T::exclusiveMinimum, //
-                                                   "exclusiveMaximum", &T::exclusiveMaximum, //
-                                                   "multipleOf", &T::multipleOf, //
-                                                   "minProperties", &T::minProperties, //
-                                                   "maxProperties", &T::maxProperties, //
-                                                   // "dependentRequired", &T::dependent_required, //
-                                                   "required", &T::required, //
-                                                   "minItems", &T::minItems, //
-                                                   "maxItems", &T::maxItems, //
-                                                   "minContains", &T::minContains, //
-                                                   "maxContains", &T::maxContains, //
-                                                   "uniqueItems", &T::uniqueItems, //
-                                                   "enum", &T::enumeration, //
-                                                   "ExtUnits", &T::ExtUnits, //
-                                                   "ExtAdvanced", &T::ExtAdvanced);
+         static constexpr std::array keys{"$ref", //
+                                          "title", //
+                                          "description", //
+                                          "default", //
+                                          "deprecated", //
+                                          "examples", //
+                                          "readOnly", //
+                                          "writeOnly", //
+                                          "const", //
+                                          "minLength", //
+                                          "maxLength", //
+                                          "pattern", //
+                                          "format", //
+                                          "minimum", //
+                                          "maximum", //
+                                          "exclusiveMinimum", //
+                                          "exclusiveMaximum", //
+                                          "multipleOf", //
+                                          "minProperties", //
+                                          "maxProperties", //
+                                          //"dependentRequired", //
+                                          "required", //
+                                          "minItems", //
+                                          "maxItems", //
+                                          "minContains", //
+                                          "maxContains", //
+                                          "uniqueItems", //
+                                          "enum", //
+                                          "ExtUnits", //
+                                          "ExtAdvanced"};
+
+         static constexpr glz::tuple value = {&T::ref, //
+                                              &T::title, //
+                                              &T::description, //
+                                              &T::defaultValue, //
+                                              &T::deprecated, //
+                                              raw<&T::examples>, //
+                                              &T::readOnly, //
+                                              &T::writeOnly, //
+                                              &T::constant, //
+                                              &T::minLength, //
+                                              &T::maxLength, //
+                                              &T::pattern, //
+                                              &T::format, //
+                                              &T::minimum, //
+                                              &T::maximum, //
+                                              &T::exclusiveMinimum, //
+                                              &T::exclusiveMaximum, //
+                                              &T::multipleOf, //
+                                              &T::minProperties, //
+                                              &T::maxProperties, //
+                                              // &T::dependent_required, //
+                                              &T::required, //
+                                              &T::minItems, //
+                                              &T::maxItems, //
+                                              &T::minContains, //
+                                              &T::maxContains, //
+                                              &T::uniqueItems, //
+                                              &T::enumeration, //
+                                              &T::ExtUnits, //
+                                              &T::ExtAdvanced};
       };
    };
 
@@ -233,40 +264,40 @@ struct glz::meta<glz::detail::schematic>
                                     "ExtAdvanced"};
 
    static constexpr glz::tuple value{&T::type, //
-                                             &T::properties, //
-                                             &T::items, //
-                                             &T::additionalProperties, //
-                                             &T::defs, //
-                                             &T::oneOf, //
-                                             raw<&T::examples>, //
-                                             &T::required, //
-                                             [](auto&& s) -> auto& { return s.attributes.title; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.description; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.defaultValue; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.deprecated; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.readOnly; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.writeOnly; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.constant; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.minLength; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.maxLength; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.pattern; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.format; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.minimum; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.maximum; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.exclusiveMinimum; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.exclusiveMaximum; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.multipleOf; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.minProperties; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.maxProperties; }, //
-                                             // [](auto&& s) -> auto& { return s.attributes.dependent_required; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.minItems; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.maxItems; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.minContains; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.maxContains; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.uniqueItems; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.enumeration; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.ExtUnits; }, //
-                                             [](auto&& s) -> auto& { return s.attributes.ExtAdvanced; }};
+                                     &T::properties, //
+                                     &T::items, //
+                                     &T::additionalProperties, //
+                                     &T::defs, //
+                                     &T::oneOf, //
+                                     raw<&T::examples>, //
+                                     &T::required, //
+                                     [](auto&& s) -> auto& { return s.attributes.title; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.description; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.defaultValue; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.deprecated; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.readOnly; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.writeOnly; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.constant; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.minLength; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.maxLength; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.pattern; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.format; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.minimum; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.maximum; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.exclusiveMinimum; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.exclusiveMaximum; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.multipleOf; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.minProperties; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.maxProperties; }, //
+                                     // [](auto&& s) -> auto& { return s.attributes.dependent_required; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.minItems; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.maxItems; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.minContains; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.maxContains; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.uniqueItems; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.enumeration; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.ExtUnits; }, //
+                                     [](auto&& s) -> auto& { return s.attributes.ExtAdvanced; }};
 };
 
 namespace glz

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -232,7 +232,7 @@ struct glz::meta<glz::detail::schematic>
                                     "ExtUnits", //
                                     "ExtAdvanced"};
 
-   static constexpr glz::tuplet::tuple value{&T::type, //
+   static constexpr glz::tuple value{&T::type, //
                                              &T::properties, //
                                              &T::items, //
                                              &T::additionalProperties, //

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -535,19 +535,11 @@ namespace glz
       };
 
       template <class T>
-      inline constexpr auto glaze_names = []() {
-         constexpr auto N = reflect<T>::size;
-         std::array<sv, N> names{};
-         for_each<N>([&](auto I) { names[I] = reflect<T>::keys[I]; });
-         return names;
-      }();
-
-      template <class T>
       consteval bool json_schema_matches_object_keys()
       {
          if constexpr (json_schema_t<T> && (count_members<json_schema_type<T>> > 0)) {
             constexpr auto& json_schema_names = member_names<json_schema_type<T>>;
-            auto fields = glaze_names<T>;
+            auto fields = reflect<T>::keys;
             std::sort(fields.begin(), fields.end());
 
             for (const auto& key : json_schema_names) {

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1433,7 +1433,7 @@ namespace glz
 
                decltype(auto) t = [&]() -> decltype(auto) {
                   if constexpr (reflectable<T>) {
-                     return to_tuple(value);
+                     return to_tie(value);
                   }
                   else {
                      return nullptr;
@@ -1721,7 +1721,7 @@ namespace glz
                      }
                   }
                   else {
-                     write_partial<JSON>::op<sub_partial, Opts>(get_member(value, get<index>(to_tuple(value))), ctx, b,
+                     write_partial<JSON>::op<sub_partial, Opts>(get_member(value, get<index>(to_tie(value))), ctx, b,
                                                                 ix);
                      if constexpr (I != N - 1) {
                         write_object_entry_separator<Opts>(ctx, b, ix);

--- a/include/glaze/reflection/get_name.hpp
+++ b/include/glaze/reflection/get_name.hpp
@@ -20,8 +20,9 @@
 // For struct fields
 namespace glz::detail
 {
+   // Do not const qualify this value to avoid duplicate `to_tie` template instantiations with rest of Glaze
    template <class T>
-   extern const T external;
+   extern T external;
 
    // using const char* simplifies the complier's output and should improve compile times
    template <auto Ptr>

--- a/include/glaze/reflection/to_tuple.hpp
+++ b/include/glaze/reflection/to_tuple.hpp
@@ -62,7 +62,7 @@ namespace glz
    GLZ_ALWAYS_INLINE constexpr decltype(auto) to_tuple(T&& t)
    {
       if constexpr (N == 0) {
-         return tuplet::tuple{};
+         return tuple{};
       }
       else if constexpr (N == 1) {
          auto& [p] = t;

--- a/include/glaze/reflection/to_tuple.hpp
+++ b/include/glaze/reflection/to_tuple.hpp
@@ -59,7 +59,7 @@ namespace glz
 
    template <class T, size_t N = detail::count_members<T>>
       requires(N <= detail::max_pure_reflection_count)
-   GLZ_ALWAYS_INLINE constexpr decltype(auto) to_tuple(T&& t)
+   GLZ_ALWAYS_INLINE constexpr decltype(auto) to_tie(T&& t)
    {
       if constexpr (N == 0) {
          return tuple{};
@@ -1277,7 +1277,7 @@ namespace glz
       template <size_t N, class T>
       constexpr auto get_ptr(T&& t) noexcept
       {
-         auto& p = get<N>(to_tuple(t));
+         auto& p = get<N>(to_tie(t));
          return ptr_t<std::remove_cvref_t<decltype(p)>>{&p};
       }
    }

--- a/include/glaze/rpc/repe/registry.hpp
+++ b/include/glaze/rpc/repe/registry.hpp
@@ -182,8 +182,8 @@ namespace glz::repe
          static constexpr auto N = reflect<T>::size;
 
          [[maybe_unused]] decltype(auto) t = [&]() -> decltype(auto) {
-            if constexpr (reflectable<T> && requires { to_tuple(value); }) {
-               return to_tuple(value);
+            if constexpr (reflectable<T> && requires { to_tie(value); }) {
+               return to_tie(value);
             }
             else {
                return nullptr;

--- a/include/glaze/stencil/stencil.hpp
+++ b/include/glaze/stencil/stencil.hpp
@@ -119,7 +119,7 @@ namespace glz
                                  if (TargetKey == key) [[likely]] {
                                     if constexpr (detail::bool_t<refl_t<T, I>>) {
                                        if constexpr (detail::reflectable<T>) {
-                                          condition = bool(get_member(value, get<I>(to_tuple(value))));
+                                          condition = bool(get_member(value, get<I>(to_tie(value))));
                                        }
                                        else if constexpr (detail::glaze_object_t<T>) {
                                           condition = bool(get_member(value, get<I>(reflect<T>::values)));
@@ -185,7 +185,7 @@ namespace glz
                            if ((TargetKey.size() == key.size()) && detail::comparitor<TargetKey>(start)) [[likely]] {
                               if constexpr (detail::reflectable<T>) {
                                  detail::write<Opts.format>::template op<RawOpts>(
-                                    get_member(value, get<I>(to_tuple(value))), ctx, buffer, ix);
+                                    get_member(value, get<I>(to_tie(value))), ctx, buffer, ix);
                               }
                               else if constexpr (detail::glaze_object_t<T>) {
                                  detail::write<Opts.format>::template op<RawOpts>(

--- a/include/glaze/stencil/stencilcount.hpp
+++ b/include/glaze/stencil/stencilcount.hpp
@@ -112,7 +112,7 @@ namespace glz
                            if ((Length == key.size()) && detail::comparitor<TargetKey>(start)) [[likely]] {
                               if constexpr (detail::reflectable<T> && N > 0) {
                                  std::ignore = write<opt_true<Opts, &opts::raw>>(
-                                    get_member(value, get<I>(to_tuple(value))), temp, ctx);
+                                    get_member(value, get<I>(to_tie(value))), temp, ctx);
                               }
                               else if constexpr (detail::glaze_object_t<T> && N > 0) {
                                  std::ignore = write<opt_true<Opts, &opts::raw>>(

--- a/include/glaze/tuplet/tuple.hpp
+++ b/include/glaze/tuplet/tuple.hpp
@@ -216,7 +216,7 @@ namespace glz
             eq_impl(static_cast<U&&>(tup), base_list(), typename tuple2::base_list());
          }
          else {
-            eq_impl(static_cast<U&&>(tup), tag_range<N>());
+            eq_impl(static_cast<U&&>(tup), tuplet::tag_range<N>());
          }
          return *this;
       }

--- a/include/glaze/tuplet/tuple.hpp
+++ b/include/glaze/tuplet/tuple.hpp
@@ -289,24 +289,6 @@ namespace glz
          return static_cast<tuple&&>(*this).all_impl(base_list(), static_cast<F&&>(func));
       }
 
-      // Map a function over every element in the tuple, using the values to
-      // construct a new tuple
-      template <class F>
-      constexpr auto map(F&& func) &
-      {
-         return map_impl(base_list(), static_cast<F&&>(func));
-      }
-      template <class F>
-      constexpr auto map(F&& func) const&
-      {
-         return map_impl(base_list(), static_cast<F&&>(func));
-      }
-      template <class F>
-      constexpr auto map(F&& func) &&
-      {
-         return static_cast<tuple&&>(*this).map_impl(base_list(), static_cast<F&&>(func));
-      }
-
      private:
       template <class U, class... B1, class... B2>
       constexpr void eq_impl(U&& u, tuplet::type_list<B1...>, tuplet::type_list<B2...>)
@@ -373,24 +355,6 @@ namespace glz
       {
          return (bool(func(static_cast<T&&>(B::value))) && ...);
       }
-
-      template <class F, class... B>
-      constexpr auto map_impl(tuplet::type_list<B...>, F&& func) & -> tuple<unwrap_ref_decay_t<decltype(func(B::value))>...>
-      {
-         return {func(B::value)...};
-      }
-      template <class F, class... B>
-      constexpr auto map_impl(tuplet::type_list<B...>,
-                              F&& func) const& -> tuple<unwrap_ref_decay_t<decltype(func(B::value))>...>
-      {
-         return {func(B::value)...};
-      }
-      template <class F, class... B>
-      constexpr auto map_impl(
-                              tuplet::type_list<B...>, F&& func) && -> tuple<unwrap_ref_decay_t<decltype(func(static_cast<T&&>(B::value)))>...>
-      {
-         return {func(static_cast<T&&>(B::value))...};
-      }
    };
    template <>
    struct tuple<> : tuplet::tuple_base_t<>
@@ -441,16 +405,6 @@ namespace glz
       constexpr bool all(F&&) const noexcept
       {
          return true;
-      }
-
-      // Map a function over every element in the tuple, using the values to
-      // construct a new tuple
-      //
-      // (Returns empty tuple when invoked on empty tuple)
-      template <class F>
-      constexpr auto map(F&&) const noexcept
-      {
-         return tuple{};
       }
    };
    template <class... Ts>

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -515,7 +515,7 @@ void test_partial()
 {
    expect(
       glz::name_v<glz::detail::member_tuple_t<some_struct>> ==
-      R"(glz::tuplet::tuple<int32_t,double,Color,std::string,std::array<uint64_t,3>,sub,std::map<std::string,int32_t>>)");
+      R"(glz::tuple<int32_t,double,Color,std::string,std::array<uint64_t,3>,sub,std::map<std::string,int32_t>>)");
 
    some_struct s{};
    some_struct s2{};

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -1517,7 +1517,7 @@ suite user_types = [] {
 
    "complex user obect member names"_test = [] {
       expect(glz::name_v<glz::detail::member_tuple_t<Thing>> ==
-             "glz::tuplet::tuple<sub_thing,std::array<sub_thing2,1>,V3,std::list<int32_t>,std::deque<double>,std::"
+             "glz::tuple<sub_thing,std::array<sub_thing2,1>,V3,std::list<int32_t>,std::deque<double>,std::"
              "vector<V3>,int32_t,double,bool,char,std::variant<var1_t,var2_t>,Color,std::vector<bool>,std::shared_ptr<"
              "sub_thing>,std::optional<V3>,std::array<std::string,4>,std::map<std::string,int32_t>,std::map<int32_t,"
              "double>,sub_thing>");
@@ -10042,7 +10042,7 @@ struct glz::meta<birds>
 {
    using T = birds;
    static constexpr std::array keys{"crow", "sparrow", "hawk"};
-   static constexpr glz::tuplet::tuple value{&T::crow, &T::sparrow, &T::hawk};
+   static constexpr glz::tuple value{&T::crow, &T::sparrow, &T::hawk};
 };
 
 suite meta_keys_for_struct = [] {


### PR DESCRIPTION
- Removing the `tuplet` namespace for less compilation overhead, smaller error messages, and easier to read ftime-trace reports.
- Renamed `to_tuple` to the more appropriate `to_tie`
- Removed unused `map` function in `tuple`
- Removes duplicate template instantiations for `to_tie`
- Faster glz::schema compilation