### PR TITLE
Removing global glz::trace

### DIFF
--- a/include/glaze/trace/trace.hpp
+++ b/include/glaze/trace/trace.hpp
@@ -163,8 +163,16 @@ namespace glz
       {
          trace& tr;
          
-         duration_scoper(trace& tr, const std::string_view name) noexcept : tr(tr), name(name) { tr.begin(name); }
-         ~duration_scoper() noexcept { tr.end(name); }
+         duration_scoper(trace& tr, const std::string_view name) noexcept : tr(tr), name(name) {
+            if (not tr.disabled) {
+               tr.begin(name);
+            }
+         }
+         ~duration_scoper() noexcept {
+            if (not tr.disabled) {
+               tr.end(name);
+            }
+         }
 
          const std::string_view name{};
       };
@@ -173,8 +181,16 @@ namespace glz
       {
          trace& tr;
          
-         async_scoper(trace& tr, const std::string_view name) noexcept : tr(tr), name(name) { tr.begin(name); }
-         ~async_scoper() noexcept { tr.end(name); }
+         async_scoper(trace& tr, const std::string_view name) noexcept : tr(tr), name(name) {
+            if (not tr.disabled) {
+               tr.begin(name);
+            }
+         }
+         ~async_scoper() noexcept {
+            if (not tr.disabled) {
+               tr.end(name);
+            }
+         }
 
          const std::string_view name{};
       };

--- a/include/glaze/trace/trace.hpp
+++ b/include/glaze/trace/trace.hpp
@@ -194,14 +194,4 @@ namespace glz
       using T = trace;
       static constexpr auto value = object(&T::traceEvents, &T::displayTimeUnit);
    };
-   
-   template <opts Opts = opts{}>
-   [[nodiscard]] error_ctx write_file_trace(const trace& result, const std::string& file_name, auto&& buffer) noexcept
-   {
-      const auto ec = write<set_json<Opts>()>(result, buffer);
-      if (bool(ec)) [[unlikely]] {
-         return ec;
-      }
-      return {buffer_to_file(buffer, file_name)};
-   }
 }

--- a/include/glaze/trace/trace.hpp
+++ b/include/glaze/trace/trace.hpp
@@ -62,16 +62,12 @@ namespace glz
 
       std::optional<std::chrono::time_point<std::chrono::steady_clock>> t0{}; // the time of the first event
 
-      std::atomic<bool> disabled = false;
       std::mutex mtx{};
 
       template <class... Args>
          requires(sizeof...(Args) <= 1)
       void begin(const std::string_view name, Args&&... args) noexcept
       {
-         if (disabled) {
-            return;
-         }
          duration(name, 'B', std::forward<Args>(args)...);
       }
 
@@ -79,9 +75,6 @@ namespace glz
          requires(sizeof...(Args) <= 1)
       void end(const std::string_view name, Args&&... args) noexcept
       {
-         if (disabled) {
-            return;
-         }
          duration(name, 'E', std::forward<Args>(args)...);
       }
 
