### PR TITLE
Remove forced reflection for top level structs in repe::registry

### DIFF
--- a/include/glaze/rpc/repe/registry.hpp
+++ b/include/glaze/rpc/repe/registry.hpp
@@ -214,7 +214,7 @@ namespace glz::repe
          }();
 
          if constexpr (parent == root && (glaze_object_t<T> ||
-                                          reflectable<T>)&&!std::same_as<std::decay_t<decltype(t)>, std::nullptr_t>) {
+                                          reflectable<T>)) {
             // build read/write calls to the top level object
             methods[root] = [&value](repe::state&& state) mutable {
                if (state.write()) {


### PR DESCRIPTION
This was blocking top level access to `glaze_object_t` structs, which had `glz::meta` defined.