### PR TITLE
Generic supported concepts

### DIFF
--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -1546,13 +1546,15 @@ namespace glz
       };
    }
 
-   template <read_beve_supported T, class Buffer>
+   template <class T, class Buffer>
+   requires (read_supported<BEVE, T>)
    [[nodiscard]] inline error_ctx read_beve(T&& value, Buffer&& buffer)
    {
       return read<opts{.format = BEVE}>(value, std::forward<Buffer>(buffer));
    }
 
-   template <read_beve_supported T, class Buffer>
+   template <class T, class Buffer>
+   requires (read_supported<BEVE, T>)
    [[nodiscard]] inline expected<T, error_ctx> read_beve(Buffer&& buffer)
    {
       T value{};
@@ -1563,7 +1565,8 @@ namespace glz
       return value;
    }
 
-   template <opts Opts = opts{}, read_beve_supported T>
+   template <opts Opts = opts{}, class T>
+   requires (read_supported<BEVE, T>)
    [[nodiscard]] inline error_ctx read_file_beve(T& value, const sv file_name, auto&& buffer)
    {
       context ctx{};
@@ -1578,14 +1581,16 @@ namespace glz
       return read<set_beve<Opts>()>(value, buffer, ctx);
    }
 
-   template <read_beve_supported T, class Buffer>
+   template <class T, class Buffer>
+   requires (read_supported<BEVE, T>)
    [[nodiscard]] inline error_ctx read_binary_untagged(T&& value, Buffer&& buffer)
    {
       return read<opts{.format = BEVE, .structs_as_arrays = true}>(std::forward<T>(value),
                                                                    std::forward<Buffer>(buffer));
    }
 
-   template <read_beve_supported T, class Buffer>
+   template <class T, class Buffer>
+   requires (read_supported<BEVE, T>)
    [[nodiscard]] inline expected<T, error_ctx> read_binary_untagged(Buffer&& buffer)
    {
       T value{};
@@ -1596,7 +1601,8 @@ namespace glz
       return value;
    }
 
-   template <opts Opts = opts{}, read_beve_supported T>
+   template <opts Opts = opts{}, class T>
+   requires (read_supported<BEVE, T>)
    [[nodiscard]] inline error_ctx read_file_beve_untagged(T& value, const std::string& file_name, auto&& buffer)
    {
       return read_file_beve<opt_true<Opts, &opts::structs_as_arrays>>(value, file_name, buffer);

--- a/include/glaze/beve/write.hpp
+++ b/include/glaze/beve/write.hpp
@@ -910,26 +910,30 @@ namespace glz
       };
    }
 
