### PR TITLE
fix static_string

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1159,7 +1159,7 @@ namespace glz
          }
          else if constexpr (static_string_t<T>) {
             const size_t n = it - start;
-            if (n > value.size()) {
+            if (n > value.capacity()) {
                ctx.error = error_code::unexpected_end;
                return;
             }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -9769,7 +9769,7 @@ struct naive_static_string_t
    naive_static_string_t(std::string_view sv) { assign(sv.data(), sv.size()); }
    operator std::string_view() const { return std::string_view(buffer, length); }
 
-   size_t size() const { return N; }
+   size_t size() const { return length; }
    size_t capacity() const { return N; }
    const char* data() const { return buffer; }
 


### PR DESCRIPTION
`static_string` should use `capacity` to check whether it has enough elements to store the string, rather than `size()` (which is used in `std::array<char, N>`).