### PR TITLE
add support of dynamically sized Eigen types

### DIFF
--- a/include/glaze/ext/eigen.hpp
+++ b/include/glaze/ext/eigen.hpp
@@ -32,6 +32,10 @@ namespace glz
          static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             ++it;
+            if (it >= end) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
             constexpr uint8_t layout = uint8_t(!T::IsRowMajor);
             if (uint8_t(*it) != layout) {
                ctx.error = error_code::syntax_error;
@@ -45,14 +49,19 @@ namespace glz
          }
       };
 
+      // A dynamic matrix in both rows and columns
       template <matrix_t T>
-         requires(T::RowsAtCompileTime < 0 || T::ColsAtCompileTime < 0)
+         requires(T::RowsAtCompileTime < 0 && T::ColsAtCompileTime < 0)
       struct from<BEVE, T>
       {
          template <auto Opts>
          static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             ++it;
+            if (it >= end) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
             constexpr uint8_t layout = uint8_t(!T::IsRowMajor);
             if (uint8_t(*it) != layout) {
                ctx.error = error_code::syntax_error;
@@ -88,8 +97,9 @@ namespace glz
          }
       };
 
+      // A dynamic matrix in both rows and columns
       template <matrix_t T>
-         requires(T::RowsAtCompileTime < 0 || T::ColsAtCompileTime < 0)
+         requires(T::RowsAtCompileTime < 0 && T::ColsAtCompileTime < 0)
       struct to<BEVE, T>
       {
          template <auto Opts>
@@ -135,42 +145,44 @@ namespace glz
          }
       };
 
+      // A dynamic matrix in both rows and columns
       template <matrix_t T>
-         requires(T::RowsAtCompileTime < 0 || T::ColsAtCompileTime < 0)
+         requires(T::RowsAtCompileTime < 0 && T::ColsAtCompileTime < 0)
       struct to<JSON, T>
       {
          template <auto Opts>
          static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
          {
-            b[ix++] = '[';
+            dump<'['>(b, ix);
             using RowColT = std::array<Eigen::Index, 2>;
             RowColT extents{value.rows(), value.cols()};
             detail::to<JSON, RowColT>::template op<Opts>(extents, ctx, b, ix);
-            b[ix++] = ',';
+            dump<','>(b, ix);
 
             std::span<typename T::Scalar> view(value.data(), value.size());
             using Value = std::remove_cvref_t<decltype(view)>;
             detail::to<JSON, Value>::template op<Opts>(view, ctx, b, ix);
-            b[ix++] = ']';
+            dump<']'>(b, ix);
          }
       };
 
+      // A dynamic matrix in both rows and columns
       template <matrix_t T>
-         requires(T::RowsAtCompileTime < 0 || T::ColsAtCompileTime < 0)
+         requires(T::RowsAtCompileTime < 0 && T::ColsAtCompileTime < 0)
       struct from<JSON, T>
       {
          template <auto Opts>
          static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
-            ++it;
+            GLZ_MATCH_OPEN_BRACKET;
             std::array<Eigen::Index, 2> extents; //NOLINT
             detail::read<JSON>::op<Opts>(extents, ctx, it, end);
             value.resize(extents[0], extents[1]);
-            ++it;
+            GLZ_MATCH_COMMA;
 
             std::span<typename T::Scalar> view(value.data(), extents[0] * extents[1]);
             detail::read<JSON>::op<Opts>(view, ctx, it, end);
-            ++it;
+            GLZ_MATCH_CLOSE_BRACKET;
          }
       };
    } // namespace detail

--- a/include/glaze/ext/eigen.hpp
+++ b/include/glaze/ext/eigen.hpp
@@ -191,7 +191,6 @@ namespace glz
                }
                std::span<typename T::Scalar> view(value.data(), extents[0] * extents[1]);
                detail::read<JSON>::op<Opts>(view, ctx, it, end);
-               return;
             }
             GLZ_MATCH_CLOSE_BRACKET;
          }

--- a/include/glaze/ext/eigen.hpp
+++ b/include/glaze/ext/eigen.hpp
@@ -154,17 +154,14 @@ namespace glz
          static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
          {
             dump<'['>(b, ix);
-            dump<'['>(b, ix);
             using RowColT = std::array<Eigen::Index, 2>;
             RowColT extents{value.rows(), value.cols()};
             detail::to<JSON, RowColT>::template op<Opts>(extents, ctx, b, ix);
-            dump<','>(b, ix);
             dump<','>(b, ix);
 
             std::span<typename T::Scalar> view(value.data(), value.size());
             using Value = std::remove_cvref_t<decltype(view)>;
             detail::to<JSON, Value>::template op<Opts>(view, ctx, b, ix);
-            dump<']'>(b, ix);
             dump<']'>(b, ix);
          }
       };