-   template <write_beve_supported T, class Buffer>
+   template <class T, class Buffer>
+   requires (write_supported<BEVE, T>)
    [[nodiscard]] error_ctx write_beve(T&& value, Buffer&& buffer)
    {
       return write<opts{.format = BEVE}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <opts Opts = opts{}, write_beve_supported T>
+   template <opts Opts = opts{}, class T>
+   requires (write_supported<BEVE, T>)
    [[nodiscard]] glz::expected<std::string, error_ctx> write_beve(T&& value)
    {
       return write<set_beve<Opts>()>(std::forward<T>(value));
    }
 
-   template <auto& Partial, write_beve_supported T, class Buffer>
+   template <auto& Partial, class T, class Buffer>
+   requires (write_supported<BEVE, T>)
    [[nodiscard]] error_ctx write_beve(T&& value, Buffer&& buffer)
    {
       return write<Partial, opts{.format = BEVE}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
    // requires file_name to be null terminated
-   template <opts Opts = opts{}, write_beve_supported T>
+   template <opts Opts = opts{}, class T>
+   requires (write_supported<BEVE, T>)
    [[nodiscard]] error_ctx write_file_beve(T&& value, const sv file_name, auto&& buffer)
    {
       static_assert(sizeof(decltype(*buffer.data())) == 1);
@@ -951,20 +955,23 @@ namespace glz
       return {};
    }
 
-   template <write_beve_supported T, class Buffer>
+   template <class T, class Buffer>
+   requires (write_supported<BEVE, T>)
    [[nodiscard]] error_ctx write_beve_untagged(T&& value, Buffer&& buffer)
    {
       return write<opts{.format = BEVE, .structs_as_arrays = true}>(std::forward<T>(value),
                                                                     std::forward<Buffer>(buffer));
    }
 
-   template <write_beve_supported T>
+   template <class T>
+   requires (write_supported<BEVE, T>)
    [[nodiscard]] error_ctx write_beve_untagged(T&& value)
    {
       return write<opts{.format = BEVE, .structs_as_arrays = true}>(std::forward<T>(value));
    }
 
-   template <opts Opts = opts{}, write_beve_supported T>
+   template <opts Opts = opts{}, class T>
+   requires (write_supported<BEVE, T>)
    [[nodiscard]] error_ctx write_file_beve_untagged(T&& value, const std::string& file_name, auto&& buffer)
    {
       return write_file_beve<opt_true<Opts, &opts::structs_as_arrays>>(std::forward<T>(value), file_name, buffer);

--- a/include/glaze/core/feature_test.hpp
+++ b/include/glaze/core/feature_test.hpp
@@ -5,6 +5,10 @@
 
 // Glaze Feature Test Macros
 
+// v5.0.0 moves to more generic read_supported and write_supported concepts
+// removes concepts like `read_json_supported` and uses `read_supported<JSON, T>`
+#define glaze_v5_0_0_generic_supported
+
 // v4.3.0 removed global glz::trace
 #define glaze_v4_3_0_trace
 

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -10,6 +10,8 @@
 namespace glz
 {
    // format
+   // Built in formats must be less than 65536
+   // User defined formats can be 65536 to 4294967296
    inline constexpr uint32_t INVALID = 0;
    inline constexpr uint32_t BEVE = 1;
    inline constexpr uint32_t JSON = 10;

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -341,85 +341,9 @@ namespace glz
       struct skip_value;
    }
 
-   template <class T>
-   concept write_beve_supported = requires { detail::to<BEVE, std::remove_cvref_t<T>>{}; };
-
-   template <class T>
-   concept read_beve_supported = requires { detail::from<BEVE, std::remove_cvref_t<T>>{}; };
-
-   template <class T>
-   concept write_json_supported = requires { detail::to<JSON, std::remove_cvref_t<T>>{}; };
-
-   template <class T>
-   concept read_json_supported = requires { detail::from<JSON, std::remove_cvref_t<T>>{}; };
-
-   template <class T>
-   concept write_ndjson_supported = requires { detail::to<NDJSON, std::remove_cvref_t<T>>{}; };
-
-   template <class T>
-   concept read_ndjson_supported = requires { detail::from<NDJSON, std::remove_cvref_t<T>>{}; };
-
-   template <class T>
-   concept write_toml_supported = requires { detail::to<TOML, std::remove_cvref_t<T>>{}; };
-
-   template <class T>
-   concept read_toml_supported = requires { detail::from<TOML, std::remove_cvref_t<T>>{}; };
-
-   template <class T>
-   concept write_csv_supported = requires { detail::to<CSV, std::remove_cvref_t<T>>{}; };
-
-   template <class T>
-   concept read_csv_supported = requires { detail::from<CSV, std::remove_cvref_t<T>>{}; };
+   template <uint32_t Format, class T>
+   concept write_supported = requires { detail::to<Format, std::remove_cvref_t<T>>{}; };
 
    template <uint32_t Format, class T>
-   consteval bool write_format_supported()
-   {
-      if constexpr (Format == BEVE) {
-         return write_beve_supported<T>;
-      }
-      else if constexpr (Format == JSON) {
-         return write_json_supported<T>;
-      }
-      else if constexpr (Format == NDJSON) {
-         return write_ndjson_supported<T>;
-      }
-      else if constexpr (Format == TOML) {
-         return write_toml_supported<T>;
-      }
-      else if constexpr (Format == CSV) {
-         return write_csv_supported<T>;
-      }
-      else {
-         static_assert(false_v<T>, "Glaze metadata is probably needed for your type");
-      }
-   }
-
-   template <uint32_t Format, class T>
-   consteval bool read_format_supported()
-   {
-      if constexpr (Format == BEVE) {
-         return read_beve_supported<T>;
-      }
-      else if constexpr (Format == JSON) {
-         return read_json_supported<T>;
-      }
-      else if constexpr (Format == NDJSON) {
-         return read_ndjson_supported<T>;
-      }
-      else if constexpr (Format == TOML) {
-         return read_toml_supported<T>;
-      }
-      else if constexpr (Format == CSV) {
-         return read_csv_supported<T>;
-      }
-      else {
-         static_assert(false_v<T>, "Glaze metadata is probably needed for your type");
-      }
-   }
-
-   template <uint32_t Format, class T>
-   concept write_supported = write_format_supported<Format, T>();
-
-   template <uint32_t Format, class T>
-   concept read_supported = read_format_supported<Format, T>();
+   concept read_supported = requires { detail::from<Format, std::remove_cvref_t<T>>{}; };
 }

--- a/include/glaze/csv/read.hpp
+++ b/include/glaze/csv/read.hpp
@@ -649,13 +649,15 @@ namespace glz
       };
    }
 
