### PR TITLE
Better API for repe requests

### DIFF
--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -1920,6 +1920,16 @@ namespace glz::detail
 
 namespace glz
 {
+   [[nodiscard]] inline std::string format_error(const error_code& ec)
+   {
+      return std::string{meta<error_code>::keys[uint32_t(ec)]};
+   }
+   
+   [[nodiscard]] inline std::string format_error(const error_ctx& pe)
+   {
+      return std::string{meta<error_code>::keys[uint32_t(pe.ec)]};
+   }
+   
    [[nodiscard]] inline std::string format_error(const error_ctx& pe, const auto& buffer)
    {
       const auto error_type_str = meta<error_code>::keys[uint32_t(pe.ec)];
@@ -1941,11 +1951,6 @@ namespace glz
       else {
          return "";
       }
-   }
-
-   [[nodiscard]] inline std::string format_error(const error_ctx& pe)
-   {
-      return std::string{meta<error_code>::keys[uint32_t(pe.ec)]};
    }
 
    template <class T>

--- a/include/glaze/ext/glaze_asio.hpp
+++ b/include/glaze/ext/glaze_asio.hpp
@@ -566,8 +566,6 @@ namespace glz
    };
 }
 
-#include <format>
-
 // IMPORTANT: The code below is an alternative version of asio_client that uses repe::message in its API
 // This is probably a better approach and may replace glz::asio_client in the future
 namespace glz
@@ -600,10 +598,14 @@ namespace glz
                uint32_t error_length{};
                std::memcpy(&error_length, msg.body.data(), 4);
                const std::string_view error_message{msg.body.data() + 4, error_length};
-               return {std::format("REPE error: {} | {}", format_error(ec), error_message)};
+               std::string ret = "REPE error: ";
+               ret.append(format_error(ec));
+               ret.append(" | ");
+               ret.append(error_message);
+               return {ret};
             }
             else {
-               return {std::format("REPE error: {}", format_error(ec))};
+               return std::string{"REPE error: "} + format_error(ec);
             }
          }
 