--- a/include/glaze/ext/eigen.hpp
+++ b/include/glaze/ext/eigen.hpp
@@ -71,6 +71,7 @@ namespace glz
             std::array<Eigen::Index, 2> extents;
             detail::read<BEVE>::op<Opts>(extents, ctx, it, end);
 
+            value.resize(extents[0], extents[1]);
             std::span<typename T::Scalar> view(value.data(), extents[0] * extents[1]);
             detail::read<BEVE>::op<Opts>(view, ctx, it, end);
          }

--- a/tests/eigen_test/eigen_test.cpp
+++ b/tests/eigen_test/eigen_test.cpp
@@ -194,53 +194,37 @@ suite additional_eigen_tests = [] {
       expect(deserialized.mcd == complex_test_value.mcd);
    };
 
-   "write_json_ref_matrix"_test = [] {
+   "json_ref_matrix"_test = [] {
       Eigen::Matrix3d source;
       source << 1, 2, 3, 4, 5, 6, 7, 8, 9;
       Eigen::Ref<Eigen::Matrix3d> ref(source);
       std::string json;
       expect(not glz::write_json(ref, json));
-      expect(json == "[1,2,3,4,5,6,7,8,9]");
+      expect(json == "[1,4,7,2,5,8,3,6,9]") << json;
+      
+      Eigen::Matrix3d parsed;
+      expect(not glz::read_json(parsed, json));
+      expect(source == parsed);
    };
 
-   "read_json_ref_matrix"_test = [] {
-      Eigen::Matrix3d source;
-      std::string input = "[9,8,7,6,5,4,3,2,1]";
-      Eigen::Ref<Eigen::Matrix3d> ref(source);
-      expect(not glz::read_json(ref, input));
-      Eigen::Matrix3d expected;
-      expected << 9, 8, 7, 6, 5, 4, 3, 2, 1;
-      expect(source == expected);
-   };
-
-   "write_json_non_square_matrix"_test = [] {
+   "json_non_square_matrix"_test = [] {
       Eigen::Matrix<double, 2, 3> m;
       m << 1, 2, 3, 4, 5, 6;
       std::string json;
       expect(not glz::write_json(m, json));
-      expect(json == "[1,2,3,4,5,6]");
-   };
-
-   "read_json_non_square_matrix"_test = [] {
-      Eigen::Matrix<double, 2, 3> m;
-      std::string input = "[7,8,9,10,11,12]";
-      expect(not glz::read_json(m, input));
-      Eigen::Matrix<double, 2, 3> expected;
-      expected << 7, 8, 9, 10, 11, 12;
-      expect(m == expected);
+      expect(json == "[1,4,2,5,3,6]") << json;
+      
+      Eigen::Matrix<double, 2, 3> parsed;
+      expect(not glz::read_json(parsed, json));
+      expect(m == parsed);
    };
 
    "write_json_zero_sized_matrix"_test = [] {
       Eigen::MatrixXd m(0, 0);
       std::string json;
       expect(not glz::write_json(m, json));
-      expect(json == "[]");
-   };
-
-   "read_json_zero_sized_matrix"_test = [] {
-      Eigen::MatrixXd m;
-      std::string input = "[]";
-      expect(not glz::read_json(m, input));
+      expect(json == "[[0,0],[]]");
+      expect(not glz::read_json(m, json));
       expect(m.rows() == 0);
       expect(m.cols() == 0);
    };

--- a/tests/eigen_test/eigen_test.cpp
+++ b/tests/eigen_test/eigen_test.cpp
@@ -147,6 +147,10 @@ int main()
       Eigen::MatrixXcd e(3, 3);
       expect(!glz::read_beve(e, b));
       expect(bool(m == e));
+      
+      expect(not glz::write_json(m, b));
+      expect(!glz::write_json(e, b));
+      expect(bool(m == e));
    };
 
    "Eigen::Ref"_test = [] {
@@ -161,6 +165,10 @@ int main()
       expect(not glz::write_beve(m, b));
       Eigen::VectorXcd e{};
       expect(!glz::read_beve(e, b));
+      expect(bool(m == e));
+      
+      expect(not glz::write_json(m, b));
+      expect(!glz::read_json(e, b));
       expect(bool(m == e));
    };
 }