-   template <uint32_t layout = rowwise, read_csv_supported T, class Buffer>
+   template <uint32_t layout = rowwise, class T, class Buffer>
+   requires (read_supported<CSV, T>)
    [[nodiscard]] inline auto read_csv(T&& value, Buffer&& buffer)
    {
       return read<opts{.format = CSV, .layout = layout}>(value, std::forward<Buffer>(buffer));
    }
 
-   template <uint32_t layout = rowwise, read_csv_supported T, class Buffer>
+   template <uint32_t layout = rowwise, class T, class Buffer>
+   requires (read_supported<CSV, T>)
    [[nodiscard]] inline auto read_csv(Buffer&& buffer)
    {
       T value{};
@@ -663,7 +665,8 @@ namespace glz
       return value;
    }
 
-   template <uint32_t layout = rowwise, read_csv_supported T, is_buffer Buffer>
+   template <uint32_t layout = rowwise, class T, is_buffer Buffer>
+   requires (read_supported<CSV, T>)
    [[nodiscard]] inline error_ctx read_file_csv(T& value, const sv file_name, Buffer&& buffer)
    {
       context ctx{};

--- a/include/glaze/csv/write.hpp
+++ b/include/glaze/csv/write.hpp
@@ -331,19 +331,22 @@ namespace glz
       };
    }
 
-   template <uint32_t layout = rowwise, write_csv_supported T, class Buffer>
+   template <uint32_t layout = rowwise, class T, class Buffer>
+   requires (write_supported<CSV, T>)
    [[nodiscard]] auto write_csv(T&& value, Buffer&& buffer)
    {
       return write<opts{.format = CSV, .layout = layout}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <uint32_t layout = rowwise, write_csv_supported T>
+   template <uint32_t layout = rowwise, class T>
+   requires (write_supported<CSV, T>)
    [[nodiscard]] expected<std::string, error_ctx> write_csv(T&& value)
    {
       return write<opts{.format = CSV, .layout = layout}>(std::forward<T>(value));
    }
 
-   template <uint32_t layout = rowwise, write_csv_supported T>
+   template <uint32_t layout = rowwise, class T>
+   requires (write_supported<CSV, T>)
    [[nodiscard]] error_ctx write_file_csv(T&& value, const std::string& file_name, auto&& buffer)
    {
       const auto ec = write<opts{.format = CSV, .layout = layout}>(std::forward<T>(value), buffer);

--- a/include/glaze/json/json_t.hpp
+++ b/include/glaze/json/json_t.hpp
@@ -348,7 +348,8 @@ namespace glz
       }
    }
 
-   template <read_json_supported T>
+   template <class T>
+      requires (read_supported<JSON, T>)
    [[nodiscard]] error_ctx read_json(T& value, const json_t& source)
    {
       auto buffer = source.dump();
@@ -360,7 +361,8 @@ namespace glz
       }
    }
 
-   template <read_json_supported T>
+   template <class T>
+      requires (read_supported<JSON, T>)
    [[nodiscard]] expected<T, error_ctx> read_json(const json_t& source)
    {
       auto buffer = source.dump();

--- a/include/glaze/json/ndjson.hpp
+++ b/include/glaze/json/ndjson.hpp
@@ -257,14 +257,16 @@ namespace glz
       };
    } // namespace detail
 
-   template <read_ndjson_supported T, class Buffer>
+   template <class T, class Buffer>
+   requires (read_supported<NDJSON, T>)
    [[nodiscard]] auto read_ndjson(T& value, Buffer&& buffer)
    {
       context ctx{};
       return read<opts{.format = NDJSON}>(value, std::forward<Buffer>(buffer), ctx);
    }
 
-   template <read_ndjson_supported T, class Buffer>
+   template <class T, class Buffer>
+   requires (read_supported<NDJSON, T>)
    [[nodiscard]] expected<T, error_ctx> read_ndjson(Buffer&& buffer)
    {
       T value{};
@@ -276,7 +278,8 @@ namespace glz
       return unexpected(ec);
    }
 
