### PR TITLE
Fix glz::seek for glz::custom fields

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -271,7 +271,7 @@ namespace glz
                           std::same_as<T, std::vector<bool>::const_reference>;
 
    template <class T>
-   concept is_no_reflect = requires(T t) { requires T::glaze_reflect == false; };
+   concept is_no_reflect = requires(T t) { requires std::remove_cvref_t<T>::glaze_reflect == false; };
 
    /// \brief check if container has fixed size and its subsequent T::value_type
    template <class T>

--- a/include/glaze/core/custom.hpp
+++ b/include/glaze/core/custom.hpp
@@ -3,7 +3,8 @@
 
 #pragma once
 
-#include "glaze/core/seek.hpp"
+#include "glaze/core/read.hpp"
+#include "glaze/core/write.hpp"
 #include "glaze/core/wrappers.hpp"
 
 namespace glz

--- a/include/glaze/core/seek.hpp
+++ b/include/glaze/core/seek.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "glaze/core/custom.hpp"
 #include "glaze/core/read.hpp"
 #include "glaze/core/reflect.hpp"
 #include "glaze/core/write.hpp"
@@ -98,6 +99,7 @@ namespace glz::detail
       if constexpr (glaze_object_t<T> || reflectable<T>) {
          static constexpr auto N = reflect<T>::size;
          static constexpr auto HashInfo = hash_info<T>;
+         static_assert(HashInfo.type != hash_type::invalid, "Hashing failed");
 
          const auto index = decode_hash_with_size<JSON_PTR, T, HashInfo, HashInfo.type>::op(
             key.data(), key.data() + key.size(), key.size());

--- a/tests/json_reflection_test/json_reflection_test.cpp
+++ b/tests/json_reflection_test/json_reflection_test.cpp
@@ -844,4 +844,47 @@ suite hash_tests = [] {
    };
 };
 
+
+struct custom_state
+{
+   std::array<uint32_t, 8> statuses() {
+      return {};
+   }
+};
+
+template <>
+struct glz::meta<custom_state>
+{
+   using T = custom_state;
+   static constexpr auto read = [](T&, const std::array<uint32_t, 8>&) {};
+   static constexpr auto value = custom<read, &T::statuses>;
+};
+
+struct custom_holder
+{
+   uint32_t x{};
+   uint32_t y{};
+   uint32_t z{};
+   custom_state state{};
+};
+
+suite custom_holder_tests = []
+{
+   "custom_holder"_test = [] {
+      custom_holder obj{};
+      std::string buffer{};
+      expect(not glz::write_json(obj, buffer));
+      expect(not glz::read_json(obj, buffer));
+   };
+   
+   "custom_holder seek"_test = []
+   {
+      custom_holder obj{};
+      std::string buffer{};
+      bool b = glz::seek([&](auto&& val) { std::ignore = glz::write_json(val, buffer); }, obj, "/state");
+      expect(b);
+      expect(buffer == "[0,0,0,0,0,0,0,0]") << buffer;
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
The concept `is_no_reflect` needed to decay the type to work appropriately for glz::custom when using `glz::seek`.