@@ -89,10 +82,6 @@ namespace glz
          requires(sizeof...(Args) <= 1)
       void duration(const std::string_view name, const char phase, Args&&... args) noexcept
       {
-         if (disabled) {
-            return;
-         }
-
          const auto tnow = std::chrono::steady_clock::now();
          trace_event* event{};
          {
@@ -115,9 +104,6 @@ namespace glz
          requires(sizeof...(Args) <= 1)
       void async_begin(const std::string_view name, Args&&... args) noexcept
       {
-         if (disabled) {
-            return;
-         }
          async(name, 'b', std::forward<Args>(args)...);
       }
 
@@ -125,9 +111,6 @@ namespace glz
          requires(sizeof...(Args) <= 1)
       void async_end(const std::string_view name, Args&&... args) noexcept
       {
-         if (disabled) {
-            return;
-         }
          async(name, 'e', std::forward<Args>(args)...);
       }
 
@@ -135,10 +118,6 @@ namespace glz
          requires(sizeof...(Args) <= 1)
       void async(const std::string_view name, const char phase, Args&&... args) noexcept
       {
-         if (disabled) {
-            return;
-         }
-
          const auto tnow = std::chrono::steady_clock::now();
          trace_event* event{};
          {

--- a/include/glaze/trace/trace.hpp
+++ b/include/glaze/trace/trace.hpp
@@ -62,12 +62,16 @@ namespace glz
 
       std::optional<std::chrono::time_point<std::chrono::steady_clock>> t0{}; // the time of the first event
 
+      std::atomic<bool> disabled = false;
       std::mutex mtx{};
 
       template <class... Args>
          requires(sizeof...(Args) <= 1)
       void begin(const std::string_view name, Args&&... args) noexcept
       {
+         if (disabled) {
+            return;
+         }
          duration(name, 'B', std::forward<Args>(args)...);
       }
 
@@ -75,6 +79,9 @@ namespace glz
          requires(sizeof...(Args) <= 1)
       void end(const std::string_view name, Args&&... args) noexcept
       {
+         if (disabled) {
+            return;
+         }
          duration(name, 'E', std::forward<Args>(args)...);
       }
 
@@ -82,6 +89,10 @@ namespace glz
          requires(sizeof...(Args) <= 1)
       void duration(const std::string_view name, const char phase, Args&&... args) noexcept
       {
+         if (disabled) {
+            return;
+         }
+
          const auto tnow = std::chrono::steady_clock::now();
          trace_event* event{};
          {
@@ -104,6 +115,9 @@ namespace glz
          requires(sizeof...(Args) <= 1)
       void async_begin(const std::string_view name, Args&&... args) noexcept
       {
+         if (disabled) {
+            return;
+         }
          async(name, 'b', std::forward<Args>(args)...);
       }
 
@@ -111,6 +125,9 @@ namespace glz
          requires(sizeof...(Args) <= 1)
       void async_end(const std::string_view name, Args&&... args) noexcept
       {
+         if (disabled) {
+            return;
+         }
          async(name, 'e', std::forward<Args>(args)...);
       }
 
@@ -118,6 +135,10 @@ namespace glz
          requires(sizeof...(Args) <= 1)
       void async(const std::string_view name, const char phase, Args&&... args) noexcept
       {
+         if (disabled) {
+            return;
+         }
+
          const auto tnow = std::chrono::steady_clock::now();
          trace_event* event{};
          {

--- a/include/glaze/trace/trace.hpp
+++ b/include/glaze/trace/trace.hpp
@@ -157,6 +157,35 @@ namespace glz
             std::ignore = glz::write_json(std::forward<Args>(args)..., event->args.str);
          }
       }
+      
+      // Automatically adds the end event when it leave scope
+      struct duration_scoper final
+      {
+         trace& tr;
+         
+         duration_scoper(trace& tr, const std::string_view name) noexcept : tr(tr), name(name) { tr.begin(name); }
+         ~duration_scoper() noexcept { tr.end(name); }
+
+         const std::string_view name{};
+      };
+      
+      struct async_scoper final
+      {
+         trace& tr;
+         
+         async_scoper(trace& tr, const std::string_view name) noexcept : tr(tr), name(name) { tr.begin(name); }
+         ~async_scoper() noexcept { tr.end(name); }
+
+         const std::string_view name{};
+      };
+      
+      duration_scoper scope(const std::string_view name) {
+         return {*this, name};
+      }
+      
+      async_scoper async_scope(const std::string_view name) {
+         return {*this, name};
+      }
    };
 
    template <>
@@ -165,85 +194,14 @@ namespace glz
       using T = trace;
       static constexpr auto value = object(&T::traceEvents, &T::displayTimeUnit);
    };
-
-   // Global approach to user a trace
-   // instead of calling: my_trace.begin("my event");
-   // you can call: glz::trace_begin("my event");
-   template <size_t I>
-   inline trace& global_trace() noexcept
-   {
-      static trace trc{};
-      return trc;
-   }
-
-   template <size_t I>
-   inline void enable_trace() noexcept
-   {
-      global_trace<0>().disabled = false;
-   }
-
-   template <size_t I>
-   inline void disable_trace() noexcept
-   {
-      global_trace<0>().disabled = true;
-   }
-
+   
    template <opts Opts = opts{}>
-   [[nodiscard]] error_ctx write_file_trace(const std::string& file_name, auto&& buffer) noexcept
+   [[nodiscard]] error_ctx write_file_trace(const trace& result, const std::string& file_name, auto&& buffer) noexcept
    {
-      const auto ec = write<set_json<Opts>()>(global_trace<0>(), buffer);
+      const auto ec = write<set_json<Opts>()>(result, buffer);
       if (bool(ec)) [[unlikely]] {
          return ec;
       }
       return {buffer_to_file(buffer, file_name)};
    }
-
-   template <class... Args>
-      requires(sizeof...(Args) <= 1)
-   constexpr void trace_begin(const std::string_view name, Args&&... args) noexcept
-   {
-      auto& trc = global_trace<0>();
-      trc.begin(name, std::forward<Args>(args)...);
-   }
-
-   template <class... Args>
-      requires(sizeof...(Args) <= 1)
-   constexpr void trace_end(const std::string_view name, Args&&... args) noexcept
-   {
-      auto& trc = global_trace<0>();
-      trc.end(name, std::forward<Args>(args)...);
-   }
-
-   template <class... Args>
-      requires(sizeof...(Args) <= 1)
-   constexpr void trace_async_begin(const std::string_view name, Args&&... args) noexcept
-   {
-      auto& trc = global_trace<0>();
-      trc.async_begin(name, std::forward<Args>(args)...);
-   }
-
-   template <class... Args>
-      requires(sizeof...(Args) <= 1)
-   constexpr void trace_async_end(const std::string_view name, Args&&... args) noexcept
-   {
-      auto& trc = global_trace<0>();
-      trc.async_end(name, std::forward<Args>(args)...);
-   }
-
-   // Automatically adds the end event when it leave scope
-   struct duration_trace final
-   {
-      duration_trace(const std::string_view name) noexcept : name(name) { trace_begin(name); }
-      ~duration_trace() noexcept { trace_end(name); }
-
-      const std::string_view name{};
-   };
-
-   struct async_trace final
-   {
-      async_trace(const std::string_view name) noexcept : name(name) { trace_async_begin(name); }
-      ~async_trace() noexcept { trace_async_end(name); }
-
-      const std::string_view name{};
-   };
 }

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -24,6 +24,8 @@
 #include "glaze/trace/trace.hpp"
 #include "ut/ut.hpp"
 
+inline glz::trace trace{};
+
 struct my_struct
 {
    int i = 287;
@@ -413,7 +415,7 @@ void bench()
 {
    using namespace ut;
    "bench"_test = [] {
-      glz::trace_begin("bench");
+      trace.begin("bench");
       std::cout << "\nPerformance regresion test: \n";
 #ifdef NDEBUG
       size_t repeat = 100000;
@@ -446,7 +448,7 @@ void bench()
       mbytes_per_sec = repeat * buffer.size() / (duration * 1048576);
       std::cout << "from_beve: " << duration << " s, " << mbytes_per_sec << " MB/s"
                 << "\n";
-      glz::trace_end("bench");
+      trace.end("bench");
    };
 }
 
@@ -1166,7 +1168,7 @@ suite signal_tests = [] {
 
 suite vector_tests = [] {
    "std::vector<uint8_t>"_test = [] {
-      glz::duration_trace trace{"test std::vector<uint8_t>"};
+      auto scoped = trace.scope("test std::vector<uint8_t>");
       std::string s;
       static constexpr auto n = 10000;
       std::vector<uint8_t> v(n);
@@ -1189,7 +1191,7 @@ suite vector_tests = [] {
    };
 
    "std::vector<uint16_t>"_test = [] {
-      glz::duration_trace trace{"test std::vector<uint16_t>"};
+      auto scoped = trace.scope("test std::vector<uint16_t>");
       std::string s;
       static constexpr auto n = 10000;
       std::vector<uint16_t> v(n);
@@ -1213,7 +1215,7 @@ suite vector_tests = [] {
    };
 
    "std::vector<float>"_test = [] {
-      glz::async_trace trace{"test std::vector<float>"};
+      auto scoped = trace.async_scope("test std::vector<float>");
       std::string s;
       static constexpr auto n = 10000;
       std::vector<float> v(n);
@@ -1237,7 +1239,7 @@ suite vector_tests = [] {
    };
 
    "std::vector<double>"_test = [] {
-      glz::async_trace trace{"test std::vector<double>"};
+      auto scoped = trace.async_scope("test std::vector<double>");
       std::string s;
       static constexpr auto n = 10000;
       std::vector<double> v(n);
@@ -2402,15 +2404,15 @@ suite pair_ranges_tests = [] {
 
 int main()
 {
-   glz::trace_begin("binary_test");
+   trace.begin("binary_test");
    write_tests();
    bench();
    test_partial();
    file_include_test();
    container_types();
 
-   glz::trace_end("binary_test");
-   const auto ec = glz::write_file_trace("binary_test.trace.json", std::string{});
+   trace.end("binary_test");
+   const auto ec = glz::write_file_trace(trace, "binary_test.trace.json", std::string{});
    if (ec) {
       std::cerr << "trace output failed\n";
    }

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -2412,7 +2412,7 @@ int main()
    container_types();
 
    trace.end("binary_test");
-   const auto ec = glz::write_file_trace(trace, "binary_test.trace.json", std::string{});
+   const auto ec = glz::write_file_json(trace, "binary_test.trace.json", std::string{});
    if (ec) {
       std::cerr << "trace output failed\n";
    }


### PR DESCRIPTION
Because C++ has inline variables and other ways to make global instances it is better to let the programmer handle global instances of `glz::trace` rather than offer two separate APIs.

This also removes the unnecessary `glz::write_file_trace` as `glz::write_file_json(trace` is more generic and there is no longer a global instance of the trace.