-   template <auto Opts = opts{.format = NDJSON}, read_ndjson_supported T>
+   template <auto Opts = opts{.format = NDJSON}, class T>
+   requires (read_supported<NDJSON, T>)
    [[nodiscard]] error_ctx read_file_ndjson(T& value, const sv file_name)
    {
       context ctx{};
@@ -293,19 +296,22 @@ namespace glz
       return read<Opts>(value, buffer, ctx);
    }
 
-   template <write_ndjson_supported T, class Buffer>
+   template <class T, class Buffer>
+   requires (write_supported<NDJSON, T>)
    [[nodiscard]] error_ctx write_ndjson(T&& value, Buffer&& buffer)
    {
       return write<opts{.format = NDJSON}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <write_ndjson_supported T>
+   template <class T>
+   requires (write_supported<NDJSON, T>)
    [[nodiscard]] expected<std::string, error_ctx> write_ndjson(T&& value)
    {
       return write<opts{.format = NDJSON}>(std::forward<T>(value));
    }
 
-   template <write_ndjson_supported T>
+   template <class T>
+   requires (write_supported<NDJSON, T>)
    [[nodiscard]] error_ctx write_file_ndjson(T&& value, const std::string& file_name, auto&& buffer)
    {
       write<opts{.format = NDJSON}>(std::forward<T>(value), buffer);

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -3245,14 +3245,16 @@ namespace glz
          skip_value, std::forward<Buffer>(buffer), ctx);
    }
 
-   template <read_json_supported T, is_buffer Buffer>
+   template <class T, is_buffer Buffer>
+   requires (read_supported<JSON, T>)
    [[nodiscard]] error_ctx read_json(T& value, Buffer&& buffer)
    {
       context ctx{};
       return read<opts{}>(value, std::forward<Buffer>(buffer), ctx);
    }
 
-   template <read_json_supported T, is_buffer Buffer>
+   template <class T, is_buffer Buffer>
+   requires (read_supported<JSON, T>)
    [[nodiscard]] expected<T, error_ctx> read_json(Buffer&& buffer)
    {
       T value{};
@@ -3264,14 +3266,16 @@ namespace glz
       return value;
    }
 
-   template <read_json_supported T, is_buffer Buffer>
+   template <class T, is_buffer Buffer>
+   requires (read_supported<JSON, T>)
    [[nodiscard]] error_ctx read_jsonc(T& value, Buffer&& buffer)
    {
       context ctx{};
       return read<opts{.comments = true}>(value, std::forward<Buffer>(buffer), ctx);
    }
 
-   template <read_json_supported T, is_buffer Buffer>
+   template <class T, is_buffer Buffer>
+   requires (read_supported<JSON, T>)
    [[nodiscard]] expected<T, error_ctx> read_jsonc(Buffer&& buffer)
    {
       T value{};
@@ -3283,7 +3287,8 @@ namespace glz
       return value;
    }
 
-   template <auto Opts = opts{}, read_json_supported T, is_buffer Buffer>
+   template <auto Opts = opts{}, class T, is_buffer Buffer>
+   requires (read_supported<JSON, T>)
    [[nodiscard]] error_ctx read_file_json(T& value, const sv file_name, Buffer&& buffer)
    {
       context ctx{};
@@ -3298,7 +3303,8 @@ namespace glz
       return read<set_json<Opts>()>(value, buffer, ctx);
    }
 
-   template <auto Opts = opts{}, read_json_supported T, is_buffer Buffer>
+   template <auto Opts = opts{}, class T, is_buffer Buffer>
+   requires (read_supported<JSON, T>)
    [[nodiscard]] error_ctx read_file_jsonc(T& value, const sv file_name, Buffer&& buffer)
    {
       context ctx{};

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1965,49 +1965,57 @@ namespace glz
       };
    } // namespace detail
 
