### PR TITLE
Create version.hpp

### DIFF
--- a/include/glaze/version.hpp
+++ b/include/glaze/version.hpp
@@ -1,0 +1,44 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+namespace glz
+{
+   /**
+    * @struct version_t
+    * @brief Represents the version of the Glaze Library
+    *
+    * Provides version information and comparison operators to check version compatibility.
+    */
+   struct version_t
+   {
+      uint8_t major = 5;
+      uint8_t minor = 0;
+      uint8_t patch = 1;
+      
+      constexpr auto operator<=>(const version_t& other) const noexcept
+      {
+         // Compare major versions first
+         if (auto cmp = major <=> other.major; cmp != 0)
+            return cmp;
+         // If major versions are equal, compare minor versions
+         if (auto cmp = minor <=> other.minor; cmp != 0)
+            return cmp;
+         // If major and minor versions are equal, compare patch versions
+         return patch <=> other.patch;
+      }
+      
+      // In C++23, this is optional when we have a custom <=> operator,
+      // but included for clarity
+      constexpr bool operator==(const version_t& other) const noexcept = default;
+   };
+   
+   /**
+    * @var version
+    * @brief Global constant instance of the current library version
+    *
+    * Provides access to the current version of the Glaze Library.
+    */
+   inline constexpr version_t version{};
+}


### PR DESCRIPTION
Adds a version header that allows compile time checks against the current Glaze version.