### PR TITLE
const char* assignment for glz::json_t

### DIFF
--- a/include/glaze/json/json_t.hpp
+++ b/include/glaze/json/json_t.hpp
@@ -177,6 +177,12 @@ namespace glz
          data = std::string(value);
          return *this;
       }
+      
+      json_t& operator=(const char* value)
+      {
+         data = std::string(value);
+         return *this;
+      }
 
       json_t& operator=(const bool value)
       {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -3726,6 +3726,12 @@ suite generic_json_tests = [] {
       json = 44;
       expect(glz::write_json(json).value() == "44");
    };
+   
+   "json_t const char*"_test = [] {
+      glz::json_t j{};
+      j["some key"] = "some value";
+      expect(j.dump() == R"({"some key":"some value"})");
+   };
 };
 
 struct holder0_t


### PR DESCRIPTION
Adds support for:
```c++
glz::json_t j{};
j["some key"] = "some value";
expect(j.dump() == R"({"some key":"some value"})");
```