-   template <write_json_supported T, output_buffer Buffer>
+   template <class T, output_buffer Buffer>
+   requires (write_supported<JSON, T>)
    [[nodiscard]] error_ctx write_json(T&& value, Buffer&& buffer)
    {
       return write<opts{}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <write_json_supported T, raw_buffer Buffer>
+   template <class T, raw_buffer Buffer>
+   requires (write_supported<JSON, T>)
    [[nodiscard]] glz::expected<size_t, error_ctx> write_json(T&& value, Buffer&& buffer)
    {
       return write<opts{}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <write_json_supported T>
+   template <class T>
+   requires (write_supported<JSON, T>)
    [[nodiscard]] glz::expected<std::string, error_ctx> write_json(T&& value)
    {
       return write<opts{}>(std::forward<T>(value));
    }
 
-   template <auto& Partial, write_json_supported T, output_buffer Buffer>
+   template <auto& Partial, class T, output_buffer Buffer>
+   requires (write_supported<JSON, T>)
    [[nodiscard]] error_ctx write_json(T&& value, Buffer&& buffer)
    {
       return write<Partial, opts{}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <auto& Partial, write_json_supported T, raw_buffer Buffer>
+   template <auto& Partial, class T, raw_buffer Buffer>
+   requires (write_supported<JSON, T>)
    [[nodiscard]] glz::expected<size_t, error_ctx> write_json(T&& value, Buffer&& buffer)
    {
       return write<Partial, opts{}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <write_json_supported T, class Buffer>
+   template <class T, class Buffer>
+   requires (write_supported<JSON, T>)
    [[nodiscard]] error_ctx write_jsonc(T&& value, Buffer&& buffer)
    {
       return write<opts{.comments = true}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <write_json_supported T>
+   template <class T>
+   requires (write_supported<JSON, T>)
    [[nodiscard]] glz::expected<std::string, error_ctx> write_jsonc(T&& value)
    {
       return write<opts{.comments = true}>(std::forward<T>(value));
    }
 
-   template <opts Opts = opts{}, write_json_supported T>
+   template <opts Opts = opts{}, class T>
+   requires (write_supported<JSON, T>)
    [[nodiscard]] error_ctx write_file_json(T&& value, const sv file_name, auto&& buffer)
    {
       const auto ec = write<set_json<Opts>()>(std::forward<T>(value), buffer);

--- a/include/glaze/toml/write.hpp
+++ b/include/glaze/toml/write.hpp
@@ -555,25 +555,29 @@ namespace glz
       };
    } // namespace detail
 
-   template <write_toml_supported T, output_buffer Buffer>
+   template <class T, output_buffer Buffer>
+   requires (write_supported<TOML, T>)
    [[nodiscard]] error_ctx write_toml(T&& value, Buffer&& buffer)
    {
       return write<opts{.format = TOML}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <write_toml_supported T, raw_buffer Buffer>
+   template <class T, raw_buffer Buffer>
+   requires (write_supported<TOML, T>)
    [[nodiscard]] glz::expected<size_t, error_ctx> write_toml(T&& value, Buffer&& buffer)
    {
       return write<opts{.format = TOML}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <write_toml_supported T>
+   template <class T>
+   requires (write_supported<TOML, T>)
    [[nodiscard]] glz::expected<std::string, error_ctx> write_toml(T&& value)
    {
       return write<opts{.format = TOML}>(std::forward<T>(value));
    }
 
-   template <opts Opts = opts{.format = TOML}, write_json_supported T>
+   template <opts Opts = opts{.format = TOML}, class T>
+   requires (write_supported<TOML, T>)
    [[nodiscard]] error_ctx write_file_toml(T&& value, const sv file_name, auto&& buffer)
    {
       const auto ec = write<set_toml<Opts>()>(std::forward<T>(value), buffer);

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -46,8 +46,8 @@ struct glz::meta<my_struct>
    );
 };
 
-static_assert(glz::write_beve_supported<my_struct>);
-static_assert(glz::read_beve_supported<my_struct>);
+static_assert(glz::write_supported<glz::BEVE, my_struct>);
+static_assert(glz::read_supported<glz::BEVE, my_struct>);
 
 struct sub_thing
 {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -61,8 +61,8 @@ struct glz::meta<my_struct>
    );
 };
 
-static_assert(glz::write_json_supported<my_struct>);
-static_assert(glz::read_json_supported<my_struct>);
+static_assert(glz::write_supported<glz::JSON, my_struct>);
+static_assert(glz::read_supported<glz::JSON, my_struct>);
 
 suite starter = [] {
    "example"_test = [] {


### PR DESCRIPTION
The format specific concepts like: `read_json_supported` and `write_beve_supported` added extra boilerplate and did not allow custom formats. This change removes these non-generic functions and simply uses:

```c++
template <uint32_t Format, class T>
concept write_supported = requires { detail::to<Format, std::remove_cvref_t<T>>{}; };

template <uint32_t Format, class T>
concept read_supported = requires { detail::from<Format, std::remove_cvref_t<T>>{}; };
```

This more generic solution simplifies the code and makes adding new formats cleaner and possible for users without needing to modify the main Glaze repository.

Requested in #1619, but also noticed when beginning to add TOML that this approach is bad, especially as the number of formats grows.