### PR TITLE
[Json] - Fix enum string read for vector of pairs in concatenate mode

### DIFF
--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -968,7 +968,7 @@ namespace glz
          }
 
          // for types like std::vector<std::pair...> that can't look up with operator[]
-         // Intead of hashing or linear searching, we just clear the input and overwrite the entire contents
+         // Instead of hashing or linear searching, we just clear the input and overwrite the entire contents
          template <auto Opts>
             requires(pair_t<range_value_t<T>> && Opts.concatenate == true)
          static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1383,7 +1383,8 @@ namespace glz
 
                using V = std::decay_t<decltype(item)>;
 
-               if constexpr (str_t<typename V::first_type>) {
+               if constexpr (str_t<typename V::first_type> ||
+                             (std::is_enum_v<typename V::first_type> && detail::glaze_t<typename V::first_type>)) {
                   read<JSON>::op<Opts>(item.first, ctx, it, end);
                   if (bool(ctx.error)) [[unlikely]]
                      return;
@@ -1783,7 +1784,7 @@ namespace glz
             GLZ_SKIP_WS();
             const size_t ws_size = size_t(it - ws_start);
 
-            if constexpr ((glaze_object_t<T> || reflectable<T>)&&num_members == 0 && Opts.error_on_unknown_keys) {
+            if constexpr ((glaze_object_t<T> || reflectable<T>) && num_members == 0 && Opts.error_on_unknown_keys) {
                if (*it == '}') [[likely]] {
                   GLZ_SUB_LEVEL;
                   ++it;
@@ -1798,8 +1799,8 @@ namespace glz
             }
             else {
                decltype(auto) fields = [&]() -> decltype(auto) {
-                  if constexpr ((glaze_object_t<T> || reflectable<T>)&&(Opts.error_on_missing_keys ||
-                                                                        Opts.partial_read)) {
+                  if constexpr ((glaze_object_t<T> || reflectable<T>) &&
+                                (Opts.error_on_missing_keys || Opts.partial_read)) {
                      return bit_array<num_members>{};
                   }
                   else {
@@ -1811,7 +1812,7 @@ namespace glz
 
                bool first = true;
                while (true) {
-                  if constexpr ((glaze_object_t<T> || reflectable<T>)&&Opts.partial_read) {
+                  if constexpr ((glaze_object_t<T> || reflectable<T>) && Opts.partial_read) {
                      static constexpr bit_array<num_members> all_fields = [] {
                         bit_array<num_members> arr{};
                         for (size_t i = 0; i < num_members; ++i) {
@@ -1828,14 +1829,14 @@ namespace glz
 
                   if (*it == '}') {
                      GLZ_SUB_LEVEL;
-                     if constexpr ((glaze_object_t<T> ||
-                                    reflectable<T>)&&(Opts.partial_read && Opts.error_on_missing_keys)) {
+                     if constexpr ((glaze_object_t<T> || reflectable<T>) &&
+                                   (Opts.partial_read && Opts.error_on_missing_keys)) {
                         ctx.error = error_code::missing_key;
                         return;
                      }
                      else {
                         ++it;
-                        if constexpr ((glaze_object_t<T> || reflectable<T>)&&Opts.error_on_missing_keys) {
+                        if constexpr ((glaze_object_t<T> || reflectable<T>) && Opts.error_on_missing_keys) {
                            constexpr auto req_fields = required_fields<T, Opts>();
                            if ((req_fields & fields) != req_fields) {
                               ctx.error = error_code::missing_key;

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -671,7 +671,7 @@ namespace glz
                }
             }
             else [[unlikely]] {
-               // What do we want to happen if the value doesnt have a mapped string
+               // What do we want to happen if the value doesn't have a mapped string
                write<JSON>::op<Opts>(static_cast<std::underlying_type_t<T>>(value), ctx, std::forward<Args>(args)...);
             }
          }

--- a/tests/example_json/example_json.cpp
+++ b/tests/example_json/example_json.cpp
@@ -118,7 +118,18 @@ struct EnumHolder
 static_assert(glz::detail::reflectable<EnumHolder>);
 
 suite enum_test = [] {
-   "enum_as_string"_test = [] {
+   "enum_as_string_key"_test = [] {
+      std::map<Color, bool> obj{{Color::Red, true}};
+      std::string json;
+      expect(not glz::write_json(obj, json));
+      expect(json == R"({"Red":true})");
+
+      std::string input = R"({"Green":true})";
+      expect(!glz::read_json(obj, input));
+      expect(obj[Color::Green]);
+   };
+
+   "enum_as_string_value"_test = [] {
       EnumHolder obj{};
       std::string json;
       expect(not glz::write_json(obj, json));
@@ -127,6 +138,20 @@ suite enum_test = [] {
       std::string input = R"({"c":"Blue"})";
       expect(!glz::read_json(obj, input));
       expect(obj.c == Color::Blue);
+   };
+
+   "enum_as_key_vector_pair_concatenate"_test = [] {
+      std::vector<std::pair<Color, int>> obj{{Color::Red, 1}, {Color::Green, 2}};
+      std::string json;
+      expect(not glz::write_json(obj, json));
+      expect(json == R"({"Red":1,"Green":2})");
+
+      std::vector<std::pair<Color, int>> obj2{};
+      std::string input = R"({"Blue":3})";
+      expect(!glz::read_json(obj2, input));
+      expect(obj2.size() == 1);
+      expect(obj2[0].first == Color::Blue);
+      expect(obj2[0].second == 3);
    };
 };
 

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -346,7 +346,7 @@ struct Thing
    std::map<int, double> mapi{{5, 3.14}, {7, 7.42}, {2, 9.63}};
    sub_thing* thing_ptr{};
 
-   Thing() : thing_ptr(&thing){};
+   Thing() : thing_ptr(&thing) {};
 };
 
 template <>
@@ -4197,7 +4197,7 @@ struct glz::meta<cat>
 
 struct person
 {
-   void eat(const std::string&){};
+   void eat(const std::string&) {};
 };
 
 template <>
@@ -6155,11 +6155,8 @@ suite char_buffer = [] {
 static_assert(!glz::detail::char_array_t<char*>);
 
 suite enum_map = [] {
-   "enum map"_test = [] {
-      std::map<Color, std::string> color_map;
-      color_map[Color::Red] = "red";
-      color_map[Color::Green] = "green";
-      color_map[Color::Blue] = "blue";
+   "enum map key"_test = [] {
+      std::map<Color, std::string> color_map{{Color::Red, "red"}, {Color::Green, "green"}, {Color::Blue, "blue"}};
 
       std::string s{};
       expect(not glz::write_json(color_map, s));
@@ -6171,6 +6168,48 @@ suite enum_map = [] {
       expect(color_map.at(Color::Red) == "red");
       expect(color_map.at(Color::Green) == "green");
       expect(color_map.at(Color::Blue) == "blue");
+   };
+
+   "enum map key vector pair concatenate"_test = [] {
+      std::vector<std::pair<Color, std::string>> colors{
+         {Color::Red, "red"}, {Color::Green, "green"}, {Color::Blue, "blue"}};
+
+      std::string s{};
+      expect(not glz::write_json(colors, s));
+
+      expect(s == R"({"Red":"red","Green":"green","Blue":"blue"})");
+
+      auto expected = colors;
+      colors.clear();
+      expect(!glz::read_json(colors, s));
+      expect(colors == expected);
+   };
+
+   "enum map value"_test = [] {
+      std::map<int, Color> color_map{{0, Color::Red}, {1, Color::Green}, {2, Color::Blue}};
+
+      std::string s{};
+      expect(not glz::write_json(color_map, s));
+
+      expect(s == R"({"0":"Red","1":"Green","2":"Blue"})");
+
+      auto expectedMap = color_map;
+      color_map.clear();
+      expect(!glz::read_json(color_map, s));
+      expect(expectedMap == color_map);
+   };
+
+   "enum map value vector pair concatenate"_test = [] {
+      std::vector<std::pair<int, Color>> colors{{0, Color::Red}, {1, Color::Green}, {2, Color::Blue}};
+
+      std::string s{};
+      expect(not glz::write_json(colors, s));
+      expect(s == R"({"0":"Red","1":"Green","2":"Blue"})");
+
+      auto expected = colors;
+      colors.clear();
+      expect(!glz::read_json(colors, s));
+      expect(colors == expected);
    };
 };
 
@@ -6419,9 +6458,8 @@ template <>
 struct glz::meta<test_mapping_t>
 {
    using T = test_mapping_t;
-   static constexpr auto value = object("id", &T::id, "coordinates", [](auto& self) {
-      return coordinates_t{&self.latitude, &self.longitude};
-   });
+   static constexpr auto value =
+      object("id", &T::id, "coordinates", [](auto& self) { return coordinates_t{&self.latitude, &self.longitude}; });
 };
 
 suite mapping_struct = [] {
@@ -9699,8 +9737,8 @@ template <class V>
 struct glz::meta<response_t<V>>
 {
    using T = response_t<V>;
-   static constexpr auto value = object(
-      "result", [](auto& s) -> auto& { return s.result; }, "id", &T::id, "error", &T::error);
+   static constexpr auto value =
+      object("result", [](auto& s) -> auto& { return s.result; }, "id", &T::id, "error", &T::error);
 };
 
 template <>
@@ -9919,7 +9957,7 @@ namespace trr
 
    struct Person
    {
-      Person(Address* const p_add) : p_add(p_add){};
+      Person(Address* const p_add) : p_add(p_add) {};
       std::string name;
       Address* const p_add; // pointer is const, Address object is mutable
    };


### PR DESCRIPTION
This PR fixes an `expected_quote` parsing error occurring for objects of type `vector<std::pair<MyEnum, ...>` when in concatenate mode and if user requests parsing of enums as strings.

This PR takes the assumption that 

```
std::is_enum_v<typename V::first_type> && detail::glaze_t<typename V::first_type>
```

is `true` **if and only if** the enum needs to be serialized / de-serialized as strings instead of values (based on my findings). Please help me correct the code if this assumption is wrong.

Updated the unit tests accordingly.