### PR TITLE
Static str

### DIFF
--- a/include/glaze/concepts/container_concepts.hpp
+++ b/include/glaze/concepts/container_concepts.hpp
@@ -67,15 +67,6 @@ namespace glz
 
    template <class Buffer>
    concept non_const_buffer = !std::is_const_v<Buffer>;
-
-   namespace detail
-   {
-      template <class T>
-      struct is_static_helper: std::false_type {};
-   }
-
-   template <class T>
-   concept is_static = detail::is_static_helper<T>::value;
 }
 
 namespace glz::detail

--- a/include/glaze/concepts/container_concepts.hpp
+++ b/include/glaze/concepts/container_concepts.hpp
@@ -68,11 +68,14 @@ namespace glz
    template <class Buffer>
    concept non_const_buffer = !std::is_const_v<Buffer>;
 
-   template <class T>
-   struct is_static_helper: std::false_type {};
+   namespace detail
+   {
+      template <class T>
+      struct is_static_helper: std::false_type {};
+   }
 
    template <class T>
-   concept is_static = is_static_helper<T>::value;
+   concept is_static = detail::is_static_helper<T>::value;
 }
 
 namespace glz::detail

--- a/include/glaze/concepts/container_concepts.hpp
+++ b/include/glaze/concepts/container_concepts.hpp
@@ -43,9 +43,6 @@ namespace glz
    concept has_size = requires(T v) { v.size(); };
 
    template <class T>
-   concept has_max_size = requires(T v) { v.max_size(); };
-
-   template <class T>
    concept has_empty = requires(T v) {
       {
          v.empty()
@@ -64,6 +61,10 @@ namespace glz
          t.capacity()
       } -> std::integral;
    };
+
+   template <class T>
+   concept has_max_capacity = requires(T v) { v.max_capacity(); };
+
 
    template <class T>
    concept contiguous = has_size<T> && has_data<T>;

--- a/include/glaze/concepts/container_concepts.hpp
+++ b/include/glaze/concepts/container_concepts.hpp
@@ -63,14 +63,16 @@ namespace glz
    };
 
    template <class T>
-   concept has_max_capacity = requires(T v) { v.max_capacity(); };
-
-
-   template <class T>
    concept contiguous = has_size<T> && has_data<T>;
 
    template <class Buffer>
    concept non_const_buffer = !std::is_const_v<Buffer>;
+
+   template <class T>
+   struct is_static_helper: std::false_type {};
+
+   template <class T>
+   concept is_static = is_static_helper<T>::value;
 }
 
 namespace glz::detail

--- a/include/glaze/concepts/container_concepts.hpp
+++ b/include/glaze/concepts/container_concepts.hpp
@@ -43,6 +43,9 @@ namespace glz
    concept has_size = requires(T v) { v.size(); };
 
    template <class T>
