### PR TITLE
reflect: fix uint16 compile error in find_unique_sized_index

### DIFF
--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -819,7 +819,7 @@ namespace glz::detail
          const auto& s = strings[i];
          // for each character in the string
          for (size_t c = 0; c < min_length; ++c) {
-            const auto k = uint16_t(s[c]) | (uint16_t(s.size()) << 8);
+            const auto k = uint16_t(uint16_t(s[c]) | (uint16_t(s.size()) << 8));
             cols[c].emplace_back(k);
          }
       }


### PR DESCRIPTION
The left-shift operator causes integer promotion which results in compiler errors on msvc with all warnings enabled.

This is just a quick fix, it might be possible to do the cast on the right hand side of the OR?