### PR TITLE
Additional max guards for MSVC

### DIFF
--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -1286,7 +1286,7 @@ namespace glz
             using S = std::make_signed_t<U>;
             // The largest magnitude we can represent in a negative value is (max + 1)
             // since -(min()) = max() + 1.
-            U limit = static_cast<U>(std::numeric_limits<I>::max()) + 1U;
+            U limit = static_cast<U>((std::numeric_limits<I>::max)()) + 1U;
             if (negative) {
                if (acc > limit) {
                   result.ec = std::errc::result_out_of_range;
@@ -1296,7 +1296,7 @@ namespace glz
                value = static_cast<I>(0 - static_cast<S>(acc));
             }
             else {
-               if (acc > static_cast<U>(std::numeric_limits<I>::max())) {
+               if (acc > static_cast<U>((std::numeric_limits<I>::max)())) {
                   result.ec = std::errc::result_out_of_range;
                   result.ptr = first;
                   return result;


### PR DESCRIPTION
Copied the fix from https://github.com/stephenberry/glaze/pull/1614/commits/430f67c27fa15ac9b5e7d3ed0828938e0ad92259 to the other ones I ran into today. Fixes some compiler errors on MSVC

```
.\glaze\include\glaze/util/parse.hpp(1284): error C2589: '(': illegal token on right side of '::'
.\glaze\include\glaze/util/parse.hpp(1284): error C2760: syntax error: '(' was unexpected here; expected ')'
.\glaze\include\glaze/util/parse.hpp(1284): error C2760: syntax error: ')' was unexpected here; expected 'expression'
.\glaze\include\glaze/util/parse.hpp(1284): error C2760: syntax error: ')' was unexpected here; expected ';'
.\glaze\include\glaze/util/parse.hpp(1284): error C3878: syntax error: unexpected token ')' following 'expression_statement'
.\glaze\include\glaze/util/parse.hpp(1284): error C3878: syntax error: unexpected token ')' following 'statement'
.\glaze\include\glaze/util/parse.hpp(1284): error C3878: syntax error: unexpected token ')' following 'statement_seq'
.\glaze\include\glaze/util/parse.hpp(1284): note: missing one of:  '}' ?
.\glaze\include\glaze/util/parse.hpp(1284): error C2760: syntax error: ')' was unexpected here; expected '}'
.\glaze\include\glaze/util/parse.hpp(1284): error C3878: syntax error: unexpected token ')' following 'compound_statement'
.\glaze\include\glaze/util/parse.hpp(1284): error C3878: syntax error: unexpected token ')' following 'selection_statement'
.\glaze\include\glaze/util/parse.hpp(1284): note: error recovery skipped: ') >'
.\glaze\include\glaze/util/parse.hpp(1284): note: error recovery skipped: ') ) ?'
.\glaze\include\glaze/util/parse.hpp(1284): note: error recovery skipped: ') :'
.\glaze\include\glaze/util/parse.hpp(1284): note: error recovery skipped: ') ) )'
.\glaze\include\glaze/util/parse.hpp(1286): error C2065: 'limit': undeclared identifier
.\glaze\include\glaze/util/parse.hpp(1291): error C2065: 'S': undeclared identifier
.\glaze\include\glaze/util/parse.hpp(1291): error C2187: syntax error: 'S' was unexpected here
.\glaze\include\glaze/util/parse.hpp(1291): error C2760: syntax error: '>' was unexpected here; expected ')'
.\glaze\include\glaze/util/parse.hpp(1291): error C3878: syntax error: unexpected token '(' following 'expression'
.\glaze\include\glaze/util/parse.hpp(1291): note: error recovery skipped: '( identifier'
.\glaze\include\glaze/util/parse.hpp(1291): error C2760: syntax error: ')' was unexpected here; expected ';'
.\glaze\include\glaze/util/parse.hpp(1291): error C3878: syntax error: unexpected token ')' following 'expression_statement'
.\glaze\include\glaze/util/parse.hpp(1291): error C3878: syntax error: unexpected token ')' following 'statement'
.\glaze\include\glaze/util/parse.hpp(1291): error C3878: syntax error: unexpected token ')' following 'statement_seq'
.\glaze\include\glaze/util/parse.hpp(1291): note: missing one of:  '}' ?
.\glaze\include\glaze/util/parse.hpp(1291): error C2760: syntax error: ')' was unexpected here; expected '}'
.\glaze\include\glaze/util/parse.hpp(1291): error C3878: syntax error: unexpected token ')' following 'compound_statement'
.\glaze\include\glaze/util/parse.hpp(1291): error C3878: syntax error: unexpected token ')' following 'selection_statement'
.\glaze\include\glaze/util/parse.hpp(1291): note: error recovery skipped: ') )'
```