### PR TITLE
Fix mismatch create function (missing noexcept)

### DIFF
--- a/include/glaze/api/lib.hpp
+++ b/include/glaze/api/lib.hpp
@@ -45,7 +45,7 @@ namespace glz
 
    struct lib_loader final
    {
-      using create = glz::iface_fn (*)(void);
+      using create = glz::iface_fn (*)(void) noexcept;
 
       iface api_map{};
       std::vector<lib_t> loaded_libs{};


### PR DESCRIPTION
https://github.com/stephenberry/glaze/issues/1586#issuecomment-2638672566 points out an undefined behavior problem because function pointer signatures do not match. I believe the issue was a missing `noexcept` on the library loader side, which this fixes.