+   concept has_max_size = requires(T v) { v.max_size(); };
+
+   template <class T>
    concept has_empty = requires(T v) {
       {
          v.empty()

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -239,10 +239,16 @@ namespace glz
          (!std::same_as<std::nullptr_t, T> && std::constructible_from<std::string_view, std::decay_t<T>>) ||
          array_char_t<T>;
 
+      // static string; not resizable
+      template <class T>
+      concept static_str_t =
+       str_t<T> && !string_view_t<T> && has_assign<T> && has_max_size<T>;
+
       // this concept requires that T is a writeable string. It can be resized, appended to, or assigned to
       template <class T>
       concept string_t =
-         str_t<T> && !string_view_t<T> && (has_assign<T> || (resizable<T> && has_data<T>) || has_append<T>);
+       str_t<T> && !string_view_t<T> &&
+                         (has_assign<T> || (resizable<T> && has_data<T>) || has_append<T>) && !has_max_size<T>;
 
       template <class T>
       concept char_array_t = str_t<T> && std::is_array_v<std::remove_pointer_t<std::remove_reference_t<T>>>;

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -239,17 +239,20 @@ namespace glz
          (!std::same_as<std::nullptr_t, T> && std::constructible_from<std::string_view, std::decay_t<T>>) ||
          array_char_t<T>;
 
+      template <class T>
+      concept is_static_string = requires { meta<std::decay_t<T>>::glaze_static_string == true; } || std::decay_t<T>::glaze_static_string == true ;
+
       // this concept requires that T is a writeable string. It can be resized, appended to, or assigned to
       template <class T>
       concept string_t =
        str_t<T> && !string_view_t<T> &&
-                         (has_assign<T> || (resizable<T> && has_data<T>) || has_append<T>) && !is_static<T>;
+                         (has_assign<T> || (resizable<T> && has_data<T>) || has_append<T>) && !is_static_string<T>;
 
       // static string; very like `string_t`, but with a fixed max capacity
       template <class T>
-      concept static_str_t =
+      concept static_string_t =
        str_t<T> && !string_view_t<T> &&
-                         (has_assign<T> || (resizable<T> && has_data<T>) || has_append<T>) && is_static<T>;
+                         (has_assign<T> || (resizable<T> && has_data<T>) || has_append<T>) && is_static_string<T>;
 
       template <class T>
       concept char_array_t = str_t<T> && std::is_array_v<std::remove_pointer_t<std::remove_reference_t<T>>>;

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -239,16 +239,17 @@ namespace glz
          (!std::same_as<std::nullptr_t, T> && std::constructible_from<std::string_view, std::decay_t<T>>) ||
          array_char_t<T>;
 
-      // static string
-      template <class T>
-      concept static_str_t =
-       str_t<T> && !string_view_t<T> && has_assign<T> && is_static<T>;
-
       // this concept requires that T is a writeable string. It can be resized, appended to, or assigned to
       template <class T>
       concept string_t =
        str_t<T> && !string_view_t<T> &&
                          (has_assign<T> || (resizable<T> && has_data<T>) || has_append<T>) && !is_static<T>;
+
+      // static string; very like `string_t`, but with a fixed max capacity
+      template <class T>
+      concept static_str_t =
+       str_t<T> && !string_view_t<T> &&
+                         (has_assign<T> || (resizable<T> && has_data<T>) || has_append<T>) && is_static<T>;
 
       template <class T>
       concept char_array_t = str_t<T> && std::is_array_v<std::remove_pointer_t<std::remove_reference_t<T>>>;

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -242,13 +242,13 @@ namespace glz
       // static string
       template <class T>
       concept static_str_t =
-       str_t<T> && !string_view_t<T> && has_assign<T> && has_max_capacity<T>;
+       str_t<T> && !string_view_t<T> && has_assign<T> && is_static<T>;
 
       // this concept requires that T is a writeable string. It can be resized, appended to, or assigned to
       template <class T>
       concept string_t =
        str_t<T> && !string_view_t<T> &&
-                         (has_assign<T> || (resizable<T> && has_data<T>) || has_append<T>) && !has_max_capacity<T>;
+                         (has_assign<T> || (resizable<T> && has_data<T>) || has_append<T>) && !is_static<T>;
 
       template <class T>
       concept char_array_t = str_t<T> && std::is_array_v<std::remove_pointer_t<std::remove_reference_t<T>>>;

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -239,7 +239,7 @@ namespace glz
          (!std::same_as<std::nullptr_t, T> && std::constructible_from<std::string_view, std::decay_t<T>>) ||
          array_char_t<T>;
 
-      // static string; not resizable
+      // static string
       template <class T>
       concept static_str_t =
        str_t<T> && !string_view_t<T> && has_assign<T> && has_max_capacity<T>;

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -242,13 +242,13 @@ namespace glz
       // static string; not resizable
       template <class T>
       concept static_str_t =
-       str_t<T> && !string_view_t<T> && has_assign<T> && has_max_size<T>;
+       str_t<T> && !string_view_t<T> && has_assign<T> && has_max_capacity<T>;
 
       // this concept requires that T is a writeable string. It can be resized, appended to, or assigned to
       template <class T>
       concept string_t =
        str_t<T> && !string_view_t<T> &&
-                         (has_assign<T> || (resizable<T> && has_data<T>) || has_append<T>) && !has_max_size<T>;
+                         (has_assign<T> || (resizable<T> && has_data<T>) || has_append<T>) && !has_max_capacity<T>;
 
       template <class T>
       concept char_array_t = str_t<T> && std::is_array_v<std::remove_pointer_t<std::remove_reference_t<T>>>;

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -987,7 +987,7 @@ namespace glz
       };
 
       template <class T>
-         requires(string_view_t<T> || char_array_t<T> || array_char_t<T> || static_str_t<T>)
+         requires(string_view_t<T> || char_array_t<T> || array_char_t<T> || static_string_t<T>)
       struct from<JSON, T>
       {
          template <auto Opts, class It, class End>
@@ -1027,7 +1027,7 @@ namespace glz
                }
                std::memcpy(value.data(), start, n);
                value[n] = '\0';
-            } else if constexpr (static_str_t<T>) {
+            } else if constexpr (static_string_t<T>) {
                const size_t n = it - start;
                if (n > value.size()) {
                   ctx.error = error_code::unexpected_end;

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1029,7 +1029,7 @@ namespace glz
                value[n] = '\0';
             } else if constexpr (static_str_t<T>) {
                const size_t n = it - start;
-               if ((n + 1) > value.max_size()) {
+               if (n > value.max_capacity()) {
                   ctx.error = error_code::unexpected_end;
                   return;
                }

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1029,7 +1029,7 @@ namespace glz
                value[n] = '\0';
             } else if constexpr (static_str_t<T>) {
                const size_t n = it - start;
-               if (n > value.max_capacity()) {
+               if (n > value.size()) {
                   ctx.error = error_code::unexpected_end;
                   return;
                }

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -987,7 +987,7 @@ namespace glz
       };
 
       template <class T>
-         requires(string_view_t<T> || char_array_t<T> || array_char_t<T>)
+         requires(string_view_t<T> || char_array_t<T> || array_char_t<T> || static_str_t<T>)
       struct from<JSON, T>
       {
          template <auto Opts, class It, class End>
@@ -1027,6 +1027,13 @@ namespace glz
                }
                std::memcpy(value.data(), start, n);
                value[n] = '\0';
+            } else if constexpr (static_str_t<T>) {
+               const size_t n = it - start;
+               if ((n + 1) > value.max_size()) {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
+               value.assign(start, n);
             }
             ++it; // skip closing quote
             GLZ_VALID_END();

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -9749,16 +9749,17 @@ struct naive_static_str_t
 
    naive_static_str_t() = default;
    naive_static_str_t(std::string_view sv) { assign(sv.data(), sv.size()); }
-   operator std::string_view() const { return std::string_view(data, length); }
+   operator std::string_view() const { return std::string_view(buffer, length); }
 
    size_t size() const { return N; }
    size_t capacity() const { return N; }
+   const char* data() const { return buffer; }
 
    naive_static_str_t& assign(const char* v, size_t sz)
    {
       const auto bytes_to_copy = std::min(N, sz);
       length = bytes_to_copy;
-      memcpy(data, v, bytes_to_copy);
+      memcpy(buffer, v, bytes_to_copy);
       return *this;
    }
 
@@ -9769,7 +9770,7 @@ struct naive_static_str_t
    }
 
    size_t length{};
-   char data[N]{};
+   char buffer[N]{};
 };
 
 template <size_t N>

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -9747,9 +9747,9 @@ struct naive_static_str_t
    using size_type = size_t;
 
    size_t size{};
-   char data[N + 1]{};
+   char data[N]{};
 
-   size_t max_size() const { return N; }
+   size_t max_capacity() const { return N; }
 
    naive_static_str_t() = default;
    naive_static_str_t(std::string_view sv) { assign(sv.data(), sv.size()); }
@@ -9773,16 +9773,23 @@ struct naive_static_str_t
 };
    static_assert(std::constructible_from<std::string_view, std::decay_t<naive_static_str_t<3>>>);
    static_assert(glz::detail::has_assign<naive_static_str_t<3>>);
