### PR TITLE
Fix wrong begin/end indices in get_name

### DIFF
--- a/include/glaze/reflection/get_name.hpp
+++ b/include/glaze/reflection/get_name.hpp
@@ -21,8 +21,10 @@
 namespace glz::detail
 {
    // Do not const qualify this value to avoid duplicate `to_tie` template instantiations with rest of Glaze
+   // Temporary fix: const qualify it despite. Caused issues with reflect begin/end indices
+   // See https://github.com/stephenberry/glaze/issues/1568
    template <class T>
-   extern T external;
+   extern const T external;
 
    // using const char* simplifies the complier's output and should improve compile times
    template <auto Ptr>


### PR DESCRIPTION
Reverts a line change introduced in https://github.com/stephenberry/glaze/pull/1514.
Fixes #1568