--- a/include/glaze/ext/glaze_asio.hpp
+++ b/include/glaze/ext/glaze_asio.hpp
@@ -255,7 +255,7 @@ namespace glz
       {
          auto request = message_pool->borrow();
          header.notify(true);
-         repe::request<Opts>(std::move(header), std::forward<Params>(params)..., *request);
+         repe::request<Opts>(std::move(header), *request, std::forward<Params>(params)...);
          if (bool(request->error())) {
             return request->error();
          }
@@ -328,7 +328,7 @@ namespace glz
       [[nodiscard]] error_code set(repe::user_header&& header, Params&& params)
       {
          auto request = message_pool->borrow();
-         repe::request<Opts>(std::move(header), std::forward<Params>(params), *request);
+         repe::request<Opts>(std::move(header), *request, std::forward<Params>(params));
          if (bool(request->error())) {
             return request->error();
          }
@@ -367,7 +367,7 @@ namespace glz
       [[nodiscard]] error_code call(repe::user_header&& header, Params&& params, Result&& result)
       {
          auto request = message_pool->borrow();
-         repe::request<Opts>(std::move(header), std::forward<Params>(params), *request);
+         repe::request<Opts>(std::move(header), *request, std::forward<Params>(params));
          if (bool(request->error())) {
             return request->error();
          }
@@ -664,7 +664,7 @@ namespace glz
       {
          auto request = message_pool->borrow();
          header.notify(true);
-         repe::request<Opts>(std::move(header), std::forward<Params>(params)..., *request);
+         repe::request<Opts>(std::move(header), *request, std::forward<Params>(params)...);
          if (bool(request->error())) {
             encode_error(request->error(), "", response);
             return;
@@ -731,7 +731,7 @@ namespace glz
       void set(repe::user_header&& header, repe::message& response, Params&&... params)
       {
          auto request = message_pool->borrow();
-         repe::request<Opts>(std::move(header), std::forward<Params>(params)..., *request);
+         repe::request<Opts>(std::move(header), *request, std::forward<Params>(params)...);
          if (bool(request->error())) {
             encode_error(request->error(), "", response);
             return;

--- a/include/glaze/ext/glaze_asio.hpp
+++ b/include/glaze/ext/glaze_asio.hpp
@@ -534,6 +534,8 @@ namespace glz
    };
 }
 
+#include <format>
+
 // IMPORTANT: The code below is an alternative version of asio_client that uses repe::message in its API
 // This is probably a better approach and may replace glz::asio_client in the future
 namespace glz

--- a/include/glaze/ext/glaze_asio.hpp
+++ b/include/glaze/ext/glaze_asio.hpp
@@ -589,6 +589,8 @@ namespace glz
          std::memcpy(msg.body.data() + 4, error_message.data(), n);
       }
 
+      // Decodes a repe::message into a structure
+      // Returns a std::string with a formatted error on error
       template <opts Opts = opts{}, class T>
       inline std::optional<std::string> decode_message(T&& value, message& msg)
       {

--- a/include/glaze/ext/glaze_asio.hpp
+++ b/include/glaze/ext/glaze_asio.hpp
@@ -666,7 +666,7 @@ namespace glz
          header.notify(true);
          repe::request<Opts>(std::move(header), *request, std::forward<Params>(params)...);
          if (bool(request->error())) {
-            encode_error(request->error(), response);
+            encode_error(request->error(), response, "bad request");
             return;
          }
 
@@ -674,7 +674,7 @@ namespace glz
          if (not socket) {
             socket.ptr.reset();
             (*is_connected) = false;
-            encode_error(error_code::send_error, response);
+            encode_error(error_code::send_error, response, "socket failure");
             return;
          }
 
@@ -684,7 +684,7 @@ namespace glz
          if (bool(ec)) {
             socket.ptr.reset();
             (*is_connected) = false;
-            encode_error(ec, response);
+            encode_error(ec, response, "send failure");
             return;
          }
       }
@@ -696,7 +696,7 @@ namespace glz
          header.read(true);
          repe::request<Opts>(std::move(header), *request);
          if (bool(request->error())) {
-            encode_error(request->error(), response);
+            encode_error(request->error(), response, "bad request");
             return;
          }
 
@@ -704,7 +704,7 @@ namespace glz
          if (not socket) {
             socket.ptr.reset();
             (*is_connected) = false;
-            encode_error(error_code::send_error, response);
+            encode_error(error_code::send_error, response, "socket failure");
             return;
          }
 
@@ -714,7 +714,7 @@ namespace glz
          if (bool(ec)) {
             socket.ptr.reset();
             (*is_connected) = false;
-            encode_error(ec, response);
+            encode_error(ec, response, "send failure");
             return;
          }
 
@@ -722,7 +722,7 @@ namespace glz
          if (bool(ec)) {
             socket.ptr.reset();
             (*is_connected) = false;
-            encode_error(ec, response);
+            encode_error(ec, response, "receive failure");
             return;
          }
       }
@@ -733,7 +733,7 @@ namespace glz
          auto request = message_pool->borrow();
          repe::request<Opts>(std::move(header), *request, std::forward<Params>(params)...);
          if (bool(request->error())) {
-            encode_error(request->error(), response);
+            encode_error(request->error(), response, "bad request");
             return;
          }
 
@@ -741,7 +741,7 @@ namespace glz
          if (not socket) {
             socket.ptr.reset();
             (*is_connected) = false;
-            encode_error(error_code::send_error, response);
+            encode_error(error_code::send_error, response, "socket failure");
             return;
          }
 
@@ -751,7 +751,7 @@ namespace glz
          if (bool(ec)) {
             socket.ptr.reset();
             (*is_connected) = false;
-            encode_error(ec, response);
+            encode_error(ec, response, "send failure");
             return;
          }
 
@@ -759,7 +759,7 @@ namespace glz
          if (bool(ec)) {
             socket.ptr.reset();
             (*is_connected) = false;
-            encode_error(ec, response);
+            encode_error(ec, response, "receive failure");
             return;
          }
       }

--- a/include/glaze/ext/glaze_asio.hpp
+++ b/include/glaze/ext/glaze_asio.hpp
@@ -279,7 +279,11 @@ namespace glz
       socket_pool* pool{};
       std::shared_ptr<asio::ip::tcp::socket> ptr{};
       size_t index{};
-      std::error_code ec{};
+#if !defined(GLZ_USING_BOOST_ASIO)
+         std::error_code ec{};
+#else
+         boost::system::error_code ec{};
+#endif
 
       std::shared_ptr<asio::ip::tcp::socket> value() { return ptr; }
 

--- a/include/glaze/ext/glaze_asio.hpp
+++ b/include/glaze/ext/glaze_asio.hpp
@@ -158,7 +158,10 @@ namespace glz
          else {
             socket = std::make_shared<asio::ip::tcp::socket>(*ctx);
             asio::ip::tcp::resolver resolver{*ctx};
-            const auto endpoint = resolver.resolve(host, service);
+            const auto endpoint = resolver.resolve(host, service, ec);
+            if (ec) {
+               return {nullptr, index, ec};
+            }
             asio::connect(*socket, endpoint, ec);
             if (ec) {
                return {nullptr, index, ec};
@@ -189,6 +192,10 @@ namespace glz
       std::shared_ptr<asio::ip::tcp::socket> value() { return ptr; }
 
       const std::shared_ptr<asio::ip::tcp::socket> value() const { return ptr; }
+      
+      operator bool() const {
+         return bool(ptr) && bool(pool);
+      }
 
       asio::ip::tcp::socket& operator*() { return *ptr; }
 
@@ -235,7 +242,7 @@ namespace glz
          is_connected = socket_pool->is_connected;
 
          unique_socket socket{socket_pool.get()};
-         if (socket.value()) {
+         if (socket) {
             return {}; // connection success
          }
          else {
@@ -254,6 +261,11 @@ namespace glz
          }
 
          unique_socket socket{socket_pool.get()};
+         if (not socket) {
+            socket.ptr.reset();
+            (*is_connected) = false;
+            return error_code::send_error;
+         }
 
          error_code ec{};
          send_buffer(*socket, *request, ec);
@@ -278,6 +290,11 @@ namespace glz
          }
 
          unique_socket socket{socket_pool.get()};
+         if (not socket) {
+            socket.ptr.reset();
+            (*is_connected) = false;
+            return error_code::send_error;
+         }
 
          error_code ec{};
          send_buffer(*socket, *request, ec);
@@ -317,6 +334,11 @@ namespace glz
          }
 
          unique_socket socket{socket_pool.get()};
+         if (not socket) {
+            socket.ptr.reset();
+            (*is_connected) = false;
+            return error_code::send_error;
+         }
 
          error_code ec{};
          send_buffer(*socket, *request, ec);
@@ -351,6 +373,11 @@ namespace glz
          }
 
          unique_socket socket{socket_pool.get()};
+         if (not socket) {
+            socket.ptr.reset();
+            (*is_connected) = false;
+            return error_code::send_error;
+         }
 
          error_code ec{};
          send_buffer(*socket, *request, ec);
@@ -389,6 +416,11 @@ namespace glz
          }
 
          unique_socket socket{socket_pool.get()};
+         if (not socket) {
+            socket.ptr.reset();
+            (*is_connected) = false;
+            return error_code::send_error;
+         }
 
          error_code ec{};
          send_buffer(*socket, *request, ec);
@@ -617,7 +649,7 @@ namespace glz
          is_connected = socket_pool->is_connected;
 
          unique_socket socket{socket_pool.get()};
-         if (socket.value()) {
+         if (socket) {
             return {}; // connection success
          }
          else {
@@ -637,6 +669,12 @@ namespace glz
          }
 
          unique_socket socket{socket_pool.get()};
+         if (not socket) {
+            socket.ptr.reset();
+            (*is_connected) = false;
+            encode_error(error_code::send_error, "", response);
+            return;
+         }
 
          error_code ec{};
          send_buffer(*socket, *request, ec);
@@ -661,6 +699,12 @@ namespace glz
          }
 
          unique_socket socket{socket_pool.get()};
+         if (not socket) {
+            socket.ptr.reset();
+            (*is_connected) = false;
+            encode_error(error_code::send_error, "", response);
+            return;
+         }
 
          error_code ec{};
          send_buffer(*socket, *request, ec);
@@ -692,6 +736,12 @@ namespace glz
          }
 
          unique_socket socket{socket_pool.get()};
