### PR TITLE
append_arrays compile time option

### DIFF
--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -63,6 +63,7 @@ namespace glz
       char indentation_char = ' '; // Prettified JSON indentation char
       uint8_t indentation_width = 3; // Prettified JSON indentation size
       bool_t new_lines_in_arrays = true; // Whether prettified arrays should have new lines for each element
+      bool_t append_arrays = false; // When reading into an array the data will be appended if the type supports it
       bool_t shrink_to_fit = false; // Shrinks dynamic containers to new size to save memory
       bool_t write_type_info = true; // Write type info for meta objects in variants
       bool_t error_on_missing_keys = false; // Require all non nullable keys to be present in the object. Use

--- a/include/glaze/core/wrappers.hpp
+++ b/include/glaze/core/wrappers.hpp
@@ -61,6 +61,10 @@ namespace glz
          return [](auto&& v) { return custom_t{v, From, To}; };
       }
    }
+   
+   // When reading into an array that is appendable, the new data will be appended rather than overwrite
+   template <auto MemPtr>
+   constexpr auto append_arrays = detail::opts_wrapper<MemPtr, &opts::append_arrays>();
 
    // Read and write booleans as numbers
    template <auto MemPtr>

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1272,7 +1272,7 @@ namespace glz
             if (*it == ']') {
                GLZ_SUB_LEVEL;
                ++it;
-               if constexpr (resizable<T>) {
+               if constexpr (resizable<T> && not Opts.append_arrays) {
                   value.clear();
 
                   if constexpr (Opts.shrink_to_fit) {
@@ -1284,42 +1284,46 @@ namespace glz
 
             const size_t ws_size = size_t(it - ws_start);
 
-            const auto n = value.size();
+            static constexpr bool should_append = resizable<T> && Opts.append_arrays;
+            if constexpr (not should_append)
+            {
+               const auto n = value.size();
 
-            auto value_it = value.begin();
+               auto value_it = value.begin();
 
-            for (size_t i = 0; i < n; ++i) {
-               read<JSON>::op<ws_handled<Opts>()>(*value_it++, ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]]
-                  return;
-               GLZ_SKIP_WS();
-               if (*it == ',') {
-                  ++it;
-
-                  if constexpr (!Opts.minified) {
-                     if (ws_size && ws_size < size_t(end - it)) {
-                        skip_matching_ws(ws_start, it, ws_size);
-                     }
-                  }
-
+               for (size_t i = 0; i < n; ++i) {
+                  read<JSON>::op<ws_handled<Opts>()>(*value_it++, ctx, it, end);
+                  if (bool(ctx.error)) [[unlikely]]
+                     return;
                   GLZ_SKIP_WS();
-               }
-               else if (*it == ']') {
-                  GLZ_SUB_LEVEL;
-                  ++it;
-                  if constexpr (erasable<T>) {
-                     value.erase(value_it,
-                                 value.end()); // use erase rather than resize for non-default constructible elements
+                  if (*it == ',') {
+                     ++it;
 
-                     if constexpr (Opts.shrink_to_fit) {
-                        value.shrink_to_fit();
+                     if constexpr (!Opts.minified) {
+                        if (ws_size && ws_size < size_t(end - it)) {
+                           skip_matching_ws(ws_start, it, ws_size);
+                        }
                      }
+
+                     GLZ_SKIP_WS();
                   }
-                  return;
-               }
-               else [[unlikely]] {
-                  ctx.error = error_code::expected_bracket;
-                  return;
+                  else if (*it == ']') {
+                     GLZ_SUB_LEVEL;
+                     ++it;
+                     if constexpr (erasable<T>) {
+                        value.erase(value_it,
+                                    value.end()); // use erase rather than resize for non-default constructible elements
+
+                        if constexpr (Opts.shrink_to_fit) {
+                           value.shrink_to_fit();
+                        }
+                     }
+                     return;
+                  }
+                  else [[unlikely]] {
+                     ctx.error = error_code::expected_bracket;
+                     return;
+                  }
                }
             }
 

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -10141,6 +10141,50 @@ suite meta_keys_for_struct = [] {
    };
 };
 
+struct append_obj
+{
+   std::vector<std::string> names{};
+   std::vector<std::array<int, 2>> arrays{};
+};
+
+template <>
+struct glz::meta<append_obj>
+{
+   using T = append_obj;
+   static constexpr auto value = object("names", append_arrays<&T::names>, "arrays", append_arrays<&T::arrays>);
+};
+
+suite append_arrays_tests = [] {
+   "append_arrays vector"_test = [] {
+      std::vector<int> v{};
+      constexpr glz::opts append_opts{.append_arrays = true};
+      expect(not glz::read<append_opts>(v, "[1,2,3]"));
+      expect(v == std::vector<int>{1,2,3});
+      expect(not glz::read<append_opts>(v, "[4,5,6]"));
+      expect(v == std::vector<int>{1,2,3,4,5,6});
+   };
+   
+   "append_arrays deque"_test = [] {
+      std::deque<int> v{};
+      constexpr glz::opts append_opts{.append_arrays = true};
+      expect(not glz::read<append_opts>(v, "[1,2,3]"));
+      expect(v == std::deque<int>{1,2,3});
+      expect(not glz::read<append_opts>(v, "[4,5,6]"));
+      expect(v == std::deque<int>{1,2,3,4,5,6});
+   };
+   
+   "append_arrays append_obj"_test = [] {
+      append_obj obj{};
+      expect(not glz::read_json(obj, R"({"names":["Bob"],"arrays":[[0,0]]})"));
+      expect(obj.names == std::vector<std::string>{"Bob"});
+      expect(obj.arrays == std::vector<std::array<int, 2>>{{0,0}});
+      
+      expect(not glz::read_json(obj, R"({"names":["Liz"],"arrays":[[1,1]]})"));
+      expect(obj.names == std::vector<std::string>{"Bob", "Liz"});
+      expect(obj.arrays == std::vector<std::array<int, 2>>{{0,0},{1,1}});
+   };
+};
+
 int main()
 {
    trace.end("json_test");


### PR DESCRIPTION
Adds the compile time option (and wrapper) `append_arrays` to append data to types like `std::vector` rather than overwrite.

Addresses: #1548 
