### PR TITLE
Fix pair handling of named enum keys

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -377,6 +377,9 @@ namespace glz
 
    template <class T>
    concept glaze_enum_t = glaze_t<T> && is_specialization_v<meta_wrapper_t<T>, detail::Enum>;
+   
+   template <class T>
+   concept is_named_enum = ((glaze_enum_t<T> || (meta_keys<T> && std::is_enum_v<T>)) && !custom_read<T>);
 
    template <class T>
    concept glaze_flags_t = glaze_t<T> && is_specialization_v<meta_wrapper_t<T>, detail::Flags>;

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1261,7 +1261,7 @@ namespace glz
    };
 
    template <class T>
-      requires((glaze_enum_t<T> || (meta_keys<T> && std::is_enum_v<T>)) && !custom_read<T>)
+      requires(is_named_enum<T>)
    struct from<JSON, T>
    {
       template <auto Opts>
@@ -2017,9 +2017,6 @@ namespace glz
             return;
          }
 
-         // Only used if error_on_missing_keys = true
-         [[maybe_unused]] bit_array<1> fields{};
-
          if (*it == '}') {
             if constexpr (not Opts.null_terminated) {
                --ctx.indentation_level;
@@ -2030,7 +2027,8 @@ namespace glz
             return;
          }
 
-         if constexpr (str_t<typename T::first_type>) {
+         using first_type = typename T::first_type;
+         if constexpr (str_t<first_type> || is_named_enum<first_type>) {
             parse<JSON>::op<Opts>(value.first, ctx, it, end);
             if (bool(ctx.error)) [[unlikely]]
                return;

--- a/tests/json_reflection_test/json_reflection_test.cpp
+++ b/tests/json_reflection_test/json_reflection_test.cpp
@@ -882,4 +882,40 @@ suite custom_holder_tests = [] {
    };
 };
 
+enum struct some_enum
+{
+   one,
+   two,
+   three
+};
+
+template <>
+struct glz::meta<some_enum> {
+   using enum some_enum;
+   static constexpr auto value = enumerate(one, two, three);
+};
+
+struct struct_with_a_pair
+{
+   std::pair<some_enum, std::string> value{};
+   
+   constexpr bool operator<=>(const struct_with_a_pair& rhs) const = default;
+};
+
+suite enum_pair_tests = []
+{
+   "enum pair"_test = [] {
+      struct_with_a_pair obj{};
+      std::string buffer{};
+      expect(not glz::write_json(obj, buffer));
+      expect(buffer == R"({"value":{"one":""}})") << buffer;
+      
+      buffer = R"({"value":{"two":"message"}})";
+      
+      expect(not glz::read_json(obj, buffer));
+      expect(obj.value.first == some_enum::two);
+      expect(obj.value.second == "message");
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
Also adds helper `is_named_enum` concept.

Makes this read pass:
```c++
enum struct some_enum
{
   one,
   two,
   three
};

template <>
struct glz::meta<some_enum> {
   using enum some_enum;
   static constexpr auto value = enumerate(one, two, three);
};

struct struct_with_a_pair
{
   std::pair<some_enum, std::string> value{};
   
   constexpr bool operator<=>(const struct_with_a_pair& rhs) const = default;
};

suite enum_pair_tests = []
{
   "enum pair"_test = [] {
      struct_with_a_pair obj{};
      std::string buffer{};
      expect(not glz::write_json(obj, buffer));
      expect(buffer == R"({"value":{"one":""}})") << buffer;
      
      buffer = R"({"value":{"two":"message"}})";
      
      expect(not glz::read_json(obj, buffer));
      expect(obj.value.first == some_enum::two);
      expect(obj.value.second == "message");
   };
};
```