### PR TITLE
Remove detail from specializations like to/from

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Glaze also supports:
 
 > [!IMPORTANT]
 >
-> Glaze `main` is currently in development for v5.0.0
+> Glaze `main` branch is currently in development for v5.0.0
 >
 > v5.0.0 will remove the `detail` namespace from `to/from` specializations and many more internal functions, which will enable cleaner user customization and shorter compilation error messages.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Glaze also supports:
 - [BEVE](https://github.com/beve-org/beve) (binary efficient versatile encoding)
 - [CSV](./docs/csv.md) (comma separated value)
 
+> [!IMPORTANT]
+>
+> Glaze `main` is currently in development for v5.0.0
+>
+> v5.0.0 will remove the `detail` namespace from `to/from` specializations and many more internal functions, which will enable cleaner user customization and shorter compilation error messages.
+
 ## With compile time reflection for MSVC, Clang, and GCC!
 
 - Read/write aggregate initializable structs without writing any metadata or macros!

--- a/include/glaze/api/impl.hpp
+++ b/include/glaze/api/impl.hpp
@@ -174,7 +174,7 @@ namespace glz
       decltype(auto) unwrap(T&& val)
       {
          using V = std::decay_t<T>;
-         if constexpr (detail::nullable_t<V>) {
+         if constexpr (nullable_t<V>) {
             if (val) {
                return unwrap(*val);
             }

--- a/include/glaze/api/trait.hpp
+++ b/include/glaze/api/trait.hpp
@@ -66,7 +66,7 @@ namespace glz
       static constexpr sv blank = ""; // to end possible macros
 
       static constexpr sv members = [] {
-         if constexpr (detail::glaze_object_t<T> || detail::reflectable<T>) {
+         if constexpr (glaze_object_t<T> || reflectable<T>) {
             return glz::name_v<detail::member_tuple_t<T>>;
          }
          else {

--- a/include/glaze/beve/beve_to_json.hpp
+++ b/include/glaze/beve/beve_to_json.hpp
@@ -14,7 +14,7 @@ namespace glz
       inline void beve_to_json_number(auto&& tag, auto&& ctx, auto&& it, auto&& end, auto& out, auto&& ix) noexcept
       {
          const auto number_type = (tag & 0b000'11'000) >> 3;
-         const uint8_t byte_count = detail::byte_count_lookup[tag >> 5];
+         const uint8_t byte_count = byte_count_lookup[tag >> 5];
 
          auto write_number = [&]<class T>(T&& value) {
             if ((it + sizeof(T)) > end) [[unlikely]] {
@@ -137,7 +137,7 @@ namespace glz
          }
          case tag::string: {
             ++it;
-            const auto n = detail::int_from_compressed(ctx, it, end);
+            const auto n = int_from_compressed(ctx, it, end);
             if (bool(ctx.error)) [[unlikely]] {
                return;
             }
@@ -173,13 +173,13 @@ namespace glz
             switch (key_type) {
             case 0: {
                // string key
-               const auto n_fields = detail::int_from_compressed(ctx, it, end);
+               const auto n_fields = int_from_compressed(ctx, it, end);
                if (bool(ctx.error)) {
                   return;
                }
                for (size_t i = 0; i < n_fields; ++i) {
                   // convert the key
-                  const auto n = detail::int_from_compressed(ctx, it, end);
+                  const auto n = int_from_compressed(ctx, it, end);
                   if (bool(ctx.error)) [[unlikely]] {
                      return;
                   }
@@ -212,7 +212,7 @@ namespace glz
                [[fallthrough]]; // signed integer key
             case 2: {
                // unsigned integer key
-               const auto n_fields = detail::int_from_compressed(ctx, it, end);
+               const auto n_fields = int_from_compressed(ctx, it, end);
                if (bool(ctx.error)) {
                   return;
                }
@@ -262,7 +262,7 @@ namespace glz
          case tag::typed_array: {
             ++it;
             const auto value_type = (tag & 0b000'11'000) >> 3;
-            const uint8_t byte_count = detail::byte_count_lookup[tag >> 5];
+            const uint8_t byte_count = byte_count_lookup[tag >> 5];
 
             auto write_array = [&]<class T>(T&& value) {
                const auto n = int_from_compressed(ctx, it, end);
@@ -373,7 +373,7 @@ namespace glz
                      return;
                   }
                   for (size_t i = 0; i < n_strings; ++i) {
-                     const auto n = detail::int_from_compressed(ctx, it, end);
+                     const auto n = int_from_compressed(ctx, it, end);
                      if (bool(ctx.error)) [[unlikely]] {
                         return;
                      }

--- a/include/glaze/beve/header.hpp
+++ b/include/glaze/beve/header.hpp
@@ -13,7 +13,7 @@
 #include "glaze/core/context.hpp"
 #include "glaze/util/inline.hpp"
 
-namespace glz::detail
+namespace glz
 {
    GLZ_ALWAYS_INLINE bool invalid_end(is_context auto& ctx, auto&& it, auto&& end) noexcept
    {
@@ -60,7 +60,7 @@ namespace glz::tag
    constexpr uint8_t f128 = 0b100'00'001;
 }
 
-namespace glz::detail
+namespace glz
 {
    template <class T>
    constexpr uint8_t byte_count = uint8_t(std::bit_width(sizeof(T)) - 1);

--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -36,7 +36,7 @@ namespace glz
          }
          else {
             using V = std::remove_cvref_t<T>;
-            detail::from<BEVE, V>::template op<Opts>(std::forward<T>(value), std::forward<Tag>(tag), std::forward<Ctx>(ctx),
+            from<BEVE, V>::template op<Opts>(std::forward<T>(value), std::forward<Tag>(tag), std::forward<Ctx>(ctx),
                                              std::forward<It0>(it), std::forward<It1>(end));
          }
       }
@@ -56,167 +56,165 @@ namespace glz
          }
          else {
             using V = std::remove_cvref_t<T>;
-            detail::from<BEVE, V>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<It0>(it),
+            from<BEVE, V>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<It0>(it),
                                              std::forward<It1>(end));
          }
       }
    };
    
-   namespace detail
+   template <class T>
+   requires(glaze_value_t<T> && !custom_read<T>)
+   struct from<BEVE, T>
    {
-      template <class T>
-         requires(glaze_value_t<T> && !custom_read<T>)
-      struct from<BEVE, T>
+      template <auto Opts, class Value, is_context Ctx, class It0, class It1>
+      GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, It0&& it, It1&& end)
       {
-         template <auto Opts, class Value, is_context Ctx, class It0, class It1>
-         GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, It0&& it, It1&& end)
-         {
-            using V = std::decay_t<decltype(get_member(std::declval<Value>(), meta_wrapper_v<T>))>;
-            from<BEVE, V>::template op<Opts>(get_member(std::forward<Value>(value), meta_wrapper_v<T>),
-                                             std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
+         using V = std::decay_t<decltype(get_member(std::declval<Value>(), meta_wrapper_v<T>))>;
+         from<BEVE, V>::template op<Opts>(get_member(std::forward<Value>(value), meta_wrapper_v<T>),
+                                          std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
+      }
+   };
+   
+   template <always_null_t T>
+   struct from<BEVE, T>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+      {
+         if (invalid_end(ctx, it, end)) {
+            return;
          }
-      };
-
-      template <always_null_t T>
-      struct from<BEVE, T>
+         if (uint8_t(*it)) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         ++it;
+      }
+   };
+   
+   template <>
+   struct from<BEVE, hidden>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, auto&&...) noexcept
       {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, auto&& it, auto&& end) noexcept
-         {
+         ctx.error = error_code::attempt_read_hidden;
+      }
+   };
+   
+   template <is_bitset T>
+   struct from<BEVE, T>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+      {
+         if (invalid_end(ctx, it, end)) {
+            return;
+         }
+         const auto tag = uint8_t(*it);
+         
+         constexpr uint8_t type = uint8_t(3) << 3;
+         constexpr uint8_t header = tag::typed_array | type;
+         
+         if (tag != header) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         
+         ++it;
+         const auto n = int_from_compressed(ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+         
+         const auto num_bytes = (value.size() + 7) / 8;
+         for (size_t byte_i{}, i{}; byte_i < num_bytes; ++byte_i, ++it) {
             if (invalid_end(ctx, it, end)) {
                return;
             }
-            if (uint8_t(*it)) [[unlikely]] {
-               ctx.error = error_code::syntax_error;
-               return;
-            }
-            ++it;
-         }
-      };
-
-      template <>
-      struct from<BEVE, hidden>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, auto&&...) noexcept
-         {
-            ctx.error = error_code::attempt_read_hidden;
-         }
-      };
-
-      template <is_bitset T>
-      struct from<BEVE, T>
-      {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
-         {
-            if (invalid_end(ctx, it, end)) {
-               return;
-            }
-            const auto tag = uint8_t(*it);
-
-            constexpr uint8_t type = uint8_t(3) << 3;
-            constexpr uint8_t header = tag::typed_array | type;
-
-            if (tag != header) [[unlikely]] {
-               ctx.error = error_code::syntax_error;
-               return;
-            }
-
-            ++it;
-            const auto n = int_from_compressed(ctx, it, end);
-            if (bool(ctx.error)) [[unlikely]] {
-               return;
-            }
-
-            const auto num_bytes = (value.size() + 7) / 8;
-            for (size_t byte_i{}, i{}; byte_i < num_bytes; ++byte_i, ++it) {
-               if (invalid_end(ctx, it, end)) {
-                  return;
-               }
-               uint8_t byte;
-               std::memcpy(&byte, it, 1);
-               for (size_t bit_i = 0; bit_i < 8 && i < n; ++bit_i, ++i) {
-                  value[i] = byte >> bit_i & uint8_t(1);
-               }
+            uint8_t byte;
+            std::memcpy(&byte, it, 1);
+            for (size_t bit_i = 0; bit_i < 8 && i < n; ++bit_i, ++i) {
+               value[i] = byte >> bit_i & uint8_t(1);
             }
          }
-      };
-
-      template <>
-      struct from<BEVE, skip>
+      }
+   };
+   
+   template <>
+   struct from<BEVE, skip>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, auto&&... args) noexcept
       {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, auto&&... args) noexcept
-         {
-            skip_value<BEVE>::op<Opts>(ctx, args...);
+         skip_value<BEVE>::op<Opts>(ctx, args...);
+      }
+   };
+   
+   template <glaze_flags_t T>
+   struct from<BEVE, T>
+   {
+      template <auto Opts, is_context Ctx, class It0, class It1>
+      static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end)
+      {
+         constexpr auto N = reflect<T>::size;
+         
+         constexpr auto Length = byte_length<T>();
+         uint8_t data[Length];
+         
+         if ((it + Length) > end) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return;
          }
-      };
-
-      template <glaze_flags_t T>
-      struct from<BEVE, T>
+         std::memcpy(data, it, Length);
+         it += Length;
+         
+         invoke_table<N>([&]<size_t I>() {
+            get_member(value, get<I>(reflect<T>::values)) = data[I / 8] & (uint8_t{1} << (7 - (I % 8)));
+         });
+      }
+   };
+   
+   template <class T>
+   requires(num_t<T> || char_t<T> || glaze_enum_t<T>)
+   struct from<BEVE, T>
+   {
+      static constexpr uint8_t type =
+      std::floating_point<T> ? 0 : (std::is_signed_v<T> ? 0b000'01'000 : 0b000'10'000);
+      static constexpr uint8_t header = tag::number | type | (byte_count<T> << 5);
+      
+      template <auto Opts>
+      requires(has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(auto&& value, const uint8_t tag, is_context auto&& ctx, auto&& it,
+                                       auto&& end) noexcept
       {
-         template <auto Opts, is_context Ctx, class It0, class It1>
-         static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end)
-         {
-            constexpr auto N = reflect<T>::size;
-
-            constexpr auto Length = byte_length<T>();
-            uint8_t data[Length];
-
-            if ((it + Length) > end) [[unlikely]] {
-               ctx.error = error_code::unexpected_end;
-               return;
-            }
-            std::memcpy(data, it, Length);
-            it += Length;
-
-            invoke_table<N>([&]<size_t I>() {
-               get_member(value, get<I>(reflect<T>::values)) = data[I / 8] & (uint8_t{1} << (7 - (I % 8)));
-            });
+         if (invalid_end(ctx, it, end)) {
+            return;
          }
-      };
-
-      template <class T>
-         requires(num_t<T> || char_t<T> || glaze_enum_t<T>)
-      struct from<BEVE, T>
-      {
-         static constexpr uint8_t type =
-            std::floating_point<T> ? 0 : (std::is_signed_v<T> ? 0b000'01'000 : 0b000'10'000);
-         static constexpr uint8_t header = tag::number | type | (byte_count<T> << 5);
-
-         template <auto Opts>
-            requires(has_no_header(Opts))
-         GLZ_ALWAYS_INLINE static void op(auto&& value, const uint8_t tag, is_context auto&& ctx, auto&& it,
-                                          auto&& end) noexcept
-         {
-            if (invalid_end(ctx, it, end)) {
-               return;
-            }
-
-            using V = std::decay_t<decltype(value)>;
-
-            constexpr auto is_volatile = std::is_volatile_v<std::remove_reference_t<decltype(value)>>;
-
-            if (tag != header) {
-               if constexpr (Opts.allow_conversions) {
-                  if constexpr (num_t<T>) {
-                     if ((tag & 0b00000111) != tag::number) {
-                        ctx.error = error_code::syntax_error;
+         
+         using V = std::decay_t<decltype(value)>;
+         
+         constexpr auto is_volatile = std::is_volatile_v<std::remove_reference_t<decltype(value)>>;
+         
+         if (tag != header) {
+            if constexpr (Opts.allow_conversions) {
+               if constexpr (num_t<T>) {
+                  if ((tag & 0b00000111) != tag::number) {
+                     ctx.error = error_code::syntax_error;
+                     return;
+                  }
+                  
+                  auto decode = [&](auto&& i) {
+                     if ((it + sizeof(i)) > end) [[unlikely]] {
+                        ctx.error = error_code::unexpected_end;
                         return;
                      }
-
-                     auto decode = [&](auto&& i) {
-                        if ((it + sizeof(i)) > end) [[unlikely]] {
-                           ctx.error = error_code::unexpected_end;
-                           return;
-                        }
-                        std::memcpy(&i, it, sizeof(i));
-                        value = static_cast<V>(i);
-                        it += sizeof(i);
-                     };
-
-                     switch (tag) {
+                     std::memcpy(&i, it, sizeof(i));
+                     value = static_cast<V>(i);
+                     it += sizeof(i);
+                  };
+                  
+                  switch (tag) {
                      case tag::f32: {
                         if constexpr (std::integral<V>) {
                            // We do not allow cross conversions from floats to integral types
@@ -277,1043 +275,985 @@ namespace glz
                         ctx.error = error_code::syntax_error;
                         return;
                      }
-                     }
                   }
                }
-               else {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
             }
-
+            else {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+         }
+         
+         if ((it + sizeof(V)) > end) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return;
+         }
+         
+         if constexpr (is_volatile) {
+            V temp;
+            std::memcpy(&temp, it, sizeof(V));
+            value = temp;
+         }
+         else {
+            std::memcpy(&value, it, sizeof(V));
+         }
+         it += sizeof(V);
+      }
+      
+      template <auto Opts>
+      requires(not has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+      {
+         if (invalid_end(ctx, it, end)) {
+            return;
+         }
+         const auto tag = uint8_t(*it);
+         ++it;
+         op<no_header_on<Opts>()>(value, tag, ctx, it, end);
+      }
+   };
+   
+   template <class T>
+   requires(std::is_enum_v<T> && !glaze_enum_t<T>)
+   struct from<BEVE, T>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+      {
+         using V = std::underlying_type_t<std::decay_t<T>>;
+         
+         if constexpr (has_no_header(Opts)) {
             if ((it + sizeof(V)) > end) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return;
             }
-
-            if constexpr (is_volatile) {
-               V temp;
-               std::memcpy(&temp, it, sizeof(V));
-               value = temp;
-            }
-            else {
-               std::memcpy(&value, it, sizeof(V));
-            }
+            
+            std::memcpy(&value, it, sizeof(V));
             it += sizeof(V);
          }
-
-         template <auto Opts>
-            requires(not has_no_header(Opts))
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
-         {
+         else {
+            constexpr uint8_t type =
+            std::floating_point<V> ? 0 : (std::is_signed_v<V> ? 0b000'01'000 : 0b000'10'000);
+            constexpr uint8_t header = tag::number | type | (byte_count<V> << 5);
+            
             if (invalid_end(ctx, it, end)) {
                return;
             }
             const auto tag = uint8_t(*it);
-            ++it;
-            op<no_header_on<Opts>()>(value, tag, ctx, it, end);
-         }
-      };
-
-      template <class T>
-         requires(std::is_enum_v<T> && !glaze_enum_t<T>)
-      struct from<BEVE, T>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
-         {
-            using V = std::underlying_type_t<std::decay_t<T>>;
-
-            if constexpr (has_no_header(Opts)) {
-               if ((it + sizeof(V)) > end) [[unlikely]] {
-                  ctx.error = error_code::unexpected_end;
-                  return;
-               }
-
-               std::memcpy(&value, it, sizeof(V));
-               it += sizeof(V);
-            }
-            else {
-               constexpr uint8_t type =
-                  std::floating_point<V> ? 0 : (std::is_signed_v<V> ? 0b000'01'000 : 0b000'10'000);
-               constexpr uint8_t header = tag::number | type | (byte_count<V> << 5);
-
-               if (invalid_end(ctx, it, end)) {
-                  return;
-               }
-               const auto tag = uint8_t(*it);
-               if (tag != header) {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-
-               ++it;
-               if ((it + sizeof(V)) > end) [[unlikely]] {
-                  ctx.error = error_code::unexpected_end;
-                  return;
-               }
-
-               std::memcpy(&value, it, sizeof(V));
-               it += sizeof(V);
-            }
-         }
-      };
-
-      template <class T>
-         requires complex_t<T>
-      struct from<BEVE, T>
-      {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
-         {
-            if constexpr (has_no_header(Opts)) {
-               using V = std::decay_t<T>;
-               if ((it + sizeof(V)) > end) [[unlikely]] {
-                  ctx.error = error_code::unexpected_end;
-                  return;
-               }
-
-               std::memcpy(&value, it, sizeof(V));
-               it += sizeof(V);
-            }
-            else {
-               constexpr uint8_t header = tag::extensions | 0b00011'000;
-
-               if (invalid_end(ctx, it, end)) {
-                  return;
-               }
-               const auto tag = uint8_t(*it);
-               if (tag != header) {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-               ++it;
-
-               using V = typename T::value_type;
-               constexpr uint8_t type =
-                  std::floating_point<V> ? 0 : (std::is_signed_v<V> ? 0b000'01'000 : 0b000'10'000);
-               constexpr uint8_t complex_number = 0;
-               constexpr uint8_t complex_header = complex_number | type | (byte_count<V> << 5);
-
-               if (invalid_end(ctx, it, end)) {
-                  return;
-               }
-               const auto complex_tag = uint8_t(*it);
-               if (complex_tag != complex_header) {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-               ++it;
-
-               if ((it + 2 * sizeof(V)) > end) [[unlikely]] {
-                  ctx.error = error_code::unexpected_end;
-                  return;
-               }
-
-               std::memcpy(&value, it, 2 * sizeof(V));
-               it += 2 * sizeof(V);
-            }
-         }
-      };
-
-      template <boolean_like T>
-      struct from<BEVE, T>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
-         {
-            if (invalid_end(ctx, it, end)) {
-               return;
-            }
-            const auto tag = uint8_t(*it);
-            if ((tag & 0b0000'1111) != tag::boolean) {
+            if (tag != header) {
                ctx.error = error_code::syntax_error;
                return;
             }
-
-            value = tag >> 4;
+            
             ++it;
-         }
-      };
-
-      template <is_member_function_pointer T>
-      struct from<BEVE, T>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& /*value*/, is_context auto&& /*ctx*/, auto&& /*it*/,
-                                          auto&& /*end*/) noexcept
-         {}
-      };
-
-      template <func_t T>
-      struct from<BEVE, T>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& /*value*/, is_context auto&& ctx, auto&& it, auto&& end) noexcept
-         {
-            skip_string_beve(ctx, it, end);
-         }
-      };
-
-      template <class T>
-      struct from<BEVE, basic_raw_json<T>>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            parse<BEVE>::op<Opts>(value.str, ctx, it, end);
-         }
-      };
-
-      template <class T>
-      struct from<BEVE, basic_text<T>>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            parse<BEVE>::op<Opts>(value.str, ctx, it, end);
-         }
-      };
-
-      template <is_variant T>
-      struct from<BEVE, T>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
-         {
-            constexpr uint8_t header = tag::extensions | 0b00001'000;
-            if (invalid_end(ctx, it, end)) {
-               return;
-            }
-            const auto tag = uint8_t(*it);
-            if (tag != header) [[unlikely]] {
-               ctx.error = error_code::syntax_error;
-               return;
-            }
-
-            ++it;
-            const auto type_index = int_from_compressed(ctx, it, end);
-            if (bool(ctx.error)) [[unlikely]] {
-               return;
-            }
-
-            if (value.index() != type_index) {
-               value = runtime_variant_map<T>()[type_index];
-            }
-            std::visit([&](auto&& v) { parse<BEVE>::op<Opts>(v, ctx, it, end); }, value);
-         }
-      };
-
-      template <str_t T>
-      struct from<BEVE, T> final
-      {
-         using V = typename std::decay_t<T>::value_type;
-         static_assert(sizeof(V) == 1);
-
-         template <auto Opts>
-            requires(has_no_header(Opts))
-         GLZ_ALWAYS_INLINE static void op(auto&& value, const uint8_t, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            const auto n = int_from_compressed(ctx, it, end);
-            if (bool(ctx.error)) [[unlikely]] {
-               return;
-            }
-            if (uint64_t(end - it) < n) [[unlikely]] {
+            if ((it + sizeof(V)) > end) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return;
             }
+            
+            std::memcpy(&value, it, sizeof(V));
+            it += sizeof(V);
+         }
+      }
+   };
+   
+   template <class T>
+   requires complex_t<T>
+   struct from<BEVE, T>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+      {
+         if constexpr (has_no_header(Opts)) {
+            using V = std::decay_t<T>;
+            if ((it + sizeof(V)) > end) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+            
+            std::memcpy(&value, it, sizeof(V));
+            it += sizeof(V);
+         }
+         else {
+            constexpr uint8_t header = tag::extensions | 0b00011'000;
+            
+            if (invalid_end(ctx, it, end)) {
+               return;
+            }
+            const auto tag = uint8_t(*it);
+            if (tag != header) {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            ++it;
+            
+            using V = typename T::value_type;
+            constexpr uint8_t type =
+            std::floating_point<V> ? 0 : (std::is_signed_v<V> ? 0b000'01'000 : 0b000'10'000);
+            constexpr uint8_t complex_number = 0;
+            constexpr uint8_t complex_header = complex_number | type | (byte_count<V> << 5);
+            
+            if (invalid_end(ctx, it, end)) {
+               return;
+            }
+            const auto complex_tag = uint8_t(*it);
+            if (complex_tag != complex_header) {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            ++it;
+            
+            if ((it + 2 * sizeof(V)) > end) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+            
+            std::memcpy(&value, it, 2 * sizeof(V));
+            it += 2 * sizeof(V);
+         }
+      }
+   };
+   
+   template <boolean_like T>
+   struct from<BEVE, T>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+      {
+         if (invalid_end(ctx, it, end)) {
+            return;
+         }
+         const auto tag = uint8_t(*it);
+         if ((tag & 0b0000'1111) != tag::boolean) {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         
+         value = tag >> 4;
+         ++it;
+      }
+   };
+   
+   template <is_member_function_pointer T>
+   struct from<BEVE, T>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& /*value*/, is_context auto&& /*ctx*/, auto&& /*it*/,
+                                       auto&& /*end*/) noexcept
+      {}
+   };
+   
+   template <func_t T>
+   struct from<BEVE, T>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& /*value*/, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+      {
+         skip_string_beve(ctx, it, end);
+      }
+   };
+   
+   template <class T>
+   struct from<BEVE, basic_raw_json<T>>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         parse<BEVE>::op<Opts>(value.str, ctx, it, end);
+      }
+   };
+   
+   template <class T>
+   struct from<BEVE, basic_text<T>>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         parse<BEVE>::op<Opts>(value.str, ctx, it, end);
+      }
+   };
+   
+   template <is_variant T>
+   struct from<BEVE, T>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+      {
+         constexpr uint8_t header = tag::extensions | 0b00001'000;
+         if (invalid_end(ctx, it, end)) {
+            return;
+         }
+         const auto tag = uint8_t(*it);
+         if (tag != header) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         
+         ++it;
+         const auto type_index = int_from_compressed(ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+         
+         if (value.index() != type_index) {
+            value = runtime_variant_map<T>()[type_index];
+         }
+         std::visit([&](auto&& v) { parse<BEVE>::op<Opts>(v, ctx, it, end); }, value);
+      }
+   };
+   
+   template <str_t T>
+   struct from<BEVE, T> final
+   {
+      using V = typename std::decay_t<T>::value_type;
+      static_assert(sizeof(V) == 1);
+      
+      template <auto Opts>
+      requires(has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(auto&& value, const uint8_t, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         const auto n = int_from_compressed(ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+         if (uint64_t(end - it) < n) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return;
+         }
+         value.resize(n);
+         std::memcpy(value.data(), it, n);
+         it += n;
+      }
+      
+      template <auto Opts>
+      requires(not has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         constexpr uint8_t header = tag::string;
+         
+         if (invalid_end(ctx, it, end)) {
+            return;
+         }
+         const auto tag = uint8_t(*it);
+         if (tag != header) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         
+         ++it;
+         const auto n = int_from_compressed(ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+         if (uint64_t(end - it) < n) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return;
+         }
+         
+         if constexpr (string_view_t<T>) {
+            value = {it, n};
+         }
+         else {
             value.resize(n);
             std::memcpy(value.data(), it, n);
-            it += n;
          }
-
-         template <auto Opts>
-            requires(not has_no_header(Opts))
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            constexpr uint8_t header = tag::string;
-
-            if (invalid_end(ctx, it, end)) {
-               return;
-            }
-            const auto tag = uint8_t(*it);
+         it += n;
+      }
+   };
+   
+   // for set types
+   template <class T>
+   requires(readable_array_t<T> && !emplace_backable<T> && !resizable<T> && emplaceable<T>)
+   struct from<BEVE, T> final
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         using V = range_value_t<std::decay_t<T>>;
+         
+         if (invalid_end(ctx, it, end)) {
+            return;
+         }
+         const auto tag = uint8_t(*it);
+         
+         if constexpr (boolean_like<V>) {
+            constexpr uint8_t type = uint8_t(3) << 3;
+            constexpr uint8_t header = tag::typed_array | type;
+            
             if (tag != header) [[unlikely]] {
                ctx.error = error_code::syntax_error;
                return;
             }
-
+            
             ++it;
             const auto n = int_from_compressed(ctx, it, end);
             if (bool(ctx.error)) [[unlikely]] {
                return;
             }
-            if (uint64_t(end - it) < n) [[unlikely]] {
-               ctx.error = error_code::unexpected_end;
-               return;
-            }
-
-            if constexpr (string_view_t<T>) {
-               value = {it, n};
-            }
-            else {
-               value.resize(n);
-               std::memcpy(value.data(), it, n);
-            }
-            it += n;
-         }
-      };
-
-      // for set types
-      template <class T>
-         requires(readable_array_t<T> && !emplace_backable<T> && !resizable<T> && emplaceable<T>)
-      struct from<BEVE, T> final
-      {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            using V = range_value_t<std::decay_t<T>>;
-
-            if (invalid_end(ctx, it, end)) {
-               return;
-            }
-            const auto tag = uint8_t(*it);
-
-            if constexpr (boolean_like<V>) {
-               constexpr uint8_t type = uint8_t(3) << 3;
-               constexpr uint8_t header = tag::typed_array | type;
-
-               if (tag != header) [[unlikely]] {
-                  ctx.error = error_code::syntax_error;
+            
+            value.clear();
+            
+            const auto num_bytes = (value.size() + 7) / 8;
+            for (size_t byte_i{}, i{}; byte_i < num_bytes; ++byte_i, ++it) {
+               if (invalid_end(ctx, it, end)) {
                   return;
                }
-
-               ++it;
-               const auto n = int_from_compressed(ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]] {
-                  return;
-               }
-
-               value.clear();
-
-               const auto num_bytes = (value.size() + 7) / 8;
-               for (size_t byte_i{}, i{}; byte_i < num_bytes; ++byte_i, ++it) {
-                  if (invalid_end(ctx, it, end)) {
-                     return;
-                  }
-                  uint8_t byte;
-                  std::memcpy(&byte, it, 1);
-                  for (size_t bit_i = 7; bit_i < 8 && i < n; --bit_i, ++i) {
-                     bool x = byte >> bit_i & uint8_t(1);
-                     value.emplace(x);
-                  }
-               }
-            }
-            else if constexpr (num_t<V>) {
-               constexpr uint8_t type =
-                  std::floating_point<V> ? 0 : (std::is_signed_v<V> ? 0b000'01'000 : 0b000'10'000);
-               constexpr uint8_t header = tag::typed_array | type | (byte_count<V> << 5);
-
-               if (tag != header) [[unlikely]] {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-
-               ++it;
-               const auto n = int_from_compressed(ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]] {
-                  return;
-               }
-
-               value.clear();
-
-               for (size_t i = 0; i < n; ++i) {
-                  if ((it + sizeof(V)) > end) [[unlikely]] {
-                     ctx.error = error_code::unexpected_end;
-                     return;
-                  }
-
-                  V x;
-                  std::memcpy(&x, it, sizeof(V));
-                  it += sizeof(V);
+               uint8_t byte;
+               std::memcpy(&byte, it, 1);
+               for (size_t bit_i = 7; bit_i < 8 && i < n; --bit_i, ++i) {
+                  bool x = byte >> bit_i & uint8_t(1);
                   value.emplace(x);
                }
             }
-            else if constexpr (str_t<V>) {
-               constexpr uint8_t type = uint8_t(3) << 3;
-               constexpr uint8_t string_indicator = uint8_t(1) << 5;
-               constexpr uint8_t header = tag::typed_array | type | string_indicator;
-
-               if (tag != header) [[unlikely]] {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-
-               ++it;
-               const auto n = int_from_compressed(ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]] {
-                  return;
-               }
-               if (uint64_t(end - it) < n) [[unlikely]] {
+         }
+         else if constexpr (num_t<V>) {
+            constexpr uint8_t type =
+            std::floating_point<V> ? 0 : (std::is_signed_v<V> ? 0b000'01'000 : 0b000'10'000);
+            constexpr uint8_t header = tag::typed_array | type | (byte_count<V> << 5);
+            
+            if (tag != header) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            
+            ++it;
+            const auto n = int_from_compressed(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            
+            value.clear();
+            
+            for (size_t i = 0; i < n; ++i) {
+               if ((it + sizeof(V)) > end) [[unlikely]] {
                   ctx.error = error_code::unexpected_end;
                   return;
                }
-
-               value.clear();
-
-               for (size_t i = 0; i < n; ++i) {
-                  const auto length = int_from_compressed(ctx, it, end);
-                  if (bool(ctx.error)) [[unlikely]] {
-                     return;
-                  }
-                  if (uint64_t(end - it) < length) [[unlikely]] {
-                     ctx.error = error_code::unexpected_end;
-                     return;
-                  }
-                  V str;
-                  str.resize(length);
-                  std::memcpy(str.data(), it, length);
-                  it += length;
-                  value.emplace(std::move(str));
-               }
+               
+               V x;
+               std::memcpy(&x, it, sizeof(V));
+               it += sizeof(V);
+               value.emplace(x);
             }
-            else if constexpr (complex_t<V>) {
-               static_assert(false_v<T>, "TODO");
+         }
+         else if constexpr (str_t<V>) {
+            constexpr uint8_t type = uint8_t(3) << 3;
+            constexpr uint8_t string_indicator = uint8_t(1) << 5;
+            constexpr uint8_t header = tag::typed_array | type | string_indicator;
+            
+            if (tag != header) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
             }
-            else {
-               // generic array
-               if ((tag & 0b00000'111) != tag::generic_array) [[unlikely]] {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-
-               ++it;
-               const auto n = int_from_compressed(ctx, it, end);
+            
+            ++it;
+            const auto n = int_from_compressed(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            if (uint64_t(end - it) < n) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+            
+            value.clear();
+            
+            for (size_t i = 0; i < n; ++i) {
+               const auto length = int_from_compressed(ctx, it, end);
                if (bool(ctx.error)) [[unlikely]] {
                   return;
                }
-
-               value.clear();
-
-               for (size_t i = 0; i < n; ++i) {
-                  V v;
-                  parse<BEVE>::op<Opts>(v, ctx, it, end);
-                  value.emplace(std::move(v));
+               if (uint64_t(end - it) < length) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
+               V str;
+               str.resize(length);
+               std::memcpy(str.data(), it, length);
+               it += length;
+               value.emplace(std::move(str));
+            }
+         }
+         else if constexpr (complex_t<V>) {
+            static_assert(false_v<T>, "TODO");
+         }
+         else {
+            // generic array
+            if ((tag & 0b00000'111) != tag::generic_array) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            
+            ++it;
+            const auto n = int_from_compressed(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            
+            value.clear();
+            
+            for (size_t i = 0; i < n; ++i) {
+               V v;
+               parse<BEVE>::op<Opts>(v, ctx, it, end);
+               value.emplace(std::move(v));
+            }
+         }
+      }
+   };
+   
+   template <readable_array_t T>
+   struct from<BEVE, T> final
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         using V = range_value_t<std::decay_t<T>>;
+         
+         if (invalid_end(ctx, it, end)) {
+            return;
+         }
+         const auto tag = uint8_t(*it);
+         
+         if constexpr (boolean_like<V>) {
+            constexpr uint8_t type = uint8_t(3) << 3;
+            constexpr uint8_t header = tag::typed_array | type;
+            
+            if (tag != header) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            
+            ++it;
+            const auto n = int_from_compressed(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            
+            if constexpr (resizable<T>) {
+               value.resize(n);
+               
+               if constexpr (Opts.shrink_to_fit) {
+                  value.shrink_to_fit();
+               }
+            }
+            
+            const auto num_bytes = (value.size() + 7) / 8;
+            for (size_t byte_i{}, i{}; byte_i < num_bytes; ++byte_i, ++it) {
+               if (invalid_end(ctx, it, end)) {
+                  return;
+               }
+               uint8_t byte;
+               std::memcpy(&byte, it, 1);
+               for (size_t bit_i = 7; bit_i < 8 && i < n; --bit_i, ++i) {
+                  value[i] = byte >> bit_i & uint8_t(1);
                }
             }
          }
-      };
-
-      template <readable_array_t T>
-      struct from<BEVE, T> final
-      {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            using V = range_value_t<std::decay_t<T>>;
-
-            if (invalid_end(ctx, it, end)) {
-               return;
-            }
-            const auto tag = uint8_t(*it);
-
-            if constexpr (boolean_like<V>) {
-               constexpr uint8_t type = uint8_t(3) << 3;
-               constexpr uint8_t header = tag::typed_array | type;
-
-               if (tag != header) [[unlikely]] {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-
+         else if constexpr (num_t<V>) {
+            constexpr uint8_t type =
+            std::floating_point<V> ? 0 : (std::is_signed_v<V> ? 0b000'01'000 : 0b000'10'000);
+            constexpr uint8_t header = tag::typed_array | type | (byte_count<V> << 5);
+            
+            auto prepare = [&](const size_t element_size) -> size_t {
                ++it;
-               const auto n = int_from_compressed(ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]] {
-                  return;
+               if (invalid_end(ctx, it, end)) {
+                  return 0;
                }
-
+               
+               std::conditional_t<Opts.partial_read, size_t, const size_t> n = int_from_compressed(ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return 0;
+               }
+               
+               if constexpr (Opts.partial_read) {
+                  n = value.size();
+               }
+               
+               if ((it + n * element_size) > end) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return 0;
+               }
+               
                if constexpr (resizable<T>) {
                   value.resize(n);
-
+                  
                   if constexpr (Opts.shrink_to_fit) {
                      value.shrink_to_fit();
                   }
                }
-
-               const auto num_bytes = (value.size() + 7) / 8;
-               for (size_t byte_i{}, i{}; byte_i < num_bytes; ++byte_i, ++it) {
-                  if (invalid_end(ctx, it, end)) {
-                     return;
-                  }
-                  uint8_t byte;
-                  std::memcpy(&byte, it, 1);
-                  for (size_t bit_i = 7; bit_i < 8 && i < n; --bit_i, ++i) {
-                     value[i] = byte >> bit_i & uint8_t(1);
+               else {
+                  if (n > value.size()) {
+                     ctx.error = error_code::syntax_error;
+                     return 0;
                   }
                }
-            }
-            else if constexpr (num_t<V>) {
-               constexpr uint8_t type =
-                  std::floating_point<V> ? 0 : (std::is_signed_v<V> ? 0b000'01'000 : 0b000'10'000);
-               constexpr uint8_t header = tag::typed_array | type | (byte_count<V> << 5);
-
-               auto prepare = [&](const size_t element_size) -> size_t {
-                  ++it;
-                  if (invalid_end(ctx, it, end)) {
-                     return 0;
-                  }
-
-                  std::conditional_t<Opts.partial_read, size_t, const size_t> n = int_from_compressed(ctx, it, end);
-                  if (bool(ctx.error)) [[unlikely]] {
-                     return 0;
-                  }
-
-                  if constexpr (Opts.partial_read) {
-                     n = value.size();
-                  }
-
-                  if ((it + n * element_size) > end) [[unlikely]] {
-                     ctx.error = error_code::unexpected_end;
-                     return 0;
-                  }
-
-                  if constexpr (resizable<T>) {
-                     value.resize(n);
-
-                     if constexpr (Opts.shrink_to_fit) {
-                        value.shrink_to_fit();
-                     }
-                  }
-                  else {
-                     if (n > value.size()) {
-                        ctx.error = error_code::syntax_error;
-                        return 0;
-                     }
-                  }
-
-                  return n;
-               };
-
-               if (tag != header) {
-                  if constexpr (Opts.allow_conversions) {
-                     if (tag != header) [[unlikely]] {
-                        if constexpr (Opts.allow_conversions) {
-                           if ((tag & 0b00000111) != tag::typed_array) {
-                              ctx.error = error_code::syntax_error;
-                              return;
-                           }
-
-                           const uint8_t byte_count = byte_count_lookup[tag >> 5];
-                           prepare(byte_count);
-                           if (bool(ctx.error)) [[unlikely]] {
-                              return;
-                           }
-
-                           for (auto&& x : value) {
-                              const uint8_t number_tag = tag::number | (tag & 0b11111000);
-                              parse<BEVE>::op<no_header_on<Opts>()>(x, number_tag, ctx, it, end);
-                           }
-                           return;
-                        }
-                        else {
+               
+               return n;
+            };
+            
+            if (tag != header) {
+               if constexpr (Opts.allow_conversions) {
+                  if (tag != header) [[unlikely]] {
+                     if constexpr (Opts.allow_conversions) {
+                        if ((tag & 0b00000111) != tag::typed_array) {
                            ctx.error = error_code::syntax_error;
                            return;
                         }
-                     }
-                  }
-                  else {
-                     ctx.error = error_code::syntax_error;
-                     return;
-                  }
-               }
-
-               const auto n = prepare(sizeof(V));
-               if (bool(ctx.error)) [[unlikely]] {
-                  return;
-               }
-
-               if constexpr (contiguous<T>) {
-                  constexpr auto is_volatile =
-                     std::is_volatile_v<std::remove_reference_t<std::remove_pointer_t<decltype(value.data())>>>;
-
-                  if constexpr (is_volatile) {
-                     V temp;
-                     for (size_t i = 0; i < n; ++i) {
-                        if ((it + sizeof(V)) > end) [[unlikely]] {
-                           ctx.error = error_code::unexpected_end;
+                        
+                        const uint8_t byte_count = byte_count_lookup[tag >> 5];
+                        prepare(byte_count);
+                        if (bool(ctx.error)) [[unlikely]] {
                            return;
                         }
-
-                        std::memcpy(&temp, it, sizeof(V));
-                        value[i] = temp;
-                        it += sizeof(V);
-                     }
-                  }
-                  else {
-                     if ((it + n * sizeof(V)) > end) [[unlikely]] {
-                        ctx.error = error_code::unexpected_end;
+                        
+                        for (auto&& x : value) {
+                           const uint8_t number_tag = tag::number | (tag & 0b11111000);
+                           parse<BEVE>::op<no_header_on<Opts>()>(x, number_tag, ctx, it, end);
+                        }
                         return;
                      }
-                     std::memcpy(value.data(), it, n * sizeof(V));
-                     it += n * sizeof(V);
+                     else {
+                        ctx.error = error_code::syntax_error;
+                        return;
+                     }
                   }
                }
                else {
-                  for (auto&& x : value) {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
+            }
+            
+            const auto n = prepare(sizeof(V));
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            
+            if constexpr (contiguous<T>) {
+               constexpr auto is_volatile =
+               std::is_volatile_v<std::remove_reference_t<std::remove_pointer_t<decltype(value.data())>>>;
+               
+               if constexpr (is_volatile) {
+                  V temp;
+                  for (size_t i = 0; i < n; ++i) {
                      if ((it + sizeof(V)) > end) [[unlikely]] {
                         ctx.error = error_code::unexpected_end;
                         return;
                      }
-
-                     std::memcpy(&x, it, sizeof(V));
+                     
+                     std::memcpy(&temp, it, sizeof(V));
+                     value[i] = temp;
                      it += sizeof(V);
                   }
                }
-            }
-            else if constexpr (str_t<V>) {
-               constexpr uint8_t type = uint8_t(3) << 3;
-               constexpr uint8_t string_indicator = uint8_t(1) << 5;
-               constexpr uint8_t header = tag::typed_array | type | string_indicator;
-
-               if (tag != header) [[unlikely]] {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-
-               ++it;
-               std::conditional_t<Opts.partial_read, size_t, const size_t> n = int_from_compressed(ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]] {
-                  return;
-               }
-
-               if constexpr (Opts.partial_read) {
-                  n = value.size();
-               }
-
-               if constexpr (resizable<T>) {
-                  value.resize(n);
-
-                  if constexpr (Opts.shrink_to_fit) {
-                     value.shrink_to_fit();
-                  }
-               }
-
-               for (auto&& x : value) {
-                  const auto length = int_from_compressed(ctx, it, end);
-                  if (bool(ctx.error)) [[unlikely]] {
-                     return;
-                  }
-                  if (uint64_t(end - it) < length) [[unlikely]] {
+               else {
+                  if ((it + n * sizeof(V)) > end) [[unlikely]] {
                      ctx.error = error_code::unexpected_end;
                      return;
                   }
-
-                  x.resize(length);
-
-                  if constexpr (Opts.shrink_to_fit) {
-                     value.shrink_to_fit();
-                  }
-
-                  std::memcpy(x.data(), it, length);
-                  it += length;
-               }
-            }
-            else if constexpr (complex_t<V>) {
-               constexpr uint8_t header = tag::extensions | 0b00011'000;
-               if (tag != header) [[unlikely]] {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-               ++it;
-               if (invalid_end(ctx, it, end)) {
-                  return;
-               }
-
-               using X = typename V::value_type;
-               constexpr uint8_t complex_array = 1;
-               constexpr uint8_t type =
-                  std::floating_point<X> ? 0 : (std::is_signed_v<X> ? 0b000'01'000 : 0b000'10'000);
-               constexpr uint8_t complex_header = complex_array | type | (byte_count<X> << 5);
-               const auto complex_tag = uint8_t(*it);
-               if (complex_tag != complex_header) [[unlikely]] {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-               ++it;
-               std::conditional_t<Opts.partial_read, size_t, const size_t> n = int_from_compressed(ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]] {
-                  return;
-               }
-
-               if constexpr (Opts.partial_read) {
-                  n = value.size();
-               }
-
-               if (uint64_t(end - it) < n * sizeof(V)) [[unlikely]] {
-                  ctx.error = error_code::unexpected_end;
-                  return;
-               }
-
-               if constexpr (resizable<T>) {
-                  value.resize(n);
-
-                  if constexpr (Opts.shrink_to_fit) {
-                     value.shrink_to_fit();
-                  }
-               }
-
-               if constexpr (contiguous<T>) {
                   std::memcpy(value.data(), it, n * sizeof(V));
                   it += n * sizeof(V);
                }
-               else {
-                  for (auto&& x : value) {
-                     std::memcpy(&x, it, sizeof(V));
-                     it += sizeof(V);
-                  }
-               }
             }
             else {
-               if ((tag & 0b00000'111) != tag::generic_array) [[unlikely]] {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-               ++it;
-               std::conditional_t<Opts.partial_read, size_t, const size_t> n = int_from_compressed(ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]] {
-                  return;
-               }
-
-               if constexpr (Opts.partial_read) {
-                  n = value.size();
-               }
-
-               if constexpr (resizable<T>) {
-                  value.resize(n);
-
-                  if constexpr (Opts.shrink_to_fit) {
-                     value.shrink_to_fit();
+               for (auto&& x : value) {
+                  if ((it + sizeof(V)) > end) [[unlikely]] {
+                     ctx.error = error_code::unexpected_end;
+                     return;
                   }
-               }
-
-               for (auto&& item : value) {
-                  parse<BEVE>::op<Opts>(item, ctx, it, end);
+                  
+                  std::memcpy(&x, it, sizeof(V));
+                  it += sizeof(V);
                }
             }
          }
-
-         // for types like std::vector<std::pair...> that can't look up with operator[]
-         // Instead of hashing or linear searching, we just clear the input and overwrite the entire contents
-         template <auto Opts>
-            requires(pair_t<range_value_t<T>> && Opts.concatenate == true)
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            using Element = typename T::value_type;
-            using Key = typename Element::first_type;
-
-            constexpr uint8_t type = str_t<Key> ? 0 : (std::is_signed_v<Key> ? 0b000'01'000 : 0b000'10'000);
-            constexpr uint8_t byte_cnt = str_t<Key> ? 0 : byte_count<Key>;
-            constexpr uint8_t header = tag::object | type | (byte_cnt << 5);
-
-            if (invalid_end(ctx, it, end)) {
-               return;
-            }
-            const auto tag = uint8_t(*it);
-            if (tag != header) [[unlikely]] {
-               if constexpr (Opts.allow_conversions) {
-                  const auto key_type = tag & 0b000'11'000;
-                  if constexpr (str_t<Key>) {
-                     if (key_type != 0) {
-                        ctx.error = error_code::syntax_error;
-                        return;
-                     }
-                  }
-                  else {
-                     if (key_type == 0) {
-                        ctx.error = error_code::syntax_error;
-                        return;
-                     }
-                  }
-               }
-               else {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-            }
-
-            ++it;
-            const size_t n = int_from_compressed(ctx, it, end);
-            if (bool(ctx.error)) [[unlikely]] {
-               return;
-            }
-
-            value.clear();
-
-            if constexpr (std::is_arithmetic_v<std::decay_t<Key>>) {
-               constexpr uint8_t key_tag = tag::number | type | (byte_cnt << 5);
-               for (size_t i = 0; i < n; ++i) {
-                  // convert the object tag to the key type tag
-                  auto& item = value.emplace_back();
-                  parse<BEVE>::op<no_header_on<Opts>()>(item.first, key_tag, ctx, it, end);
-                  parse<BEVE>::op<Opts>(item.second, ctx, it, end);
-               }
-            }
-            else {
-               constexpr uint8_t key_tag = tag::string;
-               for (size_t i = 0; i < n; ++i) {
-                  auto& item = value.emplace_back();
-                  parse<BEVE>::op<no_header_on<Opts>()>(item.first, key_tag, ctx, it, end);
-                  parse<BEVE>::op<Opts>(item.second, ctx, it, end);
-               }
-            }
-         }
-      };
-
-      template <pair_t T>
-      struct from<BEVE, T> final
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(T& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            using Key = typename T::first_type;
-
-            constexpr uint8_t type = str_t<Key> ? 0 : (std::is_signed_v<Key> ? 0b000'01'000 : 0b000'10'000);
-            constexpr uint8_t byte_cnt = str_t<Key> ? 0 : byte_count<Key>;
-            constexpr uint8_t header = tag::object | type | (byte_cnt << 5);
-
-            if (invalid_end(ctx, it, end)) {
-               return;
-            }
-            const auto tag = uint8_t(*it);
+         else if constexpr (str_t<V>) {
+            constexpr uint8_t type = uint8_t(3) << 3;
+            constexpr uint8_t string_indicator = uint8_t(1) << 5;
+            constexpr uint8_t header = tag::typed_array | type | string_indicator;
+            
             if (tag != header) [[unlikely]] {
                ctx.error = error_code::syntax_error;
                return;
             }
-
-            ++it;
-            const auto n = int_from_compressed(ctx, it, end);
-            if (bool(ctx.error)) [[unlikely]] {
-               return;
-            }
-
-            if (n != 1) [[unlikely]] {
-               ctx.error = error_code::syntax_error;
-               return;
-            }
-
-            constexpr uint8_t key_tag = type == 0 ? tag::string : (tag::number | type | (byte_cnt << 5));
-            parse<BEVE>::op<no_header_on<Opts>()>(value.first, key_tag, ctx, it, end);
-            parse<BEVE>::op<Opts>(value.second, ctx, it, end);
-         }
-      };
-
-      template <readable_map_t T>
-      struct from<BEVE, T> final
-      {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            using Key = typename T::key_type;
-
-            constexpr uint8_t type = str_t<Key> ? 0 : (std::is_signed_v<Key> ? 0b000'01'000 : 0b000'10'000);
-            constexpr uint8_t byte_cnt = str_t<Key> ? 0 : byte_count<Key>;
-            constexpr uint8_t header = tag::object | type | (byte_cnt << 5);
-
-            if (invalid_end(ctx, it, end)) {
-               return;
-            }
-            const auto tag = uint8_t(*it);
-            if (tag != header) [[unlikely]] {
-               if constexpr (Opts.allow_conversions) {
-                  const auto key_type = tag & 0b000'11'000;
-                  if constexpr (str_t<Key>) {
-                     if (key_type != 0) {
-                        ctx.error = error_code::syntax_error;
-                        return;
-                     }
-                  }
-                  else {
-                     if (key_type == 0) {
-                        ctx.error = error_code::syntax_error;
-                        return;
-                     }
-                  }
-               }
-               else {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-            }
-
+            
             ++it;
             std::conditional_t<Opts.partial_read, size_t, const size_t> n = int_from_compressed(ctx, it, end);
             if (bool(ctx.error)) [[unlikely]] {
                return;
             }
-
+            
             if constexpr (Opts.partial_read) {
                n = value.size();
             }
-
-            if constexpr (std::is_arithmetic_v<std::decay_t<Key>>) {
-               constexpr uint8_t key_tag = tag::number | type | (byte_cnt << 5);
-               Key key;
-               for (size_t i = 0; i < n; ++i) {
-                  if constexpr (Opts.partial_read) {
-                     parse<BEVE>::op<no_header_on<Opts>()>(key, key_tag, ctx, it, end);
-                     if (auto element = value.find(key); element != value.end()) {
-                        parse<BEVE>::op<Opts>(element->second, ctx, it, end);
-                     }
-                  }
-                  else {
-                     // convert the object tag to the key type tag
-                     parse<BEVE>::op<no_header_on<Opts>()>(key, key_tag, ctx, it, end);
-                     parse<BEVE>::op<Opts>(value[key], ctx, it, end);
-                  }
+            
+            if constexpr (resizable<T>) {
+               value.resize(n);
+               
+               if constexpr (Opts.shrink_to_fit) {
+                  value.shrink_to_fit();
                }
             }
-            else {
-               constexpr uint8_t key_tag = tag::string;
-               static thread_local Key key;
-               for (size_t i = 0; i < n; ++i) {
-                  if constexpr (Opts.partial_read) {
-                     parse<BEVE>::op<no_header_on<Opts>()>(key, key_tag, ctx, it, end);
-                     if (auto element = value.find(key); element != value.end()) {
-                        parse<BEVE>::op<Opts>(element->second, ctx, it, end);
-                     }
-                  }
-                  else {
-                     parse<BEVE>::op<no_header_on<Opts>()>(key, key_tag, ctx, it, end);
-                     parse<BEVE>::op<Opts>(value[key], ctx, it, end);
-                  }
-               }
-            }
-         }
-      };
-
-      template <nullable_t T>
-         requires(std::is_array_v<T>)
-      struct from<BEVE, T> final
-      {
-         template <auto Opts, class V, size_t N>
-         GLZ_ALWAYS_INLINE static void op(V (&value)[N], is_context auto&& ctx, auto&& it, auto&& end) noexcept
-         {
-            parse<BEVE>::op<Opts>(std::span{value, N}, ctx, it, end);
-         }
-      };
-
-      template <nullable_t T>
-         requires(!std::is_array_v<T>)
-      struct from<BEVE, T> final
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            if (invalid_end(ctx, it, end)) {
-               return;
-            }
-            const auto tag = uint8_t(*it);
-
-            if (tag == tag::null) {
-               ++it;
-               if constexpr (is_specialization_v<T, std::optional>)
-                  value = std::nullopt;
-               else if constexpr (is_specialization_v<T, std::unique_ptr>)
-                  value = nullptr;
-               else if constexpr (is_specialization_v<T, std::shared_ptr>)
-                  value = nullptr;
-            }
-            else {
-               if (!value) {
-                  if constexpr (is_specialization_v<T, std::optional>)
-                     value = std::make_optional<typename T::value_type>();
-                  else if constexpr (is_specialization_v<T, std::unique_ptr>)
-                     value = std::make_unique<typename T::element_type>();
-                  else if constexpr (is_specialization_v<T, std::shared_ptr>)
-                     value = std::make_shared<typename T::element_type>();
-                  else if constexpr (constructible<T>) {
-                     value = meta_construct_v<T>();
-                  }
-                  else {
-                     ctx.error = error_code::invalid_nullable_read;
-                     return;
-                     // Cannot read into unset nullable that is not std::optional, std::unique_ptr, or std::shared_ptr
-                  }
-               }
-               parse<BEVE>::op<Opts>(*value, ctx, it, end);
-            }
-         }
-      };
-
-      template <is_includer T>
-      struct from<BEVE, T>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, auto&& it, auto&& end) noexcept
-         {
-            if constexpr (has_no_header(Opts)) {
-               skip_compressed_int(ctx, it, end);
-            }
-            else {
-               constexpr uint8_t header = tag::string;
-
-               if (invalid_end(ctx, it, end)) {
-                  return;
-               }
-               const auto tag = uint8_t(*it);
-               if (tag != header) [[unlikely]] {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-
-               ++it;
-               skip_compressed_int(ctx, it, end);
-            }
-         }
-      };
-
-      template <class T>
-         requires(glaze_object_t<T> || reflectable<T>)
-      struct from<BEVE, T> final
-      {
-         template <auto Opts>
-            requires(Opts.structs_as_arrays == true)
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            if constexpr (reflectable<T>) {
-               auto t = to_tie(value);
-               parse<BEVE>::op<Opts>(t, ctx, it, end);
-            }
-            else {
-               const auto tag = uint8_t(*it);
-               if (tag != tag::generic_array) [[unlikely]] {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-               ++it;
-               using V = std::decay_t<T>;
-               constexpr auto N = reflect<V>::size;
-               const auto n = int_from_compressed(ctx, it, end);
+            
+            for (auto&& x : value) {
+               const auto length = int_from_compressed(ctx, it, end);
                if (bool(ctx.error)) [[unlikely]] {
                   return;
                }
-               if (n != N) {
-                  ctx.error = error_code::syntax_error;
+               if (uint64_t(end - it) < length) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
                   return;
                }
-
-               invoke_table<N>([&]<size_t I>() {
-                  parse<BEVE>::op<Opts>(get_member(value, get<I>(reflect<V>::values)), ctx, it, end);
-               });
+               
+               x.resize(length);
+               
+               if constexpr (Opts.shrink_to_fit) {
+                  value.shrink_to_fit();
+               }
+               
+               std::memcpy(x.data(), it, length);
+               it += length;
             }
          }
-
-         template <auto Opts>
-            requires(Opts.structs_as_arrays == false)
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            constexpr uint8_t type = 0; // string key
-            constexpr uint8_t header = tag::object | type;
-
+         else if constexpr (complex_t<V>) {
+            constexpr uint8_t header = tag::extensions | 0b00011'000;
+            if (tag != header) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            ++it;
+            if (invalid_end(ctx, it, end)) {
+               return;
+            }
+            
+            using X = typename V::value_type;
+            constexpr uint8_t complex_array = 1;
+            constexpr uint8_t type =
+            std::floating_point<X> ? 0 : (std::is_signed_v<X> ? 0b000'01'000 : 0b000'10'000);
+            constexpr uint8_t complex_header = complex_array | type | (byte_count<X> << 5);
+            const auto complex_tag = uint8_t(*it);
+            if (complex_tag != complex_header) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            ++it;
+            std::conditional_t<Opts.partial_read, size_t, const size_t> n = int_from_compressed(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            
+            if constexpr (Opts.partial_read) {
+               n = value.size();
+            }
+            
+            if (uint64_t(end - it) < n * sizeof(V)) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+            
+            if constexpr (resizable<T>) {
+               value.resize(n);
+               
+               if constexpr (Opts.shrink_to_fit) {
+                  value.shrink_to_fit();
+               }
+            }
+            
+            if constexpr (contiguous<T>) {
+               std::memcpy(value.data(), it, n * sizeof(V));
+               it += n * sizeof(V);
+            }
+            else {
+               for (auto&& x : value) {
+                  std::memcpy(&x, it, sizeof(V));
+                  it += sizeof(V);
+               }
+            }
+         }
+         else {
+            if ((tag & 0b00000'111) != tag::generic_array) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            ++it;
+            std::conditional_t<Opts.partial_read, size_t, const size_t> n = int_from_compressed(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            
+            if constexpr (Opts.partial_read) {
+               n = value.size();
+            }
+            
+            if constexpr (resizable<T>) {
+               value.resize(n);
+               
+               if constexpr (Opts.shrink_to_fit) {
+                  value.shrink_to_fit();
+               }
+            }
+            
+            for (auto&& item : value) {
+               parse<BEVE>::op<Opts>(item, ctx, it, end);
+            }
+         }
+      }
+      
+      // for types like std::vector<std::pair...> that can't look up with operator[]
+      // Instead of hashing or linear searching, we just clear the input and overwrite the entire contents
+      template <auto Opts>
+      requires(pair_t<range_value_t<T>> && Opts.concatenate == true)
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         using Element = typename T::value_type;
+         using Key = typename Element::first_type;
+         
+         constexpr uint8_t type = str_t<Key> ? 0 : (std::is_signed_v<Key> ? 0b000'01'000 : 0b000'10'000);
+         constexpr uint8_t byte_cnt = str_t<Key> ? 0 : byte_count<Key>;
+         constexpr uint8_t header = tag::object | type | (byte_cnt << 5);
+         
+         if (invalid_end(ctx, it, end)) {
+            return;
+         }
+         const auto tag = uint8_t(*it);
+         if (tag != header) [[unlikely]] {
+            if constexpr (Opts.allow_conversions) {
+               const auto key_type = tag & 0b000'11'000;
+               if constexpr (str_t<Key>) {
+                  if (key_type != 0) {
+                     ctx.error = error_code::syntax_error;
+                     return;
+                  }
+               }
+               else {
+                  if (key_type == 0) {
+                     ctx.error = error_code::syntax_error;
+                     return;
+                  }
+               }
+            }
+            else {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+         }
+         
+         ++it;
+         const size_t n = int_from_compressed(ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+         
+         value.clear();
+         
+         if constexpr (std::is_arithmetic_v<std::decay_t<Key>>) {
+            constexpr uint8_t key_tag = tag::number | type | (byte_cnt << 5);
+            for (size_t i = 0; i < n; ++i) {
+               // convert the object tag to the key type tag
+               auto& item = value.emplace_back();
+               parse<BEVE>::op<no_header_on<Opts>()>(item.first, key_tag, ctx, it, end);
+               parse<BEVE>::op<Opts>(item.second, ctx, it, end);
+            }
+         }
+         else {
+            constexpr uint8_t key_tag = tag::string;
+            for (size_t i = 0; i < n; ++i) {
+               auto& item = value.emplace_back();
+               parse<BEVE>::op<no_header_on<Opts>()>(item.first, key_tag, ctx, it, end);
+               parse<BEVE>::op<Opts>(item.second, ctx, it, end);
+            }
+         }
+      }
+   };
+   
+   template <pair_t T>
+   struct from<BEVE, T> final
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(T& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         using Key = typename T::first_type;
+         
+         constexpr uint8_t type = str_t<Key> ? 0 : (std::is_signed_v<Key> ? 0b000'01'000 : 0b000'10'000);
+         constexpr uint8_t byte_cnt = str_t<Key> ? 0 : byte_count<Key>;
+         constexpr uint8_t header = tag::object | type | (byte_cnt << 5);
+         
+         if (invalid_end(ctx, it, end)) {
+            return;
+         }
+         const auto tag = uint8_t(*it);
+         if (tag != header) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         
+         ++it;
+         const auto n = int_from_compressed(ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+         
+         if (n != 1) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         
+         constexpr uint8_t key_tag = type == 0 ? tag::string : (tag::number | type | (byte_cnt << 5));
+         parse<BEVE>::op<no_header_on<Opts>()>(value.first, key_tag, ctx, it, end);
+         parse<BEVE>::op<Opts>(value.second, ctx, it, end);
+      }
+   };
+   
+   template <readable_map_t T>
+   struct from<BEVE, T> final
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         using Key = typename T::key_type;
+         
+         constexpr uint8_t type = str_t<Key> ? 0 : (std::is_signed_v<Key> ? 0b000'01'000 : 0b000'10'000);
+         constexpr uint8_t byte_cnt = str_t<Key> ? 0 : byte_count<Key>;
+         constexpr uint8_t header = tag::object | type | (byte_cnt << 5);
+         
+         if (invalid_end(ctx, it, end)) {
+            return;
+         }
+         const auto tag = uint8_t(*it);
+         if (tag != header) [[unlikely]] {
+            if constexpr (Opts.allow_conversions) {
+               const auto key_type = tag & 0b000'11'000;
+               if constexpr (str_t<Key>) {
+                  if (key_type != 0) {
+                     ctx.error = error_code::syntax_error;
+                     return;
+                  }
+               }
+               else {
+                  if (key_type == 0) {
+                     ctx.error = error_code::syntax_error;
+                     return;
+                  }
+               }
+            }
+            else {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+         }
+         
+         ++it;
+         std::conditional_t<Opts.partial_read, size_t, const size_t> n = int_from_compressed(ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+         
+         if constexpr (Opts.partial_read) {
+            n = value.size();
+         }
+         
+         if constexpr (std::is_arithmetic_v<std::decay_t<Key>>) {
+            constexpr uint8_t key_tag = tag::number | type | (byte_cnt << 5);
+            Key key;
+            for (size_t i = 0; i < n; ++i) {
+               if constexpr (Opts.partial_read) {
+                  parse<BEVE>::op<no_header_on<Opts>()>(key, key_tag, ctx, it, end);
+                  if (auto element = value.find(key); element != value.end()) {
+                     parse<BEVE>::op<Opts>(element->second, ctx, it, end);
+                  }
+               }
+               else {
+                  // convert the object tag to the key type tag
+                  parse<BEVE>::op<no_header_on<Opts>()>(key, key_tag, ctx, it, end);
+                  parse<BEVE>::op<Opts>(value[key], ctx, it, end);
+               }
+            }
+         }
+         else {
+            constexpr uint8_t key_tag = tag::string;
+            static thread_local Key key;
+            for (size_t i = 0; i < n; ++i) {
+               if constexpr (Opts.partial_read) {
+                  parse<BEVE>::op<no_header_on<Opts>()>(key, key_tag, ctx, it, end);
+                  if (auto element = value.find(key); element != value.end()) {
+                     parse<BEVE>::op<Opts>(element->second, ctx, it, end);
+                  }
+               }
+               else {
+                  parse<BEVE>::op<no_header_on<Opts>()>(key, key_tag, ctx, it, end);
+                  parse<BEVE>::op<Opts>(value[key], ctx, it, end);
+               }
+            }
+         }
+      }
+   };
+   
+   template <nullable_t T>
+   requires(std::is_array_v<T>)
+   struct from<BEVE, T> final
+   {
+      template <auto Opts, class V, size_t N>
+      GLZ_ALWAYS_INLINE static void op(V (&value)[N], is_context auto&& ctx, auto&& it, auto&& end) noexcept
+      {
+         parse<BEVE>::op<Opts>(std::span{value, N}, ctx, it, end);
+      }
+   };
+   
+   template <nullable_t T>
+   requires(!std::is_array_v<T>)
+   struct from<BEVE, T> final
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         if (invalid_end(ctx, it, end)) {
+            return;
+         }
+         const auto tag = uint8_t(*it);
+         
+         if (tag == tag::null) {
+            ++it;
+            if constexpr (is_specialization_v<T, std::optional>)
+               value = std::nullopt;
+            else if constexpr (is_specialization_v<T, std::unique_ptr>)
+               value = nullptr;
+            else if constexpr (is_specialization_v<T, std::shared_ptr>)
+               value = nullptr;
+         }
+         else {
+            if (!value) {
+               if constexpr (is_specialization_v<T, std::optional>)
+                  value = std::make_optional<typename T::value_type>();
+               else if constexpr (is_specialization_v<T, std::unique_ptr>)
+                  value = std::make_unique<typename T::element_type>();
+               else if constexpr (is_specialization_v<T, std::shared_ptr>)
+                  value = std::make_shared<typename T::element_type>();
+               else if constexpr (constructible<T>) {
+                  value = meta_construct_v<T>();
+               }
+               else {
+                  ctx.error = error_code::invalid_nullable_read;
+                  return;
+                  // Cannot read into unset nullable that is not std::optional, std::unique_ptr, or std::shared_ptr
+               }
+            }
+            parse<BEVE>::op<Opts>(*value, ctx, it, end);
+         }
+      }
+   };
+   
+   template <is_includer T>
+   struct from<BEVE, T>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+      {
+         if constexpr (has_no_header(Opts)) {
+            skip_compressed_int(ctx, it, end);
+         }
+         else {
+            constexpr uint8_t header = tag::string;
+            
             if (invalid_end(ctx, it, end)) {
                return;
             }
@@ -1322,136 +1262,34 @@ namespace glz
                ctx.error = error_code::syntax_error;
                return;
             }
-
+            
             ++it;
-
-            static constexpr auto N = reflect<T>::size;
-
-            static constexpr bit_array<N> all_fields = [] {
-               bit_array<N> arr{};
-               for (size_t i = 0; i < N; ++i) {
-                  arr[i] = true;
-               }
-               return arr;
-            }();
-
-            decltype(auto) fields = [&]() -> decltype(auto) {
-               if constexpr (Opts.partial_read) {
-                  return bit_array<N>{};
-               }
-               else {
-                  return nullptr;
-               }
-            }();
-
-            const auto n_keys = int_from_compressed(ctx, it, end);
-            if (bool(ctx.error)) [[unlikely]] {
-               return;
-            }
-
-            for (size_t i = 0; i < n_keys; ++i) {
-               if constexpr (Opts.partial_read) {
-                  if ((all_fields & fields) == all_fields) {
-                     return;
-                  }
-               }
-
-               if constexpr (N > 0) {
-                  static constexpr auto HashInfo = hash_info<T>;
-
-                  const auto n = int_from_compressed(ctx, it, end);
-                  if (bool(ctx.error)) [[unlikely]] {
-                     return;
-                  }
-                  if (uint64_t(end - it) < n || it == end) [[unlikely]] {
-                     ctx.error = error_code::unexpected_end;
-                     return;
-                  }
-
-                  const auto index = decode_hash_with_size<BEVE, T, HashInfo, HashInfo.type>::op(it, end, n);
-
-                  if (index < N) [[likely]] {
-                     if constexpr (Opts.partial_read) {
-                        fields[index] = true;
-                     }
-
-                     const sv key{it, n};
-                     it += n;
-
-                     jump_table<N>(
-                        [&]<size_t I>() {
-                           static constexpr auto TargetKey = get<I>(reflect<T>::keys);
-                           static constexpr auto Length = TargetKey.size();
-                           if ((Length == n) && compare<Length>(TargetKey.data(), key.data())) [[likely]] {
-                              if constexpr (reflectable<T>) {
-                                 parse<BEVE>::op<Opts>(get_member(value, get<I>(to_tie(value))), ctx, it, end);
-                              }
-                              else {
-                                 parse<BEVE>::op<Opts>(get_member(value, get<I>(reflect<T>::values)), ctx, it, end);
-                              }
-                           }
-                           else {
-                              if constexpr (Opts.error_on_unknown_keys) {
-                                 ctx.error = error_code::unknown_key;
-                                 return;
-                              }
-                              else {
-                                 skip_value<BEVE>::op<Opts>(ctx, it, end);
-                                 if (bool(ctx.error)) [[unlikely]]
-                                    return;
-                              }
-                           }
-                        },
-                        index);
-
-                     if (bool(ctx.error)) [[unlikely]] {
-                        return;
-                     }
-                  }
-                  else [[unlikely]] {
-                     if constexpr (Opts.error_on_unknown_keys) {
-                        ctx.error = error_code::unknown_key;
-                        return;
-                     }
-                     else {
-                        it += n;
-                        skip_value<BEVE>::op<Opts>(ctx, it, end);
-                        if (bool(ctx.error)) [[unlikely]]
-                           return;
-                     }
-                  }
-               }
-               else if constexpr (Opts.error_on_unknown_keys) {
-                  ctx.error = error_code::unknown_key;
-                  return;
-               }
-               else {
-                  skip_value<BEVE>::op<Opts>(ctx, it, end);
-                  if (bool(ctx.error)) [[unlikely]]
-                     return;
-               }
-            }
+            skip_compressed_int(ctx, it, end);
          }
-      };
-
-      template <class T>
-         requires glaze_array_t<T>
-      struct from<BEVE, T> final
+      }
+   };
+   
+   template <class T>
+   requires(glaze_object_t<T> || reflectable<T>)
+   struct from<BEVE, T> final
+   {
+      template <auto Opts>
+      requires(Opts.structs_as_arrays == true)
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
       {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            if (invalid_end(ctx, it, end)) {
-               return;
-            }
+         if constexpr (reflectable<T>) {
+            auto t = to_tie(value);
+            parse<BEVE>::op<Opts>(t, ctx, it, end);
+         }
+         else {
             const auto tag = uint8_t(*it);
             if (tag != tag::generic_array) [[unlikely]] {
                ctx.error = error_code::syntax_error;
                return;
             }
             ++it;
-
-            constexpr auto N = reflect<T>::size;
+            using V = std::decay_t<T>;
+            constexpr auto N = reflect<V>::size;
             const auto n = int_from_compressed(ctx, it, end);
             if (bool(ctx.error)) [[unlikely]] {
                return;
@@ -1460,91 +1298,250 @@ namespace glz
                ctx.error = error_code::syntax_error;
                return;
             }
-
-            invoke_table<N>(
-               [&]<size_t I>() { parse<BEVE>::op<Opts>(get_member(value, get<I>(reflect<T>::values)), ctx, it, end); });
+            
+            invoke_table<N>([&]<size_t I>() {
+               parse<BEVE>::op<Opts>(get_member(value, get<I>(reflect<V>::values)), ctx, it, end);
+            });
          }
-      };
-
-      template <class T>
-         requires(tuple_t<T> || is_std_tuple<T>)
-      struct from<BEVE, T> final
+      }
+      
+      template <auto Opts>
+      requires(Opts.structs_as_arrays == false)
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
       {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            if (invalid_end(ctx, it, end)) {
-               return;
+         constexpr uint8_t type = 0; // string key
+         constexpr uint8_t header = tag::object | type;
+         
+         if (invalid_end(ctx, it, end)) {
+            return;
+         }
+         const auto tag = uint8_t(*it);
+         if (tag != header) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         
+         ++it;
+         
+         static constexpr auto N = reflect<T>::size;
+         
+         static constexpr bit_array<N> all_fields = [] {
+            bit_array<N> arr{};
+            for (size_t i = 0; i < N; ++i) {
+               arr[i] = true;
             }
-            const auto tag = uint8_t(*it);
-            if (tag != tag::generic_array) [[unlikely]] {
-               ctx.error = error_code::syntax_error;
-               return;
-            }
-            ++it;
-
-            using V = std::decay_t<T>;
-            constexpr auto N = glz::tuple_size_v<V>;
+            return arr;
+         }();
+         
+         decltype(auto) fields = [&]() -> decltype(auto) {
             if constexpr (Opts.partial_read) {
-               const auto n = int_from_compressed(ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]] {
-                  return;
-               }
-
-               if constexpr (is_std_tuple<T>) {
-                  for_each_short_circuit<N>([&](auto I) {
-                     if (I < n) {
-                        parse<BEVE>::op<Opts>(std::get<I>(value), ctx, it, end);
-                        return false; // continue
-                     }
-                     return true; // short circuit
-                  });
-               }
-               else {
-                  for_each_short_circuit<N>([&](auto I) {
-                     if (I < n) {
-                        parse<BEVE>::op<Opts>(glz::get<I>(value), ctx, it, end);
-                        return false; // continue
-                     }
-                     return true; // short circuit
-                  });
-               }
+               return bit_array<N>{};
             }
             else {
+               return nullptr;
+            }
+         }();
+         
+         const auto n_keys = int_from_compressed(ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+         
+         for (size_t i = 0; i < n_keys; ++i) {
+            if constexpr (Opts.partial_read) {
+               if ((all_fields & fields) == all_fields) {
+                  return;
+               }
+            }
+            
+            if constexpr (N > 0) {
+               static constexpr auto HashInfo = hash_info<T>;
+               
                const auto n = int_from_compressed(ctx, it, end);
                if (bool(ctx.error)) [[unlikely]] {
                   return;
                }
-               if (n != N) {
-                  ctx.error = error_code::syntax_error;
+               if (uint64_t(end - it) < n || it == end) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
                   return;
                }
-
-               if constexpr (is_std_tuple<T>) {
-                  invoke_table<N>([&]<size_t I>() { parse<BEVE>::op<Opts>(std::get<I>(value), ctx, it, end); });
+               
+               const auto index = decode_hash_with_size<BEVE, T, HashInfo, HashInfo.type>::op(it, end, n);
+               
+               if (index < N) [[likely]] {
+                  if constexpr (Opts.partial_read) {
+                     fields[index] = true;
+                  }
+                  
+                  const sv key{it, n};
+                  it += n;
+                  
+                  jump_table<N>(
+                                [&]<size_t I>() {
+                                   static constexpr auto TargetKey = get<I>(reflect<T>::keys);
+                                   static constexpr auto Length = TargetKey.size();
+                                   if ((Length == n) && compare<Length>(TargetKey.data(), key.data())) [[likely]] {
+                                      if constexpr (reflectable<T>) {
+                                         parse<BEVE>::op<Opts>(get_member(value, get<I>(to_tie(value))), ctx, it, end);
+                                      }
+                                      else {
+                                         parse<BEVE>::op<Opts>(get_member(value, get<I>(reflect<T>::values)), ctx, it, end);
+                                      }
+                                   }
+                                   else {
+                                      if constexpr (Opts.error_on_unknown_keys) {
+                                         ctx.error = error_code::unknown_key;
+                                         return;
+                                      }
+                                      else {
+                                         skip_value<BEVE>::op<Opts>(ctx, it, end);
+                                         if (bool(ctx.error)) [[unlikely]]
+                                            return;
+                                      }
+                                   }
+                                },
+                                index);
+                  
+                  if (bool(ctx.error)) [[unlikely]] {
+                     return;
+                  }
                }
-               else {
-                  invoke_table<N>([&]<size_t I>() { parse<BEVE>::op<Opts>(glz::get<I>(value), ctx, it, end); });
+               else [[unlikely]] {
+                  if constexpr (Opts.error_on_unknown_keys) {
+                     ctx.error = error_code::unknown_key;
+                     return;
+                  }
+                  else {
+                     it += n;
+                     skip_value<BEVE>::op<Opts>(ctx, it, end);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                  }
                }
             }
+            else if constexpr (Opts.error_on_unknown_keys) {
+               ctx.error = error_code::unknown_key;
+               return;
+            }
+            else {
+               skip_value<BEVE>::op<Opts>(ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
+            }
          }
-      };
-
-      template <filesystem_path T>
-      struct from<BEVE, T>
+      }
+   };
+   
+   template <class T>
+   requires glaze_array_t<T>
+   struct from<BEVE, T> final
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
       {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&&... args)
-         {
-            static thread_local std::string buffer{};
-            parse<BEVE>::op<Opts>(buffer, ctx, args...);
+         if (invalid_end(ctx, it, end)) {
+            return;
+         }
+         const auto tag = uint8_t(*it);
+         if (tag != tag::generic_array) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         ++it;
+         
+         constexpr auto N = reflect<T>::size;
+         const auto n = int_from_compressed(ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+         if (n != N) {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         
+         invoke_table<N>(
+                         [&]<size_t I>() { parse<BEVE>::op<Opts>(get_member(value, get<I>(reflect<T>::values)), ctx, it, end); });
+      }
+   };
+   
+   template <class T>
+   requires(tuple_t<T> || is_std_tuple<T>)
+   struct from<BEVE, T> final
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         if (invalid_end(ctx, it, end)) {
+            return;
+         }
+         const auto tag = uint8_t(*it);
+         if (tag != tag::generic_array) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         ++it;
+         
+         using V = std::decay_t<T>;
+         constexpr auto N = glz::tuple_size_v<V>;
+         if constexpr (Opts.partial_read) {
+            const auto n = int_from_compressed(ctx, it, end);
             if (bool(ctx.error)) [[unlikely]] {
                return;
             }
-            value = buffer;
+            
+            if constexpr (is_std_tuple<T>) {
+               for_each_short_circuit<N>([&](auto I) {
+                  if (I < n) {
+                     parse<BEVE>::op<Opts>(std::get<I>(value), ctx, it, end);
+                     return false; // continue
+                  }
+                  return true; // short circuit
+               });
+            }
+            else {
+               for_each_short_circuit<N>([&](auto I) {
+                  if (I < n) {
+                     parse<BEVE>::op<Opts>(glz::get<I>(value), ctx, it, end);
+                     return false; // continue
+                  }
+                  return true; // short circuit
+               });
+            }
          }
-      };
-   }
+         else {
+            const auto n = int_from_compressed(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            if (n != N) {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            
+            if constexpr (is_std_tuple<T>) {
+               invoke_table<N>([&]<size_t I>() { parse<BEVE>::op<Opts>(std::get<I>(value), ctx, it, end); });
+            }
+            else {
+               invoke_table<N>([&]<size_t I>() { parse<BEVE>::op<Opts>(glz::get<I>(value), ctx, it, end); });
+            }
+         }
+      }
+   };
+   
+   template <filesystem_path T>
+   struct from<BEVE, T>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&&... args)
+      {
+         static thread_local std::string buffer{};
+         parse<BEVE>::op<Opts>(buffer, ctx, args...);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+         value = buffer;
+      }
+   };
 
    template <class T, class Buffer>
       requires(read_supported<BEVE, T>)

--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -1383,7 +1383,7 @@ namespace glz
                            static constexpr auto TargetKey = get<I>(reflect<T>::keys);
                            static constexpr auto Length = TargetKey.size();
                            if ((Length == n) && compare<Length>(TargetKey.data(), key.data())) [[likely]] {
-                              if constexpr (detail::reflectable<T>) {
+                              if constexpr (reflectable<T>) {
                                  parse<BEVE>::op<Opts>(get_member(value, get<I>(to_tie(value))), ctx, it, end);
                               }
                               else {

--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -31,7 +31,7 @@ namespace glz
             }
             else {
                // do not read anything into the const value
-               detail::skip_value<BEVE>::op<Opts>(std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
+               skip_value<BEVE>::op<Opts>(std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
             }
          }
          else {
@@ -51,7 +51,7 @@ namespace glz
             }
             else {
                // do not read anything into the const value
-               detail::skip_value<BEVE>::op<Opts>(std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
+               skip_value<BEVE>::op<Opts>(std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
             }
          }
          else {

--- a/include/glaze/beve/skip.hpp
+++ b/include/glaze/beve/skip.hpp
@@ -9,7 +9,7 @@
 #include "glaze/file/file_ops.hpp"
 #include "glaze/util/dump.hpp"
 
-namespace glz::detail
+namespace glz
 {
    template <>
    struct skip_value<BEVE>
@@ -17,7 +17,10 @@ namespace glz::detail
       template <opts Opts>
       inline static void op(is_context auto&& ctx, auto&& it, auto&& end) noexcept;
    };
+}
 
+namespace glz::detail
+{
    inline void skip_string_beve(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       ++it;
@@ -196,7 +199,10 @@ namespace glz::detail
       ++it;
       skip_value<BEVE>::op<Opts>(ctx, it, end);
    }
+}
 
+namespace glz
+{
    template <opts Opts>
    inline void skip_value<BEVE>::op(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
@@ -204,36 +210,36 @@ namespace glz::detail
          return;
       }
       switch (uint8_t(*it) & 0b00000'111) {
-      case tag::null: {
-         ++it;
-         break;
-      }
-      case tag::number: {
-         skip_number_beve(ctx, it, end);
-         break;
-      }
-      case tag::string: {
-         skip_string_beve(ctx, it, end);
-         break;
-      }
-      case tag::object: {
-         skip_object_beve<Opts>(ctx, it, end);
-         break;
-      }
-      case tag::typed_array: {
-         skip_typed_array_beve<Opts>(ctx, it, end);
-         break;
-      }
-      case tag::generic_array: {
-         skip_untyped_array_beve<Opts>(ctx, it, end);
-         break;
-      }
-      case tag::extensions: {
-         skip_additional_beve<Opts>(ctx, it, end);
-         break;
-      }
-      default:
-         ctx.error = error_code::syntax_error;
+         case tag::null: {
+            ++it;
+            break;
+         }
+         case tag::number: {
+            skip_number_beve(ctx, it, end);
+            break;
+         }
+         case tag::string: {
+            skip_string_beve(ctx, it, end);
+            break;
+         }
+         case tag::object: {
+            skip_object_beve<Opts>(ctx, it, end);
+            break;
+         }
+         case tag::typed_array: {
+            skip_typed_array_beve<Opts>(ctx, it, end);
+            break;
+         }
+         case tag::generic_array: {
+            skip_untyped_array_beve<Opts>(ctx, it, end);
+            break;
+         }
+         case tag::extensions: {
+            skip_additional_beve<Opts>(ctx, it, end);
+            break;
+         }
+         default:
+            ctx.error = error_code::syntax_error;
       }
    }
 }

--- a/include/glaze/beve/skip.hpp
+++ b/include/glaze/beve/skip.hpp
@@ -206,6 +206,8 @@ namespace glz
    template <opts Opts>
    inline void skip_value<BEVE>::op(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
+      using namespace glz::detail;
+      
       if (invalid_end(ctx, it, end)) {
          return;
       }

--- a/include/glaze/beve/skip.hpp
+++ b/include/glaze/beve/skip.hpp
@@ -17,10 +17,7 @@ namespace glz
       template <opts Opts>
       inline static void op(is_context auto&& ctx, auto&& it, auto&& end) noexcept;
    };
-}
-
-namespace glz::detail
-{
+   
    inline void skip_string_beve(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       ++it;
@@ -34,7 +31,7 @@ namespace glz::detail
       }
       it += n;
    }
-
+   
    GLZ_ALWAYS_INLINE void skip_number_beve(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       const auto tag = uint8_t(*it);
@@ -46,7 +43,7 @@ namespace glz::detail
       }
       it += byte_count;
    }
-
+   
    template <opts Opts>
    inline void skip_object_beve(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
@@ -55,12 +52,12 @@ namespace glz::detail
       }
       const auto tag = uint8_t(*it);
       ++it;
-
+      
       const auto n_keys = int_from_compressed(ctx, it, end);
       if (bool(ctx.error)) [[unlikely]] {
          return;
       }
-
+      
       if ((tag & 0b00000'111) == tag::string) {
          for (size_t i = 0; i < n_keys; ++i) {
             const auto string_length = int_from_compressed(ctx, it, end);
@@ -71,9 +68,9 @@ namespace glz::detail
                ctx.error = error_code::unexpected_end;
                return;
             }
-
+            
             it += string_length;
-
+            
             skip_value<BEVE>::op<Opts>(ctx, it, end);
             if (bool(ctx.error)) [[unlikely]]
                return;
@@ -90,9 +87,9 @@ namespace glz::detail
                ctx.error = error_code::unexpected_end;
                return;
             }
-
+            
             it += byte_count * n;
-
+            
             skip_value<BEVE>::op<Opts>(ctx, it, end);
             if (bool(ctx.error)) [[unlikely]]
                return;
@@ -103,64 +100,64 @@ namespace glz::detail
          return;
       }
    }
-
+   
    template <opts Opts>
    inline void skip_typed_array_beve(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       const auto tag = uint8_t(*it);
       const uint8_t type = (tag & 0b000'11'000) >> 3;
       switch (type) {
-      case 0: // floating point (fallthrough)
-      case 1: // signed integer (fallthrough)
-      case 2: { // unsigned integer
-         ++it;
-         const auto n = int_from_compressed(ctx, it, end);
-         if (bool(ctx.error)) [[unlikely]] {
-            return;
-         }
-         const uint8_t byte_count = byte_count_lookup[tag >> 5];
-         if (uint64_t(end - it) < byte_count * n) [[unlikely]] {
-            ctx.error = error_code::unexpected_end;
-            return;
-         }
-         it += byte_count * n;
-         break;
-      }
-      case 3: { // bool or string
-         const bool is_bool = (tag & 0b00'1'00'000) >> 5;
-         ++it;
-         if (is_bool) {
+         case 0: // floating point (fallthrough)
+         case 1: // signed integer (fallthrough)
+         case 2: { // unsigned integer
+            ++it;
             const auto n = int_from_compressed(ctx, it, end);
             if (bool(ctx.error)) [[unlikely]] {
                return;
             }
-
-            const auto num_bytes = (n + 7) / 8;
-            if (uint64_t(end - it) < num_bytes) [[unlikely]] {
+            const uint8_t byte_count = byte_count_lookup[tag >> 5];
+            if (uint64_t(end - it) < byte_count * n) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return;
             }
-            it += num_bytes;
+            it += byte_count * n;
+            break;
          }
-         else {
-            const auto n = int_from_compressed(ctx, it, end);
-            if (bool(ctx.error)) [[unlikely]] {
-               return;
+         case 3: { // bool or string
+            const bool is_bool = (tag & 0b00'1'00'000) >> 5;
+            ++it;
+            if (is_bool) {
+               const auto n = int_from_compressed(ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+               
+               const auto num_bytes = (n + 7) / 8;
+               if (uint64_t(end - it) < num_bytes) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
+               it += num_bytes;
             }
-            if (uint64_t(end - it) < n) [[unlikely]] {
-               ctx.error = error_code::unexpected_end;
-               return;
+            else {
+               const auto n = int_from_compressed(ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+               if (uint64_t(end - it) < n) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
+               
+               it += n;
             }
-
-            it += n;
+            break;
          }
-         break;
-      }
-      default:
-         ctx.error = error_code::syntax_error;
+         default:
+            ctx.error = error_code::syntax_error;
       }
    }
-
+   
    template <opts Opts>
    inline void skip_untyped_array_beve(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
@@ -169,40 +166,37 @@ namespace glz::detail
       if (bool(ctx.error)) [[unlikely]] {
          return;
       }
-
+      
       for (size_t i = 0; i < n; ++i) {
          skip_value<BEVE>::op<Opts>(ctx, it, end);
       }
    }
-
+   
    template <opts Opts>
-      requires(Opts.format == BEVE)
+   requires(Opts.format == BEVE)
    void skip_array(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       switch (uint8_t(*it) & 0b00000'111) {
-      case tag::typed_array: {
-         skip_typed_array_beve<Opts>(ctx, it, end);
-         break;
-      }
-      case tag::generic_array: {
-         skip_untyped_array_beve<Opts>(ctx, it, end);
-         break;
-      }
-      default:
-         ctx.error = error_code::syntax_error;
+         case tag::typed_array: {
+            skip_typed_array_beve<Opts>(ctx, it, end);
+            break;
+         }
+         case tag::generic_array: {
+            skip_untyped_array_beve<Opts>(ctx, it, end);
+            break;
+         }
+         default:
+            ctx.error = error_code::syntax_error;
       }
    }
-
+   
    template <opts Opts>
    GLZ_ALWAYS_INLINE void skip_additional_beve(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       ++it;
       skip_value<BEVE>::op<Opts>(ctx, it, end);
    }
-}
-
-namespace glz
-{
+   
    template <opts Opts>
    inline void skip_value<BEVE>::op(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {

--- a/include/glaze/beve/wrappers.hpp
+++ b/include/glaze/beve/wrappers.hpp
@@ -11,7 +11,7 @@
 #include "glaze/json/read.hpp"
 #include "glaze/json/write.hpp"
 
-namespace glz::detail
+namespace glz
 {
    template <is_opts_wrapper T>
    struct from<BEVE, T>
@@ -22,7 +22,7 @@ namespace glz::detail
          parse<BEVE>::op<opt_true<Opts, T::opts_member>>(value.val, args...);
       }
    };
-
+   
    template <is_opts_wrapper T>
    struct to<BEVE, T>
    {

--- a/include/glaze/beve/wrappers.hpp
+++ b/include/glaze/beve/wrappers.hpp
@@ -19,7 +19,7 @@ namespace glz::detail
       template <auto Opts>
       GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args)
       {
-         read<BEVE>::op<opt_true<Opts, T::opts_member>>(value.val, args...);
+         parse<BEVE>::op<opt_true<Opts, T::opts_member>>(value.val, args...);
       }
    };
 
@@ -29,7 +29,7 @@ namespace glz::detail
       template <auto Opts>
       GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args)
       {
-         write<BEVE>::op<opt_true<Opts, T::opts_member>>(value.val, ctx, args...);
+         serialize<BEVE>::op<opt_true<Opts, T::opts_member>>(value.val, ctx, args...);
       }
    };
 }

--- a/include/glaze/beve/write.hpp
+++ b/include/glaze/beve/write.hpp
@@ -23,86 +23,83 @@ namespace glz
       template <auto Opts, class T, is_context Ctx, class B, class IX>
       GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
       {
-         detail::to<BEVE, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+         to<BEVE, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
                                                              std::forward<B>(b), std::forward<IX>(ix));
       }
       
       template <auto Opts, class T, is_context Ctx, class B, class IX>
       GLZ_ALWAYS_INLINE static void no_header(T&& value, Ctx&& ctx, B&& b, IX&& ix)
       {
-         detail::to<BEVE, std::remove_cvref_t<T>>::template no_header<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+         to<BEVE, std::remove_cvref_t<T>>::template no_header<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
                                                                     std::forward<B>(b), std::forward<IX>(ix));
       }
    };
    
-   namespace detail
+   GLZ_ALWAYS_INLINE void dump_type(auto&& value, auto&& b, auto&& ix)
    {
-      GLZ_ALWAYS_INLINE void dump_type(auto&& value, auto&& b, auto&& ix)
-      {
-         using V = std::decay_t<decltype(value)>;
-         constexpr auto n = sizeof(V);
-         if (const auto k = ix + n; k > b.size()) [[unlikely]] {
-            b.resize(2 * k);
-         }
-         
-         constexpr auto is_volatile = std::is_volatile_v<std::remove_reference_t<decltype(value)>>;
-         
-         if constexpr (is_volatile) {
-            const V temp = value;
-            std::memcpy(&b[ix], &temp, n);
-         }
-         else {
-            std::memcpy(&b[ix], &value, n);
-         }
-         ix += n;
+      using V = std::decay_t<decltype(value)>;
+      constexpr auto n = sizeof(V);
+      if (const auto k = ix + n; k > b.size()) [[unlikely]] {
+         b.resize(2 * k);
       }
       
-      template <uint64_t i, class... Args>
-      GLZ_ALWAYS_INLINE void dump_compressed_int(Args&&... args)
-      {
-         if constexpr (i < 64) {
-            const uint8_t c = uint8_t(i) << 2;
-            dump_type(c, args...);
-         }
-         else if constexpr (i < 16384) {
-            const uint16_t c = uint16_t(1) | (uint16_t(i) << 2);
-            dump_type(c, args...);
-         }
-         else if constexpr (i < 1073741824) {
-            const uint32_t c = uint32_t(2) | (uint32_t(i) << 2);
-            dump_type(c, args...);
-         }
-         else if constexpr (i < 4611686018427387904) {
-            const uint64_t c = uint64_t(3) | (uint64_t(i) << 2);
-            dump_type(c, args...);
-         }
-         else {
-            static_assert(i >= 4611686018427387904, "size not supported");
-         }
-      }
+      constexpr auto is_volatile = std::is_volatile_v<std::remove_reference_t<decltype(value)>>;
       
-      template <auto Opts, class... Args>
-      GLZ_ALWAYS_INLINE void dump_compressed_int(uint64_t i, Args&&... args)
-      {
-         if (i < 64) {
-            const uint8_t c = uint8_t(i) << 2;
-            dump_type(c, args...);
-         }
-         else if (i < 16384) {
-            const uint16_t c = uint16_t(1) | (uint16_t(i) << 2);
-            dump_type(c, args...);
-         }
-         else if (i < 1073741824) {
-            const uint32_t c = uint32_t(2) | (uint32_t(i) << 2);
-            dump_type(c, args...);
-         }
-         else if (i < 4611686018427387904) {
-            const uint64_t c = uint64_t(3) | (uint64_t(i) << 2);
-            dump_type(c, args...);
-         }
-         else {
-            std::abort(); // this should never happen because we should never allocate containers of this size
-         }
+      if constexpr (is_volatile) {
+         const V temp = value;
+         std::memcpy(&b[ix], &temp, n);
+      }
+      else {
+         std::memcpy(&b[ix], &value, n);
+      }
+      ix += n;
+   }
+   
+   template <uint64_t i, class... Args>
+   GLZ_ALWAYS_INLINE void dump_compressed_int(Args&&... args)
+   {
+      if constexpr (i < 64) {
+         const uint8_t c = uint8_t(i) << 2;
+         dump_type(c, args...);
+      }
+      else if constexpr (i < 16384) {
+         const uint16_t c = uint16_t(1) | (uint16_t(i) << 2);
+         dump_type(c, args...);
+      }
+      else if constexpr (i < 1073741824) {
+         const uint32_t c = uint32_t(2) | (uint32_t(i) << 2);
+         dump_type(c, args...);
+      }
+      else if constexpr (i < 4611686018427387904) {
+         const uint64_t c = uint64_t(3) | (uint64_t(i) << 2);
+         dump_type(c, args...);
+      }
+      else {
+         static_assert(i >= 4611686018427387904, "size not supported");
+      }
+   }
+   
+   template <auto Opts, class... Args>
+   GLZ_ALWAYS_INLINE void dump_compressed_int(uint64_t i, Args&&... args)
+   {
+      if (i < 64) {
+         const uint8_t c = uint8_t(i) << 2;
+         dump_type(c, args...);
+      }
+      else if (i < 16384) {
+         const uint16_t c = uint16_t(1) | (uint16_t(i) << 2);
+         dump_type(c, args...);
+      }
+      else if (i < 1073741824) {
+         const uint32_t c = uint32_t(2) | (uint32_t(i) << 2);
+         dump_type(c, args...);
+      }
+      else if (i < 4611686018427387904) {
+         const uint64_t c = uint64_t(3) | (uint64_t(i) << 2);
+         dump_type(c, args...);
+      }
+      else {
+         std::abort(); // this should never happen because we should never allocate containers of this size
       }
    }
    
@@ -145,9 +142,9 @@ namespace glz
          
          constexpr uint8_t type = 0; // string
          constexpr uint8_t tag = tag::object | type;
-         detail::dump_type(tag, b, ix);
+         dump_type(tag, b, ix);
          
-         detail::dump_compressed_int<N>(b, ix);
+         dump_compressed_int<N>(b, ix);
          
          if constexpr (glaze_object_t<T>) {
             for_each<N>([&](auto I) {
@@ -212,706 +209,703 @@ namespace glz
          }
       }
    };
-   
-   namespace detail
+
+   template <class T>
+   requires(glaze_value_t<T> && !custom_write<T>)
+   struct to<BEVE, T>
    {
-      template <class T>
-         requires(glaze_value_t<T> && !custom_write<T>)
-      struct to<BEVE, T>
+      template <auto Opts, class Value, is_context Ctx, class B, class IX>
+      GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, B&& b, IX&& ix)
       {
-         template <auto Opts, class Value, is_context Ctx, class B, class IX>
-         GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, B&& b, IX&& ix)
-         {
-            using V = std::remove_cvref_t<decltype(get_member(std::declval<Value>(), meta_wrapper_v<T>))>;
-            to<BEVE, V>::template op<Opts>(get_member(std::forward<Value>(value), meta_wrapper_v<T>),
-                                           std::forward<Ctx>(ctx), std::forward<B>(b), std::forward<IX>(ix));
+         using V = std::remove_cvref_t<decltype(get_member(std::declval<Value>(), meta_wrapper_v<T>))>;
+         to<BEVE, V>::template op<Opts>(get_member(std::forward<Value>(value), meta_wrapper_v<T>),
+                                        std::forward<Ctx>(ctx), std::forward<B>(b), std::forward<IX>(ix));
+      }
+   };
+   
+   template <always_null_t T>
+   struct to<BEVE, T>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, auto&&... args)
+      {
+         dump_type(uint8_t{0}, args...);
+      }
+   };
+   
+   template <is_bitset T>
+   struct to<BEVE, T>
+   {
+      template <auto Opts, class... Args>
+      static void op(auto&& value, is_context auto&&, auto&&... args)
+      {
+         constexpr uint8_t type = uint8_t(3) << 3;
+         constexpr uint8_t tag = tag::typed_array | type;
+         dump_type(tag, args...);
+         dump_compressed_int<Opts>(value.size(), args...);
+         
+         // constexpr auto num_bytes = (value.size() + 7) / 8;
+         const auto num_bytes = (value.size() + 7) / 8;
+         // .size() should be constexpr, but clang doesn't support this
+         std::vector<uint8_t> bytes(num_bytes);
+         // std::array<uint8_t, num_bytes> bytes{};
+         for (size_t byte_i{}, i{}; byte_i < num_bytes; ++byte_i) {
+            for (size_t bit_i = 0; bit_i < 8 && i < value.size(); ++bit_i, ++i) {
+               bytes[byte_i] |= uint8_t(value[i]) << uint8_t(bit_i);
+            }
          }
-      };
-
-      template <always_null_t T>
-      struct to<BEVE, T>
+         dump(bytes, args...);
+      }
+   };
+   
+   template <glaze_flags_t T>
+   struct to<BEVE, T>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix)
       {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, auto&&... args)
-         {
-            dump_type(uint8_t{0}, args...);
+         static constexpr auto N = reflect<T>::size;
+         
+         std::array<uint8_t, byte_length<T>()> data{};
+         
+         invoke_table<N>([&]<size_t I>() {
+            data[I / 8] |= static_cast<uint8_t>(get_member(value, get<I>(reflect<T>::values))) << (7 - (I % 8));
+         });
+         
+         dump(data, b, ix);
+      }
+   };
+   
+   template <is_member_function_pointer T>
+   struct to<BEVE, T>
+   {
+      template <auto Opts, class... Args>
+      GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, Args&&...) noexcept
+      {}
+   };
+   
+   // write includers as empty strings
+   template <is_includer T>
+   struct to<BEVE, T>
+   {
+      template <auto Opts, class... Args>
+      GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, Args&&... args)
+      {
+         constexpr uint8_t tag = tag::string;
+         
+         dump_type(tag, args...);
+         dump_compressed_int<Opts>(0, args...);
+      }
+   };
+   
+   template <boolean_like T>
+   struct to<BEVE, T> final
+   {
+      template <auto Opts, class... Args>
+      GLZ_ALWAYS_INLINE static void op(const bool value, is_context auto&&, Args&&... args)
+      {
+         dump_type(value ? tag::bool_true : tag::bool_false, args...);
+      }
+   };
+   
+   template <func_t T>
+   struct to<BEVE, T> final
+   {
+      template <auto Opts, class... Args>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
+      {
+         serialize<BEVE>::op<Opts>(name_v<std::decay_t<decltype(value)>>, ctx, args...);
+      }
+   };
+   
+   template <class T>
+   struct to<BEVE, basic_raw_json<T>> final
+   {
+      template <auto Opts, class... Args>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
+      {
+         serialize<BEVE>::op<Opts>(value.str, ctx, std::forward<Args>(args)...);
+      }
+   };
+   
+   template <class T>
+   struct to<BEVE, basic_text<T>> final
+   {
+      template <auto Opts, class... Args>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
+      {
+         serialize<BEVE>::op<Opts>(value.str, ctx, std::forward<Args>(args)...);
+      }
+   };
+   
+   template <class T, class V>
+   constexpr size_t variant_index_v = []<size_t... I>(std::index_sequence<I...>) {
+      return ((std::is_same_v<T, std::variant_alternative_t<I, V>> * I) + ...);
+   }(std::make_index_sequence<std::variant_size_v<V>>{});
+   
+   template <is_variant T>
+   struct to<BEVE, T> final
+   {
+      template <auto Opts, class... Args>
+      static void op(auto&& value, is_context auto&& ctx, Args&&... args)
+      {
+         using Variant = std::decay_t<decltype(value)>;
+         
+         std::visit(
+                    [&](auto&& v) {
+                       using V = std::decay_t<decltype(v)>;
+                       
+                       static constexpr uint64_t index = variant_index_v<V, Variant>;
+                       
+                       constexpr uint8_t tag = tag::extensions | 0b00001'000;
+                       
+                       dump_type(tag, args...);
+                       dump_compressed_int<index>(args...);
+                       serialize<BEVE>::op<Opts>(v, ctx, args...);
+                    },
+                    value);
+      }
+   };
+   
+   template <class T>
+   requires num_t<T> || char_t<T> || glaze_enum_t<T>
+   struct to<BEVE, T> final
+   {
+      template <auto Opts, class... Args>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, Args&&... args)
+      {
+         constexpr uint8_t type = std::floating_point<T> ? 0 : (std::is_signed_v<T> ? 0b000'01'000 : 0b000'10'000);
+         constexpr uint8_t tag = tag::number | type | (byte_count<T> << 5);
+         dump_type(tag, args...);
+         dump_type(value, args...);
+      }
+      
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void no_header(auto&& value, is_context auto&&, auto&&... args)
+      {
+         dump_type(value, args...);
+      }
+   };
+   
+   template <class T>
+   requires(std::is_enum_v<T> && !glaze_enum_t<T>)
+   struct to<BEVE, T> final
+   {
+      template <auto Opts, class... Args>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, Args&&... args)
+      {
+         using V = std::underlying_type_t<std::decay_t<T>>;
+         
+         constexpr uint8_t type = std::floating_point<V> ? 0 : (std::is_signed_v<V> ? 0b000'01'000 : 0b000'10'000);
+         constexpr uint8_t tag = tag::number | type | (byte_count<V> << 5);
+         dump_type(tag, args...);
+         dump_type(value, args...);
+      }
+      
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void no_header(auto&& value, is_context auto&&, auto&&... args)
+      {
+         dump_type(value, args...);
+      }
+   };
+   
+   template <class T>
+   requires complex_t<T>
+   struct to<BEVE, T> final
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&&... args)
+      {
+         constexpr uint8_t tag = tag::extensions | 0b00011'000;
+         dump_type(tag, args...);
+         
+         using V = typename T::value_type;
+         constexpr uint8_t complex_number = 0;
+         constexpr uint8_t type = std::floating_point<V> ? 0 : (std::is_signed_v<V> ? 0b000'01'000 : 0b000'10'000);
+         constexpr uint8_t complex_header = complex_number | type | (byte_count<V> << 5);
+         dump_type(complex_header, args...);
+         dump_type(value.real(), args...);
+         dump_type(value.imag(), args...);
+      }
+      
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void no_header(auto&& value, is_context auto&&, auto&&... args)
+      {
+         dump_type(value.real(), args...);
+         dump_type(value.imag(), args...);
+      }
+   };
+   
+   template <str_t T>
+   struct to<BEVE, T> final
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix)
+      {
+         const sv str = [&]() -> const sv {
+            if constexpr (!char_array_t<T> && std::is_pointer_v<std::decay_t<T>>) {
+               return value ? value : "";
+            }
+            else {
+               return value;
+            }
+         }();
+         
+         constexpr uint8_t tag = tag::string;
+         
+         dump_type(tag, b, ix);
+         const auto n = str.size();
+         dump_compressed_int<Opts>(n, b, ix);
+         
+         if (const auto k = ix + n; k > b.size()) [[unlikely]] {
+            b.resize(2 * k);
          }
-      };
-
-      template <is_bitset T>
-      struct to<BEVE, T>
+         
+         std::memcpy(&b[ix], str.data(), n);
+         ix += n;
+      }
+      
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void no_header(auto&& value, is_context auto&&, auto&& b, auto&& ix)
       {
-         template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&&, auto&&... args)
-         {
+         dump_compressed_int<Opts>(value.size(), b, ix);
+         
+         const auto n = value.size();
+         if (const auto k = ix + n; k > b.size()) [[unlikely]] {
+            b.resize(2 * k);
+         }
+         
+         std::memcpy(&b[ix], value.data(), n);
+         ix += n;
+      }
+   };
+   
+   template <writable_array_t T>
+   struct to<BEVE, T> final
+   {
+      static constexpr bool map_like_array = pair_t<range_value_t<T>>;
+      
+      template <auto Opts>
+      requires(map_like_array ? Opts.concatenate == false : true)
+      static void op(auto&& value, is_context auto&& ctx, auto&&... args)
+      {
+         using V = range_value_t<std::decay_t<T>>;
+         
+         if constexpr (boolean_like<V>) {
             constexpr uint8_t type = uint8_t(3) << 3;
             constexpr uint8_t tag = tag::typed_array | type;
             dump_type(tag, args...);
             dump_compressed_int<Opts>(value.size(), args...);
-
-            // constexpr auto num_bytes = (value.size() + 7) / 8;
-            const auto num_bytes = (value.size() + 7) / 8;
-            // .size() should be constexpr, but clang doesn't support this
-            std::vector<uint8_t> bytes(num_bytes);
-            // std::array<uint8_t, num_bytes> bytes{};
-            for (size_t byte_i{}, i{}; byte_i < num_bytes; ++byte_i) {
-               for (size_t bit_i = 0; bit_i < 8 && i < value.size(); ++bit_i, ++i) {
-                  bytes[byte_i] |= uint8_t(value[i]) << uint8_t(bit_i);
-               }
-            }
-            dump(bytes, args...);
-         }
-      };
-
-      template <glaze_flags_t T>
-      struct to<BEVE, T>
-      {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix)
-         {
-            static constexpr auto N = reflect<T>::size;
-
-            std::array<uint8_t, byte_length<T>()> data{};
-
-            invoke_table<N>([&]<size_t I>() {
-               data[I / 8] |= static_cast<uint8_t>(get_member(value, get<I>(reflect<T>::values))) << (7 - (I % 8));
-            });
-
-            dump(data, b, ix);
-         }
-      };
-
-      template <is_member_function_pointer T>
-      struct to<BEVE, T>
-      {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, Args&&...) noexcept
-         {}
-      };
-
-      // write includers as empty strings
-      template <is_includer T>
-      struct to<BEVE, T>
-      {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, Args&&... args)
-         {
-            constexpr uint8_t tag = tag::string;
-
-            dump_type(tag, args...);
-            dump_compressed_int<Opts>(0, args...);
-         }
-      };
-
-      template <boolean_like T>
-      struct to<BEVE, T> final
-      {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(const bool value, is_context auto&&, Args&&... args)
-         {
-            dump_type(value ? tag::bool_true : tag::bool_false, args...);
-         }
-      };
-
-      template <func_t T>
-      struct to<BEVE, T> final
-      {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
-         {
-            serialize<BEVE>::op<Opts>(name_v<std::decay_t<decltype(value)>>, ctx, args...);
-         }
-      };
-
-      template <class T>
-      struct to<BEVE, basic_raw_json<T>> final
-      {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
-         {
-            serialize<BEVE>::op<Opts>(value.str, ctx, std::forward<Args>(args)...);
-         }
-      };
-
-      template <class T>
-      struct to<BEVE, basic_text<T>> final
-      {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
-         {
-            serialize<BEVE>::op<Opts>(value.str, ctx, std::forward<Args>(args)...);
-         }
-      };
-
-      template <class T, class V>
-      constexpr size_t variant_index_v = []<size_t... I>(std::index_sequence<I...>) {
-         return ((std::is_same_v<T, std::variant_alternative_t<I, V>> * I) + ...);
-      }(std::make_index_sequence<std::variant_size_v<V>>{});
-
-      template <is_variant T>
-      struct to<BEVE, T> final
-      {
-         template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
-         {
-            using Variant = std::decay_t<decltype(value)>;
-
-            std::visit(
-               [&](auto&& v) {
-                  using V = std::decay_t<decltype(v)>;
-
-                  static constexpr uint64_t index = variant_index_v<V, Variant>;
-
-                  constexpr uint8_t tag = tag::extensions | 0b00001'000;
-
-                  dump_type(tag, args...);
-                  dump_compressed_int<index>(args...);
-                  serialize<BEVE>::op<Opts>(v, ctx, args...);
-               },
-               value);
-         }
-      };
-
-      template <class T>
-         requires num_t<T> || char_t<T> || glaze_enum_t<T>
-      struct to<BEVE, T> final
-      {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, Args&&... args)
-         {
-            constexpr uint8_t type = std::floating_point<T> ? 0 : (std::is_signed_v<T> ? 0b000'01'000 : 0b000'10'000);
-            constexpr uint8_t tag = tag::number | type | (byte_count<T> << 5);
-            dump_type(tag, args...);
-            dump_type(value, args...);
-         }
-
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void no_header(auto&& value, is_context auto&&, auto&&... args)
-         {
-            dump_type(value, args...);
-         }
-      };
-
-      template <class T>
-         requires(std::is_enum_v<T> && !glaze_enum_t<T>)
-      struct to<BEVE, T> final
-      {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, Args&&... args)
-         {
-            using V = std::underlying_type_t<std::decay_t<T>>;
-
-            constexpr uint8_t type = std::floating_point<V> ? 0 : (std::is_signed_v<V> ? 0b000'01'000 : 0b000'10'000);
-            constexpr uint8_t tag = tag::number | type | (byte_count<V> << 5);
-            dump_type(tag, args...);
-            dump_type(value, args...);
-         }
-
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void no_header(auto&& value, is_context auto&&, auto&&... args)
-         {
-            dump_type(value, args...);
-         }
-      };
-
-      template <class T>
-         requires complex_t<T>
-      struct to<BEVE, T> final
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&&... args)
-         {
-            constexpr uint8_t tag = tag::extensions | 0b00011'000;
-            dump_type(tag, args...);
-
-            using V = typename T::value_type;
-            constexpr uint8_t complex_number = 0;
-            constexpr uint8_t type = std::floating_point<V> ? 0 : (std::is_signed_v<V> ? 0b000'01'000 : 0b000'10'000);
-            constexpr uint8_t complex_header = complex_number | type | (byte_count<V> << 5);
-            dump_type(complex_header, args...);
-            dump_type(value.real(), args...);
-            dump_type(value.imag(), args...);
-         }
-
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void no_header(auto&& value, is_context auto&&, auto&&... args)
-         {
-            dump_type(value.real(), args...);
-            dump_type(value.imag(), args...);
-         }
-      };
-
-      template <str_t T>
-      struct to<BEVE, T> final
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix)
-         {
-            const sv str = [&]() -> const sv {
-               if constexpr (!char_array_t<T> && std::is_pointer_v<std::decay_t<T>>) {
-                  return value ? value : "";
-               }
-               else {
-                  return value;
-               }
-            }();
-
-            constexpr uint8_t tag = tag::string;
-
-            dump_type(tag, b, ix);
-            const auto n = str.size();
-            dump_compressed_int<Opts>(n, b, ix);
-
-            if (const auto k = ix + n; k > b.size()) [[unlikely]] {
-               b.resize(2 * k);
-            }
-
-            std::memcpy(&b[ix], str.data(), n);
-            ix += n;
-         }
-
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void no_header(auto&& value, is_context auto&&, auto&& b, auto&& ix)
-         {
-            dump_compressed_int<Opts>(value.size(), b, ix);
-
-            const auto n = value.size();
-            if (const auto k = ix + n; k > b.size()) [[unlikely]] {
-               b.resize(2 * k);
-            }
-
-            std::memcpy(&b[ix], value.data(), n);
-            ix += n;
-         }
-      };
-
-      template <writable_array_t T>
-      struct to<BEVE, T> final
-      {
-         static constexpr bool map_like_array = pair_t<range_value_t<T>>;
-
-         template <auto Opts>
-            requires(map_like_array ? Opts.concatenate == false : true)
-         static void op(auto&& value, is_context auto&& ctx, auto&&... args)
-         {
-            using V = range_value_t<std::decay_t<T>>;
-
-            if constexpr (boolean_like<V>) {
-               constexpr uint8_t type = uint8_t(3) << 3;
-               constexpr uint8_t tag = tag::typed_array | type;
-               dump_type(tag, args...);
-               dump_compressed_int<Opts>(value.size(), args...);
-
-               // booleans must be dumped using single bits
-               if constexpr (has_static_size<T>) {
-                  constexpr auto num_bytes = (value.size() + 7) / 8;
-                  std::array<uint8_t, num_bytes> bytes{};
-                  for (size_t byte_i{}, i{}; byte_i < num_bytes; ++byte_i) {
-                     for (size_t bit_i = 7; bit_i < 8 && i < value.size(); --bit_i, ++i) {
-                        bytes[byte_i] |= uint8_t(value[i]) << uint8_t(bit_i);
-                     }
-                  }
-                  dump(bytes, args...);
-               }
-               else if constexpr (accessible<T>) {
-                  const auto num_bytes = (value.size() + 7) / 8;
-                  for (size_t byte_i{}, i{}; byte_i < num_bytes; ++byte_i) {
-                     uint8_t byte{};
-                     for (size_t bit_i = 7; bit_i < 8 && i < value.size(); --bit_i, ++i) {
-                        byte |= uint8_t(value[i]) << uint8_t(bit_i);
-                     }
-                     dump_type(byte, args...);
+            
+            // booleans must be dumped using single bits
+            if constexpr (has_static_size<T>) {
+               constexpr auto num_bytes = (value.size() + 7) / 8;
+               std::array<uint8_t, num_bytes> bytes{};
+               for (size_t byte_i{}, i{}; byte_i < num_bytes; ++byte_i) {
+                  for (size_t bit_i = 7; bit_i < 8 && i < value.size(); --bit_i, ++i) {
+                     bytes[byte_i] |= uint8_t(value[i]) << uint8_t(bit_i);
                   }
                }
-               else {
-                  static_assert(false_v<T>);
-               }
+               dump(bytes, args...);
             }
-            else if constexpr (num_t<V>) {
-               constexpr uint8_t type =
-                  std::floating_point<V> ? 0 : (std::is_signed_v<V> ? 0b000'01'000 : 0b000'10'000);
-               constexpr uint8_t tag = tag::typed_array | type | (byte_count<V> << 5);
-               dump_type(tag, args...);
-               dump_compressed_int<Opts>(value.size(), args...);
-
-               if constexpr (contiguous<T>) {
-                  constexpr auto is_volatile =
-                     std::is_volatile_v<std::remove_reference_t<std::remove_pointer_t<decltype(value.data())>>>;
-
-                  auto dump_array = [&](auto&& b, auto&& ix) {
-                     const auto n = value.size() * sizeof(V);
-                     if (const auto k = ix + n; k > b.size()) [[unlikely]] {
-                        b.resize(2 * k);
-                     }
-
-                     if constexpr (is_volatile) {
-                        V temp;
-                        const auto n_elements = value.size();
-                        for (size_t i = 0; i < n_elements; ++i) {
-                           temp = value[i];
-                           std::memcpy(&b[ix], &temp, sizeof(V));
-                           ix += sizeof(V);
-                        }
-                     }
-                     else {
-                        std::memcpy(&b[ix], value.data(), n);
-                        ix += n;
-                     }
-                  };
-
-                  dump_array(args...);
-               }
-               else {
-                  for (auto& x : value) {
-                     dump_type(x, args...);
+            else if constexpr (accessible<T>) {
+               const auto num_bytes = (value.size() + 7) / 8;
+               for (size_t byte_i{}, i{}; byte_i < num_bytes; ++byte_i) {
+                  uint8_t byte{};
+                  for (size_t bit_i = 7; bit_i < 8 && i < value.size(); --bit_i, ++i) {
+                     byte |= uint8_t(value[i]) << uint8_t(bit_i);
                   }
-               }
-            }
-            else if constexpr (str_t<V>) {
-               constexpr uint8_t type = uint8_t(3) << 3;
-               constexpr uint8_t string_indicator = uint8_t(1) << 5;
-               constexpr uint8_t tag = tag::typed_array | type | string_indicator;
-               dump_type(tag, args...);
-               dump_compressed_int<Opts>(value.size(), args...);
-
-               for (auto& x : value) {
-                  dump_compressed_int<Opts>(x.size(), args...);
-
-                  auto dump_array = [&](auto&& b, auto&& ix) {
-                     const auto n = x.size();
-                     if (const auto k = ix + n; k > b.size()) [[unlikely]] {
-                        b.resize(2 * k);
-                     }
-
-                     std::memcpy(&b[ix], x.data(), n);
-                     ix += n;
-                  };
-
-                  dump_array(args...);
-               }
-            }
-            else if constexpr (complex_t<V>) {
-               constexpr uint8_t tag = tag::extensions | 0b00011'000;
-               dump_type(tag, args...);
-
-               using X = typename V::value_type;
-               constexpr uint8_t complex_array = 1;
-               constexpr uint8_t type =
-                  std::floating_point<X> ? 0 : (std::is_signed_v<X> ? 0b000'01'000 : 0b000'10'000);
-               constexpr uint8_t complex_header = complex_array | type | (byte_count<X> << 5);
-               dump_type(complex_header, args...);
-
-               dump_compressed_int<Opts>(value.size(), args...);
-
-               for (auto&& x : value) {
-                  serialize<BEVE>::no_header<Opts>(x, ctx, args...);
+                  dump_type(byte, args...);
                }
             }
             else {
-               constexpr uint8_t tag = tag::generic_array;
-               dump_type(tag, args...);
-               dump_compressed_int<Opts>(value.size(), args...);
-
-               for (auto&& x : value) {
-                  serialize<BEVE>::op<Opts>(x, ctx, args...);
+               static_assert(false_v<T>);
+            }
+         }
+         else if constexpr (num_t<V>) {
+            constexpr uint8_t type =
+            std::floating_point<V> ? 0 : (std::is_signed_v<V> ? 0b000'01'000 : 0b000'10'000);
+            constexpr uint8_t tag = tag::typed_array | type | (byte_count<V> << 5);
+            dump_type(tag, args...);
+            dump_compressed_int<Opts>(value.size(), args...);
+            
+            if constexpr (contiguous<T>) {
+               constexpr auto is_volatile =
+               std::is_volatile_v<std::remove_reference_t<std::remove_pointer_t<decltype(value.data())>>>;
+               
+               auto dump_array = [&](auto&& b, auto&& ix) {
+                  const auto n = value.size() * sizeof(V);
+                  if (const auto k = ix + n; k > b.size()) [[unlikely]] {
+                     b.resize(2 * k);
+                  }
+                  
+                  if constexpr (is_volatile) {
+                     V temp;
+                     const auto n_elements = value.size();
+                     for (size_t i = 0; i < n_elements; ++i) {
+                        temp = value[i];
+                        std::memcpy(&b[ix], &temp, sizeof(V));
+                        ix += sizeof(V);
+                     }
+                  }
+                  else {
+                     std::memcpy(&b[ix], value.data(), n);
+                     ix += n;
+                  }
+               };
+               
+               dump_array(args...);
+            }
+            else {
+               for (auto& x : value) {
+                  dump_type(x, args...);
                }
             }
          }
-
-         template <auto Opts>
-            requires(map_like_array && Opts.concatenate == true)
-         static auto op(auto&& value, is_context auto&& ctx, auto&&... args)
-         {
-            using Element = typename T::value_type;
-            using Key = typename Element::first_type;
-
-            constexpr uint8_t type = str_t<Key> ? 0 : (std::is_signed_v<Key> ? 0b000'01'000 : 0b000'10'000);
-            constexpr uint8_t byte_cnt = str_t<Key> ? 0 : byte_count<Key>;
-            constexpr uint8_t tag = tag::object | type | (byte_cnt << 5);
+         else if constexpr (str_t<V>) {
+            constexpr uint8_t type = uint8_t(3) << 3;
+            constexpr uint8_t string_indicator = uint8_t(1) << 5;
+            constexpr uint8_t tag = tag::typed_array | type | string_indicator;
             dump_type(tag, args...);
-
             dump_compressed_int<Opts>(value.size(), args...);
-            for (auto&& [k, v] : value) {
-               serialize<BEVE>::no_header<Opts>(k, ctx, args...);
-               serialize<BEVE>::op<Opts>(v, ctx, args...);
+            
+            for (auto& x : value) {
+               dump_compressed_int<Opts>(x.size(), args...);
+               
+               auto dump_array = [&](auto&& b, auto&& ix) {
+                  const auto n = x.size();
+                  if (const auto k = ix + n; k > b.size()) [[unlikely]] {
+                     b.resize(2 * k);
+                  }
+                  
+                  std::memcpy(&b[ix], x.data(), n);
+                  ix += n;
+               };
+               
+               dump_array(args...);
             }
          }
-      };
-
-      template <pair_t T>
-      struct to<BEVE, T> final
-      {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static auto op(auto&& value, is_context auto&& ctx, Args&&... args)
-         {
-            using Key = typename T::first_type;
-
-            constexpr uint8_t type = str_t<Key> ? 0 : (std::is_signed_v<Key> ? 0b000'01'000 : 0b000'10'000);
-            constexpr uint8_t byte_cnt = str_t<Key> ? 0 : byte_count<Key>;
-            constexpr uint8_t tag = tag::object | type | (byte_cnt << 5);
+         else if constexpr (complex_t<V>) {
+            constexpr uint8_t tag = tag::extensions | 0b00011'000;
             dump_type(tag, args...);
-
-            dump_compressed_int<Opts>(1, args...);
-            const auto& [k, v] = value;
+            
+            using X = typename V::value_type;
+            constexpr uint8_t complex_array = 1;
+            constexpr uint8_t type =
+            std::floating_point<X> ? 0 : (std::is_signed_v<X> ? 0b000'01'000 : 0b000'10'000);
+            constexpr uint8_t complex_header = complex_array | type | (byte_count<X> << 5);
+            dump_type(complex_header, args...);
+            
+            dump_compressed_int<Opts>(value.size(), args...);
+            
+            for (auto&& x : value) {
+               serialize<BEVE>::no_header<Opts>(x, ctx, args...);
+            }
+         }
+         else {
+            constexpr uint8_t tag = tag::generic_array;
+            dump_type(tag, args...);
+            dump_compressed_int<Opts>(value.size(), args...);
+            
+            for (auto&& x : value) {
+               serialize<BEVE>::op<Opts>(x, ctx, args...);
+            }
+         }
+      }
+      
+      template <auto Opts>
+      requires(map_like_array && Opts.concatenate == true)
+      static auto op(auto&& value, is_context auto&& ctx, auto&&... args)
+      {
+         using Element = typename T::value_type;
+         using Key = typename Element::first_type;
+         
+         constexpr uint8_t type = str_t<Key> ? 0 : (std::is_signed_v<Key> ? 0b000'01'000 : 0b000'10'000);
+         constexpr uint8_t byte_cnt = str_t<Key> ? 0 : byte_count<Key>;
+         constexpr uint8_t tag = tag::object | type | (byte_cnt << 5);
+         dump_type(tag, args...);
+         
+         dump_compressed_int<Opts>(value.size(), args...);
+         for (auto&& [k, v] : value) {
             serialize<BEVE>::no_header<Opts>(k, ctx, args...);
             serialize<BEVE>::op<Opts>(v, ctx, args...);
          }
-      };
-
-      template <writable_map_t T>
-      struct to<BEVE, T> final
+      }
+   };
+   
+   template <pair_t T>
+   struct to<BEVE, T> final
+   {
+      template <auto Opts, class... Args>
+      GLZ_ALWAYS_INLINE static auto op(auto&& value, is_context auto&& ctx, Args&&... args)
       {
-         template <auto Opts, class... Args>
-         static auto op(auto&& value, is_context auto&& ctx, Args&&... args)
-         {
-            using Key = typename T::key_type;
-
-            constexpr uint8_t type = str_t<Key> ? 0 : (std::is_signed_v<Key> ? 0b000'01'000 : 0b000'10'000);
-            constexpr uint8_t byte_cnt = str_t<Key> ? 0 : byte_count<Key>;
-            constexpr uint8_t tag = tag::object | type | (byte_cnt << 5);
+         using Key = typename T::first_type;
+         
+         constexpr uint8_t type = str_t<Key> ? 0 : (std::is_signed_v<Key> ? 0b000'01'000 : 0b000'10'000);
+         constexpr uint8_t byte_cnt = str_t<Key> ? 0 : byte_count<Key>;
+         constexpr uint8_t tag = tag::object | type | (byte_cnt << 5);
+         dump_type(tag, args...);
+         
+         dump_compressed_int<Opts>(1, args...);
+         const auto& [k, v] = value;
+         serialize<BEVE>::no_header<Opts>(k, ctx, args...);
+         serialize<BEVE>::op<Opts>(v, ctx, args...);
+      }
+   };
+   
+   template <writable_map_t T>
+   struct to<BEVE, T> final
+   {
+      template <auto Opts, class... Args>
+      static auto op(auto&& value, is_context auto&& ctx, Args&&... args)
+      {
+         using Key = typename T::key_type;
+         
+         constexpr uint8_t type = str_t<Key> ? 0 : (std::is_signed_v<Key> ? 0b000'01'000 : 0b000'10'000);
+         constexpr uint8_t byte_cnt = str_t<Key> ? 0 : byte_count<Key>;
+         constexpr uint8_t tag = tag::object | type | (byte_cnt << 5);
+         dump_type(tag, args...);
+         
+         dump_compressed_int<Opts>(value.size(), args...);
+         for (auto&& [k, v] : value) {
+            serialize<BEVE>::no_header<Opts>(k, ctx, args...);
+            serialize<BEVE>::op<Opts>(v, ctx, args...);
+         }
+      }
+   };
+   
+   template <nullable_t T>
+   requires(std::is_array_v<T>)
+   struct to<BEVE, T>
+   {
+      template <auto Opts, class V, size_t N, class... Args>
+      GLZ_ALWAYS_INLINE static void op(const V (&value)[N], is_context auto&& ctx, Args&&... args)
+      {
+         serialize<BEVE>::op<Opts>(std::span{value, N}, ctx, std::forward<Args>(args)...);
+      }
+   };
+   
+   template <nullable_t T>
+   requires(!std::is_array_v<T>)
+   struct to<BEVE, T> final
+   {
+      template <auto Opts, class... Args>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
+      {
+         if (value) {
+            serialize<BEVE>::op<Opts>(*value, ctx, args...);
+         }
+         else {
+            dump<tag::null>(args...);
+         }
+      }
+   };
+   
+   template <class T>
+   requires is_specialization_v<T, glz::obj> || is_specialization_v<T, glz::obj_copy>
+   struct to<BEVE, T>
+   {
+      template <auto Options>
+      static void op(auto&& value, is_context auto&& ctx, auto&&... args)
+      {
+         using V = std::decay_t<decltype(value.value)>;
+         static constexpr auto N = glz::tuple_size_v<V> / 2;
+         
+         if constexpr (!has_opening_handled(Options)) {
+            constexpr uint8_t type = 0; // string key
+            constexpr uint8_t tag = tag::object | type;
             dump_type(tag, args...);
-
-            dump_compressed_int<Opts>(value.size(), args...);
-            for (auto&& [k, v] : value) {
-               serialize<BEVE>::no_header<Opts>(k, ctx, args...);
-               serialize<BEVE>::op<Opts>(v, ctx, args...);
-            }
+            dump_compressed_int<N>(args...);
          }
-      };
-
-      template <nullable_t T>
-         requires(std::is_array_v<T>)
-      struct to<BEVE, T>
-      {
-         template <auto Opts, class V, size_t N, class... Args>
-         GLZ_ALWAYS_INLINE static void op(const V (&value)[N], is_context auto&& ctx, Args&&... args)
-         {
-            serialize<BEVE>::op<Opts>(std::span{value, N}, ctx, std::forward<Args>(args)...);
+         
+         invoke_table<N>([&]<size_t I>() {
+            constexpr auto Opts = opening_handled_off<Options>();
+            serialize<BEVE>::no_header<Opts>(get<2 * I>(value.value), ctx, args...);
+            serialize<BEVE>::op<Opts>(get<2 * I + 1>(value.value), ctx, args...);
+         });
+      }
+   };
+   
+   template <class T>
+   requires is_specialization_v<T, glz::merge>
+   consteval size_t merge_element_count()
+   {
+      size_t count{};
+      using Tuple = std::decay_t<decltype(std::declval<T>().value)>;
+      for_each<glz::tuple_size_v<Tuple>>([&](auto I) constexpr {
+         using Value = std::decay_t<glz::tuple_element_t<I, Tuple>>;
+         if constexpr (is_specialization_v<Value, glz::obj> || is_specialization_v<Value, glz::obj_copy>) {
+            count += glz::tuple_size_v<decltype(std::declval<Value>().value)> / 2;
          }
-      };
-
-      template <nullable_t T>
-         requires(!std::is_array_v<T>)
-      struct to<BEVE, T> final
-      {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
-         {
-            if (value) {
-               serialize<BEVE>::op<Opts>(*value, ctx, args...);
-            }
-            else {
-               dump<tag::null>(args...);
-            }
+         else {
+            count += reflect<Value>::N;
          }
-      };
-
-      template <class T>
-         requires is_specialization_v<T, glz::obj> || is_specialization_v<T, glz::obj_copy>
-      struct to<BEVE, T>
+      });
+      return count;
+   }
+   
+   template <class T>
+   requires is_specialization_v<T, glz::merge>
+   struct to<BEVE, T>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
       {
-         template <auto Options>
-         static void op(auto&& value, is_context auto&& ctx, auto&&... args)
-         {
-            using V = std::decay_t<decltype(value.value)>;
-            static constexpr auto N = glz::tuple_size_v<V> / 2;
-
-            if constexpr (!has_opening_handled(Options)) {
-               constexpr uint8_t type = 0; // string key
-               constexpr uint8_t tag = tag::object | type;
-               dump_type(tag, args...);
-               dump_compressed_int<N>(args...);
-            }
-
-            invoke_table<N>([&]<size_t I>() {
-               constexpr auto Opts = opening_handled_off<Options>();
-               serialize<BEVE>::no_header<Opts>(get<2 * I>(value.value), ctx, args...);
-               serialize<BEVE>::op<Opts>(get<2 * I + 1>(value.value), ctx, args...);
-            });
-         }
-      };
-
-      template <class T>
-         requires is_specialization_v<T, glz::merge>
-      consteval size_t merge_element_count()
-      {
+         using V = std::decay_t<decltype(value.value)>;
+         static constexpr auto N = glz::tuple_size_v<V>;
+         
+         constexpr uint8_t type = 0; // string key
+         constexpr uint8_t tag = tag::object | type;
+         dump_type(tag, b, ix);
+         dump_compressed_int<merge_element_count<T>()>(b, ix);
+         
+         [&]<size_t... I>(std::index_sequence<I...>) {
+            (serialize<BEVE>::op<opening_handled<Opts>()>(glz::get<I>(value.value), ctx, b, ix), ...);
+         }(std::make_index_sequence<N>{});
+      }
+   };
+   
+   template <class T>
+   requires(glaze_object_t<T> || reflectable<T>)
+   struct to<BEVE, T> final
+   {
+      static constexpr auto N = reflect<T>::size;
+      static constexpr size_t count_to_write = [] {
          size_t count{};
-         using Tuple = std::decay_t<decltype(std::declval<T>().value)>;
-         for_each<glz::tuple_size_v<Tuple>>([&](auto I) constexpr {
-            using Value = std::decay_t<glz::tuple_element_t<I, Tuple>>;
-            if constexpr (is_specialization_v<Value, glz::obj> || is_specialization_v<Value, glz::obj_copy>) {
-               count += glz::tuple_size_v<decltype(std::declval<Value>().value)> / 2;
+         invoke_table<N>([&]<size_t I>() {
+            using V = field_t<T, I>;
+            
+            if constexpr (std::same_as<V, hidden> || std::same_as<V, skip>) {
+               // do not serialize
+               // not serializing is_includer<V> would be a breaking change
             }
             else {
-               count += reflect<Value>::N;
+               ++count;
             }
          });
          return count;
-      }
-
-      template <class T>
-         requires is_specialization_v<T, glz::merge>
-      struct to<BEVE, T>
+      }();
+      
+      template <auto Opts, class... Args>
+      requires(Opts.structs_as_arrays == true)
+      static void op(auto&& value, is_context auto&& ctx, Args&&... args)
       {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
-         {
-            using V = std::decay_t<decltype(value.value)>;
-            static constexpr auto N = glz::tuple_size_v<V>;
-
-            constexpr uint8_t type = 0; // string key
-            constexpr uint8_t tag = tag::object | type;
-            dump_type(tag, b, ix);
-            dump_compressed_int<merge_element_count<T>()>(b, ix);
-
-            [&]<size_t... I>(std::index_sequence<I...>) {
-               (serialize<BEVE>::op<opening_handled<Opts>()>(glz::get<I>(value.value), ctx, b, ix), ...);
-            }(std::make_index_sequence<N>{});
-         }
-      };
-
-      template <class T>
-         requires(glaze_object_t<T> || reflectable<T>)
-      struct to<BEVE, T> final
-      {
-         static constexpr auto N = reflect<T>::size;
-         static constexpr size_t count_to_write = [] {
-            size_t count{};
-            invoke_table<N>([&]<size_t I>() {
-               using V = field_t<T, I>;
-
-               if constexpr (std::same_as<V, hidden> || std::same_as<V, skip>) {
-                  // do not serialize
-                  // not serializing is_includer<V> would be a breaking change
-               }
-               else {
-                  ++count;
-               }
-            });
-            return count;
-         }();
-
-         template <auto Opts, class... Args>
-            requires(Opts.structs_as_arrays == true)
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
-         {
-            dump<tag::generic_array>(args...);
-            dump_compressed_int<count_to_write>(args...);
-
-            [[maybe_unused]] decltype(auto) t = [&]() -> decltype(auto) {
-               if constexpr (reflectable<T>) {
-                  return to_tie(value);
-               }
-               else {
-                  return nullptr;
-               }
-            }();
-
-            invoke_table<N>([&]<size_t I>() {
-               using val_t = field_t<T, I>;
-
-               if constexpr (std::same_as<val_t, hidden> || std::same_as<val_t, skip>) {
-                  return;
-               }
-               else {
-                  if constexpr (reflectable<T>) {
-                     serialize<BEVE>::op<Opts>(get_member(value, get<I>(t)), ctx, args...);
-                  }
-                  else {
-                     serialize<BEVE>::op<Opts>(get_member(value, get<I>(reflect<T>::values)), ctx, args...);
-                  }
-               }
-            });
-         }
-
-         template <auto Options, class... Args>
-            requires(Options.structs_as_arrays == false)
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
-         {
-            if constexpr (!has_opening_handled(Options)) {
-               constexpr uint8_t type = 0; // string key
-               constexpr uint8_t tag = tag::object | type;
-               dump_type(tag, args...);
-               dump_compressed_int<count_to_write>(args...);
-            }
-            constexpr auto Opts = opening_handled_off<Options>();
-
-            [[maybe_unused]] decltype(auto) t = [&]() -> decltype(auto) {
-               if constexpr (reflectable<T>) {
-                  return to_tie(value);
-               }
-               else {
-                  return nullptr;
-               }
-            }();
-
-            invoke_table<N>([&]<size_t I>() {
-               using val_t = field_t<T, I>;
-
-               if constexpr (std::same_as<val_t, hidden> || std::same_as<val_t, skip>) {
-                  return;
-               }
-               else {
-                  static constexpr sv key = reflect<T>::keys[I];
-                  serialize<BEVE>::no_header<Opts>(key, ctx, args...);
-
-                  decltype(auto) member = [&]() -> decltype(auto) {
-                     if constexpr (reflectable<T>) {
-                        return get<I>(t);
-                     }
-                     else {
-                        return get<I>(reflect<T>::values);
-                     }
-                  }();
-
-                  serialize<BEVE>::op<Opts>(get_member(value, member), ctx, args...);
-               }
-            });
-         }
-      };
-
-      template <class T>
-         requires glaze_array_t<T>
-      struct to<BEVE, T> final
-      {
-         template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
-         {
-            dump<tag::generic_array>(args...);
-
-            static constexpr auto N = reflect<T>::size;
-            dump_compressed_int<N>(args...);
-
-            invoke_table<reflect<T>::size>(
-               [&]<size_t I>() { serialize<BEVE>::op<Opts>(get_member(value, get<I>(reflect<T>::values)), ctx, args...); });
-         }
-      };
-
-      template <class T>
-         requires(tuple_t<T> || is_std_tuple<T>)
-      struct to<BEVE, T> final
-      {
-         template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
-         {
-            dump<tag::generic_array>(args...);
-
-            static constexpr auto N = glz::tuple_size_v<T>;
-            dump_compressed_int<N>(args...);
-
-            if constexpr (is_std_tuple<T>) {
-               [&]<size_t... I>(std::index_sequence<I...>) {
-                  (serialize<BEVE>::op<Opts>(std::get<I>(value), ctx, args...), ...);
-               }(std::make_index_sequence<N>{});
+         dump<tag::generic_array>(args...);
+         dump_compressed_int<count_to_write>(args...);
+         
+         [[maybe_unused]] decltype(auto) t = [&]() -> decltype(auto) {
+            if constexpr (reflectable<T>) {
+               return to_tie(value);
             }
             else {
-               [&]<size_t... I>(std::index_sequence<I...>) {
-                  (serialize<BEVE>::op<Opts>(glz::get<I>(value), ctx, args...), ...);
-               }(std::make_index_sequence<N>{});
+               return nullptr;
             }
+         }();
+         
+         invoke_table<N>([&]<size_t I>() {
+            using val_t = field_t<T, I>;
+            
+            if constexpr (std::same_as<val_t, hidden> || std::same_as<val_t, skip>) {
+               return;
+            }
+            else {
+               if constexpr (reflectable<T>) {
+                  serialize<BEVE>::op<Opts>(get_member(value, get<I>(t)), ctx, args...);
+               }
+               else {
+                  serialize<BEVE>::op<Opts>(get_member(value, get<I>(reflect<T>::values)), ctx, args...);
+               }
+            }
+         });
+      }
+      
+      template <auto Options, class... Args>
+      requires(Options.structs_as_arrays == false)
+      static void op(auto&& value, is_context auto&& ctx, Args&&... args)
+      {
+         if constexpr (!has_opening_handled(Options)) {
+            constexpr uint8_t type = 0; // string key
+            constexpr uint8_t tag = tag::object | type;
+            dump_type(tag, args...);
+            dump_compressed_int<count_to_write>(args...);
          }
-      };
-   }
+         constexpr auto Opts = opening_handled_off<Options>();
+         
+         [[maybe_unused]] decltype(auto) t = [&]() -> decltype(auto) {
+            if constexpr (reflectable<T>) {
+               return to_tie(value);
+            }
+            else {
+               return nullptr;
+            }
+         }();
+         
+         invoke_table<N>([&]<size_t I>() {
+            using val_t = field_t<T, I>;
+            
+            if constexpr (std::same_as<val_t, hidden> || std::same_as<val_t, skip>) {
+               return;
+            }
+            else {
+               static constexpr sv key = reflect<T>::keys[I];
+               serialize<BEVE>::no_header<Opts>(key, ctx, args...);
+               
+               decltype(auto) member = [&]() -> decltype(auto) {
+                  if constexpr (reflectable<T>) {
+                     return get<I>(t);
+                  }
+                  else {
+                     return get<I>(reflect<T>::values);
+                  }
+               }();
+               
+               serialize<BEVE>::op<Opts>(get_member(value, member), ctx, args...);
+            }
+         });
+      }
+   };
+   
+   template <class T>
+   requires glaze_array_t<T>
+   struct to<BEVE, T> final
+   {
+      template <auto Opts, class... Args>
+      static void op(auto&& value, is_context auto&& ctx, Args&&... args)
+      {
+         dump<tag::generic_array>(args...);
+         
+         static constexpr auto N = reflect<T>::size;
+         dump_compressed_int<N>(args...);
+         
+         invoke_table<reflect<T>::size>(
+                                        [&]<size_t I>() { serialize<BEVE>::op<Opts>(get_member(value, get<I>(reflect<T>::values)), ctx, args...); });
+      }
+   };
+   
+   template <class T>
+   requires(tuple_t<T> || is_std_tuple<T>)
+   struct to<BEVE, T> final
+   {
+      template <auto Opts, class... Args>
+      static void op(auto&& value, is_context auto&& ctx, Args&&... args)
+      {
+         dump<tag::generic_array>(args...);
+         
+         static constexpr auto N = glz::tuple_size_v<T>;
+         dump_compressed_int<N>(args...);
+         
+         if constexpr (is_std_tuple<T>) {
+            [&]<size_t... I>(std::index_sequence<I...>) {
+               (serialize<BEVE>::op<Opts>(std::get<I>(value), ctx, args...), ...);
+            }(std::make_index_sequence<N>{});
+         }
+         else {
+            [&]<size_t... I>(std::index_sequence<I...>) {
+               (serialize<BEVE>::op<Opts>(glz::get<I>(value), ctx, args...), ...);
+            }(std::make_index_sequence<N>{});
+         }
+      }
+   };
 
    template <class T, class Buffer>
       requires(write_supported<BEVE, T>)

--- a/include/glaze/compare/approx.hpp
+++ b/include/glaze/compare/approx.hpp
@@ -11,7 +11,7 @@ namespace glz
    // Test that two meta objects are equal, with epsilon support for floating point values
    struct approx_equal_to final
    {
-      template <detail::glaze_object_t T>
+      template <glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
          constexpr auto N = reflect<T>::size;

--- a/include/glaze/compare/compare.hpp
+++ b/include/glaze/compare/compare.hpp
@@ -12,7 +12,7 @@ namespace glz
 {
    struct equal_to final
    {
-      template <detail::glaze_object_t T>
+      template <glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
          if constexpr (std::equality_comparable<T>) {
@@ -39,7 +39,7 @@ namespace glz
 
    struct less final
    {
-      template <detail::glaze_object_t T>
+      template <glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
          constexpr auto N = reflect<T>::size;
@@ -61,7 +61,7 @@ namespace glz
 
    struct less_equal final
    {
-      template <detail::glaze_object_t T>
+      template <glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
          constexpr auto N = reflect<T>::size;
@@ -83,7 +83,7 @@ namespace glz
 
    struct greater final
    {
-      template <detail::glaze_object_t T>
+      template <glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
          constexpr auto N = reflect<T>::size;
@@ -105,7 +105,7 @@ namespace glz
 
    struct greater_equal final
    {
-      template <detail::glaze_object_t T>
+      template <glaze_object_t T>
       constexpr bool operator()(T&& lhs, T&& rhs) noexcept
       {
          constexpr auto N = reflect<T>::size;

--- a/include/glaze/concepts/container_concepts.hpp
+++ b/include/glaze/concepts/container_concepts.hpp
@@ -69,7 +69,7 @@ namespace glz
    concept non_const_buffer = !std::is_const_v<Buffer>;
 }
 
-namespace glz::detail
+namespace glz
 {
    template <class T>
    concept char_t = std::same_as<std::remove_cvref_t<T>, char>;

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -408,21 +408,18 @@ namespace glz
 #endif
    };
    
-   namespace detail
+   template <is_variant T, size_t... I>
+   constexpr auto make_variant_id_map_impl(std::index_sequence<I...>, auto&& variant_ids)
    {
-      template <is_variant T, size_t... I>
-      constexpr auto make_variant_id_map_impl(std::index_sequence<I...>, auto&& variant_ids)
-      {
-         return normal_map<sv, size_t, std::variant_size_v<T>>(std::array{pair<sv, size_t>{sv(variant_ids[I]), I}...});
-      }
+      return normal_map<sv, size_t, std::variant_size_v<T>>(std::array{pair<sv, size_t>{sv(variant_ids[I]), I}...});
+   }
+   
+   template <is_variant T>
+   constexpr auto make_variant_id_map()
+   {
+      constexpr auto indices = std::make_index_sequence<std::variant_size_v<T>>{};
       
-      template <is_variant T>
-      constexpr auto make_variant_id_map()
-      {
-         constexpr auto indices = std::make_index_sequence<std::variant_size_v<T>>{};
-         
-         return make_variant_id_map_impl<T>(indices, ids_v<T>);
-      }
+      return make_variant_id_map_impl<T>(indices, ids_v<T>);
    }
 
    /**
@@ -481,37 +478,34 @@ namespace glz
    template <class Value, class Element>
    using member_t = decltype(get_member(std::declval<std::add_lvalue_reference_t<Value>>(), std::declval<Element>()));
 
-   namespace detail
+   // member_ptr and lambda wrapper helper
+   template <template <class> class Wrapper, class Wrapped>
+   struct wrap
    {
-      // member_ptr and lambda wrapper helper
-      template <template <class> class Wrapper, class Wrapped>
-      struct wrap
+      Wrapped wrapped;
+      constexpr decltype(auto) operator()(auto&& value) const
       {
-         Wrapped wrapped;
-         constexpr decltype(auto) operator()(auto&& value) const
-         {
-            return Wrapper<std::decay_t<decltype(get_member(value, wrapped))>>{get_member(value, wrapped)};
-         }
-
-         constexpr decltype(auto) unwrap(auto&& value) const { return get_member(value, wrapped); }
-      };
-
-      // Output variants in the following format  ["variant_type", variant_json_data] with
-      // glz::detail:array_variant(&T::var);
-      template <is_variant T>
-      struct array_variant_wrapper final
-      {
-         T& value;
-      };
-      // TODO: Could do this if the compiler supports alias template deduction
-      // template <class T>
-      // using array_var = wrap<array_var_wrapper, T>;
-      template <class T>
-      struct array_variant : wrap<array_variant_wrapper, T>
-      {};
-      template <class T>
-      array_variant(T) -> array_variant<T>; // Only needed on older compilers until we move to template alias deduction
-   } // namespace detail
+         return Wrapper<std::decay_t<decltype(get_member(value, wrapped))>>{get_member(value, wrapped)};
+      }
+      
+      constexpr decltype(auto) unwrap(auto&& value) const { return get_member(value, wrapped); }
+   };
+   
+   // Output variants in the following format  ["variant_type", variant_json_data] with
+   // glz::detail:array_variant(&T::var);
+   template <is_variant T>
+   struct array_variant_wrapper final
+   {
+      T& value;
+   };
+   // TODO: Could do this if the compiler supports alias template deduction
+   // template <class T>
+   // using array_var = wrap<array_var_wrapper, T>;
+   template <class T>
+   struct array_variant : wrap<array_variant_wrapper, T>
+   {};
+   template <class T>
+   array_variant(T) -> array_variant<T>; // Only needed on older compilers until we move to template alias deduction
 
    constexpr decltype(auto) conv_sv(auto&& value) noexcept
    {
@@ -555,10 +549,7 @@ namespace glz
 
    template <class T>
    unexpected_wrapper(T*) -> unexpected_wrapper<T>;
-}
-
-namespace glz::detail
-{
+   
    template <opts Opts, class Value>
    [[nodiscard]] GLZ_ALWAYS_INLINE constexpr bool skip_member(const Value& value) noexcept
    {

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -149,24 +149,6 @@ namespace glz
    template <class T>
    using core_t = std::remove_cvref_t<T>;
 
-   namespace detail
-   {
-      // These templates save typing by determining the core type used to select the proper to/from specialization
-      // Long term I would like to remove these detail indirections.
-
-      template <uint32_t Format>
-      struct read
-      {};
-
-      template <uint32_t Format>
-      struct write
-      {};
-
-      template <uint32_t Format>
-      struct write_partial
-      {};
-   }
-
    // Use std::stringview if you know the buffer is going to outlive this
    template <class string_type = std::string>
    struct basic_raw_json

--- a/include/glaze/core/custom.hpp
+++ b/include/glaze/core/custom.hpp
@@ -6,7 +6,7 @@
 #include "glaze/core/seek.hpp"
 #include "glaze/core/wrappers.hpp"
 
-namespace glz::detail
+namespace glz
 {
    template <uint32_t Format, class T>
       requires(is_specialization_v<T, custom_t>)

--- a/include/glaze/core/custom.hpp
+++ b/include/glaze/core/custom.hpp
@@ -34,7 +34,7 @@ namespace glz::detail
                   }
                   else if constexpr (glz::tuple_size_v<Tuple> == 1) {
                      std::decay_t<glz::tuple_element_t<0, Tuple>> input{};
-                     read<Format>::template op<Opts>(input, ctx, it, end);
+                     parse<Format>::template op<Opts>(input, ctx, it, end);
                      if (bool(ctx.error)) [[unlikely]]
                         return;
                      (value.val.*(value.from))(input);
@@ -63,7 +63,7 @@ namespace glz::detail
                      }
                      else if constexpr (glz::tuple_size_v<Tuple> == 1) {
                         std::decay_t<glz::tuple_element_t<0, Tuple>> input{};
-                        read<Format>::template op<Opts>(input, ctx, it, end);
+                        parse<Format>::template op<Opts>(input, ctx, it, end);
                         if (bool(ctx.error)) [[unlikely]]
                            return;
                         from(input);
@@ -77,7 +77,7 @@ namespace glz::detail
                   }
                }
                else {
-                  read<Format>::template op<Opts>(from, ctx, it, end);
+                  parse<Format>::template op<Opts>(from, ctx, it, end);
                }
             }
             else {
@@ -101,7 +101,7 @@ namespace glz::detail
                   }
                   else if constexpr (N == 2) {
                      std::decay_t<glz::tuple_element_t<1, Tuple>> input{};
-                     read<Format>::template op<Opts>(input, ctx, it, end);
+                     parse<Format>::template op<Opts>(input, ctx, it, end);
                      if (bool(ctx.error)) [[unlikely]]
                         return;
                      value.from(value.val, input);
@@ -115,7 +115,7 @@ namespace glz::detail
                }
             }
             else if constexpr (std::invocable<From, decltype(value.val)>) {
-               read<Format>::template op<Opts>(value.from(value.val), ctx, it, end);
+               parse<Format>::template op<Opts>(value.from(value.val), ctx, it, end);
             }
             else {
                static_assert(
@@ -143,7 +143,7 @@ namespace glz::detail
             if constexpr (std::is_member_function_pointer_v<To>) {
                using Tuple = typename inputs_as_tuple<To>::type;
                if constexpr (glz::tuple_size_v<Tuple> == 0) {
-                  write<Format>::template op<Opts>((value.val.*(value.to))(), ctx, args...);
+                  serialize<Format>::template op<Opts>((value.val.*(value.to))(), ctx, args...);
                }
                else {
                   static_assert(false_v<T>, "function cannot have inputs");
@@ -161,7 +161,7 @@ namespace glz::detail
                   else {
                      using Tuple = typename function_traits<Func>::arguments;
                      if constexpr (glz::tuple_size_v<Tuple> == 0) {
-                        write<Format>::template op<Opts>(to(), ctx, args...);
+                        serialize<Format>::template op<Opts>(to(), ctx, args...);
                      }
                      else {
                         static_assert(false_v<T>, "std::function cannot have inputs");
@@ -169,7 +169,7 @@ namespace glz::detail
                   }
                }
                else {
-                  write<Format>::template op<Opts>(to, ctx, args...);
+                  serialize<Format>::template op<Opts>(to, ctx, args...);
                }
             }
             else {
@@ -178,7 +178,7 @@ namespace glz::detail
          }
          else {
             if constexpr (std::invocable<To, decltype(value.val)>) {
-               write<Format>::template op<Opts>(std::invoke(value.to, value.val), ctx, args...);
+               serialize<Format>::template op<Opts>(std::invoke(value.to, value.val), ctx, args...);
             }
             else {
                static_assert(false_v<To>,

--- a/include/glaze/core/feature_test.hpp
+++ b/include/glaze/core/feature_test.hpp
@@ -20,6 +20,6 @@
 #define glaze_v3_6_0_reflect
 
 // v3.5.0 change glz::detail::to_json and glz::detail::from_json specializations
-// to glz::detail::to<JSON and glz::detail::from<JSON
+// to glz::to<JSON and glz::from<JSON
 // The template specialization takes a uint32_t Format as the first template parameter
 #define glaze_v3_5_0_to_from

--- a/include/glaze/core/meta.hpp
+++ b/include/glaze/core/meta.hpp
@@ -70,43 +70,43 @@ namespace glz
 
       template <class T>
       Flags(T) -> Flags<T>;
-
-      template <class T>
-      concept local_construct_t = requires { T::glaze::construct; };
-
-      template <class T>
-      concept global_construct_t = requires { meta<T>::construct; };
-
-      template <class T>
-      concept local_meta_t = requires { T::glaze::value; };
-
-      template <class T>
-      concept local_keys_t = requires { T::glaze::keys; };
-
-      template <class T>
-      concept global_meta_t = requires { meta<T>::value; };
-
-      template <class T>
-      concept glaze_t = requires { meta<std::decay_t<T>>::value; } || local_meta_t<std::decay_t<T>>;
-
-      template <class T>
-      concept meta_keys = requires { meta<std::decay_t<T>>::keys; } || local_keys_t<std::decay_t<T>>;
-
-      template <class T>
-      concept has_unknown_writer = requires { meta<T>::unknown_write; } || requires { T::glaze::unknown_write; };
-
-      template <class T>
-      concept has_unknown_reader = requires { meta<T>::unknown_read; } || requires { T::glaze::unknown_read; };
-
-      template <class T>
-      concept local_json_schema_t = requires { typename std::decay_t<T>::glaze_json_schema; };
-
-      template <class T>
-      concept global_json_schema_t = requires { typename json_schema<T>; };
-
-      template <class T>
-      concept json_schema_t = local_json_schema_t<T> || global_json_schema_t<T>;
    }
+   
+   template <class T>
+   concept local_construct_t = requires { T::glaze::construct; };
+   
+   template <class T>
+   concept global_construct_t = requires { meta<T>::construct; };
+   
+   template <class T>
+   concept local_meta_t = requires { T::glaze::value; };
+   
+   template <class T>
+   concept local_keys_t = requires { T::glaze::keys; };
+   
+   template <class T>
+   concept global_meta_t = requires { meta<T>::value; };
+   
+   template <class T>
+   concept glaze_t = requires { meta<std::decay_t<T>>::value; } || local_meta_t<std::decay_t<T>>;
+   
+   template <class T>
+   concept meta_keys = requires { meta<std::decay_t<T>>::keys; } || local_keys_t<std::decay_t<T>>;
+   
+   template <class T>
+   concept has_unknown_writer = requires { meta<T>::unknown_write; } || requires { T::glaze::unknown_write; };
+   
+   template <class T>
+   concept has_unknown_reader = requires { meta<T>::unknown_read; } || requires { T::glaze::unknown_read; };
+   
+   template <class T>
+   concept local_json_schema_t = requires { typename std::decay_t<T>::glaze_json_schema; };
+   
+   template <class T>
+   concept global_json_schema_t = requires { typename json_schema<T>; };
+   
+   template <class T>
+   concept json_schema_t = local_json_schema_t<T> || global_json_schema_t<T>;
 
    struct empty
    {
@@ -115,10 +115,10 @@ namespace glz
 
    template <class T>
    inline constexpr decltype(auto) meta_wrapper_v = [] {
-      if constexpr (detail::local_meta_t<T>) {
+      if constexpr (local_meta_t<T>) {
          return T::glaze::value;
       }
-      else if constexpr (detail::global_meta_t<T>) {
+      else if constexpr (global_meta_t<T>) {
          return meta<T>::value;
       }
       else {
@@ -128,10 +128,10 @@ namespace glz
 
    template <class T>
    inline constexpr auto meta_construct_v = [] {
-      if constexpr (detail::local_construct_t<T>) {
+      if constexpr (local_construct_t<T>) {
          return T::glaze::construct;
       }
-      else if constexpr (detail::global_construct_t<T>) {
+      else if constexpr (global_construct_t<T>) {
          return meta<T>::construct;
       }
       else {
@@ -141,7 +141,7 @@ namespace glz
 
    template <class T>
    inline constexpr auto meta_v = []() -> decltype(auto) {
-      if constexpr (detail::meta_keys<T>) {
+      if constexpr (meta_keys<T>) {
          return meta_wrapper_v<decay_keep_volatile_t<T>>;
       }
       else {
@@ -157,10 +157,10 @@ namespace glz
 
    template <class T>
    inline constexpr auto meta_keys_v = [] {
-      if constexpr (detail::local_meta_t<T>) {
+      if constexpr (local_meta_t<T>) {
          return T::glaze::keys;
       }
-      else if constexpr (detail::global_meta_t<T>) {
+      else if constexpr (global_meta_t<T>) {
          return meta<T>::keys;
       }
       else {
@@ -176,7 +176,7 @@ namespace glz
    {
       using type = T;
    };
-   template <detail::glaze_t T>
+   template <glaze_t T>
    struct remove_meta_wrapper<T>
    {
       using type = std::remove_pointer_t<std::remove_const_t<meta_wrapper_t<T>>>;
@@ -186,10 +186,10 @@ namespace glz
 
    template <class T>
    inline constexpr auto meta_unknown_write_v = [] {
-      if constexpr (detail::local_meta_t<T>) {
+      if constexpr (local_meta_t<T>) {
          return T::glaze::unknown_write;
       }
-      else if constexpr (detail::global_meta_t<T>) {
+      else if constexpr (global_meta_t<T>) {
          return meta<T>::unknown_write;
       }
       else {
@@ -202,10 +202,10 @@ namespace glz
 
    template <class T>
    inline constexpr auto meta_unknown_read_v = [] {
-      if constexpr (detail::local_meta_t<T>) {
+      if constexpr (local_meta_t<T>) {
          return T::glaze::unknown_read;
       }
-      else if constexpr (detail::global_meta_t<T>) {
+      else if constexpr (global_meta_t<T>) {
          return meta<T>::unknown_read;
       }
       else {
@@ -246,7 +246,7 @@ namespace glz
    template <class T>
    inline constexpr std::string_view tag_v = [] {
       if constexpr (tagged<T>) {
-         if constexpr (detail::local_meta_t<T>) {
+         if constexpr (local_meta_t<T>) {
             return std::decay_t<T>::glaze::tag;
          }
          else {
@@ -274,7 +274,7 @@ namespace glz
    template <is_variant T>
    inline constexpr auto ids_v = [] {
       if constexpr (ided<T>) {
-         if constexpr (detail::local_meta_t<T>) {
+         if constexpr (local_meta_t<T>) {
             return detail::convert_ids_to_array_of_sv(std::decay_t<T>::glaze::ids);
          }
          else {
@@ -307,12 +307,12 @@ namespace glz
    // We don't make this constexpr so that we can have heap allocated values like std::string
    // IMPORTANT: GCC has a bug that doesn't default instantiate this object when it isn't constexpr
    // The solution is to use the json_schema_type defined below to instantiate where used.
-   template <detail::json_schema_t T>
+   template <json_schema_t T>
    inline const auto json_schema_v = [] {
-      if constexpr (detail::local_json_schema_t<T>) {
+      if constexpr (local_json_schema_t<T>) {
          return typename std::decay_t<T>::glaze_json_schema{};
       }
-      else if constexpr (detail::global_json_schema_t<T>) {
+      else if constexpr (global_json_schema_t<T>) {
          return json_schema<std::decay_t<T>>{};
       }
    }();

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -331,6 +331,9 @@ namespace glz
    template <uint32_t Format = INVALID, class T = void>
    struct to_partial;
    
+   template <uint32_t Format = INVALID>
+   struct skip_value;
+   
    namespace detail
    {
       template <uint32_t Format = INVALID, class T = void>
@@ -338,9 +341,6 @@ namespace glz
 
       template <uint32_t Format = INVALID, class T = void>
       struct from;
-
-      template <uint32_t Format = INVALID>
-      struct skip_value;
    }
 
    template <uint32_t Format, class T>

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -39,13 +39,6 @@ namespace glz
    // Write padding bytes simplifies our dump calculations by making sure we have significant excess
    inline constexpr size_t write_padding_bytes = 256;
 
-   // We use a alias to a char for booleans so that compiler errors will print "0" or "1" rather than "true" or
-   // "false" This shortens compiler error printouts significantly.
-   // We use a macro rather than an alias because some compilers print out alias definitions, extending length.
-   // We tried a uint8_t in the past, but in many cases compilers would print out "unsigned char"
-   // int8_t also would produce "signed char"
-#define bool_t char
-
    // This macro exists so that Glaze tests can change the default behavior
    // to easily run tests as if strings were not null terminated
 #ifndef GLZ_NULL_TERMINATED
@@ -56,25 +49,25 @@ namespace glz
    {
       // USER CONFIGURABLE
       uint32_t format = JSON;
-      bool_t null_terminated = GLZ_NULL_TERMINATED; // Whether the input buffer is null terminated
-      bool_t comments = false; // Support reading in JSONC style comments
-      bool_t error_on_unknown_keys = true; // Error when an unknown key is encountered
-      bool_t skip_null_members = true; // Skip writing out params in an object if the value is null
-      bool_t use_hash_comparison = true; // Will replace some string equality checks with hash checks
-      bool_t prettify = false; // Write out prettified JSON
-      bool_t minified = false; // Require minified input for JSON, which results in faster read performance
+      bool null_terminated = GLZ_NULL_TERMINATED; // Whether the input buffer is null terminated
+      bool comments = false; // Support reading in JSONC style comments
+      bool error_on_unknown_keys = true; // Error when an unknown key is encountered
+      bool skip_null_members = true; // Skip writing out params in an object if the value is null
+      bool use_hash_comparison = true; // Will replace some string equality checks with hash checks
+      bool prettify = false; // Write out prettified JSON
+      bool minified = false; // Require minified input for JSON, which results in faster read performance
       char indentation_char = ' '; // Prettified JSON indentation char
       uint8_t indentation_width = 3; // Prettified JSON indentation size
-      bool_t new_lines_in_arrays = true; // Whether prettified arrays should have new lines for each element
-      bool_t append_arrays = false; // When reading into an array the data will be appended if the type supports it
-      bool_t shrink_to_fit = false; // Shrinks dynamic containers to new size to save memory
-      bool_t write_type_info = true; // Write type info for meta objects in variants
-      bool_t error_on_missing_keys = false; // Require all non nullable keys to be present in the object. Use
+      bool new_lines_in_arrays = true; // Whether prettified arrays should have new lines for each element
+      bool append_arrays = false; // When reading into an array the data will be appended if the type supports it
+      bool shrink_to_fit = false; // Shrinks dynamic containers to new size to save memory
+      bool write_type_info = true; // Write type info for meta objects in variants
+      bool error_on_missing_keys = false; // Require all non nullable keys to be present in the object. Use
                                             // skip_null_members = false to require nullable members
-      bool_t error_on_const_read =
+      bool error_on_const_read =
          false; // Error if attempt is made to read into a const value, by default the value is skipped without error
-      bool_t validate_skipped = false; // If full validation should be performed on skipped values
-      bool_t validate_trailing_whitespace =
+      bool validate_skipped = false; // If full validation should be performed on skipped values
+      bool validate_trailing_whitespace =
          false; // If, after parsing a value, we want to validate the trailing whitespace
 
       uint8_t layout = rowwise; // CSV row wise output/input
@@ -82,24 +75,24 @@ namespace glz
       // The maximum precision type used for writing floats, higher precision floats will be cast down to this precision
       float_precision float_max_write_precision{};
 
-      bool_t bools_as_numbers = false; // Read and write booleans with 1's and 0's
+      bool bools_as_numbers = false; // Read and write booleans with 1's and 0's
 
-      bool_t quoted_num = false; // treat numbers as quoted or array-like types as having quoted numbers
-      bool_t number = false; // treats all types like std::string as numbers: read/write these quoted numbers
-      bool_t raw = false; // write out string like values without quotes
-      bool_t raw_string =
+      bool quoted_num = false; // treat numbers as quoted or array-like types as having quoted numbers
+      bool number = false; // treats all types like std::string as numbers: read/write these quoted numbers
+      bool raw = false; // write out string like values without quotes
+      bool raw_string =
          false; // do not decode/encode escaped characters for strings (improves read/write performance)
-      bool_t structs_as_arrays = false; // Handle structs (reading/writing) without keys, which applies
-      bool_t allow_conversions = true; // Whether conversions between convertible types are
+      bool structs_as_arrays = false; // Handle structs (reading/writing) without keys, which applies
+      bool allow_conversions = true; // Whether conversions between convertible types are
       // allowed in binary, e.g. double -> float
 
-      bool_t partial_read =
+      bool partial_read =
          false; // Reads into the deepest structural object and then exits without parsing the rest of the input
 
       // glaze_object_t concepts
-      bool_t concatenate = true; // Concatenates ranges of std::pair into single objects when writing
+      bool concatenate = true; // Concatenates ranges of std::pair into single objects when writing
 
-      bool_t hide_non_invocable =
+      bool hide_non_invocable =
          true; // Hides non-invocable members from the cli_menu (may be applied elsewhere in the future)
 
       enum struct internal : uint32_t {
@@ -121,8 +114,6 @@ namespace glz
 
       [[nodiscard]] constexpr bool operator==(const opts&) const noexcept = default;
    };
-
-#undef bool_t
 
    consteval bool has_opening_handled(opts o) { return o.internal & uint32_t(opts::internal::opening_handled); }
 

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -328,13 +328,13 @@ namespace glz
 
 namespace glz
 {
+   template <uint32_t Format = INVALID, class T = void>
+   struct to_partial;
+   
    namespace detail
    {
       template <uint32_t Format = INVALID, class T = void>
       struct to;
-
-      template <uint32_t Format = INVALID, class T = void>
-      struct to_partial;
 
       template <uint32_t Format = INVALID, class T = void>
       struct from;

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -348,4 +348,19 @@ namespace glz
 
    template <uint32_t Format, class T>
    concept read_supported = requires { detail::from<Format, std::remove_cvref_t<T>>{}; };
+   
+   // These templates save typing by determining the core type used to select the proper to/from specialization
+   // Long term I would like to remove these detail indirections.
+   
+   template <uint32_t Format>
+   struct parse
+   {};
+   
+   template <uint32_t Format>
+   struct serialize
+   {};
+   
+   template <uint32_t Format>
+   struct serialize_partial
+   {};
 }

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -329,25 +329,22 @@ namespace glz
 namespace glz
 {
    template <uint32_t Format = INVALID, class T = void>
+   struct to;
+   
+   template <uint32_t Format = INVALID, class T = void>
+   struct from;
+   
+   template <uint32_t Format = INVALID, class T = void>
    struct to_partial;
    
    template <uint32_t Format = INVALID>
    struct skip_value;
-   
-   namespace detail
-   {
-      template <uint32_t Format = INVALID, class T = void>
-      struct to;
-
-      template <uint32_t Format = INVALID, class T = void>
-      struct from;
-   }
 
    template <uint32_t Format, class T>
-   concept write_supported = requires { detail::to<Format, std::remove_cvref_t<T>>{}; };
+   concept write_supported = requires { to<Format, std::remove_cvref_t<T>>{}; };
 
    template <uint32_t Format, class T>
-   concept read_supported = requires { detail::from<Format, std::remove_cvref_t<T>>{}; };
+   concept read_supported = requires { from<Format, std::remove_cvref_t<T>>{}; };
    
    // These templates save typing by determining the core type used to select the proper to/from specialization
    // Long term I would like to remove these detail indirections.

--- a/include/glaze/core/read.hpp
+++ b/include/glaze/core/read.hpp
@@ -57,10 +57,10 @@ namespace glz
       }
 
       if constexpr (use_padded) {
-         detail::read<Opts.format>::template op<is_padded_on<Opts>()>(value, ctx, it, end);
+         parse<Opts.format>::template op<is_padded_on<Opts>()>(value, ctx, it, end);
       }
       else {
-         detail::read<Opts.format>::template op<is_padded_off<Opts>()>(value, ctx, it, end);
+         parse<Opts.format>::template op<is_padded_off<Opts>()>(value, ctx, it, end);
       }
 
       if (bool(ctx.error)) [[unlikely]] {

--- a/include/glaze/core/read.hpp
+++ b/include/glaze/core/read.hpp
@@ -72,7 +72,7 @@ namespace glz
       // validate this, even though this memory will not affect Glaze.
       if constexpr (Opts.validate_trailing_whitespace) {
          if (it < end) {
-            detail::skip_ws<Opts>(ctx, it, end);
+            skip_ws<Opts>(ctx, it, end);
             if (bool(ctx.error)) [[unlikely]] {
                goto finish;
             }

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -130,17 +130,14 @@ namespace glz
       using type = member_t<V, decltype(get<I>(values))>;
    };
 
-   namespace detail
+   template <class T, size_t N>
+   inline constexpr auto c_style_to_sv(const std::array<T, N>& arr)
    {
-      template <class T, size_t N>
-      inline constexpr auto c_style_to_sv(const std::array<T, N>& arr)
-      {
-         std::array<sv, N> ret{};
-         for (size_t i = 0; i < N; ++i) {
-            ret[i] = arr[i];
-         }
-         return ret;
+      std::array<sv, N> ret{};
+      for (size_t i = 0; i < N; ++i) {
+         ret[i] = arr[i];
       }
+      return ret;
    }
 
    template <class T>
@@ -152,7 +149,7 @@ namespace glz
 
       static constexpr auto values = meta_wrapper_v<T>;
 
-      static constexpr auto keys = detail::c_style_to_sv(meta_keys_v<T>);
+      static constexpr auto keys = c_style_to_sv(meta_keys_v<T>);
 
       template <size_t I>
       using elem = decltype(get<I>(values));
@@ -242,7 +239,7 @@ namespace glz
    }();
 }
 
-namespace glz::detail
+namespace glz
 {
    template <size_t I, class T>
    constexpr auto key_name_v = [] {
@@ -380,7 +377,7 @@ namespace glz
    }();
 }
 
-namespace glz::detail
+namespace glz
 {
    template <class T>
    constexpr auto make_enum_to_string_map()
@@ -409,7 +406,7 @@ namespace glz::detail
    {
       using V = std::decay_t<T>;
       using U = std::underlying_type_t<V>;
-      constexpr auto arr = glz::detail::make_enum_to_string_array<V>();
+      constexpr auto arr = make_enum_to_string_array<V>();
       return arr[static_cast<U>(enum_value)];
    }
 
@@ -445,7 +442,7 @@ namespace glz
    using make_reflectable = std::initializer_list<dummy>;
 }
 
-namespace glz::detail
+namespace glz
 {
    // TODO: This is returning the total keys and not the max keys for a particular variant object
    template <class T, size_t N>
@@ -538,7 +535,7 @@ namespace glz
    }
 }
 
-namespace glz::detail
+namespace glz
 {
    GLZ_ALWAYS_INLINE constexpr uint64_t bitmix(uint64_t h, const uint64_t seed) noexcept
    {
@@ -1952,10 +1949,7 @@ namespace glz
          return "";
       }
    }
-}
-
-namespace glz::detail
-{
+   
    template <class T>
    inline constexpr size_t maximum_key_size = [] {
       constexpr auto N = reflect<T>::size;
@@ -1967,7 +1961,7 @@ namespace glz::detail
       }
       return maximum + 2; // add quotes for JSON
    }();
-
+   
    inline constexpr uint64_t round_up_to_nearest_16(const uint64_t value) noexcept { return (value + 15) & ~15ull; }
 }
 

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -86,7 +86,7 @@ namespace glz
    // MSVC requires this template specialization for when the tuple size if zero,
    // otherwise MSVC tries to instantiate calls of get<0> in invalid branches
    template <class T>
-      requires((detail::glaze_object_t<T> || detail::glaze_flags_t<T> || detail::glaze_enum_t<T>) &&
+      requires((glaze_object_t<T> || glaze_flags_t<T> || glaze_enum_t<T>) &&
                (tuple_size_v<meta_t<T>> == 0))
    struct reflect<T>
    {
@@ -99,8 +99,8 @@ namespace glz
    };
 
    template <class T>
-      requires(!detail::meta_keys<T> &&
-               (detail::glaze_object_t<T> || detail::glaze_flags_t<T> || detail::glaze_enum_t<T>) &&
+      requires(!meta_keys<T> &&
+               (glaze_object_t<T> || glaze_flags_t<T> || glaze_enum_t<T>) &&
                (tuple_size_v<meta_t<T>> != 0))
    struct reflect<T>
    {
@@ -144,7 +144,7 @@ namespace glz
    }
 
    template <class T>
-      requires(detail::meta_keys<T> && detail::glaze_t<T>)
+      requires(meta_keys<T> && glaze_t<T>)
    struct reflect<T>
    {
       using V = std::remove_cvref_t<T>;
@@ -162,12 +162,12 @@ namespace glz
    };
 
    template <class T>
-      requires(detail::is_memory_object<T>)
+      requires(is_memory_object<T>)
    struct reflect<T> : reflect<memory_type<T>>
    {};
 
    template <class T>
-      requires(detail::glaze_array_t<T>)
+      requires(glaze_array_t<T>)
    struct reflect<T>
    {
       using V = std::remove_cvref_t<T>;
@@ -184,7 +184,7 @@ namespace glz
    };
 
    template <class T>
-      requires detail::reflectable<T>
+      requires reflectable<T>
    struct reflect<T>
    {
       using V = std::remove_cvref_t<T>;
@@ -201,7 +201,7 @@ namespace glz
    };
 
    template <class T>
-      requires detail::readable_map_t<T>
+      requires readable_map_t<T>
    struct reflect<T>
    {
       static constexpr auto size = 0;
@@ -226,13 +226,13 @@ namespace glz
          if constexpr (Opts.skip_null_members) {
             // if any type could be null then we might skip
             return []<size_t... I>(std::index_sequence<I...>) {
-               return ((detail::always_skipped<field_t<T, I>> || detail::null_t<field_t<T, I>>) || ...);
+               return ((always_skipped<field_t<T, I>> || null_t<field_t<T, I>>) || ...);
             }(std::make_index_sequence<N>{});
          }
          else {
             // if we have an always_skipped type then we return true
             return []<size_t... I>(std::index_sequence<I...>) {
-               return ((detail::always_skipped<field_t<T, I>>) || ...);
+               return ((always_skipped<field_t<T, I>>) || ...);
             }(std::make_index_sequence<N>{});
          }
       }
@@ -370,7 +370,7 @@ namespace glz
    constexpr sv enum_name_v = []() -> std::string_view {
       using T = std::decay_t<decltype(Enum)>;
 
-      if constexpr (detail::glaze_t<T>) {
+      if constexpr (glaze_t<T>) {
          using U = std::underlying_type_t<T>;
          return reflect<T>::keys[static_cast<U>(Enum)];
       }
@@ -404,7 +404,7 @@ namespace glz::detail
 
    // get a std::string_view from an enum value
    template <class T>
-      requires(detail::glaze_t<T> && std::is_enum_v<std::decay_t<T>>)
+      requires(glaze_t<T> && std::is_enum_v<std::decay_t<T>>)
    constexpr auto get_enum_name(T&& enum_value)
    {
       using V = std::decay_t<T>;
@@ -413,7 +413,7 @@ namespace glz::detail
       return arr[static_cast<U>(enum_value)];
    }
 
-   template <detail::glaze_flags_t T>
+   template <glaze_flags_t T>
    consteval auto byte_length() noexcept
    {
       constexpr auto N = reflect<T>::size;
@@ -523,7 +523,7 @@ namespace glz::detail
    }
 }
 
-namespace glz::detail
+namespace glz
 {
    template <class T>
    consteval size_t key_index(const std::string_view key)
@@ -536,7 +536,10 @@ namespace glz::detail
       }
       return n;
    }
+}
 
+namespace glz::detail
+{
    GLZ_ALWAYS_INLINE constexpr uint64_t bitmix(uint64_t h, const uint64_t seed) noexcept
    {
       h *= seed;
@@ -1972,7 +1975,7 @@ namespace glz
 {
    // The Callable comes second as ranges::for_each puts the callable at the end
 
-   template <class Callable, detail::reflectable T>
+   template <class Callable, reflectable T>
    void for_each_field(T&& value, Callable&& callable)
    {
       constexpr auto N = reflect<T>::size;
@@ -1983,7 +1986,7 @@ namespace glz
       }
    }
 
-   template <class Callable, detail::glaze_object_t T>
+   template <class Callable, glaze_object_t T>
    void for_each_field(T&& value, Callable&& callable)
    {
       constexpr auto N = reflect<T>::size;

--- a/include/glaze/core/seek.hpp
+++ b/include/glaze/core/seek.hpp
@@ -97,7 +97,7 @@ namespace glz::detail
 
       if constexpr (glaze_object_t<T> || reflectable<T>) {
          static constexpr auto N = reflect<T>::size;
-         static constexpr auto HashInfo = detail::hash_info<T>;
+         static constexpr auto HashInfo = hash_info<T>;
 
          const auto index = decode_hash_with_size<JSON_PTR, T, HashInfo, HashInfo.type>::op(
             key.data(), key.data() + key.size(), key.size());
@@ -546,8 +546,8 @@ namespace glz
          constexpr auto key_str = tokens.first;
          constexpr auto rem_ptr = glz::string_literal_from_view<tokens.second.size()>(tokens.second);
          if constexpr (glz::glaze_object_t<V>) {
-            constexpr auto& HashInfo = detail::hash_info<V>;
-            constexpr auto I = detail::decode_hash_with_size<JSON, V, HashInfo, HashInfo.type>::op(
+            constexpr auto& HashInfo = hash_info<V>;
+            constexpr auto I = decode_hash_with_size<JSON, V, HashInfo, HashInfo.type>::op(
                key_str.data(), key_str.data() + key_str.size(), key_str.size());
 
             if constexpr (I < reflect<V>::size) {
@@ -571,7 +571,7 @@ namespace glz
          }
          else if constexpr (glz::glaze_array_t<V>) {
             constexpr auto member_array = glz::detail::make_array<std::decay_t<V>>();
-            constexpr auto optional_index = glz::detail::stoui(key_str); // TODO: Will not build if not int
+            constexpr auto optional_index = stoui(key_str); // TODO: Will not build if not int
             if constexpr (optional_index) {
                constexpr auto index = *optional_index;
                if constexpr (index >= 0 && index < member_array.size()) {
@@ -589,7 +589,7 @@ namespace glz
             }
          }
          else if constexpr (glz::array_t<V>) {
-            if (glz::detail::stoui(key_str)) {
+            if (stoui(key_str)) {
                return valid<range_value_t<V>, rem_ptr, Expected>();
             }
             return false;

--- a/include/glaze/core/seek.hpp
+++ b/include/glaze/core/seek.hpp
@@ -248,7 +248,7 @@ namespace glz
       detail::seek_impl(
          [&](auto&& val) {
             if constexpr (std::is_assignable_v<V, decltype(val)> &&
-                          detail::non_narrowing_convertable<std::decay_t<decltype(val)>, V>) {
+                          non_narrowing_convertable<std::decay_t<decltype(val)>, V>) {
                found = true;
                result = val;
             }
@@ -276,7 +276,7 @@ namespace glz
       detail::seek_impl(
          [&](auto&& val) {
             if constexpr (std::is_assignable_v<decltype(val), decltype(value)> &&
-                          detail::non_narrowing_convertable<std::decay_t<decltype(value)>,
+                          non_narrowing_convertable<std::decay_t<decltype(value)>,
                                                             std::decay_t<decltype(val)>>) {
                result = true;
 #if defined(__GNUC__) || defined(__GNUG__)
@@ -545,7 +545,7 @@ namespace glz
          constexpr auto tokens = tokenize_json_ptr(ptr.sv());
          constexpr auto key_str = tokens.first;
          constexpr auto rem_ptr = glz::string_literal_from_view<tokens.second.size()>(tokens.second);
-         if constexpr (glz::detail::glaze_object_t<V>) {
+         if constexpr (glz::glaze_object_t<V>) {
             constexpr auto& HashInfo = detail::hash_info<V>;
             constexpr auto I = detail::decode_hash_with_size<JSON, V, HashInfo, HashInfo.type>::op(
                key_str.data(), key_str.data() + key_str.size(), key_str.size());
@@ -566,10 +566,10 @@ namespace glz
                return false;
             }
          }
-         else if constexpr (glz::detail::writable_map_t<V>) {
+         else if constexpr (glz::writable_map_t<V>) {
             return valid<typename V::mapped_type, rem_ptr, Expected>();
          }
-         else if constexpr (glz::detail::glaze_array_t<V>) {
+         else if constexpr (glz::glaze_array_t<V>) {
             constexpr auto member_array = glz::detail::make_array<std::decay_t<V>>();
             constexpr auto optional_index = glz::detail::stoui(key_str); // TODO: Will not build if not int
             if constexpr (optional_index) {
@@ -588,13 +588,13 @@ namespace glz
                return false;
             }
          }
-         else if constexpr (glz::detail::array_t<V>) {
+         else if constexpr (glz::array_t<V>) {
             if (glz::detail::stoui(key_str)) {
                return valid<range_value_t<V>, rem_ptr, Expected>();
             }
             return false;
          }
-         else if constexpr (glz::detail::nullable_t<V>) {
+         else if constexpr (glz::nullable_t<V>) {
             using sub_t = decltype(*std::declval<V>());
             return valid<sub_t, ptr, Expected>();
          }

--- a/include/glaze/core/to.hpp
+++ b/include/glaze/core/to.hpp
@@ -8,7 +8,7 @@
 
 // Common behavior for `to` specializations, typically applies for all formats
 
-namespace glz::detail
+namespace glz
 {
    template <uint32_t Format>
    struct to<Format, hidden>

--- a/include/glaze/core/wrappers.hpp
+++ b/include/glaze/core/wrappers.hpp
@@ -18,83 +18,80 @@ namespace glz
       T& val;
    };
 
-   namespace detail
+   template <class T, auto OptsMemPtr>
+   struct opts_wrapper_t
    {
-      template <class T, auto OptsMemPtr>
-      struct opts_wrapper_t
-      {
-         static constexpr bool glaze_wrapper = true;
-         static constexpr auto glaze_reflect = false;
-         static constexpr auto opts_member = OptsMemPtr;
-         using value_type = T;
-         T& val;
+      static constexpr bool glaze_wrapper = true;
+      static constexpr auto glaze_reflect = false;
+      static constexpr auto opts_member = OptsMemPtr;
+      using value_type = T;
+      T& val;
+   };
+   
+   template <class T>
+   concept is_opts_wrapper = requires {
+      requires T::glaze_wrapper == true;
+      requires T::glaze_reflect == false;
+      T::opts_member;
+      typename T::value_type;
+      requires std::is_lvalue_reference_v<decltype(T::val)>;
+   };
+   
+   template <auto MemPtr, auto OptsMemPtr>
+   inline constexpr decltype(auto) opts_wrapper() noexcept
+   {
+      return [](auto&& val) {
+         using V = std::remove_reference_t<decltype(val.*MemPtr)>;
+         return opts_wrapper_t<V, OptsMemPtr>{val.*MemPtr};
       };
-
-      template <class T>
-      concept is_opts_wrapper = requires {
-         requires T::glaze_wrapper == true;
-         requires T::glaze_reflect == false;
-         T::opts_member;
-         typename T::value_type;
-         requires std::is_lvalue_reference_v<decltype(T::val)>;
-      };
-
-      template <auto MemPtr, auto OptsMemPtr>
-      inline constexpr decltype(auto) opts_wrapper() noexcept
-      {
-         return [](auto&& val) {
-            using V = std::remove_reference_t<decltype(val.*MemPtr)>;
-            return opts_wrapper_t<V, OptsMemPtr>{val.*MemPtr};
-         };
-      }
-
-      // custom_t allows a user to register member functions (and std::function members) to implement custom reading and
-      // writing
-      template <class T, class From, class To>
-      struct custom_t final
-      {
-         static constexpr auto glaze_reflect = false;
-         using from_t = From;
-         using to_t = To;
-         T& val;
-         From from;
-         To to;
-      };
-
-      template <class T, class From, class To>
-      custom_t(T&, From, To) -> custom_t<T, From, To>;
-
-      template <auto From, auto To>
-      inline constexpr auto custom_impl() noexcept
-      {
-         return [](auto&& v) { return custom_t{v, From, To}; };
-      }
+   }
+   
+   // custom_t allows a user to register member functions (and std::function members) to implement custom reading and
+   // writing
+   template <class T, class From, class To>
+   struct custom_t final
+   {
+      static constexpr auto glaze_reflect = false;
+      using from_t = From;
+      using to_t = To;
+      T& val;
+      From from;
+      To to;
+   };
+   
+   template <class T, class From, class To>
+   custom_t(T&, From, To) -> custom_t<T, From, To>;
+   
+   template <auto From, auto To>
+   inline constexpr auto custom_impl() noexcept
+   {
+      return [](auto&& v) { return custom_t{v, From, To}; };
    }
 
    // When reading into an array that is appendable, the new data will be appended rather than overwrite
    template <auto MemPtr>
-   constexpr auto append_arrays = detail::opts_wrapper<MemPtr, &opts::append_arrays>();
+   constexpr auto append_arrays = opts_wrapper<MemPtr, &opts::append_arrays>();
 
    // Read and write booleans as numbers
    template <auto MemPtr>
-   constexpr auto bools_as_numbers = detail::opts_wrapper<MemPtr, &opts::bools_as_numbers>();
+   constexpr auto bools_as_numbers = opts_wrapper<MemPtr, &opts::bools_as_numbers>();
 
    // Read and write numbers as strings
    template <auto MemPtr>
-   constexpr auto quoted_num = detail::opts_wrapper<MemPtr, &opts::quoted_num>();
+   constexpr auto quoted_num = opts_wrapper<MemPtr, &opts::quoted_num>();
 
    // Treat types like std::string as numbers: read and write them quoted
    template <auto MemPtr>
-   constexpr auto number = detail::opts_wrapper<MemPtr, &opts::number>();
+   constexpr auto number = opts_wrapper<MemPtr, &opts::number>();
 
    // Write out string like types without quotes
    template <auto MemPtr>
-   constexpr auto raw = detail::opts_wrapper<MemPtr, &opts::raw>();
+   constexpr auto raw = opts_wrapper<MemPtr, &opts::raw>();
 
    // Reads into only existing fields and elements and then exits without parsing the rest of the input
    template <auto MemPtr>
-   constexpr auto partial_read = detail::opts_wrapper<MemPtr, &opts::partial_read>();
+   constexpr auto partial_read = opts_wrapper<MemPtr, &opts::partial_read>();
 
    template <auto From, auto To>
-   constexpr auto custom = detail::custom_impl<From, To>();
+   constexpr auto custom = custom_impl<From, To>();
 }

--- a/include/glaze/core/write.hpp
+++ b/include/glaze/core/write.hpp
@@ -42,7 +42,7 @@ namespace glz
       }
       context ctx{};
       size_t ix = 0;
-      detail::write_partial<Opts.format>::template op<Partial, Opts>(std::forward<T>(value), ctx, buffer, ix);
+      serialize_partial<Opts.format>::template op<Partial, Opts>(std::forward<T>(value), ctx, buffer, ix);
       if constexpr (resizable<Buffer>) {
          buffer.resize(ix);
       }
@@ -55,7 +55,7 @@ namespace glz
    {
       context ctx{};
       size_t ix = 0;
-      detail::write_partial<Opts.format>::template op<Partial, Opts>(std::forward<T>(value), ctx, buffer, ix);
+      serialize_partial<Opts.format>::template op<Partial, Opts>(std::forward<T>(value), ctx, buffer, ix);
       if (bool(ctx.error)) [[unlikely]] {
          return glz::unexpected(error_ctx{.ec = ctx.error, .custom_error_message = ctx.custom_error_message});
       }

--- a/include/glaze/core/write.hpp
+++ b/include/glaze/core/write.hpp
@@ -22,7 +22,7 @@ namespace glz
          }
       }
       size_t ix = 0; // overwrite index
-      detail::to<Opts.format, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), ctx, buffer, ix);
+      to<Opts.format, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), ctx, buffer, ix);
       if constexpr (resizable<Buffer>) {
          buffer.resize(ix);
       }
@@ -88,7 +88,7 @@ namespace glz
    [[nodiscard]] glz::expected<size_t, error_ctx> write(T&& value, Buffer&& buffer, is_context auto&& ctx)
    {
       size_t ix = 0;
-      detail::to<Opts.format, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), ctx, buffer, ix);
+      to<Opts.format, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), ctx, buffer, ix);
       if (bool(ctx.error)) [[unlikely]] {
          return glz::unexpected(error_ctx{ctx.error});
       }

--- a/include/glaze/core/write_chars.hpp
+++ b/include/glaze/core/write_chars.hpp
@@ -12,7 +12,7 @@
 #include "glaze/util/dump.hpp"
 #include "glaze/util/itoa.hpp"
 
-namespace glz::detail
+namespace glz
 {
    template <class T>
    GLZ_ALWAYS_INLINE constexpr auto sized_integer_conversion() noexcept

--- a/include/glaze/csv/read.hpp
+++ b/include/glaze/csv/read.hpp
@@ -20,634 +20,631 @@ namespace glz
       template <auto Opts, class T, is_context Ctx, class It0, class It1>
       static void op(T&& value, Ctx&& ctx, It0&& it, It1 end)
       {
-         detail::from<CSV, std::decay_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+         from<CSV, std::decay_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
                                                        std::forward<It0>(it), std::forward<It1>(end));
       }
    };
    
-   namespace detail
+   GLZ_ALWAYS_INLINE bool csv_new_line(is_context auto& ctx, auto&& it) noexcept
    {
-      GLZ_ALWAYS_INLINE bool csv_new_line(is_context auto& ctx, auto&& it) noexcept
-      {
-         if (*it == '\n') {
+      if (*it == '\n') {
+         ++it;
+      }
+      else if (*it == '\r') {
+         ++it;
+         if (*it == '\n') [[likely]] {
             ++it;
-         }
-         else if (*it == '\r') {
-            ++it;
-            if (*it == '\n') [[likely]] {
-               ++it;
-            }
-            else [[unlikely]] {
-               ctx.error = error_code::syntax_error;
-               return true;
-            }
          }
          else [[unlikely]] {
             ctx.error = error_code::syntax_error;
             return true;
          }
-         return false;
       }
-
-      template <glaze_value_t T>
-      struct from<CSV, T>
+      else [[unlikely]] {
+         ctx.error = error_code::syntax_error;
+         return true;
+      }
+      return false;
+   }
+   
+   template <glaze_value_t T>
+   struct from<CSV, T>
+   {
+      template <auto Opts, is_context Ctx, class It0, class It1>
+      static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end)
       {
-         template <auto Opts, is_context Ctx, class It0, class It1>
-         static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end)
-         {
-            using V = decltype(get_member(std::declval<T>(), meta_wrapper_v<T>));
-            from<CSV, V>::template op<Opts>(get_member(value, meta_wrapper_v<T>), std::forward<Ctx>(ctx),
-                                            std::forward<It0>(it), std::forward<It1>(end));
+         using V = decltype(get_member(std::declval<T>(), meta_wrapper_v<T>));
+         from<CSV, V>::template op<Opts>(get_member(value, meta_wrapper_v<T>), std::forward<Ctx>(ctx),
+                                         std::forward<It0>(it), std::forward<It1>(end));
+      }
+   };
+   
+   template <num_t T>
+   struct from<CSV, T>
+   {
+      template <auto Opts, class It>
+      static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end) noexcept
+      {
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
          }
-      };
-
-      template <num_t T>
-      struct from<CSV, T>
-      {
-         template <auto Opts, class It>
-         static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end) noexcept
-         {
-            if (bool(ctx.error)) [[unlikely]] {
-               return;
-            }
-
-            using V = decay_keep_volatile_t<decltype(value)>;
-            if constexpr (int_t<V>) {
-               if constexpr (std::is_unsigned_v<V>) {
-                  uint64_t i{};
-                  if (*it == '-') [[unlikely]] {
-                     ctx.error = error_code::parse_number_failure;
-                     return;
-                  }
-
-                  if (not glz::detail::atoi(i, it)) [[unlikely]] {
-                     ctx.error = error_code::parse_number_failure;
-                     return;
-                  }
-
-                  if (i > (std::numeric_limits<V>::max)()) [[unlikely]] {
-                     ctx.error = error_code::parse_number_failure;
-                     return;
-                  }
-                  value = static_cast<V>(i);
-               }
-               else {
-                  uint64_t i{};
-                  int sign = 1;
-                  if (*it == '-') {
-                     sign = -1;
-                     ++it;
-                  }
-                  if (not glz::detail::atoi(i, it)) [[unlikely]] {
-                     ctx.error = error_code::parse_number_failure;
-                     return;
-                  }
-
-                  if (i > (std::numeric_limits<V>::max)()) [[unlikely]] {
-                     ctx.error = error_code::parse_number_failure;
-                     return;
-                  }
-                  value = sign * static_cast<V>(i);
-               }
-            }
-            else {
-               auto [ptr, ec] = glz::from_chars<Opts.null_terminated>(it, end, value);
-               if (ec != std::errc()) [[unlikely]] {
+         
+         using V = decay_keep_volatile_t<decltype(value)>;
+         if constexpr (int_t<V>) {
+            if constexpr (std::is_unsigned_v<V>) {
+               uint64_t i{};
+               if (*it == '-') [[unlikely]] {
                   ctx.error = error_code::parse_number_failure;
                   return;
                }
-               it = ptr;
-            }
-         }
-      };
-
-      // CSV spec: https://www.ietf.org/rfc/rfc4180.txt
-      // Quotes are escaped via double quotes
-
-      template <string_t T>
-      struct from<CSV, T>
-      {
-         template <auto Opts, class It>
-         static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end)
-         {
-            if (bool(ctx.error)) [[unlikely]] {
-               return;
-            }
-
-            value.clear();
-
-            if (it == end) {
-               return;
-            }
-
-            if (*it == '"') {
-               // Quoted field
-               ++it; // Skip the opening quote
-               while (it != end) {
-                  if (*it == '"') {
-                     ++it; // Skip the quote
-                     if (it == end) {
-                        // End of input after closing quote
-                        break;
-                     }
-                     if (*it == '"') {
-                        // Escaped quote
-                        value.push_back('"');
-                        ++it;
-                     }
-                     else {
-                        // Closing quote
-                        break;
-                     }
-                  }
-                  else {
-                     value.push_back(*it);
-                     ++it;
-                  }
-               }
-               // After closing quote, expect comma, newline, or end of input
-               if (it != end && *it != ',' && *it == '\n') {
-                  // Invalid character after closing quote
-                  ctx.error = error_code::syntax_error;
+               
+               if (not glz::atoi(i, it)) [[unlikely]] {
+                  ctx.error = error_code::parse_number_failure;
                   return;
                }
+               
+               if (i > (std::numeric_limits<V>::max)()) [[unlikely]] {
+                  ctx.error = error_code::parse_number_failure;
+                  return;
+               }
+               value = static_cast<V>(i);
             }
             else {
-               // Unquoted field
-               while (it != end && *it != ',' && *it != '\n') {
+               uint64_t i{};
+               int sign = 1;
+               if (*it == '-') {
+                  sign = -1;
+                  ++it;
+               }
+               if (not glz::atoi(i, it)) [[unlikely]] {
+                  ctx.error = error_code::parse_number_failure;
+                  return;
+               }
+               
+               if (i > (std::numeric_limits<V>::max)()) [[unlikely]] {
+                  ctx.error = error_code::parse_number_failure;
+                  return;
+               }
+               value = sign * static_cast<V>(i);
+            }
+         }
+         else {
+            auto [ptr, ec] = glz::from_chars<Opts.null_terminated>(it, end, value);
+            if (ec != std::errc()) [[unlikely]] {
+               ctx.error = error_code::parse_number_failure;
+               return;
+            }
+            it = ptr;
+         }
+      }
+   };
+   
+   // CSV spec: https://www.ietf.org/rfc/rfc4180.txt
+   // Quotes are escaped via double quotes
+   
+   template <string_t T>
+   struct from<CSV, T>
+   {
+      template <auto Opts, class It>
+      static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end)
+      {
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+         
+         value.clear();
+         
+         if (it == end) {
+            return;
+         }
+         
+         if (*it == '"') {
+            // Quoted field
+            ++it; // Skip the opening quote
+            while (it != end) {
+               if (*it == '"') {
+                  ++it; // Skip the quote
+                  if (it == end) {
+                     // End of input after closing quote
+                     break;
+                  }
+                  if (*it == '"') {
+                     // Escaped quote
+                     value.push_back('"');
+                     ++it;
+                  }
+                  else {
+                     // Closing quote
+                     break;
+                  }
+               }
+               else {
                   value.push_back(*it);
                   ++it;
                }
             }
-         }
-      };
-
-      template <bool_t T>
-      struct from<CSV, T>
-      {
-         template <auto Opts, class It>
-         static void op(auto&& value, is_context auto&& ctx, It&& it, auto&&) noexcept
-         {
-            if (bool(ctx.error)) [[unlikely]] {
+            // After closing quote, expect comma, newline, or end of input
+            if (it != end && *it != ',' && *it == '\n') {
+               // Invalid character after closing quote
+               ctx.error = error_code::syntax_error;
                return;
             }
-
-            uint64_t temp;
-            if (not glz::detail::atoi(temp, it)) [[unlikely]] {
-               ctx.error = error_code::expected_true_or_false;
-               return;
-            }
-            value = static_cast<bool>(temp);
          }
-      };
-
-      template <readable_array_t T>
-      struct from<CSV, T>
-      {
-         template <auto Opts, class It>
-         static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end)
-         {
-            parse<CSV>::op<Opts>(value.emplace_back(), ctx, it, end);
-         }
-      };
-
-      template <char delim>
-      inline void goto_delim(auto&& it, auto&& end) noexcept
-      {
-         while (++it != end && *it != delim)
-            ;
-      }
-
-      inline auto read_column_wise_keys(auto&& ctx, auto&& it, auto&& end)
-      {
-         std::vector<std::pair<sv, size_t>> keys;
-
-         auto read_key = [&](auto&& start, auto&& it) {
-            sv key{start, size_t(it - start)};
-
-            size_t csv_index{};
-
-            const auto brace_pos = key.find('[');
-            if (brace_pos != sv::npos) {
-               const auto close_brace = key.find(']');
-               const auto index = key.substr(brace_pos + 1, close_brace - (brace_pos + 1));
-               key = key.substr(0, brace_pos);
-               const auto [ptr, ec] = std::from_chars(index.data(), index.data() + index.size(), csv_index);
-               if (ec != std::errc()) {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-            }
-
-            keys.emplace_back(std::pair{key, csv_index});
-         };
-
-         auto start = it;
-         while (it != end) {
-            if (*it == ',') {
-               read_key(start, it);
+         else {
+            // Unquoted field
+            while (it != end && *it != ',' && *it != '\n') {
+               value.push_back(*it);
                ++it;
-               start = it;
             }
-            else if (*it == '\r' || *it == '\n') {
-               if (*it == '\r' && it[1] != '\n') [[unlikely]] {
-                  ctx.error = error_code::syntax_error;
-                  return keys;
-               }
-
-               if (start == it) {
-                  // trailing comma or empty
-               }
-               else {
-                  read_key(start, it);
-               }
-               break;
+         }
+      }
+   };
+   
+   template <bool_t T>
+   struct from<CSV, T>
+   {
+      template <auto Opts, class It>
+      static void op(auto&& value, is_context auto&& ctx, It&& it, auto&&) noexcept
+      {
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+         
+         uint64_t temp;
+         if (not glz::atoi(temp, it)) [[unlikely]] {
+            ctx.error = error_code::expected_true_or_false;
+            return;
+         }
+         value = static_cast<bool>(temp);
+      }
+   };
+   
+   template <readable_array_t T>
+   struct from<CSV, T>
+   {
+      template <auto Opts, class It>
+      static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end)
+      {
+         parse<CSV>::op<Opts>(value.emplace_back(), ctx, it, end);
+      }
+   };
+   
+   template <char delim>
+   inline void goto_delim(auto&& it, auto&& end) noexcept
+   {
+      while (++it != end && *it != delim)
+         ;
+   }
+   
+   inline auto read_column_wise_keys(auto&& ctx, auto&& it, auto&& end)
+   {
+      std::vector<std::pair<sv, size_t>> keys;
+      
+      auto read_key = [&](auto&& start, auto&& it) {
+         sv key{start, size_t(it - start)};
+         
+         size_t csv_index{};
+         
+         const auto brace_pos = key.find('[');
+         if (brace_pos != sv::npos) {
+            const auto close_brace = key.find(']');
+            const auto index = key.substr(brace_pos + 1, close_brace - (brace_pos + 1));
+            key = key.substr(0, brace_pos);
+            const auto [ptr, ec] = std::from_chars(index.data(), index.data() + index.size(), csv_index);
+            if (ec != std::errc()) {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+         }
+         
+         keys.emplace_back(std::pair{key, csv_index});
+      };
+      
+      auto start = it;
+      while (it != end) {
+         if (*it == ',') {
+            read_key(start, it);
+            ++it;
+            start = it;
+         }
+         else if (*it == '\r' || *it == '\n') {
+            if (*it == '\r' && it[1] != '\n') [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return keys;
+            }
+            
+            if (start == it) {
+               // trailing comma or empty
             }
             else {
-               ++it;
+               read_key(start, it);
             }
+            break;
          }
-
-         return keys;
+         else {
+            ++it;
+         }
       }
-
-      template <readable_map_t T>
-      struct from<CSV, T>
+      
+      return keys;
+   }
+   
+   template <readable_map_t T>
+   struct from<CSV, T>
+   {
+      template <auto Opts, class It>
+      static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end)
       {
-         template <auto Opts, class It>
-         static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end)
-         {
-            if constexpr (Opts.layout == rowwise) {
-               while (it != end) {
-                  auto start = it;
-                  goto_delim<','>(it, end);
-                  sv key{start, static_cast<size_t>(it - start)};
-
-                  size_t csv_index;
-
-                  const auto brace_pos = key.find('[');
-                  if (brace_pos != sv::npos) {
-                     const auto close_brace = key.find(']');
-                     const auto index = key.substr(brace_pos + 1, close_brace - (brace_pos + 1));
-                     key = key.substr(0, brace_pos);
-                     const auto [ptr, ec] = std::from_chars(index.data(), index.data() + index.size(), csv_index);
-                     if (ec != std::errc()) {
-                        ctx.error = error_code::syntax_error;
-                        return;
-                     }
-                  }
-
-                  if (match_invalid_end<',', Opts>(ctx, it, end)) {
+         if constexpr (Opts.layout == rowwise) {
+            while (it != end) {
+               auto start = it;
+               goto_delim<','>(it, end);
+               sv key{start, static_cast<size_t>(it - start)};
+               
+               size_t csv_index;
+               
+               const auto brace_pos = key.find('[');
+               if (brace_pos != sv::npos) {
+                  const auto close_brace = key.find(']');
+                  const auto index = key.substr(brace_pos + 1, close_brace - (brace_pos + 1));
+                  key = key.substr(0, brace_pos);
+                  const auto [ptr, ec] = std::from_chars(index.data(), index.data() + index.size(), csv_index);
+                  if (ec != std::errc()) {
+                     ctx.error = error_code::syntax_error;
                      return;
                   }
-
-                  using key_type = typename std::decay_t<decltype(value)>::key_type;
-                  auto& member = value[key_type(key)];
-                  using M = std::decay_t<decltype(member)>;
-                  if constexpr (fixed_array_value_t<M> && emplace_backable<M>) {
-                     size_t col = 0;
-                     while (it != end) {
-                        if (col < member.size()) [[likely]] {
-                           parse<CSV>::op<Opts>(member[col][csv_index], ctx, it, end);
+               }
+               
+               if (match_invalid_end<',', Opts>(ctx, it, end)) {
+                  return;
+               }
+               
+               using key_type = typename std::decay_t<decltype(value)>::key_type;
+               auto& member = value[key_type(key)];
+               using M = std::decay_t<decltype(member)>;
+               if constexpr (fixed_array_value_t<M> && emplace_backable<M>) {
+                  size_t col = 0;
+                  while (it != end) {
+                     if (col < member.size()) [[likely]] {
+                        parse<CSV>::op<Opts>(member[col][csv_index], ctx, it, end);
+                     }
+                     else [[unlikely]] {
+                        parse<CSV>::op<Opts>(member.emplace_back()[csv_index], ctx, it, end);
+                     }
+                     
+                     if (*it == '\r') {
+                        ++it;
+                        if (*it == '\n') {
+                           ++it;
+                           break;
                         }
                         else [[unlikely]] {
-                           parse<CSV>::op<Opts>(member.emplace_back()[csv_index], ctx, it, end);
-                        }
-
-                        if (*it == '\r') {
-                           ++it;
-                           if (*it == '\n') {
-                              ++it;
-                              break;
-                           }
-                           else [[unlikely]] {
-                              ctx.error = error_code::syntax_error;
-                              return;
-                           }
-                        }
-                        else if (*it == '\n') {
-                           ++it;
-                           break;
-                        }
-
-                        if (*it == ',') {
-                           ++it;
-                        }
-                        else {
-                           ctx.error = error_code::syntax_error;
-                           return;
-                        }
-
-                        ++col;
-                     }
-                  }
-                  else {
-                     while (it != end) {
-                        parse<CSV>::op<Opts>(member, ctx, it, end);
-
-                        if (*it == '\r') {
-                           ++it;
-                           if (*it == '\n') {
-                              ++it;
-                              break;
-                           }
-                           else [[unlikely]] {
-                              ctx.error = error_code::syntax_error;
-                              return;
-                           }
-                        }
-                        else if (*it == '\n') {
-                           ++it;
-                           break;
-                        }
-
-                        if (*it == ',') {
-                           ++it;
-                        }
-                        else {
                            ctx.error = error_code::syntax_error;
                            return;
                         }
                      }
-                  }
-               }
-            }
-            else // column wise
-            {
-               const auto keys = read_column_wise_keys(ctx, it, end);
-
-               if (bool(ctx.error)) {
-                  return;
-               }
-
-               if (csv_new_line(ctx, it)) {
-                  return;
-               }
-
-               const auto n_keys = keys.size();
-
-               size_t row = 0;
-
-               while (it != end) {
-                  for (size_t i = 0; i < n_keys; ++i) {
-                     using key_type = typename std::decay_t<decltype(value)>::key_type;
-                     auto& member = value[key_type(keys[i].first)];
-                     using M = std::decay_t<decltype(member)>;
-                     if constexpr (fixed_array_value_t<M> && emplace_backable<M>) {
-                        const auto index = keys[i].second;
-                        if (row < member.size()) [[likely]] {
-                           parse<CSV>::op<Opts>(member[row][index], ctx, it, end);
-                        }
-                        else [[unlikely]] {
-                           parse<CSV>::op<Opts>(member.emplace_back()[index], ctx, it, end);
-                        }
+                     else if (*it == '\n') {
+                        ++it;
+                        break;
                      }
-                     else {
-                        parse<CSV>::op<Opts>(member, ctx, it, end);
-                     }
-
+                     
                      if (*it == ',') {
                         ++it;
                      }
-                  }
-
-                  if (*it == '\r') {
-                     ++it;
-                     if (*it == '\n') {
-                        ++it;
-                        ++row;
+                     else {
+                        ctx.error = error_code::syntax_error;
+                        return;
                      }
-                     else [[unlikely]] {
+                     
+                     ++col;
+                  }
+               }
+               else {
+                  while (it != end) {
+                     parse<CSV>::op<Opts>(member, ctx, it, end);
+                     
+                     if (*it == '\r') {
+                        ++it;
+                        if (*it == '\n') {
+                           ++it;
+                           break;
+                        }
+                        else [[unlikely]] {
+                           ctx.error = error_code::syntax_error;
+                           return;
+                        }
+                     }
+                     else if (*it == '\n') {
+                        ++it;
+                        break;
+                     }
+                     
+                     if (*it == ',') {
+                        ++it;
+                     }
+                     else {
                         ctx.error = error_code::syntax_error;
                         return;
                      }
                   }
-                  else if (*it == '\n') {
+               }
+            }
+         }
+         else // column wise
+         {
+            const auto keys = read_column_wise_keys(ctx, it, end);
+            
+            if (bool(ctx.error)) {
+               return;
+            }
+            
+            if (csv_new_line(ctx, it)) {
+               return;
+            }
+            
+            const auto n_keys = keys.size();
+            
+            size_t row = 0;
+            
+            while (it != end) {
+               for (size_t i = 0; i < n_keys; ++i) {
+                  using key_type = typename std::decay_t<decltype(value)>::key_type;
+                  auto& member = value[key_type(keys[i].first)];
+                  using M = std::decay_t<decltype(member)>;
+                  if constexpr (fixed_array_value_t<M> && emplace_backable<M>) {
+                     const auto index = keys[i].second;
+                     if (row < member.size()) [[likely]] {
+                        parse<CSV>::op<Opts>(member[row][index], ctx, it, end);
+                     }
+                     else [[unlikely]] {
+                        parse<CSV>::op<Opts>(member.emplace_back()[index], ctx, it, end);
+                     }
+                  }
+                  else {
+                     parse<CSV>::op<Opts>(member, ctx, it, end);
+                  }
+                  
+                  if (*it == ',') {
+                     ++it;
+                  }
+               }
+               
+               if (*it == '\r') {
+                  ++it;
+                  if (*it == '\n') {
                      ++it;
                      ++row;
                   }
+                  else [[unlikely]] {
+                     ctx.error = error_code::syntax_error;
+                     return;
+                  }
+               }
+               else if (*it == '\n') {
+                  ++it;
+                  ++row;
                }
             }
          }
-      };
-
-      template <class T>
-         requires(glaze_object_t<T> || reflectable<T>)
-      struct from<CSV, T>
+      }
+   };
+   
+   template <class T>
+   requires(glaze_object_t<T> || reflectable<T>)
+   struct from<CSV, T>
+   {
+      template <auto Opts, class It>
+      static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end)
       {
-         template <auto Opts, class It>
-         static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end)
-         {
-            static constexpr auto N = reflect<T>::size;
-            static constexpr auto HashInfo = detail::hash_info<T>;
-
-            if constexpr (Opts.layout == rowwise) {
-               while (it != end) {
-                  auto start = it;
-                  goto_delim<','>(it, end);
-                  sv key{start, static_cast<size_t>(it - start)};
-
-                  size_t csv_index{};
-
-                  const auto brace_pos = key.find('[');
-                  if (brace_pos != sv::npos) {
-                     const auto close_brace = key.find(']');
-                     const auto index = key.substr(brace_pos + 1, close_brace - (brace_pos + 1));
-                     key = key.substr(0, brace_pos);
-                     const auto [ptr, ec] = std::from_chars(index.data(), index.data() + index.size(), csv_index);
-                     if (ec != std::errc()) [[unlikely]] {
-                        ctx.error = error_code::syntax_error;
-                        return;
-                     }
-                  }
-
-                  if (match_invalid_end<',', Opts>(ctx, it, end)) {
-                     return;
-                  }
-
-                  const auto index =
-                     decode_hash_with_size<CSV, T, HashInfo, HashInfo.type>::op(key.data(), end, key.size());
-
-                  if (index < N) [[likely]] {
-                     visit<N>(
-                        [&]<size_t I>() {
-                           decltype(auto) member = [&]() -> decltype(auto) {
-                              if constexpr (reflectable<T>) {
-                                 return get_member(value, get<I>(to_tie(value)));
-                              }
-                              else {
-                                 return get_member(value, get<I>(reflect<T>::values));
-                              }
-                           }();
-
-                           using M = std::decay_t<decltype(member)>;
-                           if constexpr (fixed_array_value_t<M> && emplace_backable<M>) {
-                              size_t col = 0;
-                              while (it != end) {
-                                 if (col < member.size()) [[likely]] {
-                                    parse<CSV>::op<Opts>(member[col][csv_index], ctx, it, end);
-                                 }
-                                 else [[unlikely]] {
-                                    parse<CSV>::op<Opts>(member.emplace_back()[csv_index], ctx, it, end);
-                                 }
-
-                                 if (*it == '\r') {
-                                    ++it;
-                                    if (*it == '\n') {
-                                       ++it;
-                                       break;
-                                    }
-                                    else [[unlikely]] {
-                                       ctx.error = error_code::syntax_error;
-                                       return;
-                                    }
-                                 }
-                                 else if (*it == '\n') {
-                                    ++it;
-                                    break;
-                                 }
-                                 else if (it == end) {
-                                    return;
-                                 }
-
-                                 if (*it == ',') [[likely]] {
-                                    ++it;
-                                 }
-                                 else [[unlikely]] {
-                                    ctx.error = error_code::syntax_error;
-                                    return;
-                                 }
-
-                                 ++col;
-                              }
-                           }
-                           else {
-                              while (it != end) {
-                                 parse<CSV>::op<Opts>(member, ctx, it, end);
-
-                                 if (*it == '\r') {
-                                    ++it;
-                                    if (*it == '\n') {
-                                       ++it;
-                                       break;
-                                    }
-                                    else [[unlikely]] {
-                                       ctx.error = error_code::syntax_error;
-                                       return;
-                                    }
-                                 }
-                                 else if (*it == '\n') {
-                                    ++it;
-                                    break;
-                                 }
-
-                                 if (*it == ',') [[likely]] {
-                                    ++it;
-                                 }
-                                 else [[unlikely]] {
-                                    ctx.error = error_code::syntax_error;
-                                    return;
-                                 }
-                              }
-                           }
-                        },
-                        index);
-
-                     if (bool(ctx.error)) [[unlikely]] {
-                        return;
-                     }
-                  }
-                  else [[unlikely]] {
-                     ctx.error = error_code::unknown_key;
+         static constexpr auto N = reflect<T>::size;
+         static constexpr auto HashInfo = hash_info<T>;
+         
+         if constexpr (Opts.layout == rowwise) {
+            while (it != end) {
+               auto start = it;
+               goto_delim<','>(it, end);
+               sv key{start, static_cast<size_t>(it - start)};
+               
+               size_t csv_index{};
+               
+               const auto brace_pos = key.find('[');
+               if (brace_pos != sv::npos) {
+                  const auto close_brace = key.find(']');
+                  const auto index = key.substr(brace_pos + 1, close_brace - (brace_pos + 1));
+                  key = key.substr(0, brace_pos);
+                  const auto [ptr, ec] = std::from_chars(index.data(), index.data() + index.size(), csv_index);
+                  if (ec != std::errc()) [[unlikely]] {
+                     ctx.error = error_code::syntax_error;
                      return;
                   }
                }
-            }
-            else // column wise
-            {
-               const auto keys = read_column_wise_keys(ctx, it, end);
-
-               if (bool(ctx.error)) [[unlikely]] {
+               
+               if (match_invalid_end<',', Opts>(ctx, it, end)) {
                   return;
                }
-
-               if (csv_new_line(ctx, it)) {
-                  return;
-               }
-
-               const auto n_keys = keys.size();
-
-               size_t row = 0;
-
-               bool at_end{it == end};
-               if (!at_end) {
-                  while (true) {
-                     for (size_t i = 0; i < n_keys; ++i) {
-                        const auto key = keys[i].first;
-                        const auto index = decode_hash_with_size<CSV, T, HashInfo, HashInfo.type>::op(
-                           key.data(), key.data() + key.size(), key.size());
-
-                        if (index < N) [[likely]] {
-                           visit<N>(
-                              [&]<size_t I>() {
-                                 decltype(auto) member = [&]() -> decltype(auto) {
-                                    if constexpr (reflectable<T>) {
-                                       return get_member(value, get<I>(to_tie(value)));
-                                    }
-                                    else {
-                                       return get_member(value, get<I>(reflect<T>::values));
-                                    }
-                                 }();
-
-                                 using M = std::decay_t<decltype(member)>;
-                                 if constexpr (fixed_array_value_t<M> && emplace_backable<M>) {
-                                    const auto index = keys[i].second;
-                                    if (row < member.size()) [[likely]] {
-                                       parse<CSV>::op<Opts>(member[row][index], ctx, it, end);
-                                    }
-                                    else [[unlikely]] {
-                                       parse<CSV>::op<Opts>(member.emplace_back()[index], ctx, it, end);
-                                    }
+               
+               const auto index =
+               decode_hash_with_size<CSV, T, HashInfo, HashInfo.type>::op(key.data(), end, key.size());
+               
+               if (index < N) [[likely]] {
+                  visit<N>(
+                           [&]<size_t I>() {
+                              decltype(auto) member = [&]() -> decltype(auto) {
+                                 if constexpr (reflectable<T>) {
+                                    return get_member(value, get<I>(to_tie(value)));
                                  }
                                  else {
-                                    parse<CSV>::op<Opts>(member, ctx, it, end);
+                                    return get_member(value, get<I>(reflect<T>::values));
                                  }
-                              },
-                              index);
-
-                           if (bool(ctx.error)) [[unlikely]] {
-                              return;
-                           }
-                        }
-                        else [[unlikely]] {
-                           ctx.error = error_code::unknown_key;
+                              }();
+                              
+                              using M = std::decay_t<decltype(member)>;
+                              if constexpr (fixed_array_value_t<M> && emplace_backable<M>) {
+                                 size_t col = 0;
+                                 while (it != end) {
+                                    if (col < member.size()) [[likely]] {
+                                       parse<CSV>::op<Opts>(member[col][csv_index], ctx, it, end);
+                                    }
+                                    else [[unlikely]] {
+                                       parse<CSV>::op<Opts>(member.emplace_back()[csv_index], ctx, it, end);
+                                    }
+                                    
+                                    if (*it == '\r') {
+                                       ++it;
+                                       if (*it == '\n') {
+                                          ++it;
+                                          break;
+                                       }
+                                       else [[unlikely]] {
+                                          ctx.error = error_code::syntax_error;
+                                          return;
+                                       }
+                                    }
+                                    else if (*it == '\n') {
+                                       ++it;
+                                       break;
+                                    }
+                                    else if (it == end) {
+                                       return;
+                                    }
+                                    
+                                    if (*it == ',') [[likely]] {
+                                       ++it;
+                                    }
+                                    else [[unlikely]] {
+                                       ctx.error = error_code::syntax_error;
+                                       return;
+                                    }
+                                    
+                                    ++col;
+                                 }
+                              }
+                              else {
+                                 while (it != end) {
+                                    parse<CSV>::op<Opts>(member, ctx, it, end);
+                                    
+                                    if (*it == '\r') {
+                                       ++it;
+                                       if (*it == '\n') {
+                                          ++it;
+                                          break;
+                                       }
+                                       else [[unlikely]] {
+                                          ctx.error = error_code::syntax_error;
+                                          return;
+                                       }
+                                    }
+                                    else if (*it == '\n') {
+                                       ++it;
+                                       break;
+                                    }
+                                    
+                                    if (*it == ',') [[likely]] {
+                                       ++it;
+                                    }
+                                    else [[unlikely]] {
+                                       ctx.error = error_code::syntax_error;
+                                       return;
+                                    }
+                                 }
+                              }
+                           },
+                           index);
+                  
+                  if (bool(ctx.error)) [[unlikely]] {
+                     return;
+                  }
+               }
+               else [[unlikely]] {
+                  ctx.error = error_code::unknown_key;
+                  return;
+               }
+            }
+         }
+         else // column wise
+         {
+            const auto keys = read_column_wise_keys(ctx, it, end);
+            
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            
+            if (csv_new_line(ctx, it)) {
+               return;
+            }
+            
+            const auto n_keys = keys.size();
+            
+            size_t row = 0;
+            
+            bool at_end{it == end};
+            if (!at_end) {
+               while (true) {
+                  for (size_t i = 0; i < n_keys; ++i) {
+                     const auto key = keys[i].first;
+                     const auto index = decode_hash_with_size<CSV, T, HashInfo, HashInfo.type>::op(
+                                                                                                   key.data(), key.data() + key.size(), key.size());
+                     
+                     if (index < N) [[likely]] {
+                        visit<N>(
+                                 [&]<size_t I>() {
+                                    decltype(auto) member = [&]() -> decltype(auto) {
+                                       if constexpr (reflectable<T>) {
+                                          return get_member(value, get<I>(to_tie(value)));
+                                       }
+                                       else {
+                                          return get_member(value, get<I>(reflect<T>::values));
+                                       }
+                                    }();
+                                    
+                                    using M = std::decay_t<decltype(member)>;
+                                    if constexpr (fixed_array_value_t<M> && emplace_backable<M>) {
+                                       const auto index = keys[i].second;
+                                       if (row < member.size()) [[likely]] {
+                                          parse<CSV>::op<Opts>(member[row][index], ctx, it, end);
+                                       }
+                                       else [[unlikely]] {
+                                          parse<CSV>::op<Opts>(member.emplace_back()[index], ctx, it, end);
+                                       }
+                                    }
+                                    else {
+                                       parse<CSV>::op<Opts>(member, ctx, it, end);
+                                    }
+                                 },
+                                 index);
+                        
+                        if (bool(ctx.error)) [[unlikely]] {
                            return;
                         }
-
+                     }
+                     else [[unlikely]] {
+                        ctx.error = error_code::unknown_key;
+                        return;
+                     }
+                     
+                     at_end = it == end;
+                     if (!at_end && *it == ',') {
+                        ++it;
                         at_end = it == end;
-                        if (!at_end && *it == ',') {
-                           ++it;
-                           at_end = it == end;
-                        }
                      }
-                     if (!at_end) [[likely]] {
-                        if (csv_new_line(ctx, it)) {
-                           return;
-                        }
-
-                        ++row;
-                        at_end = it == end;
-                        if (at_end) break;
+                  }
+                  if (!at_end) [[likely]] {
+                     if (csv_new_line(ctx, it)) {
+                        return;
                      }
-                     else {
-                        break;
-                     }
+                     
+                     ++row;
+                     at_end = it == end;
+                     if (at_end) break;
+                  }
+                  else {
+                     break;
                   }
                }
             }
          }
-      };
-   }
+      }
+   };
 
    template <uint32_t layout = rowwise, class T, class Buffer>
       requires(read_supported<CSV, T>)

--- a/include/glaze/csv/read.hpp
+++ b/include/glaze/csv/read.hpp
@@ -14,6 +14,17 @@
 
 namespace glz
 {
+   template <>
+   struct parse<CSV>
+   {
+      template <auto Opts, class T, is_context Ctx, class It0, class It1>
+      static void op(T&& value, Ctx&& ctx, It0&& it, It1 end)
+      {
+         detail::from<CSV, std::decay_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+                                                       std::forward<It0>(it), std::forward<It1>(end));
+      }
+   };
+   
    namespace detail
    {
       GLZ_ALWAYS_INLINE bool csv_new_line(is_context auto& ctx, auto&& it) noexcept
@@ -37,17 +48,6 @@ namespace glz
          }
          return false;
       }
-
-      template <>
-      struct read<CSV>
-      {
-         template <auto Opts, class T, is_context Ctx, class It0, class It1>
-         static void op(T&& value, Ctx&& ctx, It0&& it, It1 end)
-         {
-            from<CSV, std::decay_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
-                                                          std::forward<It0>(it), std::forward<It1>(end));
-         }
-      };
 
       template <glaze_value_t T>
       struct from<CSV, T>
@@ -207,7 +207,7 @@ namespace glz
          template <auto Opts, class It>
          static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end)
          {
-            read<CSV>::op<Opts>(value.emplace_back(), ctx, it, end);
+            parse<CSV>::op<Opts>(value.emplace_back(), ctx, it, end);
          }
       };
 
@@ -308,10 +308,10 @@ namespace glz
                      size_t col = 0;
                      while (it != end) {
                         if (col < member.size()) [[likely]] {
-                           read<CSV>::op<Opts>(member[col][csv_index], ctx, it, end);
+                           parse<CSV>::op<Opts>(member[col][csv_index], ctx, it, end);
                         }
                         else [[unlikely]] {
-                           read<CSV>::op<Opts>(member.emplace_back()[csv_index], ctx, it, end);
+                           parse<CSV>::op<Opts>(member.emplace_back()[csv_index], ctx, it, end);
                         }
 
                         if (*it == '\r') {
@@ -343,7 +343,7 @@ namespace glz
                   }
                   else {
                      while (it != end) {
-                        read<CSV>::op<Opts>(member, ctx, it, end);
+                        parse<CSV>::op<Opts>(member, ctx, it, end);
 
                         if (*it == '\r') {
                            ++it;
@@ -396,14 +396,14 @@ namespace glz
                      if constexpr (fixed_array_value_t<M> && emplace_backable<M>) {
                         const auto index = keys[i].second;
                         if (row < member.size()) [[likely]] {
-                           read<CSV>::op<Opts>(member[row][index], ctx, it, end);
+                           parse<CSV>::op<Opts>(member[row][index], ctx, it, end);
                         }
                         else [[unlikely]] {
-                           read<CSV>::op<Opts>(member.emplace_back()[index], ctx, it, end);
+                           parse<CSV>::op<Opts>(member.emplace_back()[index], ctx, it, end);
                         }
                      }
                      else {
-                        read<CSV>::op<Opts>(member, ctx, it, end);
+                        parse<CSV>::op<Opts>(member, ctx, it, end);
                      }
 
                      if (*it == ',') {
@@ -485,10 +485,10 @@ namespace glz
                               size_t col = 0;
                               while (it != end) {
                                  if (col < member.size()) [[likely]] {
-                                    read<CSV>::op<Opts>(member[col][csv_index], ctx, it, end);
+                                    parse<CSV>::op<Opts>(member[col][csv_index], ctx, it, end);
                                  }
                                  else [[unlikely]] {
-                                    read<CSV>::op<Opts>(member.emplace_back()[csv_index], ctx, it, end);
+                                    parse<CSV>::op<Opts>(member.emplace_back()[csv_index], ctx, it, end);
                                  }
 
                                  if (*it == '\r') {
@@ -523,7 +523,7 @@ namespace glz
                            }
                            else {
                               while (it != end) {
-                                 read<CSV>::op<Opts>(member, ctx, it, end);
+                                 parse<CSV>::op<Opts>(member, ctx, it, end);
 
                                  if (*it == '\r') {
                                     ++it;
@@ -603,14 +603,14 @@ namespace glz
                                  if constexpr (fixed_array_value_t<M> && emplace_backable<M>) {
                                     const auto index = keys[i].second;
                                     if (row < member.size()) [[likely]] {
-                                       read<CSV>::op<Opts>(member[row][index], ctx, it, end);
+                                       parse<CSV>::op<Opts>(member[row][index], ctx, it, end);
                                     }
                                     else [[unlikely]] {
-                                       read<CSV>::op<Opts>(member.emplace_back()[index], ctx, it, end);
+                                       parse<CSV>::op<Opts>(member.emplace_back()[index], ctx, it, end);
                                     }
                                  }
                                  else {
-                                    read<CSV>::op<Opts>(member, ctx, it, end);
+                                    parse<CSV>::op<Opts>(member, ctx, it, end);
                                  }
                               },
                               index);

--- a/include/glaze/csv/write.hpp
+++ b/include/glaze/csv/write.hpp
@@ -11,19 +11,19 @@
 
 namespace glz
 {
+   template <>
+   struct serialize<CSV>
+   {
+      template <auto Opts, class T, is_context Ctx, class B, class IX>
+      static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
+      {
+         detail::to<CSV, std::decay_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+                                                     std::forward<B>(b), std::forward<IX>(ix));
+      }
+   };
+   
    namespace detail
    {
-      template <>
-      struct write<CSV>
-      {
-         template <auto Opts, class T, is_context Ctx, class B, class IX>
-         static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
-         {
-            to<CSV, std::decay_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
-                                                        std::forward<B>(b), std::forward<IX>(ix));
-         }
-      };
-
       template <glaze_value_t T>
       struct to<CSV, T>
       {
@@ -71,7 +71,7 @@ namespace glz
                if constexpr (Opts.layout == rowwise) {
                   const auto n = value.size();
                   for (size_t i = 0; i < n; ++i) {
-                     write<CSV>::op<Opts>(value[i], ctx, b, ix);
+                     serialize<CSV>::op<Opts>(value[i], ctx, b, ix);
 
                      if (i != (n - 1)) {
                         dump<','>(b, ix);
@@ -85,7 +85,7 @@ namespace glz
             else {
                const auto n = value.size();
                for (size_t i = 0; i < n; ++i) {
-                  write<CSV>::op<Opts>(value[i], ctx, b, ix);
+                  serialize<CSV>::op<Opts>(value[i], ctx, b, ix);
 
                   if (i != (n - 1)) {
                      dump<','>(b, ix);
@@ -118,7 +118,7 @@ namespace glz
                   dump<','>(b, ix);
                   const auto n = data.size();
                   for (size_t i = 0; i < n; ++i) {
-                     write<CSV>::op<Opts>(data[i], ctx, b, ix);
+                     serialize<CSV>::op<Opts>(data[i], ctx, b, ix);
                      if (i < n - 1) {
                         dump<','>(b, ix);
                      }
@@ -150,7 +150,7 @@ namespace glz
                         break;
                      }
 
-                     write<CSV>::op<Opts>(data[row], ctx, b, ix);
+                     serialize<CSV>::op<Opts>(data[row], ctx, b, ix);
                      ++i;
                      if (i < n) {
                         dump<','>(b, ix);
@@ -214,7 +214,7 @@ namespace glz
                         dump<','>(b, ix);
 
                         for (size_t j = 0; j < count; ++j) {
-                           write<CSV>::op<Opts>(member[j][i], ctx, b, ix);
+                           serialize<CSV>::op<Opts>(member[j][i], ctx, b, ix);
                            if (j != count - 1) {
                               dump<','>(b, ix);
                            }
@@ -228,7 +228,7 @@ namespace glz
                   else {
                      dump<key>(b, ix);
                      dump<','>(b, ix);
-                     write<CSV>::op<Opts>(get_member(value, mem), ctx, b, ix);
+                     serialize<CSV>::op<Opts>(get_member(value, mem), ctx, b, ix);
                      dump<'\n'>(b, ix);
                   }
                });
@@ -262,7 +262,7 @@ namespace glz
                      }
                   }
                   else {
-                     write<CSV>::op<Opts>(key, ctx, b, ix);
+                     serialize<CSV>::op<Opts>(key, ctx, b, ix);
                   }
 
                   if (I != N - 1) {
@@ -297,7 +297,7 @@ namespace glz
 
                         const auto n = member[0].size();
                         for (size_t i = 0; i < n; ++i) {
-                           write<CSV>::op<Opts>(member[row][i], ctx, b, ix);
+                           serialize<CSV>::op<Opts>(member[row][i], ctx, b, ix);
                            if (i != n - 1) {
                               dump<','>(b, ix);
                            }
@@ -310,7 +310,7 @@ namespace glz
                            return;
                         }
 
-                        write<CSV>::op<Opts>(member[row], ctx, b, ix);
+                        serialize<CSV>::op<Opts>(member[row], ctx, b, ix);
 
                         if (I != N - 1) {
                            dump<','>(b, ix);

--- a/include/glaze/csv/write.hpp
+++ b/include/glaze/csv/write.hpp
@@ -17,182 +17,266 @@ namespace glz
       template <auto Opts, class T, is_context Ctx, class B, class IX>
       static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
       {
-         detail::to<CSV, std::decay_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+         to<CSV, std::decay_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
                                                      std::forward<B>(b), std::forward<IX>(ix));
       }
    };
    
-   namespace detail
+   template <glaze_value_t T>
+   struct to<CSV, T>
    {
-      template <glaze_value_t T>
-      struct to<CSV, T>
+      template <auto Opts, is_context Ctx, class B, class IX>
+      static void op(auto&& value, Ctx&& ctx, B&& b, IX&& ix)
       {
-         template <auto Opts, is_context Ctx, class B, class IX>
-         static void op(auto&& value, Ctx&& ctx, B&& b, IX&& ix)
-         {
-            using V = decltype(get_member(std::declval<T>(), meta_wrapper_v<T>));
-            to<CSV, V>::template op<Opts>(get_member(value, meta_wrapper_v<T>), std::forward<Ctx>(ctx),
-                                          std::forward<B>(b), std::forward<IX>(ix));
+         using V = decltype(get_member(std::declval<T>(), meta_wrapper_v<T>));
+         to<CSV, V>::template op<Opts>(get_member(value, meta_wrapper_v<T>), std::forward<Ctx>(ctx),
+                                       std::forward<B>(b), std::forward<IX>(ix));
+      }
+   };
+   
+   template <num_t T>
+   struct to<CSV, T>
+   {
+      template <auto Opts, class B>
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
+      {
+         write_chars::op<Opts>(value, ctx, b, ix);
+      }
+   };
+   
+   template <bool_t T>
+   struct to<CSV, T>
+   {
+      template <auto Opts, class B>
+      static void op(auto&& value, is_context auto&&, B&& b, auto&& ix)
+      {
+         if (value) {
+            dump<'1'>(b, ix);
          }
-      };
-
-      template <num_t T>
-      struct to<CSV, T>
-      {
-         template <auto Opts, class B>
-         static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
-         {
-            write_chars::op<Opts>(value, ctx, b, ix);
+         else {
+            dump<'0'>(b, ix);
          }
-      };
-
-      template <bool_t T>
-      struct to<CSV, T>
+      }
+   };
+   
+   template <writable_array_t T>
+   struct to<CSV, T>
+   {
+      template <auto Opts, class B>
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
       {
-         template <auto Opts, class B>
-         static void op(auto&& value, is_context auto&&, B&& b, auto&& ix)
-         {
-            if (value) {
-               dump<'1'>(b, ix);
-            }
-            else {
-               dump<'0'>(b, ix);
-            }
-         }
-      };
-
-      template <writable_array_t T>
-      struct to<CSV, T>
-      {
-         template <auto Opts, class B>
-         static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
-         {
-            if constexpr (resizable<T>) {
-               if constexpr (Opts.layout == rowwise) {
-                  const auto n = value.size();
-                  for (size_t i = 0; i < n; ++i) {
-                     serialize<CSV>::op<Opts>(value[i], ctx, b, ix);
-
-                     if (i != (n - 1)) {
-                        dump<','>(b, ix);
-                     }
-                  }
-               }
-               else {
-                  static_assert(false_v<T>, "Dynamic arrays within dynamic arrays are unsupported");
-               }
-            }
-            else {
+         if constexpr (resizable<T>) {
+            if constexpr (Opts.layout == rowwise) {
                const auto n = value.size();
                for (size_t i = 0; i < n; ++i) {
                   serialize<CSV>::op<Opts>(value[i], ctx, b, ix);
-
+                  
                   if (i != (n - 1)) {
                      dump<','>(b, ix);
                   }
                }
             }
+            else {
+               static_assert(false_v<T>, "Dynamic arrays within dynamic arrays are unsupported");
+            }
          }
-      };
-
-      template <class T>
-         requires str_t<T> || char_t<T>
-      struct to<CSV, T>
-      {
-         template <auto Opts, class B>
-         static void op(auto&& value, is_context auto&&, B&& b, auto&& ix)
-         {
-            dump_maybe_empty(value, b, ix);
-         }
-      };
-
-      template <writable_map_t T>
-      struct to<CSV, T>
-      {
-         template <auto Opts, class B>
-         static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
-         {
-            if constexpr (Opts.layout == rowwise) {
-               for (auto& [name, data] : value) {
-                  dump_maybe_empty(name, b, ix);
+         else {
+            const auto n = value.size();
+            for (size_t i = 0; i < n; ++i) {
+               serialize<CSV>::op<Opts>(value[i], ctx, b, ix);
+               
+               if (i != (n - 1)) {
                   dump<','>(b, ix);
-                  const auto n = data.size();
-                  for (size_t i = 0; i < n; ++i) {
-                     serialize<CSV>::op<Opts>(data[i], ctx, b, ix);
-                     if (i < n - 1) {
-                        dump<','>(b, ix);
-                     }
-                  }
-                  dump<'\n'>(b, ix);
                }
             }
-            else {
-               // dump titles
-               const auto n = value.size();
-               size_t i = 0;
+         }
+      }
+   };
+   
+   template <class T>
+   requires str_t<T> || char_t<T>
+   struct to<CSV, T>
+   {
+      template <auto Opts, class B>
+      static void op(auto&& value, is_context auto&&, B&& b, auto&& ix)
+      {
+         dump_maybe_empty(value, b, ix);
+      }
+   };
+   
+   template <writable_map_t T>
+   struct to<CSV, T>
+   {
+      template <auto Opts, class B>
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
+      {
+         if constexpr (Opts.layout == rowwise) {
+            for (auto& [name, data] : value) {
+               dump_maybe_empty(name, b, ix);
+               dump<','>(b, ix);
+               const auto n = data.size();
+               for (size_t i = 0; i < n; ++i) {
+                  serialize<CSV>::op<Opts>(data[i], ctx, b, ix);
+                  if (i < n - 1) {
+                     dump<','>(b, ix);
+                  }
+               }
+               dump<'\n'>(b, ix);
+            }
+         }
+         else {
+            // dump titles
+            const auto n = value.size();
+            size_t i = 0;
+            for (auto& [name, data] : value) {
+               dump_maybe_empty(name, b, ix);
+               ++i;
+               if (i < n) {
+                  dump<','>(b, ix);
+               }
+            }
+            
+            dump<'\n'>(b, ix);
+            
+            size_t row = 0;
+            bool end = false;
+            while (true) {
+               i = 0;
                for (auto& [name, data] : value) {
-                  dump_maybe_empty(name, b, ix);
+                  if (row >= data.size()) {
+                     end = true;
+                     break;
+                  }
+                  
+                  serialize<CSV>::op<Opts>(data[row], ctx, b, ix);
                   ++i;
                   if (i < n) {
                      dump<','>(b, ix);
                   }
                }
-
+               
+               if (end) {
+                  break;
+               }
+               
                dump<'\n'>(b, ix);
-
-               size_t row = 0;
-               bool end = false;
-               while (true) {
-                  i = 0;
-                  for (auto& [name, data] : value) {
-                     if (row >= data.size()) {
-                        end = true;
-                        break;
+               
+               ++row;
+            }
+         }
+      }
+   };
+   
+   template <class T>
+   requires(glaze_object_t<T> || reflectable<T>)
+   struct to<CSV, T>
+   {
+      template <auto Opts, class B>
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
+      {
+         static constexpr auto N = reflect<T>::size;
+         
+         [[maybe_unused]] decltype(auto) t = [&] {
+            if constexpr (reflectable<T>) {
+               return to_tie(value);
+            }
+            else {
+               return nullptr;
+            }
+         }();
+         
+         if constexpr (Opts.layout == rowwise) {
+            for_each<N>([&](auto I) {
+               using value_type = typename std::decay_t<refl_t<T, I>>::value_type;
+               
+               static constexpr sv key = reflect<T>::keys[I];
+               
+               decltype(auto) mem = [&]() -> decltype(auto) {
+                  if constexpr (reflectable<T>) {
+                     return get<I>(t);
+                  }
+                  else {
+                     return get<I>(reflect<T>::values);
+                  }
+               }();
+               
+               if constexpr (writable_array_t<value_type>) {
+                  decltype(auto) member = get_member(value, mem);
+                  const auto count = member.size();
+                  const auto size = member[0].size();
+                  for (size_t i = 0; i < size; ++i) {
+                     dump<key>(b, ix);
+                     dump<'['>(b, ix);
+                     write_chars::op<Opts>(i, ctx, b, ix);
+                     dump<']'>(b, ix);
+                     dump<','>(b, ix);
+                     
+                     for (size_t j = 0; j < count; ++j) {
+                        serialize<CSV>::op<Opts>(member[j][i], ctx, b, ix);
+                        if (j != count - 1) {
+                           dump<','>(b, ix);
+                        }
                      }
-
-                     serialize<CSV>::op<Opts>(data[row], ctx, b, ix);
-                     ++i;
-                     if (i < n) {
+                     
+                     if (i != size - 1) {
+                        dump<'\n'>(b, ix);
+                     }
+                  }
+               }
+               else {
+                  dump<key>(b, ix);
+                  dump<','>(b, ix);
+                  serialize<CSV>::op<Opts>(get_member(value, mem), ctx, b, ix);
+                  dump<'\n'>(b, ix);
+               }
+            });
+         }
+         else {
+            // write titles
+            for_each<N>([&](auto I) {
+               using X = refl_t<T, I>;
+               
+               static constexpr sv key = reflect<T>::keys[I];
+               
+               decltype(auto) member = [&]() -> decltype(auto) {
+                  if constexpr (reflectable<T>) {
+                     return get<I>(t);
+                  }
+                  else {
+                     return get<I>(reflect<T>::values);
+                  }
+               }();
+               
+               if constexpr (fixed_array_value_t<X>) {
+                  const auto size = get_member(value, member)[0].size();
+                  for (size_t i = 0; i < size; ++i) {
+                     dump<key>(b, ix);
+                     dump<'['>(b, ix);
+                     write_chars::op<Opts>(i, ctx, b, ix);
+                     dump<']'>(b, ix);
+                     if (i != size - 1) {
                         dump<','>(b, ix);
                      }
                   }
-
-                  if (end) {
-                     break;
-                  }
-
-                  dump<'\n'>(b, ix);
-
-                  ++row;
-               }
-            }
-         }
-      };
-
-      template <class T>
-         requires(glaze_object_t<T> || reflectable<T>)
-      struct to<CSV, T>
-      {
-         template <auto Opts, class B>
-         static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
-         {
-            static constexpr auto N = reflect<T>::size;
-
-            [[maybe_unused]] decltype(auto) t = [&] {
-               if constexpr (reflectable<T>) {
-                  return to_tie(value);
                }
                else {
-                  return nullptr;
+                  serialize<CSV>::op<Opts>(key, ctx, b, ix);
                }
-            }();
-
-            if constexpr (Opts.layout == rowwise) {
+               
+               if (I != N - 1) {
+                  dump<','>(b, ix);
+               }
+            });
+            
+            dump<'\n'>(b, ix);
+            
+            size_t row = 0;
+            bool end = false;
+            
+            while (true) {
                for_each<N>([&](auto I) {
-                  using value_type = typename std::decay_t<refl_t<T, I>>::value_type;
-
-                  static constexpr sv key = reflect<T>::keys[I];
-
+                  using X = std::decay_t<refl_t<T, I>>;
+                  
                   decltype(auto) mem = [&]() -> decltype(auto) {
                      if constexpr (reflectable<T>) {
                         return get<I>(t);
@@ -201,135 +285,48 @@ namespace glz
                         return get<I>(reflect<T>::values);
                      }
                   }();
-
-                  if constexpr (writable_array_t<value_type>) {
-                     decltype(auto) member = get_member(value, mem);
-                     const auto count = member.size();
-                     const auto size = member[0].size();
-                     for (size_t i = 0; i < size; ++i) {
-                        dump<key>(b, ix);
-                        dump<'['>(b, ix);
-                        write_chars::op<Opts>(i, ctx, b, ix);
-                        dump<']'>(b, ix);
-                        dump<','>(b, ix);
-
-                        for (size_t j = 0; j < count; ++j) {
-                           serialize<CSV>::op<Opts>(member[j][i], ctx, b, ix);
-                           if (j != count - 1) {
-                              dump<','>(b, ix);
-                           }
-                        }
-
-                        if (i != size - 1) {
-                           dump<'\n'>(b, ix);
-                        }
-                     }
-                  }
-                  else {
-                     dump<key>(b, ix);
-                     dump<','>(b, ix);
-                     serialize<CSV>::op<Opts>(get_member(value, mem), ctx, b, ix);
-                     dump<'\n'>(b, ix);
-                  }
-               });
-            }
-            else {
-               // write titles
-               for_each<N>([&](auto I) {
-                  using X = refl_t<T, I>;
-
-                  static constexpr sv key = reflect<T>::keys[I];
-
-                  decltype(auto) member = [&]() -> decltype(auto) {
-                     if constexpr (reflectable<T>) {
-                        return get<I>(t);
-                     }
-                     else {
-                        return get<I>(reflect<T>::values);
-                     }
-                  }();
-
+                  
                   if constexpr (fixed_array_value_t<X>) {
-                     const auto size = get_member(value, member)[0].size();
-                     for (size_t i = 0; i < size; ++i) {
-                        dump<key>(b, ix);
-                        dump<'['>(b, ix);
-                        write_chars::op<Opts>(i, ctx, b, ix);
-                        dump<']'>(b, ix);
-                        if (i != size - 1) {
+                     decltype(auto) member = get_member(value, mem);
+                     if (row >= member.size()) {
+                        end = true;
+                        return;
+                     }
+                     
+                     const auto n = member[0].size();
+                     for (size_t i = 0; i < n; ++i) {
+                        serialize<CSV>::op<Opts>(member[row][i], ctx, b, ix);
+                        if (i != n - 1) {
                            dump<','>(b, ix);
                         }
                      }
                   }
                   else {
-                     serialize<CSV>::op<Opts>(key, ctx, b, ix);
-                  }
-
-                  if (I != N - 1) {
-                     dump<','>(b, ix);
+                     decltype(auto) member = get_member(value, mem);
+                     if (row >= member.size()) {
+                        end = true;
+                        return;
+                     }
+                     
+                     serialize<CSV>::op<Opts>(member[row], ctx, b, ix);
+                     
+                     if (I != N - 1) {
+                        dump<','>(b, ix);
+                     }
                   }
                });
-
-               dump<'\n'>(b, ix);
-
-               size_t row = 0;
-               bool end = false;
-
-               while (true) {
-                  for_each<N>([&](auto I) {
-                     using X = std::decay_t<refl_t<T, I>>;
-
-                     decltype(auto) mem = [&]() -> decltype(auto) {
-                        if constexpr (reflectable<T>) {
-                           return get<I>(t);
-                        }
-                        else {
-                           return get<I>(reflect<T>::values);
-                        }
-                     }();
-
-                     if constexpr (fixed_array_value_t<X>) {
-                        decltype(auto) member = get_member(value, mem);
-                        if (row >= member.size()) {
-                           end = true;
-                           return;
-                        }
-
-                        const auto n = member[0].size();
-                        for (size_t i = 0; i < n; ++i) {
-                           serialize<CSV>::op<Opts>(member[row][i], ctx, b, ix);
-                           if (i != n - 1) {
-                              dump<','>(b, ix);
-                           }
-                        }
-                     }
-                     else {
-                        decltype(auto) member = get_member(value, mem);
-                        if (row >= member.size()) {
-                           end = true;
-                           return;
-                        }
-
-                        serialize<CSV>::op<Opts>(member[row], ctx, b, ix);
-
-                        if (I != N - 1) {
-                           dump<','>(b, ix);
-                        }
-                     }
-                  });
-
-                  if (end) {
-                     break;
-                  }
-
-                  ++row;
-
-                  dump<'\n'>(b, ix);
+               
+               if (end) {
+                  break;
                }
+               
+               ++row;
+               
+               dump<'\n'>(b, ix);
             }
          }
-      };
-   }
+      }
+   };
 
    template <uint32_t layout = rowwise, class T, class Buffer>
       requires(write_supported<CSV, T>)

--- a/include/glaze/ext/cli_menu.hpp
+++ b/include/glaze/ext/cli_menu.hpp
@@ -55,7 +55,7 @@ namespace glz
    }
 
    template <opts Opts = opts{.prettify = true}, class T>
-      requires(detail::glaze_object_t<T> || detail::reflectable<T>)
+      requires(glaze_object_t<T> || reflectable<T>)
    inline void run_cli_menu(T& value, cli_menu_boolean auto& show_menu)
    {
       using namespace detail;
@@ -252,7 +252,7 @@ namespace glz
    }
 
    template <opts Opts = opts{.prettify = true}, class T>
-      requires(detail::glaze_object_t<T> || detail::reflectable<T>)
+      requires(glaze_object_t<T> || reflectable<T>)
    inline void run_cli_menu(T& value)
    {
       std::atomic<bool> menu_boolean = true;

--- a/include/glaze/ext/eigen.hpp
+++ b/include/glaze/ext/eigen.hpp
@@ -42,10 +42,10 @@ namespace glz
             }
             ++it;
             std::array<Eigen::Index, 2> extents;
-            detail::read<BEVE>::op<Opts>(extents, ctx, it, end);
+            detail::parse<BEVE>::op<Opts>(extents, ctx, it, end);
 
             std::span<typename T::Scalar, T::RowsAtCompileTime * T::ColsAtCompileTime> view(value.data(), value.size());
-            detail::read<BEVE>::op<Opts>(view, ctx, it, end);
+            detail::parse<BEVE>::op<Opts>(view, ctx, it, end);
          }
       };
 
@@ -69,11 +69,11 @@ namespace glz
             }
             ++it;
             std::array<Eigen::Index, 2> extents;
-            detail::read<BEVE>::op<Opts>(extents, ctx, it, end);
+            detail::parse<BEVE>::op<Opts>(extents, ctx, it, end);
 
             value.resize(extents[0], extents[1]);
             std::span<typename T::Scalar> view(value.data(), extents[0] * extents[1]);
-            detail::read<BEVE>::op<Opts>(view, ctx, it, end);
+            detail::parse<BEVE>::op<Opts>(view, ctx, it, end);
          }
       };
 
@@ -92,10 +92,10 @@ namespace glz
             dump_type(layout, args...);
 
             std::array<Eigen::Index, 2> extents{T::RowsAtCompileTime, T::ColsAtCompileTime};
-            detail::write<BEVE>::op<Opts>(extents, ctx, args...);
+            serialize<BEVE>::op<Opts>(extents, ctx, args...);
 
             std::span<typename T::Scalar, T::RowsAtCompileTime * T::ColsAtCompileTime> view(value.data(), value.size());
-            detail::write<BEVE>::op<Opts>(view, ctx, args...);
+            serialize<BEVE>::op<Opts>(view, ctx, args...);
          }
       };
 
@@ -115,10 +115,10 @@ namespace glz
             dump_type(layout, args...);
 
             std::array<Eigen::Index, 2> extents{value.rows(), value.cols()};
-            detail::write<BEVE>::op<Opts>(extents, ctx, args...);
+            serialize<BEVE>::op<Opts>(extents, ctx, args...);
 
             std::span<typename T::Scalar> view(value.data(), extents[0] * extents[1]);
-            detail::write<BEVE>::op<Opts>(view, ctx, args...);
+            serialize<BEVE>::op<Opts>(view, ctx, args...);
          }
       };
 
@@ -130,7 +130,7 @@ namespace glz
          static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             std::span<typename T::Scalar, T::RowsAtCompileTime * T::ColsAtCompileTime> view(value.data(), value.size());
-            detail::read<JSON>::op<Opts>(view, ctx, it, end);
+            detail::parse<JSON>::op<Opts>(view, ctx, it, end);
          }
       };
 
@@ -180,7 +180,7 @@ namespace glz
                return;
             }
             std::array<Eigen::Index, 2> extents; // NOLINT
-            detail::read<JSON>::op<Opts>(extents, ctx, it, end);
+            detail::parse<JSON>::op<Opts>(extents, ctx, it, end);
             value.resize(extents[0], extents[1]);
             if (*it == ',') {
                // we have data
@@ -192,7 +192,7 @@ namespace glz
                   }
                }
                std::span<typename T::Scalar> view(value.data(), extents[0] * extents[1]);
-               detail::read<JSON>::op<Opts>(view, ctx, it, end);
+               detail::parse<JSON>::op<Opts>(view, ctx, it, end);
             }
             match<']'>(ctx, it);
          }
@@ -207,7 +207,7 @@ namespace glz
             constexpr auto size =
                Mode == Eigen::TransformTraits::AffineCompact ? (Dim + 1) * Dim : (Dim + 1) * (Dim + 1);
             std::span<Scalar, size> view(value.data(), size);
-            detail::read<JSON>::op<Opts>(view, ctx, it, end);
+            detail::parse<JSON>::op<Opts>(view, ctx, it, end);
          }
       };
 

--- a/include/glaze/ext/eigen.hpp
+++ b/include/glaze/ext/eigen.hpp
@@ -22,210 +22,207 @@ static_assert(false, "Eigen must be included to use glaze/ext/eigen.hpp");
 
 namespace glz
 {
-   namespace detail
+   template <matrix_t T>
+   requires(T::RowsAtCompileTime >= 0 && T::ColsAtCompileTime >= 0)
+   struct from<BEVE, T>
    {
-      template <matrix_t T>
-         requires(T::RowsAtCompileTime >= 0 && T::ColsAtCompileTime >= 0)
-      struct from<BEVE, T>
+      template <auto Opts>
+      static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
       {
-         template <auto Opts>
-         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
+         ++it;
+         if (it >= end) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return;
+         }
+         constexpr uint8_t layout = uint8_t(!T::IsRowMajor);
+         if (uint8_t(*it) != layout) {
+            ctx.error = error_code::syntax_error;
+         }
+         ++it;
+         std::array<Eigen::Index, 2> extents;
+         parse<BEVE>::op<Opts>(extents, ctx, it, end);
+         
+         std::span<typename T::Scalar, T::RowsAtCompileTime * T::ColsAtCompileTime> view(value.data(), value.size());
+         parse<BEVE>::op<Opts>(view, ctx, it, end);
+      }
+   };
+   
+   // A dynamic matrix in both rows and columns
+   template <matrix_t T>
+   requires(T::RowsAtCompileTime < 0 && T::ColsAtCompileTime < 0)
+   struct from<BEVE, T>
+   {
+      template <auto Opts>
+      static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         ++it;
+         if (it >= end) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return;
+         }
+         constexpr uint8_t layout = uint8_t(!T::IsRowMajor);
+         if (uint8_t(*it) != layout) {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         ++it;
+         std::array<Eigen::Index, 2> extents;
+         parse<BEVE>::op<Opts>(extents, ctx, it, end);
+         
+         value.resize(extents[0], extents[1]);
+         std::span<typename T::Scalar> view(value.data(), extents[0] * extents[1]);
+         parse<BEVE>::op<Opts>(view, ctx, it, end);
+      }
+   };
+   
+   template <matrix_t T>
+   requires(T::RowsAtCompileTime >= 0 && T::ColsAtCompileTime >= 0)
+   struct to<BEVE, T>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&&... args)
+      {
+         constexpr uint8_t matrix = 0b00010'000;
+         constexpr uint8_t tag = tag::extensions | matrix;
+         dump_type(tag, args...);
+         
+         constexpr uint8_t layout = uint8_t(!T::IsRowMajor);
+         dump_type(layout, args...);
+         
+         std::array<Eigen::Index, 2> extents{T::RowsAtCompileTime, T::ColsAtCompileTime};
+         serialize<BEVE>::op<Opts>(extents, ctx, args...);
+         
+         std::span<typename T::Scalar, T::RowsAtCompileTime * T::ColsAtCompileTime> view(value.data(), value.size());
+         serialize<BEVE>::op<Opts>(view, ctx, args...);
+      }
+   };
+   
+   // A dynamic matrix in both rows and columns
+   template <matrix_t T>
+   requires(T::RowsAtCompileTime < 0 && T::ColsAtCompileTime < 0)
+   struct to<BEVE, T>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&&... args)
+      {
+         constexpr uint8_t matrix = 0b00010'000;
+         constexpr uint8_t tag = tag::extensions | matrix;
+         dump_type(tag, args...);
+         
+         constexpr uint8_t layout = uint8_t(!T::IsRowMajor);
+         dump_type(layout, args...);
+         
+         std::array<Eigen::Index, 2> extents{value.rows(), value.cols()};
+         serialize<BEVE>::op<Opts>(extents, ctx, args...);
+         
+         std::span<typename T::Scalar> view(value.data(), extents[0] * extents[1]);
+         serialize<BEVE>::op<Opts>(view, ctx, args...);
+      }
+   };
+   
+   template <matrix_t T>
+   requires(T::RowsAtCompileTime >= 0 && T::ColsAtCompileTime >= 0)
+   struct from<JSON, T>
+   {
+      template <auto Opts>
+      static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         std::span<typename T::Scalar, T::RowsAtCompileTime * T::ColsAtCompileTime> view(value.data(), value.size());
+         parse<JSON>::op<Opts>(view, ctx, it, end);
+      }
+   };
+   
+   template <matrix_t T>
+   requires(T::RowsAtCompileTime >= 0 && T::ColsAtCompileTime >= 0)
+   struct to<JSON, T>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
+      {
+         std::span<typename T::Scalar, T::RowsAtCompileTime * T::ColsAtCompileTime> view(value.data(), value.size());
+         using Value = std::remove_cvref_t<decltype(value)>;
+         to<JSON, Value>::template op<Opts>(view, ctx, b, ix);
+      }
+   };
+   
+   // A dynamic matrix in both rows and columns
+   template <matrix_t T>
+   requires(T::RowsAtCompileTime < 0 && T::ColsAtCompileTime < 0)
+   struct to<JSON, T>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
+      {
+         dump<'['>(b, ix);
+         using RowColT = std::array<Eigen::Index, 2>;
+         RowColT extents{value.rows(), value.cols()};
+         to<JSON, RowColT>::template op<Opts>(extents, ctx, b, ix);
+         dump<','>(b, ix);
+         
+         std::span<typename T::Scalar> view(value.data(), value.size());
+         using Value = std::remove_cvref_t<decltype(view)>;
+         to<JSON, Value>::template op<Opts>(view, ctx, b, ix);
+         dump<']'>(b, ix);
+      }
+   };
+   
+   // A dynamic matrix in both rows and columns
+   template <matrix_t T>
+   requires(T::RowsAtCompileTime < 0 && T::ColsAtCompileTime < 0)
+   struct from<JSON, T>
+   {
+      template <auto Opts>
+      static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         if (match_invalid_end<'[', Opts>(ctx, it, end)) {
+            return;
+         }
+         std::array<Eigen::Index, 2> extents; // NOLINT
+         parse<JSON>::op<Opts>(extents, ctx, it, end);
+         value.resize(extents[0], extents[1]);
+         if (*it == ',') {
+            // we have data
             ++it;
-            if (it >= end) [[unlikely]] {
-               ctx.error = error_code::unexpected_end;
-               return;
-            }
-            constexpr uint8_t layout = uint8_t(!T::IsRowMajor);
-            if (uint8_t(*it) != layout) {
-               ctx.error = error_code::syntax_error;
-            }
-            ++it;
-            std::array<Eigen::Index, 2> extents;
-            parse<BEVE>::op<Opts>(extents, ctx, it, end);
-
-            std::span<typename T::Scalar, T::RowsAtCompileTime * T::ColsAtCompileTime> view(value.data(), value.size());
-            parse<BEVE>::op<Opts>(view, ctx, it, end);
-         }
-      };
-
-      // A dynamic matrix in both rows and columns
-      template <matrix_t T>
-         requires(T::RowsAtCompileTime < 0 && T::ColsAtCompileTime < 0)
-      struct from<BEVE, T>
-      {
-         template <auto Opts>
-         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            ++it;
-            if (it >= end) [[unlikely]] {
-               ctx.error = error_code::unexpected_end;
-               return;
-            }
-            constexpr uint8_t layout = uint8_t(!T::IsRowMajor);
-            if (uint8_t(*it) != layout) {
-               ctx.error = error_code::syntax_error;
-               return;
-            }
-            ++it;
-            std::array<Eigen::Index, 2> extents;
-            parse<BEVE>::op<Opts>(extents, ctx, it, end);
-
-            value.resize(extents[0], extents[1]);
-            std::span<typename T::Scalar> view(value.data(), extents[0] * extents[1]);
-            parse<BEVE>::op<Opts>(view, ctx, it, end);
-         }
-      };
-
-      template <matrix_t T>
-         requires(T::RowsAtCompileTime >= 0 && T::ColsAtCompileTime >= 0)
-      struct to<BEVE, T>
-      {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&&... args)
-         {
-            constexpr uint8_t matrix = 0b00010'000;
-            constexpr uint8_t tag = tag::extensions | matrix;
-            dump_type(tag, args...);
-
-            constexpr uint8_t layout = uint8_t(!T::IsRowMajor);
-            dump_type(layout, args...);
-
-            std::array<Eigen::Index, 2> extents{T::RowsAtCompileTime, T::ColsAtCompileTime};
-            serialize<BEVE>::op<Opts>(extents, ctx, args...);
-
-            std::span<typename T::Scalar, T::RowsAtCompileTime * T::ColsAtCompileTime> view(value.data(), value.size());
-            serialize<BEVE>::op<Opts>(view, ctx, args...);
-         }
-      };
-
-      // A dynamic matrix in both rows and columns
-      template <matrix_t T>
-         requires(T::RowsAtCompileTime < 0 && T::ColsAtCompileTime < 0)
-      struct to<BEVE, T>
-      {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&&... args)
-         {
-            constexpr uint8_t matrix = 0b00010'000;
-            constexpr uint8_t tag = tag::extensions | matrix;
-            dump_type(tag, args...);
-
-            constexpr uint8_t layout = uint8_t(!T::IsRowMajor);
-            dump_type(layout, args...);
-
-            std::array<Eigen::Index, 2> extents{value.rows(), value.cols()};
-            serialize<BEVE>::op<Opts>(extents, ctx, args...);
-
-            std::span<typename T::Scalar> view(value.data(), extents[0] * extents[1]);
-            serialize<BEVE>::op<Opts>(view, ctx, args...);
-         }
-      };
-
-      template <matrix_t T>
-         requires(T::RowsAtCompileTime >= 0 && T::ColsAtCompileTime >= 0)
-      struct from<JSON, T>
-      {
-         template <auto Opts>
-         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            std::span<typename T::Scalar, T::RowsAtCompileTime * T::ColsAtCompileTime> view(value.data(), value.size());
-            parse<JSON>::op<Opts>(view, ctx, it, end);
-         }
-      };
-
-      template <matrix_t T>
-         requires(T::RowsAtCompileTime >= 0 && T::ColsAtCompileTime >= 0)
-      struct to<JSON, T>
-      {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
-         {
-            std::span<typename T::Scalar, T::RowsAtCompileTime * T::ColsAtCompileTime> view(value.data(), value.size());
-            using Value = std::remove_cvref_t<decltype(value)>;
-            detail::to<JSON, Value>::template op<Opts>(view, ctx, b, ix);
-         }
-      };
-
-      // A dynamic matrix in both rows and columns
-      template <matrix_t T>
-         requires(T::RowsAtCompileTime < 0 && T::ColsAtCompileTime < 0)
-      struct to<JSON, T>
-      {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
-         {
-            dump<'['>(b, ix);
-            using RowColT = std::array<Eigen::Index, 2>;
-            RowColT extents{value.rows(), value.cols()};
-            detail::to<JSON, RowColT>::template op<Opts>(extents, ctx, b, ix);
-            dump<','>(b, ix);
-
-            std::span<typename T::Scalar> view(value.data(), value.size());
-            using Value = std::remove_cvref_t<decltype(view)>;
-            detail::to<JSON, Value>::template op<Opts>(view, ctx, b, ix);
-            dump<']'>(b, ix);
-         }
-      };
-
-      // A dynamic matrix in both rows and columns
-      template <matrix_t T>
-         requires(T::RowsAtCompileTime < 0 && T::ColsAtCompileTime < 0)
-      struct from<JSON, T>
-      {
-         template <auto Opts>
-         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            if (match_invalid_end<'[', Opts>(ctx, it, end)) {
-               return;
-            }
-            std::array<Eigen::Index, 2> extents; // NOLINT
-            parse<JSON>::op<Opts>(extents, ctx, it, end);
-            value.resize(extents[0], extents[1]);
-            if (*it == ',') {
-               // we have data
-               ++it;
-               if constexpr (not Opts.null_terminated) {
-                  if (it == end) [[unlikely]] {
-                     ctx.error = error_code::unexpected_end;
-                     return;
-                  }
+            if constexpr (not Opts.null_terminated) {
+               if (it == end) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return;
                }
-               std::span<typename T::Scalar> view(value.data(), extents[0] * extents[1]);
-               parse<JSON>::op<Opts>(view, ctx, it, end);
             }
-            match<']'>(ctx, it);
-         }
-      };
-
-      template <typename Scalar, int Dim, int Mode>
-      struct from<JSON, Eigen::Transform<Scalar, Dim, Mode>>
-      {
-         template <auto Opts>
-         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            constexpr auto size =
-               Mode == Eigen::TransformTraits::AffineCompact ? (Dim + 1) * Dim : (Dim + 1) * (Dim + 1);
-            std::span<Scalar, size> view(value.data(), size);
+            std::span<typename T::Scalar> view(value.data(), extents[0] * extents[1]);
             parse<JSON>::op<Opts>(view, ctx, it, end);
          }
-      };
-
-      template <typename Scalar, int Dim, int Mode>
-      struct to<JSON, Eigen::Transform<Scalar, Dim, Mode>>
+         match<']'>(ctx, it);
+      }
+   };
+   
+   template <typename Scalar, int Dim, int Mode>
+   struct from<JSON, Eigen::Transform<Scalar, Dim, Mode>>
+   {
+      template <auto Opts>
+      static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
       {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
-         {
-            constexpr auto size =
-               Mode == Eigen::TransformTraits::AffineCompact ? (Dim + 1) * Dim : (Dim + 1) * (Dim + 1);
-            std::span<Scalar, size> view(value.data(), size);
-            using Value = std::remove_cvref_t<decltype(value)>;
-            detail::to<JSON, Value>::template op<Opts>(view, ctx, b, ix);
-         }
-      };
-   } // namespace detail
-} // namespace glaze
+         constexpr auto size =
+         Mode == Eigen::TransformTraits::AffineCompact ? (Dim + 1) * Dim : (Dim + 1) * (Dim + 1);
+         std::span<Scalar, size> view(value.data(), size);
+         parse<JSON>::op<Opts>(view, ctx, it, end);
+      }
+   };
+   
+   template <typename Scalar, int Dim, int Mode>
+   struct to<JSON, Eigen::Transform<Scalar, Dim, Mode>>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
+      {
+         constexpr auto size =
+         Mode == Eigen::TransformTraits::AffineCompact ? (Dim + 1) * Dim : (Dim + 1) * (Dim + 1);
+         std::span<Scalar, size> view(value.data(), size);
+         using Value = std::remove_cvref_t<decltype(value)>;
+         to<JSON, Value>::template op<Opts>(view, ctx, b, ix);
+      }
+   };
+}
 
 template <class Scalar, int Rows, int Cols>
 struct glz::meta<Eigen::Matrix<Scalar, Rows, Cols>>

--- a/include/glaze/ext/eigen.hpp
+++ b/include/glaze/ext/eigen.hpp
@@ -42,10 +42,10 @@ namespace glz
             }
             ++it;
             std::array<Eigen::Index, 2> extents;
-            detail::parse<BEVE>::op<Opts>(extents, ctx, it, end);
+            parse<BEVE>::op<Opts>(extents, ctx, it, end);
 
             std::span<typename T::Scalar, T::RowsAtCompileTime * T::ColsAtCompileTime> view(value.data(), value.size());
-            detail::parse<BEVE>::op<Opts>(view, ctx, it, end);
+            parse<BEVE>::op<Opts>(view, ctx, it, end);
          }
       };
 
@@ -69,11 +69,11 @@ namespace glz
             }
             ++it;
             std::array<Eigen::Index, 2> extents;
-            detail::parse<BEVE>::op<Opts>(extents, ctx, it, end);
+            parse<BEVE>::op<Opts>(extents, ctx, it, end);
 
             value.resize(extents[0], extents[1]);
             std::span<typename T::Scalar> view(value.data(), extents[0] * extents[1]);
-            detail::parse<BEVE>::op<Opts>(view, ctx, it, end);
+            parse<BEVE>::op<Opts>(view, ctx, it, end);
          }
       };
 
@@ -130,7 +130,7 @@ namespace glz
          static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
          {
             std::span<typename T::Scalar, T::RowsAtCompileTime * T::ColsAtCompileTime> view(value.data(), value.size());
-            detail::parse<JSON>::op<Opts>(view, ctx, it, end);
+            parse<JSON>::op<Opts>(view, ctx, it, end);
          }
       };
 
@@ -180,7 +180,7 @@ namespace glz
                return;
             }
             std::array<Eigen::Index, 2> extents; // NOLINT
-            detail::parse<JSON>::op<Opts>(extents, ctx, it, end);
+            parse<JSON>::op<Opts>(extents, ctx, it, end);
             value.resize(extents[0], extents[1]);
             if (*it == ',') {
                // we have data
@@ -192,7 +192,7 @@ namespace glz
                   }
                }
                std::span<typename T::Scalar> view(value.data(), extents[0] * extents[1]);
-               detail::parse<JSON>::op<Opts>(view, ctx, it, end);
+               parse<JSON>::op<Opts>(view, ctx, it, end);
             }
             match<']'>(ctx, it);
          }
@@ -207,7 +207,7 @@ namespace glz
             constexpr auto size =
                Mode == Eigen::TransformTraits::AffineCompact ? (Dim + 1) * Dim : (Dim + 1) * (Dim + 1);
             std::span<Scalar, size> view(value.data(), size);
-            detail::parse<JSON>::op<Opts>(view, ctx, it, end);
+            parse<JSON>::op<Opts>(view, ctx, it, end);
          }
       };
 

--- a/include/glaze/ext/glaze_asio.hpp
+++ b/include/glaze/ext/glaze_asio.hpp
@@ -410,7 +410,7 @@ namespace glz
       void clear_registry() { registry.clear(); }
 
       template <const std::string_view& Root = repe::detail::empty_path, class T>
-         requires(glz::detail::glaze_object_t<T> || glz::detail::reflectable<T>)
+         requires(glz::glaze_object_t<T> || glz::reflectable<T>)
       void on(T& value)
       {
          registry.template on<Root>(value);

--- a/include/glaze/file/hostname_include.hpp
+++ b/include/glaze/file/hostname_include.hpp
@@ -47,95 +47,92 @@ namespace glz
       }
    };
 
-   namespace detail
+   inline void replace_first_braces(std::string& original, const std::string& replacement) noexcept
    {
-      inline void replace_first_braces(std::string& original, const std::string& replacement) noexcept
-      {
-         static constexpr std::string_view braces = "{}";
-
-         if (size_t pos = original.find(braces); pos != std::string::npos) {
-            original.replace(pos, braces.size(), replacement);
-         }
+      static constexpr std::string_view braces = "{}";
+      
+      if (size_t pos = original.find(braces); pos != std::string::npos) {
+         original.replace(pos, braces.size(), replacement);
       }
-
-      inline std::string get_hostname(context& ctx)
-      {
-         char hostname[256]{};
-
-#ifdef _WIN32
-         WSADATA wsaData;
-         if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {
-            ctx.error = error_code::hostname_failure;
-            return {};
-         }
-#endif
-
-         if (gethostname(hostname, sizeof(hostname))) {
-            ctx.error = error_code::hostname_failure;
-            return {};
-         }
-
-#ifdef _WIN32
-         WSACleanup();
-#endif
-
-         return {hostname};
-      }
-
-      template <class T>
-      struct from<JSON, hostname_includer<T>>
-      {
-         template <auto Options>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            constexpr auto Opts = ws_handled_off<Options>();
-            std::string buffer{};
-            parse<JSON>::op<Opts>(buffer, ctx, it, end);
-            if (bool(ctx.error)) [[unlikely]]
-               return;
-
-            replace_first_braces(buffer, get_hostname(ctx));
-            if (bool(ctx.error)) [[unlikely]]
-               return;
-
-            const auto file_path = relativize_if_not_absolute(std::filesystem::path(ctx.current_file).parent_path(),
-                                                              std::filesystem::path{buffer});
-
-            const auto string_file_path = file_path.string();
-            const auto ec = file_to_buffer(buffer, string_file_path);
-
-            if (bool(ec)) [[unlikely]] {
-               ctx.error = error_code::includer_error;
-               auto& error_msg = error_buffer();
-               error_msg = "file failed to open: " + string_file_path;
-               ctx.includer_error = error_msg;
-               return;
-            }
-
-            const auto current_file = ctx.current_file;
-            ctx.current_file = string_file_path;
-
-            std::string nested_buffer = buffer;
-            static constexpr auto NestedOpts = opt_true<disable_padding_on<Opts>(), &opts::null_terminated>;
-            const auto ecode = glz::read<NestedOpts>(value.value, nested_buffer, ctx);
-            if (bool(ctx.error)) [[unlikely]] {
-               ctx.error = error_code::includer_error;
-               auto& error_msg = error_buffer();
-               error_msg = glz::format_error(ecode, nested_buffer);
-               ctx.includer_error = error_msg;
-               return;
-            }
-
-            ctx.current_file = current_file;
-         }
-      };
-
-      template <class T>
-      struct to<JSON, hostname_includer<T>>
-      {
-         template <auto Opts>
-         static void op(auto&&...) noexcept
-         {}
-      };
    }
+   
+   inline std::string get_hostname(context& ctx)
+   {
+      char hostname[256]{};
+      
+#ifdef _WIN32
+      WSADATA wsaData;
+      if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {
+         ctx.error = error_code::hostname_failure;
+         return {};
+      }
+#endif
+      
+      if (gethostname(hostname, sizeof(hostname))) {
+         ctx.error = error_code::hostname_failure;
+         return {};
+      }
+      
+#ifdef _WIN32
+      WSACleanup();
+#endif
+      
+      return {hostname};
+   }
+   
+   template <class T>
+   struct from<JSON, detail::hostname_includer<T>>
+   {
+      template <auto Options>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         constexpr auto Opts = ws_handled_off<Options>();
+         std::string buffer{};
+         parse<JSON>::op<Opts>(buffer, ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+         
+         replace_first_braces(buffer, get_hostname(ctx));
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+         
+         const auto file_path = relativize_if_not_absolute(std::filesystem::path(ctx.current_file).parent_path(),
+                                                           std::filesystem::path{buffer});
+         
+         const auto string_file_path = file_path.string();
+         const auto ec = file_to_buffer(buffer, string_file_path);
+         
+         if (bool(ec)) [[unlikely]] {
+            ctx.error = error_code::includer_error;
+            auto& error_msg = error_buffer();
+            error_msg = "file failed to open: " + string_file_path;
+            ctx.includer_error = error_msg;
+            return;
+         }
+         
+         const auto current_file = ctx.current_file;
+         ctx.current_file = string_file_path;
+         
+         std::string nested_buffer = buffer;
+         static constexpr auto NestedOpts = opt_true<disable_padding_on<Opts>(), &opts::null_terminated>;
+         const auto ecode = glz::read<NestedOpts>(value.value, nested_buffer, ctx);
+         if (bool(ctx.error)) [[unlikely]] {
+            ctx.error = error_code::includer_error;
+            auto& error_msg = error_buffer();
+            error_msg = glz::format_error(ecode, nested_buffer);
+            ctx.includer_error = error_msg;
+            return;
+         }
+         
+         ctx.current_file = current_file;
+      }
+   };
+   
+   template <class T>
+   struct to<JSON, detail::hostname_includer<T>>
+   {
+      template <auto Opts>
+      static void op(auto&&...) noexcept
+      {}
+   };
 }

--- a/include/glaze/file/hostname_include.hpp
+++ b/include/glaze/file/hostname_include.hpp
@@ -90,7 +90,7 @@ namespace glz
          {
             constexpr auto Opts = ws_handled_off<Options>();
             std::string buffer{};
-            read<JSON>::op<Opts>(buffer, ctx, it, end);
+            parse<JSON>::op<Opts>(buffer, ctx, it, end);
             if (bool(ctx.error)) [[unlikely]]
                return;
 

--- a/include/glaze/file/raw_or_file.hpp
+++ b/include/glaze/file/raw_or_file.hpp
@@ -17,71 +17,68 @@ namespace glz
       std::string str = R"("")";
    };
 
-   namespace detail
+   template <>
+   struct from<JSON, raw_or_file>
    {
-      template <>
-      struct from<JSON, raw_or_file>
+      template <auto Options>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
       {
-         template <auto Options>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            constexpr auto Opts = ws_handled_off<Options>();
-            auto& v = value;
-            // check if we are decoding a string, which could be a file path
-            if (*it == '"') {
-               parse<JSON>::op<Opts>(v.str, ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]]
+         constexpr auto Opts = ws_handled_off<Options>();
+         auto& v = value;
+         // check if we are decoding a string, which could be a file path
+         if (*it == '"') {
+            parse<JSON>::op<Opts>(v.str, ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
+            
+            namespace fs = std::filesystem;
+            const auto path = relativize_if_not_absolute(fs::path(ctx.current_file).parent_path(), fs::path{v.str});
+            
+            if (fs::exists(path) && fs::is_regular_file(path)) {
+               const auto string_path = path.string();
+               const auto ec = file_to_buffer(v.str, string_path);
+               
+               if (bool(ec)) [[unlikely]] {
+                  ctx.error = error_code::includer_error;
+                  auto& error_msg = error_buffer();
+                  error_msg = "file failed to open: " + string_path;
+                  ctx.includer_error = error_msg;
                   return;
-
-               namespace fs = std::filesystem;
-               const auto path = relativize_if_not_absolute(fs::path(ctx.current_file).parent_path(), fs::path{v.str});
-
-               if (fs::exists(path) && fs::is_regular_file(path)) {
-                  const auto string_path = path.string();
-                  const auto ec = file_to_buffer(v.str, string_path);
-
-                  if (bool(ec)) [[unlikely]] {
-                     ctx.error = error_code::includer_error;
-                     auto& error_msg = error_buffer();
-                     error_msg = "file failed to open: " + string_path;
-                     ctx.includer_error = error_msg;
-                     return;
-                  }
-
-                  const auto ecode = validate_jsonc(v.str);
-                  if (ecode) [[unlikely]] {
-                     ctx.error = error_code::includer_error;
-                     auto& error_msg = error_buffer();
-                     error_msg = glz::format_error(ecode, v.str);
-                     ctx.includer_error = error_msg;
-                     return;
-                  }
                }
-               else {
-                  // The file path doesn't exist, so we want a string with quotes
-                  // But, we skipped the quotes when first reading
-                  // So, now we add back the quotes
-                  v.str = "\"" + v.str + "\"";
+               
+               const auto ecode = validate_jsonc(v.str);
+               if (ecode) [[unlikely]] {
+                  ctx.error = error_code::includer_error;
+                  auto& error_msg = error_buffer();
+                  error_msg = glz::format_error(ecode, v.str);
+                  ctx.includer_error = error_msg;
+                  return;
                }
             }
             else {
-               auto it_start = it;
-               skip_value<JSON>::op<Opts>(ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]]
-                  return;
-               value.str = {it_start, static_cast<size_t>(it - it_start)};
+               // The file path doesn't exist, so we want a string with quotes
+               // But, we skipped the quotes when first reading
+               // So, now we add back the quotes
+               v.str = "\"" + v.str + "\"";
             }
          }
-      };
-
-      template <>
-      struct to<JSON, raw_or_file>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix)
-         {
-            dump_maybe_empty(value.str, b, ix);
+         else {
+            auto it_start = it;
+            skip_value<JSON>::op<Opts>(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
+            value.str = {it_start, static_cast<size_t>(it - it_start)};
          }
-      };
-   }
+      }
+   };
+   
+   template <>
+   struct to<JSON, raw_or_file>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&& b, auto&& ix)
+      {
+         dump_maybe_empty(value.str, b, ix);
+      }
+   };
 }

--- a/include/glaze/file/raw_or_file.hpp
+++ b/include/glaze/file/raw_or_file.hpp
@@ -29,7 +29,7 @@ namespace glz
             auto& v = value;
             // check if we are decoding a string, which could be a file path
             if (*it == '"') {
-               read<JSON>::op<Opts>(v.str, ctx, it, end);
+               parse<JSON>::op<Opts>(v.str, ctx, it, end);
                if (bool(ctx.error)) [[unlikely]]
                   return;
 

--- a/include/glaze/file/read_directory.hpp
+++ b/include/glaze/file/read_directory.hpp
@@ -37,7 +37,7 @@ namespace glz
       return {};
    }
 
-   template <opts Opts = opts{}, detail::readable_map_t T>
+   template <opts Opts = opts{}, readable_map_t T>
    [[nodiscard]] error_ctx read_directory(T& value, const sv directory_path, const sv target_extension = ".json")
    {
       std::unordered_map<std::filesystem::path, std::string, detail::fs_path_hash> files{};

--- a/include/glaze/file/write_directory.hpp
+++ b/include/glaze/file/write_directory.hpp
@@ -25,7 +25,7 @@ namespace glz
       return {};
    }
 
-   template <opts Opts = opts{}, detail::writable_map_t T>
+   template <opts Opts = opts{}, writable_map_t T>
    [[nodiscard]] error_ctx write_directory(T&& value, const sv directory_path)
    {
       namespace fs = std::filesystem;

--- a/include/glaze/format/format_to.hpp
+++ b/include/glaze/format/format_to.hpp
@@ -9,7 +9,7 @@
 
 namespace glz
 {
-   template <detail::num_t T>
+   template <num_t T>
    void format_to(std::string& buffer, T&& value)
    {
       auto ix = buffer.size();

--- a/include/glaze/json/invoke.hpp
+++ b/include/glaze/json/invoke.hpp
@@ -54,7 +54,7 @@ namespace glz
                   }
                   else {
                      Tuple inputs{};
-                     read<JSON>::op<Opts>(inputs, ctx, it, end);
+                     parse<JSON>::op<Opts>(inputs, ctx, it, end);
                      if (bool(ctx.error)) [[unlikely]]
                         return;
                      std::apply(
@@ -79,7 +79,7 @@ namespace glz
                   }
                   else {
                      Tuple inputs{};
-                     read<JSON>::op<Opts>(inputs, ctx, it, end);
+                     parse<JSON>::op<Opts>(inputs, ctx, it, end);
                      if (bool(ctx.error)) [[unlikely]]
                         return;
                      std::apply(value.val, inputs);
@@ -204,7 +204,7 @@ namespace glz
                   if (input != value.prev) {
                      Tuple inputs{};
                      it = start;
-                     read<JSON>::op<Opts>(inputs, ctx, it, end);
+                     parse<JSON>::op<Opts>(inputs, ctx, it, end);
                      if (bool(ctx.error)) [[unlikely]]
                         return;
                      std::apply(value.func, inputs);

--- a/include/glaze/json/jmespath.hpp
+++ b/include/glaze/json/jmespath.hpp
@@ -454,7 +454,7 @@ namespace glz
             }
             else {
                while (true) {
-                  detail::read<Opts.format>::template op<Opts>(value.emplace_back(), ctx, it, end);
+                  parse<Opts.format>::template op<Opts>(value.emplace_back(), ctx, it, end);
                   if (bool(ctx.error)) [[unlikely]]
                      return;
 
@@ -546,7 +546,7 @@ namespace glz
             }
             else if (current_index >= start_idx && current_index < end_idx) {
                // Read this element into value
-               detail::read<Opts.format>::template op<Opts>(value.emplace_back(), ctx, it, end);
+               parse<Opts.format>::template op<Opts>(value.emplace_back(), ctx, it, end);
                if (bool(ctx.error)) [[unlikely]]
                   return;
             }
@@ -603,7 +603,7 @@ namespace glz
       context ctx{};
 
       if constexpr (N == 0) {
-         detail::read<Opts.format>::template op<Opts>(value, ctx, it, end);
+         parse<Opts.format>::template op<Opts>(value, ctx, it, end);
       }
       else {
          using namespace glz::detail;
@@ -656,7 +656,7 @@ namespace glz
                            }
 
                            // Now read the element at index n
-                           detail::read<Opts.format>::template op<Opts>(value, ctx, it, end);
+                           parse<Opts.format>::template op<Opts>(value, ctx, it, end);
                         }
                         else {
                            // Not the last token. We must still parse the element at index n so the next indexing can
@@ -750,7 +750,7 @@ namespace glz
                               }
 
                               if constexpr (I == (N - 1)) {
-                                 detail::read<Opts.format>::template op<Opts>(value, ctx, it, end);
+                                 parse<Opts.format>::template op<Opts>(value, ctx, it, end);
                               }
                               return;
                            }
@@ -807,7 +807,7 @@ namespace glz
                      }
 
                      if constexpr (I == (N - 1)) {
-                        detail::read<Opts.format>::template op<Opts>(value, ctx, it, end);
+                        parse<Opts.format>::template op<Opts>(value, ctx, it, end);
                      }
                      return;
                   }
@@ -886,7 +886,7 @@ namespace glz
       context ctx{};
 
       if (N == 0) {
-         detail::read<Opts.format>::template op<Opts>(value, ctx, it, end);
+         parse<Opts.format>::template op<Opts>(value, ctx, it, end);
       }
       else {
          using namespace glz::detail;
@@ -940,7 +940,7 @@ namespace glz
                               }
 
                               // Now read the element at index n
-                              detail::read<Opts.format>::template op<Opts>(value, ctx, it, end);
+                              parse<Opts.format>::template op<Opts>(value, ctx, it, end);
                            }
                            else {
                               // Not the last token. We must still parse the element at index n so the next indexing can
@@ -1032,7 +1032,7 @@ namespace glz
                                  }
 
                                  if (I == (N - 1)) {
-                                    detail::read<Opts.format>::template op<Opts>(value, ctx, it, end);
+                                    parse<Opts.format>::template op<Opts>(value, ctx, it, end);
                                  }
                                  return;
                               }
@@ -1089,7 +1089,7 @@ namespace glz
                         }
 
                         if (I == (N - 1)) {
-                           detail::read<Opts.format>::template op<Opts>(value, ctx, it, end);
+                           parse<Opts.format>::template op<Opts>(value, ctx, it, end);
                         }
                         return;
                      }

--- a/include/glaze/json/json_concepts.hpp
+++ b/include/glaze/json/json_concepts.hpp
@@ -9,23 +9,23 @@ namespace glz
 {
    template <class T>
    concept json_object =
-      detail::glaze_object_t<T> || detail::reflectable<T> || detail::writable_map_t<T> || detail::readable_map_t<T>;
+      glaze_object_t<T> || reflectable<T> || writable_map_t<T> || readable_map_t<T>;
 
    template <class T>
-   concept json_array = detail::array_t<T>;
+   concept json_array = array_t<T>;
 
    template <class T>
-   concept json_string = detail::str_t<T>;
+   concept json_string = str_t<T>;
 
    template <class T>
-   concept json_boolean = detail::boolean_like<T>;
+   concept json_boolean = boolean_like<T>;
 
    template <class T>
-   concept json_number = detail::num_t<T>;
+   concept json_number = num_t<T>;
 
    template <class T>
-   concept json_integer = detail::int_t<T>;
+   concept json_integer = int_t<T>;
 
    template <class T>
-   concept json_null = detail::null_t<T>;
+   concept json_null = null_t<T>;
 }

--- a/include/glaze/json/json_t.hpp
+++ b/include/glaze/json/json_t.hpp
@@ -137,7 +137,7 @@ namespace glz
       }
 
       // for integers
-      template <detail::int_t T>
+      template <int_t T>
       json_t& operator=(const T value)
       {
          data = static_cast<double>(value);

--- a/include/glaze/json/manage.hpp
+++ b/include/glaze/json/manage.hpp
@@ -9,122 +9,119 @@
 
 namespace glz
 {
-   namespace detail
+   // manage_t invokes a function call before reading and after writing from a value
+   template <class T, class Member, class From, class To>
+   struct manage_t
    {
-      // manage_t invokes a function call before reading and after writing from a value
-      template <class T, class Member, class From, class To>
-      struct manage_t
+      static constexpr auto glaze_reflect = false;
+      using from_t = From;
+      using to_t = To;
+      T& val;
+      Member member;
+      From from;
+      To to;
+   };
+   
+   template <class T, class Member, class From, class To>
+   manage_t(T&, Member, From, To) -> manage_t<T, Member, From, To>;
+   
+   template <class T>
+   requires(is_specialization_v<T, manage_t>)
+   struct from<JSON, T>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
       {
-         static constexpr auto glaze_reflect = false;
-         using from_t = From;
-         using to_t = To;
-         T& val;
-         Member member;
-         From from;
-         To to;
-      };
-
-      template <class T, class Member, class From, class To>
-      manage_t(T&, Member, From, To) -> manage_t<T, Member, From, To>;
-
-      template <class T>
-         requires(is_specialization_v<T, manage_t>)
-      struct from<JSON, T>
-      {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            using V = std::decay_t<decltype(value)>;
-            using From = typename V::from_t;
-
-            parse<JSON>::op<Opts>(get_member(value.val, value.member), ctx, it, end);
-
-            if constexpr (std::is_member_pointer_v<From>) {
-               if constexpr (std::is_member_function_pointer_v<From>) {
-                  if (!(value.val.*(value.from))()) {
-                     ctx.error = error_code::syntax_error;
-                     return;
-                  }
-               }
-               else if constexpr (std::is_member_object_pointer_v<From>) {
-                  auto& from = value.val.*(value.from);
-                  using Func = std::decay_t<decltype(from)>;
-                  if constexpr (std::is_invocable_r_v<bool, Func>) {
-                     if (!value.from()) {
-                        ctx.error = error_code::syntax_error;
-                        return;
-                     }
-                  }
-                  else {
-                     static_assert(false_v<T>, "function must have no arguments with a bool return");
-                  }
-               }
-               else {
-                  static_assert(false_v<T>, "invalid type");
-               }
-            }
-            else {
-               if (!value.from(value.val)) {
+         using V = std::decay_t<decltype(value)>;
+         using From = typename V::from_t;
+         
+         parse<JSON>::op<Opts>(get_member(value.val, value.member), ctx, it, end);
+         
+         if constexpr (std::is_member_pointer_v<From>) {
+            if constexpr (std::is_member_function_pointer_v<From>) {
+               if (!(value.val.*(value.from))()) {
                   ctx.error = error_code::syntax_error;
                   return;
                }
             }
-         }
-      };
-
-      template <class T>
-         requires(is_specialization_v<T, manage_t>)
-      struct to<JSON, T>
-      {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&&... args)
-         {
-            using V = std::decay_t<decltype(value)>;
-            using To = typename V::to_t;
-
-            if constexpr (std::is_member_pointer_v<To>) {
-               if constexpr (std::is_member_function_pointer_v<To>) {
-                  if (!(value.val.*(value.to))()) {
+            else if constexpr (std::is_member_object_pointer_v<From>) {
+               auto& from = value.val.*(value.from);
+               using Func = std::decay_t<decltype(from)>;
+               if constexpr (std::is_invocable_r_v<bool, Func>) {
+                  if (!value.from()) {
                      ctx.error = error_code::syntax_error;
                      return;
                   }
                }
-               else if constexpr (std::is_member_object_pointer_v<To>) {
-                  auto& to = value.val.*(value.to);
-                  using Func = std::decay_t<decltype(to)>;
-                  if constexpr (std::is_invocable_r_v<bool, Func>) {
-                     if (!value.to()) {
-                        ctx.error = error_code::syntax_error;
-                        return;
-                     }
-                  }
-                  else {
-                     static_assert(false_v<T>, "function must have no arguments with a bool return");
-                  }
-               }
                else {
-                  static_assert(false_v<T>, "invalid type");
+                  static_assert(false_v<T>, "function must have no arguments with a bool return");
                }
             }
             else {
-               if (!value.to(value.val)) {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
+               static_assert(false_v<T>, "invalid type");
             }
-
-            using Value = core_t<decltype(get_member(value.val, value.member))>;
-            to<JSON, Value>::template op<Opts>(get_member(value.val, value.member), ctx, args...);
          }
-      };
-
-      template <auto Member, auto From, auto To>
-      inline constexpr decltype(auto) manage_impl()
-      {
-         return [](auto&& v) { return manage_t{v, Member, From, To}; };
+         else {
+            if (!value.from(value.val)) {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+         }
       }
+   };
+   
+   template <class T>
+   requires(is_specialization_v<T, manage_t>)
+   struct to<JSON, T>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&&... args)
+      {
+         using V = std::decay_t<decltype(value)>;
+         using To = typename V::to_t;
+         
+         if constexpr (std::is_member_pointer_v<To>) {
+            if constexpr (std::is_member_function_pointer_v<To>) {
+               if (!(value.val.*(value.to))()) {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
+            }
+            else if constexpr (std::is_member_object_pointer_v<To>) {
+               auto& to = value.val.*(value.to);
+               using Func = std::decay_t<decltype(to)>;
+               if constexpr (std::is_invocable_r_v<bool, Func>) {
+                  if (!value.to()) {
+                     ctx.error = error_code::syntax_error;
+                     return;
+                  }
+               }
+               else {
+                  static_assert(false_v<T>, "function must have no arguments with a bool return");
+               }
+            }
+            else {
+               static_assert(false_v<T>, "invalid type");
+            }
+         }
+         else {
+            if (!value.to(value.val)) {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+         }
+         
+         using Value = core_t<decltype(get_member(value.val, value.member))>;
+         to<JSON, Value>::template op<Opts>(get_member(value.val, value.member), ctx, args...);
+      }
+   };
+   
+   template <auto Member, auto From, auto To>
+   inline constexpr decltype(auto) manage_impl()
+   {
+      return [](auto&& v) { return manage_t{v, Member, From, To}; };
    }
 
    template <auto Member, auto From, auto To>
-   constexpr auto manage = detail::manage_impl<Member, From, To>();
+   constexpr auto manage = manage_impl<Member, From, To>();
 }

--- a/include/glaze/json/manage.hpp
+++ b/include/glaze/json/manage.hpp
@@ -37,7 +37,7 @@ namespace glz
             using V = std::decay_t<decltype(value)>;
             using From = typename V::from_t;
 
-            read<JSON>::op<Opts>(get_member(value.val, value.member), ctx, it, end);
+            parse<JSON>::op<Opts>(get_member(value.val, value.member), ctx, it, end);
 
             if constexpr (std::is_member_pointer_v<From>) {
                if constexpr (std::is_member_function_pointer_v<From>) {

--- a/include/glaze/json/max_write_precision.hpp
+++ b/include/glaze/json/max_write_precision.hpp
@@ -57,70 +57,67 @@ namespace glz
       static constexpr auto value{[](auto& s) -> auto& { return s.val; }}; // reading just uses the value directly
    };
 
-   namespace detail
+   template <class T>
+   struct to<JSON, write_float32_t<T>>
    {
-      template <class T>
-      struct to<JSON, write_float32_t<T>>
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
       {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
-         {
-            static constexpr auto O = set_opt<Opts, &opts::float_max_write_precision>(float_precision::float32);
-            using Value = core_t<decltype(value.val)>;
-            to<JSON, Value>::template op<O>(value.val, ctx, args...);
-         }
-      };
-
-      template <class T>
-      struct to<JSON, write_float64_t<T>>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
-         {
-            static constexpr auto O = set_opt<Opts, &opts::float_max_write_precision>(float_precision::float64);
-            using Value = core_t<decltype(value.val)>;
-            to<JSON, Value>::template op<O>(value.val, ctx, args...);
-         }
-      };
-
-      template <class T>
-      struct to<JSON, write_float_full_t<T>>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
-         {
-            static constexpr auto O = set_opt<Opts, &opts::float_max_write_precision>(float_precision::full);
-            using Value = core_t<decltype(value.val)>;
-            to<JSON, Value>::template op<O>(value.val, ctx, args...);
-         }
-      };
-
-      template <auto MemPtr>
-      inline constexpr decltype(auto) write_float32_t_impl() noexcept
-      {
-         return [](auto&& val) { return write_float32_t<std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
+         static constexpr auto O = set_opt<Opts, &opts::float_max_write_precision>(float_precision::float32);
+         using Value = core_t<decltype(value.val)>;
+         to<JSON, Value>::template op<O>(value.val, ctx, args...);
       }
-
-      template <auto MemPtr>
-      inline constexpr decltype(auto) write_float64_impl() noexcept
+   };
+   
+   template <class T>
+   struct to<JSON, write_float64_t<T>>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
       {
-         return [](auto&& val) { return write_float64_t<std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
+         static constexpr auto O = set_opt<Opts, &opts::float_max_write_precision>(float_precision::float64);
+         using Value = core_t<decltype(value.val)>;
+         to<JSON, Value>::template op<O>(value.val, ctx, args...);
       }
-
-      template <auto MemPtr>
-      inline constexpr decltype(auto) write_float_full_impl() noexcept
+   };
+   
+   template <class T>
+   struct to<JSON, write_float_full_t<T>>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
       {
-         return
-            [](auto&& val) { return write_float_full_t<std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
+         static constexpr auto O = set_opt<Opts, &opts::float_max_write_precision>(float_precision::full);
+         using Value = core_t<decltype(value.val)>;
+         to<JSON, Value>::template op<O>(value.val, ctx, args...);
       }
+   };
+   
+   template <auto MemPtr>
+   inline constexpr decltype(auto) write_float32_t_impl() noexcept
+   {
+      return [](auto&& val) { return write_float32_t<std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
+   }
+   
+   template <auto MemPtr>
+   inline constexpr decltype(auto) write_float64_impl() noexcept
+   {
+      return [](auto&& val) { return write_float64_t<std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
+   }
+   
+   template <auto MemPtr>
+   inline constexpr decltype(auto) write_float_full_impl() noexcept
+   {
+      return
+      [](auto&& val) { return write_float_full_t<std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
    }
 
    template <auto MemPtr>
-   constexpr auto write_float32 = detail::write_float32_t_impl<MemPtr>();
+   constexpr auto write_float32 = write_float32_t_impl<MemPtr>();
 
    template <auto MemPtr>
-   constexpr auto write_float64 = detail::write_float64_impl<MemPtr>();
+   constexpr auto write_float64 = write_float64_impl<MemPtr>();
 
    template <auto MemPtr>
-   constexpr auto write_float_full = detail::write_float_full_impl<MemPtr>();
+   constexpr auto write_float_full = write_float_full_impl<MemPtr>();
 }

--- a/include/glaze/json/ndjson.hpp
+++ b/include/glaze/json/ndjson.hpp
@@ -8,19 +8,30 @@
 
 namespace glz
 {
+   template <>
+   struct parse<NDJSON>
+   {
+      template <auto Opts, class T, is_context Ctx, class It0, class It1>
+      static void op(T&& value, Ctx&& ctx, It0&& it, It1&& end)
+      {
+         detail::from<NDJSON, std::remove_reference_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+                                                                     std::forward<It0>(it), std::forward<It1>(end));
+      }
+   };
+   
+   template <>
+   struct serialize<NDJSON>
+   {
+      template <auto Opts, class T, is_context Ctx, class B, class IX>
+      static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
+      {
+         detail::to<NDJSON, std::decay_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+                                                        std::forward<B>(b), std::forward<IX>(ix));
+      }
+   };
+   
    namespace detail
    {
-      template <>
-      struct parse<NDJSON>
-      {
-         template <auto Opts, class T, is_context Ctx, class It0, class It1>
-         static void op(T&& value, Ctx&& ctx, It0&& it, It1&& end)
-         {
-            from<NDJSON, std::remove_reference_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
-                                                                        std::forward<It0>(it), std::forward<It1>(end));
-         }
-      };
-
       template <class T>
          requires readable_array_t<T> && (emplace_backable<T> || !resizable<T>)
       struct from<NDJSON, T>
@@ -149,17 +160,6 @@ namespace glz
                   parse<JSON>::op<Opts>(glz::get<I>(value), ctx, it, end);
                }
             });
-         }
-      };
-
-      template <>
-      struct serialize<NDJSON>
-      {
-         template <auto Opts, class T, is_context Ctx, class B, class IX>
-         static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
-         {
-            to<NDJSON, std::decay_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
-                                                           std::forward<B>(b), std::forward<IX>(ix));
          }
       };
 

--- a/include/glaze/json/ndjson.hpp
+++ b/include/glaze/json/ndjson.hpp
@@ -14,7 +14,7 @@ namespace glz
       template <auto Opts, class T, is_context Ctx, class It0, class It1>
       static void op(T&& value, Ctx&& ctx, It0&& it, It1&& end)
       {
-         detail::from<NDJSON, std::remove_reference_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+         from<NDJSON, std::remove_reference_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
                                                                      std::forward<It0>(it), std::forward<It1>(end));
       }
    };
@@ -25,237 +25,234 @@ namespace glz
       template <auto Opts, class T, is_context Ctx, class B, class IX>
       static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
       {
-         detail::to<NDJSON, std::decay_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+         to<NDJSON, std::decay_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
                                                         std::forward<B>(b), std::forward<IX>(ix));
       }
    };
    
-   namespace detail
+   template <class T>
+   requires readable_array_t<T> && (emplace_backable<T> || !resizable<T>)
+   struct from<NDJSON, T>
    {
-      template <class T>
-         requires readable_array_t<T> && (emplace_backable<T> || !resizable<T>)
-      struct from<NDJSON, T>
+      template <auto Opts>
+      static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
       {
-         template <auto Opts>
-         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            if (bool(ctx.error)) [[unlikely]] {
-               return;
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+         
+         if (it == end) {
+            if constexpr (resizable<T>) {
+               value.clear();
+               
+               if constexpr (Opts.shrink_to_fit) {
+                  value.shrink_to_fit();
+               }
             }
-
+         }
+         
+         const auto n = value.size();
+         
+         auto value_it = value.begin();
+         
+         auto read_new_lines = [&] {
+            while (*it == '\r') {
+               ++it;
+               if (*it == '\n') {
+                  ++it;
+               }
+               else {
+                  ctx.error = error_code::syntax_error; // Expected '\n' after '\r'
+                  return;
+               }
+            }
+            while (*it == '\n') {
+               ++it;
+            }
+         };
+         
+         for (size_t i = 0; i < n; ++i) {
+            parse<JSON>::op<Opts>(*value_it++, ctx, it, end);
             if (it == end) {
-               if constexpr (resizable<T>) {
-                  value.clear();
-
+               if constexpr (erasable<T>) {
+                  value.erase(value_it,
+                              value.end()); // use erase rather than resize for non-default constructible elements
+                  
                   if constexpr (Opts.shrink_to_fit) {
                      value.shrink_to_fit();
                   }
                }
-            }
-
-            const auto n = value.size();
-
-            auto value_it = value.begin();
-
-            auto read_new_lines = [&] {
-               while (*it == '\r') {
-                  ++it;
-                  if (*it == '\n') {
-                     ++it;
-                  }
-                  else {
-                     ctx.error = error_code::syntax_error; // Expected '\n' after '\r'
-                     return;
-                  }
-               }
-               while (*it == '\n') {
-                  ++it;
-               }
-            };
-
-            for (size_t i = 0; i < n; ++i) {
-               parse<JSON>::op<Opts>(*value_it++, ctx, it, end);
-               if (it == end) {
-                  if constexpr (erasable<T>) {
-                     value.erase(value_it,
-                                 value.end()); // use erase rather than resize for non-default constructible elements
-
-                     if constexpr (Opts.shrink_to_fit) {
-                        value.shrink_to_fit();
-                     }
-                  }
-                  return;
-               }
-
-               read_new_lines();
-            }
-
-            // growing
-            if constexpr (emplace_backable<T>) {
-               while (it < end) {
-                  parse<JSON>::op<Opts>(value.emplace_back(), ctx, it, end);
-                  if (bool(ctx.error)) {
-                     return;
-                  }
-
-                  read_new_lines();
-               }
-            }
-            else {
-               ctx.error = error_code::exceeded_static_array_size;
-            }
-         }
-      };
-
-      template <class T>
-         requires glaze_array_t<T> || tuple_t<T> || is_std_tuple<T>
-      struct from<NDJSON, T>
-      {
-         template <auto Opts>
-         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            if (bool(ctx.error)) [[unlikely]] {
                return;
             }
-
-            static constexpr auto N = []() constexpr {
-               if constexpr (glaze_array_t<T>) {
-                  return reflect<T>::size;
-               }
-               else {
-                  return glz::tuple_size_v<T>;
-               }
-            }();
-
-            auto read_new_lines = [&] {
-               while (*it == '\r') {
-                  ++it;
-                  if (*it == '\n') {
-                     ++it;
-                  }
-                  else {
-                     ctx.error = error_code::syntax_error; // Expected '\n' after '\r'
-                     return;
-                  }
-               }
-               while (*it == '\n') {
-                  ++it;
-               }
-            };
-
-            for_each<N>([&](auto I) {
-               if (it == end) {
+            
+            read_new_lines();
+         }
+         
+         // growing
+         if constexpr (emplace_backable<T>) {
+            while (it < end) {
+               parse<JSON>::op<Opts>(value.emplace_back(), ctx, it, end);
+               if (bool(ctx.error)) {
                   return;
                }
-               if constexpr (I != 0) {
-                  read_new_lines();
-               }
-               if constexpr (is_std_tuple<T>) {
-                  parse<JSON>::op<Opts>(std::get<I>(value), ctx, it, end);
-               }
-               else if constexpr (glaze_array_t<T>) {
-                  parse<JSON>::op<Opts>(get_member(value, glz::get<I>(meta_v<T>)), ctx, it, end);
-               }
-               else {
-                  parse<JSON>::op<Opts>(glz::get<I>(value), ctx, it, end);
-               }
-            });
-         }
-      };
-
-      template <writable_array_t T>
-      struct to<NDJSON, T>
-      {
-         template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
-         {
-            const auto is_empty = [&]() -> bool {
-               if constexpr (has_size<T>) {
-                  return value.size() ? false : true;
-               }
-               else {
-                  return value.empty();
-               }
-            }();
-
-            if (!is_empty) {
-               auto it = value.begin();
-               using Value = core_t<decltype(*it)>;
-               to<JSON, Value>::template op<Opts>(*it, ctx, b, ix);
-               ++it;
-               const auto end = value.end();
-               for (; it != end; ++it) {
-                  dump<'\n'>(b, ix);
-                  to<JSON, Value>::template op<Opts>(*it, ctx, b, ix);
-               }
+               
+               read_new_lines();
             }
          }
-      };
-
-      template <class T>
-         requires glaze_array_t<T> || tuple_t<T>
-      struct to<NDJSON, T>
-      {
-         template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
-         {
-            static constexpr auto N = []() constexpr {
-               if constexpr (glaze_array_t<std::decay_t<T>>) {
-                  return glz::tuple_size_v<meta_t<std::decay_t<T>>>;
-               }
-               else {
-                  return glz::tuple_size_v<std::decay_t<T>>;
-               }
-            }();
-
-            using V = std::decay_t<T>;
-            for_each<N>([&](auto I) {
-               if constexpr (glaze_array_t<V>) {
-                  serialize<JSON>::op<Opts>(get_member(value, glz::get<I>(meta_v<T>)), ctx, args...);
-               }
-               else {
-                  serialize<JSON>::op<Opts>(glz::get<I>(value), ctx, args...);
-               }
-               constexpr bool needs_new_line = I < N - 1;
-               if constexpr (needs_new_line) {
-                  dump<'\n'>(args...);
-               }
-            });
+         else {
+            ctx.error = error_code::exceeded_static_array_size;
          }
-      };
-
-      template <class T>
-         requires is_std_tuple<std::decay_t<T>>
-      struct to<NDJSON, T>
+      }
+   };
+   
+   template <class T>
+   requires glaze_array_t<T> || tuple_t<T> || is_std_tuple<T>
+   struct from<NDJSON, T>
+   {
+      template <auto Opts>
+      static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
       {
-         template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
-         {
-            static constexpr auto N = []() constexpr {
-               if constexpr (glaze_array_t<std::decay_t<T>>) {
-                  return glz::tuple_size_v<meta_t<std::decay_t<T>>>;
-               }
-               else {
-                  return glz::tuple_size_v<std::decay_t<T>>;
-               }
-            }();
-
-            using V = std::decay_t<T>;
-            for_each<N>([&](auto I) {
-               if constexpr (glaze_array_t<V>) {
-                  serialize<JSON>::op<Opts>(value.*std::get<I>(meta_v<V>), ctx, std::forward<Args>(args)...);
-               }
-               else {
-                  serialize<JSON>::op<Opts>(std::get<I>(value), ctx, std::forward<Args>(args)...);
-               }
-               constexpr bool needs_new_line = I < N - 1;
-               if constexpr (needs_new_line) {
-                  dump<'\n'>(std::forward<Args>(args)...);
-               }
-            });
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
          }
-      };
-   } // namespace detail
+         
+         static constexpr auto N = []() constexpr {
+            if constexpr (glaze_array_t<T>) {
+               return reflect<T>::size;
+            }
+            else {
+               return glz::tuple_size_v<T>;
+            }
+         }();
+         
+         auto read_new_lines = [&] {
+            while (*it == '\r') {
+               ++it;
+               if (*it == '\n') {
+                  ++it;
+               }
+               else {
+                  ctx.error = error_code::syntax_error; // Expected '\n' after '\r'
+                  return;
+               }
+            }
+            while (*it == '\n') {
+               ++it;
+            }
+         };
+         
+         for_each<N>([&](auto I) {
+            if (it == end) {
+               return;
+            }
+            if constexpr (I != 0) {
+               read_new_lines();
+            }
+            if constexpr (is_std_tuple<T>) {
+               parse<JSON>::op<Opts>(std::get<I>(value), ctx, it, end);
+            }
+            else if constexpr (glaze_array_t<T>) {
+               parse<JSON>::op<Opts>(get_member(value, glz::get<I>(meta_v<T>)), ctx, it, end);
+            }
+            else {
+               parse<JSON>::op<Opts>(glz::get<I>(value), ctx, it, end);
+            }
+         });
+      }
+   };
+   
+   template <writable_array_t T>
+   struct to<NDJSON, T>
+   {
+      template <auto Opts, class... Args>
+      static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
+      {
+         const auto is_empty = [&]() -> bool {
+            if constexpr (has_size<T>) {
+               return value.size() ? false : true;
+            }
+            else {
+               return value.empty();
+            }
+         }();
+         
+         if (!is_empty) {
+            auto it = value.begin();
+            using Value = core_t<decltype(*it)>;
+            to<JSON, Value>::template op<Opts>(*it, ctx, b, ix);
+            ++it;
+            const auto end = value.end();
+            for (; it != end; ++it) {
+               dump<'\n'>(b, ix);
+               to<JSON, Value>::template op<Opts>(*it, ctx, b, ix);
+            }
+         }
+      }
+   };
+   
+   template <class T>
+   requires glaze_array_t<T> || tuple_t<T>
+   struct to<NDJSON, T>
+   {
+      template <auto Opts, class... Args>
+      static void op(auto&& value, is_context auto&& ctx, Args&&... args)
+      {
+         static constexpr auto N = []() constexpr {
+            if constexpr (glaze_array_t<std::decay_t<T>>) {
+               return glz::tuple_size_v<meta_t<std::decay_t<T>>>;
+            }
+            else {
+               return glz::tuple_size_v<std::decay_t<T>>;
+            }
+         }();
+         
+         using V = std::decay_t<T>;
+         for_each<N>([&](auto I) {
+            if constexpr (glaze_array_t<V>) {
+               serialize<JSON>::op<Opts>(get_member(value, glz::get<I>(meta_v<T>)), ctx, args...);
+            }
+            else {
+               serialize<JSON>::op<Opts>(glz::get<I>(value), ctx, args...);
+            }
+            constexpr bool needs_new_line = I < N - 1;
+            if constexpr (needs_new_line) {
+               dump<'\n'>(args...);
+            }
+         });
+      }
+   };
+   
+   template <class T>
+   requires is_std_tuple<std::decay_t<T>>
+   struct to<NDJSON, T>
+   {
+      template <auto Opts, class... Args>
+      static void op(auto&& value, is_context auto&& ctx, Args&&... args)
+      {
+         static constexpr auto N = []() constexpr {
+            if constexpr (glaze_array_t<std::decay_t<T>>) {
+               return glz::tuple_size_v<meta_t<std::decay_t<T>>>;
+            }
+            else {
+               return glz::tuple_size_v<std::decay_t<T>>;
+            }
+         }();
+         
+         using V = std::decay_t<T>;
+         for_each<N>([&](auto I) {
+            if constexpr (glaze_array_t<V>) {
+               serialize<JSON>::op<Opts>(value.*std::get<I>(meta_v<V>), ctx, std::forward<Args>(args)...);
+            }
+            else {
+               serialize<JSON>::op<Opts>(std::get<I>(value), ctx, std::forward<Args>(args)...);
+            }
+            constexpr bool needs_new_line = I < N - 1;
+            if constexpr (needs_new_line) {
+               dump<'\n'>(std::forward<Args>(args)...);
+            }
+         });
+      }
+   };
 
    template <class T, class Buffer>
       requires(read_supported<NDJSON, T>)

--- a/include/glaze/json/ndjson.hpp
+++ b/include/glaze/json/ndjson.hpp
@@ -11,7 +11,7 @@ namespace glz
    namespace detail
    {
       template <>
-      struct read<NDJSON>
+      struct parse<NDJSON>
       {
          template <auto Opts, class T, is_context Ctx, class It0, class It1>
          static void op(T&& value, Ctx&& ctx, It0&& it, It1&& end)
@@ -63,7 +63,7 @@ namespace glz
             };
 
             for (size_t i = 0; i < n; ++i) {
-               read<JSON>::op<Opts>(*value_it++, ctx, it, end);
+               parse<JSON>::op<Opts>(*value_it++, ctx, it, end);
                if (it == end) {
                   if constexpr (erasable<T>) {
                      value.erase(value_it,
@@ -82,7 +82,7 @@ namespace glz
             // growing
             if constexpr (emplace_backable<T>) {
                while (it < end) {
-                  read<JSON>::op<Opts>(value.emplace_back(), ctx, it, end);
+                  parse<JSON>::op<Opts>(value.emplace_back(), ctx, it, end);
                   if (bool(ctx.error)) {
                      return;
                   }
@@ -140,20 +140,20 @@ namespace glz
                   read_new_lines();
                }
                if constexpr (is_std_tuple<T>) {
-                  read<JSON>::op<Opts>(std::get<I>(value), ctx, it, end);
+                  parse<JSON>::op<Opts>(std::get<I>(value), ctx, it, end);
                }
                else if constexpr (glaze_array_t<T>) {
-                  read<JSON>::op<Opts>(get_member(value, glz::get<I>(meta_v<T>)), ctx, it, end);
+                  parse<JSON>::op<Opts>(get_member(value, glz::get<I>(meta_v<T>)), ctx, it, end);
                }
                else {
-                  read<JSON>::op<Opts>(glz::get<I>(value), ctx, it, end);
+                  parse<JSON>::op<Opts>(glz::get<I>(value), ctx, it, end);
                }
             });
          }
       };
 
       template <>
-      struct write<NDJSON>
+      struct serialize<NDJSON>
       {
          template <auto Opts, class T, is_context Ctx, class B, class IX>
          static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
@@ -211,10 +211,10 @@ namespace glz
             using V = std::decay_t<T>;
             for_each<N>([&](auto I) {
                if constexpr (glaze_array_t<V>) {
-                  write<JSON>::op<Opts>(get_member(value, glz::get<I>(meta_v<T>)), ctx, args...);
+                  serialize<JSON>::op<Opts>(get_member(value, glz::get<I>(meta_v<T>)), ctx, args...);
                }
                else {
-                  write<JSON>::op<Opts>(glz::get<I>(value), ctx, args...);
+                  serialize<JSON>::op<Opts>(glz::get<I>(value), ctx, args...);
                }
                constexpr bool needs_new_line = I < N - 1;
                if constexpr (needs_new_line) {
@@ -243,10 +243,10 @@ namespace glz
             using V = std::decay_t<T>;
             for_each<N>([&](auto I) {
                if constexpr (glaze_array_t<V>) {
-                  write<JSON>::op<Opts>(value.*std::get<I>(meta_v<V>), ctx, std::forward<Args>(args)...);
+                  serialize<JSON>::op<Opts>(value.*std::get<I>(meta_v<V>), ctx, std::forward<Args>(args)...);
                }
                else {
-                  write<JSON>::op<Opts>(std::get<I>(value), ctx, std::forward<Args>(args)...);
+                  serialize<JSON>::op<Opts>(std::get<I>(value), ctx, std::forward<Args>(args)...);
                }
                constexpr bool needs_new_line = I < N - 1;
                if constexpr (needs_new_line) {

--- a/include/glaze/json/raw_string.hpp
+++ b/include/glaze/json/raw_string.hpp
@@ -25,66 +25,63 @@ namespace glz
       T& val;
    };
 
-   namespace detail
+   template <class T>
+   struct from<JSON, raw_string_t<T>>
    {
-      template <class T>
-      struct from<JSON, raw_string_t<T>>
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args)
       {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args)
-         {
-            parse<JSON>::op<opt_true<Opts, &opts::raw_string>>(value.val, args...);
-         }
-      };
-
-      template <class T>
-      struct to<JSON, raw_string_t<T>>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args)
-         {
-            using val_t = std::remove_cvref_t<decltype(value.val)>;
-            to<JSON, val_t>::template op<opt_true<Opts, &opts::raw_string>>(value.val, ctx, args...);
-         }
-      };
-
-      template <class T>
-      struct from<JSON, escaped_t<T>>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args)
-         {
-            parse<JSON>::op<opt_false<Opts, &opts::raw_string>>(value.val, args...);
-         }
-      };
-
-      template <class T>
-      struct to<JSON, escaped_t<T>>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args)
-         {
-            using val_t = std::remove_cvref_t<decltype(value.val)>;
-            to<JSON, val_t>::template op<opt_false<Opts, &opts::raw_string>>(value.val, ctx, args...);
-         }
-      };
-
-      template <auto MemPtr>
-      GLZ_ALWAYS_INLINE constexpr decltype(auto) raw_string_impl() noexcept
-      {
-         return [](auto&& val) { return raw_string_t<std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
+         parse<JSON>::op<opt_true<Opts, &opts::raw_string>>(value.val, args...);
       }
-
-      template <auto MemPtr>
-      GLZ_ALWAYS_INLINE constexpr decltype(auto) escaped_impl() noexcept
+   };
+   
+   template <class T>
+   struct to<JSON, raw_string_t<T>>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args)
       {
-         return [](auto&& val) { return escaped_t<std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
+         using val_t = std::remove_cvref_t<decltype(value.val)>;
+         to<JSON, val_t>::template op<opt_true<Opts, &opts::raw_string>>(value.val, ctx, args...);
       }
+   };
+   
+   template <class T>
+   struct from<JSON, escaped_t<T>>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args)
+      {
+         parse<JSON>::op<opt_false<Opts, &opts::raw_string>>(value.val, args...);
+      }
+   };
+   
+   template <class T>
+   struct to<JSON, escaped_t<T>>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args)
+      {
+         using val_t = std::remove_cvref_t<decltype(value.val)>;
+         to<JSON, val_t>::template op<opt_false<Opts, &opts::raw_string>>(value.val, ctx, args...);
+      }
+   };
+   
+   template <auto MemPtr>
+   GLZ_ALWAYS_INLINE constexpr decltype(auto) raw_string_impl() noexcept
+   {
+      return [](auto&& val) { return raw_string_t<std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
+   }
+   
+   template <auto MemPtr>
+   GLZ_ALWAYS_INLINE constexpr decltype(auto) escaped_impl() noexcept
+   {
+      return [](auto&& val) { return escaped_t<std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
    }
 
    template <auto MemPtr>
-   constexpr auto raw_string = detail::raw_string_impl<MemPtr>();
+   constexpr auto raw_string = raw_string_impl<MemPtr>();
 
    template <auto MemPtr>
-   constexpr auto escaped = detail::escaped_impl<MemPtr>();
+   constexpr auto escaped = escaped_impl<MemPtr>();
 }

--- a/include/glaze/json/raw_string.hpp
+++ b/include/glaze/json/raw_string.hpp
@@ -33,7 +33,7 @@ namespace glz
          template <auto Opts>
          GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args)
          {
-            read<JSON>::op<opt_true<Opts, &opts::raw_string>>(value.val, args...);
+            parse<JSON>::op<opt_true<Opts, &opts::raw_string>>(value.val, args...);
          }
       };
 
@@ -54,7 +54,7 @@ namespace glz
          template <auto Opts>
          GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args)
          {
-            read<JSON>::op<opt_false<Opts, &opts::raw_string>>(value.val, args...);
+            parse<JSON>::op<opt_false<Opts, &opts::raw_string>>(value.val, args...);
          }
       };
 

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -47,7 +47,7 @@ namespace glz
             }
             else {
                // do not read anything into the const value
-               detail::skip_value<JSON>::op<Opts>(std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
+               skip_value<JSON>::op<Opts>(std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
             }
          }
          else {
@@ -98,7 +98,7 @@ namespace glz
             }
          }
          else {
-            detail::skip_value<JSON>::op<Opts>(ctx, it, end);
+            skip_value<JSON>::op<Opts>(ctx, it, end);
          }
       }
    };

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -52,7 +52,7 @@ namespace glz
          }
          else {
             using V = std::remove_cvref_t<T>;
-            detail::from<JSON, V>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<It0>(it),
+            from<JSON, V>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<It0>(it),
                                              std::forward<It1>(end));
          }
       }
@@ -103,148 +103,493 @@ namespace glz
       }
    };
 
-   namespace detail
+   // Unless we can mutate the input buffer we need somewhere to store escaped strings for key lookup, etc.
+   // We don't put this in the context because we don't want to continually reallocate.
+   // IMPORTANT: Do not call use this when nested calls may be made that need additional buffers on the same thread.
+   inline std::string& string_buffer() noexcept
    {
-      // Unless we can mutate the input buffer we need somewhere to store escaped strings for key lookup, etc.
-      // We don't put this in the context because we don't want to continually reallocate.
-      // IMPORTANT: Do not call use this when nested calls may be made that need additional buffers on the same thread.
-      inline std::string& string_buffer() noexcept
+      static thread_local std::string buffer(256, '\0');
+      return buffer;
+   }
+   
+   // We use an error buffer to avoid multiple allocations in the case that errors occur multiple times.
+   inline std::string& error_buffer() noexcept
+   {
+      static thread_local std::string buffer(256, '\0');
+      return buffer;
+   }
+   
+   template <class T>
+   requires(glaze_value_t<T> && !custom_read<T>)
+   struct from<JSON, T>
+   {
+      template <auto Opts, class Value, is_context Ctx, class It0, class It1>
+      GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, It0&& it, It1&& end)
       {
-         static thread_local std::string buffer(256, '\0');
-         return buffer;
+         using V = std::decay_t<decltype(get_member(std::declval<Value>(), meta_wrapper_v<T>))>;
+         from<JSON, V>::template op<Opts>(get_member(std::forward<Value>(value), meta_wrapper_v<T>),
+                                          std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
       }
-
-      // We use an error buffer to avoid multiple allocations in the case that errors occur multiple times.
-      inline std::string& error_buffer() noexcept
-      {
-         static thread_local std::string buffer(256, '\0');
-         return buffer;
+   };
+   
+   template <auto Opts>
+   GLZ_ALWAYS_INLINE bool parse_ws_colon(is_context auto& ctx, auto&& it, auto&& end) noexcept
+   {
+      if (skip_ws<Opts>(ctx, it, end)) {
+         return true;
       }
-
-      template <class T>
-         requires(glaze_value_t<T> && !custom_read<T>)
-      struct from<JSON, T>
-      {
-         template <auto Opts, class Value, is_context Ctx, class It0, class It1>
-         GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, It0&& it, It1&& end)
-         {
-            using V = std::decay_t<decltype(get_member(std::declval<Value>(), meta_wrapper_v<T>))>;
-            from<JSON, V>::template op<Opts>(get_member(std::forward<Value>(value), meta_wrapper_v<T>),
-                                             std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
+      if (match_invalid_end<':', Opts>(ctx, it, end)) {
+         return true;
+      }
+      if (skip_ws<Opts>(ctx, it, end)) {
+         return true;
+      }
+      return false;
+   }
+   
+   template <opts Opts, class T, size_t I, class Value, class... SelectedIndex>
+   requires(glaze_object_t<T> || reflectable<T>)
+   void decode_index(Value&& value, is_context auto&& ctx, auto&& it, auto&& end, SelectedIndex&&... selected_index)
+   {
+      static constexpr auto Key = get<I>(reflect<T>::keys);
+      static constexpr auto KeyWithEndQuote = join_v<Key, chars<"\"">>;
+      static constexpr auto Length = KeyWithEndQuote.size();
+      
+      if (((it + Length) < end) && comparitor<KeyWithEndQuote>(it)) [[likely]] {
+         it += Length;
+         if constexpr (not Opts.null_terminated) {
+            if (it == end) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
          }
-      };
-
-      template <auto Opts>
-      GLZ_ALWAYS_INLINE bool parse_ws_colon(is_context auto& ctx, auto&& it, auto&& end) noexcept
-      {
+         
          if (skip_ws<Opts>(ctx, it, end)) {
-            return true;
+            return;
          }
          if (match_invalid_end<':', Opts>(ctx, it, end)) {
-            return true;
+            return;
          }
          if (skip_ws<Opts>(ctx, it, end)) {
-            return true;
+            return;
          }
-         return false;
+         
+         using V = refl_t<T, I>;
+         
+         if constexpr (const_value_v<V>) {
+            if constexpr (Opts.error_on_const_read) {
+               ctx.error = error_code::attempt_const_read;
+            }
+            else {
+               // do not read anything into the const value
+               skip_value<JSON>::op<Opts>(ctx, it, end);
+            }
+         }
+         else {
+            if constexpr (glaze_object_t<T>) {
+               from<JSON, std::remove_cvref_t<V>>::template op<ws_handled<Opts>()>(
+                                                                                   get_member(value, get<I>(reflect<T>::values)), ctx, it, end);
+            }
+            else {
+               from<JSON, std::remove_cvref_t<V>>::template op<ws_handled<Opts>()>(
+                                                                                   get_member(value, get<I>(to_tie(value))), ctx, it, end);
+            }
+         }
+         
+         if constexpr (Opts.error_on_missing_keys || Opts.partial_read) {
+            ((selected_index = I), ...);
+         }
       }
-
-      template <opts Opts, class T, size_t I, class Value, class... SelectedIndex>
-         requires(glaze_object_t<T> || reflectable<T>)
-      void decode_index(Value&& value, is_context auto&& ctx, auto&& it, auto&& end, SelectedIndex&&... selected_index)
-      {
-         static constexpr auto Key = get<I>(reflect<T>::keys);
-         static constexpr auto KeyWithEndQuote = join_v<Key, chars<"\"">>;
-         static constexpr auto Length = KeyWithEndQuote.size();
-
-         if (((it + Length) < end) && comparitor<KeyWithEndQuote>(it)) [[likely]] {
-            it += Length;
+      else [[unlikely]] {
+         if constexpr (Opts.error_on_unknown_keys) {
+            ctx.error = error_code::unknown_key;
+         }
+         else {
+            auto* start = it;
+            skip_string_view<Opts>(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
+            const sv key = {start, size_t(it - start)};
+            ++it;
             if constexpr (not Opts.null_terminated) {
                if (it == end) [[unlikely]] {
                   ctx.error = error_code::unexpected_end;
                   return;
                }
             }
-
-            if (skip_ws<Opts>(ctx, it, end)) {
+            
+            if (parse_ws_colon<Opts>(ctx, it, end)) {
                return;
             }
-            if (match_invalid_end<':', Opts>(ctx, it, end)) {
+            
+            parse<JSON>::handle_unknown<Opts>(key, value, ctx, it, end);
+         }
+      }
+   }
+   
+   template <opts Opts, class T, size_t I, class Value>
+   requires(glaze_enum_t<T> || (meta_keys<T> && std::is_enum_v<T>))
+   void decode_index(Value&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+   {
+      static constexpr auto TargetKey = glz::get<I>(reflect<T>::keys);
+      static constexpr auto Length = TargetKey.size();
+      
+      if (((it + Length) < end) && comparitor<TargetKey>(it)) [[likely]] {
+         it += Length;
+         if (*it != '"') [[unlikely]] {
+            ctx.error = error_code::unexpected_enum;
+            return;
+         }
+         value = get<I>(reflect<T>::values);
+         
+         ++it;
+         if constexpr (not Opts.null_terminated) {
+            if (it == end) {
+               ctx.error = error_code::end_reached;
                return;
-            }
-            if (skip_ws<Opts>(ctx, it, end)) {
-               return;
-            }
-
-            using V = refl_t<T, I>;
-
-            if constexpr (const_value_v<V>) {
-               if constexpr (Opts.error_on_const_read) {
-                  ctx.error = error_code::attempt_const_read;
-               }
-               else {
-                  // do not read anything into the const value
-                  skip_value<JSON>::op<Opts>(ctx, it, end);
-               }
-            }
-            else {
-               if constexpr (glaze_object_t<T>) {
-                  from<JSON, std::remove_cvref_t<V>>::template op<ws_handled<Opts>()>(
-                     get_member(value, get<I>(reflect<T>::values)), ctx, it, end);
-               }
-               else {
-                  from<JSON, std::remove_cvref_t<V>>::template op<ws_handled<Opts>()>(
-                     get_member(value, get<I>(to_tie(value))), ctx, it, end);
-               }
-            }
-
-            if constexpr (Opts.error_on_missing_keys || Opts.partial_read) {
-               ((selected_index = I), ...);
             }
          }
-         else [[unlikely]] {
+      }
+      else [[unlikely]] {
+         ctx.error = error_code::unexpected_enum;
+         return;
+      }
+   }
+   
+   template <opts Opts, class T, auto& HashInfo, class Value, class... SelectedIndex>
+   requires(glaze_object_t<T> || reflectable<T>)
+   GLZ_ALWAYS_INLINE constexpr void parse_and_invoke(Value&& value, is_context auto&& ctx, auto&& it, auto&& end,
+                                                     SelectedIndex&&... selected_index)
+   {
+      constexpr auto type = HashInfo.type;
+      constexpr auto N = reflect<T>::size;
+      
+      static_assert(bool(type), "invalid hash algorithm");
+      
+      if constexpr (N == 1) {
+         decode_index<Opts, T, 0>(value, ctx, it, end, selected_index...);
+      }
+      else {
+         const auto index = decode_hash<JSON, T, HashInfo, HashInfo.type>::op(it, end);
+         
+         if (index >= N) [[unlikely]] {
             if constexpr (Opts.error_on_unknown_keys) {
                ctx.error = error_code::unknown_key;
+               return;
             }
             else {
-               auto* start = it;
+               // we need to search until we find the ending quote of the key
+               auto start = it;
                skip_string_view<Opts>(ctx, it, end);
                if (bool(ctx.error)) [[unlikely]]
                   return;
                const sv key = {start, size_t(it - start)};
-               ++it;
+               ++it; // skip the quote
                if constexpr (not Opts.null_terminated) {
                   if (it == end) [[unlikely]] {
                      ctx.error = error_code::unexpected_end;
                      return;
                   }
                }
-
+               
                if (parse_ws_colon<Opts>(ctx, it, end)) {
                   return;
                }
-
+               
                parse<JSON>::handle_unknown<Opts>(key, value, ctx, it, end);
-            }
-         }
-      }
-
-      template <opts Opts, class T, size_t I, class Value>
-         requires(glaze_enum_t<T> || (meta_keys<T> && std::is_enum_v<T>))
-      void decode_index(Value&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
-      {
-         static constexpr auto TargetKey = glz::get<I>(reflect<T>::keys);
-         static constexpr auto Length = TargetKey.size();
-
-         if (((it + Length) < end) && comparitor<TargetKey>(it)) [[likely]] {
-            it += Length;
-            if (*it != '"') [[unlikely]] {
-               ctx.error = error_code::unexpected_enum;
                return;
             }
-            value = get<I>(reflect<T>::values);
-
-            ++it;
+         }
+         
+         if constexpr (N == 2) {
+            if (index == 0) {
+               decode_index<Opts, T, 0>(value, ctx, it, end, selected_index...);
+            }
+            else {
+               decode_index<Opts, T, 1>(value, ctx, it, end, selected_index...);
+            }
+         }
+         else {
+            // We see better performance with function pointers than a glz::jump_table here.
+            visit<N>([&]<size_t I>() { decode_index<Opts, T, I>(value, ctx, it, end, selected_index...); }, index);
+         }
+      }
+   }
+   
+   template <is_member_function_pointer T>
+   struct from<JSON, T>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, auto&&...) noexcept
+      {
+         ctx.error = error_code::attempt_member_func_read;
+      }
+   };
+   
+   template <is_includer T>
+   struct from<JSON, T>
+   {
+      template <auto Opts, class... Args>
+      static void op(auto&&, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+      {
+         if constexpr (!has_ws_handled(Opts)) {
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
+            }
+         }
+         
+         match<R"("")", Opts>(ctx, it, end);
+      }
+   };
+   
+   template <is_bitset T>
+   struct from<JSON, T>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+      {
+         if (match_invalid_end<'"', Opts>(ctx, it, end)) {
+            return;
+         }
+         
+         const auto n = value.size();
+         for (size_t i = 1; it < end; ++i, ++it) {
+            if (*it == '"') {
+               ++it;
+               if constexpr (not Opts.null_terminated) {
+                  if (it == end) {
+                     ctx.error = error_code::end_reached;
+                     return;
+                  }
+               }
+               return;
+            }
+            
+            if (i > n) {
+               ctx.error = error_code::exceeded_static_array_size;
+               return;
+            }
+            
+            if (*it == '0') {
+               value[n - i] = 0;
+            }
+            else if (*it == '1') {
+               value[n - i] = 1;
+            }
+            else [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+         }
+         
+         ctx.error = error_code::expected_quote;
+      }
+   };
+   
+   template <>
+   struct from<JSON, skip>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, auto&&... args) noexcept
+      {
+         skip_value<JSON>::op<Opts>(ctx, args...);
+      }
+   };
+   
+   template <is_reference_wrapper T>
+   struct from<JSON, T>
+   {
+      template <auto Opts, class... Args>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args)
+      {
+         using V = std::decay_t<decltype(value.get())>;
+         from<JSON, V>::template op<Opts>(value.get(), std::forward<Args>(args)...);
+      }
+   };
+   
+   template <>
+   struct from<JSON, hidden>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, auto&&...) noexcept
+      {
+         ctx.error = error_code::attempt_read_hidden;
+      }
+   };
+   
+   template <complex_t T>
+   struct from<JSON, T>
+   {
+      template <auto Options>
+      static void op(auto&& v, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+      {
+         constexpr auto Opts = ws_handled_off<Options>();
+         if constexpr (!has_ws_handled(Options)) {
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
+            }
+         }
+         if (match_invalid_end<'[', Opts>(ctx, it, end)) {
+            return;
+         }
+         if constexpr (not Opts.null_terminated) {
+            ++ctx.indentation_level;
+         }
+         
+         auto* ptr = reinterpret_cast<typename T::value_type*>(&v);
+         static_assert(sizeof(T) == sizeof(typename T::value_type) * 2);
+         parse<JSON>::op<Opts>(ptr[0], ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+         
+         if (skip_ws<Opts>(ctx, it, end)) {
+            return;
+         }
+         
+         if (match_invalid_end<',', Opts>(ctx, it, end)) {
+            return;
+         }
+         
+         parse<JSON>::op<Opts>(ptr[1], ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+         
+         if (skip_ws<Opts>(ctx, it, end)) {
+            return;
+         }
+         match<']'>(ctx, it);
+         if constexpr (not Opts.null_terminated) {
+            --ctx.indentation_level;
+         }
+      }
+   };
+   
+   template <always_null_t T>
+   struct from<JSON, T>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+      {
+         if constexpr (!has_ws_handled(Opts)) {
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
+            }
+         }
+         static constexpr sv null_string = "null";
+         if constexpr (not has_is_padded(Opts)) {
+            const auto n = size_t(end - it);
+            if ((n < 4) || not comparitor<null_string>(it)) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+            }
+         }
+         else {
+            if (not comparitor<null_string>(it)) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+            }
+         }
+         it += 4; // always advance for performance
+      }
+   };
+   
+   template <bool_t T>
+   struct from<JSON, T>
+   {
+      template <auto Opts>
+      static void op(bool_t auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+      {
+         if constexpr (Opts.quoted_num) {
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
+            }
+            if (match_invalid_end<'"', Opts>(ctx, it, end)) {
+               return;
+            }
+         }
+         
+         if constexpr (!has_ws_handled(Opts)) {
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
+            }
+         }
+         
+         if constexpr (Opts.bools_as_numbers) {
+            if (*it == '1') {
+               value = true;
+               ++it;
+            }
+            else if (*it == '0') {
+               value = false;
+               ++it;
+            }
+            else {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+         }
+         else {
+            if constexpr (not has_is_padded(Opts)) {
+               if (size_t(end - it) < 4) [[unlikely]] {
+                  ctx.error = error_code::expected_true_or_false;
+                  return;
+               }
+            }
+            
+            uint64_t c{};
+            static constexpr uint64_t u_true =
+            0b00000000'00000000'00000000'00000000'01100101'01110101'01110010'01110100;
+            static constexpr uint64_t u_false =
+            0b00000000'00000000'00000000'01100101'01110011'01101100'01100001'01100110;
+            if constexpr (Opts.null_terminated) {
+               // Note that because our buffer must be null terminated, we can read one more index without checking:
+               std::memcpy(&c, it, 5);
+               // We have to wipe the 5th character for true testing
+               if ((c & 0xFF'FF'FF'00'FF'FF'FF'FF) == u_true) {
+                  value = true;
+                  it += 4;
+               }
+               else {
+                  if (c != u_false) [[unlikely]] {
+                     ctx.error = error_code::expected_true_or_false;
+                     return;
+                  }
+                  value = false;
+                  it += 5;
+               }
+            }
+            else {
+               std::memcpy(&c, it, 4);
+               if (c == u_true) {
+                  value = true;
+                  it += 4;
+               }
+               else if (size_t(end - it) < 5) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
+               else {
+                  std::memcpy(&c, it, 5);
+                  if (c == u_false) [[likely]] {
+                     value = false;
+                     it += 5;
+                  }
+                  else [[unlikely]] {
+                     ctx.error = error_code::expected_true_or_false;
+                     return;
+                  }
+               }
+            }
+         }
+         
+         if constexpr (Opts.quoted_num) {
+            if constexpr (not Opts.null_terminated) {
+               if (it == end) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
+            }
+            if (match<'"'>(ctx, it)) {
+               return;
+            }
             if constexpr (not Opts.null_terminated) {
                if (it == end) {
                   ctx.error = error_code::end_reached;
@@ -252,513 +597,306 @@ namespace glz
                }
             }
          }
-         else [[unlikely]] {
-            ctx.error = error_code::unexpected_enum;
-            return;
-         }
-      }
-
-      template <opts Opts, class T, auto& HashInfo, class Value, class... SelectedIndex>
-         requires(glaze_object_t<T> || reflectable<T>)
-      GLZ_ALWAYS_INLINE constexpr void parse_and_invoke(Value&& value, is_context auto&& ctx, auto&& it, auto&& end,
-                                                        SelectedIndex&&... selected_index)
-      {
-         constexpr auto type = HashInfo.type;
-         constexpr auto N = reflect<T>::size;
-
-         static_assert(bool(type), "invalid hash algorithm");
-
-         if constexpr (N == 1) {
-            decode_index<Opts, T, 0>(value, ctx, it, end, selected_index...);
-         }
          else {
-            const auto index = decode_hash<JSON, T, HashInfo, HashInfo.type>::op(it, end);
-
-            if (index >= N) [[unlikely]] {
-               if constexpr (Opts.error_on_unknown_keys) {
-                  ctx.error = error_code::unknown_key;
+            if constexpr (not Opts.null_terminated) {
+               if (it == end) {
+                  ctx.error = error_code::end_reached;
                   return;
                }
-               else {
-                  // we need to search until we find the ending quote of the key
-                  auto start = it;
-                  skip_string_view<Opts>(ctx, it, end);
-                  if (bool(ctx.error)) [[unlikely]]
-                     return;
-                  const sv key = {start, size_t(it - start)};
-                  ++it; // skip the quote
-                  if constexpr (not Opts.null_terminated) {
-                     if (it == end) [[unlikely]] {
-                        ctx.error = error_code::unexpected_end;
-                        return;
-                     }
-                  }
-
-                  if (parse_ws_colon<Opts>(ctx, it, end)) {
-                     return;
-                  }
-
-                  parse<JSON>::handle_unknown<Opts>(key, value, ctx, it, end);
-                  return;
-               }
-            }
-
-            if constexpr (N == 2) {
-               if (index == 0) {
-                  decode_index<Opts, T, 0>(value, ctx, it, end, selected_index...);
-               }
-               else {
-                  decode_index<Opts, T, 1>(value, ctx, it, end, selected_index...);
-               }
-            }
-            else {
-               // We see better performance with function pointers than a glz::jump_table here.
-               visit<N>([&]<size_t I>() { decode_index<Opts, T, I>(value, ctx, it, end, selected_index...); }, index);
             }
          }
       }
-
-      template <is_member_function_pointer T>
-      struct from<JSON, T>
+   };
+   
+   template <num_t T>
+   struct from<JSON, T>
+   {
+      template <auto Opts, class It>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end) noexcept
       {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, auto&&...) noexcept
-         {
-            ctx.error = error_code::attempt_member_func_read;
-         }
-      };
-
-      template <is_includer T>
-      struct from<JSON, T>
-      {
-         template <auto Opts, class... Args>
-         static void op(auto&&, is_context auto&& ctx, auto&& it, auto&& end) noexcept
-         {
-            if constexpr (!has_ws_handled(Opts)) {
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
+         if constexpr (Opts.quoted_num) {
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
             }
-
-            match<R"("")", Opts>(ctx, it, end);
-         }
-      };
-
-      template <is_bitset T>
-      struct from<JSON, T>
-      {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
-         {
             if (match_invalid_end<'"', Opts>(ctx, it, end)) {
                return;
             }
-
-            const auto n = value.size();
-            for (size_t i = 1; it < end; ++i, ++it) {
-               if (*it == '"') {
-                  ++it;
-                  if constexpr (not Opts.null_terminated) {
-                     if (it == end) {
-                        ctx.error = error_code::end_reached;
-                        return;
-                     }
-                  }
-                  return;
-               }
-
-               if (i > n) {
-                  ctx.error = error_code::exceeded_static_array_size;
-                  return;
-               }
-
-               if (*it == '0') {
-                  value[n - i] = 0;
-               }
-               else if (*it == '1') {
-                  value[n - i] = 1;
-               }
-               else [[unlikely]] {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-            }
-
-            ctx.error = error_code::expected_quote;
          }
-      };
-
-      template <>
-      struct from<JSON, skip>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, auto&&... args) noexcept
-         {
-            skip_value<JSON>::op<Opts>(ctx, args...);
-         }
-      };
-
-      template <is_reference_wrapper T>
-      struct from<JSON, T>
-      {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args)
-         {
-            using V = std::decay_t<decltype(value.get())>;
-            from<JSON, V>::template op<Opts>(value.get(), std::forward<Args>(args)...);
-         }
-      };
-
-      template <>
-      struct from<JSON, hidden>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, auto&&...) noexcept
-         {
-            ctx.error = error_code::attempt_read_hidden;
-         }
-      };
-
-      template <complex_t T>
-      struct from<JSON, T>
-      {
-         template <auto Options>
-         static void op(auto&& v, is_context auto&& ctx, auto&& it, auto&& end) noexcept
-         {
-            constexpr auto Opts = ws_handled_off<Options>();
-            if constexpr (!has_ws_handled(Options)) {
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-            }
-            if (match_invalid_end<'[', Opts>(ctx, it, end)) {
-               return;
-            }
-            if constexpr (not Opts.null_terminated) {
-               ++ctx.indentation_level;
-            }
-
-            auto* ptr = reinterpret_cast<typename T::value_type*>(&v);
-            static_assert(sizeof(T) == sizeof(typename T::value_type) * 2);
-            parse<JSON>::op<Opts>(ptr[0], ctx, it, end);
-            if (bool(ctx.error)) [[unlikely]]
-               return;
-
+         
+         if constexpr (!has_ws_handled(Opts)) {
             if (skip_ws<Opts>(ctx, it, end)) {
                return;
             }
-
-            if (match_invalid_end<',', Opts>(ctx, it, end)) {
-               return;
-            }
-
-            parse<JSON>::op<Opts>(ptr[1], ctx, it, end);
-            if (bool(ctx.error)) [[unlikely]]
-               return;
-
-            if (skip_ws<Opts>(ctx, it, end)) {
-               return;
-            }
-            match<']'>(ctx, it);
-            if constexpr (not Opts.null_terminated) {
-               --ctx.indentation_level;
-            }
          }
-      };
-
-      template <always_null_t T>
-      struct from<JSON, T>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, auto&& it, auto&& end) noexcept
-         {
-            if constexpr (!has_ws_handled(Opts)) {
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-            }
-            static constexpr sv null_string = "null";
-            if constexpr (not has_is_padded(Opts)) {
-               const auto n = size_t(end - it);
-               if ((n < 4) || not comparitor<null_string>(it)) [[unlikely]] {
-                  ctx.error = error_code::syntax_error;
-               }
-            }
-            else {
-               if (not comparitor<null_string>(it)) [[unlikely]] {
-                  ctx.error = error_code::syntax_error;
-               }
-            }
-            it += 4; // always advance for performance
-         }
-      };
-
-      template <bool_t T>
-      struct from<JSON, T>
-      {
-         template <auto Opts>
-         static void op(bool_t auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
-         {
-            if constexpr (Opts.quoted_num) {
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-               if (match_invalid_end<'"', Opts>(ctx, it, end)) {
-                  return;
-               }
-            }
-
-            if constexpr (!has_ws_handled(Opts)) {
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-            }
-
-            if constexpr (Opts.bools_as_numbers) {
-               if (*it == '1') {
-                  value = true;
-                  ++it;
-               }
-               else if (*it == '0') {
-                  value = false;
-                  ++it;
-               }
-               else {
-                  ctx.error = error_code::syntax_error;
+         
+         using V = std::decay_t<decltype(value)>;
+         if constexpr (int_t<V>) {
+            static_assert(sizeof(*it) == sizeof(char));
+            
+            if constexpr (Opts.null_terminated) {
+               if (not glz::atoi(value, it)) [[unlikely]] {
+                  ctx.error = error_code::parse_number_failure;
                   return;
                }
             }
             else {
-               if constexpr (not has_is_padded(Opts)) {
-                  if (size_t(end - it) < 4) [[unlikely]] {
-                     ctx.error = error_code::expected_true_or_false;
-                     return;
-                  }
-               }
-
-               uint64_t c{};
-               static constexpr uint64_t u_true =
-                  0b00000000'00000000'00000000'00000000'01100101'01110101'01110010'01110100;
-               static constexpr uint64_t u_false =
-                  0b00000000'00000000'00000000'01100101'01110011'01101100'01100001'01100110;
-               if constexpr (Opts.null_terminated) {
-                  // Note that because our buffer must be null terminated, we can read one more index without checking:
-                  std::memcpy(&c, it, 5);
-                  // We have to wipe the 5th character for true testing
-                  if ((c & 0xFF'FF'FF'00'FF'FF'FF'FF) == u_true) {
-                     value = true;
-                     it += 4;
-                  }
-                  else {
-                     if (c != u_false) [[unlikely]] {
-                        ctx.error = error_code::expected_true_or_false;
-                        return;
-                     }
-                     value = false;
-                     it += 5;
-                  }
-               }
-               else {
-                  std::memcpy(&c, it, 4);
-                  if (c == u_true) {
-                     value = true;
-                     it += 4;
-                  }
-                  else if (size_t(end - it) < 5) [[unlikely]] {
-                     ctx.error = error_code::unexpected_end;
-                     return;
-                  }
-                  else {
-                     std::memcpy(&c, it, 5);
-                     if (c == u_false) [[likely]] {
-                        value = false;
-                        it += 5;
-                     }
-                     else [[unlikely]] {
-                        ctx.error = error_code::expected_true_or_false;
-                        return;
-                     }
-                  }
-               }
-            }
-
-            if constexpr (Opts.quoted_num) {
-               if constexpr (not Opts.null_terminated) {
-                  if (it == end) [[unlikely]] {
-                     ctx.error = error_code::unexpected_end;
-                     return;
-                  }
-               }
-               if (match<'"'>(ctx, it)) {
+               if (not glz::atoi(value, it, end)) [[unlikely]] {
+                  ctx.error = error_code::parse_number_failure;
                   return;
-               }
-               if constexpr (not Opts.null_terminated) {
-                  if (it == end) {
-                     ctx.error = error_code::end_reached;
-                     return;
-                  }
-               }
-            }
-            else {
-               if constexpr (not Opts.null_terminated) {
-                  if (it == end) {
-                     ctx.error = error_code::end_reached;
-                     return;
-                  }
                }
             }
          }
-      };
-
-      template <num_t T>
-      struct from<JSON, T>
-      {
-         template <auto Opts, class It>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end) noexcept
-         {
-            if constexpr (Opts.quoted_num) {
-               if (skip_ws<Opts>(ctx, it, end)) {
+         else {
+            if constexpr (is_float128<V>) {
+               auto [ptr, ec] = std::from_chars(it, end, value);
+               if (ec != std::errc()) {
+                  ctx.error = error_code::parse_number_failure;
                   return;
                }
-               if (match_invalid_end<'"', Opts>(ctx, it, end)) {
-                  return;
-               }
+               it = ptr;
             }
-
-            if constexpr (!has_ws_handled(Opts)) {
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-            }
-
-            using V = std::decay_t<decltype(value)>;
-            if constexpr (int_t<V>) {
-               static_assert(sizeof(*it) == sizeof(char));
-
-               if constexpr (Opts.null_terminated) {
-                  if (not glz::detail::atoi(value, it)) [[unlikely]] {
+            else {
+               if constexpr (std::is_volatile_v<std::remove_reference_t<decltype(value)>>) {
+                  // Hardware may interact with value changes, so we parse into a temporary and assign in one
+                  // place
+                  V temp;
+                  auto [ptr, ec] = glz::from_chars<Opts.null_terminated>(it, end, temp);
+                  if (ec != std::errc()) [[unlikely]] {
                      ctx.error = error_code::parse_number_failure;
                      return;
                   }
+                  value = temp;
+                  it = ptr;
                }
                else {
-                  if (not glz::detail::atoi(value, it, end)) [[unlikely]] {
-                     ctx.error = error_code::parse_number_failure;
-                     return;
-                  }
-               }
-            }
-            else {
-               if constexpr (is_float128<V>) {
-                  auto [ptr, ec] = std::from_chars(it, end, value);
-                  if (ec != std::errc()) {
+                  auto [ptr, ec] = glz::from_chars<Opts.null_terminated>(it, end, value);
+                  if (ec != std::errc()) [[unlikely]] {
                      ctx.error = error_code::parse_number_failure;
                      return;
                   }
                   it = ptr;
                }
-               else {
-                  if constexpr (std::is_volatile_v<std::remove_reference_t<decltype(value)>>) {
-                     // Hardware may interact with value changes, so we parse into a temporary and assign in one
-                     // place
-                     V temp;
-                     auto [ptr, ec] = glz::from_chars<Opts.null_terminated>(it, end, temp);
-                     if (ec != std::errc()) [[unlikely]] {
-                        ctx.error = error_code::parse_number_failure;
-                        return;
-                     }
-                     value = temp;
-                     it = ptr;
-                  }
-                  else {
-                     auto [ptr, ec] = glz::from_chars<Opts.null_terminated>(it, end, value);
-                     if (ec != std::errc()) [[unlikely]] {
-                        ctx.error = error_code::parse_number_failure;
-                        return;
-                     }
-                     it = ptr;
-                  }
-               }
             }
-
-            if constexpr (Opts.quoted_num) {
-               if constexpr (not Opts.null_terminated) {
-                  if (it == end) [[unlikely]] {
-                     ctx.error = error_code::unexpected_end;
-                     return;
-                  }
-               }
-               if (match<'"'>(ctx, it)) {
+         }
+         
+         if constexpr (Opts.quoted_num) {
+            if constexpr (not Opts.null_terminated) {
+               if (it == end) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
                   return;
                }
-               if constexpr (not Opts.null_terminated) {
-                  if (it == end) {
-                     ctx.error = error_code::end_reached;
-                     return;
-                  }
-               }
             }
-            else {
-               if constexpr (not Opts.null_terminated) {
-                  if (it == end) {
-                     ctx.error = error_code::end_reached;
-                     return;
-                  }
+            if (match<'"'>(ctx, it)) {
+               return;
+            }
+            if constexpr (not Opts.null_terminated) {
+               if (it == end) {
+                  ctx.error = error_code::end_reached;
+                  return;
                }
             }
          }
-      };
-
-      template <string_t T>
-      struct from<JSON, T>
-      {
-         template <auto Opts, class It, class End>
-            requires(has_is_padded(Opts))
-         static void op(auto& value, is_context auto&& ctx, It&& it, End&& end)
-         {
-            if constexpr (Opts.number) {
-               auto start = it;
-               skip_number<Opts>(ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]] {
+         else {
+            if constexpr (not Opts.null_terminated) {
+               if (it == end) {
+                  ctx.error = error_code::end_reached;
                   return;
                }
-               value.append(start, size_t(it - start));
             }
-            else {
-               if constexpr (!has_opening_handled(Opts)) {
-                  if constexpr (!has_ws_handled(Opts)) {
-                     if (skip_ws<Opts>(ctx, it, end)) {
-                        return;
-                     }
-                  }
-
-                  if (match_invalid_end<'"', Opts>(ctx, it, end)) {
+         }
+      }
+   };
+   
+   template <string_t T>
+   struct from<JSON, T>
+   {
+      template <auto Opts, class It, class End>
+      requires(has_is_padded(Opts))
+      static void op(auto& value, is_context auto&& ctx, It&& it, End&& end)
+      {
+         if constexpr (Opts.number) {
+            auto start = it;
+            skip_number<Opts>(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            value.append(start, size_t(it - start));
+         }
+         else {
+            if constexpr (!has_opening_handled(Opts)) {
+               if constexpr (!has_ws_handled(Opts)) {
+                  if (skip_ws<Opts>(ctx, it, end)) {
                      return;
                   }
                }
-
-               if constexpr (not Opts.raw_string) {
-                  static constexpr auto string_padding_bytes = 8;
-
-                  auto start = it;
-                  while (true) {
-                     if (it >= end) [[unlikely]] {
-                        ctx.error = error_code::unexpected_end;
+               
+               if (match_invalid_end<'"', Opts>(ctx, it, end)) {
+                  return;
+               }
+            }
+            
+            if constexpr (not Opts.raw_string) {
+               static constexpr auto string_padding_bytes = 8;
+               
+               auto start = it;
+               while (true) {
+                  if (it >= end) [[unlikely]] {
+                     ctx.error = error_code::unexpected_end;
+                     return;
+                  }
+                  
+                  uint64_t chunk;
+                  std::memcpy(&chunk, it, 8);
+                  const uint64_t test_chars = has_quote(chunk);
+                  if (test_chars) {
+                     it += (countr_zero(test_chars) >> 3);
+                     
+                     auto* prev = it - 1;
+                     while (*prev == '\\') {
+                        --prev;
+                     }
+                     if (size_t(it - prev) % 2) {
+                        break;
+                     }
+                     ++it; // skip the escaped quote
+                  }
+                  else {
+                     it += 8;
+                  }
+               }
+               
+               auto n = size_t(it - start);
+               value.resize(n + string_padding_bytes);
+               
+               auto* p = value.data();
+               
+               while (true) {
+                  if (start >= it) {
+                     break;
+                  }
+                  
+                  std::memcpy(p, start, 8);
+                  uint64_t swar;
+                  std::memcpy(&swar, p, 8);
+                  
+                  constexpr uint64_t lo7_mask = repeat_byte8(0b01111111);
+                  const uint64_t lo7 = swar & lo7_mask;
+                  const uint64_t backslash = (lo7 ^ repeat_byte8('\\')) + lo7_mask;
+                  const uint64_t less_32 = (swar & repeat_byte8(0b01100000)) + lo7_mask;
+                  uint64_t next = ~((backslash & less_32) | swar);
+                  
+                  next &= repeat_byte8(0b10000000);
+                  if (next == 0) {
+                     start += 8;
+                     p += 8;
+                     continue;
+                  }
+                  
+                  next = countr_zero(next) >> 3;
+                  start += next;
+                  if (start >= it) {
+                     break;
+                  }
+                  
+                  if ((*start & 0b11100000) == 0) [[unlikely]] {
+                     ctx.error = error_code::syntax_error;
+                     return;
+                  }
+                  ++start; // skip the escape
+                  if (*start == 'u') {
+                     ++start;
+                     p += next;
+                     const auto mark = start;
+                     const auto offset = handle_unicode_code_point(start, p, end);
+                     if (offset == 0) [[unlikely]] {
+                        ctx.error = error_code::unicode_escape_conversion_failure;
                         return;
                      }
-
+                     n += offset;
+                     // escape + u + unicode code points
+                     n -= 2 + uint32_t(start - mark);
+                  }
+                  else {
+                     p += next;
+                     *p = char_unescape_table[uint8_t(*start)];
+                     if (*p == 0) [[unlikely]] {
+                        ctx.error = error_code::invalid_escape;
+                        return;
+                     }
+                     ++p;
+                     ++start;
+                     --n;
+                  }
+               }
+               
+               value.resize(n);
+               ++it;
+            }
+            else {
+               // raw_string
+               auto start = it;
+               skip_string_view<Opts>(ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
+               
+               value.assign(start, size_t(it - start));
+               ++it;
+            }
+         }
+      }
+      
+      template <auto Opts, class It, class End>
+      requires(not has_is_padded(Opts))
+      static void op(auto& value, is_context auto&& ctx, It&& it, End&& end)
+      {
+         if constexpr (Opts.number) {
+            auto start = it;
+            skip_number<Opts>(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            if (start == it) [[unlikely]] {
+               ctx.error = error_code::parse_number_failure;
+               return;
+            }
+            value.append(start, size_t(it - start));
+         }
+         else {
+            if constexpr (!has_opening_handled(Opts)) {
+               if constexpr (!has_ws_handled(Opts)) {
+                  if (skip_ws<Opts>(ctx, it, end)) {
+                     return;
+                  }
+               }
+               
+               if (match_invalid_end<'"', Opts>(ctx, it, end)) {
+                  return;
+               }
+            }
+            
+            if constexpr (not Opts.raw_string) {
+               static constexpr auto string_padding_bytes = 8;
+               
+               if (size_t(end - it) >= 8) {
+                  auto start = it;
+                  const auto end8 = end - 8;
+                  while (true) {
+                     if (it >= end8) [[unlikely]] {
+                        break;
+                     }
+                     
                      uint64_t chunk;
                      std::memcpy(&chunk, it, 8);
                      const uint64_t test_chars = has_quote(chunk);
                      if (test_chars) {
                         it += (countr_zero(test_chars) >> 3);
-
+                        
                         auto* prev = it - 1;
                         while (*prev == '\\') {
                            --prev;
                         }
                         if (size_t(it - prev) % 2) {
-                           break;
+                           goto continue_decode;
                         }
                         ++it; // skip the escaped quote
                      }
@@ -766,316 +904,116 @@ namespace glz
                         it += 8;
                      }
                   }
-
+                  
+                  while (it[-1] == '\\') [[unlikely]] {
+                     // if we ended on an escape character then we need to rewind
+                     // because we lost our context
+                     --it;
+                  }
+                  
+                  for (; it < end; ++it) {
+                     if (*it == '"') {
+                        auto* prev = it - 1;
+                        while (*prev == '\\') {
+                           --prev;
+                        }
+                        if (size_t(it - prev) % 2) {
+                           goto continue_decode;
+                        }
+                     }
+                  }
+                  
+                  ctx.error = error_code::unexpected_end;
+                  return;
+                  
+               continue_decode:
+                  
+                  const auto available_padding = size_t(end - it);
                   auto n = size_t(it - start);
-                  value.resize(n + string_padding_bytes);
-
-                  auto* p = value.data();
-
-                  while (true) {
-                     if (start >= it) {
-                        break;
-                     }
-
-                     std::memcpy(p, start, 8);
-                     uint64_t swar;
-                     std::memcpy(&swar, p, 8);
-
-                     constexpr uint64_t lo7_mask = repeat_byte8(0b01111111);
-                     const uint64_t lo7 = swar & lo7_mask;
-                     const uint64_t backslash = (lo7 ^ repeat_byte8('\\')) + lo7_mask;
-                     const uint64_t less_32 = (swar & repeat_byte8(0b01100000)) + lo7_mask;
-                     uint64_t next = ~((backslash & less_32) | swar);
-
-                     next &= repeat_byte8(0b10000000);
-                     if (next == 0) {
-                        start += 8;
-                        p += 8;
-                        continue;
-                     }
-
-                     next = countr_zero(next) >> 3;
-                     start += next;
-                     if (start >= it) {
-                        break;
-                     }
-
-                     if ((*start & 0b11100000) == 0) [[unlikely]] {
-                        ctx.error = error_code::syntax_error;
-                        return;
-                     }
-                     ++start; // skip the escape
-                     if (*start == 'u') {
-                        ++start;
-                        p += next;
-                        const auto mark = start;
-                        const auto offset = handle_unicode_code_point(start, p, end);
-                        if (offset == 0) [[unlikely]] {
-                           ctx.error = error_code::unicode_escape_conversion_failure;
-                           return;
-                        }
-                        n += offset;
-                        // escape + u + unicode code points
-                        n -= 2 + uint32_t(start - mark);
-                     }
-                     else {
-                        p += next;
-                        *p = char_unescape_table[uint8_t(*start)];
-                        if (*p == 0) [[unlikely]] {
-                           ctx.error = error_code::invalid_escape;
-                           return;
-                        }
-                        ++p;
-                        ++start;
-                        --n;
-                     }
-                  }
-
-                  value.resize(n);
-                  ++it;
-               }
-               else {
-                  // raw_string
-                  auto start = it;
-                  skip_string_view<Opts>(ctx, it, end);
-                  if (bool(ctx.error)) [[unlikely]]
-                     return;
-
-                  value.assign(start, size_t(it - start));
-                  ++it;
-               }
-            }
-         }
-
-         template <auto Opts, class It, class End>
-            requires(not has_is_padded(Opts))
-         static void op(auto& value, is_context auto&& ctx, It&& it, End&& end)
-         {
-            if constexpr (Opts.number) {
-               auto start = it;
-               skip_number<Opts>(ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]] {
-                  return;
-               }
-               if (start == it) [[unlikely]] {
-                  ctx.error = error_code::parse_number_failure;
-                  return;
-               }
-               value.append(start, size_t(it - start));
-            }
-            else {
-               if constexpr (!has_opening_handled(Opts)) {
-                  if constexpr (!has_ws_handled(Opts)) {
-                     if (skip_ws<Opts>(ctx, it, end)) {
-                        return;
-                     }
-                  }
-
-                  if (match_invalid_end<'"', Opts>(ctx, it, end)) {
-                     return;
-                  }
-               }
-
-               if constexpr (not Opts.raw_string) {
-                  static constexpr auto string_padding_bytes = 8;
-
-                  if (size_t(end - it) >= 8) {
-                     auto start = it;
-                     const auto end8 = end - 8;
+                  if (available_padding >= 8) [[likely]] {
+                     value.resize(n + string_padding_bytes);
+                     
+                     auto* p = value.data();
+                     
                      while (true) {
-                        if (it >= end8) [[unlikely]] {
+                        if (start >= it) {
                            break;
                         }
-
-                        uint64_t chunk;
-                        std::memcpy(&chunk, it, 8);
-                        const uint64_t test_chars = has_quote(chunk);
-                        if (test_chars) {
-                           it += (countr_zero(test_chars) >> 3);
-
-                           auto* prev = it - 1;
-                           while (*prev == '\\') {
-                              --prev;
+                        
+                        std::memcpy(p, start, 8);
+                        uint64_t swar;
+                        std::memcpy(&swar, p, 8);
+                        
+                        constexpr uint64_t lo7_mask = repeat_byte8(0b01111111);
+                        const uint64_t lo7 = swar & lo7_mask;
+                        const uint64_t backslash = (lo7 ^ repeat_byte8('\\')) + lo7_mask;
+                        const uint64_t less_32 = (swar & repeat_byte8(0b01100000)) + lo7_mask;
+                        uint64_t next = ~((backslash & less_32) | swar);
+                        
+                        next &= repeat_byte8(0b10000000);
+                        if (next == 0) {
+                           start += 8;
+                           p += 8;
+                           continue;
+                        }
+                        
+                        next = countr_zero(next) >> 3;
+                        start += next;
+                        if (start >= it) {
+                           break;
+                        }
+                        
+                        if ((*start & 0b11100000) == 0) [[unlikely]] {
+                           ctx.error = error_code::syntax_error;
+                           return;
+                        }
+                        ++start; // skip the escape
+                        if (*start == 'u') {
+                           ++start;
+                           p += next;
+                           const auto mark = start;
+                           const auto offset = handle_unicode_code_point(start, p, end);
+                           if (offset == 0) [[unlikely]] {
+                              ctx.error = error_code::unicode_escape_conversion_failure;
+                              return;
                            }
-                           if (size_t(it - prev) % 2) {
-                              goto continue_decode;
-                           }
-                           ++it; // skip the escaped quote
+                           n += offset;
+                           // escape + u + unicode code points
+                           n -= 2 + uint32_t(start - mark);
                         }
                         else {
-                           it += 8;
-                        }
-                     }
-
-                     while (it[-1] == '\\') [[unlikely]] {
-                        // if we ended on an escape character then we need to rewind
-                        // because we lost our context
-                        --it;
-                     }
-
-                     for (; it < end; ++it) {
-                        if (*it == '"') {
-                           auto* prev = it - 1;
-                           while (*prev == '\\') {
-                              --prev;
-                           }
-                           if (size_t(it - prev) % 2) {
-                              goto continue_decode;
-                           }
-                        }
-                     }
-
-                     ctx.error = error_code::unexpected_end;
-                     return;
-
-                  continue_decode:
-
-                     const auto available_padding = size_t(end - it);
-                     auto n = size_t(it - start);
-                     if (available_padding >= 8) [[likely]] {
-                        value.resize(n + string_padding_bytes);
-
-                        auto* p = value.data();
-
-                        while (true) {
-                           if (start >= it) {
-                              break;
-                           }
-
-                           std::memcpy(p, start, 8);
-                           uint64_t swar;
-                           std::memcpy(&swar, p, 8);
-
-                           constexpr uint64_t lo7_mask = repeat_byte8(0b01111111);
-                           const uint64_t lo7 = swar & lo7_mask;
-                           const uint64_t backslash = (lo7 ^ repeat_byte8('\\')) + lo7_mask;
-                           const uint64_t less_32 = (swar & repeat_byte8(0b01100000)) + lo7_mask;
-                           uint64_t next = ~((backslash & less_32) | swar);
-
-                           next &= repeat_byte8(0b10000000);
-                           if (next == 0) {
-                              start += 8;
-                              p += 8;
-                              continue;
-                           }
-
-                           next = countr_zero(next) >> 3;
-                           start += next;
-                           if (start >= it) {
-                              break;
-                           }
-
-                           if ((*start & 0b11100000) == 0) [[unlikely]] {
-                              ctx.error = error_code::syntax_error;
+                           p += next;
+                           *p = char_unescape_table[uint8_t(*start)];
+                           if (*p == 0) [[unlikely]] {
+                              ctx.error = error_code::invalid_escape;
                               return;
                            }
-                           ++start; // skip the escape
-                           if (*start == 'u') {
-                              ++start;
-                              p += next;
-                              const auto mark = start;
-                              const auto offset = handle_unicode_code_point(start, p, end);
-                              if (offset == 0) [[unlikely]] {
-                                 ctx.error = error_code::unicode_escape_conversion_failure;
-                                 return;
-                              }
-                              n += offset;
-                              // escape + u + unicode code points
-                              n -= 2 + uint32_t(start - mark);
-                           }
-                           else {
-                              p += next;
-                              *p = char_unescape_table[uint8_t(*start)];
-                              if (*p == 0) [[unlikely]] {
-                                 ctx.error = error_code::invalid_escape;
-                                 return;
-                              }
-                              ++p;
-                              ++start;
-                              --n;
-                           }
+                           ++p;
+                           ++start;
+                           --n;
                         }
-
-                        value.resize(n);
-                        ++it;
                      }
-                     else {
-                        // For large inputs this case of running out of buffer is very rare
-                        value.resize(n);
-                        auto* p = value.data();
-
-                        it = start;
-                        while (it < end) [[likely]] {
-                           *p = *it;
-                           if (*it == '"') {
-                              value.resize(size_t(p - value.data()));
-                              ++it;
-                              return;
-                           }
-                           else if (*it == '\\') {
-                              ++it; // skip the escape
-                              if (*it == 'u') {
-                                 ++it;
-                                 if (!handle_unicode_code_point(it, p, end)) [[unlikely]] {
-                                    ctx.error = error_code::unicode_escape_conversion_failure;
-                                    return;
-                                 }
-                              }
-                              else {
-                                 *p = char_unescape_table[uint8_t(*it)];
-                                 if (*p == 0) [[unlikely]] {
-                                    ctx.error = error_code::invalid_escape;
-                                    return;
-                                 }
-                                 ++p;
-                                 ++it;
-                              }
-                           }
-                           else {
-                              ++it;
-                              ++p;
-                           }
-                        }
-
-                        ctx.error = error_code::unexpected_end;
-                     }
+                     
+                     value.resize(n);
+                     ++it;
                   }
                   else {
-                     // For short strings
-
-                     std::array<char, 8> buffer{};
-
-                     auto* p = buffer.data();
-
+                     // For large inputs this case of running out of buffer is very rare
+                     value.resize(n);
+                     auto* p = value.data();
+                     
+                     it = start;
                      while (it < end) [[likely]] {
                         *p = *it;
                         if (*it == '"') {
-                           value.assign(buffer.data(), size_t(p - buffer.data()));
+                           value.resize(size_t(p - value.data()));
                            ++it;
-                           if constexpr (not Opts.null_terminated) {
-                              if (it == end) {
-                                 ctx.error = error_code::end_reached;
-                                 return;
-                              }
-                           }
                            return;
                         }
                         else if (*it == '\\') {
                            ++it; // skip the escape
-                           if constexpr (not Opts.null_terminated) {
-                              if (it == end) [[unlikely]] {
-                                 ctx.error = error_code::unexpected_end;
-                                 return;
-                              }
-                           }
                            if (*it == 'u') {
                               ++it;
-                              if constexpr (not Opts.null_terminated) {
-                                 if (it == end) [[unlikely]] {
-                                    ctx.error = error_code::unexpected_end;
-                                    return;
-                                 }
-                              }
                               if (!handle_unicode_code_point(it, p, end)) [[unlikely]] {
                                  ctx.error = error_code::unicode_escape_conversion_failure;
                                  return;
@@ -1096,108 +1034,168 @@ namespace glz
                            ++p;
                         }
                      }
-
+                     
                      ctx.error = error_code::unexpected_end;
                   }
                }
                else {
-                  // raw_string
-                  auto start = it;
-                  skip_string_view<Opts>(ctx, it, end);
-                  if (bool(ctx.error)) [[unlikely]]
-                     return;
-
-                  value.assign(start, size_t(it - start));
-                  ++it;
-               }
-            }
-         }
-      };
-
-      template <class T>
-         requires(string_view_t<T> || char_array_t<T> || array_char_t<T> || static_string_t<T>)
-      struct from<JSON, T>
-      {
-         template <auto Opts, class It, class End>
-         GLZ_ALWAYS_INLINE static void op(auto& value, is_context auto&& ctx, It&& it, End&& end) noexcept
-         {
-            if constexpr (!has_opening_handled(Opts)) {
-               if constexpr (!has_ws_handled(Opts)) {
-                  if (skip_ws<Opts>(ctx, it, end)) {
-                     return;
+                  // For short strings
+                  
+                  std::array<char, 8> buffer{};
+                  
+                  auto* p = buffer.data();
+                  
+                  while (it < end) [[likely]] {
+                     *p = *it;
+                     if (*it == '"') {
+                        value.assign(buffer.data(), size_t(p - buffer.data()));
+                        ++it;
+                        if constexpr (not Opts.null_terminated) {
+                           if (it == end) {
+                              ctx.error = error_code::end_reached;
+                              return;
+                           }
+                        }
+                        return;
+                     }
+                     else if (*it == '\\') {
+                        ++it; // skip the escape
+                        if constexpr (not Opts.null_terminated) {
+                           if (it == end) [[unlikely]] {
+                              ctx.error = error_code::unexpected_end;
+                              return;
+                           }
+                        }
+                        if (*it == 'u') {
+                           ++it;
+                           if constexpr (not Opts.null_terminated) {
+                              if (it == end) [[unlikely]] {
+                                 ctx.error = error_code::unexpected_end;
+                                 return;
+                              }
+                           }
+                           if (!handle_unicode_code_point(it, p, end)) [[unlikely]] {
+                              ctx.error = error_code::unicode_escape_conversion_failure;
+                              return;
+                           }
+                        }
+                        else {
+                           *p = char_unescape_table[uint8_t(*it)];
+                           if (*p == 0) [[unlikely]] {
+                              ctx.error = error_code::invalid_escape;
+                              return;
+                           }
+                           ++p;
+                           ++it;
+                        }
+                     }
+                     else {
+                        ++it;
+                        ++p;
+                     }
                   }
-               }
-
-               if (match_invalid_end<'"', Opts>(ctx, it, end)) {
-                  return;
-               }
-            }
-
-            auto start = it;
-            skip_string_view<Opts>(ctx, it, end);
-            if (bool(ctx.error)) [[unlikely]]
-               return;
-
-            if constexpr (string_view_t<T>) {
-               value = {start, size_t(it - start)};
-            }
-            else if constexpr (char_array_t<T>) {
-               const size_t n = it - start;
-               if ((n + 1) > sizeof(value)) {
+                  
                   ctx.error = error_code::unexpected_end;
-                  return;
-               }
-               std::memcpy(value, start, n);
-               value[n] = '\0';
-            }
-            else if constexpr (array_char_t<T>) {
-               const size_t n = it - start;
-               if ((n + 1) > value.size()) {
-                  ctx.error = error_code::unexpected_end;
-                  return;
-               }
-               std::memcpy(value.data(), start, n);
-               value[n] = '\0';
-            }
-            else if constexpr (static_string_t<T>) {
-               const size_t n = it - start;
-               if (n > value.size()) {
-                  ctx.error = error_code::unexpected_end;
-                  return;
-               }
-               value.assign(start, n);
-            }
-            ++it; // skip closing quote
-            if constexpr (not Opts.null_terminated) {
-               if (it == end) {
-                  ctx.error = error_code::end_reached;
-                  return;
                }
             }
-         }
-      };
-
-      template <char_t T>
-      struct from<JSON, T>
-      {
-         template <auto Opts>
-         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
-         {
-            if constexpr (!has_opening_handled(Opts)) {
-               if constexpr (!has_ws_handled(Opts)) {
-                  if (skip_ws<Opts>(ctx, it, end)) {
-                     return;
-                  }
-               }
-
-               if (match_invalid_end<'"', Opts>(ctx, it, end)) {
+            else {
+               // raw_string
+               auto start = it;
+               skip_string_view<Opts>(ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]]
                   return;
-               }
-            }
-
-            if (*it == '\\') [[unlikely]] {
+               
+               value.assign(start, size_t(it - start));
                ++it;
-               switch (*it) {
+            }
+         }
+      }
+   };
+   
+   template <class T>
+   requires(string_view_t<T> || char_array_t<T> || array_char_t<T> || static_string_t<T>)
+   struct from<JSON, T>
+   {
+      template <auto Opts, class It, class End>
+      GLZ_ALWAYS_INLINE static void op(auto& value, is_context auto&& ctx, It&& it, End&& end) noexcept
+      {
+         if constexpr (!has_opening_handled(Opts)) {
+            if constexpr (!has_ws_handled(Opts)) {
+               if (skip_ws<Opts>(ctx, it, end)) {
+                  return;
+               }
+            }
+            
+            if (match_invalid_end<'"', Opts>(ctx, it, end)) {
+               return;
+            }
+         }
+         
+         auto start = it;
+         skip_string_view<Opts>(ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+         
+         if constexpr (string_view_t<T>) {
+            value = {start, size_t(it - start)};
+         }
+         else if constexpr (char_array_t<T>) {
+            const size_t n = it - start;
+            if ((n + 1) > sizeof(value)) {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+            std::memcpy(value, start, n);
+            value[n] = '\0';
+         }
+         else if constexpr (array_char_t<T>) {
+            const size_t n = it - start;
+            if ((n + 1) > value.size()) {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+            std::memcpy(value.data(), start, n);
+            value[n] = '\0';
+         }
+         else if constexpr (static_string_t<T>) {
+            const size_t n = it - start;
+            if (n > value.size()) {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+            value.assign(start, n);
+         }
+         ++it; // skip closing quote
+         if constexpr (not Opts.null_terminated) {
+            if (it == end) {
+               ctx.error = error_code::end_reached;
+               return;
+            }
+         }
+      }
+   };
+   
+   template <char_t T>
+   struct from<JSON, T>
+   {
+      template <auto Opts>
+      static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+      {
+         if constexpr (!has_opening_handled(Opts)) {
+            if constexpr (!has_ws_handled(Opts)) {
+               if (skip_ws<Opts>(ctx, it, end)) {
+                  return;
+               }
+            }
+            
+            if (match_invalid_end<'"', Opts>(ctx, it, end)) {
+               return;
+            }
+         }
+         
+         if (*it == '\\') [[unlikely]] {
+            ++it;
+            switch (*it) {
                case '\0': {
                   ctx.error = error_code::unexpected_end;
                   return;
@@ -1235,281 +1233,329 @@ namespace glz
                   ctx.error = error_code::invalid_escape;
                   return;
                }
-               }
-            }
-            else {
-               if (it == end) [[unlikely]] {
-                  ctx.error = error_code::unexpected_end;
-                  return;
-               }
-               value = *it++;
-            }
-            if constexpr (not Opts.null_terminated) {
-               if (it == end) [[unlikely]] {
-                  ctx.error = error_code::unexpected_end;
-                  return;
-               }
-            }
-            if (match<'"'>(ctx, it)) {
-               return;
-            }
-            if constexpr (not Opts.null_terminated) {
-               if (it == end) {
-                  ctx.error = error_code::end_reached;
-                  return;
-               }
             }
          }
-      };
-
-      template <class T>
-         requires((glaze_enum_t<T> || (meta_keys<T> && std::is_enum_v<T>)) && !custom_read<T>)
-      struct from<JSON, T>
-      {
-         template <auto Opts>
-         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
-         {
-            if constexpr (!has_ws_handled(Opts)) {
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-            }
-
-            constexpr auto N = reflect<T>::size;
-
-            if (*it != '"') [[unlikely]] {
-               ctx.error = error_code::expected_quote;
+         else {
+            if (it == end) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
                return;
+            }
+            value = *it++;
+         }
+         if constexpr (not Opts.null_terminated) {
+            if (it == end) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+         }
+         if (match<'"'>(ctx, it)) {
+            return;
+         }
+         if constexpr (not Opts.null_terminated) {
+            if (it == end) {
+               ctx.error = error_code::end_reached;
+               return;
+            }
+         }
+      }
+   };
+   
+   template <class T>
+   requires((glaze_enum_t<T> || (meta_keys<T> && std::is_enum_v<T>)) && !custom_read<T>)
+   struct from<JSON, T>
+   {
+      template <auto Opts>
+      static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+      {
+         if constexpr (!has_ws_handled(Opts)) {
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
+            }
+         }
+         
+         constexpr auto N = reflect<T>::size;
+         
+         if (*it != '"') [[unlikely]] {
+            ctx.error = error_code::expected_quote;
+            return;
+         }
+         ++it;
+         if constexpr (not Opts.null_terminated) {
+            if (it == end) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+         }
+         
+         if constexpr (N == 1) {
+            decode_index<Opts, T, 0>(value, ctx, it, end);
+         }
+         else {
+            static constexpr auto HashInfo = hash_info<T>;
+            
+            const auto index = decode_hash<JSON, T, HashInfo, HashInfo.type>::op(it, end);
+            
+            if (index >= N) [[unlikely]] {
+               ctx.error = error_code::unexpected_enum;
+               return;
+            }
+            
+            jump_table<N>([&]<size_t I>() { decode_index<Opts, T, I>(value, ctx, it, end); }, index);
+         }
+      }
+   };
+   
+   template <class T>
+   requires(std::is_enum_v<T> && !glaze_enum_t<T> && !meta_keys<T> && !custom_read<T>)
+   struct from<JSON, T>
+   {
+      template <auto Opts>
+      static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+      {
+         // TODO: use std::bit_cast???
+         std::underlying_type_t<std::decay_t<T>> x{};
+         parse<JSON>::op<Opts>(x, ctx, it, end);
+         value = static_cast<std::decay_t<T>>(x);
+      }
+   };
+   
+   template <func_t T>
+   struct from<JSON, T>
+   {
+      template <auto Opts>
+      static void op(auto& /*value*/, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         if constexpr (!has_ws_handled(Opts)) {
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
+            }
+         }
+         if (match_invalid_end<'"', Opts>(ctx, it, end)) {
+            return;
+         }
+         skip_string_view<Opts>(ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+         if (match<'"'>(ctx, it)) {
+            return;
+         }
+         if constexpr (not Opts.null_terminated) {
+            if (it == end) {
+               ctx.error = error_code::end_reached;
+               return;
+            }
+         }
+      }
+   };
+   
+   template <class T>
+   struct from<JSON, basic_raw_json<T>>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         auto it_start = it;
+         if (*it == 'n') {
+            match<"null", Opts>(ctx, it, end);
+         }
+         else if (is_digit(uint8_t(*it))) {
+            skip_number<Opts>(ctx, it, end);
+         }
+         else {
+            skip_value<JSON>::op<Opts>(ctx, it, end);
+         }
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+         value.str = {it_start, static_cast<size_t>(it - it_start)};
+      }
+   };
+   
+   template <class T>
+   struct from<JSON, basic_text<T>>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&& it, auto&& end)
+      {
+         value.str = {it, static_cast<size_t>(end - it)}; // read entire contents as string
+         it = end;
+      }
+   };
+   
+   // for set types
+   template <class T>
+   requires(readable_array_t<T> && !emplace_backable<T> && !resizable<T> && emplaceable<T>)
+   struct from<JSON, T>
+   {
+      template <auto Options>
+      static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         constexpr auto Opts = ws_handled_off<Options>();
+         if constexpr (!has_ws_handled(Options)) {
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
+            }
+         }
+         
+         if (match_invalid_end<'[', Opts>(ctx, it, end)) {
+            return;
+         }
+         if constexpr (not Opts.null_terminated) {
+            ++ctx.indentation_level;
+         }
+         if (skip_ws<Opts>(ctx, it, end)) {
+            return;
+         }
+         
+         value.clear();
+         if (*it == ']') [[unlikely]] {
+            if constexpr (not Opts.null_terminated) {
+               --ctx.indentation_level;
             }
             ++it;
-            if constexpr (not Opts.null_terminated) {
-               if (it == end) [[unlikely]] {
-                  ctx.error = error_code::unexpected_end;
-                  return;
-               }
-            }
-
-            if constexpr (N == 1) {
-               decode_index<Opts, T, 0>(value, ctx, it, end);
-            }
-            else {
-               static constexpr auto HashInfo = hash_info<T>;
-
-               const auto index = decode_hash<JSON, T, HashInfo, HashInfo.type>::op(it, end);
-
-               if (index >= N) [[unlikely]] {
-                  ctx.error = error_code::unexpected_enum;
-                  return;
-               }
-
-               jump_table<N>([&]<size_t I>() { decode_index<Opts, T, I>(value, ctx, it, end); }, index);
-            }
+            return;
          }
-      };
-
-      template <class T>
-         requires(std::is_enum_v<T> && !glaze_enum_t<T> && !meta_keys<T> && !custom_read<T>)
-      struct from<JSON, T>
-      {
-         template <auto Opts>
-         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
-         {
-            // TODO: use std::bit_cast???
-            std::underlying_type_t<std::decay_t<T>> x{};
-            parse<JSON>::op<Opts>(x, ctx, it, end);
-            value = static_cast<std::decay_t<T>>(x);
-         }
-      };
-
-      template <func_t T>
-      struct from<JSON, T>
-      {
-         template <auto Opts>
-         static void op(auto& /*value*/, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            if constexpr (!has_ws_handled(Opts)) {
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-            }
-            if (match_invalid_end<'"', Opts>(ctx, it, end)) {
-               return;
-            }
-            skip_string_view<Opts>(ctx, it, end);
+         
+         while (true) {
+            using V = range_value_t<T>;
+            V v;
+            parse<JSON>::op<Opts>(v, ctx, it, end);
             if (bool(ctx.error)) [[unlikely]]
                return;
-            if (match<'"'>(ctx, it)) {
-               return;
-            }
-            if constexpr (not Opts.null_terminated) {
-               if (it == end) {
-                  ctx.error = error_code::end_reached;
-                  return;
-               }
-            }
-         }
-      };
-
-      template <class T>
-      struct from<JSON, basic_raw_json<T>>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            auto it_start = it;
-            if (*it == 'n') {
-               match<"null", Opts>(ctx, it, end);
-            }
-            else if (is_digit(uint8_t(*it))) {
-               skip_number<Opts>(ctx, it, end);
-            }
-            else {
-               skip_value<JSON>::op<Opts>(ctx, it, end);
-            }
-            if (bool(ctx.error)) [[unlikely]]
-               return;
-            value.str = {it_start, static_cast<size_t>(it - it_start)};
-         }
-      };
-
-      template <class T>
-      struct from<JSON, basic_text<T>>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, auto&& it, auto&& end)
-         {
-            value.str = {it, static_cast<size_t>(end - it)}; // read entire contents as string
-            it = end;
-         }
-      };
-
-      // for set types
-      template <class T>
-         requires(readable_array_t<T> && !emplace_backable<T> && !resizable<T> && emplaceable<T>)
-      struct from<JSON, T>
-      {
-         template <auto Options>
-         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            constexpr auto Opts = ws_handled_off<Options>();
-            if constexpr (!has_ws_handled(Options)) {
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-            }
-
-            if (match_invalid_end<'[', Opts>(ctx, it, end)) {
-               return;
-            }
-            if constexpr (not Opts.null_terminated) {
-               ++ctx.indentation_level;
-            }
+            value.emplace(std::move(v));
             if (skip_ws<Opts>(ctx, it, end)) {
                return;
             }
-
-            value.clear();
-            if (*it == ']') [[unlikely]] {
-               if constexpr (not Opts.null_terminated) {
-                  --ctx.indentation_level;
-               }
-               ++it;
-               return;
-            }
-
-            while (true) {
-               using V = range_value_t<T>;
-               V v;
-               parse<JSON>::op<Opts>(v, ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]]
-                  return;
-               value.emplace(std::move(v));
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-               if (*it == ']') {
-                  if constexpr (not Opts.null_terminated) {
-                     --ctx.indentation_level;
-                  }
-                  ++it;
-                  return;
-               }
-               if (match_invalid_end<',', Opts>(ctx, it, end)) {
-                  return;
-               }
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-            }
-         }
-      };
-
-      // for types like std::vector, std::array, std::deque, etc.
-      template <class T>
-         requires(readable_array_t<T> && (emplace_backable<T> || !resizable<T>) && !emplaceable<T>)
-      struct from<JSON, T>
-      {
-         template <auto Options>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            constexpr auto Opts = ws_handled_off<Options>();
-            if constexpr (!has_ws_handled(Options)) {
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-            }
-
-            if (match_invalid_end<'[', Opts>(ctx, it, end)) {
-               return;
-            }
-            if constexpr (not Opts.null_terminated) {
-               ++ctx.indentation_level;
-            }
-
-            const auto ws_start = it;
-            if (skip_ws<Opts>(ctx, it, end)) {
-               return;
-            }
-
             if (*it == ']') {
                if constexpr (not Opts.null_terminated) {
                   --ctx.indentation_level;
                }
                ++it;
-               if constexpr (resizable<T> && not Opts.append_arrays) {
-                  value.clear();
-
-                  if constexpr (Opts.shrink_to_fit) {
-                     value.shrink_to_fit();
-                  }
-               }
                return;
             }
-
-            const size_t ws_size = size_t(it - ws_start);
-
-            static constexpr bool should_append = resizable<T> && Opts.append_arrays;
-            if constexpr (not should_append) {
-               const auto n = value.size();
-
-               auto value_it = value.begin();
-
-               for (size_t i = 0; i < n; ++i) {
-                  parse<JSON>::op<ws_handled<Opts>()>(*value_it++, ctx, it, end);
+            if (match_invalid_end<',', Opts>(ctx, it, end)) {
+               return;
+            }
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
+            }
+         }
+      }
+   };
+   
+   // for types like std::vector, std::array, std::deque, etc.
+   template <class T>
+   requires(readable_array_t<T> && (emplace_backable<T> || !resizable<T>) && !emplaceable<T>)
+   struct from<JSON, T>
+   {
+      template <auto Options>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         constexpr auto Opts = ws_handled_off<Options>();
+         if constexpr (!has_ws_handled(Options)) {
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
+            }
+         }
+         
+         if (match_invalid_end<'[', Opts>(ctx, it, end)) {
+            return;
+         }
+         if constexpr (not Opts.null_terminated) {
+            ++ctx.indentation_level;
+         }
+         
+         const auto ws_start = it;
+         if (skip_ws<Opts>(ctx, it, end)) {
+            return;
+         }
+         
+         if (*it == ']') {
+            if constexpr (not Opts.null_terminated) {
+               --ctx.indentation_level;
+            }
+            ++it;
+            if constexpr (resizable<T> && not Opts.append_arrays) {
+               value.clear();
+               
+               if constexpr (Opts.shrink_to_fit) {
+                  value.shrink_to_fit();
+               }
+            }
+            return;
+         }
+         
+         const size_t ws_size = size_t(it - ws_start);
+         
+         static constexpr bool should_append = resizable<T> && Opts.append_arrays;
+         if constexpr (not should_append) {
+            const auto n = value.size();
+            
+            auto value_it = value.begin();
+            
+            for (size_t i = 0; i < n; ++i) {
+               parse<JSON>::op<ws_handled<Opts>()>(*value_it++, ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
+               if (skip_ws<Opts>(ctx, it, end)) {
+                  return;
+               }
+               if (*it == ',') {
+                  ++it;
+                  
+                  if constexpr (!Opts.minified) {
+                     if (ws_size && ws_size < size_t(end - it)) {
+                        skip_matching_ws(ws_start, it, ws_size);
+                     }
+                  }
+                  
+                  if (skip_ws<Opts>(ctx, it, end)) {
+                     return;
+                  }
+               }
+               else if (*it == ']') {
+                  if constexpr (not Opts.null_terminated) {
+                     --ctx.indentation_level;
+                  }
+                  ++it;
+                  if constexpr (erasable<T>) {
+                     value.erase(value_it,
+                                 value.end()); // use erase rather than resize for non-default constructible elements
+                     
+                     if constexpr (Opts.shrink_to_fit) {
+                        value.shrink_to_fit();
+                     }
+                  }
+                  return;
+               }
+               else [[unlikely]] {
+                  ctx.error = error_code::expected_bracket;
+                  return;
+               }
+            }
+         }
+         
+         if constexpr (Opts.partial_read) {
+            return;
+         }
+         else {
+            // growing
+            if constexpr (emplace_backable<T>) {
+               while (it < end) {
+                  parse<JSON>::op<ws_handled<Opts>()>(value.emplace_back(), ctx, it, end);
                   if (bool(ctx.error)) [[unlikely]]
                      return;
                   if (skip_ws<Opts>(ctx, it, end)) {
                      return;
                   }
-                  if (*it == ',') {
+                  if (*it == ',') [[likely]] {
                      ++it;
-
+                     
                      if constexpr (!Opts.minified) {
                         if (ws_size && ws_size < size_t(end - it)) {
                            skip_matching_ws(ws_start, it, ws_size);
                         }
                      }
-
+                     
                      if (skip_ws<Opts>(ctx, it, end)) {
                         return;
                      }
@@ -1519,14 +1565,6 @@ namespace glz
                         --ctx.indentation_level;
                      }
                      ++it;
-                     if constexpr (erasable<T>) {
-                        value.erase(value_it,
-                                    value.end()); // use erase rather than resize for non-default constructible elements
-
-                        if constexpr (Opts.shrink_to_fit) {
-                           value.shrink_to_fit();
-                        }
-                     }
                      return;
                   }
                   else [[unlikely]] {
@@ -1535,176 +1573,136 @@ namespace glz
                   }
                }
             }
-
-            if constexpr (Opts.partial_read) {
-               return;
-            }
             else {
-               // growing
-               if constexpr (emplace_backable<T>) {
-                  while (it < end) {
-                     parse<JSON>::op<ws_handled<Opts>()>(value.emplace_back(), ctx, it, end);
-                     if (bool(ctx.error)) [[unlikely]]
-                        return;
-                     if (skip_ws<Opts>(ctx, it, end)) {
-                        return;
-                     }
-                     if (*it == ',') [[likely]] {
-                        ++it;
-
-                        if constexpr (!Opts.minified) {
-                           if (ws_size && ws_size < size_t(end - it)) {
-                              skip_matching_ws(ws_start, it, ws_size);
-                           }
-                        }
-
-                        if (skip_ws<Opts>(ctx, it, end)) {
-                           return;
-                        }
-                     }
-                     else if (*it == ']') {
-                        if constexpr (not Opts.null_terminated) {
-                           --ctx.indentation_level;
-                        }
-                        ++it;
-                        return;
-                     }
-                     else [[unlikely]] {
-                        ctx.error = error_code::expected_bracket;
-                        return;
-                     }
-                  }
-               }
-               else {
-                  ctx.error = error_code::exceeded_static_array_size;
-               }
+               ctx.error = error_code::exceeded_static_array_size;
             }
          }
-
-         // for types like std::vector<std::pair...> that can't look up with operator[]
-         // Intead of hashing or linear searching, we just clear the input and overwrite the entire contents
-         template <auto Options>
-            requires(pair_t<range_value_t<T>> && Options.concatenate == true)
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            static constexpr auto Opts = opening_handled_off<ws_handled_off<Options>()>();
-            if constexpr (!has_opening_handled(Options)) {
-               if constexpr (!has_ws_handled(Options)) {
-                  if (skip_ws<Opts>(ctx, it, end)) {
+      }
+      
+      // for types like std::vector<std::pair...> that can't look up with operator[]
+      // Intead of hashing or linear searching, we just clear the input and overwrite the entire contents
+      template <auto Options>
+      requires(pair_t<range_value_t<T>> && Options.concatenate == true)
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         static constexpr auto Opts = opening_handled_off<ws_handled_off<Options>()>();
+         if constexpr (!has_opening_handled(Options)) {
+            if constexpr (!has_ws_handled(Options)) {
+               if (skip_ws<Opts>(ctx, it, end)) {
+                  return;
+               }
+            }
+            if (match_invalid_end<'{', Opts>(ctx, it, end)) {
+               return;
+            }
+            if constexpr (not Opts.null_terminated) {
+               if (it == end) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
+            }
+            if constexpr (not Opts.null_terminated) {
+               ++ctx.indentation_level;
+            }
+         }
+         
+         // clear all contents and repopulate
+         value.clear();
+         
+         while (it < end) {
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
+            }
+            
+            if (*it == '}') {
+               ++it;
+               if constexpr (not Opts.null_terminated) {
+                  --ctx.indentation_level;
+               }
+               if constexpr (not Opts.null_terminated) {
+                  if (it == end) {
+                     ctx.error = error_code::end_reached;
                      return;
                   }
                }
-               if (match_invalid_end<'{', Opts>(ctx, it, end)) {
+               return;
+            }
+            
+            auto& item = value.emplace_back();
+            
+            using V = std::decay_t<decltype(item)>;
+            
+            if constexpr (str_t<typename V::first_type> ||
+                          (std::is_enum_v<typename V::first_type> && glaze_t<typename V::first_type>)) {
+               parse<JSON>::op<Opts>(item.first, ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]]
                   return;
+            }
+            else {
+               std::string_view key;
+               parse<JSON>::op<Opts>(key, ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
+               if constexpr (Opts.null_terminated) {
+                  parse<JSON>::op<Opts>(item.first, ctx, key.data(), key.data() + key.size());
                }
+               else {
+                  if (size_t(end - it) == key.size()) [[unlikely]] {
+                     ctx.error = error_code::unexpected_end;
+                     return;
+                  }
+                  // For the non-null terminated case we just want one more character so that we don't parse
+                  // until the end of the buffer and create an end_reached code (unless there is an error).
+                  parse<JSON>::op<Opts>(item.first, ctx, key.data(), key.data() + key.size() + 1);
+               }
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
+            }
+            
+            if (parse_ws_colon<Opts>(ctx, it, end)) {
+               return;
+            }
+            
+            parse<JSON>::op<Opts>(item.second, ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
+            
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
+            }
+            
+            if (*it == ',') {
+               ++it;
                if constexpr (not Opts.null_terminated) {
                   if (it == end) [[unlikely]] {
                      ctx.error = error_code::unexpected_end;
                      return;
                   }
                }
-               if constexpr (not Opts.null_terminated) {
-                  ++ctx.indentation_level;
-               }
             }
-
-            // clear all contents and repopulate
-            value.clear();
-
-            while (it < end) {
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-
-               if (*it == '}') {
-                  ++it;
-                  if constexpr (not Opts.null_terminated) {
-                     --ctx.indentation_level;
-                  }
-                  if constexpr (not Opts.null_terminated) {
-                     if (it == end) {
-                        ctx.error = error_code::end_reached;
-                        return;
-                     }
-                  }
-                  return;
-               }
-
-               auto& item = value.emplace_back();
-
-               using V = std::decay_t<decltype(item)>;
-
-               if constexpr (str_t<typename V::first_type> ||
-                             (std::is_enum_v<typename V::first_type> && glaze_t<typename V::first_type>)) {
-                  parse<JSON>::op<Opts>(item.first, ctx, it, end);
-                  if (bool(ctx.error)) [[unlikely]]
-                     return;
-               }
-               else {
-                  std::string_view key;
-                  parse<JSON>::op<Opts>(key, ctx, it, end);
-                  if (bool(ctx.error)) [[unlikely]]
-                     return;
-                  if constexpr (Opts.null_terminated) {
-                     parse<JSON>::op<Opts>(item.first, ctx, key.data(), key.data() + key.size());
-                  }
-                  else {
-                     if (size_t(end - it) == key.size()) [[unlikely]] {
-                        ctx.error = error_code::unexpected_end;
-                        return;
-                     }
-                     // For the non-null terminated case we just want one more character so that we don't parse
-                     // until the end of the buffer and create an end_reached code (unless there is an error).
-                     parse<JSON>::op<Opts>(item.first, ctx, key.data(), key.data() + key.size() + 1);
-                  }
-                  if (bool(ctx.error)) [[unlikely]]
-                     return;
-               }
-
-               if (parse_ws_colon<Opts>(ctx, it, end)) {
-                  return;
-               }
-
-               parse<JSON>::op<Opts>(item.second, ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]]
-                  return;
-
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-
-               if (*it == ',') {
-                  ++it;
-                  if constexpr (not Opts.null_terminated) {
-                     if (it == end) [[unlikely]] {
-                        ctx.error = error_code::unexpected_end;
-                        return;
-                     }
-                  }
-               }
-            }
-
-            ctx.error = error_code::unexpected_end;
          }
-      };
-
-      // counts the number of JSON array elements
-      // needed for classes that are resizable, but do not have an emplace_back
-      // 'it' is copied so that it does not actually progress the iterator
-      // expects the opening brace ([) to have already been consumed
-      template <auto Opts>
-      [[nodiscard]] size_t number_of_array_elements(is_context auto&& ctx, auto it, auto&& end) noexcept
-      {
-         skip_ws<Opts>(ctx, it, end);
-         if (bool(ctx.error)) [[unlikely]]
-            return {};
-
-         if (*it == ']') [[unlikely]] {
-            return 0;
-         }
-         size_t count = 1;
-         while (true) {
-            switch (*it) {
+         
+         ctx.error = error_code::unexpected_end;
+      }
+   };
+   
+   // counts the number of JSON array elements
+   // needed for classes that are resizable, but do not have an emplace_back
+   // 'it' is copied so that it does not actually progress the iterator
+   // expects the opening brace ([) to have already been consumed
+   template <auto Opts>
+   [[nodiscard]] size_t number_of_array_elements(is_context auto&& ctx, auto it, auto&& end) noexcept
+   {
+      skip_ws<Opts>(ctx, it, end);
+      if (bool(ctx.error)) [[unlikely]]
+         return {};
+      
+      if (*it == ']') [[unlikely]] {
+         return 0;
+      }
+      size_t count = 1;
+      while (true) {
+         switch (*it) {
             case ',': {
                ++count;
                ++it;
@@ -1743,334 +1741,136 @@ namespace glz
             }
             default:
                ++it;
-            }
          }
-         unreachable();
       }
-
-      // For types like std::forward_list
-      template <class T>
-         requires readable_array_t<T> && (!emplace_backable<T> && resizable<T>)
-      struct from<JSON, T>
+      unreachable();
+   }
+   
+   // For types like std::forward_list
+   template <class T>
+   requires readable_array_t<T> && (!emplace_backable<T> && resizable<T>)
+   struct from<JSON, T>
+   {
+      template <auto Options>
+      static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
       {
-         template <auto Options>
-         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            constexpr auto Opts = ws_handled_off<Options>();
-            if constexpr (!has_ws_handled(Options)) {
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-            }
-
-            if (match_invalid_end<'[', Opts>(ctx, it, end)) {
-               return;
-            }
-            if constexpr (not Opts.null_terminated) {
-               ++ctx.indentation_level;
-            }
-            const auto n = number_of_array_elements<Opts>(ctx, it, end);
-            if (bool(ctx.error)) [[unlikely]]
-               return;
-            value.resize(n);
-            size_t i = 0;
-            for (auto& x : value) {
-               parse<JSON>::op<Opts>(x, ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]]
-                  return;
-
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-               if (i < n - 1) {
-                  if (match_invalid_end<',', Opts>(ctx, it, end)) {
-                     return;
-                  }
-               }
-               ++i;
-            }
-            match<']'>(ctx, it);
-            if constexpr (not Opts.null_terminated) {
-               --ctx.indentation_level;
-            }
-         }
-      };
-
-      template <class T>
-         requires glaze_array_t<T> || tuple_t<T> || is_std_tuple<T>
-      struct from<JSON, T>
-      {
-         template <auto Opts>
-         static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            static constexpr auto N = []() constexpr {
-               if constexpr (glaze_array_t<T>) {
-                  return reflect<T>::size;
-               }
-               else {
-                  return glz::tuple_size_v<T>;
-               }
-            }();
-
-            if constexpr (!has_ws_handled(Opts)) {
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-            }
-
-            if (match_invalid_end<'[', Opts>(ctx, it, end)) {
-               return;
-            }
-            if constexpr (not Opts.null_terminated) {
-               ++ctx.indentation_level;
-            }
+         constexpr auto Opts = ws_handled_off<Options>();
+         if constexpr (!has_ws_handled(Options)) {
             if (skip_ws<Opts>(ctx, it, end)) {
                return;
             }
-
-            invoke_table<N>([&]<size_t I>() {
-               if (bool(ctx.error)) [[unlikely]]
-                  return;
-
-               if (*it == ']') {
-                  if constexpr (not Opts.null_terminated) {
-                     --ctx.indentation_level;
-                  }
-                  return;
-               }
-               if constexpr (I != 0) {
-                  if (match_invalid_end<',', Opts>(ctx, it, end)) {
-                     return;
-                  }
-                  if (skip_ws<Opts>(ctx, it, end)) {
-                     return;
-                  }
-               }
-               if constexpr (is_std_tuple<T>) {
-                  parse<JSON>::op<ws_handled<Opts>()>(std::get<I>(value), ctx, it, end);
-                  if (bool(ctx.error)) [[unlikely]]
-                     return;
-               }
-               else if constexpr (glaze_array_t<T>) {
-                  parse<JSON>::op<ws_handled<Opts>()>(get_member(value, glz::get<I>(meta_v<T>)), ctx, it, end);
-                  if (bool(ctx.error)) [[unlikely]]
-                     return;
-               }
-               else {
-                  parse<JSON>::op<ws_handled<Opts>()>(glz::get<I>(value), ctx, it, end);
-                  if (bool(ctx.error)) [[unlikely]]
-                     return;
-               }
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-            });
-
-            if constexpr (Opts.partial_read) {
-               return;
-            }
-            else {
-               if (bool(ctx.error)) [[unlikely]]
-                  return;
-               match<']'>(ctx, it);
-               if constexpr (not Opts.null_terminated) {
-                  --ctx.indentation_level;
-               }
-               if constexpr (not Opts.null_terminated) {
-                  if (it == end) {
-                     ctx.error = error_code::end_reached;
-                     return;
-                  }
-               }
-            }
          }
-      };
-
-      template <glaze_flags_t T>
-      struct from<JSON, T>
-      {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            if constexpr (!has_ws_handled(Opts)) {
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-            }
-
-            if (match_invalid_end<'[', Opts>(ctx, it, end)) {
+         
+         if (match_invalid_end<'[', Opts>(ctx, it, end)) {
+            return;
+         }
+         if constexpr (not Opts.null_terminated) {
+            ++ctx.indentation_level;
+         }
+         const auto n = number_of_array_elements<Opts>(ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+         value.resize(n);
+         size_t i = 0;
+         for (auto& x : value) {
+            parse<JSON>::op<Opts>(x, ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
+            
+            if (skip_ws<Opts>(ctx, it, end)) {
                return;
             }
-            if constexpr (not Opts.null_terminated) {
-               ++ctx.indentation_level;
-            }
-
-            std::string& s = string_buffer();
-
-            constexpr auto& HashInfo = detail::hash_info<T>;
-            static_assert(bool(HashInfo.type));
-
-            while (true) {
-               parse<JSON>::op<ws_handled_off<Opts>()>(s, ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]]
-                  return;
-
-               const auto index =
-                  decode_hash_with_size<JSON, T, HashInfo, HashInfo.type>::op(s.data(), s.data() + s.size(), s.size());
-
-               constexpr auto N = reflect<T>::size;
-               if (index < N) [[likely]] {
-                  visit<N>([&]<size_t I>() { get_member(value, get<I>(reflect<T>::values)) = true; }, index);
-               }
-               else [[unlikely]] {
-                  ctx.error = error_code::invalid_flag_input;
-                  return;
-               }
-
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-               if (*it == ']') {
-                  if constexpr (not Opts.null_terminated) {
-                     --ctx.indentation_level;
-                  }
-                  ++it;
-                  if constexpr (not Opts.null_terminated) {
-                     if (it == end) {
-                        ctx.error = error_code::end_reached;
-                        return;
-                     }
-                  }
-                  return;
-               }
+            if (i < n - 1) {
                if (match_invalid_end<',', Opts>(ctx, it, end)) {
                   return;
                }
             }
+            ++i;
          }
-      };
-
-      template <class T>
-      struct from<JSON, includer<T>>
-      {
-         template <auto Options>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            constexpr auto Opts = ws_handled_off<Options>();
-            std::string buffer{};
-            parse<JSON>::op<Opts>(buffer, ctx, it, end);
-            if (bool(ctx.error)) [[unlikely]]
-               return;
-
-            const auto file_path = relativize_if_not_absolute(std::filesystem::path(ctx.current_file).parent_path(),
-                                                              std::filesystem::path{buffer});
-
-            const auto string_file_path = file_path.string();
-            const auto ec = file_to_buffer(buffer, string_file_path);
-
-            if (bool(ec)) [[unlikely]] {
-               ctx.error = error_code::includer_error;
-               auto& error_msg = error_buffer();
-               error_msg = "file failed to open: " + string_file_path;
-               ctx.includer_error = error_msg;
-               return;
-            }
-
-            const auto current_file = ctx.current_file;
-            ctx.current_file = string_file_path;
-
-            // We need to allocate a new buffer here because we could call another includer that uses the buffer
-            std::string nested_buffer = buffer;
-            static constexpr auto NestedOpts = opt_true<disable_padding_on<Opts>(), &opts::null_terminated>;
-            const auto ecode = glz::read<NestedOpts>(value.value, nested_buffer, ctx);
-            if (bool(ctx.error)) [[unlikely]] {
-               ctx.error = error_code::includer_error;
-               auto& error_msg = error_buffer();
-               error_msg = glz::format_error(ecode, nested_buffer);
-               ctx.includer_error = error_msg;
-               return;
-            }
-
-            ctx.current_file = current_file;
+         match<']'>(ctx, it);
+         if constexpr (not Opts.null_terminated) {
+            --ctx.indentation_level;
          }
-      };
-
-      template <pair_t T>
-      struct from<JSON, T>
+      }
+   };
+   
+   template <class T>
+   requires glaze_array_t<T> || tuple_t<T> || is_std_tuple<T>
+   struct from<JSON, T>
+   {
+      template <auto Opts>
+      static void op(auto& value, is_context auto&& ctx, auto&& it, auto&& end)
       {
-         template <opts Options, string_literal tag = "">
-         static void op(T& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            constexpr auto Opts = opening_handled_off<ws_handled_off<Options>()>();
-            if constexpr (!has_opening_handled(Options)) {
-               if constexpr (!has_ws_handled(Options)) {
-                  if (skip_ws<Opts>(ctx, it, end)) {
-                     return;
-                  }
-               }
-               if (match_invalid_end<'{', Opts>(ctx, it, end)) {
-                  return;
-               }
-               if constexpr (not Opts.null_terminated) {
-                  ++ctx.indentation_level;
-               }
+         static constexpr auto N = []() constexpr {
+            if constexpr (glaze_array_t<T>) {
+               return reflect<T>::size;
             }
+            else {
+               return glz::tuple_size_v<T>;
+            }
+         }();
+         
+         if constexpr (!has_ws_handled(Opts)) {
             if (skip_ws<Opts>(ctx, it, end)) {
                return;
             }
-
-            // Only used if error_on_missing_keys = true
-            [[maybe_unused]] bit_array<1> fields{};
-
-            if (*it == '}') {
+         }
+         
+         if (match_invalid_end<'[', Opts>(ctx, it, end)) {
+            return;
+         }
+         if constexpr (not Opts.null_terminated) {
+            ++ctx.indentation_level;
+         }
+         if (skip_ws<Opts>(ctx, it, end)) {
+            return;
+         }
+         
+         invoke_table<N>([&]<size_t I>() {
+            if (bool(ctx.error)) [[unlikely]]
+               return;
+            
+            if (*it == ']') {
                if constexpr (not Opts.null_terminated) {
                   --ctx.indentation_level;
                }
-               if constexpr (Opts.error_on_missing_keys) {
-                  ctx.error = error_code::missing_key;
-               }
                return;
             }
-
-            if constexpr (str_t<typename T::first_type>) {
-               parse<JSON>::op<Opts>(value.first, ctx, it, end);
+            if constexpr (I != 0) {
+               if (match_invalid_end<',', Opts>(ctx, it, end)) {
+                  return;
+               }
+               if (skip_ws<Opts>(ctx, it, end)) {
+                  return;
+               }
+            }
+            if constexpr (is_std_tuple<T>) {
+               parse<JSON>::op<ws_handled<Opts>()>(std::get<I>(value), ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
+            }
+            else if constexpr (glaze_array_t<T>) {
+               parse<JSON>::op<ws_handled<Opts>()>(get_member(value, glz::get<I>(meta_v<T>)), ctx, it, end);
                if (bool(ctx.error)) [[unlikely]]
                   return;
             }
             else {
-               std::string_view key;
-               parse<JSON>::op<Opts>(key, ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]]
-                  return;
-               if constexpr (Opts.null_terminated) {
-                  parse<JSON>::op<Opts>(value.first, ctx, key.data(), key.data() + key.size());
-               }
-               else {
-                  if (size_t(end - it) == key.size()) [[unlikely]] {
-                     ctx.error = error_code::unexpected_end;
-                     return;
-                  }
-                  // For the non-null terminated case we just want one more character so that we don't parse
-                  // until the end of the buffer and create an end_reached code (unless there is an error).
-                  parse<JSON>::op<Opts>(value.first, ctx, key.data(), key.data() + key.size() + 1);
-               }
+               parse<JSON>::op<ws_handled<Opts>()>(glz::get<I>(value), ctx, it, end);
                if (bool(ctx.error)) [[unlikely]]
                   return;
             }
-
-            if (parse_ws_colon<Opts>(ctx, it, end)) {
-               return;
-            }
-
-            parse<JSON>::op<Opts>(value.second, ctx, it, end);
-            if (bool(ctx.error)) [[unlikely]]
-               return;
-
             if (skip_ws<Opts>(ctx, it, end)) {
                return;
             }
-
-            match<'}'>(ctx, it);
+         });
+         
+         if constexpr (Opts.partial_read) {
+            return;
+         }
+         else {
+            if (bool(ctx.error)) [[unlikely]]
+               return;
+            match<']'>(ctx, it);
             if constexpr (not Opts.null_terminated) {
                --ctx.indentation_level;
             }
@@ -2081,66 +1881,414 @@ namespace glz
                }
             }
          }
-      };
-
-      template <class T, string_literal Tag>
-      inline consteval bool contains_tag()
+      }
+   };
+   
+   template <glaze_flags_t T>
+   struct from<JSON, T>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
       {
-         auto& keys = reflect<T>::keys;
-         for (size_t i = 0; i < keys.size(); ++i) {
-            if (Tag.sv() == keys[i]) {
-               return true;
+         if constexpr (!has_ws_handled(Opts)) {
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
             }
          }
-         return false;
+         
+         if (match_invalid_end<'[', Opts>(ctx, it, end)) {
+            return;
+         }
+         if constexpr (not Opts.null_terminated) {
+            ++ctx.indentation_level;
+         }
+         
+         std::string& s = string_buffer();
+         
+         constexpr auto& HashInfo = hash_info<T>;
+         static_assert(bool(HashInfo.type));
+         
+         while (true) {
+            parse<JSON>::op<ws_handled_off<Opts>()>(s, ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
+            
+            const auto index =
+            decode_hash_with_size<JSON, T, HashInfo, HashInfo.type>::op(s.data(), s.data() + s.size(), s.size());
+            
+            constexpr auto N = reflect<T>::size;
+            if (index < N) [[likely]] {
+               visit<N>([&]<size_t I>() { get_member(value, get<I>(reflect<T>::values)) = true; }, index);
+            }
+            else [[unlikely]] {
+               ctx.error = error_code::invalid_flag_input;
+               return;
+            }
+            
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
+            }
+            if (*it == ']') {
+               if constexpr (not Opts.null_terminated) {
+                  --ctx.indentation_level;
+               }
+               ++it;
+               if constexpr (not Opts.null_terminated) {
+                  if (it == end) {
+                     ctx.error = error_code::end_reached;
+                     return;
+                  }
+               }
+               return;
+            }
+            if (match_invalid_end<',', Opts>(ctx, it, end)) {
+               return;
+            }
+         }
       }
-
-      template <class T>
-         requires readable_map_t<T> || glaze_object_t<T> || reflectable<T>
-      struct from<JSON, T>
+   };
+   
+   template <class T>
+   struct from<JSON, includer<T>>
+   {
+      template <auto Options>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
       {
-         template <auto Options, string_literal tag = "">
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            static constexpr auto num_members = reflect<T>::size;
-
-            static constexpr auto Opts = opening_handled_off<ws_handled_off<Options>()>();
-            if constexpr (!has_opening_handled(Options)) {
-               if constexpr (!has_ws_handled(Options)) {
+         constexpr auto Opts = ws_handled_off<Options>();
+         std::string buffer{};
+         parse<JSON>::op<Opts>(buffer, ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+         
+         const auto file_path = relativize_if_not_absolute(std::filesystem::path(ctx.current_file).parent_path(),
+                                                           std::filesystem::path{buffer});
+         
+         const auto string_file_path = file_path.string();
+         const auto ec = file_to_buffer(buffer, string_file_path);
+         
+         if (bool(ec)) [[unlikely]] {
+            ctx.error = error_code::includer_error;
+            auto& error_msg = error_buffer();
+            error_msg = "file failed to open: " + string_file_path;
+            ctx.includer_error = error_msg;
+            return;
+         }
+         
+         const auto current_file = ctx.current_file;
+         ctx.current_file = string_file_path;
+         
+         // We need to allocate a new buffer here because we could call another includer that uses the buffer
+         std::string nested_buffer = buffer;
+         static constexpr auto NestedOpts = opt_true<disable_padding_on<Opts>(), &opts::null_terminated>;
+         const auto ecode = glz::read<NestedOpts>(value.value, nested_buffer, ctx);
+         if (bool(ctx.error)) [[unlikely]] {
+            ctx.error = error_code::includer_error;
+            auto& error_msg = error_buffer();
+            error_msg = glz::format_error(ecode, nested_buffer);
+            ctx.includer_error = error_msg;
+            return;
+         }
+         
+         ctx.current_file = current_file;
+      }
+   };
+   
+   template <pair_t T>
+   struct from<JSON, T>
+   {
+      template <opts Options, string_literal tag = "">
+      static void op(T& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         constexpr auto Opts = opening_handled_off<ws_handled_off<Options>()>();
+         if constexpr (!has_opening_handled(Options)) {
+            if constexpr (!has_ws_handled(Options)) {
+               if (skip_ws<Opts>(ctx, it, end)) {
+                  return;
+               }
+            }
+            if (match_invalid_end<'{', Opts>(ctx, it, end)) {
+               return;
+            }
+            if constexpr (not Opts.null_terminated) {
+               ++ctx.indentation_level;
+            }
+         }
+         if (skip_ws<Opts>(ctx, it, end)) {
+            return;
+         }
+         
+         // Only used if error_on_missing_keys = true
+         [[maybe_unused]] bit_array<1> fields{};
+         
+         if (*it == '}') {
+            if constexpr (not Opts.null_terminated) {
+               --ctx.indentation_level;
+            }
+            if constexpr (Opts.error_on_missing_keys) {
+               ctx.error = error_code::missing_key;
+            }
+            return;
+         }
+         
+         if constexpr (str_t<typename T::first_type>) {
+            parse<JSON>::op<Opts>(value.first, ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
+         }
+         else {
+            std::string_view key;
+            parse<JSON>::op<Opts>(key, ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
+            if constexpr (Opts.null_terminated) {
+               parse<JSON>::op<Opts>(value.first, ctx, key.data(), key.data() + key.size());
+            }
+            else {
+               if (size_t(end - it) == key.size()) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
+               // For the non-null terminated case we just want one more character so that we don't parse
+               // until the end of the buffer and create an end_reached code (unless there is an error).
+               parse<JSON>::op<Opts>(value.first, ctx, key.data(), key.data() + key.size() + 1);
+            }
+            if (bool(ctx.error)) [[unlikely]]
+               return;
+         }
+         
+         if (parse_ws_colon<Opts>(ctx, it, end)) {
+            return;
+         }
+         
+         parse<JSON>::op<Opts>(value.second, ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+         
+         if (skip_ws<Opts>(ctx, it, end)) {
+            return;
+         }
+         
+         match<'}'>(ctx, it);
+         if constexpr (not Opts.null_terminated) {
+            --ctx.indentation_level;
+         }
+         if constexpr (not Opts.null_terminated) {
+            if (it == end) {
+               ctx.error = error_code::end_reached;
+               return;
+            }
+         }
+      }
+   };
+   
+   template <class T, string_literal Tag>
+   inline consteval bool contains_tag()
+   {
+      auto& keys = reflect<T>::keys;
+      for (size_t i = 0; i < keys.size(); ++i) {
+         if (Tag.sv() == keys[i]) {
+            return true;
+         }
+      }
+      return false;
+   }
+   
+   template <class T>
+   requires readable_map_t<T> || glaze_object_t<T> || reflectable<T>
+   struct from<JSON, T>
+   {
+      template <auto Options, string_literal tag = "">
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         static constexpr auto num_members = reflect<T>::size;
+         
+         static constexpr auto Opts = opening_handled_off<ws_handled_off<Options>()>();
+         if constexpr (!has_opening_handled(Options)) {
+            if constexpr (!has_ws_handled(Options)) {
+               if (skip_ws<Opts>(ctx, it, end)) {
+                  return;
+               }
+            }
+            if (match_invalid_end<'{', Opts>(ctx, it, end)) {
+               return;
+            }
+            if constexpr (not Opts.null_terminated) {
+               if (it == end) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
+            }
+            if constexpr (not Opts.null_terminated) {
+               ++ctx.indentation_level;
+            }
+         }
+         const auto ws_start = it;
+         if (skip_ws<Opts>(ctx, it, end)) {
+            return;
+         }
+         const size_t ws_size = size_t(it - ws_start);
+         
+         if constexpr ((glaze_object_t<T> || reflectable<T>)&&num_members == 0 && Opts.error_on_unknown_keys) {
+            if constexpr (not tag.sv().empty()) {
+               if (*it == '"') {
+                  ++it;
+                  if constexpr (not Opts.null_terminated) {
+                     if (it == end) [[unlikely]] {
+                        ctx.error = error_code::unexpected_end;
+                        return;
+                     }
+                  }
+                  
+                  const auto start = it;
+                  skip_string_view<Opts>(ctx, it, end);
+                  if (bool(ctx.error)) [[unlikely]]
+                     return;
+                  const sv key{start, size_t(it - start)};
+                  ++it;
+                  if constexpr (not Opts.null_terminated) {
+                     if (it == end) [[unlikely]] {
+                        ctx.error = error_code::unexpected_end;
+                        return;
+                     }
+                  }
+                  
+                  if (key == tag.sv()) {
+                     if (parse_ws_colon<Opts>(ctx, it, end)) {
+                        return;
+                     }
+                     
+                     parse<JSON>::handle_unknown<Opts>(key, value, ctx, it, end);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                     
+                     if (skip_ws<Opts>(ctx, it, end)) {
+                        return;
+                     }
+                  }
+                  else {
+                     ctx.error = error_code::unknown_key;
+                     return;
+                  }
+               }
+            }
+            
+            if (*it == '}') [[likely]] {
+               if constexpr (not Opts.null_terminated) {
+                  --ctx.indentation_level;
+               }
+               ++it;
+               if constexpr (not Opts.null_terminated) {
+                  if (it == end) {
+                     ctx.error = error_code::end_reached;
+                     return;
+                  }
+               }
+               if constexpr (Opts.partial_read) {
+                  ctx.error = error_code::partial_read_complete;
+               }
+               return;
+            }
+            ctx.error = error_code::unknown_key;
+            return;
+         }
+         else {
+            decltype(auto) fields = [&]() -> decltype(auto) {
+               if constexpr ((glaze_object_t<T> || reflectable<T>)&&(Opts.error_on_missing_keys ||
+                                                                     Opts.partial_read)) {
+                  return bit_array<num_members>{};
+               }
+               else {
+                  return nullptr;
+               }
+            }();
+            
+            size_t read_count{}; // for partial_read
+            
+            bool first = true;
+            while (true) {
+               if constexpr ((glaze_object_t<T> || reflectable<T>)&&Opts.partial_read) {
+                  static constexpr bit_array<num_members> all_fields = [] {
+                     bit_array<num_members> arr{};
+                     for (size_t i = 0; i < num_members; ++i) {
+                        arr[i] = true;
+                     }
+                     return arr;
+                  }();
+                  
+                  if ((all_fields & fields) == all_fields) {
+                     ctx.error = error_code::partial_read_complete;
+                     return;
+                  }
+               }
+               
+               if (*it == '}') {
+                  if constexpr (not Opts.null_terminated) {
+                     --ctx.indentation_level;
+                  }
+                  if constexpr ((glaze_object_t<T> ||
+                                 reflectable<T>)&&(Opts.partial_read && Opts.error_on_missing_keys)) {
+                     ctx.error = error_code::missing_key;
+                     return;
+                  }
+                  else {
+                     ++it;
+                     if constexpr ((glaze_object_t<T> || reflectable<T>)&&Opts.error_on_missing_keys) {
+                        constexpr auto req_fields = required_fields<T, Opts>();
+                        if ((req_fields & fields) != req_fields) {
+                           ctx.error = error_code::missing_key;
+                           return;
+                        }
+                     }
+                     if constexpr (not Opts.null_terminated) {
+                        if (it == end) {
+                           ctx.error = error_code::end_reached;
+                           return;
+                        }
+                     }
+                  }
+                  return;
+               }
+               else if (first) {
+                  first = false;
+               }
+               else {
+                  if (match_invalid_end<',', Opts>(ctx, it, end)) {
+                     return;
+                  }
+                  if constexpr (not Opts.null_terminated) {
+                     if (it == end) [[unlikely]] {
+                        ctx.error = error_code::unexpected_end;
+                        return;
+                     }
+                  }
+                  
+                  if constexpr ((not Opts.minified) && (num_members > 1 || not Opts.error_on_unknown_keys)) {
+                     if (ws_size && ws_size < size_t(end - it)) {
+                        skip_matching_ws(ws_start, it, ws_size);
+                     }
+                  }
+                  
                   if (skip_ws<Opts>(ctx, it, end)) {
                      return;
                   }
                }
-               if (match_invalid_end<'{', Opts>(ctx, it, end)) {
-                  return;
-               }
-               if constexpr (not Opts.null_terminated) {
-                  if (it == end) [[unlikely]] {
-                     ctx.error = error_code::unexpected_end;
-                     return;
+               
+               constexpr auto reflection_type = glaze_object_t<T> || reflectable<T>;
+               
+               if constexpr (reflection_type && (num_members == 0)) {
+                  if constexpr (Opts.error_on_unknown_keys) {
+                     static_assert(false_v<T>, "This should be unreachable");
                   }
-               }
-               if constexpr (not Opts.null_terminated) {
-                  ++ctx.indentation_level;
-               }
-            }
-            const auto ws_start = it;
-            if (skip_ws<Opts>(ctx, it, end)) {
-               return;
-            }
-            const size_t ws_size = size_t(it - ws_start);
-
-            if constexpr ((glaze_object_t<T> || reflectable<T>)&&num_members == 0 && Opts.error_on_unknown_keys) {
-               if constexpr (not tag.sv().empty()) {
-                  if (*it == '"') {
-                     ++it;
-                     if constexpr (not Opts.null_terminated) {
-                        if (it == end) [[unlikely]] {
-                           ctx.error = error_code::unexpected_end;
-                           return;
-                        }
+                  else {
+                     if (match_invalid_end<'"', Opts>(ctx, it, end)) {
+                        return;
                      }
-
+                     
+                     // parsing to an empty object, but at this point the JSON presents keys
+                     
+                     // Unknown key handler does not unescape keys. Unknown escaped keys are
+                     // handled by the user.
+                     
                      const auto start = it;
                      skip_string_view<Opts>(ctx, it, end);
                      if (bool(ctx.error)) [[unlikely]]
@@ -2153,179 +2301,46 @@ namespace glz
                            return;
                         }
                      }
-
-                     if (key == tag.sv()) {
-                        if (parse_ws_colon<Opts>(ctx, it, end)) {
-                           return;
-                        }
-
-                        parse<JSON>::handle_unknown<Opts>(key, value, ctx, it, end);
-                        if (bool(ctx.error)) [[unlikely]]
-                           return;
-
-                        if (skip_ws<Opts>(ctx, it, end)) {
-                           return;
-                        }
-                     }
-                     else {
-                        ctx.error = error_code::unknown_key;
+                     
+                     if (parse_ws_colon<Opts>(ctx, it, end)) {
                         return;
                      }
-                  }
-               }
-
-               if (*it == '}') [[likely]] {
-                  if constexpr (not Opts.null_terminated) {
-                     --ctx.indentation_level;
-                  }
-                  ++it;
-                  if constexpr (not Opts.null_terminated) {
-                     if (it == end) {
-                        ctx.error = error_code::end_reached;
+                     
+                     parse<JSON>::handle_unknown<Opts>(key, value, ctx, it, end);
+                     if (bool(ctx.error)) [[unlikely]]
                         return;
-                     }
-                  }
-                  if constexpr (Opts.partial_read) {
-                     ctx.error = error_code::partial_read_complete;
-                  }
-                  return;
-               }
-               ctx.error = error_code::unknown_key;
-               return;
-            }
-            else {
-               decltype(auto) fields = [&]() -> decltype(auto) {
-                  if constexpr ((glaze_object_t<T> || reflectable<T>)&&(Opts.error_on_missing_keys ||
-                                                                        Opts.partial_read)) {
-                     return bit_array<num_members>{};
-                  }
-                  else {
-                     return nullptr;
-                  }
-               }();
-
-               size_t read_count{}; // for partial_read
-
-               bool first = true;
-               while (true) {
-                  if constexpr ((glaze_object_t<T> || reflectable<T>)&&Opts.partial_read) {
-                     static constexpr bit_array<num_members> all_fields = [] {
-                        bit_array<num_members> arr{};
-                        for (size_t i = 0; i < num_members; ++i) {
-                           arr[i] = true;
-                        }
-                        return arr;
-                     }();
-
-                     if ((all_fields & fields) == all_fields) {
-                        ctx.error = error_code::partial_read_complete;
-                        return;
-                     }
-                  }
-
-                  if (*it == '}') {
-                     if constexpr (not Opts.null_terminated) {
-                        --ctx.indentation_level;
-                     }
-                     if constexpr ((glaze_object_t<T> ||
-                                    reflectable<T>)&&(Opts.partial_read && Opts.error_on_missing_keys)) {
-                        ctx.error = error_code::missing_key;
-                        return;
-                     }
-                     else {
-                        ++it;
-                        if constexpr ((glaze_object_t<T> || reflectable<T>)&&Opts.error_on_missing_keys) {
-                           constexpr auto req_fields = required_fields<T, Opts>();
-                           if ((req_fields & fields) != req_fields) {
-                              ctx.error = error_code::missing_key;
-                              return;
-                           }
-                        }
-                        if constexpr (not Opts.null_terminated) {
-                           if (it == end) {
-                              ctx.error = error_code::end_reached;
-                              return;
-                           }
-                        }
-                     }
-                     return;
-                  }
-                  else if (first) {
-                     first = false;
-                  }
-                  else {
-                     if (match_invalid_end<',', Opts>(ctx, it, end)) {
-                        return;
-                     }
                      if constexpr (not Opts.null_terminated) {
                         if (it == end) [[unlikely]] {
                            ctx.error = error_code::unexpected_end;
                            return;
                         }
                      }
-
-                     if constexpr ((not Opts.minified) && (num_members > 1 || not Opts.error_on_unknown_keys)) {
-                        if (ws_size && ws_size < size_t(end - it)) {
-                           skip_matching_ws(ws_start, it, ws_size);
-                        }
-                     }
-
-                     if (skip_ws<Opts>(ctx, it, end)) {
+                  }
+               }
+               else if constexpr (reflection_type) {
+                  static_assert(bool(hash_info<T>.type));
+                  
+                  if (*it != '"') [[unlikely]] {
+                     ctx.error = error_code::expected_quote;
+                     return;
+                  }
+                  ++it;
+                  if constexpr (not Opts.null_terminated) {
+                     if (it == end) [[unlikely]] {
+                        ctx.error = error_code::unexpected_end;
                         return;
                      }
                   }
-
-                  constexpr auto reflection_type = glaze_object_t<T> || reflectable<T>;
-
-                  if constexpr (reflection_type && (num_members == 0)) {
-                     if constexpr (Opts.error_on_unknown_keys) {
-                        static_assert(false_v<T>, "This should be unreachable");
-                     }
-                     else {
-                        if (match_invalid_end<'"', Opts>(ctx, it, end)) {
-                           return;
-                        }
-
-                        // parsing to an empty object, but at this point the JSON presents keys
-
-                        // Unknown key handler does not unescape keys. Unknown escaped keys are
-                        // handled by the user.
-
-                        const auto start = it;
-                        skip_string_view<Opts>(ctx, it, end);
-                        if (bool(ctx.error)) [[unlikely]]
-                           return;
-                        const sv key{start, size_t(it - start)};
-                        ++it;
-                        if constexpr (not Opts.null_terminated) {
-                           if (it == end) [[unlikely]] {
-                              ctx.error = error_code::unexpected_end;
-                              return;
-                           }
-                        }
-
-                        if (parse_ws_colon<Opts>(ctx, it, end)) {
-                           return;
-                        }
-
-                        parse<JSON>::handle_unknown<Opts>(key, value, ctx, it, end);
-                        if (bool(ctx.error)) [[unlikely]]
-                           return;
-                        if constexpr (not Opts.null_terminated) {
-                           if (it == end) [[unlikely]] {
-                              ctx.error = error_code::unexpected_end;
-                              return;
-                           }
-                        }
-                     }
-                  }
-                  else if constexpr (reflection_type) {
-                     static_assert(bool(hash_info<T>.type));
-
-                     if (*it != '"') [[unlikely]] {
-                        ctx.error = error_code::expected_quote;
+                  
+                  if constexpr (not tag.sv().empty() && not contains_tag<T, tag>()) {
+                     // For tagged variants we first check to see if the key matches the tag
+                     // We only need to do this if the tag is not part of the keys
+                     
+                     const auto start = it;
+                     skip_string_view<Opts>(ctx, it, end);
+                     if (bool(ctx.error)) [[unlikely]]
                         return;
-                     }
+                     const sv key{start, size_t(it - start)};
                      ++it;
                      if constexpr (not Opts.null_terminated) {
                         if (it == end) [[unlikely]] {
@@ -2333,303 +2348,286 @@ namespace glz
                            return;
                         }
                      }
-
-                     if constexpr (not tag.sv().empty() && not contains_tag<T, tag>()) {
-                        // For tagged variants we first check to see if the key matches the tag
-                        // We only need to do this if the tag is not part of the keys
-
-                        const auto start = it;
-                        skip_string_view<Opts>(ctx, it, end);
+                     
+                     if (key == tag.sv()) {
+                        if (parse_ws_colon<Opts>(ctx, it, end)) {
+                           return;
+                        }
+                        
+                        parse<JSON>::handle_unknown<Opts>(key, value, ctx, it, end);
                         if (bool(ctx.error)) [[unlikely]]
                            return;
-                        const sv key{start, size_t(it - start)};
-                        ++it;
-                        if constexpr (not Opts.null_terminated) {
-                           if (it == end) [[unlikely]] {
-                              ctx.error = error_code::unexpected_end;
-                              return;
-                           }
-                        }
-
-                        if (key == tag.sv()) {
-                           if (parse_ws_colon<Opts>(ctx, it, end)) {
-                              return;
-                           }
-
-                           parse<JSON>::handle_unknown<Opts>(key, value, ctx, it, end);
-                           if (bool(ctx.error)) [[unlikely]]
-                              return;
-
-                           if (skip_ws<Opts>(ctx, it, end)) {
-                              return;
-                           }
-                           continue;
-                        }
-                        else {
-                           it = start; // reset the iterator
-                        }
-                     }
-
-                     if constexpr (Opts.error_on_missing_keys || Opts.partial_read) {
-                        size_t index = num_members;
-                        parse_and_invoke<Opts, T, hash_info<T>>(value, ctx, it, end, index);
-                        if (bool(ctx.error)) [[unlikely]]
+                        
+                        if (skip_ws<Opts>(ctx, it, end)) {
                            return;
-                        if (index < num_members) {
-                           fields[index] = true;
                         }
+                        continue;
                      }
                      else {
-                        parse_and_invoke<Opts, T, hash_info<T>>(value, ctx, it, end);
-                        if (bool(ctx.error)) [[unlikely]]
-                           return;
+                        it = start; // reset the iterator
+                     }
+                  }
+                  
+                  if constexpr (Opts.error_on_missing_keys || Opts.partial_read) {
+                     size_t index = num_members;
+                     parse_and_invoke<Opts, T, hash_info<T>>(value, ctx, it, end, index);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                     if (index < num_members) {
+                        fields[index] = true;
                      }
                   }
                   else {
-                     // For types like std::map, std::unordered_map
-
-                     auto reading = [&](auto&& key) {
-                        if constexpr (Opts.partial_read) {
-                           if (auto element = value.find(key); element != value.end()) {
-                              ++read_count;
-                              parse<JSON>::op<ws_handled<Opts>()>(element->second, ctx, it, end);
-                           }
-                           else {
-                              skip_value<JSON>::op<Opts>(ctx, it, end);
-                           }
+                     parse_and_invoke<Opts, T, hash_info<T>>(value, ctx, it, end);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                  }
+               }
+               else {
+                  // For types like std::map, std::unordered_map
+                  
+                  auto reading = [&](auto&& key) {
+                     if constexpr (Opts.partial_read) {
+                        if (auto element = value.find(key); element != value.end()) {
+                           ++read_count;
+                           parse<JSON>::op<ws_handled<Opts>()>(element->second, ctx, it, end);
                         }
                         else {
-                           parse<JSON>::op<ws_handled<Opts>()>(value[key], ctx, it, end);
+                           skip_value<JSON>::op<Opts>(ctx, it, end);
                         }
-                     };
-
-                     // using Key = std::conditional_t<heterogeneous_map<T>, sv, typename T::key_type>;
-                     using Key = typename T::key_type;
-                     if constexpr (std::is_same_v<Key, std::string>) {
-                        static thread_local Key key;
-                        parse<JSON>::op<Opts>(key, ctx, it, end);
-                        if (bool(ctx.error)) [[unlikely]]
-                           return;
-
-                        if (parse_ws_colon<Opts>(ctx, it, end)) {
-                           return;
-                        }
-
-                        reading(key);
-                        if constexpr (Opts.partial_read) {
-                           if (read_count == value.size()) {
-                              return;
-                           }
-                        }
-                        if (bool(ctx.error)) [[unlikely]]
-                           return;
-                     }
-                     else if constexpr (str_t<Key>) {
-                        Key key;
-                        parse<JSON>::op<Opts>(key, ctx, it, end);
-                        if (bool(ctx.error)) [[unlikely]]
-                           return;
-
-                        if (parse_ws_colon<Opts>(ctx, it, end)) {
-                           return;
-                        }
-
-                        reading(key);
-                        if constexpr (Opts.partial_read) {
-                           if (read_count == value.size()) {
-                              return;
-                           }
-                        }
-                        if (bool(ctx.error)) [[unlikely]]
-                           return;
                      }
                      else {
-                        Key key_value{};
-                        if constexpr (glaze_enum_t<Key>) {
-                           parse<JSON>::op<Opts>(key_value, ctx, it, end);
-                        }
-                        else if constexpr (std::is_arithmetic_v<Key>) {
-                           // prefer over quoted_t below to avoid double parsing of quoted_t
-                           parse<JSON>::op<opt_true<Opts, &opts::quoted_num>>(key_value, ctx, it, end);
-                        }
-                        else {
-                           parse<JSON>::op<opt_false<Opts, &opts::raw_string>>(quoted_t<Key>{key_value}, ctx, it, end);
-                        }
-                        if (bool(ctx.error)) [[unlikely]]
-                           return;
-
-                        if (parse_ws_colon<Opts>(ctx, it, end)) {
-                           return;
-                        }
-
-                        reading(key_value);
-                        if constexpr (Opts.partial_read) {
-                           if (read_count == value.size()) {
-                              return;
-                           }
-                        }
-                        if (bool(ctx.error)) [[unlikely]]
-                           return;
+                        parse<JSON>::op<ws_handled<Opts>()>(value[key], ctx, it, end);
                      }
+                  };
+                  
+                  // using Key = std::conditional_t<heterogeneous_map<T>, sv, typename T::key_type>;
+                  using Key = typename T::key_type;
+                  if constexpr (std::is_same_v<Key, std::string>) {
+                     static thread_local Key key;
+                     parse<JSON>::op<Opts>(key, ctx, it, end);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                     
+                     if (parse_ws_colon<Opts>(ctx, it, end)) {
+                        return;
+                     }
+                     
+                     reading(key);
+                     if constexpr (Opts.partial_read) {
+                        if (read_count == value.size()) {
+                           return;
+                        }
+                     }
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
                   }
-                  if (skip_ws<Opts>(ctx, it, end)) {
-                     return;
+                  else if constexpr (str_t<Key>) {
+                     Key key;
+                     parse<JSON>::op<Opts>(key, ctx, it, end);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                     
+                     if (parse_ws_colon<Opts>(ctx, it, end)) {
+                        return;
+                     }
+                     
+                     reading(key);
+                     if constexpr (Opts.partial_read) {
+                        if (read_count == value.size()) {
+                           return;
+                        }
+                     }
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
                   }
+                  else {
+                     Key key_value{};
+                     if constexpr (glaze_enum_t<Key>) {
+                        parse<JSON>::op<Opts>(key_value, ctx, it, end);
+                     }
+                     else if constexpr (std::is_arithmetic_v<Key>) {
+                        // prefer over quoted_t below to avoid double parsing of quoted_t
+                        parse<JSON>::op<opt_true<Opts, &opts::quoted_num>>(key_value, ctx, it, end);
+                     }
+                     else {
+                        parse<JSON>::op<opt_false<Opts, &opts::raw_string>>(quoted_t<Key>{key_value}, ctx, it, end);
+                     }
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                     
+                     if (parse_ws_colon<Opts>(ctx, it, end)) {
+                        return;
+                     }
+                     
+                     reading(key_value);
+                     if constexpr (Opts.partial_read) {
+                        if (read_count == value.size()) {
+                           return;
+                        }
+                     }
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                  }
+               }
+               if (skip_ws<Opts>(ctx, it, end)) {
+                  return;
                }
             }
          }
-      };
-
-      template <is_variant T>
-      consteval auto variant_is_auto_deducible()
-      {
-         // Contains at most one each of the basic json types bool, numeric, string, object, array
-         // If all objects are meta-objects then we can attempt to deduce them as well either through a type tag or
-         // unique combinations of keys
-         int bools{}, numbers{}, strings{}, objects{}, meta_objects{}, arrays{};
-         constexpr auto N = std::variant_size_v<T>;
-         for_each<N>([&](auto I) {
-            using V = std::decay_t<std::variant_alternative_t<I, T>>;
-            // ICE workaround
-            bools += bool_t<V>;
-            numbers += num_t<V>;
-            strings += str_t<V>;
-            strings += glaze_enum_t<V>;
-            objects += pair_t<V>;
-            objects += (writable_map_t<V> || readable_map_t<V> || is_memory_object<V>);
-            objects += glaze_object_t<V>;
-            meta_objects += glaze_object_t<V> || reflectable<V> || is_memory_object<V>;
-            arrays += glaze_array_t<V>;
-            arrays += array_t<V>;
-            // TODO null
-         });
-         return bools < 2 && numbers < 2 && strings < 2 && (objects < 2 || meta_objects == objects) && arrays < 2;
       }
-
-      template <class>
-      struct variant_types;
-
-      template <class... Ts>
-      struct variant_types<std::variant<Ts...>>
+   };
+   
+   template <is_variant T>
+   consteval auto variant_is_auto_deducible()
+   {
+      // Contains at most one each of the basic json types bool, numeric, string, object, array
+      // If all objects are meta-objects then we can attempt to deduce them as well either through a type tag or
+      // unique combinations of keys
+      int bools{}, numbers{}, strings{}, objects{}, meta_objects{}, arrays{};
+      constexpr auto N = std::variant_size_v<T>;
+      for_each<N>([&](auto I) {
+         using V = std::decay_t<std::variant_alternative_t<I, T>>;
+         // ICE workaround
+         bools += bool_t<V>;
+         numbers += num_t<V>;
+         strings += str_t<V>;
+         strings += glaze_enum_t<V>;
+         objects += pair_t<V>;
+         objects += (writable_map_t<V> || readable_map_t<V> || is_memory_object<V>);
+         objects += glaze_object_t<V>;
+         meta_objects += glaze_object_t<V> || reflectable<V> || is_memory_object<V>;
+         arrays += glaze_array_t<V>;
+         arrays += array_t<V>;
+         // TODO null
+      });
+      return bools < 2 && numbers < 2 && strings < 2 && (objects < 2 || meta_objects == objects) && arrays < 2;
+   }
+   
+   template <class>
+   struct variant_types;
+   
+   template <class... Ts>
+   struct variant_types<std::variant<Ts...>>
+   {
+      // TODO: this way of filtering types is compile time intensive.
+      using bool_types =
+      decltype(tuplet::tuple_cat(std::conditional_t<bool_t<remove_meta_wrapper_t<Ts>>, tuple<Ts>, tuple<>>{}...));
+      using number_types =
+      decltype(tuplet::tuple_cat(std::conditional_t<num_t<remove_meta_wrapper_t<Ts>>, tuple<Ts>, tuple<>>{}...));
+      using string_types = decltype(tuplet::tuple_cat( // glaze_enum_t remove_meta_wrapper_t supports constexpr
+                                                      // types while the other supports non const
+                                                      std::conditional_t < str_t<remove_meta_wrapper_t<Ts>> || glaze_enum_t<remove_meta_wrapper_t<Ts>> ||
+                                                      glaze_enum_t<Ts>,
+                                                      tuple<Ts>, tuple < >> {}...));
+      using object_types = decltype(tuplet::tuple_cat(std::conditional_t<json_object<Ts>, tuple<Ts>, tuple<>>{}...));
+      using array_types = decltype(tuplet::tuple_cat(
+                                                     std::conditional_t < array_t<remove_meta_wrapper_t<Ts>> || glaze_array_t<Ts>, tuple<Ts>, tuple < >> {}...));
+      using nullable_types = decltype(tuplet::tuple_cat(std::conditional_t<null_t<Ts>, tuple<Ts>, tuple<>>{}...));
+      using nullable_objects =
+      decltype(tuplet::tuple_cat(std::conditional_t<is_memory_object<Ts>, tuple<Ts>, tuple<>>{}...));
+   };
+   
+   // post process output of variant_types
+   template <class>
+   struct tuple_types;
+   
+   template <class... Ts>
+   struct tuple_types<tuple<Ts...>>
+   {
+      using glaze_const_types =
+      decltype(tuplet::tuple_cat(std::conditional_t<glaze_const_value_t<Ts>, tuple<Ts>, tuple<>>{}...));
+      using glaze_non_const_types =
+      decltype(tuplet::tuple_cat(std::conditional_t<!glaze_const_value_t<Ts>, tuple<Ts>, tuple<>>{}...));
+   };
+   
+   template <class>
+   struct variant_type_count;
+   
+   template <class... Ts>
+   struct variant_type_count<std::variant<Ts...>>
+   {
+      using V = variant_types<std::variant<Ts...>>;
+      static constexpr auto n_bool = glz::tuple_size_v<typename V::bool_types>;
+      static constexpr auto n_number = glz::tuple_size_v<typename V::number_types>;
+      static constexpr auto n_string = glz::tuple_size_v<typename V::string_types>;
+      static constexpr auto n_nullable_object = glz::tuple_size_v<typename V::nullable_objects>;
+      static constexpr auto n_object = glz::tuple_size_v<typename V::object_types> + n_nullable_object;
+      static constexpr auto n_array = glz::tuple_size_v<typename V::array_types>;
+      static constexpr auto n_null = glz::tuple_size_v<typename V::nullable_types>;
+   };
+   
+   template <class Tuple>
+   struct process_arithmetic_boolean_string_or_array
+   {
+      template <auto Options>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
       {
-         // TODO: this way of filtering types is compile time intensive.
-         using bool_types =
-            decltype(tuplet::tuple_cat(std::conditional_t<bool_t<remove_meta_wrapper_t<Ts>>, tuple<Ts>, tuple<>>{}...));
-         using number_types =
-            decltype(tuplet::tuple_cat(std::conditional_t<num_t<remove_meta_wrapper_t<Ts>>, tuple<Ts>, tuple<>>{}...));
-         using string_types = decltype(tuplet::tuple_cat( // glaze_enum_t remove_meta_wrapper_t supports constexpr
-                                                          // types while the other supports non const
-            std::conditional_t < str_t<remove_meta_wrapper_t<Ts>> || glaze_enum_t<remove_meta_wrapper_t<Ts>> ||
-               glaze_enum_t<Ts>,
-            tuple<Ts>, tuple < >> {}...));
-         using object_types = decltype(tuplet::tuple_cat(std::conditional_t<json_object<Ts>, tuple<Ts>, tuple<>>{}...));
-         using array_types = decltype(tuplet::tuple_cat(
-            std::conditional_t < array_t<remove_meta_wrapper_t<Ts>> || glaze_array_t<Ts>, tuple<Ts>, tuple < >> {}...));
-         using nullable_types = decltype(tuplet::tuple_cat(std::conditional_t<null_t<Ts>, tuple<Ts>, tuple<>>{}...));
-         using nullable_objects =
-            decltype(tuplet::tuple_cat(std::conditional_t<is_memory_object<Ts>, tuple<Ts>, tuple<>>{}...));
-      };
-
-      // post process output of variant_types
-      template <class>
-      struct tuple_types;
-
-      template <class... Ts>
-      struct tuple_types<tuple<Ts...>>
-      {
-         using glaze_const_types =
-            decltype(tuplet::tuple_cat(std::conditional_t<glaze_const_value_t<Ts>, tuple<Ts>, tuple<>>{}...));
-         using glaze_non_const_types =
-            decltype(tuplet::tuple_cat(std::conditional_t<!glaze_const_value_t<Ts>, tuple<Ts>, tuple<>>{}...));
-      };
-
-      template <class>
-      struct variant_type_count;
-
-      template <class... Ts>
-      struct variant_type_count<std::variant<Ts...>>
-      {
-         using V = variant_types<std::variant<Ts...>>;
-         static constexpr auto n_bool = glz::tuple_size_v<typename V::bool_types>;
-         static constexpr auto n_number = glz::tuple_size_v<typename V::number_types>;
-         static constexpr auto n_string = glz::tuple_size_v<typename V::string_types>;
-         static constexpr auto n_nullable_object = glz::tuple_size_v<typename V::nullable_objects>;
-         static constexpr auto n_object = glz::tuple_size_v<typename V::object_types> + n_nullable_object;
-         static constexpr auto n_array = glz::tuple_size_v<typename V::array_types>;
-         static constexpr auto n_null = glz::tuple_size_v<typename V::nullable_types>;
-      };
-
-      template <class Tuple>
-      struct process_arithmetic_boolean_string_or_array
-      {
-         template <auto Options>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            if constexpr (glz::tuple_size_v<Tuple> < 1) {
-               ctx.error = error_code::no_matching_variant_type;
-            }
-            else {
-               using const_glaze_types = typename tuple_types<Tuple>::glaze_const_types;
-               bool found_match{};
-               for_each<glz::tuple_size_v<const_glaze_types>>([&]([[maybe_unused]] auto I) {
-                  if (found_match) {
-                     return;
-                  }
-                  using V = glz::tuple_element_t<I, const_glaze_types>;
-                  // run time substitute to compare to const value
-                  std::remove_const_t<std::remove_pointer_t<std::remove_const_t<meta_wrapper_t<V>>>> substitute{};
-                  auto copy_it{it};
-                  parse<JSON>::op<ws_handled<Options>()>(substitute, ctx, it, end);
-                  static constexpr auto const_value{*meta_wrapper_v<V>};
-                  if (substitute == const_value) {
-                     found_match = true;
-                     if (!std::holds_alternative<V>(value)) {
-                        value = V{};
-                     }
-                  }
-                  else {
-                     if constexpr (not Options.null_terminated) {
-                        if (ctx.error == error_code::end_reached) {
-                           // reset the context for next attempt
-                           ctx.error = error_code::none;
-                        }
-                     }
-                     it = copy_it;
-                  }
-               });
+         if constexpr (glz::tuple_size_v<Tuple> < 1) {
+            ctx.error = error_code::no_matching_variant_type;
+         }
+         else {
+            using const_glaze_types = typename tuple_types<Tuple>::glaze_const_types;
+            bool found_match{};
+            for_each<glz::tuple_size_v<const_glaze_types>>([&]([[maybe_unused]] auto I) {
                if (found_match) {
                   return;
                }
-
-               using non_const_types = typename tuple_types<Tuple>::glaze_non_const_types;
-               if constexpr (glz::tuple_size_v < non_const_types >> 0) {
-                  using V = glz::tuple_element_t<0, non_const_types>;
-                  if (!std::holds_alternative<V>(value)) value = V{};
-                  parse<JSON>::op<ws_handled<Options>()>(std::get<V>(value), ctx, it, end);
-               }
-               else {
-                  ctx.error = error_code::no_matching_variant_type;
-               }
-            }
-         }
-      };
-
-      template <is_variant T>
-      struct from<JSON, T>
-      {
-         // Note that items in the variant are required to be default constructable for us to switch types
-         template <auto Options>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            constexpr auto Opts = ws_handled_off<Options>();
-            if constexpr (variant_is_auto_deducible<T>()) {
-               if constexpr (not has_ws_handled(Options)) {
-                  if (skip_ws<Opts>(ctx, it, end)) {
-                     return;
+               using V = glz::tuple_element_t<I, const_glaze_types>;
+               // run time substitute to compare to const value
+               std::remove_const_t<std::remove_pointer_t<std::remove_const_t<meta_wrapper_t<V>>>> substitute{};
+               auto copy_it{it};
+               parse<JSON>::op<ws_handled<Options>()>(substitute, ctx, it, end);
+               static constexpr auto const_value{*meta_wrapper_v<V>};
+               if (substitute == const_value) {
+                  found_match = true;
+                  if (!std::holds_alternative<V>(value)) {
+                     value = V{};
                   }
                }
-
-               switch (*it) {
+               else {
+                  if constexpr (not Options.null_terminated) {
+                     if (ctx.error == error_code::end_reached) {
+                        // reset the context for next attempt
+                        ctx.error = error_code::none;
+                     }
+                  }
+                  it = copy_it;
+               }
+            });
+            if (found_match) {
+               return;
+            }
+            
+            using non_const_types = typename tuple_types<Tuple>::glaze_non_const_types;
+            if constexpr (glz::tuple_size_v < non_const_types >> 0) {
+               using V = glz::tuple_element_t<0, non_const_types>;
+               if (!std::holds_alternative<V>(value)) value = V{};
+               parse<JSON>::op<ws_handled<Options>()>(std::get<V>(value), ctx, it, end);
+            }
+            else {
+               ctx.error = error_code::no_matching_variant_type;
+            }
+         }
+      }
+   };
+   
+   template <is_variant T>
+   struct from<JSON, T>
+   {
+      // Note that items in the variant are required to be default constructable for us to switch types
+      template <auto Options>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         constexpr auto Opts = ws_handled_off<Options>();
+         if constexpr (variant_is_auto_deducible<T>()) {
+            if constexpr (not has_ws_handled(Options)) {
+               if (skip_ws<Opts>(ctx, it, end)) {
+                  return;
+               }
+            }
+            
+            switch (*it) {
                case '\0':
                   ctx.error = error_code::unexpected_end;
                   return;
@@ -2641,7 +2639,7 @@ namespace glz
                   // In the null terminated case this guards for stack overflow
                   // Depth counting is done at the object level when not null terminated
                   ++ctx.indentation_level;
-
+                  
                   ++it;
                   if constexpr (not Opts.null_terminated) {
                      if (it == end) [[unlikely]] {
@@ -2670,7 +2668,7 @@ namespace glz
                   }
                   else {
                      auto possible_types = bit_array<std::variant_size_v<T>>{}.flip();
-                     static constexpr auto deduction_map = detail::make_variant_deduction_map<T>();
+                     static constexpr auto deduction_map = make_variant_deduction_map<T>();
                      static constexpr auto tag_literal = string_literal_from_view<tag_v<T>.size()>(tag_v<T>);
                      if (skip_ws<Opts>(ctx, it, end)) {
                         return;
@@ -2682,24 +2680,24 @@ namespace glz
                               return;
                            }
                         }
-
+                        
                         if (skip_ws<Opts>(ctx, it, end)) {
                            return;
                         }
                         if (match_invalid_end<'"', Opts>(ctx, it, end)) {
                            return;
                         }
-
+                        
                         auto* key_start = it;
                         skip_string_view<Opts>(ctx, it, end);
                         if (bool(ctx.error)) [[unlikely]]
                            return;
                         const sv key = {key_start, size_t(it - key_start)};
-
+                        
                         if (match_invalid_end<'"', Opts>(ctx, it, end)) {
                            return;
                         }
-
+                        
                         if constexpr (deduction_map.size()) {
                            // We first check if a tag is defined and see if the key matches the tag
                            if constexpr (not tag_v<T>.empty()) {
@@ -2718,7 +2716,7 @@ namespace glz
                                     ctx.error = error_code::syntax_error;
                                     return;
                                  }
-
+                                 
                                  static constexpr auto id_map = make_variant_id_map<T>();
                                  auto id_it = id_map.find(type_id);
                                  if (id_it != id_map.end()) [[likely]] {
@@ -2726,43 +2724,43 @@ namespace glz
                                     const auto type_index = id_it->second;
                                     if (value.index() != type_index) value = runtime_variant_map<T>()[type_index];
                                     std::visit(
-                                       [&](auto&& v) {
-                                          using V = std::decay_t<decltype(v)>;
-                                          constexpr bool is_object = glaze_object_t<V> || reflectable<V>;
-                                          if constexpr (is_object) {
-                                             from<JSON, V>::template op<opening_handled<Opts>(), tag_literal>(v, ctx,
-                                                                                                              it, end);
-                                          }
-                                          else if constexpr (is_memory_object<V>) {
-                                             if (!v) {
-                                                if constexpr (is_specialization_v<V, std::optional>) {
-                                                   if constexpr (requires { v.emplace(); }) {
-                                                      v.emplace();
-                                                   }
-                                                   else {
-                                                      v = typename V::value_type{};
-                                                   }
-                                                }
-                                                else if constexpr (is_specialization_v<V, std::unique_ptr>)
-                                                   v = std::make_unique<typename V::element_type>();
-                                                else if constexpr (is_specialization_v<V, std::shared_ptr>)
-                                                   v = std::make_shared<typename V::element_type>();
-                                                else if constexpr (constructible<V>) {
-                                                   v = meta_construct_v<V>();
-                                                }
-                                                else {
-                                                   ctx.error = error_code::invalid_nullable_read;
-                                                   return;
-                                                   // Cannot read into unset nullable that is not std::optional,
-                                                   // std::unique_ptr, or std::shared_ptr
-                                                }
-                                             }
-                                             from<JSON, memory_type<V>>::template op<opening_handled<Opts>(),
-                                                                                     tag_literal>(*v, ctx, it, end);
-                                          }
-                                       },
-                                       value);
-
+                                               [&](auto&& v) {
+                                                  using V = std::decay_t<decltype(v)>;
+                                                  constexpr bool is_object = glaze_object_t<V> || reflectable<V>;
+                                                  if constexpr (is_object) {
+                                                     from<JSON, V>::template op<opening_handled<Opts>(), tag_literal>(v, ctx,
+                                                                                                                      it, end);
+                                                  }
+                                                  else if constexpr (is_memory_object<V>) {
+                                                     if (!v) {
+                                                        if constexpr (is_specialization_v<V, std::optional>) {
+                                                           if constexpr (requires { v.emplace(); }) {
+                                                              v.emplace();
+                                                           }
+                                                           else {
+                                                              v = typename V::value_type{};
+                                                           }
+                                                        }
+                                                        else if constexpr (is_specialization_v<V, std::unique_ptr>)
+                                                           v = std::make_unique<typename V::element_type>();
+                                                        else if constexpr (is_specialization_v<V, std::shared_ptr>)
+                                                           v = std::make_shared<typename V::element_type>();
+                                                        else if constexpr (constructible<V>) {
+                                                           v = meta_construct_v<V>();
+                                                        }
+                                                        else {
+                                                           ctx.error = error_code::invalid_nullable_read;
+                                                           return;
+                                                           // Cannot read into unset nullable that is not std::optional,
+                                                           // std::unique_ptr, or std::shared_ptr
+                                                        }
+                                                     }
+                                                     from<JSON, memory_type<V>>::template op<opening_handled<Opts>(),
+                                                     tag_literal>(*v, ctx, it, end);
+                                                  }
+                                               },
+                                               value);
+                                    
                                     if constexpr (Opts.null_terminated) {
                                        // In the null terminated case this guards for stack overflow
                                        // Depth counting is done at the object level when not null terminated
@@ -2776,7 +2774,7 @@ namespace glz
                                  }
                               }
                            }
-
+                           
                            auto deduction_it = deduction_map.find(key);
                            if (deduction_it != deduction_map.end()) [[likely]] {
                               possible_types &= deduction_it->second;
@@ -2792,7 +2790,7 @@ namespace glz
                               if (parse_ws_colon<Opts>(ctx, it, end)) {
                                  return;
                               }
-
+                              
                               std::string_view type_id{};
                               parse<JSON>::op<ws_handled<Opts>()>(type_id, ctx, it, end);
                               if (bool(ctx.error)) [[unlikely]]
@@ -2800,7 +2798,7 @@ namespace glz
                               if (skip_ws<Opts>(ctx, it, end)) {
                                  return;
                               }
-
+                              
                               static constexpr auto id_map = make_variant_id_map<T>();
                               auto id_it = id_map.find(type_id);
                               if (id_it != id_map.end()) [[likely]] {
@@ -2823,7 +2821,7 @@ namespace glz
                            ctx.error = error_code::unknown_key;
                            return;
                         }
-
+                        
                         auto matching_types = possible_types.popcount();
                         if (matching_types == 0) {
                            ctx.error = error_code::no_matching_variant_type;
@@ -2835,42 +2833,42 @@ namespace glz
                            if (value.index() != static_cast<size_t>(type_index))
                               value = runtime_variant_map<T>()[type_index];
                            std::visit(
-                              [&](auto&& v) {
-                                 using V = std::decay_t<decltype(v)>;
-                                 constexpr bool is_object = glaze_object_t<V> || reflectable<V>;
-                                 if constexpr (is_object) {
-                                    from<JSON, V>::template op<opening_handled<Opts>(), tag_literal>(v, ctx, it, end);
-                                 }
-                                 else if constexpr (is_memory_object<V>) {
-                                    if (!v) {
-                                       if constexpr (is_specialization_v<V, std::optional>) {
-                                          if constexpr (requires { v.emplace(); }) {
-                                             v.emplace();
-                                          }
-                                          else {
-                                             v = typename V::value_type{};
-                                          }
-                                       }
-                                       else if constexpr (is_specialization_v<V, std::unique_ptr>)
-                                          v = std::make_unique<typename V::element_type>();
-                                       else if constexpr (is_specialization_v<V, std::shared_ptr>)
-                                          v = std::make_shared<typename V::element_type>();
-                                       else if constexpr (constructible<V>) {
-                                          v = meta_construct_v<V>();
-                                       }
-                                       else {
-                                          ctx.error = error_code::invalid_nullable_read;
-                                          return;
-                                          // Cannot read into unset nullable that is not std::optional,
-                                          // std::unique_ptr, or std::shared_ptr
-                                       }
-                                    }
-                                    from<JSON, memory_type<V>>::template op<opening_handled<Opts>(), tag_literal>(
-                                       *v, ctx, it, end);
-                                 }
-                              },
-                              value);
-
+                                      [&](auto&& v) {
+                                         using V = std::decay_t<decltype(v)>;
+                                         constexpr bool is_object = glaze_object_t<V> || reflectable<V>;
+                                         if constexpr (is_object) {
+                                            from<JSON, V>::template op<opening_handled<Opts>(), tag_literal>(v, ctx, it, end);
+                                         }
+                                         else if constexpr (is_memory_object<V>) {
+                                            if (!v) {
+                                               if constexpr (is_specialization_v<V, std::optional>) {
+                                                  if constexpr (requires { v.emplace(); }) {
+                                                     v.emplace();
+                                                  }
+                                                  else {
+                                                     v = typename V::value_type{};
+                                                  }
+                                               }
+                                               else if constexpr (is_specialization_v<V, std::unique_ptr>)
+                                                  v = std::make_unique<typename V::element_type>();
+                                               else if constexpr (is_specialization_v<V, std::shared_ptr>)
+                                                  v = std::make_shared<typename V::element_type>();
+                                               else if constexpr (constructible<V>) {
+                                                  v = meta_construct_v<V>();
+                                               }
+                                               else {
+                                                  ctx.error = error_code::invalid_nullable_read;
+                                                  return;
+                                                  // Cannot read into unset nullable that is not std::optional,
+                                                  // std::unique_ptr, or std::shared_ptr
+                                               }
+                                            }
+                                            from<JSON, memory_type<V>>::template op<opening_handled<Opts>(), tag_literal>(
+                                                                                                                          *v, ctx, it, end);
+                                         }
+                                      },
+                                      value);
+                           
                            if constexpr (Opts.null_terminated) {
                               // In the null terminated case this guards for stack overflow
                               // Depth counting is done at the object level when not null terminated
@@ -2881,7 +2879,7 @@ namespace glz
                         if (parse_ws_colon<Opts>(ctx, it, end)) {
                            return;
                         }
-
+                        
                         skip_value<JSON>::op<Opts>(ctx, it, end);
                         if (bool(ctx.error)) [[unlikely]]
                            return;
@@ -2894,7 +2892,7 @@ namespace glz
                   break;
                case '[':
                   using array_types = typename variant_types<T>::array_types;
-
+                  
                   if (ctx.indentation_level >= max_recursive_depth_limit) {
                      ctx.error = error_code::exceeded_max_recursive_depth;
                      return;
@@ -2936,176 +2934,118 @@ namespace glz
                   using number_types = typename variant_types<T>::number_types;
                   process_arithmetic_boolean_string_or_array<number_types>::template op<Opts>(value, ctx, it, end);
                }
-               }
-            }
-            else {
-               std::visit([&](auto&& v) { parse<JSON>::op<Options>(v, ctx, it, end); }, value);
             }
          }
-      };
-
-      template <class T>
-      struct from<JSON, array_variant_wrapper<T>>
+         else {
+            std::visit([&](auto&& v) { parse<JSON>::op<Options>(v, ctx, it, end); }, value);
+         }
+      }
+   };
+   
+   template <class T>
+   struct from<JSON, array_variant_wrapper<T>>
+   {
+      template <auto Options>
+      static void op(auto&& wrapper, is_context auto&& ctx, auto&& it, auto&& end)
       {
-         template <auto Options>
-         static void op(auto&& wrapper, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            auto& value = wrapper.value;
-
-            constexpr auto Opts = ws_handled_off<Options>();
-            if constexpr (!has_ws_handled(Options)) {
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-            }
-
-            if (match_invalid_end<'[', Opts>(ctx, it, end)) {
+         auto& value = wrapper.value;
+         
+         constexpr auto Opts = ws_handled_off<Options>();
+         if constexpr (!has_ws_handled(Options)) {
+            if (skip_ws<Opts>(ctx, it, end)) {
                return;
             }
+         }
+         
+         if (match_invalid_end<'[', Opts>(ctx, it, end)) {
+            return;
+         }
+         if constexpr (not Opts.null_terminated) {
+            ++ctx.indentation_level;
+         }
+         if (skip_ws<Opts>(ctx, it, end)) {
+            return;
+         }
+         
+         // TODO Use key parsing for compiletime known keys
+         if (match_invalid_end<'"', Opts>(ctx, it, end)) {
+            return;
+         }
+         auto start = it;
+         skip_string_view<Opts>(ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+         sv type_id = {start, size_t(it - start)};
+         if (match<'"'>(ctx, it)) {
+            return;
+         }
+         if constexpr (not Opts.null_terminated) {
+            if (it == end) {
+               ctx.error = error_code::end_reached;
+               return;
+            }
+         }
+         
+         static constexpr auto id_map = make_variant_id_map<T>();
+         auto id_it = id_map.find(type_id);
+         if (id_it != id_map.end()) [[likely]] {
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
+            }
+            if (match_invalid_end<',', Opts>(ctx, it, end)) {
+               return;
+            }
+            const auto type_index = id_it->second;
+            if (value.index() != type_index) value = runtime_variant_map<T>()[type_index];
+            std::visit([&](auto&& v) { parse<JSON>::op<Opts>(v, ctx, it, end); }, value);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
+         }
+         else {
+            ctx.error = error_code::no_matching_variant_type;
+            return;
+         }
+         
+         if (skip_ws<Opts>(ctx, it, end)) {
+            return;
+         }
+         match<']'>(ctx, it);
+         if constexpr (not Opts.null_terminated) {
+            --ctx.indentation_level;
+         }
+      }
+   };
+   
+   template <is_expected T>
+   struct from<JSON, T>
+   {
+      template <auto Opts, class... Args>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         if constexpr (!has_ws_handled(Opts)) {
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
+            }
+         }
+         
+         if (*it == '{') {
             if constexpr (not Opts.null_terminated) {
                ++ctx.indentation_level;
             }
-            if (skip_ws<Opts>(ctx, it, end)) {
-               return;
-            }
-
-            // TODO Use key parsing for compiletime known keys
-            if (match_invalid_end<'"', Opts>(ctx, it, end)) {
-               return;
-            }
             auto start = it;
-            skip_string_view<Opts>(ctx, it, end);
-            if (bool(ctx.error)) [[unlikely]]
-               return;
-            sv type_id = {start, size_t(it - start)};
-            if (match<'"'>(ctx, it)) {
-               return;
-            }
+            ++it;
             if constexpr (not Opts.null_terminated) {
-               if (it == end) {
-                  ctx.error = error_code::end_reached;
+               if (it == end) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
                   return;
                }
             }
-
-            static constexpr auto id_map = make_variant_id_map<T>();
-            auto id_it = id_map.find(type_id);
-            if (id_it != id_map.end()) [[likely]] {
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-               if (match_invalid_end<',', Opts>(ctx, it, end)) {
-                  return;
-               }
-               const auto type_index = id_it->second;
-               if (value.index() != type_index) value = runtime_variant_map<T>()[type_index];
-               std::visit([&](auto&& v) { parse<JSON>::op<Opts>(v, ctx, it, end); }, value);
-               if (bool(ctx.error)) [[unlikely]]
-                  return;
-            }
-            else {
-               ctx.error = error_code::no_matching_variant_type;
-               return;
-            }
-
             if (skip_ws<Opts>(ctx, it, end)) {
                return;
             }
-            match<']'>(ctx, it);
-            if constexpr (not Opts.null_terminated) {
-               --ctx.indentation_level;
-            }
-         }
-      };
-
-      template <is_expected T>
-      struct from<JSON, T>
-      {
-         template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            if constexpr (!has_ws_handled(Opts)) {
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-            }
-
-            if (*it == '{') {
-               if constexpr (not Opts.null_terminated) {
-                  ++ctx.indentation_level;
-               }
-               auto start = it;
-               ++it;
-               if constexpr (not Opts.null_terminated) {
-                  if (it == end) [[unlikely]] {
-                     ctx.error = error_code::unexpected_end;
-                     return;
-                  }
-               }
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-               if (*it == '}') {
-                  it = start;
-                  // empty object
-                  if (value) {
-                     parse<JSON>::op<Opts>(*value, ctx, it, end);
-                  }
-                  else {
-                     value.emplace();
-                     parse<JSON>::op<Opts>(*value, ctx, it, end);
-                  }
-               }
-               else {
-                  // either we have an unexpected value or we are decoding an object
-                  auto& key = string_buffer();
-                  parse<JSON>::op<Opts>(key, ctx, it, end);
-                  if (bool(ctx.error)) [[unlikely]]
-                     return;
-                  if (key == "unexpected") {
-                     if (skip_ws<Opts>(ctx, it, end)) {
-                        return;
-                     }
-                     if (match_invalid_end<':', Opts>(ctx, it, end)) {
-                        return;
-                     }
-                     // read in unexpected value
-                     if (!value) {
-                        parse<JSON>::op<Opts>(value.error(), ctx, it, end);
-                        if (bool(ctx.error)) [[unlikely]]
-                           return;
-                     }
-                     else {
-                        // set value to unexpected
-                        using error_ctx = typename std::decay_t<decltype(value)>::error_type;
-                        std::decay_t<error_ctx> error{};
-                        parse<JSON>::op<Opts>(error, ctx, it, end);
-                        if (bool(ctx.error)) [[unlikely]]
-                           return;
-                        value = glz::unexpected(error);
-                     }
-                     if (skip_ws<Opts>(ctx, it, end)) {
-                        return;
-                     }
-                     match<'}'>(ctx, it);
-                     if constexpr (not Opts.null_terminated) {
-                        --ctx.indentation_level;
-                     }
-                  }
-                  else {
-                     it = start;
-                     if (value) {
-                        parse<JSON>::op<Opts>(*value, ctx, it, end);
-                     }
-                     else {
-                        value.emplace();
-                        parse<JSON>::op<Opts>(*value, ctx, it, end);
-                     }
-                  }
-               }
-            }
-            else {
-               // this is not an object and therefore cannot be an unexpected value
+            if (*it == '}') {
+               it = start;
+               // empty object
                if (value) {
                   parse<JSON>::op<Opts>(*value, ctx, it, end);
                }
@@ -3114,117 +3054,174 @@ namespace glz
                   parse<JSON>::op<Opts>(*value, ctx, it, end);
                }
             }
-         }
-      };
-
-      template <nullable_t T>
-         requires(std::is_array_v<T>)
-      struct from<JSON, T>
-      {
-         template <auto Opts, class V, size_t N>
-         GLZ_ALWAYS_INLINE static void op(V (&value)[N], is_context auto&& ctx, auto&& it, auto&& end) noexcept
-         {
-            parse<JSON>::op<Opts>(std::span{value, N}, ctx, it, end);
-         }
-      };
-
-      template <class T>
-         requires((nullable_t<T> || nullable_value_t<T>) && not is_expected<T> && not std::is_array_v<T> &&
-                  not custom_read<T>)
-      struct from<JSON, T>
-      {
-         template <auto Options>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            constexpr auto Opts = ws_handled_off<Options>();
-            if constexpr (!has_ws_handled(Options)) {
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-            }
-
-            if (*it == 'n') {
-               ++it;
-               if constexpr (not Opts.null_terminated) {
-                  if (it == end) [[unlikely]] {
-                     ctx.error = error_code::unexpected_end;
-                     return;
-                  }
-               }
-               match<"ull", Opts>(ctx, it, end);
+            else {
+               // either we have an unexpected value or we are decoding an object
+               auto& key = string_buffer();
+               parse<JSON>::op<Opts>(key, ctx, it, end);
                if (bool(ctx.error)) [[unlikely]]
                   return;
-               if constexpr (requires { value.reset(); }) {
-                  value.reset();
+               if (key == "unexpected") {
+                  if (skip_ws<Opts>(ctx, it, end)) {
+                     return;
+                  }
+                  if (match_invalid_end<':', Opts>(ctx, it, end)) {
+                     return;
+                  }
+                  // read in unexpected value
+                  if (!value) {
+                     parse<JSON>::op<Opts>(value.error(), ctx, it, end);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                  }
+                  else {
+                     // set value to unexpected
+                     using error_ctx = typename std::decay_t<decltype(value)>::error_type;
+                     std::decay_t<error_ctx> error{};
+                     parse<JSON>::op<Opts>(error, ctx, it, end);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                     value = glz::unexpected(error);
+                  }
+                  if (skip_ws<Opts>(ctx, it, end)) {
+                     return;
+                  }
+                  match<'}'>(ctx, it);
+                  if constexpr (not Opts.null_terminated) {
+                     --ctx.indentation_level;
+                  }
+               }
+               else {
+                  it = start;
+                  if (value) {
+                     parse<JSON>::op<Opts>(*value, ctx, it, end);
+                  }
+                  else {
+                     value.emplace();
+                     parse<JSON>::op<Opts>(*value, ctx, it, end);
+                  }
                }
             }
+         }
+         else {
+            // this is not an object and therefore cannot be an unexpected value
+            if (value) {
+               parse<JSON>::op<Opts>(*value, ctx, it, end);
+            }
             else {
-               if constexpr (nullable_value_t<T>) {
-                  if (not value.has_value()) {
-                     if constexpr (constructible<T>) {
-                        value = meta_construct_v<T>();
-                     }
-                     else if constexpr (requires { value.emplace(); }) {
+               value.emplace();
+               parse<JSON>::op<Opts>(*value, ctx, it, end);
+            }
+         }
+      }
+   };
+   
+   template <nullable_t T>
+   requires(std::is_array_v<T>)
+   struct from<JSON, T>
+   {
+      template <auto Opts, class V, size_t N>
+      GLZ_ALWAYS_INLINE static void op(V (&value)[N], is_context auto&& ctx, auto&& it, auto&& end) noexcept
+      {
+         parse<JSON>::op<Opts>(std::span{value, N}, ctx, it, end);
+      }
+   };
+   
+   template <class T>
+   requires((nullable_t<T> || nullable_value_t<T>) && not is_expected<T> && not std::is_array_v<T> &&
+            not custom_read<T>)
+   struct from<JSON, T>
+   {
+      template <auto Options>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         constexpr auto Opts = ws_handled_off<Options>();
+         if constexpr (!has_ws_handled(Options)) {
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
+            }
+         }
+         
+         if (*it == 'n') {
+            ++it;
+            if constexpr (not Opts.null_terminated) {
+               if (it == end) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
+            }
+            match<"ull", Opts>(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
+            if constexpr (requires { value.reset(); }) {
+               value.reset();
+            }
+         }
+         else {
+            if constexpr (nullable_value_t<T>) {
+               if (not value.has_value()) {
+                  if constexpr (constructible<T>) {
+                     value = meta_construct_v<T>();
+                  }
+                  else if constexpr (requires { value.emplace(); }) {
+                     value.emplace();
+                  }
+                  else {
+                     static_assert(false_v<T>,
+                                   "Your nullable type must have `emplace()` or be glz::meta constructible, or "
+                                   "create a custom glz::from specialization");
+                  }
+               }
+               parse<JSON>::op<Opts>(value.value(), ctx, it, end);
+            }
+            else {
+               if (!value) {
+                  if constexpr (optional_like<T>) {
+                     if constexpr (requires { value.emplace(); }) {
                         value.emplace();
                      }
                      else {
-                        static_assert(false_v<T>,
-                                      "Your nullable type must have `emplace()` or be glz::meta constructible, or "
-                                      "create a custom glz::detail::from specialization");
+                        value = typename T::value_type{};
                      }
                   }
-                  parse<JSON>::op<Opts>(value.value(), ctx, it, end);
-               }
-               else {
-                  if (!value) {
-                     if constexpr (optional_like<T>) {
-                        if constexpr (requires { value.emplace(); }) {
-                           value.emplace();
-                        }
-                        else {
-                           value = typename T::value_type{};
-                        }
-                     }
-                     else if constexpr (is_specialization_v<T, std::unique_ptr>)
-                        value = std::make_unique<typename T::element_type>();
-                     else if constexpr (is_specialization_v<T, std::shared_ptr>)
-                        value = std::make_shared<typename T::element_type>();
-                     else if constexpr (constructible<T>) {
-                        value = meta_construct_v<T>();
-                     }
-                     else {
-                        // Cannot read into a null raw pointer
-                        ctx.error = error_code::invalid_nullable_read;
-                        return;
-                     }
+                  else if constexpr (is_specialization_v<T, std::unique_ptr>)
+                     value = std::make_unique<typename T::element_type>();
+                  else if constexpr (is_specialization_v<T, std::shared_ptr>)
+                     value = std::make_shared<typename T::element_type>();
+                  else if constexpr (constructible<T>) {
+                     value = meta_construct_v<T>();
                   }
-                  parse<JSON>::op<Opts>(*value, ctx, it, end);
+                  else {
+                     // Cannot read into a null raw pointer
+                     ctx.error = error_code::invalid_nullable_read;
+                     return;
+                  }
                }
+               parse<JSON>::op<Opts>(*value, ctx, it, end);
             }
          }
-      };
-
-      template <filesystem_path T>
-      struct from<JSON, T>
+      }
+   };
+   
+   template <filesystem_path T>
+   struct from<JSON, T>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
       {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            std::string& buffer = string_buffer();
-            parse<JSON>::op<Opts>(buffer, ctx, it, end);
-            if constexpr (Opts.null_terminated) {
-               if (bool(ctx.error)) [[unlikely]]
-                  return;
-            }
-            else {
-               if (size_t(ctx.error) > size_t(error_code::end_reached)) [[unlikely]] {
-                  return;
-               }
-            }
-            value = buffer;
+         std::string& buffer = string_buffer();
+         parse<JSON>::op<Opts>(buffer, ctx, it, end);
+         if constexpr (Opts.null_terminated) {
+            if (bool(ctx.error)) [[unlikely]]
+               return;
          }
-      };
-   } // namespace detail
+         else {
+            if (size_t(ctx.error) > size_t(error_code::end_reached)) [[unlikely]] {
+               return;
+            }
+         }
+         value = buffer;
+      }
+   };
 
    template <is_buffer Buffer>
    [[nodiscard]] error_ctx validate_json(Buffer&& buffer) noexcept

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -62,12 +62,12 @@ namespace glz
       static void handle_unknown(const sv& key, T&& value, Ctx&& ctx, It0&& it, It1&& end)
       {
          using ValueType = std::decay_t<decltype(value)>;
-         if constexpr (detail::has_unknown_reader<ValueType>) {
+         if constexpr (has_unknown_reader<ValueType>) {
             constexpr auto& reader = meta_unknown_read_v<ValueType>;
             using ReaderType = meta_unknown_read_t<ValueType>;
             if constexpr (std::is_member_object_pointer_v<ReaderType>) {
                using MemberType = typename member_value<ReaderType>::type;
-               if constexpr (detail::map_subscriptable<MemberType>) {
+               if constexpr (map_subscriptable<MemberType>) {
                   parse<JSON>::op<Opts>((value.*reader)[key], ctx, it, end);
                }
                else {
@@ -1635,7 +1635,7 @@ namespace glz
                using V = std::decay_t<decltype(item)>;
 
                if constexpr (str_t<typename V::first_type> ||
-                             (std::is_enum_v<typename V::first_type> && detail::glaze_t<typename V::first_type>)) {
+                             (std::is_enum_v<typename V::first_type> && glaze_t<typename V::first_type>)) {
                   parse<JSON>::op<Opts>(item.first, ctx, it, end);
                   if (bool(ctx.error)) [[unlikely]]
                      return;

--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -319,7 +319,7 @@ namespace glz
             else if constexpr (glaze_const_value_t<T>) { // &T::constexpr_member
                using constexpr_val_t = member_t<T, meta_wrapper_t<T>>;
                static constexpr auto val_v{*glz::meta_wrapper_v<T>};
-               if constexpr (glz::detail::glaze_enum_t<constexpr_val_t>) {
+               if constexpr (glz::glaze_enum_t<constexpr_val_t>) {
                   s.attributes.constant = glz::enum_name_v<val_v>;
                }
                else {

--- a/include/glaze/json/skip.hpp
+++ b/include/glaze/json/skip.hpp
@@ -5,20 +5,23 @@
 
 #include "glaze/util/parse.hpp"
 
-namespace glz::detail
+namespace glz
 {
    template <>
    struct skip_value<JSON>
    {
       template <opts Opts>
-         requires(not Opts.comments)
+      requires(not Opts.comments)
       GLZ_ALWAYS_INLINE static void op(is_context auto&& ctx, auto&& it, auto&& end) noexcept;
-
+      
       template <opts Opts>
-         requires(bool(Opts.comments))
+      requires(bool(Opts.comments))
       GLZ_ALWAYS_INLINE static void op(is_context auto&& ctx, auto&& it, auto&& end) noexcept;
    };
+}
 
+namespace glz::detail
+{
    template <opts Opts>
    void skip_object(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
@@ -180,10 +183,27 @@ namespace glz::detail
       }
    }
 
+   // parse_value is used for JSON pointer reading
+   // we want the JSON pointer access to not care about trailing whitespace
+   // so we use validate_skipped for precise validation and value skipping
+   // expects opening whitespace to be handled
    template <opts Opts>
-      requires(not Opts.comments)
+   GLZ_ALWAYS_INLINE auto parse_value(is_context auto&& ctx, auto&& it, auto&& end) noexcept
+   {
+      auto start = it;
+      skip_value<JSON>::op<opt_true<Opts, &opts::validate_skipped>>(ctx, it, end);
+      return std::span{start, size_t(it - start)};
+   }
+}
+
+namespace glz
+{
+   template <opts Opts>
+   requires(not Opts.comments)
    GLZ_ALWAYS_INLINE void skip_value<JSON>::op(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
+      using namespace glz::detail;
+      
       if constexpr (not Opts.validate_skipped) {
          if constexpr (not has_ws_handled(Opts)) {
             if (skip_ws<Opts>(ctx, it, end)) {
@@ -192,54 +212,54 @@ namespace glz::detail
          }
          while (true) {
             switch (*it) {
-            case '{':
-               ++it;
-               if constexpr (not Opts.null_terminated) {
-                  if (it == end) [[unlikely]] {
-                     ctx.error = error_code::unexpected_end;
-                     return;
+               case '{':
+                  ++it;
+                  if constexpr (not Opts.null_terminated) {
+                     if (it == end) [[unlikely]] {
+                        ctx.error = error_code::unexpected_end;
+                        return;
+                     }
                   }
-               }
-               skip_until_closed<Opts, '{', '}'>(ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]]
-                  return;
-               break;
-            case '[':
-               ++it;
-               if constexpr (not Opts.null_terminated) {
-                  if (it == end) [[unlikely]] {
-                     ctx.error = error_code::unexpected_end;
+                  skip_until_closed<Opts, '{', '}'>(ctx, it, end);
+                  if (bool(ctx.error)) [[unlikely]]
                      return;
+                  break;
+               case '[':
+                  ++it;
+                  if constexpr (not Opts.null_terminated) {
+                     if (it == end) [[unlikely]] {
+                        ctx.error = error_code::unexpected_end;
+                        return;
+                     }
                   }
-               }
-               skip_until_closed<Opts, '[', ']'>(ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]]
-                  return;
-               break;
-            case '"':
-               skip_string<Opts>(ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]]
-                  return;
-               break;
-            case ',':
-            case '}':
-            case ']':
-               break;
-            case '\0':
-               ctx.error = error_code::unexpected_end;
-               return;
-            default: {
-               ++it;
-               if constexpr (not Opts.null_terminated) {
-                  if (it == end) [[unlikely]] {
-                     ctx.error = error_code::unexpected_end;
+                  skip_until_closed<Opts, '[', ']'>(ctx, it, end);
+                  if (bool(ctx.error)) [[unlikely]]
                      return;
+                  break;
+               case '"':
+                  skip_string<Opts>(ctx, it, end);
+                  if (bool(ctx.error)) [[unlikely]]
+                     return;
+                  break;
+               case ',':
+               case '}':
+               case ']':
+                  break;
+               case '\0':
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               default: {
+                  ++it;
+                  if constexpr (not Opts.null_terminated) {
+                     if (it == end) [[unlikely]] {
+                        ctx.error = error_code::unexpected_end;
+                        return;
+                     }
                   }
+                  continue;
                }
-               continue;
             }
-            }
-
+            
             break;
          }
       }
@@ -250,6 +270,56 @@ namespace glz::detail
             }
          }
          switch (*it) {
+            case '{': {
+               skip_object<Opts>(ctx, it, end);
+               break;
+            }
+            case '[': {
+               skip_array<Opts>(ctx, it, end);
+               break;
+            }
+            case '"': {
+               skip_string<Opts>(ctx, it, end);
+               break;
+            }
+            case 'n': {
+               ++it;
+               match<"ull", Opts>(ctx, it, end);
+               break;
+            }
+            case 'f': {
+               ++it;
+               match<"alse", Opts>(ctx, it, end);
+               break;
+            }
+            case 't': {
+               ++it;
+               match<"rue", Opts>(ctx, it, end);
+               break;
+            }
+            case '\0': {
+               ctx.error = error_code::unexpected_end;
+               break;
+            }
+            default: {
+               skip_number<Opts>(ctx, it, end);
+            }
+         }
+      }
+   }
+   
+   template <opts Opts>
+   requires(bool(Opts.comments))
+   GLZ_ALWAYS_INLINE void skip_value<JSON>::op(is_context auto&& ctx, auto&& it, auto&& end) noexcept
+   {
+      using namespace glz::detail;
+      
+      if constexpr (not has_ws_handled(Opts)) {
+         if (skip_ws<Opts>(ctx, it, end)) {
+            return;
+         }
+      }
+      switch (*it) {
          case '{': {
             skip_object<Opts>(ctx, it, end);
             break;
@@ -260,6 +330,12 @@ namespace glz::detail
          }
          case '"': {
             skip_string<Opts>(ctx, it, end);
+            break;
+         }
+         case '/': {
+            skip_comment(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
             break;
          }
          case 'n': {
@@ -284,72 +360,6 @@ namespace glz::detail
          default: {
             skip_number<Opts>(ctx, it, end);
          }
-         }
       }
-   }
-
-   template <opts Opts>
-      requires(bool(Opts.comments))
-   GLZ_ALWAYS_INLINE void skip_value<JSON>::op(is_context auto&& ctx, auto&& it, auto&& end) noexcept
-   {
-      if constexpr (not has_ws_handled(Opts)) {
-         if (skip_ws<Opts>(ctx, it, end)) {
-            return;
-         }
-      }
-      switch (*it) {
-      case '{': {
-         skip_object<Opts>(ctx, it, end);
-         break;
-      }
-      case '[': {
-         skip_array<Opts>(ctx, it, end);
-         break;
-      }
-      case '"': {
-         skip_string<Opts>(ctx, it, end);
-         break;
-      }
-      case '/': {
-         skip_comment(ctx, it, end);
-         if (bool(ctx.error)) [[unlikely]]
-            return;
-         break;
-      }
-      case 'n': {
-         ++it;
-         match<"ull", Opts>(ctx, it, end);
-         break;
-      }
-      case 'f': {
-         ++it;
-         match<"alse", Opts>(ctx, it, end);
-         break;
-      }
-      case 't': {
-         ++it;
-         match<"rue", Opts>(ctx, it, end);
-         break;
-      }
-      case '\0': {
-         ctx.error = error_code::unexpected_end;
-         break;
-      }
-      default: {
-         skip_number<Opts>(ctx, it, end);
-      }
-      }
-   }
-
-   // parse_value is used for JSON pointer reading
-   // we want the JSON pointer access to not care about trailing whitespace
-   // so we use validate_skipped for precise validation and value skipping
-   // expects opening whitespace to be handled
-   template <opts Opts>
-   GLZ_ALWAYS_INLINE auto parse_value(is_context auto&& ctx, auto&& it, auto&& end) noexcept
-   {
-      auto start = it;
-      skip_value<JSON>::op<opt_true<Opts, &opts::validate_skipped>>(ctx, it, end);
-      return std::span{start, size_t(it - start)};
    }
 }

--- a/include/glaze/json/skip.hpp
+++ b/include/glaze/json/skip.hpp
@@ -18,10 +18,7 @@ namespace glz
       requires(bool(Opts.comments))
       GLZ_ALWAYS_INLINE static void op(is_context auto&& ctx, auto&& it, auto&& end) noexcept;
    };
-}
-
-namespace glz::detail
-{
+   
    template <opts Opts>
    void skip_object(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
@@ -109,9 +106,9 @@ namespace glz::detail
          }
       }
    }
-
+   
    template <opts Opts>
-      requires(Opts.format == JSON || Opts.format == NDJSON)
+   requires(Opts.format == JSON || Opts.format == NDJSON)
    void skip_array(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       if constexpr (!Opts.validate_skipped) {
@@ -182,7 +179,7 @@ namespace glz::detail
          }
       }
    }
-
+   
    // parse_value is used for JSON pointer reading
    // we want the JSON pointer access to not care about trailing whitespace
    // so we use validate_skipped for precise validation and value skipping
@@ -194,10 +191,7 @@ namespace glz::detail
       skip_value<JSON>::op<opt_true<Opts, &opts::validate_skipped>>(ctx, it, end);
       return std::span{start, size_t(it - start)};
    }
-}
-
-namespace glz
-{
+   
    template <opts Opts>
    requires(not Opts.comments)
    GLZ_ALWAYS_INLINE void skip_value<JSON>::op(is_context auto&& ctx, auto&& it, auto&& end) noexcept

--- a/include/glaze/json/wrappers.hpp
+++ b/include/glaze/json/wrappers.hpp
@@ -22,7 +22,7 @@ namespace glz
          static void op(auto&& value, is_context auto&& ctx, auto&&... args)
          {
             static thread_local std::string s{};
-            read<JSON>::op<Opts>(s, ctx, args...);
+            parse<JSON>::op<Opts>(s, ctx, args...);
             auto pe = glz::read<Opts>(value.val, s);
             if (pe) [[unlikely]] {
                ctx.error = pe.ec;
@@ -52,7 +52,7 @@ namespace glz
          template <auto Opts>
          GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args)
          {
-            read<JSON>::op<opt_true<Opts, T::opts_member>>(value.val, args...);
+            parse<JSON>::op<opt_true<Opts, T::opts_member>>(value.val, args...);
          }
       };
 

--- a/include/glaze/json/wrappers.hpp
+++ b/include/glaze/json/wrappers.hpp
@@ -13,68 +13,65 @@
 
 namespace glz
 {
-   namespace detail
+   template <class T>
+   struct from<JSON, quoted_t<T>>
    {
-      template <class T>
-      struct from<JSON, quoted_t<T>>
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&&... args)
       {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&&... args)
-         {
-            static thread_local std::string s{};
-            parse<JSON>::op<Opts>(s, ctx, args...);
-            auto pe = glz::read<Opts>(value.val, s);
-            if (pe) [[unlikely]] {
-               ctx.error = pe.ec;
-            }
+         static thread_local std::string s{};
+         parse<JSON>::op<Opts>(s, ctx, args...);
+         auto pe = glz::read<Opts>(value.val, s);
+         if (pe) [[unlikely]] {
+            ctx.error = pe.ec;
          }
-      };
-
-      template <class T>
-      struct to<JSON, quoted_t<T>>
-      {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
-         {
-            static thread_local std::string s(128, ' ');
-            size_t oix = 0; // overwrite index
-            using Value = core_t<decltype(value.val)>;
-            to<JSON, Value>::template op<Opts>(value.val, ctx, s, oix);
-            s.resize(oix);
-            using S = core_t<decltype(s)>;
-            to<JSON, S>::template op<Opts>(s, ctx, b, ix);
-         }
-      };
-
-      template <is_opts_wrapper T>
-      struct from<JSON, T>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args)
-         {
-            parse<JSON>::op<opt_true<Opts, T::opts_member>>(value.val, args...);
-         }
-      };
-
-      template <is_opts_wrapper T>
-      struct to<JSON, T>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args)
-         {
-            using Value = core_t<decltype(value.val)>;
-            to<JSON, Value>::template op<opt_true<Opts, T::opts_member>>(value.val, ctx, args...);
-         }
-      };
-
-      template <auto MemPtr>
-      inline constexpr decltype(auto) quoted_impl() noexcept
-      {
-         return [](auto&& val) { return quoted_t<std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
       }
+   };
+   
+   template <class T>
+   struct to<JSON, quoted_t<T>>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
+      {
+         static thread_local std::string s(128, ' ');
+         size_t oix = 0; // overwrite index
+         using Value = core_t<decltype(value.val)>;
+         to<JSON, Value>::template op<Opts>(value.val, ctx, s, oix);
+         s.resize(oix);
+         using S = core_t<decltype(s)>;
+         to<JSON, S>::template op<Opts>(s, ctx, b, ix);
+      }
+   };
+   
+   template <is_opts_wrapper T>
+   struct from<JSON, T>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args)
+      {
+         parse<JSON>::op<opt_true<Opts, T::opts_member>>(value.val, args...);
+      }
+   };
+   
+   template <is_opts_wrapper T>
+   struct to<JSON, T>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args)
+      {
+         using Value = core_t<decltype(value.val)>;
+         to<JSON, Value>::template op<opt_true<Opts, T::opts_member>>(value.val, ctx, args...);
+      }
+   };
+   
+   template <auto MemPtr>
+   inline constexpr decltype(auto) quoted_impl() noexcept
+   {
+      return [](auto&& val) { return quoted_t<std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
    }
 
    // Read a value as a string and unescape, to avoid the user having to parse twice
    template <auto MemPtr>
-   constexpr auto quoted = detail::quoted_impl<MemPtr>();
+   constexpr auto quoted = quoted_impl<MemPtr>();
 }

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -43,7 +43,7 @@ namespace glz
       template <auto Opts, class T, is_context Ctx, class B, class IX>
       GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
       {
-         detail::to<JSON, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+         to<JSON, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
                                                              std::forward<B>(b), std::forward<IX>(ix));
       }
    };
@@ -125,7 +125,7 @@ namespace glz
          static constexpr auto num_members = reflect<T>::size;
          
          if constexpr ((num_members > 0) && (glaze_object_t<T> || reflectable<T>)) {
-            detail::invoke_table<N>([&]<size_t I>() {
+            invoke_table<N>([&]<size_t I>() {
                if (bool(ctx.error)) [[unlikely]] {
                   return;
                }
@@ -202,816 +202,906 @@ namespace glz
       }
    };
    
-   namespace detail
+   template <class T>
+   requires(glaze_value_t<T> && !custom_write<T>)
+   struct to<JSON, T>
    {
-      template <class T>
-         requires(glaze_value_t<T> && !custom_write<T>)
-      struct to<JSON, T>
+      template <auto Opts, class Value, is_context Ctx, class B, class IX>
+      GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, B&& b, IX&& ix)
       {
-         template <auto Opts, class Value, is_context Ctx, class B, class IX>
-         GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, B&& b, IX&& ix)
-         {
-            using V = std::remove_cvref_t<decltype(get_member(std::declval<Value>(), meta_wrapper_v<T>))>;
-            to<JSON, V>::template op<Opts>(get_member(std::forward<Value>(value), meta_wrapper_v<T>),
-                                           std::forward<Ctx>(ctx), std::forward<B>(b), std::forward<IX>(ix));
+         using V = std::remove_cvref_t<decltype(get_member(std::declval<Value>(), meta_wrapper_v<T>))>;
+         to<JSON, V>::template op<Opts>(get_member(std::forward<Value>(value), meta_wrapper_v<T>),
+                                        std::forward<Ctx>(ctx), std::forward<B>(b), std::forward<IX>(ix));
+      }
+   };
+   
+   // Returns 0 if we cannot determine the required padding,
+   // in which case the `to` specialization must allocate buffer space
+   // Some types like numbers must have space to be quoted
+   // All types must have space for a trailing comma
+   template <class T>
+   constexpr size_t required_padding()
+   {
+      const auto value = []() -> size_t {
+         if constexpr (boolean_like<T>) {
+            return 8;
          }
-      };
-
-      // Returns 0 if we cannot determine the required padding,
-      // in which case the `to` specialization must allocate buffer space
-      // Some types like numbers must have space to be quoted
-      // All types must have space for a trailing comma
-      template <class T>
-      constexpr size_t required_padding()
-      {
-         const auto value = []() -> size_t {
-            if constexpr (boolean_like<T>) {
-               return 8;
-            }
-            else if constexpr (num_t<T>) {
-               if constexpr (std::floating_point<T>) {
-                  if constexpr (sizeof(T) > 8) {
-                     return 64;
-                  }
-                  else if constexpr (sizeof(T) > 4) {
-                     return 32;
-                  }
-                  else {
-                     return 24;
-                  }
+         else if constexpr (num_t<T>) {
+            if constexpr (std::floating_point<T>) {
+               if constexpr (sizeof(T) > 8) {
+                  return 64;
                }
                else if constexpr (sizeof(T) > 4) {
+                  return 32;
+               }
+               else {
                   return 24;
                }
-               else if constexpr (sizeof(T) > 2) {
-                  return 16;
-               }
-               else {
-                  return 8;
-               }
             }
-            else if constexpr (nullable_like<T>) {
-               if constexpr (has_value_type<T>) {
-                  return required_padding<typename T::value_type>();
-               }
-               else if constexpr (has_element_type<T>) {
-                  return required_padding<typename T::element_type>();
-               }
-               else {
-                  return 0;
-               }
+            else if constexpr (sizeof(T) > 4) {
+               return 24;
             }
-            else if constexpr (always_null_t<T>) {
+            else if constexpr (sizeof(T) > 2) {
+               return 16;
+            }
+            else {
                return 8;
+            }
+         }
+         else if constexpr (nullable_like<T>) {
+            if constexpr (has_value_type<T>) {
+               return required_padding<typename T::value_type>();
+            }
+            else if constexpr (has_element_type<T>) {
+               return required_padding<typename T::element_type>();
             }
             else {
                return 0;
             }
-         }();
-
-         if (value >= (write_padding_bytes - 16)) {
-            // we always require 16 bytes available from write_padding_bytes
-            // for opening and closing characters
+         }
+         else if constexpr (always_null_t<T>) {
+            return 8;
+         }
+         else {
             return 0;
          }
-         return value;
+      }();
+      
+      if (value >= (write_padding_bytes - 16)) {
+         // we always require 16 bytes available from write_padding_bytes
+         // for opening and closing characters
+         return 0;
       }
-
-      template <is_bitset T>
-      struct to<JSON, T>
+      return value;
+   }
+   
+   template <is_bitset T>
+   struct to<JSON, T>
+   {
+      template <auto Opts, class B>
+      static void op(auto&& value, auto&&, B&& b, auto&& ix)
       {
-         template <auto Opts, class B>
-         static void op(auto&& value, auto&&, B&& b, auto&& ix)
-         {
-            if constexpr (vector_like<B>) {
-               const auto n = ix + 2 + value.size(); // 2 quotes + spaces for character
-               if (n >= b.size()) [[unlikely]] {
-                  b.resize(2 * n);
-               }
+         if constexpr (vector_like<B>) {
+            const auto n = ix + 2 + value.size(); // 2 quotes + spaces for character
+            if (n >= b.size()) [[unlikely]] {
+               b.resize(2 * n);
             }
-
-            std::memcpy(&b[ix], "\"", 1);
-            ++ix;
-            for (size_t i = value.size(); i > 0; --i) {
-               if (value[i - 1]) {
-                  std::memcpy(&b[ix], "1", 1);
-               }
-               else {
-                  std::memcpy(&b[ix], "0", 1);
-               }
-               ++ix;
-            }
-            std::memcpy(&b[ix], "\"", 1);
-            ++ix;
          }
-      };
-
-      template <glaze_flags_t T>
-      struct to<JSON, T>
-      {
-         template <auto Opts, class B>
-         static void op(auto&& value, is_context auto&&, B&& b, auto&& ix)
-         {
-            static constexpr auto N = reflect<T>::size;
-
-            static constexpr auto max_length = [] {
-               size_t length{};
-               [&]<size_t... I>(std::index_sequence<I...>) {
-                  ((length += reflect<T>::keys[I].size()), ...);
-               }(std::make_index_sequence<N>{});
-               return length;
-            }() + 4 + 4 * N; // add extra characters
-
-            if constexpr (vector_like<B>) {
-               if (const auto n = ix + max_length; n > b.size()) [[unlikely]] {
-                  b.resize(2 * n);
-               }
-            }
-
-            std::memcpy(&b[ix], "[", 1);
-            ++ix;
-
-            invoke_table<N>([&]<size_t I>() {
-               if (get_member(value, get<I>(reflect<T>::values))) {
-                  std::memcpy(&b[ix], "\"", 1);
-                  ++ix;
-                  constexpr auto& key = reflect<T>::keys[I];
-                  if constexpr (not key.empty()) {
-                     constexpr auto n = key.size();
-                     std::memcpy(&b[ix], key.data(), n);
-                     ix += n;
-                  }
-                  std::memcpy(&b[ix], "\",", 2);
-                  ix += 2;
-               }
-            });
-
-            if (b[ix - 1] == ',') {
-               b[ix - 1] = ']';
+         
+         std::memcpy(&b[ix], "\"", 1);
+         ++ix;
+         for (size_t i = value.size(); i > 0; --i) {
+            if (value[i - 1]) {
+               std::memcpy(&b[ix], "1", 1);
             }
             else {
-               std::memcpy(&b[ix], "]", 1);
+               std::memcpy(&b[ix], "0", 1);
+            }
+            ++ix;
+         }
+         std::memcpy(&b[ix], "\"", 1);
+         ++ix;
+      }
+   };
+   
+   template <glaze_flags_t T>
+   struct to<JSON, T>
+   {
+      template <auto Opts, class B>
+      static void op(auto&& value, is_context auto&&, B&& b, auto&& ix)
+      {
+         static constexpr auto N = reflect<T>::size;
+         
+         static constexpr auto max_length = [] {
+            size_t length{};
+            [&]<size_t... I>(std::index_sequence<I...>) {
+               ((length += reflect<T>::keys[I].size()), ...);
+            }(std::make_index_sequence<N>{});
+            return length;
+         }() + 4 + 4 * N; // add extra characters
+         
+         if constexpr (vector_like<B>) {
+            if (const auto n = ix + max_length; n > b.size()) [[unlikely]] {
+               b.resize(2 * n);
+            }
+         }
+         
+         std::memcpy(&b[ix], "[", 1);
+         ++ix;
+         
+         invoke_table<N>([&]<size_t I>() {
+            if (get_member(value, get<I>(reflect<T>::values))) {
+               std::memcpy(&b[ix], "\"", 1);
                ++ix;
-            }
-         }
-      };
-
-      template <is_member_function_pointer T>
-      struct to<JSON, T>
-      {
-         template <auto Opts>
-         static void op(auto&&, is_context auto&&, auto&&...) noexcept
-         {}
-      };
-
-      template <is_reference_wrapper T>
-      struct to<JSON, T>
-      {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args)
-         {
-            using V = std::remove_cvref_t<decltype(value.get())>;
-            to<JSON, V>::template op<Opts>(value.get(), std::forward<Args>(args)...);
-         }
-      };
-
-      template <complex_t T>
-      struct to<JSON, T>
-      {
-         template <auto Opts, class B>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
-         {
-            static_assert(num_t<typename T::value_type>);
-            // we need to know it is a number type to allocate buffer space
-
-            if constexpr (vector_like<B>) {
-               static constexpr size_t max_length = 256;
-               if (const auto n = ix + max_length; n > b.size()) [[unlikely]] {
-                  b.resize(2 * n);
+               constexpr auto& key = reflect<T>::keys[I];
+               if constexpr (not key.empty()) {
+                  constexpr auto n = key.size();
+                  std::memcpy(&b[ix], key.data(), n);
+                  ix += n;
                }
+               std::memcpy(&b[ix], "\",", 2);
+               ix += 2;
             }
-
-            static constexpr auto O = write_unchecked_on<Opts>();
-
-            std::memcpy(&b[ix], "[", 1);
-            ++ix;
-            using Value = core_t<typename T::value_type>;
-            to<JSON, Value>::template op<O>(value.real(), ctx, b, ix);
-            std::memcpy(&b[ix], ",", 1);
-            ++ix;
-            to<JSON, Value>::template op<O>(value.imag(), ctx, b, ix);
+         });
+         
+         if (b[ix - 1] == ',') {
+            b[ix - 1] = ']';
+         }
+         else {
             std::memcpy(&b[ix], "]", 1);
             ++ix;
          }
-      };
-
-      template <boolean_like T>
-      struct to<JSON, T>
+      }
+   };
+   
+   template <is_member_function_pointer T>
+   struct to<JSON, T>
+   {
+      template <auto Opts>
+      static void op(auto&&, is_context auto&&, auto&&...) noexcept
+      {}
+   };
+   
+   template <is_reference_wrapper T>
+   struct to<JSON, T>
+   {
+      template <auto Opts, class... Args>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args)
       {
-         template <auto Opts, class B>
-         GLZ_ALWAYS_INLINE static void op(const bool value, is_context auto&&, B&& b, auto&& ix)
-         {
-            static constexpr auto checked = not has_write_unchecked(Opts);
-            if constexpr (checked && vector_like<B>) {
-               if (const auto n = ix + 8; n > b.size()) [[unlikely]] {
-                  b.resize(2 * n);
-               }
-            }
-
-            if constexpr (Opts.bools_as_numbers) {
-               if (value) {
-                  std::memcpy(&b[ix], "1", 1);
-               }
-               else {
-                  std::memcpy(&b[ix], "0", 1);
-               }
-               ++ix;
-            }
-            else {
-               if (value) {
-                  std::memcpy(&b[ix], "true", 4);
-                  ix += 4;
-               }
-               else {
-                  std::memcpy(&b[ix], "false", 5);
-                  ix += 5;
-               }
+         using V = std::remove_cvref_t<decltype(value.get())>;
+         to<JSON, V>::template op<Opts>(value.get(), std::forward<Args>(args)...);
+      }
+   };
+   
+   template <complex_t T>
+   struct to<JSON, T>
+   {
+      template <auto Opts, class B>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
+      {
+         static_assert(num_t<typename T::value_type>);
+         // we need to know it is a number type to allocate buffer space
+         
+         if constexpr (vector_like<B>) {
+            static constexpr size_t max_length = 256;
+            if (const auto n = ix + max_length; n > b.size()) [[unlikely]] {
+               b.resize(2 * n);
             }
          }
-      };
-
-      template <num_t T>
-      struct to<JSON, T>
+         
+         static constexpr auto O = write_unchecked_on<Opts>();
+         
+         std::memcpy(&b[ix], "[", 1);
+         ++ix;
+         using Value = core_t<typename T::value_type>;
+         to<JSON, Value>::template op<O>(value.real(), ctx, b, ix);
+         std::memcpy(&b[ix], ",", 1);
+         ++ix;
+         to<JSON, Value>::template op<O>(value.imag(), ctx, b, ix);
+         std::memcpy(&b[ix], "]", 1);
+         ++ix;
+      }
+   };
+   
+   template <boolean_like T>
+   struct to<JSON, T>
+   {
+      template <auto Opts, class B>
+      GLZ_ALWAYS_INLINE static void op(const bool value, is_context auto&&, B&& b, auto&& ix)
       {
-         template <auto Opts, class B>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
-         {
-            if constexpr (not has_write_unchecked(Opts) && vector_like<B>) {
-               static_assert(required_padding<T>());
-               if (const auto n = ix + required_padding<T>(); n > b.size()) [[unlikely]] {
-                  b.resize(2 * n);
-               }
-            }
-
-            static constexpr auto O = write_unchecked_on<Opts>();
-
-            if constexpr (Opts.quoted_num) {
-               std::memcpy(&b[ix], "\"", 1);
-               ++ix;
-               write_chars::op<O>(value, ctx, b, ix);
-               std::memcpy(&b[ix], "\"", 1);
-               ++ix;
-            }
-            else {
-               write_chars::op<O>(value, ctx, b, ix);
+         static constexpr auto checked = not has_write_unchecked(Opts);
+         if constexpr (checked && vector_like<B>) {
+            if (const auto n = ix + 8; n > b.size()) [[unlikely]] {
+               b.resize(2 * n);
             }
          }
-      };
-
-      inline constexpr std::array<uint16_t, 256> char_escape_table = [] {
-         auto combine = [](const char chars[2]) -> uint16_t { return uint16_t(chars[0]) | (uint16_t(chars[1]) << 8); };
-
-         std::array<uint16_t, 256> t{};
-         t['\b'] = combine(R"(\b)");
-         t['\t'] = combine(R"(\t)");
-         t['\n'] = combine(R"(\n)");
-         t['\f'] = combine(R"(\f)");
-         t['\r'] = combine(R"(\r)");
-         t['\"'] = combine(R"(\")");
-         t['\\'] = combine(R"(\\)");
-         return t;
-      }();
-
-      template <class T>
-         requires str_t<T> || char_t<T>
-      struct to<JSON, T>
-      {
-         template <auto Opts, class B>
-         static void op(auto&& value, is_context auto&&, B&& b, auto&& ix)
-         {
-            if constexpr (Opts.number) {
-               dump_maybe_empty(value, b, ix);
+         
+         if constexpr (Opts.bools_as_numbers) {
+            if (value) {
+               std::memcpy(&b[ix], "1", 1);
             }
-            else if constexpr (char_t<T>) {
-               if constexpr (Opts.raw) {
-                  dump(value, b, ix);
-               }
-               else {
-                  if constexpr (resizable<B>) {
-                     const auto k = ix + 8; // 4 characters is enough for quotes and escaped character
-                     if (k > b.size()) [[unlikely]] {
-                        b.resize(2 * k);
-                     }
+            else {
+               std::memcpy(&b[ix], "0", 1);
+            }
+            ++ix;
+         }
+         else {
+            if (value) {
+               std::memcpy(&b[ix], "true", 4);
+               ix += 4;
+            }
+            else {
+               std::memcpy(&b[ix], "false", 5);
+               ix += 5;
+            }
+         }
+      }
+   };
+   
+   template <num_t T>
+   struct to<JSON, T>
+   {
+      template <auto Opts, class B>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
+      {
+         if constexpr (not has_write_unchecked(Opts) && vector_like<B>) {
+            static_assert(required_padding<T>());
+            if (const auto n = ix + required_padding<T>(); n > b.size()) [[unlikely]] {
+               b.resize(2 * n);
+            }
+         }
+         
+         static constexpr auto O = write_unchecked_on<Opts>();
+         
+         if constexpr (Opts.quoted_num) {
+            std::memcpy(&b[ix], "\"", 1);
+            ++ix;
+            write_chars::op<O>(value, ctx, b, ix);
+            std::memcpy(&b[ix], "\"", 1);
+            ++ix;
+         }
+         else {
+            write_chars::op<O>(value, ctx, b, ix);
+         }
+      }
+   };
+   
+   inline constexpr std::array<uint16_t, 256> char_escape_table = [] {
+      auto combine = [](const char chars[2]) -> uint16_t { return uint16_t(chars[0]) | (uint16_t(chars[1]) << 8); };
+      
+      std::array<uint16_t, 256> t{};
+      t['\b'] = combine(R"(\b)");
+      t['\t'] = combine(R"(\t)");
+      t['\n'] = combine(R"(\n)");
+      t['\f'] = combine(R"(\f)");
+      t['\r'] = combine(R"(\r)");
+      t['\"'] = combine(R"(\")");
+      t['\\'] = combine(R"(\\)");
+      return t;
+   }();
+   
+   template <class T>
+   requires str_t<T> || char_t<T>
+   struct to<JSON, T>
+   {
+      template <auto Opts, class B>
+      static void op(auto&& value, is_context auto&&, B&& b, auto&& ix)
+      {
+         if constexpr (Opts.number) {
+            dump_maybe_empty(value, b, ix);
+         }
+         else if constexpr (char_t<T>) {
+            if constexpr (Opts.raw) {
+               dump(value, b, ix);
+            }
+            else {
+               if constexpr (resizable<B>) {
+                  const auto k = ix + 8; // 4 characters is enough for quotes and escaped character
+                  if (k > b.size()) [[unlikely]] {
+                     b.resize(2 * k);
                   }
-
-                  std::memcpy(&b[ix], "\"", 1);
+               }
+               
+               std::memcpy(&b[ix], "\"", 1);
+               ++ix;
+               if (const auto escaped = char_escape_table[uint8_t(value)]; escaped) {
+                  std::memcpy(&b[ix], &escaped, 2);
+                  ix += 2;
+               }
+               else if (value == '\0') {
+                  // null character treated as empty string
+               }
+               else {
+                  std::memcpy(&b[ix], &value, 1);
                   ++ix;
-                  if (const auto escaped = char_escape_table[uint8_t(value)]; escaped) {
-                     std::memcpy(&b[ix], &escaped, 2);
-                     ix += 2;
-                  }
-                  else if (value == '\0') {
-                     // null character treated as empty string
+               }
+               std::memcpy(&b[ix], "\"", 1);
+               ++ix;
+            }
+         }
+         else {
+            if constexpr (Opts.raw_string) {
+               const sv str = [&]() -> const sv {
+                  if constexpr (!char_array_t<T> && std::is_pointer_v<std::decay_t<T>>) {
+                     return value ? value : "";
                   }
                   else {
-                     std::memcpy(&b[ix], &value, 1);
-                     ++ix;
+                     return value;
                   }
-                  std::memcpy(&b[ix], "\"", 1);
-                  ++ix;
+               }();
+               
+               // We need space for quotes and the string length: 2 + n.
+               // Use +8 for extra buffer
+               if constexpr (resizable<B>) {
+                  const auto n = str.size();
+                  const auto k = ix + 8 + n;
+                  if (k > b.size()) [[unlikely]] {
+                     b.resize(2 * k);
+                  }
                }
+               // now we don't have to check writing
+               
+               std::memcpy(&b[ix], "\"", 1);
+               ++ix;
+               if (str.size()) [[likely]] {
+                  const auto n = str.size();
+                  std::memcpy(&b[ix], str.data(), n);
+                  ix += n;
+               }
+               std::memcpy(&b[ix], "\"", 1);
+               ++ix;
             }
             else {
-               if constexpr (Opts.raw_string) {
-                  const sv str = [&]() -> const sv {
-                     if constexpr (!char_array_t<T> && std::is_pointer_v<std::decay_t<T>>) {
-                        return value ? value : "";
-                     }
-                     else {
-                        return value;
-                     }
-                  }();
-
-                  // We need space for quotes and the string length: 2 + n.
-                  // Use +8 for extra buffer
-                  if constexpr (resizable<B>) {
-                     const auto n = str.size();
-                     const auto k = ix + 8 + n;
-                     if (k > b.size()) [[unlikely]] {
-                        b.resize(2 * k);
-                     }
+               const sv str = [&]() -> const sv {
+                  if constexpr (!char_array_t<T> && std::is_pointer_v<std::decay_t<T>>) {
+                     return value ? value : "";
                   }
-                  // now we don't have to check writing
-
-                  std::memcpy(&b[ix], "\"", 1);
-                  ++ix;
-                  if (str.size()) [[likely]] {
-                     const auto n = str.size();
+                  else if constexpr (array_char_t<T>) {
+                     return *value.data() ? sv{value.data()} : "";
+                  }
+                  else {
+                     return value;
+                  }
+               }();
+               const auto n = str.size();
+               
+               // In the case n == 0 we need two characters for quotes.
+               // For each individual character we need room for two characters to handle escapes.
+               // So, we need 2 + 2 * n characters to handle all cases.
+               // We add another 8 characters to support SWAR
+               if constexpr (resizable<B>) {
+                  const auto k = ix + 10 + 2 * n;
+                  if (k > b.size()) [[unlikely]] {
+                     b.resize(2 * k);
+                  }
+               }
+               // now we don't have to check writing
+               
+               if constexpr (Opts.raw) {
+                  const auto n = str.size();
+                  if (n) {
                      std::memcpy(&b[ix], str.data(), n);
                      ix += n;
                   }
-                  std::memcpy(&b[ix], "\"", 1);
-                  ++ix;
                }
                else {
-                  const sv str = [&]() -> const sv {
-                     if constexpr (!char_array_t<T> && std::is_pointer_v<std::decay_t<T>>) {
-                        return value ? value : "";
-                     }
-                     else if constexpr (array_char_t<T>) {
-                        return *value.data() ? sv{value.data()} : "";
-                     }
-                     else {
-                        return value;
-                     }
-                  }();
-                  const auto n = str.size();
-
-                  // In the case n == 0 we need two characters for quotes.
-                  // For each individual character we need room for two characters to handle escapes.
-                  // So, we need 2 + 2 * n characters to handle all cases.
-                  // We add another 8 characters to support SWAR
-                  if constexpr (resizable<B>) {
-                     const auto k = ix + 10 + 2 * n;
-                     if (k > b.size()) [[unlikely]] {
-                        b.resize(2 * k);
-                     }
-                  }
-                  // now we don't have to check writing
-
-                  if constexpr (Opts.raw) {
-                     const auto n = str.size();
-                     if (n) {
-                        std::memcpy(&b[ix], str.data(), n);
-                        ix += n;
-                     }
-                  }
-                  else {
-                     std::memcpy(&b[ix], "\"", 1);
-                     ++ix;
-
-                     const auto* c = str.data();
-                     const auto* const e = c + n;
-                     const auto start = &b[ix];
-                     auto data = start;
-
-                     // We don't check for writing out invalid characters as this can be tested by the user if
-                     // necessary. In the case of invalid JSON characters we write out null characters to
-                     // showcase the error and make the JSON invalid. These would then be detected upon reading
-                     // the JSON.
-
-                     // This 128bit SWAR approach tends to be slower than SIMD approaches
-                     /*for (const auto end_m15 = e - 15; c < end_m15;) {
-                        std::memcpy(data, c, 16);
-                        __uint128_t swar;
-                        std::memcpy(&swar, c, 16);
-
-                        constexpr __uint128_t lo7_mask = repeat_byte16(0b01111111);
-                        const __uint128_t lo7 = swar & lo7_mask;
-                        const __uint128_t quote = (lo7 ^ repeat_byte16('"')) + lo7_mask;
-                        const __uint128_t backslash = (lo7 ^ repeat_byte16('\\')) + lo7_mask;
-                        const __uint128_t less_32 = (swar & repeat_byte16(0b01100000)) + lo7_mask;
-                        __uint128_t next = ~((quote & backslash & less_32) | swar);
-
-                        next &= repeat_byte16(0b10000000);
-                        if (next == 0) {
-                           data += 16;
-                           c += 16;
+                  std::memcpy(&b[ix], "\"", 1);
+                  ++ix;
+                  
+                  const auto* c = str.data();
+                  const auto* const e = c + n;
+                  const auto start = &b[ix];
+                  auto data = start;
+                  
+                  // We don't check for writing out invalid characters as this can be tested by the user if
+                  // necessary. In the case of invalid JSON characters we write out null characters to
+                  // showcase the error and make the JSON invalid. These would then be detected upon reading
+                  // the JSON.
+                  
+                  // This 128bit SWAR approach tends to be slower than SIMD approaches
+                  /*for (const auto end_m15 = e - 15; c < end_m15;) {
+                   std::memcpy(data, c, 16);
+                   __uint128_t swar;
+                   std::memcpy(&swar, c, 16);
+                   
+                   constexpr __uint128_t lo7_mask = repeat_byte16(0b01111111);
+                   const __uint128_t lo7 = swar & lo7_mask;
+                   const __uint128_t quote = (lo7 ^ repeat_byte16('"')) + lo7_mask;
+                   const __uint128_t backslash = (lo7 ^ repeat_byte16('\\')) + lo7_mask;
+                   const __uint128_t less_32 = (swar & repeat_byte16(0b01100000)) + lo7_mask;
+                   __uint128_t next = ~((quote & backslash & less_32) | swar);
+                   
+                   next &= repeat_byte16(0b10000000);
+                   if (next == 0) {
+                   data += 16;
+                   c += 16;
+                   continue;
+                   }
+                   
+                   const auto length = (countr_zero(next) >> 3);
+                   c += length;
+                   data += length;
+                   
+                   std::memcpy(data, &char_escape_table[uint8_t(*c)], 2);
+                   data += 2;
+                   ++c;
+                   }*/
+                  
+#if defined(__APPLE__)
+                  // This approach is faster when strings don't contain many escapes
+                  // But, this is not faster in the general case
+                  /*if (n > 15) {
+                   const uint8x16_t lo7_mask = vdupq_n_u8(0b01111111);
+                   const uint8x16_t quote_char = vdupq_n_u8('"');
+                   const uint8x16_t backslash_char = vdupq_n_u8('\\');
+                   const uint8x16_t less_32_mask = vdupq_n_u8(0b01100000);
+                   const uint8x16_t high_bit_mask = vdupq_n_u8(0b10000000);
+                   
+                   for (const auto end_m15 = e - 15; c < end_m15;) {
+                   uint8x16_t v = vld1q_u8(reinterpret_cast<const uint8_t*>(c));
+                   
+                   vst1q_u8(reinterpret_cast<uint8_t*>(data), v);
+                   
+                   const uint8x16_t lo7 = vandq_u8(v, lo7_mask);
+                   const uint8x16_t quote = vaddq_u8(veorq_u8(lo7, quote_char), lo7_mask);
+                   const uint8x16_t backslash = vaddq_u8(veorq_u8(lo7, backslash_char), lo7_mask);
+                   const uint8x16_t less_32 = vaddq_u8(vandq_u8(v, less_32_mask), lo7_mask);
+                   
+                   uint8x16_t temp = vandq_u8(quote, backslash);
+                   temp = vandq_u8(temp, less_32);
+                   temp = vorrq_u8(temp, v);
+                   uint8x16_t next = vmvnq_u8(temp);
+                   next = vandq_u8(next, high_bit_mask);
+                   
+                   uint64x2_t next64 = vreinterpretq_u64_u8(next);
+                   uint64_t next_low = vgetq_lane_u64(next64, 0);
+                   uint64_t next_high = vgetq_lane_u64(next64, 1);
+                   
+                   if (next_low == 0 && next_high == 0) {
+                   data += 16;
+                   c += 16;
+                   continue;
+                   }
+                   
+                   uint32_t length;
+                   if (next_low != 0) {
+                   length = (__builtin_ctzll(next_low)) >> 3;
+                   }
+                   else {
+                   length = (__builtin_ctzll(next_high) >> 3) + 8;
+                   }
+                   
+                   c += length;
+                   data += length;
+                   
+                   std::memcpy(data, &char_escape_table[uint8_t(*c)], 2);
+                   data += 2;
+                   ++c;
+                   }
+                   }*/
+#elif defined(GLZ_USE_AVX2)
+                  // Optimization for systems with AVX2 support
+                  if (n > 31) {
+                     const __m256i lo7_mask = _mm256_set1_epi8(0b01111111);
+                     const __m256i quote_char = _mm256_set1_epi8('"');
+                     const __m256i backslash_char = _mm256_set1_epi8('\\');
+                     const __m256i less_32_mask = _mm256_set1_epi8(0b01100000);
+                     const __m256i high_bit_mask = _mm256_set1_epi8(static_cast<int8_t>(0b10000000));
+                     
+                     for (const char* end_m31 = e - 31; c < end_m31;) {
+                        __m256i v = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(c));
+                        
+                        _mm256_storeu_si256(reinterpret_cast<__m256i*>(data), v);
+                        
+                        const __m256i lo7 = _mm256_and_si256(v, lo7_mask);
+                        const __m256i quote = _mm256_add_epi8(_mm256_xor_si256(lo7, quote_char), lo7_mask);
+                        const __m256i backslash = _mm256_add_epi8(_mm256_xor_si256(lo7, backslash_char), lo7_mask);
+                        const __m256i less_32 = _mm256_add_epi8(_mm256_and_si256(v, less_32_mask), lo7_mask);
+                        
+                        __m256i temp = _mm256_and_si256(quote, backslash);
+                        temp = _mm256_and_si256(temp, less_32);
+                        temp = _mm256_or_si256(temp, v);
+                        __m256i next = _mm256_andnot_si256(temp, _mm256_set1_epi8(-1)); // Equivalent to ~temp
+                        next = _mm256_and_si256(next, high_bit_mask);
+                        
+                        uint32_t mask = _mm256_movemask_epi8(next);
+                        
+                        if (mask == 0) {
+                           data += 32;
+                           c += 32;
                            continue;
                         }
-
-                        const auto length = (countr_zero(next) >> 3);
+                        
+                        uint32_t length = countr_zero(mask);
+                        
                         c += length;
                         data += length;
-
+                        
                         std::memcpy(data, &char_escape_table[uint8_t(*c)], 2);
                         data += 2;
                         ++c;
-                     }*/
-
-#if defined(__APPLE__)
-                     // This approach is faster when strings don't contain many escapes
-                     // But, this is not faster in the general case
-                     /*if (n > 15) {
-                        const uint8x16_t lo7_mask = vdupq_n_u8(0b01111111);
-                        const uint8x16_t quote_char = vdupq_n_u8('"');
-                        const uint8x16_t backslash_char = vdupq_n_u8('\\');
-                        const uint8x16_t less_32_mask = vdupq_n_u8(0b01100000);
-                        const uint8x16_t high_bit_mask = vdupq_n_u8(0b10000000);
-
-                        for (const auto end_m15 = e - 15; c < end_m15;) {
-                           uint8x16_t v = vld1q_u8(reinterpret_cast<const uint8_t*>(c));
-
-                           vst1q_u8(reinterpret_cast<uint8_t*>(data), v);
-
-                           const uint8x16_t lo7 = vandq_u8(v, lo7_mask);
-                           const uint8x16_t quote = vaddq_u8(veorq_u8(lo7, quote_char), lo7_mask);
-                           const uint8x16_t backslash = vaddq_u8(veorq_u8(lo7, backslash_char), lo7_mask);
-                           const uint8x16_t less_32 = vaddq_u8(vandq_u8(v, less_32_mask), lo7_mask);
-
-                           uint8x16_t temp = vandq_u8(quote, backslash);
-                           temp = vandq_u8(temp, less_32);
-                           temp = vorrq_u8(temp, v);
-                           uint8x16_t next = vmvnq_u8(temp);
-                           next = vandq_u8(next, high_bit_mask);
-
-                           uint64x2_t next64 = vreinterpretq_u64_u8(next);
-                           uint64_t next_low = vgetq_lane_u64(next64, 0);
-                           uint64_t next_high = vgetq_lane_u64(next64, 1);
-
-                           if (next_low == 0 && next_high == 0) {
-                              data += 16;
-                              c += 16;
-                              continue;
-                           }
-
-                           uint32_t length;
-                           if (next_low != 0) {
-                              length = (__builtin_ctzll(next_low)) >> 3;
-                           }
-                           else {
-                              length = (__builtin_ctzll(next_high) >> 3) + 8;
-                           }
-
-                           c += length;
-                           data += length;
-
-                           std::memcpy(data, &char_escape_table[uint8_t(*c)], 2);
-                           data += 2;
-                           ++c;
-                        }
-                     }*/
-#elif defined(GLZ_USE_AVX2)
-                     // Optimization for systems with AVX2 support
-                     if (n > 31) {
-                        const __m256i lo7_mask = _mm256_set1_epi8(0b01111111);
-                        const __m256i quote_char = _mm256_set1_epi8('"');
-                        const __m256i backslash_char = _mm256_set1_epi8('\\');
-                        const __m256i less_32_mask = _mm256_set1_epi8(0b01100000);
-                        const __m256i high_bit_mask = _mm256_set1_epi8(static_cast<int8_t>(0b10000000));
-
-                        for (const char* end_m31 = e - 31; c < end_m31;) {
-                           __m256i v = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(c));
-
-                           _mm256_storeu_si256(reinterpret_cast<__m256i*>(data), v);
-
-                           const __m256i lo7 = _mm256_and_si256(v, lo7_mask);
-                           const __m256i quote = _mm256_add_epi8(_mm256_xor_si256(lo7, quote_char), lo7_mask);
-                           const __m256i backslash = _mm256_add_epi8(_mm256_xor_si256(lo7, backslash_char), lo7_mask);
-                           const __m256i less_32 = _mm256_add_epi8(_mm256_and_si256(v, less_32_mask), lo7_mask);
-
-                           __m256i temp = _mm256_and_si256(quote, backslash);
-                           temp = _mm256_and_si256(temp, less_32);
-                           temp = _mm256_or_si256(temp, v);
-                           __m256i next = _mm256_andnot_si256(temp, _mm256_set1_epi8(-1)); // Equivalent to ~temp
-                           next = _mm256_and_si256(next, high_bit_mask);
-
-                           uint32_t mask = _mm256_movemask_epi8(next);
-
-                           if (mask == 0) {
-                              data += 32;
-                              c += 32;
-                              continue;
-                           }
-
-                           uint32_t length = countr_zero(mask);
-
-                           c += length;
-                           data += length;
-
-                           std::memcpy(data, &char_escape_table[uint8_t(*c)], 2);
-                           data += 2;
-                           ++c;
-                        }
                      }
+                  }
 #endif
-
-                     if (n > 7) {
-                        for (const auto end_m7 = e - 7; c < end_m7;) {
-                           std::memcpy(data, c, 8);
-                           uint64_t swar;
-                           std::memcpy(&swar, c, 8);
-
-                           constexpr uint64_t lo7_mask = repeat_byte8(0b01111111);
-                           const uint64_t lo7 = swar & lo7_mask;
-                           const uint64_t quote = (lo7 ^ repeat_byte8('"')) + lo7_mask;
-                           const uint64_t backslash = (lo7 ^ repeat_byte8('\\')) + lo7_mask;
-                           const uint64_t less_32 = (swar & repeat_byte8(0b01100000)) + lo7_mask;
-                           uint64_t next = ~((quote & backslash & less_32) | swar);
-
-                           next &= repeat_byte8(0b10000000);
-                           if (next == 0) {
-                              data += 8;
-                              c += 8;
-                              continue;
-                           }
-
-                           const auto length = (countr_zero(next) >> 3);
-                           c += length;
-                           data += length;
-
-                           std::memcpy(data, &char_escape_table[uint8_t(*c)], 2);
-                           data += 2;
-                           ++c;
+                  
+                  if (n > 7) {
+                     for (const auto end_m7 = e - 7; c < end_m7;) {
+                        std::memcpy(data, c, 8);
+                        uint64_t swar;
+                        std::memcpy(&swar, c, 8);
+                        
+                        constexpr uint64_t lo7_mask = repeat_byte8(0b01111111);
+                        const uint64_t lo7 = swar & lo7_mask;
+                        const uint64_t quote = (lo7 ^ repeat_byte8('"')) + lo7_mask;
+                        const uint64_t backslash = (lo7 ^ repeat_byte8('\\')) + lo7_mask;
+                        const uint64_t less_32 = (swar & repeat_byte8(0b01100000)) + lo7_mask;
+                        uint64_t next = ~((quote & backslash & less_32) | swar);
+                        
+                        next &= repeat_byte8(0b10000000);
+                        if (next == 0) {
+                           data += 8;
+                           c += 8;
+                           continue;
                         }
+                        
+                        const auto length = (countr_zero(next) >> 3);
+                        c += length;
+                        data += length;
+                        
+                        std::memcpy(data, &char_escape_table[uint8_t(*c)], 2);
+                        data += 2;
+                        ++c;
                      }
-
-                     // Tail end of buffer. Uncommon for long strings.
-                     for (; c < e; ++c) {
-                        if (const auto escaped = char_escape_table[uint8_t(*c)]; escaped) {
-                           std::memcpy(data, &escaped, 2);
-                           data += 2;
-                        }
-                        else {
-                           std::memcpy(data, c, 1);
-                           ++data;
-                        }
+                  }
+                  
+                  // Tail end of buffer. Uncommon for long strings.
+                  for (; c < e; ++c) {
+                     if (const auto escaped = char_escape_table[uint8_t(*c)]; escaped) {
+                        std::memcpy(data, &escaped, 2);
+                        data += 2;
                      }
-
-                     ix += size_t(data - start);
-
-                     std::memcpy(&b[ix], "\"", 1);
+                     else {
+                        std::memcpy(data, c, 1);
+                        ++data;
+                     }
+                  }
+                  
+                  ix += size_t(data - start);
+                  
+                  std::memcpy(&b[ix], "\"", 1);
+                  ++ix;
+               }
+            }
+         }
+      }
+   };
+   
+   template <class T>
+   requires((glaze_enum_t<T> || (meta_keys<T> && std::is_enum_v<std::decay_t<T>>)) && not custom_write<T>)
+   struct to<JSON, T>
+   {
+      template <auto Opts, class... Args>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
+      {
+         // TODO: Use new hashing approach for better performance
+         // TODO: Check if sequenced and use the value as the index if so
+         using key_t = std::underlying_type_t<T>;
+         static constexpr auto frozen_map = make_enum_to_string_map<T>();
+         const auto& member_it = frozen_map.find(static_cast<key_t>(value));
+         if (member_it != frozen_map.end()) {
+            const sv str = {member_it->second.data(), member_it->second.size()};
+            // TODO: Assumes people dont use strings with chars that need to be escaped for their enum names
+            // TODO: Could create a pre quoted map for better performance
+            if constexpr (not Opts.raw) {
+               dump<'"'>(args...);
+            }
+            dump_maybe_empty(str, args...);
+            if constexpr (not Opts.raw) {
+               dump<'"'>(args...);
+            }
+         }
+         else [[unlikely]] {
+            // What do we want to happen if the value doesn't have a mapped string
+            serialize<JSON>::op<Opts>(static_cast<std::underlying_type_t<T>>(value), ctx, std::forward<Args>(args)...);
+         }
+      }
+   };
+   
+   template <class T>
+   requires(!meta_keys<T> && std::is_enum_v<std::decay_t<T>> && !glaze_enum_t<T> && !custom_write<T>)
+   struct to<JSON, T>
+   {
+      template <auto Opts, class... Args>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
+      {
+         // serialize as underlying number
+         serialize<JSON>::op<Opts>(static_cast<std::underlying_type_t<std::decay_t<T>>>(value), ctx,
+                                   std::forward<Args>(args)...);
+      }
+   };
+   
+   template <func_t T>
+   struct to<JSON, T>
+   {
+      template <auto Opts, class B>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, B&& b, auto&& ix)
+      {
+         static constexpr auto name = name_v<std::decay_t<decltype(value)>>;
+         constexpr auto n = name.size();
+         
+         if constexpr (vector_like<B>) {
+            if (const auto k = ix + 8 + n; k > b.size()) [[unlikely]] {
+               b.resize(2 * k);
+            }
+         }
+         
+         std::memcpy(&b[ix], "\"", 1);
+         ++ix;
+         if constexpr (not name.empty()) {
+            std::memcpy(&b[ix], name.data(), n);
+            ix += n;
+         }
+         std::memcpy(&b[ix], "\"", 1);
+         ++ix;
+      }
+   };
+   
+   template <class T>
+   struct to<JSON, basic_raw_json<T>>
+   {
+      template <auto Opts, class B>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, B&& b, auto&& ix)
+      {
+         const auto n = value.str.size();
+         if (n) {
+            if constexpr (vector_like<B>) {
+               if (const auto k = ix + n + write_padding_bytes; k > b.size()) [[unlikely]] {
+                  b.resize(2 * k);
+               }
+            }
+            
+            std::memcpy(&b[ix], value.str.data(), n);
+            ix += n;
+         }
+      }
+   };
+   
+   template <class T>
+   struct to<JSON, basic_text<T>>
+   {
+      template <auto Opts, class B>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, B&& b, auto&& ix)
+      {
+         const auto n = value.str.size();
+         if (n) {
+            if constexpr (vector_like<B>) {
+               if (const auto k = ix + n + write_padding_bytes; k > b.size()) [[unlikely]] {
+                  b.resize(2 * k);
+               }
+            }
+            
+            std::memcpy(&b[ix], value.str.data(), n);
+            ix += n;
+         }
+      }
+   };
+   
+   template <opts Opts, bool minified_check = true, class B>
+   GLZ_ALWAYS_INLINE void write_array_entry_separator(is_context auto&& ctx, B&& b, auto&& ix)
+   {
+      if constexpr (Opts.prettify) {
+         if constexpr (vector_like<B>) {
+            if (const auto k = ix + ctx.indentation_level + write_padding_bytes; k > b.size()) [[unlikely]] {
+               b.resize(2 * k);
+            }
+         }
+         if constexpr (Opts.new_lines_in_arrays) {
+            std::memcpy(&b[ix], ",\n", 2);
+            ix += 2;
+            std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
+            ix += ctx.indentation_level;
+         }
+         else {
+            std::memcpy(&b[ix], ", ", 2);
+            ix += 2;
+         }
+      }
+      else {
+         if constexpr (vector_like<B>) {
+            if constexpr (minified_check) {
+               if (ix >= b.size()) [[unlikely]] {
+                  b.resize(2 * ix);
+               }
+            }
+         }
+         std::memcpy(&b[ix], ",", 1);
+         ++ix;
+      }
+   }
+   
+   // "key":value pair output
+   template <opts Opts, class Key, class Value, is_context Ctx, class B>
+   GLZ_ALWAYS_INLINE void write_pair_content(const Key& key, Value&& value, Ctx& ctx, B&& b, auto&& ix)
+   {
+      if constexpr (str_t<Key> || char_t<Key> || glaze_enum_t<Key> || Opts.quoted_num) {
+         to<JSON, core_t<Key>>::template op<Opts>(key, ctx, b, ix);
+      }
+      else if constexpr (num_t<Key>) {
+         serialize<JSON>::op<opt_true<Opts, &opts::quoted_num>>(key, ctx, b, ix);
+      }
+      else {
+         serialize<JSON>::op<opt_false<Opts, &opts::raw_string>>(quoted_t<const Key>{key}, ctx, b, ix);
+      }
+      if constexpr (Opts.prettify) {
+         dump<": ">(b, ix);
+      }
+      else {
+         dump<':'>(b, ix);
+      }
+      
+      using V = core_t<decltype(value)>;
+      to<JSON, V>::template op<opening_and_closing_handled_off<Opts>()>(value, ctx, b, ix);
+   }
+   
+   template <class T>
+   concept array_padding_known =
+   requires { typename T::value_type; } && (required_padding<typename T::value_type>() > 0);
+   
+   template <class T>
+   requires(writable_array_t<T> || writable_map_t<T>)
+   struct to<JSON, T>
+   {
+      static constexpr bool map_like_array = writable_array_t<T> && pair_t<range_value_t<T>>;
+      
+      template <auto Opts, class B>
+      requires(writable_array_t<T> && (map_like_array ? Opts.concatenate == false : true))
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
+      {
+         if (empty_range(value)) {
+            dump<"[]">(b, ix);
+         }
+         else {
+            if constexpr (has_size<T> && array_padding_known<T>) {
+               const auto n = value.size();
+               
+               static constexpr auto value_padding = required_padding<typename T::value_type>();
+               
+               if constexpr (Opts.prettify) {
+                  if constexpr (Opts.new_lines_in_arrays) {
+                     ctx.indentation_level += Opts.indentation_width;
+                  }
+                  
+                  if constexpr (vector_like<B>) {
+                     // add space for '\n' and ',' characters for each element, hence `+ 2`
+                     // use n + 1 because we put the end array character after the last element with whitespace
+                     if (const auto k =
+                         ix + (n + 1) * (value_padding + ctx.indentation_level + 2) + write_padding_bytes;
+                         k > b.size()) {
+                        b.resize(2 * k);
+                     }
+                  }
+                  
+                  if constexpr (Opts.new_lines_in_arrays) {
+                     std::memcpy(&b[ix], "[\n", 2);
+                     ix += 2;
+                     std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
+                     ix += ctx.indentation_level;
+                  }
+                  else {
+                     std::memcpy(&b[ix], "[", 1);
                      ++ix;
                   }
                }
-            }
-         }
-      };
-
-      template <class T>
-         requires((glaze_enum_t<T> || (meta_keys<T> && std::is_enum_v<std::decay_t<T>>)) && not custom_write<T>)
-      struct to<JSON, T>
-      {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
-         {
-            // TODO: Use new hashing approach for better performance
-            // TODO: Check if sequenced and use the value as the index if so
-            using key_t = std::underlying_type_t<T>;
-            static constexpr auto frozen_map = detail::make_enum_to_string_map<T>();
-            const auto& member_it = frozen_map.find(static_cast<key_t>(value));
-            if (member_it != frozen_map.end()) {
-               const sv str = {member_it->second.data(), member_it->second.size()};
-               // TODO: Assumes people dont use strings with chars that need to be escaped for their enum names
-               // TODO: Could create a pre quoted map for better performance
-               if constexpr (not Opts.raw) {
-                  dump<'"'>(args...);
-               }
-               dump_maybe_empty(str, args...);
-               if constexpr (not Opts.raw) {
-                  dump<'"'>(args...);
-               }
-            }
-            else [[unlikely]] {
-               // What do we want to happen if the value doesn't have a mapped string
-               serialize<JSON>::op<Opts>(static_cast<std::underlying_type_t<T>>(value), ctx, std::forward<Args>(args)...);
-            }
-         }
-      };
-
-      template <class T>
-         requires(!meta_keys<T> && std::is_enum_v<std::decay_t<T>> && !glaze_enum_t<T> && !custom_write<T>)
-      struct to<JSON, T>
-      {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
-         {
-            // serialize as underlying number
-            serialize<JSON>::op<Opts>(static_cast<std::underlying_type_t<std::decay_t<T>>>(value), ctx,
-                                  std::forward<Args>(args)...);
-         }
-      };
-
-      template <func_t T>
-      struct to<JSON, T>
-      {
-         template <auto Opts, class B>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, B&& b, auto&& ix)
-         {
-            static constexpr auto name = name_v<std::decay_t<decltype(value)>>;
-            constexpr auto n = name.size();
-
-            if constexpr (vector_like<B>) {
-               if (const auto k = ix + 8 + n; k > b.size()) [[unlikely]] {
-                  b.resize(2 * k);
-               }
-            }
-
-            std::memcpy(&b[ix], "\"", 1);
-            ++ix;
-            if constexpr (not name.empty()) {
-               std::memcpy(&b[ix], name.data(), n);
-               ix += n;
-            }
-            std::memcpy(&b[ix], "\"", 1);
-            ++ix;
-         }
-      };
-
-      template <class T>
-      struct to<JSON, basic_raw_json<T>>
-      {
-         template <auto Opts, class B>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, B&& b, auto&& ix)
-         {
-            const auto n = value.str.size();
-            if (n) {
-               if constexpr (vector_like<B>) {
-                  if (const auto k = ix + n + write_padding_bytes; k > b.size()) [[unlikely]] {
-                     b.resize(2 * k);
-                  }
-               }
-
-               std::memcpy(&b[ix], value.str.data(), n);
-               ix += n;
-            }
-         }
-      };
-
-      template <class T>
-      struct to<JSON, basic_text<T>>
-      {
-         template <auto Opts, class B>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&&, B&& b, auto&& ix)
-         {
-            const auto n = value.str.size();
-            if (n) {
-               if constexpr (vector_like<B>) {
-                  if (const auto k = ix + n + write_padding_bytes; k > b.size()) [[unlikely]] {
-                     b.resize(2 * k);
-                  }
-               }
-
-               std::memcpy(&b[ix], value.str.data(), n);
-               ix += n;
-            }
-         }
-      };
-
-      template <opts Opts, bool minified_check = true, class B>
-      GLZ_ALWAYS_INLINE void write_array_entry_separator(is_context auto&& ctx, B&& b, auto&& ix)
-      {
-         if constexpr (Opts.prettify) {
-            if constexpr (vector_like<B>) {
-               if (const auto k = ix + ctx.indentation_level + write_padding_bytes; k > b.size()) [[unlikely]] {
-                  b.resize(2 * k);
-               }
-            }
-            if constexpr (Opts.new_lines_in_arrays) {
-               std::memcpy(&b[ix], ",\n", 2);
-               ix += 2;
-               std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
-               ix += ctx.indentation_level;
-            }
-            else {
-               std::memcpy(&b[ix], ", ", 2);
-               ix += 2;
-            }
-         }
-         else {
-            if constexpr (vector_like<B>) {
-               if constexpr (minified_check) {
-                  if (ix >= b.size()) [[unlikely]] {
-                     b.resize(2 * ix);
-                  }
-               }
-            }
-            std::memcpy(&b[ix], ",", 1);
-            ++ix;
-         }
-      }
-
-      // "key":value pair output
-      template <opts Opts, class Key, class Value, is_context Ctx, class B>
-      GLZ_ALWAYS_INLINE void write_pair_content(const Key& key, Value&& value, Ctx& ctx, B&& b, auto&& ix)
-      {
-         if constexpr (str_t<Key> || char_t<Key> || glaze_enum_t<Key> || Opts.quoted_num) {
-            to<JSON, core_t<Key>>::template op<Opts>(key, ctx, b, ix);
-         }
-         else if constexpr (num_t<Key>) {
-            serialize<JSON>::op<opt_true<Opts, &opts::quoted_num>>(key, ctx, b, ix);
-         }
-         else {
-            serialize<JSON>::op<opt_false<Opts, &opts::raw_string>>(quoted_t<const Key>{key}, ctx, b, ix);
-         }
-         if constexpr (Opts.prettify) {
-            dump<": ">(b, ix);
-         }
-         else {
-            dump<':'>(b, ix);
-         }
-
-         using V = core_t<decltype(value)>;
-         to<JSON, V>::template op<opening_and_closing_handled_off<Opts>()>(value, ctx, b, ix);
-      }
-
-      template <class T>
-      concept array_padding_known =
-         requires { typename T::value_type; } && (required_padding<typename T::value_type>() > 0);
-
-      template <class T>
-         requires(writable_array_t<T> || writable_map_t<T>)
-      struct to<JSON, T>
-      {
-         static constexpr bool map_like_array = writable_array_t<T> && pair_t<range_value_t<T>>;
-
-         template <auto Opts, class B>
-            requires(writable_array_t<T> && (map_like_array ? Opts.concatenate == false : true))
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
-         {
-            if (empty_range(value)) {
-               dump<"[]">(b, ix);
-            }
-            else {
-               if constexpr (has_size<T> && array_padding_known<T>) {
-                  const auto n = value.size();
-
-                  static constexpr auto value_padding = required_padding<typename T::value_type>();
-
-                  if constexpr (Opts.prettify) {
-                     if constexpr (Opts.new_lines_in_arrays) {
-                        ctx.indentation_level += Opts.indentation_width;
-                     }
-
-                     if constexpr (vector_like<B>) {
-                        // add space for '\n' and ',' characters for each element, hence `+ 2`
-                        // use n + 1 because we put the end array character after the last element with whitespace
-                        if (const auto k =
-                               ix + (n + 1) * (value_padding + ctx.indentation_level + 2) + write_padding_bytes;
-                            k > b.size()) {
+               else {
+                  if constexpr (vector_like<B>) {
+                     static constexpr auto comma_padding = 1;
+                     if (const auto k = ix + n * (value_padding + comma_padding) + write_padding_bytes; k > b.size())
+                        [[unlikely]] {
                            b.resize(2 * k);
                         }
-                     }
-
+                  }
+                  std::memcpy(&b[ix], "[", 1);
+                  ++ix;
+               }
+               
+               auto it = std::begin(value);
+               using val_t = std::remove_cvref_t<decltype(*it)>;
+               to<JSON, val_t>::template op<write_unchecked_on<Opts>()>(*it, ctx, b, ix);
+               
+               ++it;
+               for (const auto fin = std::end(value); it != fin; ++it) {
+                  if constexpr (Opts.prettify) {
                      if constexpr (Opts.new_lines_in_arrays) {
-                        std::memcpy(&b[ix], "[\n", 2);
+                        std::memcpy(&b[ix], ",\n", 2);
                         ix += 2;
                         std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
                         ix += ctx.indentation_level;
                      }
                      else {
-                        std::memcpy(&b[ix], "[", 1);
-                        ++ix;
+                        std::memcpy(&b[ix], ", ", 2);
+                        ix += 2;
                      }
                   }
                   else {
-                     if constexpr (vector_like<B>) {
-                        static constexpr auto comma_padding = 1;
-                        if (const auto k = ix + n * (value_padding + comma_padding) + write_padding_bytes; k > b.size())
-                           [[unlikely]] {
+                     std::memcpy(&b[ix], ",", 1);
+                     ++ix;
+                  }
+                  
+                  to<JSON, val_t>::template op<write_unchecked_on<Opts>()>(*it, ctx, b, ix);
+               }
+               if constexpr (Opts.prettify && Opts.new_lines_in_arrays) {
+                  ctx.indentation_level -= Opts.indentation_width;
+                  std::memcpy(&b[ix], "\n", 1);
+                  ++ix;
+                  std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
+                  ix += ctx.indentation_level;
+               }
+               
+               std::memcpy(&b[ix], "]", 1);
+               ++ix;
+            }
+            else {
+               // we either can't get the size (std::forward_list) or we cannot compute the allocation size
+               
+               if constexpr (Opts.prettify) {
+                  if constexpr (Opts.new_lines_in_arrays) {
+                     ctx.indentation_level += Opts.indentation_width;
+                  }
+                  
+                  if constexpr (vector_like<B>) {
+                     if (const auto k = ix + ctx.indentation_level + write_padding_bytes; k > b.size())
+                        [[unlikely]] {
                            b.resize(2 * k);
                         }
-                     }
+                  }
+                  
+                  if constexpr (Opts.new_lines_in_arrays) {
+                     std::memcpy(&b[ix], "[\n", 2);
+                     ix += 2;
+                     std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
+                     ix += ctx.indentation_level;
+                  }
+                  else {
                      std::memcpy(&b[ix], "[", 1);
                      ++ix;
                   }
-
-                  auto it = std::begin(value);
-                  using val_t = std::remove_cvref_t<decltype(*it)>;
+               }
+               else {
+                  if constexpr (vector_like<B>) {
+                     if (const auto k = ix + write_padding_bytes; k > b.size()) [[unlikely]] {
+                        b.resize(2 * k);
+                     }
+                  }
+                  std::memcpy(&b[ix], "[", 1);
+                  ++ix;
+               }
+               
+               auto it = std::begin(value);
+               using val_t = std::remove_cvref_t<decltype(*it)>;
+               if constexpr (required_padding<val_t>()) {
                   to<JSON, val_t>::template op<write_unchecked_on<Opts>()>(*it, ctx, b, ix);
-
-                  ++it;
-                  for (const auto fin = std::end(value); it != fin; ++it) {
+               }
+               else {
+                  to<JSON, val_t>::template op<Opts>(*it, ctx, b, ix);
+               }
+               
+               ++it;
+               for (const auto fin = std::end(value); it != fin; ++it) {
+                  if constexpr (required_padding<val_t>()) {
+                     if constexpr (vector_like<B>) {
+                        if constexpr (Opts.prettify) {
+                           if (const auto k = ix + ctx.indentation_level + write_padding_bytes; k > b.size())
+                              [[unlikely]] {
+                                 b.resize(2 * k);
+                              }
+                        }
+                        else {
+                           if (const auto k = ix + write_padding_bytes; k > b.size()) [[unlikely]] {
+                              b.resize(2 * k);
+                           }
+                        }
+                     }
+                     
                      if constexpr (Opts.prettify) {
                         if constexpr (Opts.new_lines_in_arrays) {
                            std::memcpy(&b[ix], ",\n", 2);
@@ -1028,661 +1118,519 @@ namespace glz
                         std::memcpy(&b[ix], ",", 1);
                         ++ix;
                      }
-
-                     to<JSON, val_t>::template op<write_unchecked_on<Opts>()>(*it, ctx, b, ix);
-                  }
-                  if constexpr (Opts.prettify && Opts.new_lines_in_arrays) {
-                     ctx.indentation_level -= Opts.indentation_width;
-                     std::memcpy(&b[ix], "\n", 1);
-                     ++ix;
-                     std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
-                     ix += ctx.indentation_level;
-                  }
-
-                  std::memcpy(&b[ix], "]", 1);
-                  ++ix;
-               }
-               else {
-                  // we either can't get the size (std::forward_list) or we cannot compute the allocation size
-
-                  if constexpr (Opts.prettify) {
-                     if constexpr (Opts.new_lines_in_arrays) {
-                        ctx.indentation_level += Opts.indentation_width;
-                     }
-
-                     if constexpr (vector_like<B>) {
-                        if (const auto k = ix + ctx.indentation_level + write_padding_bytes; k > b.size())
-                           [[unlikely]] {
-                           b.resize(2 * k);
-                        }
-                     }
-
-                     if constexpr (Opts.new_lines_in_arrays) {
-                        std::memcpy(&b[ix], "[\n", 2);
-                        ix += 2;
-                        std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
-                        ix += ctx.indentation_level;
-                     }
-                     else {
-                        std::memcpy(&b[ix], "[", 1);
-                        ++ix;
-                     }
-                  }
-                  else {
-                     if constexpr (vector_like<B>) {
-                        if (const auto k = ix + write_padding_bytes; k > b.size()) [[unlikely]] {
-                           b.resize(2 * k);
-                        }
-                     }
-                     std::memcpy(&b[ix], "[", 1);
-                     ++ix;
-                  }
-
-                  auto it = std::begin(value);
-                  using val_t = std::remove_cvref_t<decltype(*it)>;
-                  if constexpr (required_padding<val_t>()) {
+                     
                      to<JSON, val_t>::template op<write_unchecked_on<Opts>()>(*it, ctx, b, ix);
                   }
                   else {
+                     write_array_entry_separator<Opts>(ctx, b, ix);
                      to<JSON, val_t>::template op<Opts>(*it, ctx, b, ix);
                   }
-
+               }
+               if constexpr (Opts.prettify && Opts.new_lines_in_arrays) {
+                  ctx.indentation_level -= Opts.indentation_width;
+                  dump_newline_indent<Opts.indentation_char>(ctx.indentation_level, b, ix);
+               }
+               
+               dump<']'>(b, ix);
+            }
+         }
+      }
+      
+      template <auto Opts, class B>
+      requires(writable_map_t<T> || (map_like_array && Opts.concatenate == true))
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
+      {
+         if constexpr (not has_opening_handled(Opts)) {
+            dump<'{'>(b, ix);
+         }
+         
+         if (!empty_range(value)) {
+            if constexpr (!has_opening_handled(Opts)) {
+               if constexpr (Opts.prettify) {
+                  ctx.indentation_level += Opts.indentation_width;
+                  if constexpr (vector_like<B>) {
+                     if (const auto k = ix + ctx.indentation_level + write_padding_bytes; k > b.size())
+                        [[unlikely]] {
+                           b.resize(2 * k);
+                        }
+                  }
+                  std::memcpy(&b[ix], "\n", 1);
+                  ++ix;
+                  std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
+                  ix += ctx.indentation_level;
+               }
+            }
+            
+            using val_t = detail::iterator_second_type<T>; // the type of value in each [key, value] pair
+            
+            if constexpr (not always_skipped<val_t>) {
+               if constexpr (null_t<val_t> && Opts.skip_null_members) {
+                  auto write_first_entry = [&](auto&& it) {
+                     auto&& [key, entry_val] = *it;
+                     if (skip_member<Opts>(entry_val)) {
+                        return true;
+                     }
+                     write_pair_content<Opts>(key, entry_val, ctx, b, ix);
+                     return false;
+                  };
+                  
+                  auto it = std::begin(value);
+                  bool first = write_first_entry(it);
                   ++it;
-                  for (const auto fin = std::end(value); it != fin; ++it) {
-                     if constexpr (required_padding<val_t>()) {
-                        if constexpr (vector_like<B>) {
-                           if constexpr (Opts.prettify) {
-                              if (const auto k = ix + ctx.indentation_level + write_padding_bytes; k > b.size())
-                                 [[unlikely]] {
-                                 b.resize(2 * k);
-                              }
-                           }
-                           else {
-                              if (const auto k = ix + write_padding_bytes; k > b.size()) [[unlikely]] {
-                                 b.resize(2 * k);
-                              }
-                           }
-                        }
-
-                        if constexpr (Opts.prettify) {
-                           if constexpr (Opts.new_lines_in_arrays) {
-                              std::memcpy(&b[ix], ",\n", 2);
-                              ix += 2;
-                              std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
-                              ix += ctx.indentation_level;
-                           }
-                           else {
-                              std::memcpy(&b[ix], ", ", 2);
-                              ix += 2;
-                           }
-                        }
-                        else {
-                           std::memcpy(&b[ix], ",", 1);
-                           ++ix;
-                        }
-
-                        to<JSON, val_t>::template op<write_unchecked_on<Opts>()>(*it, ctx, b, ix);
+                  for (const auto end = std::end(value); it != end; ++it) {
+                     auto&& [key, entry_val] = *it;
+                     if (skip_member<Opts>(entry_val)) {
+                        continue;
                      }
-                     else {
-                        write_array_entry_separator<Opts>(ctx, b, ix);
-                        to<JSON, val_t>::template op<Opts>(*it, ctx, b, ix);
-                     }
-                  }
-                  if constexpr (Opts.prettify && Opts.new_lines_in_arrays) {
-                     ctx.indentation_level -= Opts.indentation_width;
-                     dump_newline_indent<Opts.indentation_char>(ctx.indentation_level, b, ix);
-                  }
-
-                  dump<']'>(b, ix);
-               }
-            }
-         }
-
-         template <auto Opts, class B>
-            requires(writable_map_t<T> || (map_like_array && Opts.concatenate == true))
-         static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
-         {
-            if constexpr (not has_opening_handled(Opts)) {
-               dump<'{'>(b, ix);
-            }
-
-            if (!empty_range(value)) {
-               if constexpr (!has_opening_handled(Opts)) {
-                  if constexpr (Opts.prettify) {
-                     ctx.indentation_level += Opts.indentation_width;
-                     if constexpr (vector_like<B>) {
-                        if (const auto k = ix + ctx.indentation_level + write_padding_bytes; k > b.size())
-                           [[unlikely]] {
-                           b.resize(2 * k);
-                        }
-                     }
-                     std::memcpy(&b[ix], "\n", 1);
-                     ++ix;
-                     std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
-                     ix += ctx.indentation_level;
-                  }
-               }
-
-               using val_t = iterator_second_type<T>; // the type of value in each [key, value] pair
-
-               if constexpr (not always_skipped<val_t>) {
-                  if constexpr (null_t<val_t> && Opts.skip_null_members) {
-                     auto write_first_entry = [&](auto&& it) {
-                        auto&& [key, entry_val] = *it;
-                        if (skip_member<Opts>(entry_val)) {
-                           return true;
-                        }
-                        write_pair_content<Opts>(key, entry_val, ctx, b, ix);
-                        return false;
-                     };
-
-                     auto it = std::begin(value);
-                     bool first = write_first_entry(it);
-                     ++it;
-                     for (const auto end = std::end(value); it != end; ++it) {
-                        auto&& [key, entry_val] = *it;
-                        if (skip_member<Opts>(entry_val)) {
-                           continue;
-                        }
-
-                        // When Opts.skip_null_members, *any* entry may be skipped, meaning separator dumping must be
-                        // conditional for every entry.
-                        // Alternatively, write separator after each entry except last but then branch is permanent
-                        if (not first) {
-                           write_object_entry_separator<Opts>(ctx, b, ix);
-                        }
-
-                        write_pair_content<Opts>(key, entry_val, ctx, b, ix);
-
-                        first = false;
-                     }
-                  }
-                  else {
-                     auto write_first_entry = [&](auto&& it) {
-                        auto&& [key, entry_val] = *it;
-                        write_pair_content<Opts>(key, entry_val, ctx, b, ix);
-                     };
-
-                     auto it = std::begin(value);
-                     write_first_entry(it);
-                     ++it;
-                     for (const auto end = std::end(value); it != end; ++it) {
-                        auto&& [key, entry_val] = *it;
+                     
+                     // When Opts.skip_null_members, *any* entry may be skipped, meaning separator dumping must be
+                     // conditional for every entry.
+                     // Alternatively, write separator after each entry except last but then branch is permanent
+                     if (not first) {
                         write_object_entry_separator<Opts>(ctx, b, ix);
-                        write_pair_content<Opts>(key, entry_val, ctx, b, ix);
                      }
+                     
+                     write_pair_content<Opts>(key, entry_val, ctx, b, ix);
+                     
+                     first = false;
                   }
-               }
-
-               if constexpr (!has_closing_handled(Opts)) {
-                  if constexpr (Opts.prettify) {
-                     ctx.indentation_level -= Opts.indentation_width;
-                     if constexpr (vector_like<B>) {
-                        if (const auto k = ix + ctx.indentation_level + write_padding_bytes; k > b.size())
-                           [[unlikely]] {
-                           b.resize(2 * k);
-                        }
-                     }
-                     std::memcpy(&b[ix], "\n", 1);
-                     ++ix;
-                     std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
-                     ix += ctx.indentation_level;
-                  }
-               }
-            }
-
-            if constexpr (!has_closing_handled(Opts)) {
-               dump<'}'>(b, ix);
-            }
-         }
-      };
-
-      template <pair_t T>
-      struct to<JSON, T>
-      {
-         template <glz::opts Opts, class B, class Ix>
-         static void op(const T& value, is_context auto&& ctx, B&& b, Ix&& ix)
-         {
-            const auto& [key, val] = value;
-            if (skip_member<Opts>(val)) {
-               return dump<"{}">(b, ix);
-            }
-
-            if constexpr (Opts.prettify) {
-               ctx.indentation_level += Opts.indentation_width;
-               if constexpr (vector_like<B>) {
-                  if (const auto k = ix + ctx.indentation_level + 2; k > b.size()) [[unlikely]] {
-                     b.resize(2 * k);
-                  }
-               }
-               dump<"{\n", false>(b, ix);
-               std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
-               ix += ctx.indentation_level;
-            }
-            else {
-               dump<'{'>(b, ix);
-            }
-
-            write_pair_content<Opts>(key, val, ctx, b, ix);
-
-            if constexpr (Opts.prettify) {
-               ctx.indentation_level -= Opts.indentation_width;
-               dump_newline_indent<Opts.indentation_char>(ctx.indentation_level, b, ix);
-               dump<'}', false>(b, ix);
-            }
-            else {
-               dump<'}'>(b, ix);
-            }
-         }
-      };
-
-      template <is_expected T>
-      struct to<JSON, T>
-      {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
-         {
-            if (value) {
-               serialize<JSON>::op<Opts>(*value, ctx, std::forward<Args>(args)...);
-            }
-            else {
-               serialize<JSON>::op<Opts>(unexpected_wrapper{&value.error()}, ctx, std::forward<Args>(args)...);
-            }
-         }
-      };
-
-      // for C style arrays
-      template <nullable_t T>
-         requires(std::is_array_v<T>)
-      struct to<JSON, T>
-      {
-         template <auto Opts, class V, size_t N, class... Args>
-         GLZ_ALWAYS_INLINE static void op(const V (&value)[N], is_context auto&& ctx, Args&&... args)
-         {
-            serialize<JSON>::op<Opts>(std::span{value, N}, ctx, std::forward<Args>(args)...);
-         }
-      };
-
-      template <nullable_like T>
-      struct to<JSON, T>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
-         {
-            if (value) {
-               if constexpr (required_padding<T>()) {
-                  serialize<JSON>::op<Opts>(*value, ctx, b, ix);
                }
                else {
-                  serialize<JSON>::op<write_unchecked_off<Opts>()>(*value, ctx, b, ix);
+                  auto write_first_entry = [&](auto&& it) {
+                     auto&& [key, entry_val] = *it;
+                     write_pair_content<Opts>(key, entry_val, ctx, b, ix);
+                  };
+                  
+                  auto it = std::begin(value);
+                  write_first_entry(it);
+                  ++it;
+                  for (const auto end = std::end(value); it != end; ++it) {
+                     auto&& [key, entry_val] = *it;
+                     write_object_entry_separator<Opts>(ctx, b, ix);
+                     write_pair_content<Opts>(key, entry_val, ctx, b, ix);
+                  }
                }
             }
-            else {
-               dump<"null", not has_write_unchecked(Opts)>(b, ix);
+            
+            if constexpr (!has_closing_handled(Opts)) {
+               if constexpr (Opts.prettify) {
+                  ctx.indentation_level -= Opts.indentation_width;
+                  if constexpr (vector_like<B>) {
+                     if (const auto k = ix + ctx.indentation_level + write_padding_bytes; k > b.size())
+                        [[unlikely]] {
+                           b.resize(2 * k);
+                        }
+                  }
+                  std::memcpy(&b[ix], "\n", 1);
+                  ++ix;
+                  std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
+                  ix += ctx.indentation_level;
+               }
             }
          }
-      };
-
-      template <class T>
-         requires(nullable_value_t<T> && not nullable_like<T> && not is_expected<T>)
-      struct to<JSON, T>
-      {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
-         {
-            if (value.has_value()) {
-               serialize<JSON>::op<Opts>(value.value(), ctx, b, ix);
-            }
-            else {
-               dump<"null">(b, ix);
-            }
+         
+         if constexpr (!has_closing_handled(Opts)) {
+            dump<'}'>(b, ix);
          }
-      };
-
-      template <always_null_t T>
-      struct to<JSON, T>
+      }
+   };
+   
+   template <pair_t T>
+   struct to<JSON, T>
+   {
+      template <glz::opts Opts, class B, class Ix>
+      static void op(const T& value, is_context auto&& ctx, B&& b, Ix&& ix)
       {
-         template <auto Opts, class B>
-         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, B&& b, auto&& ix)
-         {
-            if constexpr (not has_write_unchecked(Opts)) {
-               if (const auto k = ix + 4; k > b.size()) [[unlikely]] {
+         const auto& [key, val] = value;
+         if (skip_member<Opts>(val)) {
+            return dump<"{}">(b, ix);
+         }
+         
+         if constexpr (Opts.prettify) {
+            ctx.indentation_level += Opts.indentation_width;
+            if constexpr (vector_like<B>) {
+               if (const auto k = ix + ctx.indentation_level + 2; k > b.size()) [[unlikely]] {
                   b.resize(2 * k);
                }
             }
-            static constexpr uint32_t null_v = 1819047278;
-            std::memcpy(&b[ix], &null_v, 4);
-            ix += 4;
+            dump<"{\n", false>(b, ix);
+            std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
+            ix += ctx.indentation_level;
          }
-      };
-
-      template <is_variant T>
-      struct to<JSON, T>
-      {
-         template <auto Opts, class B>
-         static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
-         {
-            std::visit(
-               [&](auto&& val) {
-                  using V = std::decay_t<decltype(val)>;
-
-                  if constexpr (Opts.write_type_info && not tag_v<T>.empty() && glaze_object_t<V>) {
-                     constexpr auto N = reflect<V>::size;
-
-                     // must first write out type
-                     if constexpr (Opts.prettify) {
-                        dump<"{\n">(b, ix);
-                        ctx.indentation_level += Opts.indentation_width;
-                        dumpn<Opts.indentation_char>(ctx.indentation_level, b, ix);
-                        dump<'"'>(b, ix);
-                        dump_maybe_empty(tag_v<T>, b, ix);
-                        dump<"\": \"">(b, ix);
-                        dump_maybe_empty(ids_v<T>[value.index()], b, ix);
-                        if constexpr (N == 0) {
-                           dump<"\"\n">(b, ix);
-                        }
-                        else {
-                           dump<"\",\n">(b, ix);
-                        }
-                        dumpn<Opts.indentation_char>(ctx.indentation_level, b, ix);
-                     }
-                     else {
-                        dump<"{\"">(b, ix);
-                        dump_maybe_empty(tag_v<T>, b, ix);
-                        dump<"\":\"">(b, ix);
-                        dump_maybe_empty(ids_v<T>[value.index()], b, ix);
-                        if constexpr (N == 0) {
-                           dump<R"(")">(b, ix);
-                        }
-                        else {
-                           dump<R"(",)">(b, ix);
-                        }
-                     }
-                     to<JSON, V>::template op<opening_and_closing_handled<Opts>()>(val, ctx, b, ix);
-                     // If we skip everything then we may have an extra comma, which we want to revert
-                     if constexpr (Opts.skip_null_members) {
-                        if (b[ix - 1] == ',') {
-                           --ix;
-                        }
-                     }
-
-                     if constexpr (Opts.prettify) {
-                        ctx.indentation_level -= Opts.indentation_width;
-                        if constexpr (vector_like<B>) {
-                           if (const auto k = ix + ctx.indentation_level + write_padding_bytes; k > b.size())
-                              [[unlikely]] {
-                              b.resize(2 * k);
-                           }
-                        }
-                        std::memcpy(&b[ix], "\n", 1);
-                        ++ix;
-                        std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
-                        ix += ctx.indentation_level;
-                        std::memcpy(&b[ix], "}", 1);
-                        ++ix;
-                     }
-                     else {
-                        dump<'}'>(b, ix);
-                     }
-                  }
-                  else {
-                     to<JSON, V>::template op<Opts>(val, ctx, b, ix);
-                  }
-               },
-               value);
+         else {
+            dump<'{'>(b, ix);
          }
-      };
-
-      template <class T>
-      struct to<JSON, array_variant_wrapper<T>>
+         
+         write_pair_content<Opts>(key, val, ctx, b, ix);
+         
+         if constexpr (Opts.prettify) {
+            ctx.indentation_level -= Opts.indentation_width;
+            dump_newline_indent<Opts.indentation_char>(ctx.indentation_level, b, ix);
+            dump<'}', false>(b, ix);
+         }
+         else {
+            dump<'}'>(b, ix);
+         }
+      }
+   };
+   
+   template <is_expected T>
+   struct to<JSON, T>
+   {
+      template <auto Opts, class... Args>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
       {
-         template <auto Opts, class... Args>
-         static void op(auto&& wrapper, is_context auto&& ctx, Args&&... args)
-         {
-            auto& value = wrapper.value;
-            dump<'['>(args...);
-            if constexpr (Opts.prettify) {
+         if (value) {
+            serialize<JSON>::op<Opts>(*value, ctx, std::forward<Args>(args)...);
+         }
+         else {
+            serialize<JSON>::op<Opts>(unexpected_wrapper{&value.error()}, ctx, std::forward<Args>(args)...);
+         }
+      }
+   };
+   
+   // for C style arrays
+   template <nullable_t T>
+   requires(std::is_array_v<T>)
+   struct to<JSON, T>
+   {
+      template <auto Opts, class V, size_t N, class... Args>
+      GLZ_ALWAYS_INLINE static void op(const V (&value)[N], is_context auto&& ctx, Args&&... args)
+      {
+         serialize<JSON>::op<Opts>(std::span{value, N}, ctx, std::forward<Args>(args)...);
+      }
+   };
+   
+   template <nullable_like T>
+   struct to<JSON, T>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
+      {
+         if (value) {
+            if constexpr (required_padding<T>()) {
+               serialize<JSON>::op<Opts>(*value, ctx, b, ix);
+            }
+            else {
+               serialize<JSON>::op<write_unchecked_off<Opts>()>(*value, ctx, b, ix);
+            }
+         }
+         else {
+            dump<"null", not has_write_unchecked(Opts)>(b, ix);
+         }
+      }
+   };
+   
+   template <class T>
+   requires(nullable_value_t<T> && not nullable_like<T> && not is_expected<T>)
+   struct to<JSON, T>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
+      {
+         if (value.has_value()) {
+            serialize<JSON>::op<Opts>(value.value(), ctx, b, ix);
+         }
+         else {
+            dump<"null">(b, ix);
+         }
+      }
+   };
+   
+   template <always_null_t T>
+   struct to<JSON, T>
+   {
+      template <auto Opts, class B>
+      GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, B&& b, auto&& ix)
+      {
+         if constexpr (not has_write_unchecked(Opts)) {
+            if (const auto k = ix + 4; k > b.size()) [[unlikely]] {
+               b.resize(2 * k);
+            }
+         }
+         static constexpr uint32_t null_v = 1819047278;
+         std::memcpy(&b[ix], &null_v, 4);
+         ix += 4;
+      }
+   };
+   
+   template <is_variant T>
+   struct to<JSON, T>
+   {
+      template <auto Opts, class B>
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
+      {
+         std::visit(
+                    [&](auto&& val) {
+                       using V = std::decay_t<decltype(val)>;
+                       
+                       if constexpr (Opts.write_type_info && not tag_v<T>.empty() && glaze_object_t<V>) {
+                          constexpr auto N = reflect<V>::size;
+                          
+                          // must first write out type
+                          if constexpr (Opts.prettify) {
+                             dump<"{\n">(b, ix);
+                             ctx.indentation_level += Opts.indentation_width;
+                             dumpn<Opts.indentation_char>(ctx.indentation_level, b, ix);
+                             dump<'"'>(b, ix);
+                             dump_maybe_empty(tag_v<T>, b, ix);
+                             dump<"\": \"">(b, ix);
+                             dump_maybe_empty(ids_v<T>[value.index()], b, ix);
+                             if constexpr (N == 0) {
+                                dump<"\"\n">(b, ix);
+                             }
+                             else {
+                                dump<"\",\n">(b, ix);
+                             }
+                             dumpn<Opts.indentation_char>(ctx.indentation_level, b, ix);
+                          }
+                          else {
+                             dump<"{\"">(b, ix);
+                             dump_maybe_empty(tag_v<T>, b, ix);
+                             dump<"\":\"">(b, ix);
+                             dump_maybe_empty(ids_v<T>[value.index()], b, ix);
+                             if constexpr (N == 0) {
+                                dump<R"(")">(b, ix);
+                             }
+                             else {
+                                dump<R"(",)">(b, ix);
+                             }
+                          }
+                          to<JSON, V>::template op<opening_and_closing_handled<Opts>()>(val, ctx, b, ix);
+                          // If we skip everything then we may have an extra comma, which we want to revert
+                          if constexpr (Opts.skip_null_members) {
+                             if (b[ix - 1] == ',') {
+                                --ix;
+                             }
+                          }
+                          
+                          if constexpr (Opts.prettify) {
+                             ctx.indentation_level -= Opts.indentation_width;
+                             if constexpr (vector_like<B>) {
+                                if (const auto k = ix + ctx.indentation_level + write_padding_bytes; k > b.size())
+                                   [[unlikely]] {
+                                      b.resize(2 * k);
+                                   }
+                             }
+                             std::memcpy(&b[ix], "\n", 1);
+                             ++ix;
+                             std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
+                             ix += ctx.indentation_level;
+                             std::memcpy(&b[ix], "}", 1);
+                             ++ix;
+                          }
+                          else {
+                             dump<'}'>(b, ix);
+                          }
+                       }
+                       else {
+                          to<JSON, V>::template op<Opts>(val, ctx, b, ix);
+                       }
+                    },
+                    value);
+      }
+   };
+   
+   template <class T>
+   struct to<JSON, array_variant_wrapper<T>>
+   {
+      template <auto Opts, class... Args>
+      static void op(auto&& wrapper, is_context auto&& ctx, Args&&... args)
+      {
+         auto& value = wrapper.value;
+         dump<'['>(args...);
+         if constexpr (Opts.prettify) {
+            ctx.indentation_level += Opts.indentation_width;
+            dump_newline_indent<Opts.indentation_char>(ctx.indentation_level, args...);
+         }
+         dump<'"'>(args...);
+         dump_maybe_empty(ids_v<T>[value.index()], args...);
+         dump<"\",">(args...);
+         if constexpr (Opts.prettify) {
+            dump_newline_indent<Opts.indentation_char>(ctx.indentation_level, args...);
+         }
+         std::visit([&](auto&& v) { serialize<JSON>::op<Opts>(v, ctx, args...); }, value);
+         if constexpr (Opts.prettify) {
+            ctx.indentation_level -= Opts.indentation_width;
+            dump_newline_indent<Opts.indentation_char>(ctx.indentation_level, args...);
+         }
+         dump<']'>(args...);
+      }
+   };
+   
+   template <class T>
+   requires is_specialization_v<T, arr>
+   struct to<JSON, T>
+   {
+      template <auto Opts, class... Args>
+      static void op(auto&& value, is_context auto&& ctx, Args&&... args)
+      {
+         using V = std::decay_t<decltype(value.value)>;
+         static constexpr auto N = glz::tuple_size_v<V>;
+         
+         dump<'['>(args...);
+         if constexpr (N > 0 && Opts.prettify) {
+            if constexpr (Opts.new_lines_in_arrays) {
                ctx.indentation_level += Opts.indentation_width;
                dump_newline_indent<Opts.indentation_char>(ctx.indentation_level, args...);
             }
-            dump<'"'>(args...);
-            dump_maybe_empty(ids_v<T>[value.index()], args...);
-            dump<"\",">(args...);
-            if constexpr (Opts.prettify) {
-               dump_newline_indent<Opts.indentation_char>(ctx.indentation_level, args...);
+         }
+         invoke_table<N>([&]<size_t I>() {
+            if constexpr (glaze_array_t<V>) {
+               serialize<JSON>::op<Opts>(get_member(value.value, glz::get<I>(meta_v<T>)), ctx, args...);
             }
-            std::visit([&](auto&& v) { serialize<JSON>::op<Opts>(v, ctx, args...); }, value);
-            if constexpr (Opts.prettify) {
+            else {
+               serialize<JSON>::op<Opts>(glz::get<I>(value.value), ctx, args...);
+            }
+            constexpr bool needs_comma = I < N - 1;
+            if constexpr (needs_comma) {
+               write_array_entry_separator<Opts>(ctx, args...);
+            }
+         });
+         if constexpr (N > 0 && Opts.prettify) {
+            if constexpr (Opts.new_lines_in_arrays) {
                ctx.indentation_level -= Opts.indentation_width;
                dump_newline_indent<Opts.indentation_char>(ctx.indentation_level, args...);
             }
-            dump<']'>(args...);
          }
-      };
-
-      template <class T>
-         requires is_specialization_v<T, arr>
-      struct to<JSON, T>
-      {
-         template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
-         {
-            using V = std::decay_t<decltype(value.value)>;
-            static constexpr auto N = glz::tuple_size_v<V>;
-
-            dump<'['>(args...);
-            if constexpr (N > 0 && Opts.prettify) {
-               if constexpr (Opts.new_lines_in_arrays) {
-                  ctx.indentation_level += Opts.indentation_width;
-                  dump_newline_indent<Opts.indentation_char>(ctx.indentation_level, args...);
-               }
-            }
-            invoke_table<N>([&]<size_t I>() {
-               if constexpr (glaze_array_t<V>) {
-                  serialize<JSON>::op<Opts>(get_member(value.value, glz::get<I>(meta_v<T>)), ctx, args...);
-               }
-               else {
-                  serialize<JSON>::op<Opts>(glz::get<I>(value.value), ctx, args...);
-               }
-               constexpr bool needs_comma = I < N - 1;
-               if constexpr (needs_comma) {
-                  write_array_entry_separator<Opts>(ctx, args...);
-               }
-            });
-            if constexpr (N > 0 && Opts.prettify) {
-               if constexpr (Opts.new_lines_in_arrays) {
-                  ctx.indentation_level -= Opts.indentation_width;
-                  dump_newline_indent<Opts.indentation_char>(ctx.indentation_level, args...);
-               }
-            }
-            dump<']'>(args...);
-         }
-      };
-
-      template <class T>
-         requires glaze_array_t<T> || tuple_t<std::decay_t<T>> || is_std_tuple<T>
-      struct to<JSON, T>
-      {
-         template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
-         {
-            static constexpr auto N = []() constexpr {
-               if constexpr (glaze_array_t<std::decay_t<T>>) {
-                  return glz::tuple_size_v<meta_t<std::decay_t<T>>>;
-               }
-               else {
-                  return glz::tuple_size_v<std::decay_t<T>>;
-               }
-            }();
-
-            dump<'['>(args...);
-            if constexpr (N > 0 && Opts.prettify) {
-               if constexpr (Opts.new_lines_in_arrays) {
-                  ctx.indentation_level += Opts.indentation_width;
-                  dump_newline_indent<Opts.indentation_char>(ctx.indentation_level, args...);
-               }
-            }
-            using V = std::decay_t<T>;
-            invoke_table<N>([&]<size_t I>() {
-               if constexpr (glaze_array_t<V>) {
-                  serialize<JSON>::op<Opts>(get_member(value, glz::get<I>(meta_v<T>)), ctx, args...);
-               }
-               else if constexpr (is_std_tuple<T>) {
-                  using Value = core_t<decltype(std::get<I>(value))>;
-                  to<JSON, Value>::template op<Opts>(std::get<I>(value), ctx, args...);
-               }
-               else {
-                  using Value = core_t<decltype(glz::get<I>(value))>;
-                  to<JSON, Value>::template op<Opts>(glz::get<I>(value), ctx, args...);
-               }
-               constexpr bool needs_comma = I < N - 1;
-               if constexpr (needs_comma) {
-                  write_array_entry_separator<Opts>(ctx, args...);
-               }
-            });
-            if constexpr (N > 0 && Opts.prettify) {
-               if constexpr (Opts.new_lines_in_arrays) {
-                  ctx.indentation_level -= Opts.indentation_width;
-                  dump_newline_indent<Opts.indentation_char>(ctx.indentation_level, args...);
-               }
-            }
-            dump<']'>(args...);
-         }
-      };
-
-      template <is_includer T>
-      struct to<JSON, T>
-      {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, Args&&... args)
-         {
-            dump<R"("")">(args...); // dump an empty string
-         }
-      };
-
-      template <const std::string_view& S>
-      GLZ_ALWAYS_INLINE constexpr auto array_from_sv() noexcept
-      {
-         constexpr auto N = S.size();
-         std::array<char, N> arr;
-         std::copy_n(S.data(), N, arr.data());
-         return arr;
+         dump<']'>(args...);
       }
-
-      template <class T>
-         requires is_specialization_v<T, glz::obj> || is_specialization_v<T, glz::obj_copy>
-      struct to<JSON, T>
+   };
+   
+   template <class T>
+   requires glaze_array_t<T> || tuple_t<std::decay_t<T>> || is_std_tuple<T>
+   struct to<JSON, T>
+   {
+      template <auto Opts, class... Args>
+      static void op(auto&& value, is_context auto&& ctx, Args&&... args)
       {
-         template <auto Options>
-         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
-         {
-            if constexpr (!has_opening_handled(Options)) {
-               dump<'{'>(b, ix);
-               if constexpr (Options.prettify) {
-                  ctx.indentation_level += Options.indentation_width;
-                  dump<'\n'>(b, ix);
-                  dumpn<Options.indentation_char>(ctx.indentation_level, b, ix);
-               }
+         static constexpr auto N = []() constexpr {
+            if constexpr (glaze_array_t<std::decay_t<T>>) {
+               return glz::tuple_size_v<meta_t<std::decay_t<T>>>;
             }
-
-            using V = std::decay_t<decltype(value.value)>;
-            static constexpr auto N = glz::tuple_size_v<V> / 2;
-
-            bool first = true;
-            invoke_table<N>([&]<size_t I>() {
-               constexpr auto Opts = opening_and_closing_handled_off<ws_handled_off<Options>()>();
-               decltype(auto) item = glz::get<2 * I + 1>(value.value);
-               using val_t = std::decay_t<decltype(item)>;
-
-               if (skip_member<Opts>(item)) {
-                  return;
-               }
-
-               // skip
-               if constexpr (always_skipped<val_t>) {
-                  return;
-               }
-               else {
-                  if (first) {
-                     first = false;
-                  }
-                  else {
-                     // Null members may be skipped so we can't just write it out for all but the last member unless
-                     // trailing commas are allowed
-                     write_object_entry_separator<Opts>(ctx, b, ix);
-                  }
-
-                  using Key = typename std::decay_t<glz::tuple_element_t<2 * I, V>>;
-
-                  if constexpr (str_t<Key> || char_t<Key>) {
-                     const sv key = glz::get<2 * I>(value.value);
-                     to<JSON, decltype(key)>::template op<Opts>(key, ctx, b, ix);
-                     dump<':'>(b, ix);
-                     if constexpr (Opts.prettify) {
-                        dump<' '>(b, ix);
-                     }
-                  }
-                  else {
-                     dump<'"'>(b, ix);
-                     to<JSON, val_t>::template op<Opts>(item, ctx, b, ix);
-                     dump_not_empty(Opts.prettify ? "\": " : "\":", b, ix);
-                  }
-
-                  to<JSON, val_t>::template op<Opts>(item, ctx, b, ix);
-               }
-            });
-
-            if constexpr (!has_closing_handled(Options)) {
-               if constexpr (Options.prettify) {
-                  ctx.indentation_level -= Options.indentation_width;
-                  dump<'\n'>(b, ix);
-                  dumpn<Options.indentation_char>(ctx.indentation_level, b, ix);
-               }
-               dump<'}'>(b, ix);
+            else {
+               return glz::tuple_size_v<std::decay_t<T>>;
+            }
+         }();
+         
+         dump<'['>(args...);
+         if constexpr (N > 0 && Opts.prettify) {
+            if constexpr (Opts.new_lines_in_arrays) {
+               ctx.indentation_level += Opts.indentation_width;
+               dump_newline_indent<Opts.indentation_char>(ctx.indentation_level, args...);
             }
          }
-      };
-
-      template <class T>
-         requires is_specialization_v<T, glz::merge>
-      struct to<JSON, T>
+         using V = std::decay_t<T>;
+         invoke_table<N>([&]<size_t I>() {
+            if constexpr (glaze_array_t<V>) {
+               serialize<JSON>::op<Opts>(get_member(value, glz::get<I>(meta_v<T>)), ctx, args...);
+            }
+            else if constexpr (is_std_tuple<T>) {
+               using Value = core_t<decltype(std::get<I>(value))>;
+               to<JSON, Value>::template op<Opts>(std::get<I>(value), ctx, args...);
+            }
+            else {
+               using Value = core_t<decltype(glz::get<I>(value))>;
+               to<JSON, Value>::template op<Opts>(glz::get<I>(value), ctx, args...);
+            }
+            constexpr bool needs_comma = I < N - 1;
+            if constexpr (needs_comma) {
+               write_array_entry_separator<Opts>(ctx, args...);
+            }
+         });
+         if constexpr (N > 0 && Opts.prettify) {
+            if constexpr (Opts.new_lines_in_arrays) {
+               ctx.indentation_level -= Opts.indentation_width;
+               dump_newline_indent<Opts.indentation_char>(ctx.indentation_level, args...);
+            }
+         }
+         dump<']'>(args...);
+      }
+   };
+   
+   template <is_includer T>
+   struct to<JSON, T>
+   {
+      template <auto Opts, class... Args>
+      GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, Args&&... args)
       {
-         template <auto Options>
-         static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
-         {
-            if constexpr (!has_opening_handled(Options)) {
-               dump<'{'>(b, ix);
-               if constexpr (Options.prettify) {
-                  ctx.indentation_level += Options.indentation_width;
-                  dump<'\n'>(b, ix);
-                  dumpn<Options.indentation_char>(ctx.indentation_level, b, ix);
-               }
+         dump<R"("")">(args...); // dump an empty string
+      }
+   };
+   
+   template <const std::string_view& S>
+   GLZ_ALWAYS_INLINE constexpr auto array_from_sv() noexcept
+   {
+      constexpr auto N = S.size();
+      std::array<char, N> arr;
+      std::copy_n(S.data(), N, arr.data());
+      return arr;
+   }
+   
+   template <class T>
+   requires is_specialization_v<T, glz::obj> || is_specialization_v<T, glz::obj_copy>
+   struct to<JSON, T>
+   {
+      template <auto Options>
+      static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
+      {
+         if constexpr (!has_opening_handled(Options)) {
+            dump<'{'>(b, ix);
+            if constexpr (Options.prettify) {
+               ctx.indentation_level += Options.indentation_width;
+               dump<'\n'>(b, ix);
+               dumpn<Options.indentation_char>(ctx.indentation_level, b, ix);
             }
-
-            using V = std::decay_t<decltype(value.value)>;
-            static constexpr auto N = glz::tuple_size_v<V>;
-
-            [[maybe_unused]] static constexpr auto Opts = opening_and_closing_handled<Options>();
-
-            // When merging it is possible that objects are completed empty
-            // and therefore behave like skipped members even when skip_null_members is off
-
-            invoke_table<N>([&]<size_t I>() {
-               // We don't want to dump a comma when nothing is written
-               const auto ix_start = ix;
-               using Value = core_t<decltype(get<I>(value.value))>;
-               to<JSON, Value>::template op<Opts>(get<I>(value.value), ctx, b, ix);
-               if (ix > ix_start) // we wrote something
-               {
-                  dump<','>(b, ix);
-               }
-            });
-
-            // we may have a trailing comma, which needs to be removed
-            if (b[ix - 1] == ',') {
-               --ix;
+         }
+         
+         using V = std::decay_t<decltype(value.value)>;
+         static constexpr auto N = glz::tuple_size_v<V> / 2;
+         
+         bool first = true;
+         invoke_table<N>([&]<size_t I>() {
+            constexpr auto Opts = opening_and_closing_handled_off<ws_handled_off<Options>()>();
+            decltype(auto) item = glz::get<2 * I + 1>(value.value);
+            using val_t = std::decay_t<decltype(item)>;
+            
+            if (skip_member<Opts>(item)) {
+               return;
             }
-
+            
+            // skip
+            if constexpr (always_skipped<val_t>) {
+               return;
+            }
+            else {
+               if (first) {
+                  first = false;
+               }
+               else {
+                  // Null members may be skipped so we can't just write it out for all but the last member unless
+                  // trailing commas are allowed
+                  write_object_entry_separator<Opts>(ctx, b, ix);
+               }
+               
+               using Key = typename std::decay_t<glz::tuple_element_t<2 * I, V>>;
+               
+               if constexpr (str_t<Key> || char_t<Key>) {
+                  const sv key = glz::get<2 * I>(value.value);
+                  to<JSON, decltype(key)>::template op<Opts>(key, ctx, b, ix);
+                  dump<':'>(b, ix);
+                  if constexpr (Opts.prettify) {
+                     dump<' '>(b, ix);
+                  }
+               }
+               else {
+                  dump<'"'>(b, ix);
+                  to<JSON, val_t>::template op<Opts>(item, ctx, b, ix);
+                  dump_not_empty(Opts.prettify ? "\": " : "\":", b, ix);
+               }
+               
+               to<JSON, val_t>::template op<Opts>(item, ctx, b, ix);
+            }
+         });
+         
+         if constexpr (!has_closing_handled(Options)) {
             if constexpr (Options.prettify) {
                ctx.indentation_level -= Options.indentation_width;
                dump<'\n'>(b, ix);
@@ -1690,281 +1638,330 @@ namespace glz
             }
             dump<'}'>(b, ix);
          }
-      };
-
-      // Only use this if you are not prettifying
-      // Returns zero if the fixed size cannot be determined
-      template <class T>
-      inline constexpr size_t fixed_padding = [] {
-         constexpr auto N = reflect<T>::size;
-         size_t fixed = 2 + 16; // {} + extra padding
-         for_each_short_circuit<N>([&](auto I) -> bool {
-            using val_t = field_t<T, I>;
-            if constexpr (required_padding<val_t>()) {
-               fixed += required_padding<val_t>();
-               fixed += reflect<T>::keys[I].size() + 2; // quoted key length
-               fixed += 2; // colon and comma
-               return false; // continue
+      }
+   };
+   
+   template <class T>
+   requires is_specialization_v<T, glz::merge>
+   struct to<JSON, T>
+   {
+      template <auto Options>
+      static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
+      {
+         if constexpr (!has_opening_handled(Options)) {
+            dump<'{'>(b, ix);
+            if constexpr (Options.prettify) {
+               ctx.indentation_level += Options.indentation_width;
+               dump<'\n'>(b, ix);
+               dumpn<Options.indentation_char>(ctx.indentation_level, b, ix);
             }
-            else {
-               fixed = 0;
-               return true; // break
+         }
+         
+         using V = std::decay_t<decltype(value.value)>;
+         static constexpr auto N = glz::tuple_size_v<V>;
+         
+         [[maybe_unused]] static constexpr auto Opts = opening_and_closing_handled<Options>();
+         
+         // When merging it is possible that objects are completed empty
+         // and therefore behave like skipped members even when skip_null_members is off
+         
+         invoke_table<N>([&]<size_t I>() {
+            // We don't want to dump a comma when nothing is written
+            const auto ix_start = ix;
+            using Value = core_t<decltype(get<I>(value.value))>;
+            to<JSON, Value>::template op<Opts>(get<I>(value.value), ctx, b, ix);
+            if (ix > ix_start) // we wrote something
+            {
+               dump<','>(b, ix);
             }
          });
-         if (fixed) {
-            fixed = round_up_to_nearest_16(fixed);
+         
+         // we may have a trailing comma, which needs to be removed
+         if (b[ix - 1] == ',') {
+            --ix;
          }
-         return fixed;
-      }();
-
-      template <class T>
-         requires glaze_object_t<T> || reflectable<T>
-      struct to<JSON, T>
+         
+         if constexpr (Options.prettify) {
+            ctx.indentation_level -= Options.indentation_width;
+            dump<'\n'>(b, ix);
+            dumpn<Options.indentation_char>(ctx.indentation_level, b, ix);
+         }
+         dump<'}'>(b, ix);
+      }
+   };
+   
+   // Only use this if you are not prettifying
+   // Returns zero if the fixed size cannot be determined
+   template <class T>
+   inline constexpr size_t fixed_padding = [] {
+      constexpr auto N = reflect<T>::size;
+      size_t fixed = 2 + 16; // {} + extra padding
+      for_each_short_circuit<N>([&](auto I) -> bool {
+         using val_t = field_t<T, I>;
+         if constexpr (required_padding<val_t>()) {
+            fixed += required_padding<val_t>();
+            fixed += reflect<T>::keys[I].size() + 2; // quoted key length
+            fixed += 2; // colon and comma
+            return false; // continue
+         }
+         else {
+            fixed = 0;
+            return true; // break
+         }
+      });
+      if (fixed) {
+         fixed = round_up_to_nearest_16(fixed);
+      }
+      return fixed;
+   }();
+   
+   template <class T>
+   requires glaze_object_t<T> || reflectable<T>
+   struct to<JSON, T>
+   {
+      template <auto Options, class V, class B>
+      requires(not std::is_pointer_v<std::remove_cvref_t<V>>)
+      static void op(V&& value, is_context auto&& ctx, B&& b, auto&& ix)
       {
-         template <auto Options, class V, class B>
-            requires(not std::is_pointer_v<std::remove_cvref_t<V>>)
-         static void op(V&& value, is_context auto&& ctx, B&& b, auto&& ix)
-         {
-            using ValueType = std::decay_t<V>;
-            if constexpr (has_unknown_writer<ValueType> && not has_disable_write_unknown(Options)) {
-               constexpr auto& writer = meta_unknown_write_v<ValueType>;
-
-               using WriterType = meta_unknown_write_t<ValueType>;
-               if constexpr (std::is_member_object_pointer_v<WriterType>) {
-                  decltype(auto) unknown_writer = value.*writer;
-                  if (unknown_writer.size() > 0) {
-                     // TODO: This intermediate is added to get GCC 14 to build
-                     decltype(auto) merged = glz::merge{value, unknown_writer};
-                     serialize<JSON>::op<disable_write_unknown_on<Options>()>(std::move(merged), ctx, b, ix);
-                  }
-                  else {
-                     serialize<JSON>::op<disable_write_unknown_on<Options>()>(value, ctx, b, ix);
-                  }
-               }
-               else if constexpr (std::is_member_function_pointer_v<WriterType>) {
-                  decltype(auto) unknown_writer = (value.*writer)();
-                  if (unknown_writer.size() > 0) {
-                     // TODO: This intermediate is added to get GCC 14 to build
-                     decltype(auto) merged = glz::merge{value, unknown_writer};
-                     serialize<JSON>::op<disable_write_unknown_on<Options>()>(std::move(merged), ctx, b, ix);
-                  }
-                  else {
-                     serialize<JSON>::op<disable_write_unknown_on<Options>()>(value, ctx, b, ix);
-                  }
+         using ValueType = std::decay_t<V>;
+         if constexpr (has_unknown_writer<ValueType> && not has_disable_write_unknown(Options)) {
+            constexpr auto& writer = meta_unknown_write_v<ValueType>;
+            
+            using WriterType = meta_unknown_write_t<ValueType>;
+            if constexpr (std::is_member_object_pointer_v<WriterType>) {
+               decltype(auto) unknown_writer = value.*writer;
+               if (unknown_writer.size() > 0) {
+                  // TODO: This intermediate is added to get GCC 14 to build
+                  decltype(auto) merged = glz::merge{value, unknown_writer};
+                  serialize<JSON>::op<disable_write_unknown_on<Options>()>(std::move(merged), ctx, b, ix);
                }
                else {
-                  static_assert(false_v<T>, "unknown_write type not handled");
+                  serialize<JSON>::op<disable_write_unknown_on<Options>()>(value, ctx, b, ix);
+               }
+            }
+            else if constexpr (std::is_member_function_pointer_v<WriterType>) {
+               decltype(auto) unknown_writer = (value.*writer)();
+               if (unknown_writer.size() > 0) {
+                  // TODO: This intermediate is added to get GCC 14 to build
+                  decltype(auto) merged = glz::merge{value, unknown_writer};
+                  serialize<JSON>::op<disable_write_unknown_on<Options>()>(std::move(merged), ctx, b, ix);
+               }
+               else {
+                  serialize<JSON>::op<disable_write_unknown_on<Options>()>(value, ctx, b, ix);
                }
             }
             else {
-               // handles glaze_object_t without extra unknown fields
-               static constexpr auto Opts =
-                  disable_write_unknown_off<opening_and_closing_handled_off<ws_handled_off<Options>()>()>();
-
-               if constexpr (not has_opening_handled(Options)) {
-                  if constexpr (Options.prettify) {
-                     ctx.indentation_level += Options.indentation_width;
-                     if constexpr (vector_like<B>) {
-                        if (const auto k = ix + ctx.indentation_level + write_padding_bytes; k > b.size())
-                           [[unlikely]] {
+               static_assert(false_v<T>, "unknown_write type not handled");
+            }
+         }
+         else {
+            // handles glaze_object_t without extra unknown fields
+            static constexpr auto Opts =
+            disable_write_unknown_off<opening_and_closing_handled_off<ws_handled_off<Options>()>()>();
+            
+            if constexpr (not has_opening_handled(Options)) {
+               if constexpr (Options.prettify) {
+                  ctx.indentation_level += Options.indentation_width;
+                  if constexpr (vector_like<B>) {
+                     if (const auto k = ix + ctx.indentation_level + write_padding_bytes; k > b.size())
+                        [[unlikely]] {
                            b.resize(2 * k);
                         }
+                  }
+                  std::memcpy(&b[ix], "{\n", 2);
+                  ix += 2;
+                  std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
+                  ix += ctx.indentation_level;
+               }
+               else {
+                  dump<'{'>(b, ix);
+               }
+            }
+            
+            static constexpr auto N = reflect<T>::size;
+            
+            decltype(auto) t = [&]() -> decltype(auto) {
+               if constexpr (reflectable<T>) {
+                  return to_tie(value);
+               }
+               else {
+                  return nullptr;
+               }
+            }();
+            
+            static constexpr auto padding = round_up_to_nearest_16(maximum_key_size<T> + write_padding_bytes);
+            if constexpr (maybe_skipped<Opts, T>) {
+               bool first = true;
+               invoke_table<N>([&]<size_t I>() {
+                  using val_t = field_t<T, I>;
+                  
+                  if constexpr (always_skipped<val_t>) {
+                     return;
+                  }
+                  else {
+                     if constexpr (null_t<val_t> && Opts.skip_null_members) {
+                        if constexpr (always_null_t<val_t>)
+                           return;
+                        else {
+                           const auto is_null = [&]() {
+                              decltype(auto) element = [&]() -> decltype(auto) {
+                                 if constexpr (reflectable<T>) {
+                                    return get<I>(t);
+                                 }
+                                 else {
+                                    return get<I>(reflect<T>::values);
+                                 }
+                              };
+                              
+                              if constexpr (nullable_wrapper<val_t>) {
+                                 return !bool(element()(value).val);
+                              }
+                              else if constexpr (nullable_value_t<val_t>) {
+                                 return !get_member(value, element()).has_value();
+                              }
+                              else {
+                                 return !bool(get_member(value, element()));
+                              }
+                           }();
+                           if (is_null) return;
+                        }
                      }
-                     std::memcpy(&b[ix], "{\n", 2);
+                     
+                     if constexpr (Opts.prettify) {
+                        maybe_pad(padding + ctx.indentation_level, b, ix);
+                     }
+                     else {
+                        maybe_pad<padding>(b, ix);
+                     }
+                     
+                     if (first) {
+                        first = false;
+                     }
+                     else {
+                        // Null members may be skipped so we cant just write it out for all but the last member
+                        if constexpr (Opts.prettify) {
+                           std::memcpy(&b[ix], ",\n", 2);
+                           ix += 2;
+                           std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
+                           ix += ctx.indentation_level;
+                        }
+                        else {
+                           std::memcpy(&b[ix], ",", 1);
+                           ++ix;
+                        }
+                     }
+                     
+                     // MSVC requires get<I> rather than keys[I]
+                     static constexpr auto key = glz::get<I>(reflect<T>::keys); // GCC 14 requires auto here
+                     static constexpr auto quoted_key = quoted_key_v<key, Opts.prettify>;
+                     static constexpr auto n = quoted_key.size();
+                     std::memcpy(&b[ix], quoted_key.data(), n);
+                     ix += n;
+                     
+                     static constexpr auto check_opts =
+                     required_padding<val_t>() ? write_unchecked_on<Opts>() : Opts;
+                     if constexpr (reflectable<T>) {
+                        to<JSON, val_t>::template op<check_opts>(get_member(value, get<I>(t)), ctx, b, ix);
+                     }
+                     else {
+                        to<JSON, val_t>::template op<check_opts>(get_member(value, get<I>(reflect<T>::values)), ctx,
+                                                                 b, ix);
+                     }
+                  }
+               });
+            }
+            else {
+               static constexpr size_t fixed_max_size = fixed_padding<T>;
+               if constexpr (fixed_max_size) {
+                  maybe_pad<fixed_max_size>(b, ix);
+               }
+               
+               invoke_table<N>([&]<size_t I>() {
+                  if constexpr (not fixed_max_size) {
+                     if constexpr (Opts.prettify) {
+                        maybe_pad(padding + ctx.indentation_level, b, ix);
+                     }
+                     else {
+                        maybe_pad<padding>(b, ix);
+                     }
+                  }
+                  
+                  if constexpr (I != 0 && Opts.prettify) {
+                     std::memcpy(&b[ix], ",\n", 2);
                      ix += 2;
                      std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
                      ix += ctx.indentation_level;
                   }
-                  else {
-                     dump<'{'>(b, ix);
-                  }
-               }
-
-               static constexpr auto N = reflect<T>::size;
-
-               decltype(auto) t = [&]() -> decltype(auto) {
-                  if constexpr (reflectable<T>) {
-                     return to_tie(value);
-                  }
-                  else {
-                     return nullptr;
-                  }
-               }();
-
-               static constexpr auto padding = round_up_to_nearest_16(maximum_key_size<T> + write_padding_bytes);
-               if constexpr (maybe_skipped<Opts, T>) {
-                  bool first = true;
-                  invoke_table<N>([&]<size_t I>() {
-                     using val_t = field_t<T, I>;
-
-                     if constexpr (always_skipped<val_t>) {
-                        return;
+                  
+                  using val_t = field_t<T, I>;
+                  
+                  // MSVC requires get<I> rather than keys[I]
+                  static constexpr auto key = glz::get<I>(reflect<T>::keys); // GCC 14 requires auto here
+                  if constexpr (always_null_t<val_t>) {
+                     if constexpr (I == 0 || Opts.prettify) {
+                        static constexpr auto quoted_key = join_v<quoted_key_v<key, Opts.prettify>, chars<"null">>;
+                        static constexpr auto n = quoted_key.size();
+                        std::memcpy(&b[ix], quoted_key.data(), n);
+                        ix += n;
                      }
                      else {
-                        if constexpr (null_t<val_t> && Opts.skip_null_members) {
-                           if constexpr (always_null_t<val_t>)
-                              return;
-                           else {
-                              const auto is_null = [&]() {
-                                 decltype(auto) element = [&]() -> decltype(auto) {
-                                    if constexpr (reflectable<T>) {
-                                       return get<I>(t);
-                                    }
-                                    else {
-                                       return get<I>(reflect<T>::values);
-                                    }
-                                 };
-
-                                 if constexpr (nullable_wrapper<val_t>) {
-                                    return !bool(element()(value).val);
-                                 }
-                                 else if constexpr (nullable_value_t<val_t>) {
-                                    return !get_member(value, element()).has_value();
-                                 }
-                                 else {
-                                    return !bool(get_member(value, element()));
-                                 }
-                              }();
-                              if (is_null) return;
-                           }
-                        }
-
-                        if constexpr (Opts.prettify) {
-                           maybe_pad(padding + ctx.indentation_level, b, ix);
-                        }
-                        else {
-                           maybe_pad<padding>(b, ix);
-                        }
-
-                        if (first) {
-                           first = false;
-                        }
-                        else {
-                           // Null members may be skipped so we cant just write it out for all but the last member
-                           if constexpr (Opts.prettify) {
-                              std::memcpy(&b[ix], ",\n", 2);
-                              ix += 2;
-                              std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
-                              ix += ctx.indentation_level;
-                           }
-                           else {
-                              std::memcpy(&b[ix], ",", 1);
-                              ++ix;
-                           }
-                        }
-
-                        // MSVC requires get<I> rather than keys[I]
-                        static constexpr auto key = glz::get<I>(reflect<T>::keys); // GCC 14 requires auto here
+                        static constexpr auto quoted_key = join_v<chars<",">, quoted_key_v<key>, chars<"null">>;
+                        static constexpr auto n = quoted_key.size();
+                        std::memcpy(&b[ix], quoted_key.data(), n);
+                        ix += n;
+                     }
+                  }
+                  else {
+                     if constexpr (I == 0 || Opts.prettify) {
                         static constexpr auto quoted_key = quoted_key_v<key, Opts.prettify>;
                         static constexpr auto n = quoted_key.size();
                         std::memcpy(&b[ix], quoted_key.data(), n);
                         ix += n;
-
-                        static constexpr auto check_opts =
-                           required_padding<val_t>() ? write_unchecked_on<Opts>() : Opts;
-                        if constexpr (reflectable<T>) {
-                           to<JSON, val_t>::template op<check_opts>(get_member(value, get<I>(t)), ctx, b, ix);
-                        }
-                        else {
-                           to<JSON, val_t>::template op<check_opts>(get_member(value, get<I>(reflect<T>::values)), ctx,
-                                                                    b, ix);
-                        }
-                     }
-                  });
-               }
-               else {
-                  static constexpr size_t fixed_max_size = fixed_padding<T>;
-                  if constexpr (fixed_max_size) {
-                     maybe_pad<fixed_max_size>(b, ix);
-                  }
-
-                  invoke_table<N>([&]<size_t I>() {
-                     if constexpr (not fixed_max_size) {
-                        if constexpr (Opts.prettify) {
-                           maybe_pad(padding + ctx.indentation_level, b, ix);
-                        }
-                        else {
-                           maybe_pad<padding>(b, ix);
-                        }
-                     }
-
-                     if constexpr (I != 0 && Opts.prettify) {
-                        std::memcpy(&b[ix], ",\n", 2);
-                        ix += 2;
-                        std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
-                        ix += ctx.indentation_level;
-                     }
-
-                     using val_t = field_t<T, I>;
-
-                     // MSVC requires get<I> rather than keys[I]
-                     static constexpr auto key = glz::get<I>(reflect<T>::keys); // GCC 14 requires auto here
-                     if constexpr (always_null_t<val_t>) {
-                        if constexpr (I == 0 || Opts.prettify) {
-                           static constexpr auto quoted_key = join_v<quoted_key_v<key, Opts.prettify>, chars<"null">>;
-                           static constexpr auto n = quoted_key.size();
-                           std::memcpy(&b[ix], quoted_key.data(), n);
-                           ix += n;
-                        }
-                        else {
-                           static constexpr auto quoted_key = join_v<chars<",">, quoted_key_v<key>, chars<"null">>;
-                           static constexpr auto n = quoted_key.size();
-                           std::memcpy(&b[ix], quoted_key.data(), n);
-                           ix += n;
-                        }
                      }
                      else {
-                        if constexpr (I == 0 || Opts.prettify) {
-                           static constexpr auto quoted_key = quoted_key_v<key, Opts.prettify>;
-                           static constexpr auto n = quoted_key.size();
-                           std::memcpy(&b[ix], quoted_key.data(), n);
-                           ix += n;
-                        }
-                        else {
-                           static constexpr auto quoted_key = join_v<chars<",">, quoted_key_v<key>>;
-                           static constexpr auto n = quoted_key.size();
-                           std::memcpy(&b[ix], quoted_key.data(), n);
-                           ix += n;
-                        }
-
-                        static constexpr auto check_opts =
-                           required_padding<val_t>() ? write_unchecked_on<Opts>() : Opts;
-                        if constexpr (reflectable<T>) {
-                           to<JSON, val_t>::template op<check_opts>(get_member(value, get<I>(t)), ctx, b, ix);
-                        }
-                        else {
-                           to<JSON, val_t>::template op<check_opts>(get_member(value, get<I>(reflect<T>::values)), ctx,
-                                                                    b, ix);
-                        }
+                        static constexpr auto quoted_key = join_v<chars<",">, quoted_key_v<key>>;
+                        static constexpr auto n = quoted_key.size();
+                        std::memcpy(&b[ix], quoted_key.data(), n);
+                        ix += n;
                      }
-                  });
-               }
-
-               // Options is required here, because it must be the top level
-               if constexpr (not has_closing_handled(Options)) {
-                  if constexpr (Options.prettify) {
-                     ctx.indentation_level -= Options.indentation_width;
-                     if constexpr (vector_like<B>) {
-                        if (const auto k = ix + ctx.indentation_level + write_padding_bytes; k > b.size())
-                           [[unlikely]] {
+                     
+                     static constexpr auto check_opts =
+                     required_padding<val_t>() ? write_unchecked_on<Opts>() : Opts;
+                     if constexpr (reflectable<T>) {
+                        to<JSON, val_t>::template op<check_opts>(get_member(value, get<I>(t)), ctx, b, ix);
+                     }
+                     else {
+                        to<JSON, val_t>::template op<check_opts>(get_member(value, get<I>(reflect<T>::values)), ctx,
+                                                                 b, ix);
+                     }
+                  }
+               });
+            }
+            
+            // Options is required here, because it must be the top level
+            if constexpr (not has_closing_handled(Options)) {
+               if constexpr (Options.prettify) {
+                  ctx.indentation_level -= Options.indentation_width;
+                  if constexpr (vector_like<B>) {
+                     if (const auto k = ix + ctx.indentation_level + write_padding_bytes; k > b.size())
+                        [[unlikely]] {
                            b.resize(2 * k);
                         }
-                     }
-                     std::memcpy(&b[ix], "\n", 1);
-                     ++ix;
-                     std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
-                     ix += ctx.indentation_level;
-                     std::memcpy(&b[ix], "}", 1);
-                     ++ix;
                   }
-                  else {
-                     dump<'}'>(b, ix);
-                  }
+                  std::memcpy(&b[ix], "\n", 1);
+                  ++ix;
+                  std::memset(&b[ix], Opts.indentation_char, ctx.indentation_level);
+                  ix += ctx.indentation_level;
+                  std::memcpy(&b[ix], "}", 1);
+                  ++ix;
+               }
+               else {
+                  dump<'}'>(b, ix);
                }
             }
          }
-      };
-   } // namespace detail
+      }
+   };
 
    template <class T, output_buffer Buffer>
       requires(write_supported<JSON, T>)

--- a/include/glaze/record/recorder.hpp
+++ b/include/glaze/record/recorder.hpp
@@ -84,14 +84,14 @@ namespace glz
             const size_t n = value.data.size();
             for (size_t i = 0; i < n; ++i) {
                auto& [name, v] = value.data[i];
-               write<JSON>::op<Opts>(name, ctx, args...); // write name as key
+               serialize<JSON>::op<Opts>(name, ctx, args...); // write name as key
 
                dump<':'>(args...);
                if constexpr (Opts.prettify) {
                   dump<' '>(args...);
                }
 
-               write<JSON>::op<Opts>(v.first, ctx, args...); // write deque
+               serialize<JSON>::op<Opts>(v.first, ctx, args...); // write deque
                if (i < n - 1) {
                   dump<','>(std::forward<Args>(args)...);
                }
@@ -165,7 +165,7 @@ namespace glz
                   return;
                }
 
-               std::visit([&](auto&& deq) { read<JSON>::op<Opts>(deq, ctx, it, end); }, v.first);
+               std::visit([&](auto&& deq) { parse<JSON>::op<Opts>(deq, ctx, it, end); }, v.first);
 
                if (i < n - 1) {
                   if (skip_ws<Opts>(ctx, it, end)) {
@@ -203,7 +203,7 @@ namespace glz
 
                   std::visit(
                      [&](auto& x) {
-                        write<CSV>::op<Opts>(x, ctx, args...); // write deque
+                        serialize<CSV>::op<Opts>(x, ctx, args...); // write deque
                      },
                      v.first);
 
@@ -239,7 +239,7 @@ namespace glz
                               breakout = true;
                               return;
                            }
-                           write<CSV>::op<Opts>(v[row], ctx, args...); // write deque
+                           serialize<CSV>::op<Opts>(v[row], ctx, args...); // write deque
                         },
                         data.first);
 

--- a/include/glaze/record/recorder.hpp
+++ b/include/glaze/record/recorder.hpp
@@ -62,207 +62,204 @@ namespace glz
       }
    };
 
-   namespace detail
+   template <class T>
+   concept is_recorder = is_specialization_v<T, recorder>;
+   
+   template <is_recorder T>
+   struct to<JSON, T>
    {
-      template <class T>
-      concept is_recorder = is_specialization_v<T, recorder>;
-
-      template <is_recorder T>
-      struct to<JSON, T>
+      template <auto Opts, class... Args>
+      static void op(auto&& value, is_context auto&& ctx, Args&&... args)
       {
-         template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
-         {
-            dump<'{'>(std::forward<Args>(args)...);
-
+         dump<'{'>(std::forward<Args>(args)...);
+         
+         if constexpr (Opts.prettify) {
+            ctx.indentation_level += Opts.indentation_width;
+            dump<'\n'>(args...);
+            dumpn<Opts.indentation_char>(ctx.indentation_level, args...);
+         }
+         
+         const size_t n = value.data.size();
+         for (size_t i = 0; i < n; ++i) {
+            auto& [name, v] = value.data[i];
+            serialize<JSON>::op<Opts>(name, ctx, args...); // write name as key
+            
+            dump<':'>(args...);
             if constexpr (Opts.prettify) {
-               ctx.indentation_level += Opts.indentation_width;
+               dump<' '>(args...);
+            }
+            
+            serialize<JSON>::op<Opts>(v.first, ctx, args...); // write deque
+            if (i < n - 1) {
+               dump<','>(std::forward<Args>(args)...);
+            }
+            
+            if constexpr (Opts.prettify) {
                dump<'\n'>(args...);
                dumpn<Opts.indentation_char>(ctx.indentation_level, args...);
             }
-
+         }
+         
+         if constexpr (Opts.prettify) {
+            ctx.indentation_level -= Opts.indentation_width;
+            dump<'\n'>(args...);
+            dumpn<Opts.indentation_char>(ctx.indentation_level, args...);
+         }
+         dump<'}'>(args...);
+      }
+   };
+   
+   template <is_recorder T>
+   struct from<JSON, T>
+   {
+      template <auto Options>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+         
+         constexpr auto Opts = opening_handled_off<ws_handled_off<Options>()>();
+         
+         if constexpr (!has_opening_handled(Options)) {
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
+            }
+            if (match_invalid_end<'{', Opts>(ctx, it, end)) {
+               return;
+            }
+         }
+         
+         if (skip_ws<Opts>(ctx, it, end)) {
+            return;
+         }
+         
+         // we read into available containers, we do not intialize here
+         const size_t n = value.data.size();
+         for (size_t i = 0; i < n; ++i) {
+            if (*it == '}') [[unlikely]] {
+               ctx.error = error_code::expected_brace;
+            }
+            
+            // find the string, escape characters are not supported for recorders
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
+            }
+            const auto name = parse_key(ctx, it, end);
+            
+            auto& [str, v] = value.data[i];
+            if (name != str) {
+               ctx.error = error_code::name_mismatch; // Recorder read of name does not match initialized state
+               return;
+            }
+            
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
+            }
+            if (match_invalid_end<':', Opts>(ctx, it, end)) {
+               return;
+            }
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
+            }
+            
+            std::visit([&](auto&& deq) { parse<JSON>::op<Opts>(deq, ctx, it, end); }, v.first);
+            
+            if (i < n - 1) {
+               if (skip_ws<Opts>(ctx, it, end)) {
+                  return;
+               }
+               if (match_invalid_end<',', Opts>(ctx, it, end)) {
+                  return;
+               }
+               if (skip_ws<Opts>(ctx, it, end)) {
+                  return;
+               }
+            }
+         }
+         
+         if (skip_ws<Opts>(ctx, it, end)) {
+            return;
+         }
+         match<'}'>(ctx, it);
+      }
+   };
+   
+   template <is_recorder T>
+   struct to<CSV, T>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&&... args)
+      {
+         if constexpr (Opts.layout == rowwise) {
             const size_t n = value.data.size();
             for (size_t i = 0; i < n; ++i) {
                auto& [name, v] = value.data[i];
-               serialize<JSON>::op<Opts>(name, ctx, args...); // write name as key
-
-               dump<':'>(args...);
-               if constexpr (Opts.prettify) {
-                  dump<' '>(args...);
-               }
-
-               serialize<JSON>::op<Opts>(v.first, ctx, args...); // write deque
+               dump_maybe_empty(name, args...);
+               
+               dump<','>(args...);
+               
+               std::visit(
+                          [&](auto& x) {
+                             serialize<CSV>::op<Opts>(x, ctx, args...); // write deque
+                          },
+                          v.first);
+               
                if (i < n - 1) {
-                  dump<','>(std::forward<Args>(args)...);
-               }
-
-               if constexpr (Opts.prettify) {
                   dump<'\n'>(args...);
-                  dumpn<Opts.indentation_char>(ctx.indentation_level, args...);
                }
             }
-
-            if constexpr (Opts.prettify) {
-               ctx.indentation_level -= Opts.indentation_width;
-               dump<'\n'>(args...);
-               dumpn<Opts.indentation_char>(ctx.indentation_level, args...);
-            }
-            dump<'}'>(args...);
          }
-      };
-
-      template <is_recorder T>
-      struct from<JSON, T>
-      {
-         template <auto Options>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
-         {
-            if (bool(ctx.error)) [[unlikely]] {
-               return;
-            }
-
-            constexpr auto Opts = opening_handled_off<ws_handled_off<Options>()>();
-
-            if constexpr (!has_opening_handled(Options)) {
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-               if (match_invalid_end<'{', Opts>(ctx, it, end)) {
-                  return;
-               }
-            }
-
-            if (skip_ws<Opts>(ctx, it, end)) {
-               return;
-            }
-
-            // we read into available containers, we do not intialize here
-            const size_t n = value.data.size();
-            for (size_t i = 0; i < n; ++i) {
-               if (*it == '}') [[unlikely]] {
-                  ctx.error = error_code::expected_brace;
-               }
-
-               // find the string, escape characters are not supported for recorders
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-               const auto name = parse_key(ctx, it, end);
-
-               auto& [str, v] = value.data[i];
-               if (name != str) {
-                  ctx.error = error_code::name_mismatch; // Recorder read of name does not match initialized state
-                  return;
-               }
-
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-               if (match_invalid_end<':', Opts>(ctx, it, end)) {
-                  return;
-               }
-               if (skip_ws<Opts>(ctx, it, end)) {
-                  return;
-               }
-
-               std::visit([&](auto&& deq) { parse<JSON>::op<Opts>(deq, ctx, it, end); }, v.first);
-
-               if (i < n - 1) {
-                  if (skip_ws<Opts>(ctx, it, end)) {
-                     return;
-                  }
-                  if (match_invalid_end<',', Opts>(ctx, it, end)) {
-                     return;
-                  }
-                  if (skip_ws<Opts>(ctx, it, end)) {
-                     return;
-                  }
-               }
-            }
-
-            if (skip_ws<Opts>(ctx, it, end)) {
-               return;
-            }
-            match<'}'>(ctx, it);
-         }
-      };
-
-      template <is_recorder T>
-      struct to<CSV, T>
-      {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&&... args)
-         {
-            if constexpr (Opts.layout == rowwise) {
-               const size_t n = value.data.size();
-               for (size_t i = 0; i < n; ++i) {
-                  auto& [name, v] = value.data[i];
-                  dump_maybe_empty(name, args...);
-
+         else {
+            // dump titles
+            const auto n = value.data.size();
+            size_t i = 0;
+            for (auto& [name, data] : value.data) {
+               dump_maybe_empty(name, args...);
+               ++i;
+               if (i < n) {
                   dump<','>(args...);
-
-                  std::visit(
-                     [&](auto& x) {
-                        serialize<CSV>::op<Opts>(x, ctx, args...); // write deque
-                     },
-                     v.first);
-
-                  if (i < n - 1) {
-                     dump<'\n'>(args...);
-                  }
                }
             }
-            else {
-               // dump titles
-               const auto n = value.data.size();
-               size_t i = 0;
+            
+            dump<'\n'>(args...);
+            
+            size_t row = 0;
+            bool end = false;
+            while (true) {
+               i = 0;
                for (auto& [name, data] : value.data) {
-                  dump_maybe_empty(name, args...);
+                  bool breakout = false;
+                  std::visit(
+                             [&](auto& v) {
+                                if (row >= v.size()) {
+                                   end = true;
+                                   breakout = true;
+                                   return;
+                                }
+                                serialize<CSV>::op<Opts>(v[row], ctx, args...); // write deque
+                             },
+                             data.first);
+                  
+                  if (breakout) {
+                     break;
+                  }
+                  
                   ++i;
                   if (i < n) {
                      dump<','>(args...);
                   }
                }
-
-               dump<'\n'>(args...);
-
-               size_t row = 0;
-               bool end = false;
-               while (true) {
-                  i = 0;
-                  for (auto& [name, data] : value.data) {
-                     bool breakout = false;
-                     std::visit(
-                        [&](auto& v) {
-                           if (row >= v.size()) {
-                              end = true;
-                              breakout = true;
-                              return;
-                           }
-                           serialize<CSV>::op<Opts>(v[row], ctx, args...); // write deque
-                        },
-                        data.first);
-
-                     if (breakout) {
-                        break;
-                     }
-
-                     ++i;
-                     if (i < n) {
-                        dump<','>(args...);
-                     }
-                  }
-
-                  if (end) {
-                     break;
-                  }
-
-                  dump<'\n'>(args...);
-
-                  ++row;
+               
+               if (end) {
+                  break;
                }
+               
+               dump<'\n'>(args...);
+               
+               ++row;
             }
          }
-      };
-   }
+      }
+   };
 }

--- a/include/glaze/rpc/repe/registry.hpp
+++ b/include/glaze/rpc/repe/registry.hpp
@@ -93,7 +93,7 @@ namespace glz::repe
       }
       auto start = b;
 
-      glz::detail::read<Opts.format>::template op<Opts>(std::forward<Value>(value), ctx, b, e);
+      glz::parse<Opts.format>::template op<Opts>(std::forward<Value>(value), ctx, b, e);
 
       if (bool(ctx.error)) {
          state.out.header.ec = ctx.error;

--- a/include/glaze/rpc/repe/registry.hpp
+++ b/include/glaze/rpc/repe/registry.hpp
@@ -198,7 +198,7 @@ namespace glz::repe
 
       // Register a C++ type that stores pointers to the value, so be sure to keep the registered value alive
       template <const std::string_view& root = detail::empty_path, class T, const std::string_view& parent = root>
-         requires(glz::detail::glaze_object_t<T> || glz::detail::reflectable<T>)
+         requires(glz::glaze_object_t<T> || glz::reflectable<T>)
       void on(T& value)
       {
          using namespace glz::detail;

--- a/include/glaze/stencil/stencil.hpp
+++ b/include/glaze/stencil/stencil.hpp
@@ -117,11 +117,11 @@ namespace glz
                               [&]<size_t I>() {
                                  static constexpr auto TargetKey = get<I>(reflect<T>::keys);
                                  if (TargetKey == key) [[likely]] {
-                                    if constexpr (detail::bool_t<refl_t<T, I>>) {
-                                       if constexpr (detail::reflectable<T>) {
+                                    if constexpr (bool_t<refl_t<T, I>>) {
+                                       if constexpr (reflectable<T>) {
                                           condition = bool(get_member(value, get<I>(to_tie(value))));
                                        }
-                                       else if constexpr (detail::glaze_object_t<T>) {
+                                       else if constexpr (glaze_object_t<T>) {
                                           condition = bool(get_member(value, get<I>(reflect<T>::values)));
                                        }
                                     }
@@ -183,11 +183,11 @@ namespace glz
                         [&]<size_t I>() {
                            static constexpr auto TargetKey = get<I>(reflect<T>::keys);
                            if ((TargetKey.size() == key.size()) && detail::comparitor<TargetKey>(start)) [[likely]] {
-                              if constexpr (detail::reflectable<T>) {
+                              if constexpr (reflectable<T>) {
                                  serialize<Opts.format>::template op<RawOpts>(
                                     get_member(value, get<I>(to_tie(value))), ctx, buffer, ix);
                               }
-                              else if constexpr (detail::glaze_object_t<T>) {
+                              else if constexpr (glaze_object_t<T>) {
                                  serialize<Opts.format>::template op<RawOpts>(
                                     get_member(value, get<I>(reflect<T>::values)), ctx, buffer, ix);
                               }

--- a/include/glaze/stencil/stencil.hpp
+++ b/include/glaze/stencil/stencil.hpp
@@ -26,7 +26,7 @@ namespace glz
 
       if (not bool(ctx.error)) [[likely]] {
          auto skip_whitespace = [&] {
-            while (it < end && detail::whitespace_table[uint8_t(*it)]) {
+            while (it < end && whitespace_table[uint8_t(*it)]) {
                ++it;
             }
          };
@@ -103,9 +103,9 @@ namespace glz
                      bool condition = false;
                      {
                         static constexpr auto N = reflect<T>::size;
-                        static constexpr auto HashInfo = detail::hash_info<T>;
+                        static constexpr auto HashInfo = hash_info<T>;
 
-                        const auto index = detail::decode_hash_with_size<STENCIL, T, HashInfo, HashInfo.type>::op(
+                        const auto index = decode_hash_with_size<STENCIL, T, HashInfo, HashInfo.type>::op(
                            start, end, key.size());
 
                         if (index >= N) {
@@ -162,10 +162,10 @@ namespace glz
 
                   // Handle regular placeholder
                   static constexpr auto N = reflect<T>::size;
-                  static constexpr auto HashInfo = detail::hash_info<T>;
+                  static constexpr auto HashInfo = hash_info<T>;
 
                   const auto index =
-                     detail::decode_hash_with_size<STENCIL, T, HashInfo, HashInfo.type>::op(start, end, key.size());
+                     decode_hash_with_size<STENCIL, T, HashInfo, HashInfo.type>::op(start, end, key.size());
 
                   if (index >= N) [[unlikely]] {
                      ctx.error = error_code::unknown_key;
@@ -182,7 +182,7 @@ namespace glz
                      visit<N>(
                         [&]<size_t I>() {
                            static constexpr auto TargetKey = get<I>(reflect<T>::keys);
-                           if ((TargetKey.size() == key.size()) && detail::comparitor<TargetKey>(start)) [[likely]] {
+                           if ((TargetKey.size() == key.size()) && comparitor<TargetKey>(start)) [[likely]] {
                               if constexpr (reflectable<T>) {
                                  serialize<Opts.format>::template op<RawOpts>(
                                     get_member(value, get<I>(to_tie(value))), ctx, buffer, ix);

--- a/include/glaze/stencil/stencil.hpp
+++ b/include/glaze/stencil/stencil.hpp
@@ -184,11 +184,11 @@ namespace glz
                            static constexpr auto TargetKey = get<I>(reflect<T>::keys);
                            if ((TargetKey.size() == key.size()) && detail::comparitor<TargetKey>(start)) [[likely]] {
                               if constexpr (detail::reflectable<T>) {
-                                 detail::write<Opts.format>::template op<RawOpts>(
+                                 serialize<Opts.format>::template op<RawOpts>(
                                     get_member(value, get<I>(to_tie(value))), ctx, buffer, ix);
                               }
                               else if constexpr (detail::glaze_object_t<T>) {
-                                 detail::write<Opts.format>::template op<RawOpts>(
+                                 serialize<Opts.format>::template op<RawOpts>(
                                     get_member(value, get<I>(reflect<T>::values)), ctx, buffer, ix);
                               }
                            }

--- a/include/glaze/stencil/stencilcount.hpp
+++ b/include/glaze/stencil/stencilcount.hpp
@@ -27,7 +27,7 @@ namespace glz
       }
       if (not bool(ctx.error)) [[likely]] {
          auto skip_whitespace = [&] {
-            while (detail::whitespace_table[uint8_t(*it)]) {
+            while (whitespace_table[uint8_t(*it)]) {
                ++it;
             }
          };
@@ -101,7 +101,7 @@ namespace glz
                   static constexpr auto HashInfo = hash_info<T>;
 
                   const auto index =
-                     detail::decode_hash_with_size<STENCIL, T, HashInfo, HashInfo.type>::op(start, end, key.size());
+                     decode_hash_with_size<STENCIL, T, HashInfo, HashInfo.type>::op(start, end, key.size());
 
                   if (index < N) [[likely]] {
                      static thread_local std::string temp{};
@@ -109,7 +109,7 @@ namespace glz
                         [&]<size_t I>() {
                            static constexpr auto TargetKey = get<I>(reflect<T>::keys);
                            static constexpr auto Length = TargetKey.size();
-                           if ((Length == key.size()) && detail::comparitor<TargetKey>(start)) [[likely]] {
+                           if ((Length == key.size()) && comparitor<TargetKey>(start)) [[likely]] {
                               if constexpr (reflectable<T> && N > 0) {
                                  std::ignore = write<opt_true<Opts, &opts::raw>>(
                                     get_member(value, get<I>(to_tie(value))), temp, ctx);

--- a/include/glaze/stencil/stencilcount.hpp
+++ b/include/glaze/stencil/stencilcount.hpp
@@ -110,11 +110,11 @@ namespace glz
                            static constexpr auto TargetKey = get<I>(reflect<T>::keys);
                            static constexpr auto Length = TargetKey.size();
                            if ((Length == key.size()) && detail::comparitor<TargetKey>(start)) [[likely]] {
-                              if constexpr (detail::reflectable<T> && N > 0) {
+                              if constexpr (reflectable<T> && N > 0) {
                                  std::ignore = write<opt_true<Opts, &opts::raw>>(
                                     get_member(value, get<I>(to_tie(value))), temp, ctx);
                               }
-                              else if constexpr (detail::glaze_object_t<T> && N > 0) {
+                              else if constexpr (glaze_object_t<T> && N > 0) {
                                  std::ignore = write<opt_true<Opts, &opts::raw>>(
                                     get_member(value, get<I>(reflect<T>::values)), temp, ctx);
                               }

--- a/include/glaze/stencil/stencilcount.hpp
+++ b/include/glaze/stencil/stencilcount.hpp
@@ -98,7 +98,7 @@ namespace glz
                   skip_whitespace();
 
                   static constexpr auto N = reflect<T>::size;
-                  static constexpr auto HashInfo = detail::hash_info<T>;
+                  static constexpr auto HashInfo = hash_info<T>;
 
                   const auto index =
                      detail::decode_hash_with_size<STENCIL, T, HashInfo, HashInfo.type>::op(start, end, key.size());

--- a/include/glaze/thread/async_string.hpp
+++ b/include/glaze/thread/async_string.hpp
@@ -428,7 +428,7 @@ namespace glz::detail
       static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
       {
          auto proxy = value.write();
-         read<Format>::template op<Opts>(*proxy, ctx, it, end);
+         parse<Format>::template op<Opts>(*proxy, ctx, it, end);
       }
    };
 
@@ -439,7 +439,7 @@ namespace glz::detail
       static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
       {
          auto proxy = value.read();
-         write<Format>::template op<Opts>(*proxy, ctx, args...);
+         serialize<Format>::template op<Opts>(*proxy, ctx, args...);
       }
    };
 }

--- a/include/glaze/thread/async_string.hpp
+++ b/include/glaze/thread/async_string.hpp
@@ -419,7 +419,7 @@ namespace glz
 
 }
 
-namespace glz::detail
+namespace glz
 {
    template <uint32_t Format>
    struct from<Format, glz::async_string>

--- a/include/glaze/thread/atomic.hpp
+++ b/include/glaze/thread/atomic.hpp
@@ -7,7 +7,7 @@
 
 // Supports serialization/deserialization of std::atomic
 
-namespace glz::detail
+namespace glz
 {
    template <typename T>
    concept is_atomic = requires(T a, typename std::remove_reference_t<decltype(a.load())>& expected,

--- a/include/glaze/thread/atomic.hpp
+++ b/include/glaze/thread/atomic.hpp
@@ -41,7 +41,7 @@ namespace glz::detail
       {
          using V = typename T::value_type;
          V temp{};
-         read<Format>::template op<Opts>(temp, ctx, it, end);
+         parse<Format>::template op<Opts>(temp, ctx, it, end);
          value.store(temp);
       }
    };
@@ -54,7 +54,7 @@ namespace glz::detail
       static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
       {
          const auto v = value.load();
-         write<Format>::template op<Opts>(v, ctx, args...);
+         serialize<Format>::template op<Opts>(v, ctx, args...);
       }
    };
 }

--- a/include/glaze/thread/value_proxy.hpp
+++ b/include/glaze/thread/value_proxy.hpp
@@ -5,7 +5,7 @@
 
 #include "glaze/core/common.hpp"
 
-namespace glz::detail
+namespace glz
 {
    template <class T>
    concept is_value_proxy = requires { T::glaze_value_proxy; };

--- a/include/glaze/thread/value_proxy.hpp
+++ b/include/glaze/thread/value_proxy.hpp
@@ -16,7 +16,7 @@ namespace glz::detail
       template <auto Opts>
       static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
       {
-         read<JSON>::op<Opts>(value.value(), ctx, it, end);
+         parse<JSON>::op<Opts>(value.value(), ctx, it, end);
       }
    };
 }

--- a/include/glaze/toml/write.hpp
+++ b/include/glaze/toml/write.hpp
@@ -18,7 +18,7 @@ namespace glz
    namespace detail
    {
       template <>
-      struct write<TOML>
+      struct serialize<TOML>
       {
          template <auto Opts, class T, is_context Ctx, class B, class IX>
          GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
@@ -48,7 +48,7 @@ namespace glz
          GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
          {
             if (value) {
-               write<TOML>::op<Opts>(*value, ctx, b, ix);
+               serialize<TOML>::op<Opts>(*value, ctx, b, ix);
             }
          }
       };
@@ -501,7 +501,7 @@ namespace glz
          template <auto Opts, class V, size_t N, class... Args>
          GLZ_ALWAYS_INLINE static void op(const V (&value)[N], is_context auto&& ctx, Args&&... args)
          {
-            write<TOML>::op<Opts>(std::span{value, N}, ctx, std::forward<Args>(args)...);
+            serialize<TOML>::op<Opts>(std::span{value, N}, ctx, std::forward<Args>(args)...);
          }
       };
 
@@ -525,7 +525,7 @@ namespace glz
             using V = std::decay_t<T>;
             invoke_table<N>([&]<size_t I>() {
                if constexpr (glaze_array_t<V>) {
-                  write<TOML>::op<Opts>(get_member(value, glz::get<I>(meta_v<T>)), ctx, args...);
+                  serialize<TOML>::op<Opts>(get_member(value, glz::get<I>(meta_v<T>)), ctx, args...);
                }
                else if constexpr (is_std_tuple<T>) {
                   using Value = core_t<decltype(std::get<I>(value))>;

--- a/include/glaze/toml/write.hpp
+++ b/include/glaze/toml/write.hpp
@@ -21,539 +21,536 @@ namespace glz
       template <auto Opts, class T, is_context Ctx, class B, class IX>
       GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
       {
-         detail::to<TOML, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+         to<TOML, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
                                                              std::forward<B>(b), std::forward<IX>(ix));
       }
    };
    
-   namespace detail
+   template <class T>
+   requires(glaze_value_t<T> && !custom_write<T>)
+   struct to<TOML, T>
    {
-      template <class T>
-         requires(glaze_value_t<T> && !custom_write<T>)
-      struct to<TOML, T>
+      template <auto Opts, class Value, is_context Ctx, class B, class IX>
+      GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, B&& b, IX&& ix)
       {
-         template <auto Opts, class Value, is_context Ctx, class B, class IX>
-         GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, B&& b, IX&& ix)
-         {
-            using V = std::remove_cvref_t<decltype(get_member(std::declval<Value>(), meta_wrapper_v<T>))>;
-            to<TOML, V>::template op<Opts>(get_member(std::forward<Value>(value), meta_wrapper_v<T>),
-                                           std::forward<Ctx>(ctx), std::forward<B>(b), std::forward<IX>(ix));
+         using V = std::remove_cvref_t<decltype(get_member(std::declval<Value>(), meta_wrapper_v<T>))>;
+         to<TOML, V>::template op<Opts>(get_member(std::forward<Value>(value), meta_wrapper_v<T>),
+                                        std::forward<Ctx>(ctx), std::forward<B>(b), std::forward<IX>(ix));
+      }
+   };
+   
+   template <nullable_like T>
+   struct to<TOML, T>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
+      {
+         if (value) {
+            serialize<TOML>::op<Opts>(*value, ctx, b, ix);
          }
-      };
-
-      template <nullable_like T>
-      struct to<TOML, T>
+      }
+   };
+   
+   template <boolean_like T>
+   struct to<TOML, T>
+   {
+      template <auto Opts, class B>
+      GLZ_ALWAYS_INLINE static void op(const bool value, is_context auto&&, B&& b, auto&& ix)
       {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
-         {
+         static constexpr auto checked = not has_write_unchecked(Opts);
+         if constexpr (checked && vector_like<B>) {
+            if (const auto n = ix + 8; n > b.size()) [[unlikely]] {
+               b.resize(2 * n);
+            }
+         }
+         
+         if constexpr (Opts.bools_as_numbers) {
             if (value) {
-               serialize<TOML>::op<Opts>(*value, ctx, b, ix);
-            }
-         }
-      };
-
-      template <boolean_like T>
-      struct to<TOML, T>
-      {
-         template <auto Opts, class B>
-         GLZ_ALWAYS_INLINE static void op(const bool value, is_context auto&&, B&& b, auto&& ix)
-         {
-            static constexpr auto checked = not has_write_unchecked(Opts);
-            if constexpr (checked && vector_like<B>) {
-               if (const auto n = ix + 8; n > b.size()) [[unlikely]] {
-                  b.resize(2 * n);
-               }
-            }
-
-            if constexpr (Opts.bools_as_numbers) {
-               if (value) {
-                  std::memcpy(&b[ix], "1", 1);
-               }
-               else {
-                  std::memcpy(&b[ix], "0", 1);
-               }
-               ++ix;
+               std::memcpy(&b[ix], "1", 1);
             }
             else {
-               if (value) {
-                  std::memcpy(&b[ix], "true", 4);
-                  ix += 4;
-               }
-               else {
-                  std::memcpy(&b[ix], "false", 5);
-                  ix += 5;
-               }
+               std::memcpy(&b[ix], "0", 1);
             }
+            ++ix;
          }
-      };
-
-      template <num_t T>
-      struct to<TOML, T>
-      {
-         template <auto Opts, class B>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
-         {
-            if constexpr (Opts.quoted_num) {
-               std::memcpy(&b[ix], "\"", 1);
-               ++ix;
-               write_chars::op<Opts>(value, ctx, b, ix);
-               std::memcpy(&b[ix], "\"", 1);
-               ++ix;
+         else {
+            if (value) {
+               std::memcpy(&b[ix], "true", 4);
+               ix += 4;
             }
             else {
-               write_chars::op<Opts>(value, ctx, b, ix);
+               std::memcpy(&b[ix], "false", 5);
+               ix += 5;
             }
          }
-      };
-
-      constexpr std::array<uint16_t, 256> char_escape_table = [] {
-         auto combine = [](const char chars[2]) -> uint16_t { return uint16_t(chars[0]) | (uint16_t(chars[1]) << 8); };
-
-         std::array<uint16_t, 256> t{};
-         t['\b'] = combine(R"(\b)");
-         t['\t'] = combine(R"(\t)");
-         t['\n'] = combine(R"(\n)");
-         t['\f'] = combine(R"(\f)");
-         t['\r'] = combine(R"(\r)");
-         t['\"'] = combine(R"(\")");
-         t['\\'] = combine(R"(\\)");
-         return t;
-      }();
-
-      template <class T>
-         requires str_t<T> || char_t<T>
-      struct to<TOML, T>
+      }
+   };
+   
+   template <num_t T>
+   struct to<TOML, T>
+   {
+      template <auto Opts, class B>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
       {
-         template <auto Opts, class B>
-         static void op(auto&& value, is_context auto&&, B&& b, auto&& ix)
-         {
-            if constexpr (Opts.number) {
-               dump_maybe_empty(value, b, ix);
+         if constexpr (Opts.quoted_num) {
+            std::memcpy(&b[ix], "\"", 1);
+            ++ix;
+            write_chars::op<Opts>(value, ctx, b, ix);
+            std::memcpy(&b[ix], "\"", 1);
+            ++ix;
+         }
+         else {
+            write_chars::op<Opts>(value, ctx, b, ix);
+         }
+      }
+   };
+   
+   constexpr std::array<uint16_t, 256> char_escape_table = [] {
+      auto combine = [](const char chars[2]) -> uint16_t { return uint16_t(chars[0]) | (uint16_t(chars[1]) << 8); };
+      
+      std::array<uint16_t, 256> t{};
+      t['\b'] = combine(R"(\b)");
+      t['\t'] = combine(R"(\t)");
+      t['\n'] = combine(R"(\n)");
+      t['\f'] = combine(R"(\f)");
+      t['\r'] = combine(R"(\r)");
+      t['\"'] = combine(R"(\")");
+      t['\\'] = combine(R"(\\)");
+      return t;
+   }();
+   
+   template <class T>
+   requires str_t<T> || char_t<T>
+   struct to<TOML, T>
+   {
+      template <auto Opts, class B>
+      static void op(auto&& value, is_context auto&&, B&& b, auto&& ix)
+      {
+         if constexpr (Opts.number) {
+            dump_maybe_empty(value, b, ix);
+         }
+         else if constexpr (char_t<T>) {
+            if constexpr (Opts.raw) {
+               dump(value, b, ix);
             }
-            else if constexpr (char_t<T>) {
-               if constexpr (Opts.raw) {
-                  dump(value, b, ix);
-               }
-               else {
-                  if constexpr (resizable<B>) {
-                     const auto k = ix + 8;
-                     if (k > b.size()) [[unlikely]] {
-                        b.resize(2 * k);
-                     }
+            else {
+               if constexpr (resizable<B>) {
+                  const auto k = ix + 8;
+                  if (k > b.size()) [[unlikely]] {
+                     b.resize(2 * k);
                   }
-
-                  std::memcpy(&b[ix], "\"", 1);
+               }
+               
+               std::memcpy(&b[ix], "\"", 1);
+               ++ix;
+               if (const auto escaped = char_escape_table[uint8_t(value)]; escaped) {
+                  std::memcpy(&b[ix], &escaped, 2);
+                  ix += 2;
+               }
+               else if (value == '\0') {
+                  // null character treated as empty string
+               }
+               else {
+                  std::memcpy(&b[ix], &value, 1);
                   ++ix;
-                  if (const auto escaped = char_escape_table[uint8_t(value)]; escaped) {
-                     std::memcpy(&b[ix], &escaped, 2);
-                     ix += 2;
-                  }
-                  else if (value == '\0') {
-                     // null character treated as empty string
+               }
+               std::memcpy(&b[ix], "\"", 1);
+               ++ix;
+            }
+         }
+         else {
+            if constexpr (Opts.raw_string) {
+               const sv str = [&]() -> const sv {
+                  if constexpr (!char_array_t<T> && std::is_pointer_v<std::decay_t<T>>) {
+                     return value ? value : "";
                   }
                   else {
-                     std::memcpy(&b[ix], &value, 1);
-                     ++ix;
+                     return value;
                   }
-                  std::memcpy(&b[ix], "\"", 1);
-                  ++ix;
+               }();
+               
+               if constexpr (resizable<B>) {
+                  const auto n = str.size();
+                  const auto k = ix + 8 + n;
+                  if (k > b.size()) [[unlikely]] {
+                     b.resize(2 * k);
+                  }
                }
+               
+               std::memcpy(&b[ix], "\"", 1);
+               ++ix;
+               if (str.size()) [[likely]] {
+                  const auto n = str.size();
+                  std::memcpy(&b[ix], str.data(), n);
+                  ix += n;
+               }
+               std::memcpy(&b[ix], "\"", 1);
+               ++ix;
             }
             else {
-               if constexpr (Opts.raw_string) {
-                  const sv str = [&]() -> const sv {
-                     if constexpr (!char_array_t<T> && std::is_pointer_v<std::decay_t<T>>) {
-                        return value ? value : "";
-                     }
-                     else {
-                        return value;
-                     }
-                  }();
-
-                  if constexpr (resizable<B>) {
-                     const auto n = str.size();
-                     const auto k = ix + 8 + n;
-                     if (k > b.size()) [[unlikely]] {
-                        b.resize(2 * k);
-                     }
+               const sv str = [&]() -> const sv {
+                  if constexpr (!char_array_t<T> && std::is_pointer_v<std::decay_t<T>>) {
+                     return value ? value : "";
                   }
-
-                  std::memcpy(&b[ix], "\"", 1);
-                  ++ix;
-                  if (str.size()) [[likely]] {
-                     const auto n = str.size();
+                  else if constexpr (array_char_t<T>) {
+                     return *value.data() ? sv{value.data()} : "";
+                  }
+                  else {
+                     return value;
+                  }
+               }();
+               const auto n = str.size();
+               if constexpr (resizable<B>) {
+                  const auto k = ix + 10 + 2 * n;
+                  if (k > b.size()) [[unlikely]] {
+                     b.resize(2 * k);
+                  }
+               }
+               
+               if constexpr (Opts.raw) {
+                  const auto n = str.size();
+                  if (n) {
                      std::memcpy(&b[ix], str.data(), n);
                      ix += n;
                   }
+               }
+               else {
+                  std::memcpy(&b[ix], "\"", 1);
+                  ++ix;
+                  const auto* c = str.data();
+                  const auto* const e = c + n;
+                  const auto start = &b[ix];
+                  auto data = start;
+                  
+                  if (n > 7) {
+                     for (const auto end_m7 = e - 7; c < end_m7;) {
+                        std::memcpy(data, c, 8);
+                        uint64_t swar;
+                        std::memcpy(&swar, c, 8);
+                        
+                        constexpr uint64_t lo7_mask = repeat_byte8(0b01111111);
+                        const uint64_t lo7 = swar & lo7_mask;
+                        const uint64_t quote = (lo7 ^ repeat_byte8('"')) + lo7_mask;
+                        const uint64_t backslash = (lo7 ^ repeat_byte8('\\')) + lo7_mask;
+                        const uint64_t less_32 = (swar & repeat_byte8(0b01100000)) + lo7_mask;
+                        uint64_t next = ~((quote & backslash & less_32) | swar);
+                        
+                        next &= repeat_byte8(0b10000000);
+                        if (next == 0) {
+                           data += 8;
+                           c += 8;
+                           continue;
+                        }
+                        
+                        const auto length = (countr_zero(next) >> 3);
+                        c += length;
+                        data += length;
+                        
+                        std::memcpy(data, &char_escape_table[uint8_t(*c)], 2);
+                        data += 2;
+                        ++c;
+                     }
+                  }
+                  
+                  for (; c < e; ++c) {
+                     if (const auto escaped = char_escape_table[uint8_t(*c)]; escaped) {
+                        std::memcpy(data, &escaped, 2);
+                        data += 2;
+                     }
+                     else {
+                        std::memcpy(data, c, 1);
+                        ++data;
+                     }
+                  }
+                  
+                  ix += size_t(data - start);
+                  
                   std::memcpy(&b[ix], "\"", 1);
                   ++ix;
                }
-               else {
-                  const sv str = [&]() -> const sv {
-                     if constexpr (!char_array_t<T> && std::is_pointer_v<std::decay_t<T>>) {
-                        return value ? value : "";
-                     }
-                     else if constexpr (array_char_t<T>) {
-                        return *value.data() ? sv{value.data()} : "";
-                     }
-                     else {
-                        return value;
-                     }
-                  }();
-                  const auto n = str.size();
-                  if constexpr (resizable<B>) {
-                     const auto k = ix + 10 + 2 * n;
-                     if (k > b.size()) [[unlikely]] {
-                        b.resize(2 * k);
-                     }
-                  }
-
-                  if constexpr (Opts.raw) {
-                     const auto n = str.size();
-                     if (n) {
-                        std::memcpy(&b[ix], str.data(), n);
-                        ix += n;
-                     }
-                  }
+            }
+         }
+      }
+   };
+   
+   template <opts Opts, bool minified_check = true, class B>
+   requires(Opts.format == TOML)
+   GLZ_ALWAYS_INLINE void write_array_entry_separator(is_context auto&&, B&& b, auto&& ix)
+   {
+      if constexpr (vector_like<B>) {
+         if constexpr (minified_check) {
+            if (ix >= b.size()) [[unlikely]] {
+               b.resize(2 * ix);
+            }
+         }
+      }
+      std::memcpy(&b[ix], ", ", 2);
+      ix += 2;
+   }
+   
+   template <opts Opts, bool minified_check = true, class B>
+   requires(Opts.format == TOML)
+   GLZ_ALWAYS_INLINE void write_object_entry_separator(is_context auto&&, B&& b, auto&& ix)
+   {
+      std::memcpy(&b[ix], "\n", 1);
+      ++ix;
+   }
+   
+   template <class T>
+   requires(glaze_object_t<T> || reflectable<T>)
+   struct to<TOML, T>
+   {
+      template <auto Options, class V, class B>
+      requires(not std::is_pointer_v<std::remove_cvref_t<V>>)
+      static void op(V&& value, is_context auto&& ctx, B&& b, auto&& ix)
+      {
+         // Do not write opening/closing braces.
+         static constexpr auto N = reflect<T>::size;
+         decltype(auto) t = [&]() -> decltype(auto) {
+            if constexpr (reflectable<T>) {
+               return to_tie(value);
+            }
+            else {
+               return nullptr;
+            }
+         }();
+         
+         static constexpr auto padding = round_up_to_nearest_16(maximum_key_size<T> + write_padding_bytes);
+         bool first = true;
+         
+         invoke_table<N>([&]<size_t I>() {
+            using val_t = field_t<T, I>;
+            
+            if constexpr (always_skipped<val_t>)
+               return;
+            else {
+               if constexpr (null_t<val_t>) {
+                  if constexpr (always_null_t<val_t>)
+                     return;
                   else {
-                     std::memcpy(&b[ix], "\"", 1);
-                     ++ix;
-                     const auto* c = str.data();
-                     const auto* const e = c + n;
-                     const auto start = &b[ix];
-                     auto data = start;
-
-                     if (n > 7) {
-                        for (const auto end_m7 = e - 7; c < end_m7;) {
-                           std::memcpy(data, c, 8);
-                           uint64_t swar;
-                           std::memcpy(&swar, c, 8);
-
-                           constexpr uint64_t lo7_mask = repeat_byte8(0b01111111);
-                           const uint64_t lo7 = swar & lo7_mask;
-                           const uint64_t quote = (lo7 ^ repeat_byte8('"')) + lo7_mask;
-                           const uint64_t backslash = (lo7 ^ repeat_byte8('\\')) + lo7_mask;
-                           const uint64_t less_32 = (swar & repeat_byte8(0b01100000)) + lo7_mask;
-                           uint64_t next = ~((quote & backslash & less_32) | swar);
-
-                           next &= repeat_byte8(0b10000000);
-                           if (next == 0) {
-                              data += 8;
-                              c += 8;
-                              continue;
+                     const auto is_null = [&]() {
+                        decltype(auto) element = [&]() -> decltype(auto) {
+                           if constexpr (reflectable<T>) {
+                              return get<I>(t);
                            }
-
-                           const auto length = (countr_zero(next) >> 3);
-                           c += length;
-                           data += length;
-
-                           std::memcpy(data, &char_escape_table[uint8_t(*c)], 2);
-                           data += 2;
-                           ++c;
-                        }
-                     }
-
-                     for (; c < e; ++c) {
-                        if (const auto escaped = char_escape_table[uint8_t(*c)]; escaped) {
-                           std::memcpy(data, &escaped, 2);
-                           data += 2;
-                        }
-                        else {
-                           std::memcpy(data, c, 1);
-                           ++data;
-                        }
-                     }
-
-                     ix += size_t(data - start);
-
-                     std::memcpy(&b[ix], "\"", 1);
-                     ++ix;
+                           else {
+                              return get<I>(reflect<T>::values);
+                           }
+                        };
+                        
+                        if constexpr (nullable_wrapper<val_t>)
+                           return !bool(element()(value).val);
+                        else if constexpr (nullable_value_t<val_t>)
+                           return !get_member(value, element()).has_value();
+                        else
+                           return !bool(get_member(value, element()));
+                     }();
+                     if (is_null) return;
                   }
                }
-            }
-         }
-      };
-
-      template <opts Opts, bool minified_check = true, class B>
-         requires(Opts.format == TOML)
-      GLZ_ALWAYS_INLINE void write_array_entry_separator(is_context auto&&, B&& b, auto&& ix)
-      {
-         if constexpr (vector_like<B>) {
-            if constexpr (minified_check) {
-               if (ix >= b.size()) [[unlikely]] {
-                  b.resize(2 * ix);
-               }
-            }
-         }
-         std::memcpy(&b[ix], ", ", 2);
-         ix += 2;
-      }
-
-      template <opts Opts, bool minified_check = true, class B>
-         requires(Opts.format == TOML)
-      GLZ_ALWAYS_INLINE void write_object_entry_separator(is_context auto&&, B&& b, auto&& ix)
-      {
-         std::memcpy(&b[ix], "\n", 1);
-         ++ix;
-      }
-
-      template <class T>
-         requires(glaze_object_t<T> || reflectable<T>)
-      struct to<TOML, T>
-      {
-         template <auto Options, class V, class B>
-            requires(not std::is_pointer_v<std::remove_cvref_t<V>>)
-         static void op(V&& value, is_context auto&& ctx, B&& b, auto&& ix)
-         {
-            // Do not write opening/closing braces.
-            static constexpr auto N = reflect<T>::size;
-            decltype(auto) t = [&]() -> decltype(auto) {
-               if constexpr (reflectable<T>) {
-                  return to_tie(value);
-               }
-               else {
-                  return nullptr;
-               }
-            }();
-
-            static constexpr auto padding = round_up_to_nearest_16(maximum_key_size<T> + write_padding_bytes);
-            bool first = true;
-
-            invoke_table<N>([&]<size_t I>() {
-               using val_t = field_t<T, I>;
-
-               if constexpr (always_skipped<val_t>)
-                  return;
-               else {
-                  if constexpr (null_t<val_t>) {
-                     if constexpr (always_null_t<val_t>)
-                        return;
-                     else {
-                        const auto is_null = [&]() {
-                           decltype(auto) element = [&]() -> decltype(auto) {
-                              if constexpr (reflectable<T>) {
-                                 return get<I>(t);
-                              }
-                              else {
-                                 return get<I>(reflect<T>::values);
-                              }
-                           };
-
-                           if constexpr (nullable_wrapper<val_t>)
-                              return !bool(element()(value).val);
-                           else if constexpr (nullable_value_t<val_t>)
-                              return !get_member(value, element()).has_value();
-                           else
-                              return !bool(get_member(value, element()));
-                        }();
-                        if (is_null) return;
-                     }
-                  }
-
-                  maybe_pad<padding>(b, ix);
-
-                  // --- Check if this field is a nested object ---
-                  if constexpr (glaze_object_t<val_t> || reflectable<val_t>) {
-                     // Print the table header (e.g. "[inner]") for the nested object.
-                     if (!first) {
-                        std::memcpy(&b[ix], "\n", 1);
-                        ++ix;
-                     }
-                     else {
-                        first = false;
-                     }
-                     static constexpr auto key = glz::get<I>(reflect<T>::keys);
-                     std::memcpy(&b[ix], "[", 1);
-                     ++ix;
-                     std::memcpy(&b[ix], key.data(), key.size());
-                     ix += key.size();
-                     std::memcpy(&b[ix], "]\n", 2);
-                     ix += 2;
-
-                     // Serialize the nested object.
-                     if constexpr (reflectable<T>) {
-                        to<TOML, val_t>::template op<Options>(get_member(value, get<I>(t)), ctx, b, ix);
-                     }
-                     else {
-                        to<TOML, val_t>::template op<Options>(get_member(value, get<I>(reflect<T>::values)), ctx, b,
-                                                              ix);
-                     }
-                     // Add an extra newline to separate this table section from following keys.
+               
+               maybe_pad<padding>(b, ix);
+               
+               // --- Check if this field is a nested object ---
+               if constexpr (glaze_object_t<val_t> || reflectable<val_t>) {
+                  // Print the table header (e.g. "[inner]") for the nested object.
+                  if (!first) {
                      std::memcpy(&b[ix], "\n", 1);
                      ++ix;
                   }
                   else {
-                     // --- Field is not an object, so output a key/value pair ---
-                     if (!first) {
-                        std::memcpy(&b[ix], "\n", 1);
-                        ++ix;
-                     }
-                     else {
-                        first = false;
-                     }
-                     static constexpr auto key = glz::get<I>(reflect<T>::keys);
-                     std::memcpy(&b[ix], key.data(), key.size());
-                     ix += key.size();
-
-                     std::memcpy(&b[ix], " = ", 3);
-                     ix += 3;
-
-                     if constexpr (reflectable<T>) {
-                        to<TOML, val_t>::template op<Options>(get_member(value, get<I>(t)), ctx, b, ix);
-                     }
-                     else {
-                        to<TOML, val_t>::template op<Options>(get_member(value, get<I>(reflect<T>::values)), ctx, b,
-                                                              ix);
-                     }
+                     first = false;
+                  }
+                  static constexpr auto key = glz::get<I>(reflect<T>::keys);
+                  std::memcpy(&b[ix], "[", 1);
+                  ++ix;
+                  std::memcpy(&b[ix], key.data(), key.size());
+                  ix += key.size();
+                  std::memcpy(&b[ix], "]\n", 2);
+                  ix += 2;
+                  
+                  // Serialize the nested object.
+                  if constexpr (reflectable<T>) {
+                     to<TOML, val_t>::template op<Options>(get_member(value, get<I>(t)), ctx, b, ix);
+                  }
+                  else {
+                     to<TOML, val_t>::template op<Options>(get_member(value, get<I>(reflect<T>::values)), ctx, b,
+                                                           ix);
+                  }
+                  // Add an extra newline to separate this table section from following keys.
+                  std::memcpy(&b[ix], "\n", 1);
+                  ++ix;
+               }
+               else {
+                  // --- Field is not an object, so output a key/value pair ---
+                  if (!first) {
+                     std::memcpy(&b[ix], "\n", 1);
+                     ++ix;
+                  }
+                  else {
+                     first = false;
+                  }
+                  static constexpr auto key = glz::get<I>(reflect<T>::keys);
+                  std::memcpy(&b[ix], key.data(), key.size());
+                  ix += key.size();
+                  
+                  std::memcpy(&b[ix], " = ", 3);
+                  ix += 3;
+                  
+                  if constexpr (reflectable<T>) {
+                     to<TOML, val_t>::template op<Options>(get_member(value, get<I>(t)), ctx, b, ix);
+                  }
+                  else {
+                     to<TOML, val_t>::template op<Options>(get_member(value, get<I>(reflect<T>::values)), ctx, b,
+                                                           ix);
                   }
                }
-            });
-         }
-      };
-
-      template <class T>
-         requires(writable_array_t<T> || writable_map_t<T>)
-      struct to<TOML, T>
+            }
+         });
+      }
+   };
+   
+   template <class T>
+   requires(writable_array_t<T> || writable_map_t<T>)
+   struct to<TOML, T>
+   {
+      static constexpr bool map_like_array = writable_array_t<T> && pair_t<range_value_t<T>>;
+      
+      // --- Array-like container writer ---
+      template <auto Opts, class B>
+      requires(writable_array_t<T> && (map_like_array ? Opts.concatenate == false : true))
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
       {
-         static constexpr bool map_like_array = writable_array_t<T> && pair_t<range_value_t<T>>;
-
-         // --- Array-like container writer ---
-         template <auto Opts, class B>
-            requires(writable_array_t<T> && (map_like_array ? Opts.concatenate == false : true))
-         GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
-         {
-            if (empty_range(value)) {
-               dump<"[]">(b, ix);
+         if (empty_range(value)) {
+            dump<"[]">(b, ix);
+         }
+         else {
+            if constexpr (has_size<T>) {
+               const auto n = value.size();
+               if constexpr (vector_like<B>) {
+                  // Use 2 bytes per separator (", ")
+                  static constexpr auto comma_padding = 2;
+                  if (const auto k = ix + n * comma_padding + write_padding_bytes; k > b.size()) [[unlikely]] {
+                     b.resize(2 * k);
+                  }
+               }
+               std::memcpy(&b[ix], "[", 1);
+               ++ix;
+               auto it = std::begin(value);
+               using val_t = std::remove_cvref_t<decltype(*it)>;
+               to<TOML, val_t>::template op<Opts>(*it, ctx, b, ix);
+               ++it;
+               for (const auto fin = std::end(value); it != fin; ++it) {
+                  write_array_entry_separator<Opts>(ctx, b, ix);
+                  to<TOML, val_t>::template op<Opts>(*it, ctx, b, ix);
+               }
+               std::memcpy(&b[ix], "]", 1);
+               ++ix;
             }
             else {
-               if constexpr (has_size<T>) {
-                  const auto n = value.size();
-                  if constexpr (vector_like<B>) {
-                     // Use 2 bytes per separator (", ")
-                     static constexpr auto comma_padding = 2;
-                     if (const auto k = ix + n * comma_padding + write_padding_bytes; k > b.size()) [[unlikely]] {
-                        b.resize(2 * k);
-                     }
+               if constexpr (vector_like<B>) {
+                  if (const auto k = ix + write_padding_bytes; k > b.size()) [[unlikely]] {
+                     b.resize(2 * k);
                   }
-                  std::memcpy(&b[ix], "[", 1);
-                  ++ix;
-                  auto it = std::begin(value);
-                  using val_t = std::remove_cvref_t<decltype(*it)>;
-                  to<TOML, val_t>::template op<Opts>(*it, ctx, b, ix);
-                  ++it;
-                  for (const auto fin = std::end(value); it != fin; ++it) {
-                     write_array_entry_separator<Opts>(ctx, b, ix);
-                     to<TOML, val_t>::template op<Opts>(*it, ctx, b, ix);
-                  }
-                  std::memcpy(&b[ix], "]", 1);
-                  ++ix;
                }
-               else {
-                  if constexpr (vector_like<B>) {
-                     if (const auto k = ix + write_padding_bytes; k > b.size()) [[unlikely]] {
-                        b.resize(2 * k);
-                     }
-                  }
-                  std::memcpy(&b[ix], "[", 1);
-                  ++ix;
-                  auto it = std::begin(value);
-                  using val_t = std::remove_cvref_t<decltype(*it)>;
+               std::memcpy(&b[ix], "[", 1);
+               ++ix;
+               auto it = std::begin(value);
+               using val_t = std::remove_cvref_t<decltype(*it)>;
+               to<TOML, val_t>::template op<Opts>(*it, ctx, b, ix);
+               ++it;
+               for (const auto fin = std::end(value); it != fin; ++it) {
+                  write_array_entry_separator<Opts>(ctx, b, ix);
                   to<TOML, val_t>::template op<Opts>(*it, ctx, b, ix);
-                  ++it;
-                  for (const auto fin = std::end(value); it != fin; ++it) {
-                     write_array_entry_separator<Opts>(ctx, b, ix);
-                     to<TOML, val_t>::template op<Opts>(*it, ctx, b, ix);
-                  }
-                  dump<']'>(b, ix);
                }
+               dump<']'>(b, ix);
             }
          }
-
-         // --- Map-like container writer ---
-         template <auto Opts, class B>
-            requires(writable_map_t<T> || (map_like_array && Opts.concatenate == true))
-         static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
-         {
-            bool first = true;
-            for (auto&& [key, val] : value) {
-               if (!first) {
-                  write_object_entry_separator<Opts>(ctx, b, ix);
-               }
-               else {
-                  first = false;
-               }
-               // Write the key as a bare key
-               std::memcpy(&b[ix], key.data(), key.size());
-               ix += key.size();
-               std::memcpy(&b[ix], " = ", 3);
-               ix += 3;
-               to<TOML, decltype(val)>::template op<Opts>(val, ctx, b, ix);
+      }
+      
+      // --- Map-like container writer ---
+      template <auto Opts, class B>
+      requires(writable_map_t<T> || (map_like_array && Opts.concatenate == true))
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto&& ix)
+      {
+         bool first = true;
+         for (auto&& [key, val] : value) {
+            if (!first) {
+               write_object_entry_separator<Opts>(ctx, b, ix);
             }
+            else {
+               first = false;
+            }
+            // Write the key as a bare key
+            std::memcpy(&b[ix], key.data(), key.size());
+            ix += key.size();
+            std::memcpy(&b[ix], " = ", 3);
+            ix += 3;
+            to<TOML, decltype(val)>::template op<Opts>(val, ctx, b, ix);
          }
-      };
-
-      // (The remainder of the code – for C arrays, tuples, includers, etc. – is unchanged.)
-      template <nullable_t T>
-         requires(std::is_array_v<T>)
-      struct to<TOML, T>
+      }
+   };
+   
+   // (The remainder of the code – for C arrays, tuples, includers, etc. – is unchanged.)
+   template <nullable_t T>
+   requires(std::is_array_v<T>)
+   struct to<TOML, T>
+   {
+      template <auto Opts, class V, size_t N, class... Args>
+      GLZ_ALWAYS_INLINE static void op(const V (&value)[N], is_context auto&& ctx, Args&&... args)
       {
-         template <auto Opts, class V, size_t N, class... Args>
-         GLZ_ALWAYS_INLINE static void op(const V (&value)[N], is_context auto&& ctx, Args&&... args)
-         {
-            serialize<TOML>::op<Opts>(std::span{value, N}, ctx, std::forward<Args>(args)...);
-         }
-      };
-
-      template <class T>
-         requires glaze_array_t<T> || tuple_t<std::decay_t<T>> || is_std_tuple<T>
-      struct to<TOML, T>
+         serialize<TOML>::op<Opts>(std::span{value, N}, ctx, std::forward<Args>(args)...);
+      }
+   };
+   
+   template <class T>
+   requires glaze_array_t<T> || tuple_t<std::decay_t<T>> || is_std_tuple<T>
+   struct to<TOML, T>
+   {
+      template <auto Opts, class... Args>
+      static void op(auto&& value, is_context auto&& ctx, Args&&... args)
       {
-         template <auto Opts, class... Args>
-         static void op(auto&& value, is_context auto&& ctx, Args&&... args)
-         {
-            static constexpr auto N = []() constexpr {
-               if constexpr (glaze_array_t<std::decay_t<T>>) {
-                  return glz::tuple_size_v<meta_t<std::decay_t<T>>>;
-               }
-               else {
-                  return glz::tuple_size_v<std::decay_t<T>>;
-               }
-            }();
-
-            dump<'['>(args...);
-            using V = std::decay_t<T>;
-            invoke_table<N>([&]<size_t I>() {
-               if constexpr (glaze_array_t<V>) {
-                  serialize<TOML>::op<Opts>(get_member(value, glz::get<I>(meta_v<T>)), ctx, args...);
-               }
-               else if constexpr (is_std_tuple<T>) {
-                  using Value = core_t<decltype(std::get<I>(value))>;
-                  to<TOML, Value>::template op<Opts>(std::get<I>(value), ctx, args...);
-               }
-               else {
-                  using Value = core_t<decltype(glz::get<I>(value))>;
-                  to<TOML, Value>::template op<Opts>(glz::get<I>(value), ctx, args...);
-               }
-               constexpr bool needs_comma = I < N - 1;
-               if constexpr (needs_comma) {
-                  write_array_entry_separator<Opts>(ctx, args...);
-               }
-            });
-            dump<']'>(args...);
-         }
-      };
-
-      template <is_includer T>
-      struct to<TOML, T>
+         static constexpr auto N = []() constexpr {
+            if constexpr (glaze_array_t<std::decay_t<T>>) {
+               return glz::tuple_size_v<meta_t<std::decay_t<T>>>;
+            }
+            else {
+               return glz::tuple_size_v<std::decay_t<T>>;
+            }
+         }();
+         
+         dump<'['>(args...);
+         using V = std::decay_t<T>;
+         invoke_table<N>([&]<size_t I>() {
+            if constexpr (glaze_array_t<V>) {
+               serialize<TOML>::op<Opts>(get_member(value, glz::get<I>(meta_v<T>)), ctx, args...);
+            }
+            else if constexpr (is_std_tuple<T>) {
+               using Value = core_t<decltype(std::get<I>(value))>;
+               to<TOML, Value>::template op<Opts>(std::get<I>(value), ctx, args...);
+            }
+            else {
+               using Value = core_t<decltype(glz::get<I>(value))>;
+               to<TOML, Value>::template op<Opts>(glz::get<I>(value), ctx, args...);
+            }
+            constexpr bool needs_comma = I < N - 1;
+            if constexpr (needs_comma) {
+               write_array_entry_separator<Opts>(ctx, args...);
+            }
+         });
+         dump<']'>(args...);
+      }
+   };
+   
+   template <is_includer T>
+   struct to<TOML, T>
+   {
+      template <auto Opts, class... Args>
+      GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, Args&&... args)
       {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, Args&&... args)
-         {
-            dump<R"("")">(args...); // dump an empty string
-         }
-      };
-   } // namespace detail
+         dump<R"("")">(args...); // dump an empty string
+      }
+   };
 
    template <class T, output_buffer Buffer>
       requires(write_supported<TOML, T>)

--- a/include/glaze/toml/write.hpp
+++ b/include/glaze/toml/write.hpp
@@ -15,19 +15,19 @@
 
 namespace glz
 {
+   template <>
+   struct serialize<TOML>
+   {
+      template <auto Opts, class T, is_context Ctx, class B, class IX>
+      GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
+      {
+         detail::to<TOML, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+                                                             std::forward<B>(b), std::forward<IX>(ix));
+      }
+   };
+   
    namespace detail
    {
-      template <>
-      struct serialize<TOML>
-      {
-         template <auto Opts, class T, is_context Ctx, class B, class IX>
-         GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
-         {
-            to<TOML, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
-                                                                std::forward<B>(b), std::forward<IX>(ix));
-         }
-      };
-
       template <class T>
          requires(glaze_value_t<T> && !custom_write<T>)
       struct to<TOML, T>

--- a/include/glaze/util/atoi.hpp
+++ b/include/glaze/util/atoi.hpp
@@ -46,7 +46,7 @@
 #pragma warning(disable : 4244)
 #endif
 
-namespace glz::detail
+namespace glz
 {
    inline constexpr std::array<uint64_t, 20> powers_of_ten_int{1ull,
                                                                10ull,
@@ -792,7 +792,7 @@ namespace glz::detail
 
          const auto start = data.data();
          const auto* c = start;
-         const auto valid = glz::detail::atoi(v, c);
+         const auto valid = glz::atoi(v, c);
          it += size_t(c - start);
          return valid;
       }

--- a/include/glaze/util/bit_array.hpp
+++ b/include/glaze/util/bit_array.hpp
@@ -7,7 +7,7 @@
 #include <bit>
 #include <limits>
 
-namespace glz::detail
+namespace glz
 {
    // Basicly std::bitset but exposes things normally not availible like the bitscan functions
    template <size_t N, std::unsigned_integral Chunk = uint64_t>

--- a/include/glaze/util/compare.hpp
+++ b/include/glaze/util/compare.hpp
@@ -8,7 +8,7 @@
 #include <string_view>
 #include <type_traits>
 
-namespace glz::detail
+namespace glz
 {
    template <class Char>
    inline bool compare(const Char* lhs, const Char* rhs, uint64_t count) noexcept

--- a/include/glaze/util/dump.hpp
+++ b/include/glaze/util/dump.hpp
@@ -13,7 +13,7 @@
 #include "glaze/core/opts.hpp"
 #include "glaze/util/convert.hpp"
 
-namespace glz::detail
+namespace glz
 {
    template <class T, class V = std::remove_cvref_t<T>>
    concept byte_sized = sizeof(T) == 1 && (std::same_as<V, char> || std::same_as<V, std::byte>);

--- a/include/glaze/util/expected.hpp
+++ b/include/glaze/util/expected.hpp
@@ -723,7 +723,7 @@ namespace glz
       }
 
       template <class F, class V = T&, class U = std::remove_cvref_t<std::invoke_result_t<F, V> > >
-         requires detail::is_expected<U> && std::is_same_v<typename U::error_type, E> &&
+         requires is_expected<U> && std::is_same_v<typename U::error_type, E> &&
                   std::is_copy_constructible_v<E> && std::is_copy_constructible_v<T>
       constexpr auto and_then(F&& f) &
       {
@@ -734,7 +734,7 @@ namespace glz
       }
 
       template <class F, class V = const T&, class U = std::remove_cvref_t<std::invoke_result_t<F, V> > >
-         requires detail::is_expected<U> && std::is_same_v<typename U::error_type, E> &&
+         requires is_expected<U> && std::is_same_v<typename U::error_type, E> &&
                   std::is_copy_constructible_v<E> && std::is_copy_constructible_v<T>
       constexpr auto and_then(F&& f) const&
       {
@@ -745,7 +745,7 @@ namespace glz
       }
 
       template <class F, class V = T&&, class U = std::remove_cvref_t<std::invoke_result_t<F, V> > >
-         requires detail::is_expected<U> && std::is_same_v<typename U::error_type, E> &&
+         requires is_expected<U> && std::is_same_v<typename U::error_type, E> &&
                   std::is_move_constructible_v<E> && std::is_move_constructible_v<T>
       constexpr auto and_then(F&& f) &&
       {
@@ -756,7 +756,7 @@ namespace glz
       }
 
       template <class F, class V = const T&&, class U = std::remove_cvref_t<std::invoke_result_t<F, V> > >
-         requires detail::is_expected<U> && std::is_same_v<typename U::error_type, E> &&
+         requires is_expected<U> && std::is_same_v<typename U::error_type, E> &&
                   std::is_move_constructible_v<E> && std::is_move_constructible_v<T>
       constexpr auto and_then(F&& f) const&&
       {
@@ -767,7 +767,7 @@ namespace glz
       }
 
       template <class F, class V = E&, class G = std::remove_cvref_t<std::invoke_result_t<F, V> > >
-         requires detail::is_expected<G> && std::is_same_v<typename G::value_type, T> &&
+         requires is_expected<G> && std::is_same_v<typename G::value_type, T> &&
                   std::is_copy_constructible_v<T> && std::is_copy_constructible_v<E>
       constexpr auto or_else(F&& f) &
       {
@@ -778,7 +778,7 @@ namespace glz
       }
 
       template <class F, class V = const E&, class G = std::remove_cvref_t<std::invoke_result_t<F, V> > >
-         requires detail::is_expected<G> && std::is_same_v<typename G::value_type, T> &&
+         requires is_expected<G> && std::is_same_v<typename G::value_type, T> &&
                   std::is_copy_constructible_v<T> && std::is_copy_constructible_v<E>
       constexpr auto or_else(F&& f) const&
       {
@@ -789,7 +789,7 @@ namespace glz
       }
 
       template <class F, class V = E&&, class G = std::remove_cvref_t<std::invoke_result_t<F, V> > >
-         requires detail::is_expected<G> && std::is_same_v<typename G::value_type, T> &&
+         requires is_expected<G> && std::is_same_v<typename G::value_type, T> &&
                   std::is_move_constructible_v<T> && std::is_move_constructible_v<E>
       constexpr auto or_else(F&& f) &&
       {
@@ -800,7 +800,7 @@ namespace glz
       }
 
       template <class F, class V = const E&&, class G = std::remove_cvref_t<std::invoke_result_t<F, V> > >
-         requires detail::is_expected<G> && std::is_same_v<typename G::value_type, T> &&
+         requires is_expected<G> && std::is_same_v<typename G::value_type, T> &&
                   std::is_move_constructible_v<T> && std::is_move_constructible_v<E>
       constexpr auto or_else(F&& f) const&&
       {
@@ -981,7 +981,7 @@ namespace glz
       }
 
       template <typename T2>
-         requires(!detail::is_expected<T2>)
+         requires(!is_expected<T2>)
       friend constexpr bool operator==(const expected& x, const T2& v)
       {
          return x.has_value() && bool(*x == v);
@@ -1254,7 +1254,7 @@ namespace glz
 
       // monadic
       template <class F, class U = std::remove_cvref_t<std::invoke_result_t<F> > >
-         requires detail::is_expected<U> && std::is_same_v<typename U::error_type, E> && std::is_copy_constructible_v<E>
+         requires is_expected<U> && std::is_same_v<typename U::error_type, E> && std::is_copy_constructible_v<E>
       constexpr auto and_then(F&& f) &
       {
          if (has_value()) {
@@ -1264,7 +1264,7 @@ namespace glz
       }
 
       template <class F, class U = std::remove_cvref_t<std::invoke_result_t<F> > >
-         requires detail::is_expected<U> && std::is_same_v<typename U::error_type, E> && std::is_copy_constructible_v<E>
+         requires is_expected<U> && std::is_same_v<typename U::error_type, E> && std::is_copy_constructible_v<E>
       constexpr auto and_then(F&& f) const&
       {
          if (has_value()) {
@@ -1274,7 +1274,7 @@ namespace glz
       }
 
       template <class F, class U = std::remove_cvref_t<std::invoke_result_t<F> > >
-         requires detail::is_expected<U> && std::is_same_v<typename U::error_type, E> && std::is_move_constructible_v<E>
+         requires is_expected<U> && std::is_same_v<typename U::error_type, E> && std::is_move_constructible_v<E>
       constexpr auto and_then(F&& f) &&
       {
          if (has_value()) {
@@ -1284,7 +1284,7 @@ namespace glz
       }
 
       template <class F, class U = std::remove_cvref_t<std::invoke_result_t<F> > >
-         requires detail::is_expected<U> && std::is_same_v<typename U::error_type, E> && std::is_move_constructible_v<E>
+         requires is_expected<U> && std::is_same_v<typename U::error_type, E> && std::is_move_constructible_v<E>
       constexpr auto and_then(F&& f) const&&
       {
          if (has_value()) {
@@ -1294,7 +1294,7 @@ namespace glz
       }
 
       template <class F, class V = E&, class G = std::remove_cvref_t<std::invoke_result_t<F, V> > >
-         requires detail::is_expected<G> && std::is_same_v<typename G::value_type, void> &&
+         requires is_expected<G> && std::is_same_v<typename G::value_type, void> &&
                   std::is_copy_constructible_v<E>
       constexpr auto or_else(F&& f) &
       {
@@ -1305,7 +1305,7 @@ namespace glz
       }
 
       template <class F, class V = const E&, class G = std::remove_cvref_t<std::invoke_result_t<F, V> > >
-         requires detail::is_expected<G> && std::is_same_v<typename G::value_type, void> &&
+         requires is_expected<G> && std::is_same_v<typename G::value_type, void> &&
                   std::is_copy_constructible_v<E>
       constexpr auto or_else(F&& f) const&
       {
@@ -1316,7 +1316,7 @@ namespace glz
       }
 
       template <class F, class V = E&&, class G = std::remove_cvref_t<std::invoke_result_t<F, V> > >
-         requires detail::is_expected<G> && std::is_same_v<typename G::value_type, void> &&
+         requires is_expected<G> && std::is_same_v<typename G::value_type, void> &&
                   std::is_move_constructible_v<E>
       constexpr auto or_else(F&& f) &&
       {
@@ -1327,7 +1327,7 @@ namespace glz
       }
 
       template <class F, class V = const E&&, class G = std::remove_cvref_t<std::invoke_result_t<F, V> > >
-         requires detail::is_expected<G> && std::is_same_v<typename G::value_type, void> &&
+         requires is_expected<G> && std::is_same_v<typename G::value_type, void> &&
                   std::is_move_constructible_v<E>
       constexpr auto or_else(F&& f) const&&
       {

--- a/include/glaze/util/expected.hpp
+++ b/include/glaze/util/expected.hpp
@@ -210,6 +210,10 @@ namespace glz
 
    template <detail::non_void_destructible T, std::destructible E>
    class expected;
+   
+   template <typename T>
+   concept is_expected =
+   std::same_as<std::remove_cvref_t<T>, expected<typename T::value_type, typename T::error_type> >;
 
    namespace detail
    {
@@ -259,10 +263,6 @@ namespace glz
 
       template <typename T>
       concept is_unexpected = std::same_as<std::remove_cvref_t<T>, unexpected<typename T::value_type> >;
-
-      template <typename T>
-      concept is_expected =
-         std::same_as<std::remove_cvref_t<T>, expected<typename T::value_type, typename T::error_type> >;
 
       // This function makes sure expected doesn't get into valueless_by_exception
       // state due to any exception while assignment

--- a/include/glaze/util/for_each.hpp
+++ b/include/glaze/util/for_each.hpp
@@ -81,7 +81,7 @@ namespace glz
    macro(a) __VA_OPT__(, ) __VA_OPT__(GLZ_FOR_EACH_AGAIN GLZ_PARENS(macro, __VA_ARGS__))
 #define GLZ_FOR_EACH_AGAIN() GLZ_FOR_EACH_HELPER
 
-namespace glz::detail
+namespace glz
 {
 #define GLZ_EVERY(macro, ...) __VA_OPT__(GLZ_EXPAND(GLZ_EVERY_HELPER(macro, __VA_ARGS__)))
 #define GLZ_EVERY_HELPER(macro, a, ...) macro(a) __VA_OPT__(GLZ_EVERY_AGAIN GLZ_PARENS(macro, __VA_ARGS__))

--- a/include/glaze/util/hash_map.hpp
+++ b/include/glaze/util/hash_map.hpp
@@ -67,7 +67,7 @@ namespace glz
    }
 }
 
-namespace glz::detail
+namespace glz
 {
    inline constexpr size_t naive_map_max_size = 128;
 
@@ -520,7 +520,7 @@ namespace glz::detail
          else {
             std::array<std::array<storage_type, max_bucket_size>, N> full_buckets{};
             std::array<size_t, N> bucket_sizes{};
-            detail::naive_prng gen{};
+            naive_prng gen{};
 
             bool failed;
             do {

--- a/include/glaze/util/hash_map.hpp
+++ b/include/glaze/util/hash_map.hpp
@@ -52,7 +52,7 @@ namespace glz
    template <class T1, class T2>
    pair(T1, T2) -> pair<T1, T2>;
 
-   template <size_t I, detail::pair_t T>
+   template <size_t I, pair_t T>
    constexpr decltype(auto) get(T&& p) noexcept
    {
       if constexpr (I == 0) {

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -41,7 +41,7 @@ namespace glz::detail
       t['E'] = true;
       return t;
    }();
-
+   
    inline constexpr std::array<char, 256> char_unescape_table = [] {
       std::array<char, 256> t{};
       t['"'] = '"';
@@ -54,7 +54,7 @@ namespace glz::detail
       t['t'] = '\t';
       return t;
    }();
-
+   
    inline constexpr std::array<bool, 256> valid_escape_table = [] {
       std::array<bool, 256> t{};
       t['"'] = true;
@@ -68,7 +68,7 @@ namespace glz::detail
       t['u'] = true;
       return t;
    }();
-
+   
    inline constexpr std::array<bool, 256> whitespace_table = [] {
       std::array<bool, 256> t{};
       t['\n'] = true;
@@ -77,7 +77,7 @@ namespace glz::detail
       t[' '] = true;
       return t;
    }();
-
+   
    inline constexpr std::array<bool, 256> whitespace_comment_table = [] {
       std::array<bool, 256> t{};
       t['\n'] = true;
@@ -87,7 +87,7 @@ namespace glz::detail
       t['/'] = true;
       return t;
    }();
-
+   
    inline constexpr std::array<uint8_t, 256> digit_hex_table = [] {
       std::array<uint8_t, 256> t;
       std::fill(t.begin(), t.end(), uint8_t(255));
@@ -115,11 +115,11 @@ namespace glz::detail
       t['F'] = 0xF;
       return t;
    }();
-
+   
    consteval uint32_t repeat_byte4(const auto repeat) { return uint32_t(0x01010101u) * uint8_t(repeat); }
-
+   
    consteval uint64_t repeat_byte8(const uint8_t repeat) { return 0x0101010101010101ull * repeat; }
-
+   
 #if defined(__SIZEOF_INT128__)
    consteval __uint128_t repeat_byte16(const uint8_t repeat)
    {
@@ -127,9 +127,9 @@ namespace glz::detail
       return multiplier * repeat;
    }
 #endif
-
+   
    consteval uint64_t not_repeat_byte8(const uint8_t repeat) { return ~(0x0101010101010101ull * repeat); }
-
+   
    [[nodiscard]] GLZ_ALWAYS_INLINE uint32_t hex_to_u32(const char* c) noexcept
    {
       constexpr auto& t = digit_hex_table;
@@ -139,7 +139,7 @@ namespace glz::detail
       if (chunk & repeat_byte4(0b11110000u)) [[unlikely]] {
          return 0xFFFFFFFFu;
       }
-
+      
       // TODO: can you use std::bit_cast here?
       // now pack into first four bytes of uint32_t
       uint32_t packed{};
@@ -149,7 +149,7 @@ namespace glz::detail
       packed |= (chunk & 0x0F000000) >> 12;
       return packed;
    }
-
+   
    template <class Char>
    [[nodiscard]] GLZ_ALWAYS_INLINE uint32_t code_point_to_utf8(const uint32_t code_point, Char* c) noexcept
    {
@@ -177,7 +177,7 @@ namespace glz::detail
       }
       return 0;
    }
-
+   
    [[nodiscard]] GLZ_ALWAYS_INLINE uint32_t skip_code_point(const uint32_t code_point) noexcept
    {
       if (code_point <= 0x7F) {
@@ -194,27 +194,27 @@ namespace glz::detail
       }
       return 0;
    }
-
+   
    namespace unicode
    {
       constexpr uint32_t generic_surrogate_mask = 0xF800;
       constexpr uint32_t generic_surrogate_value = 0xD800;
-
+      
       constexpr uint32_t surrogate_mask = 0xFC00;
       constexpr uint32_t high_surrogate_value = 0xD800;
       constexpr uint32_t low_surrogate_value = 0xDC00;
-
+      
       constexpr uint32_t surrogate_codepoint_offset = 0x10000;
       constexpr uint32_t surrogate_codepoint_mask = 0x03FF;
       constexpr uint32_t surrogate_codepoint_bits = 10;
    }
-
+   
    template <class Char>
    [[nodiscard]] GLZ_ALWAYS_INLINE uint32_t handle_unicode_code_point(const Char*& it, Char*& dst,
                                                                       const Char* end) noexcept
    {
       using namespace unicode;
-
+      
       if (it + 4 >= end) [[unlikely]] {
          return false;
       }
@@ -223,15 +223,15 @@ namespace glz::detail
          return false;
       }
       it += 4; // skip the code point characters
-
+      
       uint32_t code_point;
-
+      
       if ((high & generic_surrogate_mask) == generic_surrogate_value) {
          // surrogate pair code points
          if ((high & surrogate_mask) != high_surrogate_value) {
             return false;
          }
-
+         
          if (it + 6 >= end) [[unlikely]] {
             return false;
          }
@@ -248,11 +248,11 @@ namespace glz::detail
             return false;
          }
          it += 4;
-
+         
          if ((low & surrogate_mask) != low_surrogate_value) [[unlikely]] {
             return false;
          }
-
+         
          code_point = (high & surrogate_codepoint_mask) << surrogate_codepoint_bits;
          code_point |= (low & surrogate_codepoint_mask);
          code_point += surrogate_codepoint_offset;
@@ -264,7 +264,7 @@ namespace glz::detail
       dst += offset;
       return offset;
    }
-
+   
    template <class Char>
    [[nodiscard]] GLZ_ALWAYS_INLINE bool skip_unicode_code_point(const Char*& it, const Char* end) noexcept
    {
@@ -272,21 +272,21 @@ namespace glz::detail
       if (it + 4 >= end) [[unlikely]] {
          return false;
       }
-
+      
       const uint32_t high = hex_to_u32(it);
       if (high == 0xFFFFFFFFu) [[unlikely]] {
          return false;
       }
       it += 4; // skip the code point characters
-
+      
       uint32_t code_point;
-
+      
       if ((high & generic_surrogate_mask) == generic_surrogate_value) {
          // surrogate pair code points
          if ((high & surrogate_mask) != high_surrogate_value) [[unlikely]] {
             return false;
          }
-
+         
          if (it + 6 >= end) [[unlikely]] {
             return false;
          }
@@ -303,11 +303,11 @@ namespace glz::detail
             return false;
          }
          it += 4;
-
+         
          if ((low & surrogate_mask) != low_surrogate_value) [[unlikely]] {
             return false;
          }
-
+         
          code_point = (high & surrogate_codepoint_mask) << surrogate_codepoint_bits;
          code_point |= (low & surrogate_codepoint_mask);
          code_point += surrogate_codepoint_offset;
@@ -317,7 +317,7 @@ namespace glz::detail
       }
       return skip_code_point(code_point) > 0;
    }
-
+   
    // Checks for a character and validates that we are not at the end (considered an error)
    template <char C, auto Opts>
    GLZ_ALWAYS_INLINE bool match_invalid_end(is_context auto& ctx, auto&& it, auto&& end) noexcept
@@ -354,7 +354,7 @@ namespace glz::detail
       }
       return false;
    }
-
+   
    template <char C>
    GLZ_ALWAYS_INLINE bool match(is_context auto& ctx, auto&& it) noexcept
    {
@@ -384,9 +384,9 @@ namespace glz::detail
          return false;
       }
    }
-
+   
    template <string_literal str, opts Opts>
-      requires(has_is_padded(Opts) && str.size() <= padding_bytes)
+   requires(has_is_padded(Opts) && str.size() <= padding_bytes)
    GLZ_ALWAYS_INLINE void match(is_context auto&& ctx, auto&& it, auto&&) noexcept
    {
       static constexpr auto S = str.sv();
@@ -397,9 +397,9 @@ namespace glz::detail
          it += str.size();
       }
    }
-
+   
    template <string_literal str, opts Opts>
-      requires(!has_is_padded(Opts))
+   requires(!has_is_padded(Opts))
    GLZ_ALWAYS_INLINE void match(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       const auto n = size_t(end - it);
@@ -411,7 +411,7 @@ namespace glz::detail
          it += str.size();
       }
    }
-
+   
    GLZ_ALWAYS_INLINE void skip_comment(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
       ++it;
@@ -438,47 +438,52 @@ namespace glz::detail
          ctx.error = error_code::expected_end_comment;
       }
    }
-
+   
    GLZ_ALWAYS_INLINE constexpr auto has_zero(const uint64_t chunk) noexcept
    {
       return (((chunk - 0x0101010101010101u) & ~chunk) & 0x8080808080808080u);
    }
-
+   
    GLZ_ALWAYS_INLINE constexpr auto has_quote(const uint64_t chunk) noexcept
    {
       return has_zero(chunk ^ repeat_byte8('"'));
    }
-
+   
    GLZ_ALWAYS_INLINE constexpr auto has_escape(const uint64_t chunk) noexcept
    {
       return has_zero(chunk ^ repeat_byte8('\\'));
    }
-
+   
    GLZ_ALWAYS_INLINE constexpr auto has_space(const uint64_t chunk) noexcept
    {
       return has_zero(chunk ^ repeat_byte8(' '));
    }
-
+   
    template <char Char>
    GLZ_ALWAYS_INLINE constexpr auto has_char(const uint64_t chunk) noexcept
    {
       return has_zero(chunk ^ repeat_byte8(Char));
    }
-
+   
    GLZ_ALWAYS_INLINE constexpr uint64_t is_less_32(const uint64_t chunk) noexcept
    {
       return has_zero(chunk & repeat_byte8(0b11100000u));
    }
-
+   
    GLZ_ALWAYS_INLINE constexpr uint64_t is_greater_15(const uint64_t chunk) noexcept
    {
       return (chunk & repeat_byte8(0b11110000u));
    }
+}
 
+namespace glz
+{
    // skip whitespace
    template <opts Opts>
    GLZ_ALWAYS_INLINE bool skip_ws(is_context auto&& ctx, auto&& it, auto&& end) noexcept
    {
+      using namespace glz::detail;
+      
       if constexpr (!Opts.minified) {
          if constexpr (Opts.null_terminated) {
             if constexpr (Opts.comments) {
@@ -529,10 +534,13 @@ namespace glz::detail
             }
          }
       }
-
+      
       return false;
    }
-
+}
+   
+namespace glz::detail
+{
    GLZ_ALWAYS_INLINE void skip_matching_ws(const auto* ws, auto&& it, uint64_t length) noexcept
    {
       if (length > 7) {

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -20,7 +20,7 @@
 #include "glaze/util/inline.hpp"
 #include "glaze/util/string_literal.hpp"
 
-namespace glz::detail
+namespace glz
 {
    inline constexpr std::array<bool, 256> numeric_table = [] {
       std::array<bool, 256> t{};
@@ -475,7 +475,7 @@ namespace glz::detail
       return (chunk & repeat_byte8(0b11110000u));
    }
 }
-
+   
 namespace glz
 {
    // skip whitespace
@@ -537,10 +537,7 @@ namespace glz
       
       return false;
    }
-}
    
-namespace glz::detail
-{
    GLZ_ALWAYS_INLINE void skip_matching_ws(const auto* ws, auto&& it, uint64_t length) noexcept
    {
       if (length > 7) {

--- a/include/glaze/util/variant.hpp
+++ b/include/glaze/util/variant.hpp
@@ -16,15 +16,12 @@ namespace glz
    template <class T>
    concept is_variant = is_specialization_v<T, std::variant>;
 
-   namespace detail
+   template <is_variant T>
+   GLZ_ALWAYS_INLINE constexpr auto runtime_variant_map()
    {
-      template <is_variant T>
-      GLZ_ALWAYS_INLINE constexpr auto runtime_variant_map()
-      {
-         constexpr auto N = std::variant_size_v<T>;
-         return [&]<size_t... I>(std::index_sequence<I...>) {
-            return std::array<T, N>{std::variant_alternative_t<I, T>{}...};
-         }(std::make_index_sequence<N>{});
-      }
+      constexpr auto N = std::variant_size_v<T>;
+      return [&]<size_t... I>(std::index_sequence<I...>) {
+         return std::array<T, N>{std::variant_alternative_t<I, T>{}...};
+      }(std::make_index_sequence<N>{});
    }
 }

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -1319,7 +1319,7 @@ struct reflectable_t
    constexpr bool operator==(const reflectable_t&) const noexcept = default;
 };
 
-static_assert(glz::detail::reflectable<reflectable_t>);
+static_assert(glz::reflectable<reflectable_t>);
 
 suite reflection_test = [] {
    "reflectable_t"_test = [] {

--- a/tests/example_json/example_json.cpp
+++ b/tests/example_json/example_json.cpp
@@ -16,7 +16,7 @@ struct BasicStruct
    std::string str{};
    std::array<uint32_t, 3> arr{};
 };
-static_assert(glz::detail::reflectable<BasicStruct>);
+static_assert(glz::reflectable<BasicStruct>);
 
 // Demonstration of reading and writing a basic reflectable struct without `glz::meta`.
 suite basic_reflection = [] {
@@ -75,7 +75,7 @@ struct WithOptional
    std::string required = "default";
    std::optional<double> maybe = {};
 };
-static_assert(glz::detail::reflectable<WithOptional>);
+static_assert(glz::reflectable<WithOptional>);
 
 suite optional_fields = [] {
    "optional_fields_test"_test = [] {
@@ -115,7 +115,7 @@ struct EnumHolder
 {
    Color c{Color::Green};
 };
-static_assert(glz::detail::reflectable<EnumHolder>);
+static_assert(glz::reflectable<EnumHolder>);
 
 suite enum_test = [] {
    "enum_as_string_key"_test = [] {
@@ -166,7 +166,7 @@ struct ContainerStruct
    std::deque<float> dq{3.14f, 2.71f};
    std::list<int> lis{10, 11, 12};
 };
-static_assert(glz::detail::reflectable<ContainerStruct>);
+static_assert(glz::reflectable<ContainerStruct>);
 
 suite container_test = [] {
    "containers_read_write"_test = [] {
@@ -193,7 +193,7 @@ struct MapStruct
    std::map<std::string, int> str_map{{"one", 1}, {"two", 2}};
    std::unordered_map<int, std::string> umap{{5, "five"}, {7, "seven"}};
 };
-static_assert(glz::detail::reflectable<MapStruct>);
+static_assert(glz::reflectable<MapStruct>);
 
 suite map_test = [] {
    "map_unordered_map"_test = [] {
@@ -296,7 +296,7 @@ struct CommentStruct
 {
    int val{};
 };
-static_assert(glz::detail::reflectable<CommentStruct>);
+static_assert(glz::reflectable<CommentStruct>);
 
 suite comment_parsing = [] {
    "comment_test"_test = [] {

--- a/tests/exceptions_test/exceptions_test.cpp
+++ b/tests/exceptions_test/exceptions_test.cpp
@@ -252,7 +252,7 @@ suite shared_async_map_tests = [] {
       }
    };
 
-   static_assert(glz::detail::readable_map_t<glz::shared_async_map<std::string, std::atomic<int>>>);
+   static_assert(glz::readable_map_t<glz::shared_async_map<std::string, std::atomic<int>>>);
 
    "shared_async_map write_json"_test = [] {
       glz::shared_async_map<std::string, std::atomic<int>> map;

--- a/tests/json_reflection_test/json_reflection_test.cpp
+++ b/tests/json_reflection_test/json_reflection_test.cpp
@@ -695,7 +695,7 @@ namespace glz::detail
       static void op(std::chrono::seconds& value, is_context auto&& ctx, auto&&... args)
       {
          int32_t sec_count{};
-         read<JSON>::op<Opts>(sec_count, ctx, args...);
+         parse<JSON>::op<Opts>(sec_count, ctx, args...);
          if (glz::error_code::none == ctx.error) value = std::chrono::seconds{sec_count};
       }
    };

--- a/tests/json_reflection_test/json_reflection_test.cpp
+++ b/tests/json_reflection_test/json_reflection_test.cpp
@@ -15,7 +15,7 @@ struct my_struct
    std::array<uint64_t, 3> arr{};
 };
 
-static_assert(glz::detail::reflectable<my_struct>);
+static_assert(glz::reflectable<my_struct>);
 
 static_assert(glz::name_v<my_struct> == "my_struct");
 
@@ -68,7 +68,7 @@ struct nested_t
    my_struct thing{};
 };
 
-static_assert(glz::detail::reflectable<nested_t>);
+static_assert(glz::reflectable<nested_t>);
 
 #ifndef _MSC_VER
 suite nested_reflection = [] {
@@ -487,7 +487,7 @@ struct V2Wrapper
    V2 x{};
 };
 
-static_assert(glz::detail::reflectable<V2Wrapper>);
+static_assert(glz::reflectable<V2Wrapper>);
 static_assert(glz::detail::count_members<V2Wrapper> == 1);
 
 suite v2_wrapper_test = [] {
@@ -528,7 +528,7 @@ struct glz::json_schema<meta_schema_t>
 };
 
 static_assert(glz::detail::json_schema_t<glz::json_schema<meta_schema_t>>);
-static_assert(glz::detail::reflectable<glz::json_schema<meta_schema_t>>);
+static_assert(glz::reflectable<glz::json_schema<meta_schema_t>>);
 static_assert(glz::detail::count_members<glz::json_schema<meta_schema_t>> == 3);
 
 struct local_schema_t

--- a/tests/json_reflection_test/json_reflection_test.cpp
+++ b/tests/json_reflection_test/json_reflection_test.cpp
@@ -686,7 +686,7 @@ suite large_struct_tests = [] {
    };
 };
 
-namespace glz::detail
+namespace glz
 {
    template <>
    struct from<JSON, std::chrono::seconds>
@@ -821,9 +821,9 @@ suite hash_tests = [] {
    };
 
    "front_64"_test = [] {
-      glz::detail::keys_info_t info{.min_length = 8, .max_length = 8};
+      glz::keys_info_t info{.min_length = 8, .max_length = 8};
       [[maybe_unused]] const auto valid =
-         glz::detail::front_bytes_hash_info<uint64_t>(glz::reflect<front_64_t>::keys, info);
+         glz::front_bytes_hash_info<uint64_t>(glz::reflect<front_64_t>::keys, info);
 
       front_64_t obj{};
       std::string_view buffer = R"({"aaaaaaaa":1,"aaaaaaaz":2,"aaaaaaza":3})";

--- a/tests/json_reflection_test/json_reflection_test.cpp
+++ b/tests/json_reflection_test/json_reflection_test.cpp
@@ -527,7 +527,7 @@ struct glz::json_schema<meta_schema_t>
    schema is_valid{.description = "for validation"};
 };
 
-static_assert(glz::detail::json_schema_t<glz::json_schema<meta_schema_t>>);
+static_assert(glz::json_schema_t<glz::json_schema<meta_schema_t>>);
 static_assert(glz::reflectable<glz::json_schema<meta_schema_t>>);
 static_assert(glz::detail::count_members<glz::json_schema<meta_schema_t>> == 3);
 
@@ -545,8 +545,8 @@ struct local_schema_t
    };
 };
 
-static_assert(glz::detail::local_json_schema_t<local_schema_t>);
-static_assert(glz::detail::json_schema_t<local_schema_t>);
+static_assert(glz::local_json_schema_t<local_schema_t>);
+static_assert(glz::json_schema_t<local_schema_t>);
 
 suite meta_schema_reflection_tests = [] {
    "meta_schema_reflection"_test = [] {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -165,13 +165,13 @@ struct glz::meta<Color>
 
 static_assert(glz::enum_name_v<Color::Red> == "Red");
 
-static_assert(glz::detail::get_enum_name(Color::Green) == "Green");
+static_assert(glz::get_enum_name(Color::Green) == "Green");
 
 suite get_enum_name_tests = [] {
    "get_enum_name"_test = [] {
       auto color = Color::Green;
 
-      const auto name = glz::detail::get_enum_name(color);
+      const auto name = glz::get_enum_name(color);
       expect(name == "Green");
    };
 };
@@ -3253,7 +3253,7 @@ template <>
 struct glz::meta<holds_some_num>
 {
    using T = holds_some_num;
-   static constexpr auto value = object("num", glz::detail::array_variant{&T::num});
+   static constexpr auto value = object("num", glz::array_variant{&T::num});
 };
 
 struct OptionA
@@ -4413,7 +4413,7 @@ struct glz::meta<date>
    static constexpr auto value = object("date", &T::human_readable);
 };
 
-namespace glz::detail
+namespace glz
 {
    template <>
    struct from<JSON, date>
@@ -7652,10 +7652,10 @@ suite hostname_include_test = [] {
       hostname_include_struct obj{};
 
       glz::context ctx{};
-      const auto hostname = glz::detail::get_hostname(ctx);
+      const auto hostname = glz::get_hostname(ctx);
 
       std::string file_name = "../{}_config.json";
-      glz::detail::replace_first_braces(file_name, hostname);
+      glz::replace_first_braces(file_name, hostname);
 
       const auto config_buffer = R"(
 // testing opening whitespace and comment
@@ -7709,10 +7709,10 @@ suite nested_include_tests = [] {
       expect(glz::error_code::none == glz::buffer_to_file(std::string_view{R"({"number":3.5})"}, "./core.jsonc"));
 
       glz::context ctx{};
-      const auto hostname = glz::detail::get_hostname(ctx);
+      const auto hostname = glz::get_hostname(ctx);
 
       std::string file_name = "./{}_include_test.jsonc";
-      glz::detail::replace_first_braces(file_name, hostname);
+      glz::replace_first_braces(file_name, hostname);
       expect(glz::error_code::none ==
              glz::buffer_to_file(std::string_view{R"({"core":{"include": "./core.jsonc"}})"}, file_name));
 
@@ -8501,7 +8501,7 @@ struct custom_struct
    std::string str{};
 };
 
-namespace glz::detail
+namespace glz
 {
    template <>
    struct from<JSON, custom_struct>
@@ -9400,7 +9400,7 @@ struct front_16_t
    int cb{0};
 };
 
-static_assert(bool(glz::detail::hash_info<front_16_t>.type));
+static_assert(bool(glz::hash_info<front_16_t>.type));
 
 suite front_16_test = [] {
    "front_16"_test = [] {
@@ -9429,7 +9429,7 @@ struct glz::meta<custom_errors_t>
    static constexpr auto value = object(&T::a, &T::alpha);
 };
 
-namespace glz::detail
+namespace glz
 {
    template <>
    struct from<JSON, custom_errors_t>
@@ -9949,8 +9949,8 @@ struct same_length_keys
 
 suite same_length_keys_test = [] {
    "same_length_keys"_test = [] {
-      static constexpr auto info = glz::detail::make_keys_info(glz::reflect<same_length_keys>::keys);
-      static_assert(info.type == glz::detail::hash_type::full_flat);
+      static constexpr auto info = glz::make_keys_info(glz::reflect<same_length_keys>::keys);
+      static_assert(info.type == glz::hash_type::full_flat);
 
       same_length_keys obj{};
       std::string buffer{};
@@ -9974,8 +9974,8 @@ struct offset_one
 
 suite offset_one_test = [] {
    "offset_one"_test = [] {
-      static constexpr auto info = glz::detail::make_keys_info(glz::reflect<same_length_keys>::keys);
-      static_assert(info.type == glz::detail::hash_type::full_flat);
+      static constexpr auto info = glz::make_keys_info(glz::reflect<same_length_keys>::keys);
+      static_assert(info.type == glz::hash_type::full_flat);
 
       offset_one obj{};
       std::string buffer{};
@@ -10018,7 +10018,7 @@ suite ndjson_options = [] {
 suite atomics = [] {
    "atomics"_test = [] {
       std::atomic<int> i{};
-      static_assert(glz::detail::is_atomic<decltype(i)>);
+      static_assert(glz::is_atomic<decltype(i)>);
       expect(not glz::read_json(i, R"(55)"));
       expect(i.load() == 55);
 

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -901,7 +901,7 @@ suite container_types = [] {
       }
       std::string buffer{};
       std::map<std::string, int> map2{};
-      static_assert(glz::detail::writable_map_t<decltype(map2)>);
+      static_assert(glz::writable_map_t<decltype(map2)>);
       expect(not glz::write_json(map, buffer));
       expect(glz::read_json(map2, buffer) == glz::error_code::none);
       // expect(map == map2);
@@ -2647,7 +2647,7 @@ suite write_tests = [] {
 
    "Read empty object structure"_test = [] {
       EmptyObject e;
-      static_assert(glz::detail::glaze_object_t<EmptyObject>);
+      static_assert(glz::glaze_object_t<EmptyObject>);
       expect(glz::read_json(e, "{}") == glz::error_code::none);
       expect(glz::read_json(e, " {    } ") == glz::error_code::none);
       expect(glz::read_json(e, "{ \"reject\": 44 }") == glz::error_code::unknown_key);
@@ -3107,9 +3107,9 @@ struct local_meta
    };
 };
 
-static_assert(glz::detail::glaze_t<local_meta>);
-static_assert(glz::detail::glaze_object_t<local_meta>);
-static_assert(glz::detail::local_meta_t<local_meta>);
+static_assert(glz::glaze_t<local_meta>);
+static_assert(glz::glaze_object_t<local_meta>);
+static_assert(glz::local_meta_t<local_meta>);
 
 suite local_meta_tests = [] {
    "local_meta"_test = [] {
@@ -4243,7 +4243,7 @@ template <>
 struct glz::meta<string_t>
 {
    static constexpr std::string_view name = "string_t";
-   using T = string_t;
+   using T = ::string_t;
    static constexpr auto value = object("string", &T::string);
 };
 
@@ -4727,7 +4727,7 @@ suite custom_unique_tests = [] {
 #include <set>
 #include <unordered_set>
 
-static_assert(glz::detail::emplaceable<std::set<std::string>>);
+static_assert(glz::emplaceable<std::set<std::string>>);
 
 suite sets = [] {
    "std::unordered_set"_test = [] {
@@ -5930,7 +5930,7 @@ struct direct_cx_value_conversion
       static constexpr auto value{&direct_cx_value_conversion::const_v};
    };
 };
-static_assert(glz::detail::glaze_const_value_t<direct_cx_value_conversion>);
+static_assert(glz::glaze_const_value_t<direct_cx_value_conversion>);
 
 struct direct_cx_value_conversion_different_value
 {
@@ -5940,7 +5940,7 @@ struct direct_cx_value_conversion_different_value
       static constexpr auto value{&direct_cx_value_conversion_different_value::const_v};
    };
 };
-static_assert(glz::detail::glaze_const_value_t<direct_cx_value_conversion_different_value>);
+static_assert(glz::glaze_const_value_t<direct_cx_value_conversion_different_value>);
 
 struct string_direct_cx_value_conversion
 {
@@ -5950,7 +5950,7 @@ struct string_direct_cx_value_conversion
       static constexpr auto value{&string_direct_cx_value_conversion::const_v};
    };
 };
-static_assert(glz::detail::glaze_const_value_t<string_direct_cx_value_conversion>);
+static_assert(glz::glaze_const_value_t<string_direct_cx_value_conversion>);
 
 struct string_two_direct_cx_value_conversion
 {
@@ -5960,7 +5960,7 @@ struct string_two_direct_cx_value_conversion
       static constexpr auto value{&string_two_direct_cx_value_conversion::const_v};
    };
 };
-static_assert(glz::detail::glaze_const_value_t<string_two_direct_cx_value_conversion>);
+static_assert(glz::glaze_const_value_t<string_two_direct_cx_value_conversion>);
 
 struct array_direct_cx_value_conversion
 {
@@ -5970,7 +5970,7 @@ struct array_direct_cx_value_conversion
       static constexpr auto value{&array_direct_cx_value_conversion::const_v};
    };
 };
-static_assert(glz::detail::glaze_const_value_t<array_direct_cx_value_conversion>);
+static_assert(glz::glaze_const_value_t<array_direct_cx_value_conversion>);
 
 struct array_two_direct_cx_value_conversion
 {
@@ -5980,7 +5980,7 @@ struct array_two_direct_cx_value_conversion
       static constexpr auto value{&array_two_direct_cx_value_conversion::const_v};
    };
 };
-static_assert(glz::detail::glaze_const_value_t<array_two_direct_cx_value_conversion>);
+static_assert(glz::glaze_const_value_t<array_two_direct_cx_value_conversion>);
 
 struct non_cx_direct_value_conversion
 {
@@ -5990,7 +5990,7 @@ struct non_cx_direct_value_conversion
       static constexpr auto value{&non_cx_direct_value_conversion::some_other};
    };
 };
-static_assert(!glz::detail::glaze_const_value_t<non_cx_direct_value_conversion>);
+static_assert(!glz::glaze_const_value_t<non_cx_direct_value_conversion>);
 
 struct const_red
 {
@@ -6176,7 +6176,7 @@ suite char_buffer = [] {
    };
 };
 
-static_assert(!glz::detail::char_array_t<char*>);
+static_assert(!glz::char_array_t<char*>);
 
 suite enum_map = [] {
    "enum map key"_test = [] {
@@ -8221,7 +8221,7 @@ struct glz::json_schema<meta_schema_t>
    schema is_valid{.description = "for validation"};
 };
 
-static_assert(glz::detail::json_schema_t<meta_schema_t>);
+static_assert(glz::json_schema_t<meta_schema_t>);
 static_assert(glz::detail::count_members<glz::json_schema_type<meta_schema_t>> > 0);
 
 suite meta_schema_tests = [] {
@@ -8679,7 +8679,7 @@ struct glz::meta<path_test_struct>
 };
 
 suite filesystem_tests = [] {
-   static_assert(glz::detail::filesystem_path<std::filesystem::path>);
+   static_assert(glz::filesystem_path<std::filesystem::path>);
 
    "std::filesystem::path"_test = [] {
       std::filesystem::path p{"."};
@@ -8700,7 +8700,7 @@ suite filesystem_tests = [] {
    };
 };
 
-static_assert(glz::detail::readable_array_t<std::span<double, 4>>);
+static_assert(glz::readable_array_t<std::span<double, 4>>);
 
 struct struct_c_arrays
 {
@@ -9779,9 +9779,9 @@ struct glz::meta<naive_static_string_t<N>>
 };
 
 static_assert(std::constructible_from<std::string_view, std::decay_t<naive_static_string_t<3>>>);
-static_assert(glz::detail::has_assign<naive_static_string_t<3>>);
-static_assert(glz::detail::is_static_string<naive_static_string_t<3>>);
-static_assert(glz::detail::static_string_t<naive_static_string_t<3>>);
+static_assert(glz::has_assign<naive_static_string_t<3>>);
+static_assert(glz::is_static_string<naive_static_string_t<3>>);
+static_assert(glz::static_string_t<naive_static_string_t<3>>);
 
 suite static_string_tests = [] {
    "static_str<N> value"_test = [] {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -4421,7 +4421,7 @@ namespace glz::detail
       template <auto Opts>
       static void op(date& value, auto&&... args)
       {
-         read<JSON>::op<Opts>(value.human_readable, args...);
+         parse<JSON>::op<Opts>(value.human_readable, args...);
          value.data = std::stoi(value.human_readable);
       }
    };
@@ -4433,7 +4433,7 @@ namespace glz::detail
       static void op(date& value, auto&&... args) noexcept
       {
          value.human_readable = std::to_string(value.data);
-         write<JSON>::op<Opts>(value.human_readable, args...);
+         serialize<JSON>::op<Opts>(value.human_readable, args...);
       }
    };
 }
@@ -8509,7 +8509,7 @@ namespace glz::detail
       template <auto Opts>
       static void op(custom_struct& value, auto&&... args)
       {
-         read<JSON>::op<Opts>(value.str, args...);
+         parse<JSON>::op<Opts>(value.str, args...);
          value.str += "read";
       }
    };
@@ -8521,14 +8521,14 @@ namespace glz::detail
       static void op(custom_struct& value, auto&&... args) noexcept
       {
          value.str += "write";
-         write<JSON>::op<Opts>(value.str, args...);
+         serialize<JSON>::op<Opts>(value.str, args...);
       }
 
       // For std::set testing, because iterators are const
       template <auto Opts>
       static void op(const custom_struct& value, auto&&... args) noexcept
       {
-         write<JSON>::op<Opts>(value.str, args...);
+         serialize<JSON>::op<Opts>(value.str, args...);
       }
    };
 }

--- a/tests/json_test/jsonschema_test.cpp
+++ b/tests/json_test/jsonschema_test.cpp
@@ -70,7 +70,7 @@ auto expect_property(const test_case& test, std::string_view key, Value value)
       expect[std::holds_alternative<Value>(prop_value.value())];
       expect(std::get<Value>(prop_value.value()) == value);
    }
-   else if constexpr (is_optional<prop_value_t> && glz::detail::is_span<typename prop_value_t::value_type>) {
+   else if constexpr (is_optional<prop_value_t> && glz::is_span<typename prop_value_t::value_type>) {
       expect(fatal(prop_value.value().size() == value.size()));
       for (std::size_t i = 0; i < prop_value.value().size(); ++i) {
          expect(prop_value.value()[i] == value[i]);


### PR DESCRIPTION
- Changed `glz::detail::read` and `glz::detail::write` to `glz::parse` and `glz::serialize`. These are intermediate helpers that were easily confused with `glz::read` and `glz::write`, which still exist.
- Moved lots of glaze concepts out of the `detail` namespace for general use. This does clutter the namespace more, but it avoids collisions between the `glz` namespace and the `glz::detail` namespace and it moves towards building a library that is much more customizable and easier to add custom formats and new formats. This also reduces the text length in compiler error messages.