--- a/tests/eigen_test/eigen_test.cpp
+++ b/tests/eigen_test/eigen_test.cpp
@@ -190,7 +190,8 @@ suite additional_eigen_tests = [] {
         std::string json;
         expect(not glz::write_json(complex_test_value, json));
         complex_struct deserialized;
-        expect(!glz::read_json(deserialized, json));
+       auto ec = glz::read_json(deserialized, json);
+        expect(!ec) << glz::format_error(ec, json);
         expect(deserialized.mf == complex_test_value.mf);
         expect(deserialized.vi == complex_test_value.vi);
         expect(deserialized.mcd == complex_test_value.mcd);
@@ -356,7 +357,7 @@ int main()
       expect(boolean);
    };
 
-   "dynamic array beve"_test = [] {
+   "dynamic array"_test = [] {
       Eigen::VectorXd m(10);
       for (int i = 0; i < m.size(); ++i) {
          m[i] = i;
@@ -365,8 +366,11 @@ int main()
       expect(not glz::write_beve(m, b));
       Eigen::VectorXd e{};
       expect(!glz::read_beve(e, b));
-      const bool boolean = m == e;
-      expect(boolean);
+      expect(m == e);
+      
+      expect(not glz::write_json(m, b));
+      expect(!glz::read_json(e, b));
+      expect(m == e);
    };
 
    "Eigen::VectorXcd"_test = [] {
@@ -396,7 +400,7 @@ int main()
       expect(boolean);
    };
 
-   "Eigen::MatrixXcd beve"_test = [] {
+   "Eigen::MatrixXcd"_test = [] {
       Eigen::MatrixXcd m(3, 3);
       for (int i = 0; i < m.size(); ++i) {
          m.array()(i) = {double(i), 2 * double(i)};

--- a/tests/eigen_test/eigen_test.cpp
+++ b/tests/eigen_test/eigen_test.cpp
@@ -40,9 +40,9 @@ suite matrix3d = [] {
 // Struct with multiple Eigen types
 struct complex_struct
 {
-    Eigen::Matrix2f mf;
-    Eigen::Vector4i vi;
-    Eigen::MatrixXcd mcd;
+   Eigen::Matrix2f mf;
+   Eigen::Vector4i vi;
+   Eigen::MatrixXcd mcd;
 } complex_test_value;
 
 template <>
@@ -55,232 +55,212 @@ struct glz::meta<complex_struct>
 // Initialize complex_test_value
 void initialize_complex_struct()
 {
-    complex_test_value.mf << 1.1f, 2.2f,
-                             3.3f, 4.4f;
-    complex_test_value.vi << 1, 2, 3, 4;
-    complex_test_value.mcd = Eigen::MatrixXcd(2, 2);
-    complex_test_value.mcd << std::complex<double>(1, 2), std::complex<double>(3, 4),
-                              std::complex<double>(5, 6), std::complex<double>(7, 8);
+   complex_test_value.mf << 1.1f, 2.2f, 3.3f, 4.4f;
+   complex_test_value.vi << 1, 2, 3, 4;
+   complex_test_value.mcd = Eigen::MatrixXcd(2, 2);
+   complex_test_value.mcd << std::complex<double>(1, 2), std::complex<double>(3, 4), std::complex<double>(5, 6),
+      std::complex<double>(7, 8);
 }
 
 suite additional_eigen_tests = [] {
-    "write_json_matrix4d"_test = [] {
-        Eigen::Matrix4d m;
-        m << 1, 2, 3, 4,
-             5, 6, 7, 8,
-             9, 10, 11, 12,
-             13, 14, 15, 16;
-        std::string json;
-        expect(not glz::write_json(m, json));
-        expect(json == "[1,5,9,13,2,6,10,14,3,7,11,15,4,8,12,16]") << json;
-    };
+   "write_json_matrix4d"_test = [] {
+      Eigen::Matrix4d m;
+      m << 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16;
+      std::string json;
+      expect(not glz::write_json(m, json));
+      expect(json == "[1,5,9,13,2,6,10,14,3,7,11,15,4,8,12,16]") << json;
+   };
 
-    "read_json_matrix4d"_test = [] {
-        Eigen::Matrix4d m;
-        std::string input = "[1,5,9,13,2,6,10,14,3,7,11,15,4,8,12,16]";
-        expect(not glz::read_json(m, input));
-        Eigen::Matrix4d expected;
-        expected << 1, 2, 3, 4,
-                    5, 6, 7, 8,
-                    9,10,11,12,
-                   13,14,15,16;
-        expect(m == expected);
-    };
+   "read_json_matrix4d"_test = [] {
+      Eigen::Matrix4d m;
+      std::string input = "[1,5,9,13,2,6,10,14,3,7,11,15,4,8,12,16]";
+      expect(not glz::read_json(m, input));
+      Eigen::Matrix4d expected;
+      expected << 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16;
+      expect(m == expected);
+   };
 
-    "write_beve_row_major"_test = [] {
-        Eigen::Matrix<double, 2, 3, Eigen::RowMajor> m;
-        m << 1, 2, 3,
-             4, 5, 6;
-        std::string b;
-        expect(not glz::write_beve(m, b));
-        // BEVE layout specifics can vary; adjust expected value accordingly
-        // Here we assume it writes row-major
-        Eigen::Matrix<double, 2, 3, Eigen::RowMajor> e;
-        expect(!glz::read_beve(e, b));
-        expect(m == e);
-    };
+   "write_beve_row_major"_test = [] {
+      Eigen::Matrix<double, 2, 3, Eigen::RowMajor> m;
+      m << 1, 2, 3, 4, 5, 6;
+      std::string b;
+      expect(not glz::write_beve(m, b));
+      // BEVE layout specifics can vary; adjust expected value accordingly
+      // Here we assume it writes row-major
+      Eigen::Matrix<double, 2, 3, Eigen::RowMajor> e;
+      expect(!glz::read_beve(e, b));
+      expect(m == e);
+   };
 
-    "read_json_empty_matrix"_test = [] {
-        Eigen::MatrixXd m;
-        std::string input = "[[0,0]]"; // Empty array
-        expect(not glz::read_json(m, input));
-        expect(m.rows() == 0);
-        expect(m.cols() == 0);
-    };
+   "read_json_empty_matrix"_test = [] {
+      Eigen::MatrixXd m;
+      std::string input = "[[0,0]]"; // Empty array
+      expect(not glz::read_json(m, input));
+      expect(m.rows() == 0);
+      expect(m.cols() == 0);
+   };
 
-    "write_json_large_matrix"_test = [] {
-        Eigen::MatrixXd m(100, 100);
-        m.setRandom();
-        std::string json;
-        expect(not glz::write_json(m, json));
-        // Here we check the JSON starts with '[' and has the correct number of elements
-        expect(!json.empty());
-        expect(json.front() == '[');
-        expect(json.back() == ']');
-    };
+   "write_json_large_matrix"_test = [] {
+      Eigen::MatrixXd m(100, 100);
+      m.setRandom();
+      std::string json;
+      expect(not glz::write_json(m, json));
+      // Here we check the JSON starts with '[' and has the correct number of elements
+      expect(!json.empty());
+      expect(json.front() == '[');
+      expect(json.back() == ']');
+   };
 
-    "read_json_matrix"_test = [] {
-        std::string input = "[[3,3],[1,4,7,2,5,8,3,6,9]]";
-        Eigen::MatrixXd m;
-        expect(not glz::read_json(m, input));
-        Eigen::MatrixXd expected(3,3);
-        expected << 1,2,3,
-                    4,5,6,
-                    7,8,9;
-        expect(m == expected);
-    };
+   "read_json_matrix"_test = [] {
+      std::string input = "[[3,3],[1,4,7,2,5,8,3,6,9]]";
+      Eigen::MatrixXd m;
+      expect(not glz::read_json(m, input));
+      Eigen::MatrixXd expected(3, 3);
+      expected << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+      expect(m == expected);
+   };
 
-    "write_json_vector4f"_test = [] {
-        Eigen::Vector4f v{1.0f, 2.0f, 3.0f, 4.0f};
-        std::string json;
-        expect(not glz::write_json(v, json));
-        expect(json == "[1,2,3,4]");
-    };
+   "write_json_vector4f"_test = [] {
+      Eigen::Vector4f v{1.0f, 2.0f, 3.0f, 4.0f};
+      std::string json;
+      expect(not glz::write_json(v, json));
+      expect(json == "[1,2,3,4]");
+   };
 
-    "read_json_vector4f"_test = [] {
-        Eigen::Vector4f v;
-        std::string input = "[5.5,6.6,7.7,8.8]";
-        expect(not glz::read_json(v, input));
-        Eigen::Vector4f expected{5.5f, 6.6f, 7.7f, 8.8f};
-        expect(v == expected);
-    };
+   "read_json_vector4f"_test = [] {
+      Eigen::Vector4f v;
+      std::string input = "[5.5,6.6,7.7,8.8]";
+      expect(not glz::read_json(v, input));
+      Eigen::Vector4f expected{5.5f, 6.6f, 7.7f, 8.8f};
+      expect(v == expected);
+   };
 
-    "write_json_integer_matrix"_test = [] {
-        Eigen::Matrix<int, 3, 3> m;
-        m << 1, 2, 3,
-             4, 5, 6,
-             7, 8, 9;
-        std::string json;
-        expect(not glz::write_json(m, json));
-        expect(json == "[1,4,7,2,5,8,3,6,9]") << json;
-    };
+   "write_json_integer_matrix"_test = [] {
+      Eigen::Matrix<int, 3, 3> m;
+      m << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+      std::string json;
+      expect(not glz::write_json(m, json));
+      expect(json == "[1,4,7,2,5,8,3,6,9]") << json;
+   };
 
-    "read_json_integer_matrix"_test = [] {
-        Eigen::Matrix<int, 3, 3> m;
-        std::string input = "[10,40,70,20,50,80,30,60,90]";
-        expect(not glz::read_json(m, input));
-        Eigen::Matrix<int, 3, 3> expected;
-        expected << 10, 20, 30,
-                    40, 50, 60,
-                    70, 80, 90;
-        expect(m == expected);
-    };
+   "read_json_integer_matrix"_test = [] {
+      Eigen::Matrix<int, 3, 3> m;
+      std::string input = "[10,40,70,20,50,80,30,60,90]";
+      expect(not glz::read_json(m, input));
+      Eigen::Matrix<int, 3, 3> expected;
+      expected << 10, 20, 30, 40, 50, 60, 70, 80, 90;
+      expect(m == expected);
+   };
 
-    "write_beve_complex_matrix"_test = [] {
-        Eigen::MatrixXcd m(2, 2);
-        m << std::complex<double>(1,1), std::complex<double>(2,2),
-             std::complex<double>(3,3), std::complex<double>(4,4);
-        std::string b;
-        expect(not glz::write_beve(m, b));
-        Eigen::MatrixXcd e;
-        expect(not glz::read_beve(e, b));
-        expect(m == e);
-    };
+   "write_beve_complex_matrix"_test = [] {
+      Eigen::MatrixXcd m(2, 2);
+      m << std::complex<double>(1, 1), std::complex<double>(2, 2), std::complex<double>(3, 3),
+         std::complex<double>(4, 4);
+      std::string b;
+      expect(not glz::write_beve(m, b));
+      Eigen::MatrixXcd e;
+      expect(not glz::read_beve(e, b));
+      expect(m == e);
+   };
 
-    "read_beve_invalid_data"_test = [] {
-        Eigen::MatrixXd m;
-        std::string invalid_beve = "invalid_binary_data";
-        // Assuming read_beve returns an error code or sets m to a default state
-        // Adjust based on actual Glaze behavior
-        expect(glz::read_beve(m, invalid_beve) != glz::error_code::none);
-    };
+   "read_beve_invalid_data"_test = [] {
+      Eigen::MatrixXd m;
+      std::string invalid_beve = "invalid_binary_data";
+      // Assuming read_beve returns an error code or sets m to a default state
+      // Adjust based on actual Glaze behavior
+      expect(glz::read_beve(m, invalid_beve) != glz::error_code::none);
+   };
 
-    "serialize_deserialize_complex_struct_json"_test = [] {
-        initialize_complex_struct();
-        std::string json;
-        expect(not glz::write_json(complex_test_value, json));
-        complex_struct deserialized;
-       auto ec = glz::read_json(deserialized, json);
-        expect(!ec) << glz::format_error(ec, json);
-        expect(deserialized.mf == complex_test_value.mf);
-        expect(deserialized.vi == complex_test_value.vi);
-        expect(deserialized.mcd == complex_test_value.mcd);
-    };
+   "serialize_deserialize_complex_struct_json"_test = [] {
+      initialize_complex_struct();
+      std::string json;
+      expect(not glz::write_json(complex_test_value, json));
+      complex_struct deserialized;
+      auto ec = glz::read_json(deserialized, json);
+      expect(!ec) << glz::format_error(ec, json);
+      expect(deserialized.mf == complex_test_value.mf);
+      expect(deserialized.vi == complex_test_value.vi);
+      expect(deserialized.mcd == complex_test_value.mcd);
+   };
 
-    "serialize_deserialize_complex_struct_beve"_test = [] {
-        initialize_complex_struct();
-        std::string b;
-        expect(not glz::write_beve(complex_test_value, b));
-        complex_struct deserialized;
-        expect(!glz::read_beve(deserialized, b));
-        expect(deserialized.mf == complex_test_value.mf);
-        expect(deserialized.vi == complex_test_value.vi);
-        expect(deserialized.mcd == complex_test_value.mcd);
-    };
+   "serialize_deserialize_complex_struct_beve"_test = [] {
+      initialize_complex_struct();
+      std::string b;
+      expect(not glz::write_beve(complex_test_value, b));
+      complex_struct deserialized;
+      expect(!glz::read_beve(deserialized, b));
+      expect(deserialized.mf == complex_test_value.mf);
+      expect(deserialized.vi == complex_test_value.vi);
+      expect(deserialized.mcd == complex_test_value.mcd);
+   };
 
-    "write_json_ref_matrix"_test = [] {
-        Eigen::Matrix3d source;
-        source << 1,2,3,4,5,6,7,8,9;
-        Eigen::Ref<Eigen::Matrix3d> ref(source);
-        std::string json;
-        expect(not glz::write_json(ref, json));
-        expect(json == "[1,2,3,4,5,6,7,8,9]");
-    };
+   "write_json_ref_matrix"_test = [] {
+      Eigen::Matrix3d source;
+      source << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+      Eigen::Ref<Eigen::Matrix3d> ref(source);
+      std::string json;
+      expect(not glz::write_json(ref, json));
+      expect(json == "[1,2,3,4,5,6,7,8,9]");
+   };
 
-    "read_json_ref_matrix"_test = [] {
-        Eigen::Matrix3d source;
-        std::string input = "[9,8,7,6,5,4,3,2,1]";
-        Eigen::Ref<Eigen::Matrix3d> ref(source);
-        expect(not glz::read_json(ref, input));
-        Eigen::Matrix3d expected;
-        expected << 9,8,7,6,5,4,3,2,1;
-        expect(source == expected);
-    };
+   "read_json_ref_matrix"_test = [] {
+      Eigen::Matrix3d source;
+      std::string input = "[9,8,7,6,5,4,3,2,1]";
+      Eigen::Ref<Eigen::Matrix3d> ref(source);
+      expect(not glz::read_json(ref, input));
+      Eigen::Matrix3d expected;
+      expected << 9, 8, 7, 6, 5, 4, 3, 2, 1;
+      expect(source == expected);
+   };
 
-    "write_json_non_square_matrix"_test = [] {
-        Eigen::Matrix<double, 2, 3> m;
-        m << 1, 2, 3,
-             4, 5, 6;
-        std::string json;
-        expect(not glz::write_json(m, json));
-        expect(json == "[1,2,3,4,5,6]");
-    };
+   "write_json_non_square_matrix"_test = [] {
+      Eigen::Matrix<double, 2, 3> m;
+      m << 1, 2, 3, 4, 5, 6;
+      std::string json;
+      expect(not glz::write_json(m, json));
+      expect(json == "[1,2,3,4,5,6]");
+   };
 
-    "read_json_non_square_matrix"_test = [] {
-        Eigen::Matrix<double, 2, 3> m;
-        std::string input = "[7,8,9,10,11,12]";
-        expect(not glz::read_json(m, input));
-        Eigen::Matrix<double, 2, 3> expected;
-        expected << 7,8,9,
-                   10,11,12;
-        expect(m == expected);
-    };
+   "read_json_non_square_matrix"_test = [] {
+      Eigen::Matrix<double, 2, 3> m;
+      std::string input = "[7,8,9,10,11,12]";
+      expect(not glz::read_json(m, input));
+      Eigen::Matrix<double, 2, 3> expected;
+      expected << 7, 8, 9, 10, 11, 12;
+      expect(m == expected);
+   };
 
-    "write_json_zero_sized_matrix"_test = [] {
-        Eigen::MatrixXd m(0, 0);
-        std::string json;
-        expect(not glz::write_json(m, json));
-        expect(json == "[]");
-    };
+   "write_json_zero_sized_matrix"_test = [] {
+      Eigen::MatrixXd m(0, 0);
+      std::string json;
+      expect(not glz::write_json(m, json));
+      expect(json == "[]");
+   };
 
-    "read_json_zero_sized_matrix"_test = [] {
-        Eigen::MatrixXd m;
-        std::string input = "[]";
-        expect(not glz::read_json(m, input));
-        expect(m.rows() == 0);
-        expect(m.cols() == 0);
-    };
+   "read_json_zero_sized_matrix"_test = [] {
+      Eigen::MatrixXd m;
+      std::string input = "[]";
+      expect(not glz::read_json(m, input));
+      expect(m.rows() == 0);
+      expect(m.cols() == 0);
+   };
 
-    "write_json_mixed_storage_order"_test = [] {
-        Eigen::Matrix<double, 3, 3, Eigen::RowMajor> m;
-        m << 1, 2, 3,
-             4, 5, 6,
-             7, 8, 9;
-        std::string json;
-        expect(not glz::write_json(m, json));
-        expect(json == "[1,2,3,4,5,6,7,8,9]");
-    };
+   "write_json_mixed_storage_order"_test = [] {
+      Eigen::Matrix<double, 3, 3, Eigen::RowMajor> m;
+      m << 1, 2, 3, 4, 5, 6, 7, 8, 9;
+      std::string json;
+      expect(not glz::write_json(m, json));
+      expect(json == "[1,2,3,4,5,6,7,8,9]");
+   };
 
-    "read_json_mixed_storage_order"_test = [] {
-        Eigen::Matrix<double, 3, 3, Eigen::RowMajor> m;
-        std::string input = "[9,8,7,6,5,4,3,2,1]";
-        expect(not glz::read_json(m, input));
-        Eigen::Matrix<double, 3, 3, Eigen::RowMajor> expected;
-        expected << 9,8,7,
-                    6,5,4,
-                    3,2,1;
-        expect(m == expected);
-    };
+   "read_json_mixed_storage_order"_test = [] {
+      Eigen::Matrix<double, 3, 3, Eigen::RowMajor> m;
+      std::string input = "[9,8,7,6,5,4,3,2,1]";
+      expect(not glz::read_json(m, input));
+      Eigen::Matrix<double, 3, 3, Eigen::RowMajor> expected;
+      expected << 9, 8, 7, 6, 5, 4, 3, 2, 1;
+      expect(m == expected);
+   };
 };
 
 int main()
@@ -367,7 +347,7 @@ int main()
       Eigen::VectorXd e{};
       expect(!glz::read_beve(e, b));
       expect(m == e);
-      
+
       expect(not glz::write_json(m, b));
       expect(!glz::read_json(e, b));
       expect(m == e);
@@ -410,7 +390,7 @@ int main()
       Eigen::MatrixXcd e(3, 3);
       expect(!glz::read_beve(e, b));
       expect(bool(m == e));
-      
+
       expect(not glz::write_json(m, b));
       expect(!glz::write_json(e, b));
       expect(bool(m == e));
@@ -429,7 +409,7 @@ int main()
       Eigen::VectorXcd e{};
       expect(!glz::read_beve(e, b));
       expect(bool(m == e));
-      
+
       expect(not glz::write_json(m, b));
       expect(!glz::read_json(e, b));
       expect(bool(m == e));

--- a/tests/eigen_test/eigen_test.cpp
+++ b/tests/eigen_test/eigen_test.cpp
@@ -78,7 +78,7 @@ suite additional_eigen_tests = [] {
     "read_json_matrix4d"_test = [] {
         Eigen::Matrix4d m;
         std::string input = "[1,5,9,13,2,6,10,14,3,7,11,15,4,8,12,16]";
-        expect(glz::read_json(m, input) == glz::error_code::none);
+        expect(not glz::read_json(m, input));
         Eigen::Matrix4d expected;
         expected << 1, 2, 3, 4,
                     5, 6, 7, 8,
@@ -103,7 +103,7 @@ suite additional_eigen_tests = [] {
     "read_json_empty_matrix"_test = [] {
         Eigen::MatrixXd m;
         std::string input = "[[0,0]]"; // Empty array
-        expect(glz::read_json(m, input) == glz::error_code::none);
+        expect(not glz::read_json(m, input));
         expect(m.rows() == 0);
         expect(m.cols() == 0);
     };
@@ -220,7 +220,7 @@ suite additional_eigen_tests = [] {
         Eigen::Matrix3d source;
         std::string input = "[9,8,7,6,5,4,3,2,1]";
         Eigen::Ref<Eigen::Matrix3d> ref(source);
-        expect(glz::read_json(ref, input) == glz::error_code::none);
+        expect(not glz::read_json(ref, input));
         Eigen::Matrix3d expected;
         expected << 9,8,7,6,5,4,3,2,1;
         expect(source == expected);
@@ -238,7 +238,7 @@ suite additional_eigen_tests = [] {
     "read_json_non_square_matrix"_test = [] {
         Eigen::Matrix<double, 2, 3> m;
         std::string input = "[7,8,9,10,11,12]";
-        expect(glz::read_json(m, input) == glz::error_code::none);
+        expect(not glz::read_json(m, input));
         Eigen::Matrix<double, 2, 3> expected;
         expected << 7,8,9,
                    10,11,12;
@@ -255,7 +255,7 @@ suite additional_eigen_tests = [] {
     "read_json_zero_sized_matrix"_test = [] {
         Eigen::MatrixXd m;
         std::string input = "[]";
-        expect(glz::read_json(m, input) == glz::error_code::none);
+        expect(not glz::read_json(m, input));
         expect(m.rows() == 0);
         expect(m.cols() == 0);
     };
@@ -273,7 +273,7 @@ suite additional_eigen_tests = [] {
     "read_json_mixed_storage_order"_test = [] {
         Eigen::Matrix<double, 3, 3, Eigen::RowMajor> m;
         std::string input = "[9,8,7,6,5,4,3,2,1]";
-        expect(glz::read_json(m, input) == glz::error_code::none);
+        expect(not glz::read_json(m, input));
         Eigen::Matrix<double, 3, 3, Eigen::RowMajor> expected;
         expected << 9,8,7,
                     6,5,4,
@@ -294,7 +294,7 @@ int main()
 
    "read_json"_test = [] {
       Eigen::Matrix<double, 2, 2> m{};
-      expect(glz::read_json(m, "[2,1,7,4]") == glz::error_code::none);
+      expect(not glz::read_json(m, "[2,1,7,4]"));
       expect(m.rows() == 2);
       expect(m.cols() == 2);
       expect(m(0, 1) == 7);
@@ -351,7 +351,7 @@ int main()
       std::string b;
       expect(not glz::write_json(m, b));
       Eigen::VectorXd e{};
-      expect(glz::read_json(e, b) == glz::error_code::none);
+      expect(not glz::read_json(e, b));
       const bool boolean = m == e;
       expect(boolean);
    };
@@ -391,7 +391,7 @@ int main()
       expect(json == "[[2,3],[9,1,7,2,0,3]]"); // [2,3] are rows and cols
 
       Eigen::MatrixXd mat2{};
-      expect(glz::read_json(mat2, json) == glz::error_code::none);
+      expect(not glz::read_json(mat2, json));
       const bool boolean = mat1 == mat2;
       expect(boolean);
    };

--- a/tests/eigen_test/eigen_test.cpp
+++ b/tests/eigen_test/eigen_test.cpp
@@ -57,7 +57,7 @@ void initialize_complex_struct()
 {
    complex_test_value.mf << 1.1f, 2.2f, 3.3f, 4.4f;
    complex_test_value.vi << 1, 2, 3, 4;
-   complex_test_value.mcd = Eigen::MatrixXcd(2, 2);
+   complex_test_value.mcd = Eigen::MatrixXcd(2,2);
    complex_test_value.mcd << std::complex<double>(1, 2), std::complex<double>(3, 4), std::complex<double>(5, 6),
       std::complex<double>(7, 8);
 }


### PR DESCRIPTION
I use `b[ix++] = '[';` because I saw something like
```
if (const auto k = ix + write_padding_bytes; k > b.size()) [[unlikely]] {
   b.resize(2 * k);
}
```
so this might be safe. Not so sure.

A quick test:
```
#include <Eigen/Core>
#include <iostream>

#include "glaze/ext/eigen.hpp"
#include "glaze/glaze.hpp"

class Example
{
   int a{1}, b{2}, c{3}, d{4}, e{5}, f{6}; // ... and many many more

   friend struct glz::meta<Example>;

  public:
   Eigen::MatrixXd mat;
   Eigen::VectorXd vec;
};

template <>
struct glz::meta<Example>
{
   using T = Example;
   static constexpr auto value = object(&T::a, &T::b, &T::c, &T::d, &T::e, &T::f, &T::mat, &T::vec);
};

int main()
{
   Example obj1{}, obj2{};
   obj1.mat.resize(2, 3);
   for (int j = 0; j < 2 * 3; ++j) {
      obj1.mat(j) = j + 1.01;
   }
   obj1.vec.resize(3);
   obj1.vec << 1, 2, 3.33333;

   std::string buffer = glz::write_json(obj1).value();
   std::cout << buffer << '\n';

   assert(obj2.mat.size() == 0);
   assert(obj2.vec.size() == 0);

   auto ec = glz::read_json(obj2, buffer); // populates s from buffer
   if (ec) {
      std::cout << "error" << std::endl;
   }
   assert(obj2.mat.rows() == 2);
   assert(obj2.mat.cols() == 3);
   assert(obj2.vec.size() == 3);
   assert(obj1.mat == obj2.mat);
   assert(obj1.vec == obj2.vec);
}
```