### PR TITLE
Add GLZ_THROW_OR_ABORT to required headers

### DIFF
--- a/include/glaze/containers/flat_map.hpp
+++ b/include/glaze/containers/flat_map.hpp
@@ -14,6 +14,16 @@
 
 #include "glaze/util/expected.hpp"
 
+#ifndef GLZ_THROW_OR_ABORT
+#if __cpp_exceptions
+#define GLZ_THROW_OR_ABORT(EXC) (throw(EXC))
+#define GLZ_NOEXCEPT noexcept(false)
+#else
+#define GLZ_THROW_OR_ABORT(EXC) (std::abort())
+#define GLZ_NOEXCEPT noexcept(true)
+#endif
+#endif
+
 // A flat_map. This version uses a single container for key/value pairs for the sake of cache locality. The
 // std::flat_map uses separate key/value arrays.
 

--- a/include/glaze/thread/shared_async_map.hpp
+++ b/include/glaze/thread/shared_async_map.hpp
@@ -12,6 +12,16 @@
 #include "glaze/thread/value_proxy.hpp"
 #include "glaze/util/expected.hpp"
 
+#ifndef GLZ_THROW_OR_ABORT
+#if __cpp_exceptions
+#define GLZ_THROW_OR_ABORT(EXC) (throw(EXC))
+#define GLZ_NOEXCEPT noexcept(false)
+#else
+#define GLZ_THROW_OR_ABORT(EXC) (std::abort())
+#define GLZ_NOEXCEPT noexcept(true)
+#endif
+#endif
+
 // Provides a semi-safe flat map
 // This shared_async_map only provides thread safety when inserting/deletion
 // It is intended to store thread safe types for more efficient access

--- a/include/glaze/thread/shared_async_vector.hpp
+++ b/include/glaze/thread/shared_async_vector.hpp
@@ -12,6 +12,16 @@
 #include "glaze/thread/value_proxy.hpp"
 #include "glaze/util/expected.hpp"
 
+#ifndef GLZ_THROW_OR_ABORT
+#if __cpp_exceptions
+#define GLZ_THROW_OR_ABORT(EXC) (throw(EXC))
+#define GLZ_NOEXCEPT noexcept(false)
+#else
+#define GLZ_THROW_OR_ABORT(EXC) (std::abort())
+#define GLZ_NOEXCEPT noexcept(true)
+#endif
+#endif
+
 // Provides a thread-safe vector with shared ownership
 // This shared_async_vector allows multiple instances to share the same data and mutex
 // It ensures thread safety during read and write operations


### PR DESCRIPTION
We don't use a common header because we are moving towards C++20 modules