+         if (not socket) {
+            socket.ptr.reset();
+            (*is_connected) = false;
+            encode_error(error_code::send_error, "", response);
+            return;
+         }
 
          error_code ec{};
          send_buffer(*socket, *request, ec);

--- a/include/glaze/ext/glaze_asio.hpp
+++ b/include/glaze/ext/glaze_asio.hpp
@@ -351,7 +351,7 @@ namespace glz
             return;
          }
 
-         if (not header.notify()) {
+         if (not header.notify) {
             receive_buffer(*socket, response, ec);
             if (bool(ec)) {
                socket.ptr.reset();

--- a/include/glaze/ext/glaze_asio.hpp
+++ b/include/glaze/ext/glaze_asio.hpp
@@ -286,7 +286,7 @@ namespace glz
       const std::shared_ptr<asio::ip::tcp::socket> value() const { return ptr; }
       
       operator bool() const {
-         return bool(ptr) && bool(pool);
+         return bool(ptr) && bool(pool) && not bool(ec);
       }
 
       asio::ip::tcp::socket& operator*() { return *ptr; }

--- a/include/glaze/ext/glaze_asio.hpp
+++ b/include/glaze/ext/glaze_asio.hpp
@@ -572,7 +572,7 @@ namespace glz
 {
    namespace repe
    {
-      inline void encode_error(const error_code& ec, const std::string_view error_message, message& msg)
+      inline void encode_error(const error_code& ec, message& msg, const std::string_view error_message = "")
       {
          msg.header.ec = ec;
          if (error_message.size() > (std::numeric_limits<uint32_t>::max)()) {
@@ -666,7 +666,7 @@ namespace glz
          header.notify(true);
          repe::request<Opts>(std::move(header), *request, std::forward<Params>(params)...);
          if (bool(request->error())) {
-            encode_error(request->error(), "", response);
+            encode_error(request->error(), response);
             return;
          }
 
@@ -674,7 +674,7 @@ namespace glz
          if (not socket) {
             socket.ptr.reset();
             (*is_connected) = false;
-            encode_error(error_code::send_error, "", response);
+            encode_error(error_code::send_error, response);
             return;
          }
 
@@ -684,7 +684,7 @@ namespace glz
          if (bool(ec)) {
             socket.ptr.reset();
             (*is_connected) = false;
-            encode_error(ec, "", response);
+            encode_error(ec, response);
             return;
          }
       }
@@ -696,7 +696,7 @@ namespace glz
          header.read(true);
          repe::request<Opts>(std::move(header), *request);
          if (bool(request->error())) {
-            encode_error(request->error(), "", response);
+            encode_error(request->error(), response);
             return;
          }
 
@@ -704,7 +704,7 @@ namespace glz
          if (not socket) {
             socket.ptr.reset();
             (*is_connected) = false;
-            encode_error(error_code::send_error, "", response);
+            encode_error(error_code::send_error, response);
             return;
          }
 
@@ -714,7 +714,7 @@ namespace glz
          if (bool(ec)) {
             socket.ptr.reset();
             (*is_connected) = false;
-            encode_error(ec, "", response);
+            encode_error(ec, response);
             return;
          }
 
@@ -722,7 +722,7 @@ namespace glz
          if (bool(ec)) {
             socket.ptr.reset();
             (*is_connected) = false;
-            encode_error(ec, "", response);
+            encode_error(ec, response);
             return;
          }
       }
@@ -733,7 +733,7 @@ namespace glz
          auto request = message_pool->borrow();
          repe::request<Opts>(std::move(header), *request, std::forward<Params>(params)...);
          if (bool(request->error())) {
-            encode_error(request->error(), "", response);
+            encode_error(request->error(), response);
             return;
          }
 
@@ -741,7 +741,7 @@ namespace glz
          if (not socket) {
             socket.ptr.reset();
             (*is_connected) = false;
-            encode_error(error_code::send_error, "", response);
+            encode_error(error_code::send_error, response);
             return;
          }
 
@@ -751,7 +751,7 @@ namespace glz
          if (bool(ec)) {
             socket.ptr.reset();
             (*is_connected) = false;
-            encode_error(ec, "", response);
+            encode_error(ec, response);
             return;
          }
 
@@ -759,7 +759,7 @@ namespace glz
          if (bool(ec)) {
             socket.ptr.reset();
             (*is_connected) = false;
-            encode_error(ec, "", response);
+            encode_error(ec, response);
             return;
          }
       }

--- a/include/glaze/ext/glaze_asio.hpp
+++ b/include/glaze/ext/glaze_asio.hpp
@@ -630,7 +630,7 @@ namespace glz
       {
          auto request = message_pool->borrow();
          header.notify(true);
-         repe::request<Opts>(std::move(header), repe::request<Opts>(std::forward<Params>(params)...), *request);
+         repe::request<Opts>(std::move(header), std::forward<Params>(params)..., *request);
          if (bool(request->error())) {
             encode_error(request->error(), "", response);
             return;
@@ -685,7 +685,7 @@ namespace glz
       void set(repe::user_header&& header, repe::message& response, Params&&... params)
       {
          auto request = message_pool->borrow();
-         repe::request<Opts>(std::move(header), repe::request<Opts>(std::forward<Params>(params)...), *request);
+         repe::request<Opts>(std::move(header), std::forward<Params>(params)..., *request);
          if (bool(request->error())) {
             encode_error(request->error(), "", response);
             return;

--- a/include/glaze/rpc/repe/header.hpp
+++ b/include/glaze/rpc/repe/header.hpp
@@ -25,7 +25,7 @@ namespace glz::repe
       //
       uint16_t spec{0x1507}; // (5383) Magic two bytes to denote the REPE specification
       uint8_t version = 1; // REPE version
-      bool error{}; // Whether an error has occurred
+      uint8_t reserved{}; // Must be zero
       repe::action action{}; // Action to take, multiple actions may be bit-packed together
       //
       uint64_t id{}; // Identifier
@@ -36,7 +36,7 @@ namespace glz::repe
       //
       uint16_t query_format{};
       uint16_t body_format{};
-      uint32_t reserved{}; // Must be set to zero
+      error_code ec{};
 
       bool notify() const { return bool(uint32_t(action) & uint32_t(repe::action::notify)); }
 
@@ -83,6 +83,14 @@ namespace glz::repe
       repe::header header{};
       std::string query{};
       std::string body{};
+      
+      operator bool() const {
+         return bool(header.ec);
+      }
+      
+      error_code error() const {
+         return header.ec;
+      }
    };
 
    // User interface that will be encoded into a REPE header
@@ -90,7 +98,7 @@ namespace glz::repe
    {
       std::string_view query = ""; // The JSON pointer path to call or member to access/assign
       uint64_t id{}; // Identifier
-      bool error{}; // Whether an error has occurred
+      error_code ec{};
 
       repe::action action{}; // Action to take, multiple actions may be bit-packed together
 
@@ -134,7 +142,7 @@ namespace glz::repe
    inline repe::header encode(const user_header& h) noexcept
    {
       repe::header ret{
-         .error = h.error, //
+         .ec = h.ec, //
          .action = h.action, //
          .id = h.id, //
          .query_length = h.query.size() //

--- a/include/glaze/rpc/repe/header.hpp
+++ b/include/glaze/rpc/repe/header.hpp
@@ -16,6 +16,14 @@ namespace glz::repe
       read = 1 << 1, // Read a value or return the result of invoking a function
       write = 1 << 2 // Write a value or invoke a function
    };
+   
+   inline action pack_action(bool notify, bool read, bool write) noexcept {
+       return static_cast<action>(
+           (notify ? uint32_t(action::notify) : 0) |
+           (read ? uint32_t(action::read) : 0) |
+           (write ? uint32_t(action::write) : 0)
+       );
+   }
 
    inline constexpr auto no_length_provided = (std::numeric_limits<uint64_t>::max)();
 
@@ -100,49 +108,15 @@ namespace glz::repe
       uint64_t id{}; // Identifier
       error_code ec{};
 
-      repe::action action{}; // Action to take, multiple actions may be bit-packed together
-
-      bool notify() const { return bool(uint32_t(action) & uint32_t(repe::action::notify)); }
-
-      bool read() const { return bool(uint32_t(action) & uint32_t(repe::action::read)); }
-
-      bool write() const { return bool(uint32_t(action) & uint32_t(repe::action::write)); }
-
-      void notify(bool enable)
-      {
-         if (enable) {
-            action = static_cast<repe::action>(uint32_t(action) | uint32_t(action::notify));
-         }
-         else {
-            action = static_cast<repe::action>(uint32_t(action) & ~uint32_t(action::notify));
-         }
-      }
-
-      void read(bool enable)
-      {
-         if (enable) {
-            action = static_cast<repe::action>(uint32_t(action) | uint32_t(action::read));
-         }
-         else {
-            action = static_cast<repe::action>(uint32_t(action) & ~uint32_t(action::read));
-         }
-      }
-
-      void write(bool enable)
-      {
-         if (enable) {
-            action = static_cast<repe::action>(uint32_t(action) | uint32_t(action::write));
-         }
-         else {
-            action = static_cast<repe::action>(uint32_t(action) & ~uint32_t(action::write));
-         }
-      }
+      bool notify{};
+      bool read{};
+      bool write{};
    };
 
    inline repe::header encode(const user_header& h) noexcept
    {
       repe::header ret{
-         .action = h.action, //
+         .action = pack_action(h.notify, h.read, h.write), //
          .id = h.id, //
          .query_length = h.query.size(), //
          .ec = h.ec //

--- a/include/glaze/rpc/repe/header.hpp
+++ b/include/glaze/rpc/repe/header.hpp
@@ -142,10 +142,10 @@ namespace glz::repe
    inline repe::header encode(const user_header& h) noexcept
    {
       repe::header ret{
-         .ec = h.ec, //
          .action = h.action, //
          .id = h.id, //
-         .query_length = h.query.size() //
+         .query_length = h.query.size(), //
+         .ec = h.ec //
       };
       return ret;
    }

--- a/include/glaze/rpc/repe/registry.hpp
+++ b/include/glaze/rpc/repe/registry.hpp
@@ -156,7 +156,7 @@ namespace glz::repe
          }
 
          template <class Value>
-         void operator()(const user_header& h, Value&& value, message& msg) const
+         void operator()(const user_header& h, message& msg, Value&& value) const
          {
             msg.header = encode(h);
             msg.query = std::string{h.query};

--- a/include/glaze/rpc/repe/registry.hpp
+++ b/include/glaze/rpc/repe/registry.hpp
@@ -488,7 +488,7 @@ namespace glz::repe
             }
          }
          else {
-            static constexpr sv body{"method not found"};
+            std::string body = "invalid_query: " + in.query;
 
             const uint32_t n = uint32_t(body.size());
             const auto body_length = 4 + n; // 4 bytes for size, + message

--- a/include/glaze/thread/async_string.hpp
+++ b/include/glaze/thread/async_string.hpp
@@ -89,6 +89,36 @@ namespace glz
          return *this;
       }
 
+      struct proxy
+      {
+         std::string* ptr{};
+         std::unique_lock<std::shared_mutex> lock{};
+
+        public:
+         proxy(std::string& p, std::unique_lock<std::shared_mutex>&& lock) noexcept : ptr{&p}, lock(std::move(lock)) {}
+
+         std::string* operator->() noexcept { return ptr; }
+
+         std::string& operator*() noexcept { return *ptr; }
+      };
+      
+      proxy write() { return {str, std::unique_lock{mutex}}; }
+      
+      struct const_proxy
+      {
+         const std::string* ptr{};
+         std::shared_lock<std::shared_mutex> lock{};
+
+        public:
+         const_proxy(const std::string& p, std::shared_lock<std::shared_mutex>&& lock) noexcept : ptr{&p}, lock(std::move(lock)) {}
+
+         const std::string* operator->() const noexcept { return ptr; }
+
+         const std::string& operator*() const noexcept { return *ptr; }
+      };
+
+      const_proxy read() const { return {str, std::shared_lock{mutex}}; }
+
       // Capacity
       size_t size() const noexcept
       {

--- a/tests/asio_repe/asio_repe.cpp
+++ b/tests/asio_repe/asio_repe.cpp
@@ -41,9 +41,7 @@ void notify_test()
       }
 
       glz::repe::message msg{};
-      glz::repe::user_header header{"/hello"};
-      header.notify(true);
-      client.call(header, msg);
+      client.call({.query = "/hello", .notify = true}, msg);
       if (bool(msg.error())) {
          throw std::runtime_error(glz::repe::decode_error(msg));
       }

--- a/tests/asio_repe/asio_repe.cpp
+++ b/tests/asio_repe/asio_repe.cpp
@@ -36,15 +36,15 @@ void notify_test()
    try {
       glz::asio_client<> client{"localhost", std::to_string(port)};
 
-      if (auto ec = client.init()) {
+      if (auto ec = client.init(); bool(ec)) {
          throw std::runtime_error(glz::write_json(ec).value_or("error"));
       }
 
-      if (auto ec = client.notify({"/hello"})) {
+      if (auto ec = client.notify({"/hello"}); bool(ec)) {
          throw std::runtime_error(glz::write_json(ec).value_or("error"));
       }
 
-      if (auto ec = client.call({"/hello"})) {
+      if (auto ec = client.call({"/hello"}); bool(ec)) {
          throw std::runtime_error(glz::write_json(ec).value_or("error"));
       }
 
@@ -83,16 +83,16 @@ void async_clients_test()
    try {
       glz::asio_client<> client{"localhost", std::to_string(port)};
 
-      if (auto ec = client.init()) {
+      if (auto ec = client.init(); bool(ec)) {
          throw std::runtime_error(glz::write_json(ec).value_or("error"));
       }
 
-      if (auto ec = client.set({"/age"}, 29)) {
+      if (auto ec = client.set({"/age"}, 29); bool(ec)) {
          std::cerr << glz::write_json(ec).value_or("error") << '\n';
       }
 
       int age{};
-      if (auto ec = client.get({"/age"}, age)) {
+      if (auto ec = client.get({"/age"}, age); bool(ec)) {
          std::cerr << glz::write_json(ec).value_or("error") << '\n';
       }
 
@@ -154,7 +154,7 @@ void asio_client_test()
       for (size_t i = 0; i < N; ++i) {
          threads.emplace_back(std::async([&, i] {
             auto& client = clients[i];
-            if (auto ec = client.init()) {
+            if (auto ec = client.init(); bool(ec)) {
                std::cerr << "Error: " << glz::write_json(ec).value_or("error") << std::endl;
             }
 
@@ -164,7 +164,7 @@ void asio_client_test()
             }
 
             int sum{};
-            if (auto ec = client.call({"/sum"}, data, sum)) {
+            if (auto ec = client.call({"/sum"}, data, sum); bool(ec)) {
                std::cerr << glz::write_json(ec).value_or("error") << '\n';
             }
             else {
@@ -283,9 +283,9 @@ void raw_json_tests()
    (void)client.init();
 
    auto ec = client.get({"/do_nothing"}, results);
-   expect(not ec);
-   if (ec) {
-      std::cerr << ec.message << '\n';
+   expect(not bool(ec));
+   if (bool(ec)) {
+      std::cerr << glz::format_error(ec) << '\n';
    }
 
    server.stop();
@@ -312,7 +312,7 @@ void async_server_test()
 
    int result{};
    auto ec = client.call({"/times_two"}, 100, result);
-   expect(not ec);
+   expect(not bool(ec));
 
    expect(result == 200);
 }

--- a/tests/asio_repe/asio_repe.cpp
+++ b/tests/asio_repe/asio_repe.cpp
@@ -41,7 +41,9 @@ void notify_test()
       }
 
       glz::repe::message msg{};
-      client.notify({"/hello"}, msg);
+      glz::repe::user_header header{"/hello"};
+      header.notify(true);
+      client.call(header, msg);
       if (bool(msg.error())) {
          throw std::runtime_error(glz::repe::decode_error(msg));
       }
@@ -91,7 +93,7 @@ void async_clients_test()
       }
 
       glz::repe::message msg{};
-      client.set({"/age"}, msg, 29);
+      client.call({"/age"}, msg, 29);
       if (bool(msg.error())) {
          std::cerr << glz::repe::decode_error(msg) << '\n';
       }
@@ -297,7 +299,7 @@ void raw_json_tests()
    (void)client.init();
 
    glz::repe::message msg{};
-   client.get({"/do_nothing"}, msg);
+   client.call({"/do_nothing"}, msg);
    if (bool(msg.error())) {
       std::cerr << glz::repe::decode_error(msg) << '\n';
    }

--- a/tests/repe_test/repe_test.cpp
+++ b/tests/repe_test/repe_test.cpp
@@ -430,9 +430,8 @@ struct tester
 };
 
 suite multi_threading_tests = [] {
-   // TODO: There is a test case that is randomly failing with this code only on Linux with Clang, need to investigate
-   // this further
-   /*"multi-threading"_test = [] {
+   // TODO: Is this still randomly failing with Linux with Clang???
+   "multi-threading"_test = [] {
       repe::registry registry{};
       tester obj{};
 
@@ -441,7 +440,7 @@ suite multi_threading_tests = [] {
       static constexpr size_t N = 10'000;
 
       repe::message read_msg{};
-      repe::request_json(read_msg, {"/str"});
+      repe::request_json({"/str"}, read_msg);
 
       std::thread reader_str([&] {
          size_t response_counter{};
@@ -454,7 +453,7 @@ suite multi_threading_tests = [] {
       });
 
       repe::message read_integer{};
-      repe::request_json(read_integer, {"/integer"});
+      repe::request_json({"/integer"}, read_integer);
 
       std::thread reader_integer([&] {
          size_t response_counter{};
@@ -467,7 +466,7 @@ suite multi_threading_tests = [] {
       });
 
       repe::message read_full{};
-      repe::request_json(read_full, {""});
+      repe::request_json({""}, read_full);
 
       std::thread reader_full([&] {
          size_t response_counter{};
@@ -487,7 +486,7 @@ suite multi_threading_tests = [] {
          for (size_t i = 0; i < N; ++i) {
             message.append("x");
             repe::message write_msg{};
-            repe::request_json(write_msg, {"/str"}, message);
+            repe::request_json({"/str"}, write_msg, message);
             repe::message response{};
             registry.call(write_msg, response);
             response_counter += response.body.size();
@@ -503,7 +502,7 @@ suite multi_threading_tests = [] {
          size_t response_counter{};
          for (size_t i = 0; i < N; ++i) {
             repe::message write_msg{};
-            repe::request_json(write_msg, {"/integer"}, i);
+            repe::request_json({"/integer"}, write_msg, i);
             repe::message response{};
             registry.call(write_msg, response);
             response_counter += response.body.size();
@@ -514,7 +513,8 @@ suite multi_threading_tests = [] {
       {
          latch.wait();
          bool valid = true;
-         for (char c : obj.str.string()) {
+         auto read_proxy = obj.str.read();
+         for (char c : *read_proxy) {
             if (c != 'x') {
                valid = false;
                break;
@@ -528,7 +528,7 @@ suite multi_threading_tests = [] {
       reader_full.join();
       writer_str.join();
       writer_integer.join();
-   };*/
+   };
 };
 
 struct glaze_types

--- a/tests/repe_test/repe_test.cpp
+++ b/tests/repe_test/repe_test.cpp
@@ -342,7 +342,7 @@ suite structs_of_functions_beve = [] {
    };
 };
 
-/*template <class T>
+template <class T>
 struct wrapper_t
 {
    T* sub{};
@@ -365,11 +365,11 @@ suite wrapper_tests = [] {
       repe::message request{};
       repe::message response{};
 
-      repe::request_json(request, {"/sub/my_functions/void_func"});
+      repe::request_json({"/sub/my_functions/void_func"}, request);
       server.call(request, response);
       expect(response.body == "null") << response.body;
 
-      repe::request_json(request, {"/sub/my_functions/hello"});
+      repe::request_json({"/sub/my_functions/hello"}, request);
       server.call(request, response);
       expect(response.body == R"("Hello")");
    };
@@ -386,11 +386,11 @@ suite root_tests = [] {
       repe::message request{};
       repe::message response{};
 
-      repe::request_json(request, {"/sub/my_functions/void_func"});
+      repe::request_json({"/sub/my_functions/void_func"}, request);
       server.call(request, response);
       expect(response.body == "null") << response.body;
 
-      repe::request_json(request, {"/sub/my_functions/hello"});
+      repe::request_json({"/sub/my_functions/hello"}, request);
       server.call(request, response);
       expect(response.body == R"("Hello")");
    };
@@ -408,20 +408,20 @@ suite wrapper_tests_beve = [] {
       repe::message request{};
       repe::message response{};
 
-      repe::request_beve(request, {"/sub/my_functions/void_func"});
+      repe::request_beve({"/sub/my_functions/void_func"}, request);
       server.call(request, response);
 
       std::string res{};
       expect(!glz::beve_to_json(response.body, res));
       expect(res == "null") << res;
 
-      repe::request_beve(request, {"/sub/my_functions/hello"});
+      repe::request_beve({"/sub/my_functions/hello"}, request);
       server.call(request, response);
 
       expect(!glz::beve_to_json(response.body, res));
       expect(res == R"("Hello")");
    };
-};*/
+};
 
 struct tester
 {

--- a/tests/repe_test/repe_test.cpp
+++ b/tests/repe_test/repe_test.cpp
@@ -4,7 +4,6 @@
 #include <latch>
 #include <thread>
 
-#include "glaze/ext/cli_menu.hpp"
 #include "glaze/glaze.hpp"
 #include "glaze/rpc/repe/registry.hpp"
 #include "glaze/thread/async_string.hpp"

--- a/tests/repe_test/repe_test.cpp
+++ b/tests/repe_test/repe_test.cpp
@@ -94,7 +94,7 @@ suite structs_of_functions = [] {
       expect(response.body == R"(42)");
    };
 
-   /*"nested_structs_of_functions"_test = [] {
+   "nested_structs_of_functions"_test = [] {
       repe::registry server{};
 
       my_nested_functions_t obj{};
@@ -104,49 +104,49 @@ suite structs_of_functions = [] {
       repe::message request{};
       repe::message response{};
 
-      repe::request_json(request, {"/my_functions/void_func"});
+      repe::request_json({"/my_functions/void_func"}, request);
       server.call(request, response);
       expect(response.body == "null") << response.body;
 
-      repe::request_json(request, {"/my_functions/hello"});
+      repe::request_json({"/my_functions/hello"}, request);
       server.call(request, response);
       expect(response.body == R"("Hello")");
 
-      repe::request_json(request, {"/meta_functions/hello"});
+      repe::request_json({"/meta_functions/hello"}, request);
       server.call(request, response);
       expect(response.body == R"("Hello")");
 
-      repe::request_json(request, {"/append_awesome"}, "you are");
+      repe::request_json({"/append_awesome"}, request, "you are");
       server.call(request, response);
       expect(response.body == R"("you are awesome!")");
 
-      repe::request_json(request, {"/my_string"}, "Howdy!");
+      repe::request_json({"/my_string"}, request, "Howdy!");
       server.call(request, response);
       expect(response.body == "null");
 
-      repe::request_json(request, {"/my_string"});
+      repe::request_json({"/my_string"}, request);
       server.call(request, response);
       expect(response.body == R"("Howdy!")") << response.body;
 
       obj.my_string.clear();
 
-      repe::request_json(request, {"/my_string"});
+      repe::request_json({"/my_string"}, request);
       server.call(request, response);
       // we expect an empty string returned because we cleared it
       expect(response.body == R"("")");
 
-      repe::request_json(request, {"/my_functions/max"}, std::vector<double>{1.1, 3.3, 2.25});
+      repe::request_json({"/my_functions/max"}, request, std::vector<double>{1.1, 3.3, 2.25});
       server.call(request, response);
       expect(response.body == R"(3.3)") << response.body;
 
-      repe::request_json(request, {"/my_functions"});
+      repe::request_json({"/my_functions"}, request);
       server.call(request, response);
       expect(
          response.body ==
          R"({"i":0,"hello":"std::function<std::string_view()>","world":"std::function<std::string_view()>","get_number":"std::function<int32_t()>","void_func":"std::function<void()>","max":"std::function<double(std::vector<double>&)>"})")
          << response.body;
 
-      repe::request_json(request, {""});
+      repe::request_json({""}, request);
       server.call(request, response);
       expect(
          response.body ==
@@ -164,29 +164,29 @@ suite structs_of_functions = [] {
       repe::message request{};
       repe::message response{};
 
-      repe::request_json(request, {"/name"}, "Susan");
+      repe::request_json({"/name"}, request, "Susan");
       server.call(request, response);
       expect(response.body == "null") << response.body;
 
-      repe::request_json(request, {"/get_name"});
+      repe::request_json({"/get_name"}, request);
       server.call(request, response);
       expect(response.body == R"("Susan")") << response.body;
 
-      repe::request_json(request, {"/get_name"}, "Bob");
+      repe::request_json({"/get_name"}, request, "Bob");
       server.call(request, response);
       expect(obj.name == "Susan"); // we expect the name to not have changed because this function take no inputs
       expect(response.body == R"("Susan")") << response.body;
 
-      repe::request_json(request, {"/set_name"}, "Bob");
+      repe::request_json({"/set_name"}, request, "Bob");
       server.call(request, response);
       expect(obj.name == "Bob");
       expect(response.body == "null") << response.body;
 
-      repe::request_json(request, {"/custom_name"}, "Alice");
+      repe::request_json({"/custom_name"}, request, "Alice");
       server.call(request, response);
       expect(obj.name == "Alice");
       expect(response.body == "null") << response.body;
-   };*/
+   };
 };
 
 /*suite structs_of_functions_beve = [] {

--- a/tests/repe_test/repe_test.cpp
+++ b/tests/repe_test/repe_test.cpp
@@ -189,7 +189,7 @@ suite structs_of_functions = [] {
    };
 };
 
-/*suite structs_of_functions_beve = [] {
+suite structs_of_functions_beve = [] {
    "structs_of_functions"_test = [] {
       repe::registry<glz::opts{.format = glz::BEVE}> server{};
 
@@ -202,23 +202,23 @@ suite structs_of_functions = [] {
       repe::message request{};
       repe::message response{};
 
-      repe::request_beve(request, {"/i"});
+      repe::request_beve({"/i"}, request);
       server.call(request, response);
       std::string res{};
       expect(!glz::beve_to_json(response.body, res));
       expect(res == R"(55)") << res;
 
-      repe::request_beve(request, {.query = "/i"}, 42);
+      repe::request_beve({.query = "/i"}, request, 42);
       server.call(request, response);
       expect(!glz::beve_to_json(response.body, res));
       expect(res == "null") << res;
 
-      repe::request_beve(request, {"/hello"});
+      repe::request_beve({"/hello"}, request);
       server.call(request, response);
       expect(!glz::beve_to_json(response.body, res));
       expect(res == R"("Hello")");
 
-      repe::request_beve(request, {"/get_number"});
+      repe::request_beve({"/get_number"}, request);
       server.call(request, response);
       expect(!glz::beve_to_json(response.body, res));
       expect(res == R"(42)");
@@ -234,52 +234,52 @@ suite structs_of_functions = [] {
       repe::message request{};
       repe::message response{};
 
-      repe::request_beve(request, {"/my_functions/void_func"});
+      repe::request_beve({"/my_functions/void_func"}, request);
       server.call(request, response);
 
       std::string res{};
       expect(!glz::beve_to_json(response.body, res));
       expect(res == "null") << res;
 
-      repe::request_beve(request, {"/my_functions/hello"});
+      repe::request_beve({"/my_functions/hello"}, request);
       server.call(request, response);
       expect(!glz::beve_to_json(response.body, res));
       expect(res == R"("Hello")");
 
-      repe::request_beve(request, {"/meta_functions/hello"});
+      repe::request_beve({"/meta_functions/hello"}, request);
       server.call(request, response);
       expect(!glz::beve_to_json(response.body, res));
       expect(res == R"("Hello")");
 
-      repe::request_beve(request, {"/append_awesome"}, "you are");
+      repe::request_beve({"/append_awesome"}, request, "you are");
       server.call(request, response);
       expect(!glz::beve_to_json(response.body, res));
       expect(res == R"("you are awesome!")");
 
-      repe::request_beve(request, {"/my_string"}, "Howdy!");
+      repe::request_beve({"/my_string"}, request, "Howdy!");
       server.call(request, response);
       expect(!glz::beve_to_json(response.body, res));
       expect(res == "null");
 
-      repe::request_beve(request, {"/my_string"});
+      repe::request_beve({"/my_string"}, request);
       server.call(request, response);
       expect(!glz::beve_to_json(response.body, res));
       expect(res == R"("Howdy!")") << res;
 
       obj.my_string.clear();
 
-      repe::request_beve(request, {"/my_string"});
+      repe::request_beve({"/my_string"}, request);
       server.call(request, response);
       expect(!glz::beve_to_json(response.body, res));
       // we expect an empty string returned because we cleared it
       expect(res == R"("")");
 
-      repe::request_beve(request, {"/my_functions/max"}, std::vector<double>{1.1, 3.3, 2.25});
+      repe::request_beve({"/my_functions/max"}, request, std::vector<double>{1.1, 3.3, 2.25});
       server.call(request, response);
       expect(!glz::beve_to_json(response.body, res));
       expect(res == R"(3.3)") << res;
 
-      repe::request_beve(request, {"/my_functions"});
+      repe::request_beve({"/my_functions"}, request);
       server.call(request, response);
       expect(!glz::beve_to_json(response.body, res));
       expect(
@@ -287,7 +287,7 @@ suite structs_of_functions = [] {
          R"({"i":0,"hello":"std::function<std::string_view()>","world":"std::function<std::string_view()>","get_number":"std::function<int32_t()>","void_func":"std::function<void()>","max":"std::function<double(std::vector<double>&)>"})")
          << res;
 
-      repe::request_beve(request, {""});
+      repe::request_beve({""}, request);
       server.call(request, response);
       expect(!glz::beve_to_json(response.body, res));
       expect(
@@ -306,34 +306,34 @@ suite structs_of_functions = [] {
       repe::message request{};
       repe::message response{};
 
-      repe::request_beve(request, {"/name"}, "Susan");
+      repe::request_beve({"/name"}, request, "Susan");
       server.call(request, response);
 
       std::string res{};
       expect(!glz::beve_to_json(response.body, res));
       expect(res == "null") << res;
 
-      repe::request_beve(request, {"/get_name"});
+      repe::request_beve({"/get_name"}, request);
       server.call(request, response);
 
       expect(!glz::beve_to_json(response.body, res));
       expect(res == R"("Susan")") << res;
 
-      repe::request_beve(request, {"/get_name"}, "Bob");
+      repe::request_beve({"/get_name"}, request, "Bob");
       server.call(request, response);
 
       expect(!glz::beve_to_json(response.body, res));
       expect(obj.name == "Susan"); // we expect the name to not have changed because this function take no inputs
       expect(res == R"("Susan")") << res;
 
-      repe::request_beve(request, {"/set_name"}, "Bob");
+      repe::request_beve({"/set_name"}, request, "Bob");
       server.call(request, response);
 
       expect(!glz::beve_to_json(response.body, res));
       expect(obj.name == "Bob");
       expect(res == "null") << res;
 
-      repe::request_beve(request, {"/custom_name"}, "Alice");
+      repe::request_beve({"/custom_name"}, request, "Alice");
       server.call(request, response);
 
       expect(!glz::beve_to_json(response.body, res));
@@ -342,7 +342,7 @@ suite structs_of_functions = [] {
    };
 };
 
-template <class T>
+/*template <class T>
 struct wrapper_t
 {
    T* sub{};

--- a/tests/repe_test/repe_test.cpp
+++ b/tests/repe_test/repe_test.cpp
@@ -79,27 +79,22 @@ suite structs_of_functions = [] {
 
       obj.i = 55;
 
-      repe::message request{};
       repe::message response{};
 
-      repe::request_json(request, {"/i"});
-      server.call(request, response);
+      server.call(repe::request_json({"/i"}), response);
       expect(response.body == R"(55)") << response.body;
 
-      repe::request_json(request, {.query = "/i"}, 42);
-      server.call(request, response);
+      server.call(repe::request_json({.query = "/i"}, 42), response);
       expect(response.body == "null") << response.body;
 
-      repe::request_json(request, {"/hello"});
-      server.call(request, response);
+      server.call(repe::request_json({"/hello"}), response);
       expect(response.body == R"("Hello")");
 
-      repe::request_json(request, {"/get_number"});
-      server.call(request, response);
+      server.call(repe::request_json({"/get_number"}), response);
       expect(response.body == R"(42)");
    };
 
-   "nested_structs_of_functions"_test = [] {
+   /*"nested_structs_of_functions"_test = [] {
       repe::registry server{};
 
       my_nested_functions_t obj{};
@@ -191,10 +186,10 @@ suite structs_of_functions = [] {
       server.call(request, response);
       expect(obj.name == "Alice");
       expect(response.body == "null") << response.body;
-   };
+   };*/
 };
 
-suite structs_of_functions_beve = [] {
+/*suite structs_of_functions_beve = [] {
    "structs_of_functions"_test = [] {
       repe::registry<glz::opts{.format = glz::BEVE}> server{};
 
@@ -426,7 +421,7 @@ suite wrapper_tests_beve = [] {
       expect(!glz::beve_to_json(response.body, res));
       expect(res == R"("Hello")");
    };
-};
+};*/
 
 struct tester
 {

--- a/tests/repe_test/repe_test.cpp
+++ b/tests/repe_test/repe_test.cpp
@@ -430,8 +430,8 @@ struct tester
 };
 
 suite multi_threading_tests = [] {
-   // TODO: Is this still randomly failing with Linux with Clang???
-   "multi-threading"_test = [] {
+   // TODO: Why is this randomly failing with Linux with Clang???
+   /*"multi-threading"_test = [] {
       repe::registry registry{};
       tester obj{};
 
@@ -528,7 +528,7 @@ suite multi_threading_tests = [] {
       reader_full.join();
       writer_str.join();
       writer_integer.join();
-   };
+   };*/
 };
 
 struct glaze_types


### PR DESCRIPTION
Major refactor of API for RPC code. This merges error handling into the repe::message, instead of needing to handle errors through error codes, the repe::message, and throws from asio.