-   static_assert(glz::has_max_size<naive_static_str_t<3>>);
+   static_assert(glz::has_max_capacity<naive_static_str_t<3>>);
    static_assert(glz::detail::static_str_t<naive_static_str_t<3>>);
 
-suite static_string_tests = [] {
-   "static_string<N> value"_test = [] {
+suite static_str_tests = [] {
+   "static_str<N> value"_test = [] {
       naive_static_str_t<6> value{};
       expect(not glz::read_json(value, R"("hello")"));
       expect(std::string_view{value} == "hello");
       expect(glz::write_json(value).value_or("error") == R"("hello")");
-      expect(glz::read_json(value, R"("hello---too long")"));
+
+      expect(not glz::read_json(value, R"("hello!")"));
+      expect(std::string_view{value} == "hello!");
+      expect(glz::write_json(value).value_or("error") == R"("hello!")");
+
+      // too long!!
+      expect(glz::read_json(value, R"("hello!!")"));
+
       expect(not glz::read_json(value, R"("bye")"));
       expect(std::string_view{value} == "bye");
    };

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -9741,21 +9741,21 @@ suite array_char_tests = [] {
 };
 
 template <size_t N>
-struct naive_static_str_t
+struct naive_static_string_t
 {
    using value_type = char;
    using size_type = size_t;
 
 
-   naive_static_str_t() = default;
-   naive_static_str_t(std::string_view sv) { assign(sv.data(), sv.size()); }
+   naive_static_string_t() = default;
+   naive_static_string_t(std::string_view sv) { assign(sv.data(), sv.size()); }
    operator std::string_view() const { return std::string_view(buffer, length); }
 
    size_t size() const { return N; }
    size_t capacity() const { return N; }
    const char* data() const { return buffer; }
 
-   naive_static_str_t& assign(const char* v, size_t sz)
+   naive_static_string_t& assign(const char* v, size_t sz)
    {
       const auto bytes_to_copy = std::min(N, sz);
       length = bytes_to_copy;
@@ -9774,16 +9774,18 @@ struct naive_static_str_t
 };
 
 template <size_t N>
-struct glz::detail::is_static_helper<naive_static_str_t<N>>: std::true_type{};
+struct glz::meta<naive_static_string_t<N>> {
+ static constexpr auto glaze_static_string = true;
+};
 
-static_assert(std::constructible_from<std::string_view, std::decay_t<naive_static_str_t<3>>>);
-static_assert(glz::detail::has_assign<naive_static_str_t<3>>);
-static_assert(glz::is_static<naive_static_str_t<3>>);
-static_assert(glz::detail::static_str_t<naive_static_str_t<3>>);
+static_assert(std::constructible_from<std::string_view, std::decay_t<naive_static_string_t<3>>>);
+static_assert(glz::detail::has_assign<naive_static_string_t<3>>);
+static_assert(glz::detail::is_static_string<naive_static_string_t<3>>);
+static_assert(glz::detail::static_string_t<naive_static_string_t<3>>);
 
-suite static_str_tests = [] {
+suite static_string_tests = [] {
    "static_str<N> value"_test = [] {
-      naive_static_str_t<6> value{};
+      naive_static_string_t<6> value{};
       expect(not glz::read_json(value, R"("hello")"));
       expect(std::string_view{value} == "hello");
       expect(glz::write_json(value).value_or("error") == R"("hello")");


### PR DESCRIPTION
There is a special kind of string, `static_string`, which behaves almost same as 'std::string' except that it has a fixed capacity. This kind of string is used for better performance, for it usually uses compile-fixed buffers and is POD. Here is an example, [boost.static_string](https://github.com/boostorg/static_string).

When applying `static_string` in glaze, however, thery are usually recognized as `string_t`. When we try to read `static_string` in glaze, an optimization `static constexpr auto string_padding_bytes = 8;` tryies to reserve extra memories for alignment, which may exceed the capacity of the 'static_string'. These behavior will cause some undefined behaviors and the program will crash.

In this PR, I try to show the usage of 'static_string' and fix this issue.