### PR TITLE
Erlang term parse and serialize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ if(glaze_BUILD_EXAMPLES)
   add_subdirectory(examples)
 endif()
 
-option(glaze_ERLANG_FORMAT "Enable Erlang external term format parsing" ON)
+option(glaze_ERLANG_FORMAT "Enable Erlang external term format parsing" OFF)
 
 if(glaze_ERLANG_FORMAT)
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
@@ -72,5 +72,6 @@ if(glaze_ERLANG_FORMAT)
     INTERFACE
       Erlang::EI
       Erlang::Erlang
-)
+  )
+  target_compile_definitions(glaze_glaze INTERFACE GLZ_ENABLE_EETF)
 endif(glaze_ERLANG_FORMAT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,3 +61,16 @@ option(glaze_BUILD_EXAMPLES "Build GLAZE examples" OFF)
 if(glaze_BUILD_EXAMPLES)
   add_subdirectory(examples)
 endif()
+
+option(glaze_ERLANG_FORMAT "Enable Erlang external term format parsing" ON)
+
+if(glaze_ERLANG_FORMAT)
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+  find_package(Erlang REQUIRED)
+  target_link_libraries(
+    glaze_glaze ${warning_guard}
+    INTERFACE
+      Erlang::EI
+      Erlang::Erlang
+)
+endif(glaze_ERLANG_FORMAT)

--- a/cmake/FindErlang.cmake
+++ b/cmake/FindErlang.cmake
@@ -1,0 +1,171 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindErlang
+-------
+
+Finds Erlang libraries.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``Erlang::Erlang``
+  Header only interface library suitible for compiling NIFs.
+
+``Erlang::EI``
+  Erlang interface library.
+
+``Erlang::ERTS``
+  Erlang runtime system library.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``Erlang_FOUND``
+  True if the system has the Erlang library.
+``Erlang_RUNTIME``
+  The path to the Erlang runtime.
+``Erlang_COMPILE``
+  The path to the Erlang compiler.
+``Erlang_EI_PATH``
+  The path to the Erlang erl_interface path.
+``Erlang_ERTS_PATH``
+  The path to the Erlang erts path.
+``Erlang_EI_INCLUDE_DIRS``
+  /include appended to Erlang_EI_PATH.
+``Erlang_EI_LIBRARY_PATH``
+  /lib appended to Erlang_EI_PATH.
+``Erlang_ERTS_INCLUDE_DIRS``
+  /include appended to Erlang_ERTS_PATH.
+``Erlang_ERTS_LIBRARY_PATH``
+  /lib appended to Erlang_ERTS_PATH.
+``Erlang_OTP_VERSION``
+  Current Erlang OTP version
+
+#]=======================================================================]
+include(FindPackageHandleStandardArgs)
+
+SET(Erlang_BIN_PATH
+  $ENV{ERLANG_HOME}/bin
+  /opt/bin
+  /sw/bin
+  /usr/bin
+  /usr/local/bin
+  /opt/local/bin
+  )
+
+FIND_PROGRAM(Erlang_RUNTIME
+  NAMES erl
+  PATHS ${Erlang_BIN_PATH}
+  )
+
+FIND_PROGRAM(Erlang_COMPILE
+  NAMES erlc
+  PATHS ${Erlang_BIN_PATH}
+  )
+
+EXECUTE_PROCESS(
+  COMMAND         erl -noshell -eval "io:format(\"~s\", [code:lib_dir()])" -s erlang halt
+  OUTPUT_VARIABLE Erlang_OTP_LIB_DIR
+  )
+
+EXECUTE_PROCESS(
+  COMMAND         erl -noshell -eval "io:format(\"~s\", [code:root_dir()])" -s erlang halt
+  OUTPUT_VARIABLE Erlang_OTP_ROOT_DIR
+  )
+
+EXECUTE_PROCESS(
+  COMMAND         erl -noshell -eval "io:format(\"~s\",[filename:basename(code:lib_dir('erl_interface'))])" -s erlang halt
+  OUTPUT_VARIABLE Erlang_EI_DIR
+  )
+
+EXECUTE_PROCESS(
+  COMMAND         erl -noshell -eval "io:format(\"~s\",[filename:basename(code:lib_dir('erts'))])" -s erlang halt
+  OUTPUT_VARIABLE Erlang_ERTS_DIR
+  )
+
+EXECUTE_PROCESS(
+  COMMAND         erl -noshell -eval "io:format(\"~s\", [erlang:system_info(otp_release)])" -s erlang halt
+  OUTPUT_VARIABLE Erlang_OTP_VERSION
+  )
+
+SET(Erlang_EI_PATH           ${Erlang_OTP_LIB_DIR}/${Erlang_EI_DIR})
+SET(Erlang_EI_INCLUDE_DIRS   ${Erlang_OTP_LIB_DIR}/${Erlang_EI_DIR}/include)
+SET(Erlang_EI_LIBRARY_PATH   ${Erlang_OTP_LIB_DIR}/${Erlang_EI_DIR}/lib)
+
+SET(Erlang_ERTS_PATH         ${Erlang_OTP_ROOT_DIR}/${Erlang_ERTS_DIR})
+SET(Erlang_ERTS_INCLUDE_DIRS ${Erlang_OTP_ROOT_DIR}/${Erlang_ERTS_DIR}/include)
+SET(Erlang_ERTS_LIBRARY_PATH ${Erlang_OTP_ROOT_DIR}/${Erlang_ERTS_DIR}/lib)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(
+  Erlang
+  DEFAULT_MSG
+  Erlang_RUNTIME
+  Erlang_COMPILE
+  Erlang_OTP_LIB_DIR
+  Erlang_OTP_ROOT_DIR
+  Erlang_EI_DIR
+  Erlang_ERTS_DIR
+  Erlang_OTP_VERSION
+  )
+
+if(Erlang_FOUND)
+  if(NOT TARGET Erlang::Erlang)
+    add_library(Erlang::Erlang INTERFACE IMPORTED)
+    set_target_properties(Erlang::Erlang
+      PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES ${Erlang_OTP_ROOT_DIR}/usr/include
+      )
+  endif()
+
+  if(NOT TARGET Erlang::ERTS)
+    add_library(Erlang::ERTS STATIC IMPORTED)
+    set_target_properties(Erlang::ERTS
+      PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES ${Erlang_ERTS_INCLUDE_DIRS}
+      IMPORTED_LOCATION             ${Erlang_ERTS_LIBRARY_PATH}/liberts.a
+      )
+  endif()
+
+  if(NOT TARGET Erlang::EI)
+    add_library(erlang_ei STATIC IMPORTED)
+    set_property(TARGET erlang_ei PROPERTY
+      IMPORTED_LOCATION ${Erlang_EI_LIBRARY_PATH}/libei.a
+      )
+    add_library(Erlang::EI INTERFACE IMPORTED)
+    set_property(TARGET Erlang::EI PROPERTY
+      INTERFACE_INCLUDE_DIRECTORIES ${Erlang_EI_INCLUDE_DIRS}
+      )
+    set_property(TARGET Erlang::EI PROPERTY
+      INTERFACE_LINK_LIBRARIES erlang_ei
+      )
+  endif()
+endif(Erlang_FOUND)
+
+
+
+#[[
+https://gist.github.com/JayKickliter/dd0016bd5545de466e7ca158d4b19417
+How I compile Erlang from source on macOS
+
+CFLAGS="-Og -ggdb3 -fno-omit-frame-pointer" \
+CXXFLAGS="-Og -ggdb3 -fno-omit-frame-pointer" \
+./configure \
+      --prefix=$HOME/.local \
+      --disable-silent-rules \
+      --enable-dynamic-ssl-lib \
+      --with-ssl=/usr/local/opt/openssl \
+      --disable-hipe \
+      --enable-sctp \
+      --enable-shared-zlib \
+      --enable-smp-support \
+      --enable-threads \
+      --enable-wx \
+      --without-javac \
+      --enable-darwin-64bit
+]]

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -26,6 +26,10 @@ namespace glz
    inline constexpr uint8_t rowwise = 0;
    inline constexpr uint8_t colwise = 1;
 
+   // layout erlang term
+   inline constexpr uint8_t map = 0;
+   inline constexpr uint8_t proplist = 1;
+
    enum struct float_precision : uint8_t { //
       full, //
       float32 = 4, //
@@ -418,6 +422,12 @@ namespace glz
       auto ret = Opts;
       ret.format = TOML;
       return ret;
+   }
+
+   template <auto Opts, uint32_t Format>
+   consteval bool has_format()
+   {
+      return Opts.format == Format;
    }
 }
 

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -26,10 +26,6 @@ namespace glz
    inline constexpr uint8_t rowwise = 0;
    inline constexpr uint8_t colwise = 1;
 
-   // layout erlang term
-   inline constexpr uint8_t map = 0;
-   inline constexpr uint8_t proplist = 1;
-
    enum struct float_precision : uint8_t { //
       full, //
       float32 = 4, //

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -419,12 +419,6 @@ namespace glz
       ret.format = TOML;
       return ret;
    }
-
-   template <auto Opts, uint32_t Format>
-   consteval bool has_format()
-   {
-      return Opts.format == Format;
-   }
 }
 
 namespace glz

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -20,6 +20,7 @@ namespace glz
    inline constexpr uint32_t TOML = 400;
    inline constexpr uint32_t STENCIL = 500;
    inline constexpr uint32_t CSV = 10000;
+   inline constexpr uint32_t ERLANG = 20000;
 
    // layout
    inline constexpr uint8_t rowwise = 0;

--- a/include/glaze/eetf.hpp
+++ b/include/glaze/eetf.hpp
@@ -1,0 +1,7 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include "glaze/eetf/read.hpp"
+#include "glaze/eetf/write.hpp"

--- a/include/glaze/eetf.hpp
+++ b/include/glaze/eetf.hpp
@@ -3,5 +3,9 @@
 
 #pragma once
 
+#if defined GLZ_ENABLE_EETF
+
 #include "glaze/eetf/read.hpp"
 #include "glaze/eetf/write.hpp"
+
+#endif

--- a/include/glaze/eetf/cmp.hpp
+++ b/include/glaze/eetf/cmp.hpp
@@ -1,59 +1,54 @@
 #pragma once
 
 #include <array>
-#include <utility>
-
 #include <glaze/concepts/container_concepts.hpp>
+#include <utility>
 
 namespace glz::eetf
 {
 
-namespace detail
-{
+   namespace detail
+   {
 
-// Primary template
-template <typename Tag>
-struct in_impl;
+      // Primary template
+      template <typename Tag>
+      struct in_impl;
 
-// Specialization for `int...`
-template <int N, int... Vs>
-struct in_impl<std::integer_sequence<int, N, Vs...>>
-{
-	bool value{false};
+      // Specialization for `int...`
+      template <int N, int... Vs>
+      struct in_impl<std::integer_sequence<int, N, Vs...>>
+      {
+         bool value{false};
 
-	template <int_t T>
-	constexpr in_impl(const T & val)
-		: value{(val == N) || in_impl<std::integer_sequence<int, Vs...>>(val).value}
-	{
-	}
-};
+         template <int_t T>
+         constexpr in_impl(const T& val) : value{(val == N) || in_impl<std::integer_sequence<int, Vs...>>(val).value}
+         {}
+      };
 
-template <int N>
-struct in_impl<std::integer_sequence<int, N>>
-{
-	bool value{false};
+      template <int N>
+      struct in_impl<std::integer_sequence<int, N>>
+      {
+         bool value{false};
 
-	template <int_t T>
-	constexpr in_impl(const T & val)
-		: value{val == N}
-	{
-	}
-};
+         template <int_t T>
+         constexpr in_impl(const T& val) : value{val == N}
+         {}
+      };
 
-} // namespace detail
+   } // namespace detail
 
-template <typename T>
-using in = detail::in_impl<T>;
+   template <typename T>
+   using in = detail::in_impl<T>;
 
-namespace cmp
-{
+   namespace cmp
+   {
 
-template <template <class> class Op, int... Vs, typename T>
-constexpr bool is(const T & val)
-{
-	return Op<std::integer_sequence<int, Vs...>>(val).value;
-}
+      template <template <class> class Op, int... Vs, typename T>
+      constexpr bool is(const T& val)
+      {
+         return Op<std::integer_sequence<int, Vs...>>(val).value;
+      }
 
-};
+   };
 
 } // namespace erlterm

--- a/include/glaze/eetf/cmp.hpp
+++ b/include/glaze/eetf/cmp.hpp
@@ -3,6 +3,8 @@
 #include <array>
 #include <utility>
 
+#include <glaze/concepts/container_concepts.hpp>
+
 namespace glz::eetf
 {
 
@@ -19,7 +21,7 @@ struct in_impl<std::integer_sequence<int, N, Vs...>>
 {
 	bool value{false};
 
-	template <glz::detail::int_t T>
+	template <int_t T>
 	constexpr in_impl(const T & val)
 		: value{(val == N) || in_impl<std::integer_sequence<int, Vs...>>(val).value}
 	{
@@ -31,7 +33,7 @@ struct in_impl<std::integer_sequence<int, N>>
 {
 	bool value{false};
 
-	template <glz::detail::int_t T>
+	template <int_t T>
 	constexpr in_impl(const T & val)
 		: value{val == N}
 	{

--- a/include/glaze/eetf/cmp.hpp
+++ b/include/glaze/eetf/cmp.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <array>
+#include <utility>
+
+namespace glz::eetf
+{
+
+namespace detail
+{
+
+// Primary template
+template <typename Tag>
+struct in_impl;
+
+// Specialization for `int...`
+template <int N, int... Vs>
+struct in_impl<std::integer_sequence<int, N, Vs...>>
+{
+	bool value{false};
+
+	template <glz::detail::int_t T>
+	constexpr in_impl(const T & val)
+		: value{(val == N) || in_impl<std::integer_sequence<int, Vs...>>(val).value}
+	{
+	}
+};
+
+template <int N>
+struct in_impl<std::integer_sequence<int, N>>
+{
+	bool value{false};
+
+	template <glz::detail::int_t T>
+	constexpr in_impl(const T & val)
+		: value{val == N}
+	{
+	}
+};
+
+} // namespace detail
+
+template <typename T>
+using in = detail::in_impl<T>;
+
+namespace cmp
+{
+
+template <template <class> class Op, int... Vs, typename T>
+constexpr bool is(const T & val)
+{
+	return Op<std::integer_sequence<int, Vs...>>(val).value;
+}
+
+};
+
+} // namespace erlterm

--- a/include/glaze/eetf/cmp.hpp
+++ b/include/glaze/eetf/cmp.hpp
@@ -1,9 +1,5 @@
 #pragma once
 
-#include <array>
-#include <glaze/concepts/container_concepts.hpp>
-#include <utility>
-
 namespace glz::eetf
 {
 

--- a/include/glaze/eetf/defs.hpp
+++ b/include/glaze/eetf/defs.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "glaze/core/common.hpp"
+
+#include "types.hpp"
+
+namespace glz
+{
+   template <class T>
+   concept atom_t = detail::string_t<T> && std::same_as<typename T::tag, eetf::tag_atom>;
+
+   // template <class T>
+   // concept erl_str_t = detail::string_t<T> && std::same_as<typename T::tag, eetf::tag_string>;
+
+} // namespace glz

--- a/include/glaze/eetf/defs.hpp
+++ b/include/glaze/eetf/defs.hpp
@@ -7,7 +7,7 @@
 namespace glz
 {
    template <class T>
-   concept atom_t = detail::string_t<T> && std::same_as<typename T::tag, eetf::tag_atom>;
+   concept atom_t = string_t<T> && std::same_as<typename T::tag, eetf::tag_atom>;
 
    // template <class T>
    // concept erl_str_t = detail::string_t<T> && std::same_as<typename T::tag, eetf::tag_string>;

--- a/include/glaze/eetf/defs.hpp
+++ b/include/glaze/eetf/defs.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "glaze/core/common.hpp"
+#include <glaze/core/common.hpp>
+
 #include "types.hpp"
 
 namespace glz

--- a/include/glaze/eetf/defs.hpp
+++ b/include/glaze/eetf/defs.hpp
@@ -1,15 +1,11 @@
 #pragma once
 
 #include "glaze/core/common.hpp"
-
 #include "types.hpp"
 
 namespace glz
 {
    template <class T>
    concept atom_t = string_t<T> && std::same_as<typename T::tag, eetf::tag_atom>;
-
-   // template <class T>
-   // concept erl_str_t = detail::string_t<T> && std::same_as<typename T::tag, eetf::tag_string>;
 
 } // namespace glz

--- a/include/glaze/eetf/ei.hpp
+++ b/include/glaze/eetf/ei.hpp
@@ -402,10 +402,11 @@ namespace glz
    }
 
    template <class... Args>
-   GLZ_ALWAYS_INLINE void encode_tuple_header(int arity, Args&&... args)
+   GLZ_ALWAYS_INLINE void encode_tuple_header(std::size_t arity, Args&&... args)
    {
       using namespace std::placeholders;
-      detail::encode_impl(std::bind(ei_encode_tuple_header, _1, _2, arity), std::forward<Args>(args)...);
+      detail::encode_impl(std::bind(ei_encode_tuple_header, _1, _2, static_cast<int>(arity)),
+                          std::forward<Args>(args)...);
    }
 
    template <class... Args>

--- a/include/glaze/eetf/ei.hpp
+++ b/include/glaze/eetf/ei.hpp
@@ -1,0 +1,425 @@
+#pragma once
+
+#include <ei.h>
+
+#include <glaze/concepts/container_concepts.hpp>
+#include <glaze/core/common.hpp>
+#include <glaze/core/context.hpp>
+
+#include "defs.hpp"
+#include "types.hpp"
+
+namespace glz
+{
+
+#define CHECK_OFFSET(off)                     \
+   if ((it + (off)) > end) [[unlikely]] {     \
+      ctx.error = error_code::unexpected_end; \
+      return;                                 \
+   }
+
+   namespace detail
+   {
+      template <class F, is_context Ctx, class It0, class It1>
+      GLZ_ALWAYS_INLINE void decode_impl(F&& func, Ctx&& ctx, It0&& it, It1&& end)
+      {
+         int index{};
+         if (func(it, &index) < 0) [[unlikely]] {
+            ctx.error = error_code::parse_number_failure;
+            return;
+         }
+
+         CHECK_OFFSET(index);
+         std::advance(it, index);
+      }
+
+      template <output_buffer B, class IX>
+      [[nodiscard]] GLZ_ALWAYS_INLINE int resize_buffer(B&& b, IX&& ix, int index)
+      {
+         if (b.size() < static_cast<std::size_t>(index)) {
+            b.resize((std::max)(b.size() * 2, static_cast<std::size_t>(index)));
+         }
+
+         return static_cast<int>(ix);
+      }
+
+      template <class F, is_context Ctx, class B, class IX>
+      GLZ_ALWAYS_INLINE void encode_impl(F&& func, Ctx&& ctx, B&& b, IX&& ix)
+      {
+         int index{static_cast<int>(ix)};
+         if (func(nullptr, &index) < 0) {
+            ctx.error = error_code::seek_failure;
+            return;
+         }
+
+         index = resize_buffer(b, ix, index);
+         if (func(b.data(), &index) < 0) {
+            ctx.error = error_code::seek_failure;
+            return;
+         }
+
+         ix = index;
+      }
+
+   } // namespace detail
+
+   template <class It>
+   GLZ_ALWAYS_INLINE void decode_version(is_context auto&& ctx, It&& it)
+   {
+      int index{};
+      int version{};
+      if (ei_decode_version(it, &index, &version) < 0) [[unlikely]] {
+         ctx.error = error_code::syntax_error;
+         return;
+      }
+
+      // TODO find out where is 131 located in .h files
+      if (version != 131) [[unlikely]] {
+         ctx.error = error_code::version_mismatch;
+         return;
+      }
+
+      std::advance(it, index);
+   }
+
+   template <class It>
+   GLZ_ALWAYS_INLINE int get_type(is_context auto&& ctx, It&& it)
+   {
+      int type{};
+      int size{};
+      int index{};
+      if (ei_get_type(it, &index, &type, &size) < 0) {
+         ctx.error = error_code::syntax_error;
+         return -1;
+      }
+
+      return type;
+   }
+
+   template <class It>
+   auto skip_term(is_context auto&& ctx, It&& it)
+   {
+      int index{};
+      if (ei_skip_term(it, &index) < 0) {
+         ctx.error = error_code::syntax_error;
+         index = 0;
+      }
+
+      return it + index;
+   }
+
+   template <detail::num_t T, class... Args>
+   GLZ_ALWAYS_INLINE void decode_number(T&& value, Args&&... args)
+   {
+      using namespace std::placeholders;
+      using V = std::remove_cvref_t<T>;
+      if constexpr (detail::float_t<T>) {
+         double v;
+         detail::decode_impl(std::bind(ei_decode_double, _1, _2, &v), std::forward<Args>(args)...);
+         value = static_cast<std::remove_cvref_t<T>>(v);
+      }
+      else {
+         if constexpr (sizeof(V) > sizeof(long)) {
+            if constexpr (std::is_signed_v<V>) {
+               long long v;
+               detail::decode_impl(std::bind(ei_decode_longlong, _1, _2, &v), std::forward<Args>(args)...);
+               value = static_cast<T>(v);
+            }
+            else {
+               unsigned long long v;
+               detail::decode_impl(std::bind(ei_decode_ulonglong, _1, _2, &v), std::forward<Args>(args)...);
+               value = static_cast<T>(v);
+            }
+         }
+         else {
+            if constexpr (std::is_signed_v<V>) {
+               long v;
+               detail::decode_impl(std::bind(ei_decode_long, _1, _2, &v), std::forward<Args>(args)...);
+               value = static_cast<T>(v);
+            }
+            else {
+               unsigned long v;
+               detail::decode_impl(std::bind(ei_decode_ulong, _1, _2, &v), std::forward<Args>(args)...);
+               value = static_cast<T>(v);
+            }
+         }
+      }
+   }
+
+   template <class It0, class It1>
+   GLZ_ALWAYS_INLINE void decode_token(auto&& value, is_context auto&& ctx, It0&& it, It1&& end)
+   {
+      using namespace std::placeholders;
+
+      int index{};
+      int type{};
+      int sz{};
+      if (ei_get_type(it, &index, &type, &sz) < 0) [[unlikely]] {
+         ctx.error = error_code::syntax_error;
+         return;
+      }
+
+      CHECK_OFFSET(sz);
+
+      value.resize(sz);
+      if (eetf::is_atom(type)) {
+         detail::decode_impl(std::bind(ei_decode_atom, _1, _2, value.data()), ctx, it, end);
+      }
+      else {
+         detail::decode_impl(std::bind(ei_decode_string, _1, _2, value.data()), ctx, it, end);
+      }
+   }
+
+   template <class... Args>
+   GLZ_ALWAYS_INLINE void decode_boolean(auto&& value, Args&&... args)
+   {
+      using namespace std::placeholders;
+
+      int v{};
+      detail::decode_impl(std::bind(ei_decode_boolean, _1, _2, &v), std::forward<Args>(args)...);
+      value = v != 0;
+   }
+
+   template <auto Opts, class T, class It0>
+   void decode_binary(T&& value, std::size_t sz, is_context auto&& ctx, It0&& it, auto&& end)
+   {
+      using namespace std::placeholders;
+
+      CHECK_OFFSET(sz * sizeof(std::uint8_t));
+
+      using V = range_value_t<std::decay_t<T>>;
+
+      if constexpr (resizable<T>) {
+         value.resize(sz);
+         if constexpr (Opts.shrink_to_fit) {
+            value.shrink_to_fit();
+         }
+      }
+      else {
+         if (sz > value.size()) {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+      }
+
+      [[maybe_unused]] long szl{};
+      if constexpr (sizeof(V) == sizeof(std::uint8_t)) {
+         detail::decode_impl(std::bind(ei_decode_binary, _1, _2, value.data(), &szl), ctx, it, end);
+      }
+      else {
+         std::vector<std::uint8_t> buff(sz);
+         detail::decode_impl(std::bind(ei_decode_binary, _1, _2, buff.data(), &szl), ctx, it, end);
+         std::copy(buff.begin(), buff.end(), value.begin());
+      }
+   }
+
+   template <auto Opts, class T>
+   GLZ_ALWAYS_INLINE void decode_list(T&& value, is_context auto&& ctx, auto&& it, auto&& end)
+   {
+      using V = range_value_t<std::decay_t<T>>;
+
+      int index{};
+      int arity{};
+      if (ei_decode_list_header(it, &index, &arity) < 0) [[unlikely]] {
+         ctx.error = error_code::syntax_error;
+         return;
+      }
+
+      if constexpr (resizable<T>) {
+         value.resize(arity);
+         if constexpr (Opts.shrink_to_fit) {
+            value.shrink_to_fit();
+         }
+      }
+      else {
+         if (static_cast<std::size_t>(arity) > value.size()) {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+      }
+
+      CHECK_OFFSET(index);
+      std::advance(it, index);
+
+      for (int idx = 0; idx < arity; idx++) {
+         V v;
+         detail::from<ERLANG, V>::template op<Opts>(v, ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+
+         value[idx] = std::move(v);
+      }
+
+      // TODO handle elang list endings
+   }
+
+   template <opts Opts, class T, is_context Ctx, class It0, class It1>
+   GLZ_ALWAYS_INLINE void decode_sequence(T&& value, Ctx&& ctx, It0&& it, It1&& end)
+   {
+      int index{};
+      int type{};
+      int sz{};
+      if (ei_get_type(it, &index, &type, &sz) < 0) [[unlikely]] {
+         ctx.error = error_code::syntax_error;
+         return;
+      }
+
+      if (eetf::is_binary(type)) {
+         decode_binary<Opts>(std::forward<T>(value), static_cast<std::size_t>(sz), std::forward<Ctx>(ctx),
+                             std::forward<It0>(it), std::forward<It1>(end));
+      }
+      else if (eetf::is_list(type)) {
+         if (eetf::is_string(type)) {
+            std::string buff;
+            decode_token(buff, std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
+            if constexpr (resizable<T>) {
+               value.resize(sz);
+               if constexpr (Opts.shrink_to_fit) {
+                  value.shrink_to_fit();
+               }
+            }
+            else {
+               if (static_cast<std::size_t>(sz) > value.size()) {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
+            }
+            std::copy(buff.begin(), buff.end(), value.begin());
+         }
+         else {
+            decode_list<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<It0>(it),
+                              std::forward<It1>(end));
+         }
+      }
+      // else if tuple?
+      else {
+         ctx.error = error_code::elements_not_convertible_to_design;
+      }
+   }
+
+   template <class It>
+   GLZ_ALWAYS_INLINE auto decode_map_header(is_context auto&& ctx, It&& it)
+   {
+      int arity{};
+      int index{};
+      if (ei_decode_map_header(it, &index, &arity) < 0) [[unlikely]] {
+         ctx.error = error_code::syntax_error;
+         return std::pair<std::size_t, std::size_t>(-1ull, -1ull);
+      }
+
+      return std::pair<std::size_t, std::size_t>(static_cast<std::size_t>(arity), static_cast<std::size_t>(index));
+   }
+
+   template <class It>
+   GLZ_ALWAYS_INLINE auto decode_tuple_header(is_context auto&& ctx, It&& it)
+   {
+      int arity{};
+      int index{};
+      if (ei_decode_tuple_header(it, &index, &arity) < 0) [[unlikely]] {
+         ctx.error = error_code::syntax_error;
+         return std::pair<std::size_t, std::size_t>(-1ull, -1ull);
+      }
+
+      return std::pair<std::size_t, std::size_t>(static_cast<std::size_t>(arity), static_cast<std::size_t>(index));
+   }
+
+   template <class B, class IX>
+   GLZ_ALWAYS_INLINE void encode_version(is_context auto&& ctx, B&& b, IX&& ix)
+   {
+      int index{static_cast<int>(ix)};
+      if (ei_encode_version(b.data(), &index) < 0) [[unlikely]] {
+         ctx.error = error_code::unexpected_end;
+         return;
+      }
+
+      ix = index;
+   }
+
+   template <class... Args>
+   GLZ_ALWAYS_INLINE void encode_boolean(const bool value, Args&&... args)
+   {
+      using namespace std::placeholders;
+      detail::encode_impl(std::bind(ei_encode_boolean, _1, _2, value), std::forward<Args>(args)...);
+   }
+
+   template <class T, class... Args>
+   GLZ_ALWAYS_INLINE void encode_number(T&& value, Args&&... args)
+   {
+      using namespace std::placeholders;
+
+      using V = std::remove_cvref_t<T>;
+      if constexpr (detail::float_t<V>) {
+         detail::encode_impl(std::bind(ei_encode_double, _1, _2, value), std::forward<Args>(args)...);
+      }
+      else if constexpr (sizeof(T) > sizeof(long)) {
+         if constexpr (std::is_signed_v<V>) {
+            detail::encode_impl(std::bind(ei_encode_longlong, _1, _2, value), std::forward<Args>(args)...);
+         }
+         else {
+            detail::encode_impl(std::bind(ei_encode_ulonglong, _1, _2, value), std::forward<Args>(args)...);
+         }
+      }
+      else {
+         if constexpr (std::is_signed_v<V>) {
+            detail::encode_impl(std::bind(ei_encode_long, _1, _2, value), std::forward<Args>(args)...);
+         }
+         else {
+            detail::encode_impl(std::bind(ei_encode_ulong, _1, _2, value), std::forward<Args>(args)...);
+         }
+      }
+   }
+
+   template <class... Args>
+   GLZ_ALWAYS_INLINE void encode_atom(auto&& value, Args&&... args)
+   {
+      using namespace std::placeholders;
+      detail::encode_impl(std::bind(ei_encode_atom, _1, _2, value.data()), std::forward<Args>(args)...);
+   }
+
+   template <class... Args>
+   GLZ_ALWAYS_INLINE void encode_atom_len(auto&& value, std::size_t sz, Args&&... args)
+   {
+      using namespace std::placeholders;
+      detail::encode_impl(std::bind(ei_encode_atom_len, _1, _2, value.data(), static_cast<int>(sz)),
+                          std::forward<Args>(args)...);
+   }
+
+   template <class... Args>
+   GLZ_ALWAYS_INLINE void encode_string(auto&& value, Args&&... args)
+   {
+      using namespace std::placeholders;
+      detail::encode_impl(std::bind(ei_encode_string, _1, _2, value.data()), std::forward<Args>(args)...);
+   }
+
+   template <class... Args>
+   GLZ_ALWAYS_INLINE void encode_tuple_header(int arity, Args&&... args)
+   {
+      using namespace std::placeholders;
+      detail::encode_impl(std::bind(ei_encode_tuple_header, _1, _2, arity), std::forward<Args>(args)...);
+   }
+
+   template <class... Args>
+   GLZ_ALWAYS_INLINE void encode_list_header(std::size_t arity, Args&&... args)
+   {
+      using namespace std::placeholders;
+      detail::encode_impl(std::bind(ei_encode_list_header, _1, _2, static_cast<int>(arity)),
+                          std::forward<Args>(args)...);
+   }
+
+   template <class... Args>
+   GLZ_ALWAYS_INLINE void encode_list_tail(Args&&... args)
+   {
+      using namespace std::placeholders;
+      detail::encode_impl(std::bind(ei_encode_list_header, _1, _2, 0), std::forward<Args>(args)...);
+   }
+
+   template <class... Args>
+   GLZ_ALWAYS_INLINE void encode_map_header(std::size_t arity, Args&&... args)
+   {
+      using namespace std::placeholders;
+      detail::encode_impl(std::bind(ei_encode_map_header, _1, _2, static_cast<int>(arity)),
+                          std::forward<Args>(args)...);
+   }
+
+} // namespace glz

--- a/include/glaze/eetf/ei.hpp
+++ b/include/glaze/eetf/ei.hpp
@@ -96,8 +96,8 @@ namespace glz
       return type;
    }
 
-   template <class It>
-   auto skip_term(is_context auto&& ctx, It&& it)
+   template <class It0, class It1>
+   auto skip_term(is_context auto&& ctx, It0&& it, It1&& end)
    {
       int index{};
       if (ei_skip_term(it, &index) < 0) {
@@ -105,7 +105,8 @@ namespace glz
          index = 0;
       }
 
-      return it + index;
+      CHECK_OFFSET(index);
+      std::advance(it, index);
    }
 
    template <detail::num_t T, class... Args>

--- a/include/glaze/eetf/ei.hpp
+++ b/include/glaze/eetf/ei.hpp
@@ -263,7 +263,7 @@ namespace glz
       // TODO handle elang list endings
    }
 
-   template <opts Opts, class T, is_context Ctx, class It0, class It1>
+   template <auto Opts, class T, is_context Ctx, class It0, class It1>
    GLZ_ALWAYS_INLINE void decode_sequence(T&& value, Ctx&& ctx, It0&& it, It1&& end)
    {
       int index{};

--- a/include/glaze/eetf/ei.hpp
+++ b/include/glaze/eetf/ei.hpp
@@ -53,7 +53,7 @@ namespace glz
          }
 
          index = resize_buffer(b, ix, index);
-         if (func(b.data(), &index) < 0) {
+         if (func(reinterpret_cast<char*>(b.data()), &index) < 0) {
             ctx.error = error_code::seek_failure;
             return;
          }
@@ -114,7 +114,7 @@ namespace glz
    {
       using namespace std::placeholders;
       using V = std::remove_cvref_t<T>;
-      if constexpr (detail::float_t<T>) {
+      if constexpr (std::floating_point<std::remove_cvref_t<T>>) {
          double v;
          detail::decode_impl(std::bind(ei_decode_double, _1, _2, &v), std::forward<Args>(args)...);
          value = static_cast<std::remove_cvref_t<T>>(v);
@@ -329,7 +329,7 @@ namespace glz
    GLZ_ALWAYS_INLINE void encode_version(is_context auto&& ctx, B&& b, IX&& ix)
    {
       int index{static_cast<int>(ix)};
-      if (ei_encode_version(b.data(), &index) < 0) [[unlikely]] {
+      if (ei_encode_version(reinterpret_cast<char*>(b.data()), &index) < 0) [[unlikely]] {
          ctx.error = error_code::unexpected_end;
          return;
       }
@@ -350,7 +350,7 @@ namespace glz
       using namespace std::placeholders;
 
       using V = std::remove_cvref_t<T>;
-      if constexpr (detail::float_t<V>) {
+      if constexpr (std::floating_point<std::remove_cvref_t<T>>) {
          detail::encode_impl(std::bind(ei_encode_double, _1, _2, value), std::forward<Args>(args)...);
       }
       else if constexpr (sizeof(T) > sizeof(long)) {

--- a/include/glaze/eetf/opts.hpp
+++ b/include/glaze/eetf/opts.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <glaze/core/opts.hpp>
+
+namespace glz::eetf
+{
+
+   // layout erlang term
+   inline constexpr uint8_t map_layout = 0;
+   inline constexpr uint8_t proplist_layout = 1;
+
+   struct eetf_opts
+   {
+      uint32_t format;
+      uint8_t layout{map_layout};
+      bool error_on_unknown_keys{true};
+      bool shrink_to_fit{false};
+      uint32_t internal{};
+   };
+
+} // namespace glz::eetf

--- a/include/glaze/eetf/read.hpp
+++ b/include/glaze/eetf/read.hpp
@@ -9,340 +9,376 @@
 
 namespace glz
 {
-   template <opts Opts, bool Padded = false>
-      requires(has_format(Opts, ERLANG))
-   auto read_iterators(is_context auto&& ctx, contiguous auto&& buffer) noexcept
-   {
-      auto [s, e] = detail::read_iterators_impl<Padded>(buffer);
 
-      // decode version
-      decode_version(ctx, s);
-      return std::pair{s, e};
-   }
-
-   namespace detail
+   template <>
+   struct skip_value<ERLANG>
    {
-      template <>
-      struct skip_value<ERLANG>
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(is_context auto&& ctx, auto&& it, auto&& end) noexcept
       {
-         template <auto Opts>
-         GLZ_ALWAYS_INLINE static void op(is_context auto&& ctx, auto&& it, auto&& end) noexcept
-         {
-            skip_term(ctx, it, end);
+         skip_term(ctx, it, end);
+      }
+   };
+
+   template <>
+   struct parse<ERLANG>
+   {
+      template <auto Opts, class T, is_context Ctx, class It0, class It1>
+         requires(not has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
+      {
+         // TODO Check version
+         const auto version = decode_version(ctx, it);
+         if (version != 131) { // TODO find in erlang files
+            ctx.error = error_code::version_mismatch;
+            return;
          }
-      };
 
-      template <>
-      struct read<ERLANG>
+         if (it == end) {
+            ctx.error = error_code::unexpected_end;
+            return;
+         }
+
+         parse<Opts.format>::template op<no_header_on<Opts>()>(std::forward<T>(value), std::forward<Ctx>(ctx),
+                                                               std::forward<It0>(it), std::forward<It1>(end));
+      }
+
+      template <auto Opts, class T, is_context Ctx, class It0, class It1>
+         requires(has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
       {
-         template <auto Opts, class T, is_context Ctx, class It0, class It1>
-            requires(not has_no_header(Opts))
-         GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
-         {
-            if (bool(ctx.error)) {
-               return;
-            }
+         if (bool(ctx.error)) {
+            return;
+         }
 
-            if constexpr (std::is_const_v<std::remove_reference_t<T>>) {
-               if constexpr (Opts.error_on_const_read) {
-                  ctx.error = error_code::attempt_const_read;
-               }
-               else {
-                  // do not read anything into the const value
-                  skip_value<ERLANG>::op<Opts>(std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
-               }
+         if constexpr (std::is_const_v<std::remove_reference_t<T>>) {
+            if constexpr (Opts.error_on_const_read) {
+               ctx.error = error_code::attempt_const_read;
             }
             else {
-               from<ERLANG, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
-                                                                       std::forward<It0>(it), std::forward<It1>(end));
+               // do not read anything into the const value
+               skip_value<ERLANG>::op<Opts>(std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
             }
          }
-      };
-
-      template <readable_array_t T>
-      struct from<ERLANG, T> final
-      {
-         template <auto Opts, is_context Ctx, class It0, class It1>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
-         {
-            GLZ_END_CHECK();
-            decode_sequence<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<It0>(it),
-                                  std::forward<It1>(end));
+         else {
+            from<ERLANG, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+                                                                    std::forward<It0>(it), std::forward<It1>(end));
          }
-      };
+      }
+   };
 
-      template <boolean_like T>
-      struct from<ERLANG, T>
+   template <readable_array_t T>
+   struct from<ERLANG, T> final
+   {
+      template <auto Opts, is_context Ctx, class It0, class It1>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
       {
-         template <auto Opts, is_context Ctx, class It0, class It1>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
-         {
-            GLZ_END_CHECK();
-            decode_boolean(std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<It0>(it),
-                           std::forward<It1>(end));
+         decode_sequence<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<It0>(it),
+                               std::forward<It1>(end));
+      }
+   };
+
+   template <boolean_like T>
+   struct from<ERLANG, T>
+   {
+      template <auto Opts, is_context Ctx, class It0, class It1>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
+      {
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
          }
-      };
 
-      template <num_t T>
-      struct from<ERLANG, T> final
-      {
-         template <auto Opts, is_context Ctx, class It0, class It1>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
-         {
-            GLZ_END_CHECK();
-
-            decode_number(std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<It0>(it),
-                          std::forward<It1>(end));
+         if (it == end) {
+            return;
          }
-      };
 
-      template <atom_t T>
-      struct from<ERLANG, T> final
+         decode_boolean(std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
+      }
+   };
+
+   template <num_t T>
+   struct from<ERLANG, T> final
+   {
+      template <auto Opts, is_context Ctx, class It0, class It1>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
       {
-         template <auto Opts, is_context Ctx, class It0, class It1>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
-         {
-            GLZ_END_CHECK();
-
-            decode_token(std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
          }
-      };
 
-      template <str_t T>
-      struct from<ERLANG, T> final
-      {
-         template <auto Opts, is_context Ctx, class It0, class It1>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
-         {
-            GLZ_END_CHECK();
-
-            decode_token(std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
+         if (it == end) {
+            return;
          }
-      };
 
-      template <class T>
-         requires(tuple_t<T> || is_std_tuple<T>)
-      struct from<ERLANG, T> final
+         decode_number(std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
+      }
+   };
+
+   template <atom_t T>
+   struct from<ERLANG, T> final
+   {
+      template <auto Opts, is_context Ctx, class It0, class It1>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
       {
-         template <auto Opts>
-         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
-         {
-            GLZ_END_CHECK();
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
 
-            auto [fields_count, index] = decode_tuple_header(ctx, it);
+         value.clear();
+
+         if (it == end) {
+            return;
+         }
+
+         decode_token(std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
+      }
+   };
+
+   template <str_t T>
+   struct from<ERLANG, T> final
+   {
+      template <auto Opts, is_context Ctx, class It0, class It1>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
+      {
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+
+         value.clear();
+
+         if (it == end) {
+            return;
+         }
+
+         decode_token(std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
+      }
+   };
+
+   template <class T>
+      requires(tuple_t<T> || is_std_tuple<T>)
+   struct from<ERLANG, T> final
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+      {
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+
+         if (it == end) {
+            return;
+         }
+
+         auto [fields_count, index] = decode_tuple_header(ctx, it);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+
+         if (it + index > end) {
+            ctx.error = error_code::unexpected_end;
+            return;
+         }
+
+         it += index;
+
+         using V = std::decay_t<T>;
+         constexpr auto N = glz::tuple_size_v<V>;
+
+         if (fields_count != N) {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+
+         if constexpr (is_std_tuple<T>) {
+            invoke_table<N>([&]<size_t I>() { parse<ERLANG>::op<Opts>(std::get<I>(value), ctx, it, end); });
+         }
+         else {
+            invoke_table<N>([&]<size_t I>() { parse<ERLANG>::op<Opts>(glz::get<I>(value), ctx, it, end); });
+         }
+      }
+   };
+
+   template <class T>
+      requires glaze_object_t<T> || reflectable<T>
+   struct from<ERLANG, T> final
+   {
+      template <is_context Ctx, class It0, class It1>
+      class field_iterator
+      {
+        public:
+         template <typename F>
+         field_iterator(F&& f, Ctx&& ctx, It0&& it, It1&& end)
+         {
+            term_header = f(ctx, it);
             if (bool(ctx.error)) [[unlikely]] {
                return;
             }
 
-            if (it + index > end) {
-               ctx.error = error_code::unexpected_end;
-               return;
-            }
-
-            it += index;
-
-            using V = std::decay_t<T>;
-            constexpr auto N = glz::tuple_size_v<V>;
-
-            if (fields_count != N) {
-               ctx.error = error_code::syntax_error;
-               return;
-            }
-
-            if constexpr (is_std_tuple<T>) {
-               invoke_table<N>([&]<size_t I>() { read<ERLANG>::op<Opts>(std::get<I>(value), ctx, it, end); });
-            }
-            else {
-               invoke_table<N>([&]<size_t I>() { read<ERLANG>::op<Opts>(glz::get<I>(value), ctx, it, end); });
-            }
+            CHECK_OFFSET(term_header.second);
+            std::advance(it, term_header.second);
          }
+
+         field_iterator(error_code ec, Ctx&& ctx) : term_header{-1ull, -1ull} { ctx.error = ec; }
+
+         template <auto Opts>
+         bool next(Ctx&& ctx, It0&& it, It1&& end)
+         {
+            if (term_header.first == 0) {
+               return false;
+            }
+
+            if constexpr (Opts.layout == glz::proplist) {
+               const auto header = decode_tuple_header(ctx, it);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return false;
+               }
+
+               if (header.first != 2) [[unlikely]] {
+                  ctx.error = error_code::syntax_error;
+                  return false;
+               }
+
+               if ((it + header.second) > end) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return false;
+               }
+
+               std::advance(it, header.second);
+            }
+
+            term_header.first -= 1;
+            return true;
+         }
+
+         bool empty() const { return term_header.first == 0; }
+
+        private:
+         header_pair term_header;
       };
 
-      template <class T>
-         requires glaze_object_t<T> || reflectable<T>
-      struct from<ERLANG, T> final
+      template <auto Opts, is_context Ctx, class It0, class It1>
+      static auto make_term_iterator(Ctx&& ctx, It0&& it, It1&& end)
       {
-         template <is_context Ctx, class It0, class It1>
-         class field_iterator
-         {
-           public:
-            template <typename F>
-            field_iterator(F&& f, Ctx&& ctx, It0&& it, It1&& end)
-            {
-               term_header = f(ctx, it);
+         using fi = field_iterator<Ctx, It0, It1>;
+         const auto tag = get_type(ctx, it);
+         if (bool(ctx.error)) [[unlikely]] {
+            return fi(ctx.error, ctx);
+         }
+
+         if (eetf::is_map(tag) && Opts.layout == glz::map) {
+            return fi(decode_map_header<Ctx, It0>, ctx, it, end);
+         }
+         else if (eetf::is_list(tag) && Opts.layout == glz::proplist) {
+            return fi(decode_list_header<Ctx, It0>, ctx, it, end);
+         }
+
+         return fi(error_code::invalid_header, ctx);
+      }
+
+      template <opts Opts, is_context Ctx, class It0, class It1>
+      static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
+      {
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+
+         if (it == end) {
+            return;
+         }
+
+         auto term_it = make_term_iterator<Opts>(ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+
+         // empty term
+         if (term_it.empty()) [[unlikely]] {
+            return;
+         }
+
+         static constexpr auto N = reflect<T>::size;
+         while (term_it.template next<Opts>(ctx, it, end)) {
+            if constexpr (N > 0) {
+               static constexpr auto HashInfo = hash_info<T>;
+
+               // TODO this is only for erlmap with atom keys
+               eetf::atom mkey;
+               from<ERLANG, eetf::atom>::op<Opts>(mkey, ctx, it, end);
                if (bool(ctx.error)) [[unlikely]] {
                   return;
                }
 
-               CHECK_OFFSET(term_header.second);
-               std::advance(it, term_header.second);
-            }
+               const auto n = mkey.size();
+               const auto index =
+                  decode_hash_with_size<ERLANG, T, HashInfo, HashInfo.type>::op(mkey.data(), mkey.data() + n, n);
+               if (index < N) [[likely]] {
+                  const sv key{mkey.data(), n};
 
-            field_iterator(error_code ec, Ctx&& ctx) : term_header{-1ull, -1ull} { ctx.error = ec; }
-
-            template <auto Opts>
-            bool next(Ctx&& ctx, It0&& it, It1&& end)
-            {
-               if (term_header.first == 0) {
-                  return false;
-               }
-
-               if constexpr (Opts.layout == glz::proplist) {
-                  const auto header = decode_tuple_header(ctx, it);
-                  if (bool(ctx.error)) [[unlikely]] {
-                     return false;
-                  }
-
-                  if (header.first != 2) [[unlikely]] {
-                     ctx.error = error_code::syntax_error;
-                     return false;
-                  }
-
-                  if ((it + header.second) > end) [[unlikely]] {
-                     ctx.error = error_code::unexpected_end;
-                     return false;
-                  }
-
-                  std::advance(it, header.second);
-               }
-
-               term_header.first -= 1;
-               return true;
-            }
-
-            bool empty() const { return term_header.first == 0; }
-
-           private:
-            header_pair term_header;
-         };
-
-         template <auto Opts, is_context Ctx, class It0, class It1>
-         static auto make_term_iterator(Ctx&& ctx, It0&& it, It1&& end)
-         {
-            using fi = field_iterator<Ctx, It0, It1>;
-            const auto tag = get_type(ctx, it);
-            if (bool(ctx.error)) [[unlikely]] {
-               return fi(ctx.error, ctx);
-            }
-
-            if (eetf::is_map(tag) && Opts.layout == glz::map) {
-               return fi(decode_map_header<Ctx, It0>, ctx, it, end);
-            }
-            else if (eetf::is_list(tag) && Opts.layout == glz::proplist) {
-               return fi(decode_list_header<Ctx, It0>, ctx, it, end);
-            }
-
-            return fi(error_code::invalid_header, ctx);
-         }
-
-         template <opts Opts, is_context Ctx, class It0, class It1>
-         static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
-         {
-            GLZ_END_CHECK();
-
-            auto term_it = make_term_iterator<Opts>(ctx, it, end);
-            if (bool(ctx.error)) [[unlikely]] {
-               return;
-            }
-
-            // empty term
-            if (term_it.empty()) [[unlikely]] {
-               return;
-            }
-
-            static constexpr auto N = reflect<T>::size;
-            while (term_it.template next<Opts>(ctx, it, end)) {
-               if constexpr (N > 0) {
-                  static constexpr auto HashInfo = hash_info<T>;
-
-                  // TODO this is only for erlmap with atom keys
-                  eetf::atom mkey;
-                  from<ERLANG, eetf::atom>::op<Opts>(mkey, ctx, it, end);
-                  if (bool(ctx.error)) [[unlikely]] {
-                     return;
-                  }
-
-                  const auto n = mkey.size();
-                  const auto index =
-                     decode_hash_with_size<ERLANG, T, HashInfo, HashInfo.type>::op(mkey.data(), mkey.data() + n, n);
-                  if (index < N) [[likely]] {
-                     const sv key{mkey.data(), n};
-
-                     jump_table<N>(
-                        [&]<size_t I>() {
-                           static constexpr auto TargetKey = get<I>(reflect<T>::keys);
-                           static constexpr auto Length = TargetKey.size();
-                           if ((Length == n) && compare<Length>(TargetKey.data(), key.data())) [[likely]] {
-                              if constexpr (detail::reflectable<T>) {
-                                 read<ERLANG>::op<Opts>(get_member(value, get<I>(detail::to_tuple(value))), ctx, it,
-                                                        end);
-                              }
-                              else {
-                                 read<ERLANG>::op<Opts>(get_member(value, get<I>(reflect<T>::values)), ctx, it, end);
-                              }
+                  jump_table<N>(
+                     [&]<size_t I>() {
+                        static constexpr auto TargetKey = get<I>(reflect<T>::keys);
+                        static constexpr auto Length = TargetKey.size();
+                        if ((Length == n) && compare<Length>(TargetKey.data(), key.data())) [[likely]] {
+                           if constexpr (reflectable<T>) {
+                              parse<ERLANG>::op<Opts>(get_member(value, get<I>(to_tie(value))), ctx, it, end);
                            }
                            else {
-                              if constexpr (Opts.error_on_unknown_keys) {
-                                 ctx.error = error_code::unknown_key;
-                                 return;
-                              }
-                              else {
-                                 skip_value<ERLANG>::op<Opts>(ctx, it, end);
-                                 if (bool(ctx.error)) [[unlikely]]
-                                    return;
-                              }
+                              parse<ERLANG>::op<Opts>(get_member(value, get<I>(reflect<T>::values)), ctx, it, end);
                            }
-                        },
-                        index);
+                        }
+                        else {
+                           if constexpr (Opts.error_on_unknown_keys) {
+                              ctx.error = error_code::unknown_key;
+                              return;
+                           }
+                           else {
+                              skip_value<ERLANG>::op<Opts>(ctx, it, end);
+                              if (bool(ctx.error)) [[unlikely]]
+                                 return;
+                           }
+                        }
+                     },
+                     index);
 
-                     if (bool(ctx.error)) [[unlikely]] {
-                        return;
-                     }
-                  }
-                  else [[unlikely]] {
-                     if constexpr (Opts.error_on_unknown_keys) {
-                        ctx.error = error_code::unknown_key;
-                        return;
-                     }
-                     else {
-                        skip_value<ERLANG>::op<Opts>(ctx, it, end);
-                        if (bool(ctx.error)) [[unlikely]]
-                           return;
-                     }
-                  }
-               }
-               else if constexpr (Opts.error_on_unknown_keys) {
-                  ctx.error = error_code::unknown_key;
-                  return;
-               }
-               else {
-                  skip_value<ERLANG>::op<Opts>(ctx, it, end);
                   if (bool(ctx.error)) [[unlikely]] {
                      return;
                   }
                }
+               else [[unlikely]] {
+                  if constexpr (Opts.error_on_unknown_keys) {
+                     ctx.error = error_code::unknown_key;
+                     return;
+                  }
+                  else {
+                     skip_value<ERLANG>::op<Opts>(ctx, it, end);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                  }
+               }
+            }
+            else if constexpr (Opts.error_on_unknown_keys) {
+               ctx.error = error_code::unknown_key;
+               return;
+            }
+            else {
+               skip_value<ERLANG>::op<Opts>(ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
             }
          }
-      };
-
-   } // namespace detail
-
-   template <class T>
-   concept read_eetf_supported = requires { detail::from<ERLANG, std::remove_cvref_t<T>>{}; };
-
-   template <class T>
-   struct read_format_supported<ERLANG, T>
-   {
-      static constexpr auto value = read_eetf_supported<T>;
+      }
    };
 
-   template <uint32_t layout = glz::map, read_eetf_supported T, class Buffer>
+   template <uint32_t layout = glz::map, class T, class Buffer>
+      requires(read_supported<ERLANG, T>)
    [[nodiscard]] inline error_ctx read_term(T&& value, Buffer&& buffer) noexcept
    {
       return read<opts{.format = ERLANG, .layout = layout}>(value, std::forward<Buffer>(buffer));
    }
 
-   template <uint32_t layout = glz::map, read_eetf_supported T, is_buffer Buffer>
+   template <uint32_t layout = glz::map, class T, is_buffer Buffer>
+      requires(read_supported<ERLANG, T>)
    [[nodiscard]] expected<T, error_ctx> read_term(Buffer&& buffer) noexcept
    {
       T value{};

--- a/include/glaze/eetf/read.hpp
+++ b/include/glaze/eetf/read.hpp
@@ -1,0 +1,313 @@
+#pragma once
+
+#include <glaze/core/opts.hpp>
+#include <glaze/core/read.hpp>
+#include <glaze/core/reflect.hpp>
+
+#include "defs.hpp"
+#include "ei.hpp"
+
+namespace glz
+{
+   template <opts Opts, bool Padded = false>
+      requires(has_format(Opts, ERLANG))
+   auto read_iterators(is_context auto&& ctx, contiguous auto&& buffer) noexcept
+   {
+      auto [s, e] = detail::read_iterators_impl<Padded>(buffer);
+
+      // decode version
+      decode_version(ctx, s);
+      return std::pair{s, e};
+   }
+
+   namespace detail
+   {
+      // TODO skip value
+      template <>
+      struct skip_value<ERLANG>
+      {
+         template <auto Opts>
+         GLZ_ALWAYS_INLINE static void op(is_context auto&& /* ctx */, auto&& /* it */, auto&& /* end */) noexcept
+         {}
+      };
+
+      template <>
+      struct read<ERLANG>
+      {
+         template <auto Opts, class T, is_context Ctx, class It0, class It1>
+            requires(not has_no_header(Opts))
+         GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
+         {
+            if (bool(ctx.error)) {
+               return;
+            }
+
+            if constexpr (std::is_const_v<std::remove_reference_t<T>>) {
+               if constexpr (Opts.error_on_const_read) {
+                  ctx.error = error_code::attempt_const_read;
+               }
+               else {
+                  // do not read anything into the const value
+                  skip_value<ERLANG>::op<Opts>(std::forward<Ctx>(ctx), std::forward<It0>(it), std::forward<It1>(end));
+               }
+            }
+            else {
+               from<ERLANG, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+                                                                       std::forward<It0>(it), std::forward<It1>(end));
+            }
+         }
+      };
+
+      template <readable_array_t T>
+      struct from<ERLANG, T> final
+      {
+         template <auto Opts, is_context Ctx, class It0, class It1>
+         GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
+         {
+            GLZ_END_CHECK();
+            decode_sequence<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<It0>(it),
+                                           std::forward<It1>(end));
+         }
+      };
+
+      template <boolean_like T>
+      struct from<ERLANG, T>
+      {
+         template <auto Opts, is_context Ctx, class It0, class It1>
+         GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
+         {
+            GLZ_END_CHECK();
+            decode_boolean(std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<It0>(it),
+                                    std::forward<It1>(end));
+         }
+      };
+
+      template <num_t T>
+      struct from<ERLANG, T> final
+      {
+         template <auto Opts, is_context Ctx, class It0, class It1>
+         GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
+         {
+            GLZ_END_CHECK();
+
+            decode_number(std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<It0>(it),
+                                   std::forward<It1>(end));
+         }
+      };
+
+      template <atom_t T>
+      struct from<ERLANG, T> final
+      {
+         template <auto Opts, is_context Ctx, class It0, class It1>
+         GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
+         {
+            GLZ_END_CHECK();
+
+            decode_token(std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<It0>(it),
+                                  std::forward<It1>(end));
+         }
+      };
+
+      template <str_t T>
+      struct from<ERLANG, T> final
+      {
+         template <auto Opts, is_context Ctx, class It0, class It1>
+         GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
+         {
+            GLZ_END_CHECK();
+
+            decode_token(std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<It0>(it),
+                                  std::forward<It1>(end));
+         }
+      };
+
+      template <class T>
+         requires(tuple_t<T> || is_std_tuple<T>)
+      struct from<ERLANG, T> final
+      {
+         template <auto Opts>
+         static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
+         {
+            GLZ_END_CHECK();
+
+            auto [fields_count, index] = decode_tuple_header(ctx, it);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+
+            if (it + index > end) {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+
+            it += index;
+
+            using V = std::decay_t<T>;
+            constexpr auto N = glz::tuple_size_v<V>;
+
+            if (fields_count != N) {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+
+            if constexpr (is_std_tuple<T>) {
+               invoke_table<N>([&]<size_t I>() { read<ERLANG>::op<Opts>(std::get<I>(value), ctx, it, end); });
+            }
+            else {
+               invoke_table<N>([&]<size_t I>() { read<ERLANG>::op<Opts>(glz::get<I>(value), ctx, it, end); });
+            }
+         }
+      };
+
+      template <class T>
+         requires glaze_object_t<T> || reflectable<T>
+      struct from<ERLANG, T> final
+      {
+         template <auto Opts, is_context Ctx, class It0, class It1>
+         static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
+         {
+            GLZ_END_CHECK();
+
+            const auto tag = get_type(ctx, it);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+
+            static constexpr auto N = reflect<T>::size;
+
+            std::size_t fields_count{0};
+            if (eetf::is_map(tag)) [[likely]] {
+               [[maybe_unused]] auto [arity, idx] = decode_map_header(std::forward<Ctx>(ctx), it);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+
+               if (it + idx > end) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
+
+               it += idx;
+               fields_count = arity;
+            }
+            else if (eetf::is_tuple(tag)) {
+               // parse tuple
+            }
+            else if (eetf::is_list(tag)) {
+               // parse list
+            }
+            else [[unlikely]] {
+               // error
+               ctx.error = error_code::elements_not_convertible_to_design;
+               return;
+            }
+
+            // empty term
+            if (fields_count == 0) {
+               return;
+            }
+
+            for (size_t i = 0; i < fields_count; ++i) {
+               if constexpr (N > 0) {
+                  static constexpr auto HashInfo = hash_info<T>;
+
+                  // TODO this is only for erlmap + atom keys
+                  eetf::atom mkey;
+                  from<ERLANG, eetf::atom>::op<Opts>(mkey, ctx, it, end);
+                  if (bool(ctx.error)) [[unlikely]] {
+                     return;
+                  }
+
+                  const auto n = mkey.size();
+                  const auto index = decode_hash_with_size<ERLANG, T, HashInfo, HashInfo.type>::op(mkey.data(), end, n);
+                  if (index < N) [[likely]] {
+                     const sv key{mkey.data(), n};
+
+                     jump_table<N>(
+                        [&]<size_t I>() {
+                           static constexpr auto TargetKey = get<I>(reflect<T>::keys);
+                           static constexpr auto Length = TargetKey.size();
+                           if ((Length == n) && compare<Length>(TargetKey.data(), key.data())) [[likely]] {
+                              if constexpr (detail::reflectable<T>) {
+                                 read<ERLANG>::op<Opts>(get_member(value, get<I>(detail::to_tuple(value))), ctx, it,
+                                                        end);
+                              }
+                              else {
+                                 read<ERLANG>::op<Opts>(get_member(value, get<I>(reflect<T>::values)), ctx, it, end);
+                              }
+                           }
+                           else {
+                              if constexpr (Opts.error_on_unknown_keys) {
+                                 ctx.error = error_code::unknown_key;
+                                 return;
+                              }
+                              else {
+                                 skip_value<ERLANG>::op<Opts>(ctx, it, end);
+                                 if (bool(ctx.error)) [[unlikely]]
+                                    return;
+                              }
+                           }
+                        },
+                        index);
+
+                     if (bool(ctx.error)) [[unlikely]] {
+                        return;
+                     }
+                  }
+                  else [[unlikely]] {
+                     if constexpr (Opts.error_on_unknown_keys) {
+                        ctx.error = error_code::unknown_key;
+                        return;
+                     }
+                     else {
+                        it += n;
+                        skip_value<ERLANG>::op<Opts>(ctx, it, end);
+                        if (bool(ctx.error)) [[unlikely]]
+                           return;
+                     }
+                  }
+               }
+               else if constexpr (Opts.error_on_unknown_keys) {
+                  ctx.error = error_code::unknown_key;
+                  return;
+               }
+               else {
+                  skip_value<ERLANG>::op<Opts>(ctx, it, end);
+                  if (bool(ctx.error)) [[unlikely]] {
+                     return;
+                  }
+               }
+            }
+         }
+      };
+
+   } // namespace detail
+
+   template <class T>
+   concept read_eetf_supported = requires { detail::from<ERLANG, std::remove_cvref_t<T>>{}; };
+
+   template <class T>
+   struct read_format_supported<ERLANG, T>
+   {
+      static constexpr auto value = read_eetf_supported<T>;
+   };
+
+   template <read_eetf_supported T, class Buffer>
+   [[nodiscard]] inline error_ctx read_term(T&& value, Buffer&& buffer) noexcept
+   {
+      return read<opts{.format = ERLANG}>(value, std::forward<Buffer>(buffer));
+   }
+
+   template <read_eetf_supported T, is_buffer Buffer>
+   [[nodiscard]] expected<T, error_ctx> read_term(Buffer&& buffer) noexcept
+   {
+      T value{};
+      context ctx{};
+      const error_ctx ec = read<opts{.format = ERLANG}>(value, std::forward<Buffer>(buffer), ctx);
+      if (ec) {
+         return unexpected<error_ctx>(ec);
+      }
+      return value;
+   }
+
+} // namespace glz

--- a/include/glaze/eetf/read.hpp
+++ b/include/glaze/eetf/read.hpp
@@ -301,7 +301,6 @@ namespace glz
             if constexpr (N > 0) {
                static constexpr auto HashInfo = hash_info<T>;
 
-               // TODO this is only for erlmap with atom keys
                eetf::atom mkey;
                from<ERLANG, eetf::atom>::op<Opts>(mkey, ctx, it, end);
                if (bool(ctx.error)) [[unlikely]] {

--- a/include/glaze/eetf/types.hpp
+++ b/include/glaze/eetf/types.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <ei.h>
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+#include "cmp.hpp"
+
+namespace glz::eetf
+{
+   struct tag_atom
+   {};
+
+   struct tag_string
+   {};
+
+   template <typename Tag>
+   struct tagged_string : std::string
+   {
+      using tag = Tag;
+   };
+
+   using atom = tagged_string<tag_atom>;
+   constexpr atom operator""_atom(const char* str, std::size_t sz)
+   {
+      // TODO check if valid atom
+      return atom(std::string(str, sz));
+   }
+
+   template <typename Tag>
+   [[nodiscard]] constexpr bool is_atom(const Tag& tag)
+   {
+      return cmp::is<in, ERL_ATOM_EXT, ERL_SMALL_ATOM_EXT, ERL_ATOM_UTF8_EXT, ERL_SMALL_ATOM_UTF8_EXT>(tag);
+   }
+
+   template <typename Tag>
+   [[nodiscard]] constexpr bool is_integer(const Tag& tag)
+   {
+      return cmp::is<in, ERL_INTEGER_EXT, ERL_SMALL_INTEGER_EXT, ERL_SMALL_BIG_EXT, ERL_LARGE_BIG_EXT>(tag);
+   }
+
+   template <typename Tag>
+   [[nodiscard]] constexpr bool is_floating_point(const Tag& tag)
+   {
+      return cmp::is<in, ERL_FLOAT_EXT, NEW_FLOAT_EXT>(tag);
+   }
+
+   template <typename Tag>
+   [[nodiscard]] constexpr bool is_string(const Tag& tag)
+   {
+      return cmp::is<in, ERL_STRING_EXT, ERL_NIL_EXT>(tag);
+   }
+
+   template <typename Tag>
+   [[nodiscard]] constexpr bool is_tuple(const Tag& tag)
+   {
+      return cmp::is<in, ERL_SMALL_TUPLE_EXT, ERL_LARGE_TUPLE_EXT>(tag);
+   }
+
+   template <typename Tag>
+   [[nodiscard]] constexpr bool is_list(const Tag& tag)
+   {
+      return cmp::is<in, ERL_LIST_EXT, ERL_STRING_EXT, ERL_NIL_EXT>(tag);
+   }
+
+   template <typename Tag>
+   [[nodiscard]] constexpr bool is_map(const Tag& tag)
+   {
+      return cmp::is<in, ERL_MAP_EXT>(tag);
+   }
+
+   template <typename Tag>
+   [[nodiscard]] constexpr bool is_binary(const Tag& tag)
+   {
+      return cmp::is<in, ERL_BINARY_EXT>(tag);
+   }
+
+} // namespace glz::eetf

--- a/include/glaze/eetf/wrappers.hpp
+++ b/include/glaze/eetf/wrappers.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+namespace glz::detail
+{
+   template <class T>
+   struct string_as_atom_t
+   {
+      T& val;
+   };
+
+   // Read and write string as atoms
+
+   template <class T>
+   struct from<ERLANG, string_as_atom_t<T>>
+   {
+      template <auto Opts>
+      static void op(auto&& value, auto&&... args)
+      {
+         eetf::atom a;
+         read<ERLANG>::op<Opts>(a, args...);
+         value.val = a;
+      }
+   };
+
+   template <class T>
+   struct to<ERLANG, string_as_atom_t<T>>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
+      {
+         write<ERLANG>::op<Opts>(eetf::atom{value.val}, ctx, args...);
+      }
+   };
+
+   template <auto MemPtr>
+   constexpr decltype(auto) string_as_atom()
+   {
+      return [](auto&& val) { return string_as_atom_t<std::decay_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
+   }
+}

--- a/include/glaze/eetf/wrappers.hpp
+++ b/include/glaze/eetf/wrappers.hpp
@@ -1,29 +1,53 @@
 #pragma once
 
-#include "glaze/core/wrappers.hpp"
+#include <glaze/core/wrappers.hpp>
+
+#include "opts.hpp"
+#include "read.hpp"
+#include "types.hpp"
+#include "write.hpp"
 
 namespace glz
 {
-   // template <is_opts_wrapper T>
-   // struct from<ERLANG, T>
-   // {
-   //    template <auto Opts>
-   //    GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args)
-   //    {
-   //       parse<ERLANG>::op<opt_true<Opts, T::opts_bit>>(value.val, args...);
-   //    }
-   // };
+   template <class T>
+   struct atom_as_string_t
+   {
+      static constexpr bool glaze_wrapper = true;
+      using value_type = T;
+      T& val;
+   };
 
-   // template <is_opts_wrapper T>
-   // struct to<ERLANG, T>
-   // {
-   //    template <auto Opts>
-   //    GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args)
-   //    {
-   //       serialize<ERLANG>::op<opt_true<Opts, T::opts_bit>>(value.val, ctx, args...);
-   //    }
-   // };
+   template <class T>
+   struct from<ERLANG, atom_as_string_t<T>>
+   {
+      template <auto Opts>
+      static void op(auto&& value, auto&&... args)
+      {
+         static thread_local eetf::atom a{};
+         parse<ERLANG>::op<Opts>(a, args...);
+         value.val = a;
+      }
+   };
 
-   // template <auto MemPtr>
-   // constexpr auto atom_as_string = opts_wrapper<MemPtr, option::atom_as_string>();
+   template <class T>
+   struct to<ERLANG, atom_as_string_t<T>>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
+      {
+         static thread_local eetf::atom s(value.val);
+         using S = core_t<decltype(s)>;
+         to<ERLANG, S>::template op<Opts>(s, ctx, b, ix);
+      }
+   };
+
+   template <auto MemPtr>
+   inline constexpr decltype(auto) aas_impl() noexcept
+   {
+      return [](auto&& val) { return atom_as_string_t<std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
+   }
+
+   // Read and write atoms as string
+   template <auto MemPtr>
+   constexpr auto atom_as_string = aas_impl<MemPtr>();
 }

--- a/include/glaze/eetf/wrappers.hpp
+++ b/include/glaze/eetf/wrappers.hpp
@@ -1,40 +1,29 @@
 #pragma once
 
-namespace glz::detail
+#include "glaze/core/wrappers.hpp"
+
+namespace glz
 {
-   template <class T>
-   struct string_as_atom_t
-   {
-      T& val;
-   };
+   // template <is_opts_wrapper T>
+   // struct from<ERLANG, T>
+   // {
+   //    template <auto Opts>
+   //    GLZ_ALWAYS_INLINE static void op(auto&& value, auto&&... args)
+   //    {
+   //       parse<ERLANG>::op<opt_true<Opts, T::opts_bit>>(value.val, args...);
+   //    }
+   // };
 
-   // Read and write string as atoms
+   // template <is_opts_wrapper T>
+   // struct to<ERLANG, T>
+   // {
+   //    template <auto Opts>
+   //    GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args)
+   //    {
+   //       serialize<ERLANG>::op<opt_true<Opts, T::opts_bit>>(value.val, ctx, args...);
+   //    }
+   // };
 
-   template <class T>
-   struct from<ERLANG, string_as_atom_t<T>>
-   {
-      template <auto Opts>
-      static void op(auto&& value, auto&&... args)
-      {
-         eetf::atom a;
-         read<ERLANG>::op<Opts>(a, args...);
-         value.val = a;
-      }
-   };
-
-   template <class T>
-   struct to<ERLANG, string_as_atom_t<T>>
-   {
-      template <auto Opts>
-      static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
-      {
-         write<ERLANG>::op<Opts>(eetf::atom{value.val}, ctx, args...);
-      }
-   };
-
-   template <auto MemPtr>
-   constexpr decltype(auto) string_as_atom()
-   {
-      return [](auto&& val) { return string_as_atom_t<std::decay_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
-   }
+   // template <auto MemPtr>
+   // constexpr auto atom_as_string = opts_wrapper<MemPtr, option::atom_as_string>();
 }

--- a/include/glaze/eetf/write.hpp
+++ b/include/glaze/eetf/write.hpp
@@ -1,15 +1,237 @@
 #pragma once
 
-// namespace glz
-// {
+#include <glaze/core/opts.hpp>
+#include <glaze/core/reflect.hpp>
+#include <glaze/core/write.hpp>
 
-// template <class T>
-// concept write_term_supported = requires { detail::to<ERLANG, std::remove_cvref_t<T>>{}; };
+#include "defs.hpp"
+#include "ei.hpp"
 
-// template <class T>
-// struct write_format_supported<erlterm::ERLANG, T>
-// {
-// 	static const auto value = write_term_supported<T>;
-// };
+namespace glz
+{
 
-// } // namespace glz
+   namespace detail
+   {
+
+      template <>
+      struct write<ERLANG>
+      {
+         //  class T, is_context Ctx, output_buffer B, class IX
+         template <auto Opts, class T, class... Args>
+            requires(has_no_header(Opts))
+         GLZ_ALWAYS_INLINE static void op(T&& value, Args&&... args) noexcept
+         {
+            to<ERLANG, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Args>(args)...);
+         }
+
+         template <auto Opts, class T, is_context Ctx, output_buffer B, class IX>
+            requires(not has_no_header(Opts))
+         GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix) noexcept
+         {
+            encode_version(ctx, b, ix);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+
+            using V = std::remove_cvref_t<T>;
+            to<ERLANG, V>::template op<no_header_on<Opts>()>(std::forward<V>(value), std::forward<Ctx>(ctx),
+                                                             std::forward<B>(b), std::forward<IX>(ix));
+         }
+      };
+
+      template <boolean_like T>
+      struct to<ERLANG, T>
+      {
+         template <auto Opts, class... Args>
+         GLZ_ALWAYS_INLINE static void op(const bool value, Args&&... args) noexcept
+         {
+            encode_boolean(value, std::forward<Args>(args)...);
+         }
+      };
+
+      template <num_t T>
+      struct to<ERLANG, T> final
+      {
+         template <auto Opts, class... Args>
+         GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args) noexcept
+         {
+            encode_number(value, std::forward<Args>(args)...);
+         }
+      };
+
+      template <atom_t T>
+      struct to<ERLANG, T> final
+      {
+         template <auto Opts, class... Args>
+         GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args) noexcept
+         {
+            encode_atom(value, std::forward<Args>(args)...);
+         }
+      };
+
+      // using for write reflectable map keys
+      template <str_t T>
+      struct to<ERLANG, T> final
+      {
+         template <auto Opts, class... Args>
+         GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args) noexcept
+         {
+            encode_atom_len(value, value.size(), std::forward<Args>(args)...);
+         }
+      };
+
+      template <string_t T>
+      struct to<ERLANG, T> final
+      {
+         template <auto Opts, class... Args>
+         GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args) noexcept
+         {
+            encode_string(value, std::forward<Args>(args)...);
+         }
+      };
+
+      template <class T>
+         requires(tuple_t<T> || is_std_tuple<T>)
+      struct to<ERLANG, T> final
+      {
+         template <auto Opts, is_context Ctx, class... Args>
+         GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, Args&&... args) noexcept
+         {
+            static constexpr auto N = glz::tuple_size_v<T>;
+
+            encode_tuple_header(N, ctx, std::forward<Args>(args)...);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+
+            if constexpr (is_std_tuple<T>) {
+               [&]<size_t... I>(std::index_sequence<I...>) {
+                  (write<ERLANG>::op<Opts>(std::get<I>(value), ctx, args...), ...);
+               }(std::make_index_sequence<N>{});
+            }
+            else {
+               [&]<size_t... I>(std::index_sequence<I...>) {
+                  (write<ERLANG>::op<Opts>(glz::get<I>(value), ctx, args...), ...);
+               }(std::make_index_sequence<N>{});
+            }
+         }
+      };
+
+      template <writable_array_t T>
+      struct to<ERLANG, T> final
+      {
+         template <auto Opts, is_context Ctx, class... Args>
+         GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, Args&&... args) noexcept
+         {
+            const auto n = value.size();
+            encode_list_header(n, ctx, std::forward<Args>(args)...);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+
+            for (auto& i : value) {
+               write<ERLANG>::op<Opts>(i, ctx, args...);
+            }
+
+            encode_list_tail(ctx, std::forward<Args>(args)...);
+         }
+      };
+
+      template <writable_map_t T>
+      struct to<ERLANG, T> final
+      {
+         template <auto Opts, is_context Ctx, class... Args>
+         GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, Args&&... args) noexcept
+         {
+            const auto n = value.size();
+            encode_map_header(n, ctx, std::forward<Args>(args)...);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+
+            for (auto&& [k, v] : value) {
+               write<ERLANG>::op<Opts>(k, ctx, args...);
+               write<ERLANG>::op<Opts>(v, ctx, args...);
+            }
+         }
+      };
+
+      template <reflectable T>
+      struct to<ERLANG, T> final
+      {
+         template <auto Opts, is_context Ctx, class... Args>
+         GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, Args&&... args) noexcept
+         {
+            static constexpr auto N = reflect<T>::size;
+            [[maybe_unused]] decltype(auto) t = [&]() -> decltype(auto) {
+               if constexpr (reflectable<T>) {
+                  return to_tuple(value);
+               }
+               else {
+                  return nullptr;
+               }
+            }();
+
+            encode_map_header(N, ctx, std::forward<Args>(args)...);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+
+            invoke_table<N>([&]<size_t I>() {
+               static constexpr sv key = reflect<T>::keys[I];
+               write<ERLANG>::op<Opts>(key, ctx, args...);
+
+               decltype(auto) member = [&]() -> decltype(auto) {
+                  if constexpr (reflectable<T>) {
+                     return get<I>(t);
+                  }
+                  else {
+                     return get<I>(reflect<T>::values);
+                  }
+               }();
+
+               write<ERLANG>::op<Opts>(get_member(value, member), ctx, args...);
+            });
+         }
+      };
+
+      template <class T>
+      struct to<ERLANG, T> final
+      {
+         // template <auto Opts, is_context Ctx, output_buffer B>
+         // GLZ_ALWAYS_INLINE static void op(T && /* value */, Ctx && /* ctx */, B && /* b */) noexcept
+         // {
+         // 	// std::cerr << "here\n";
+         // }
+      };
+
+   } // namespace detail
+
+   template <class T>
+   concept write_term_supported = requires { detail::to<ERLANG, std::remove_cvref_t<T>>{}; };
+
+   template <class T>
+   struct write_format_supported<ERLANG, T>
+   {
+      static const auto value = write_term_supported<T>;
+   };
+
+   template <write_term_supported T, output_buffer Buffer>
+   [[nodiscard]] error_ctx write_term(T&& value, Buffer&& buffer) noexcept
+   {
+      return write<opts{.format = ERLANG}>(std::forward<T>(value), std::forward<Buffer>(buffer));
+   }
+
+   template <write_term_supported T, raw_buffer Buffer>
+   [[nodiscard]] expected<size_t, error_ctx> write_term(T&& value, Buffer&& buffer) noexcept
+   {
+      return write<opts{.format = ERLANG}>(std::forward<T>(value), std::forward<Buffer>(buffer));
+   }
+
+   template <write_term_supported T>
+   [[nodiscard]] expected<std::string, error_ctx> write_term(T&& value) noexcept
+   {
+      return write<opts{.format = ERLANG}>(std::forward<T>(value));
+   }
+
+} // namespace glz

--- a/include/glaze/eetf/write.hpp
+++ b/include/glaze/eetf/write.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+// namespace glz
+// {
+
+// template <class T>
+// concept write_term_supported = requires { detail::to<ERLANG, std::remove_cvref_t<T>>{}; };
+
+// template <class T>
+// struct write_format_supported<erlterm::ERLANG, T>
+// {
+// 	static const auto value = write_term_supported<T>;
+// };
+
+// } // namespace glz

--- a/include/glaze/eetf/write.hpp
+++ b/include/glaze/eetf/write.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <glaze/core/opts.hpp>
 #include <glaze/core/reflect.hpp>
 #include <glaze/core/write.hpp>
 
 #include "defs.hpp"
 #include "ei.hpp"
+#include "opts.hpp"
 
 namespace glz
 {
@@ -224,7 +224,7 @@ namespace glz
 
       template <auto Opts, class... Args>
          requires(has_no_header(Opts))
-      GLZ_ALWAYS_INLINE static void op(auto&& value, [[maybe_unused]]is_context auto&& ctx, Args&&... args) noexcept
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
       {
          static constexpr auto N = reflect<T>::size;
          [[maybe_unused]] decltype(auto) t = [&]() -> decltype(auto) {
@@ -268,25 +268,27 @@ namespace glz
       // empty for compilation error if use unsupported value type
    };
 
-   template <uint32_t layout = glz::map, class T, output_buffer Buffer>
+   template <uint8_t layout = glz::eetf::map_layout, class T, output_buffer Buffer>
       requires(write_supported<ERLANG, T>)
    [[nodiscard]] error_ctx write_term(T&& value, Buffer&& buffer) noexcept
    {
-      return write<opts{.format = ERLANG, .layout = layout}>(std::forward<T>(value), std::forward<Buffer>(buffer));
+      return write<eetf::eetf_opts{.format = ERLANG, .layout = layout}>(std::forward<T>(value),
+                                                                        std::forward<Buffer>(buffer));
    }
 
-   template <uint32_t layout = glz::map, class T, raw_buffer Buffer>
+   template <uint8_t layout = glz::eetf::map_layout, class T, raw_buffer Buffer>
       requires(write_supported<ERLANG, T>)
    [[nodiscard]] expected<size_t, error_ctx> write_term(T&& value, Buffer&& buffer) noexcept
    {
-      return write<opts{.format = ERLANG, .layout = layout}>(std::forward<T>(value), std::forward<Buffer>(buffer));
+      return write<eetf::eetf_opts{.format = ERLANG, .layout = layout}>(std::forward<T>(value),
+                                                                        std::forward<Buffer>(buffer));
    }
 
    template <class T>
       requires(write_supported<ERLANG, T>)
    [[nodiscard]] expected<std::string, error_ctx> write_term(T&& value) noexcept
    {
-      return write<opts{.format = ERLANG}>(std::forward<T>(value));
+      return write<eetf::eetf_opts{.format = ERLANG}>(std::forward<T>(value));
    }
 
 } // namespace glz

--- a/include/glaze/eetf/write.hpp
+++ b/include/glaze/eetf/write.hpp
@@ -10,225 +10,280 @@
 namespace glz
 {
 
-   namespace detail
+   template <>
+   struct serialize<ERLANG>
    {
-
-      template <>
-      struct write<ERLANG>
+      template <auto Opts, class T, class... Args>
+         requires(has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(T&& value, Args&&... args) noexcept
       {
-         //  class T, is_context Ctx, output_buffer B, class IX
-         template <auto Opts, class T, class... Args>
-            requires(has_no_header(Opts))
-         GLZ_ALWAYS_INLINE static void op(T&& value, Args&&... args) noexcept
-         {
-            to<ERLANG, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Args>(args)...);
+         to<ERLANG, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Args>(args)...);
+      }
+   };
+
+   template <boolean_like T>
+   struct to<ERLANG, T>
+   {
+      template <auto Opts, class V, class... Args>
+         requires(not has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(V&& v, Args... args) noexcept
+      {
+         encode_version(std::forward<Args>(args)...);
+         op<no_header_on<Opts>()>(std::forward<V>(v), std::forward<Args>(args)...);
+      }
+
+      template <auto Opts, class... Args>
+         requires(has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(const bool value, Args&&... args) noexcept
+      {
+         encode_boolean(value, std::forward<Args>(args)...);
+      }
+   };
+
+   template <num_t T>
+   struct to<ERLANG, T> final
+   {
+      template <auto Opts, class V, class... Args>
+         requires(not has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(V&& v, Args... args) noexcept
+      {
+         encode_version(std::forward<Args>(args)...);
+         op<no_header_on<Opts>()>(std::forward<V>(v), std::forward<Args>(args)...);
+      }
+
+      template <auto Opts, class... Args>
+         requires(has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args) noexcept
+      {
+         encode_number(value, std::forward<Args>(args)...);
+      }
+   };
+
+   template <atom_t T>
+   struct to<ERLANG, T> final
+   {
+      template <auto Opts, class V, class... Args>
+         requires(not has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(V&& v, Args... args) noexcept
+      {
+         encode_version(std::forward<Args>(args)...);
+         op<no_header_on<Opts>()>(std::forward<V>(v), std::forward<Args>(args)...);
+      }
+
+      template <auto Opts, class... Args>
+         requires(has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args) noexcept
+      {
+         encode_atom(value, std::forward<Args>(args)...);
+      }
+   };
+
+   // using for write reflectable map keys
+   template <str_t T>
+   struct to<ERLANG, T> final
+   {
+      template <auto Opts, class V, class... Args>
+         requires(not has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(V&& v, Args... args) noexcept
+      {
+         encode_version(std::forward<Args>(args)...);
+         op<no_header_on<Opts>()>(std::forward<V>(v), std::forward<Args>(args)...);
+      }
+
+      template <auto Opts, class... Args>
+         requires(has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args) noexcept
+      {
+         encode_atom_len(value, value.size(), std::forward<Args>(args)...);
+      }
+   };
+
+   template <string_t T>
+   struct to<ERLANG, T> final
+   {
+      template <auto Opts, class V, class... Args>
+         requires(not has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(V&& v, Args... args) noexcept
+      {
+         encode_version(std::forward<Args>(args)...);
+         op<no_header_on<Opts>()>(std::forward<V>(v), std::forward<Args>(args)...);
+      }
+
+      template <auto Opts, class... Args>
+         requires(has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args) noexcept
+      {
+         encode_string(value, std::forward<Args>(args)...);
+      }
+   };
+
+   template <class T>
+      requires(tuple_t<T> || is_std_tuple<T>)
+   struct to<ERLANG, T> final
+   {
+      template <auto Opts, class V, class... Args>
+         requires(not has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(V&& v, Args... args) noexcept
+      {
+         encode_version(std::forward<Args>(args)...);
+         op<no_header_on<Opts>()>(std::forward<V>(v), std::forward<Args>(args)...);
+      }
+
+      template <auto Opts, is_context Ctx, class... Args>
+         requires(has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, Args&&... args) noexcept
+      {
+         static constexpr auto N = glz::tuple_size_v<T>;
+
+         encode_tuple_header(N, ctx, std::forward<Args>(args)...);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
          }
 
-         template <auto Opts, class T, is_context Ctx, output_buffer B, class IX>
-            requires(not has_no_header(Opts))
-         GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix) noexcept
-         {
-            encode_version(ctx, b, ix);
-            if (bool(ctx.error)) [[unlikely]] {
-               return;
-            }
-
-            using V = std::remove_cvref_t<T>;
-            to<ERLANG, V>::template op<no_header_on<Opts>()>(std::forward<V>(value), std::forward<Ctx>(ctx),
-                                                             std::forward<B>(b), std::forward<IX>(ix));
+         if constexpr (is_std_tuple<T>) {
+            [&]<size_t... I>(std::index_sequence<I...>) {
+               (serialize<ERLANG>::op<Opts>(std::get<I>(value), ctx, args...), ...);
+            }(std::make_index_sequence<N>{});
          }
-      };
-
-      template <boolean_like T>
-      struct to<ERLANG, T>
-      {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(const bool value, Args&&... args) noexcept
-         {
-            encode_boolean(value, std::forward<Args>(args)...);
+         else {
+            [&]<size_t... I>(std::index_sequence<I...>) {
+               (serialize<ERLANG>::op<Opts>(glz::get<I>(value), ctx, args...), ...);
+            }(std::make_index_sequence<N>{});
          }
-      };
+      }
+   };
 
-      template <num_t T>
-      struct to<ERLANG, T> final
+   template <writable_array_t T>
+   struct to<ERLANG, T> final
+   {
+      template <auto Opts, class V, class... Args>
+         requires(not has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(V&& v, Args... args) noexcept
       {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args) noexcept
-         {
-            encode_number(value, std::forward<Args>(args)...);
+         encode_version(std::forward<Args>(args)...);
+         op<no_header_on<Opts>()>(std::forward<V>(v), std::forward<Args>(args)...);
+      }
+
+      template <auto Opts, is_context Ctx, class... Args>
+         requires(has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, Args&&... args) noexcept
+      {
+         const auto n = value.size();
+         encode_list_header(n, ctx, std::forward<Args>(args)...);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
          }
-      };
 
-      template <atom_t T>
-      struct to<ERLANG, T> final
-      {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args) noexcept
-         {
-            encode_atom(value, std::forward<Args>(args)...);
+         for (auto& i : value) {
+            serialize<ERLANG>::op<Opts>(i, ctx, args...);
          }
-      };
 
-      // using for write reflectable map keys
-      template <str_t T>
-      struct to<ERLANG, T> final
+         encode_list_tail(ctx, std::forward<Args>(args)...);
+      }
+   };
+
+   template <writable_map_t T>
+   struct to<ERLANG, T> final
+   {
+      template <auto Opts, class V, class... Args>
+         requires(not has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(V&& v, Args... args) noexcept
       {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args) noexcept
-         {
-            encode_atom_len(value, value.size(), std::forward<Args>(args)...);
+         encode_version(std::forward<Args>(args)...);
+         op<no_header_on<Opts>()>(std::forward<V>(v), std::forward<Args>(args)...);
+      }
+
+      template <auto Opts, is_context Ctx, class... Args>
+         requires(has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, Args&&... args) noexcept
+      {
+         const auto n = value.size();
+         encode_map_header(n, ctx, std::forward<Args>(args)...);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
          }
-      };
 
-      template <string_t T>
-      struct to<ERLANG, T> final
-      {
-         template <auto Opts, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, Args&&... args) noexcept
-         {
-            encode_string(value, std::forward<Args>(args)...);
+         for (auto&& [k, v] : value) {
+            serialize<ERLANG>::op<Opts>(k, ctx, args...);
+            serialize<ERLANG>::op<Opts>(v, ctx, args...);
          }
-      };
+      }
+   };
 
-      template <class T>
-         requires(tuple_t<T> || is_std_tuple<T>)
-      struct to<ERLANG, T> final
+   template <class T>
+      requires glaze_object_t<T> || reflectable<T>
+   struct to<ERLANG, T> final
+   {
+      template <auto Opts, class V, class... Args>
+         requires(not has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(V&& v, Args&&... args) noexcept
       {
-         template <auto Opts, is_context Ctx, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, Args&&... args) noexcept
-         {
-            static constexpr auto N = glz::tuple_size_v<T>;
+         encode_version(std::forward<Args>(args)...);
+         op<no_header_on<Opts>()>(std::forward<V>(v), std::forward<Args>(args)...);
+      }
 
-            encode_tuple_header(N, ctx, std::forward<Args>(args)...);
-            if (bool(ctx.error)) [[unlikely]] {
-               return;
-            }
-
-            if constexpr (is_std_tuple<T>) {
-               [&]<size_t... I>(std::index_sequence<I...>) {
-                  (write<ERLANG>::op<Opts>(std::get<I>(value), ctx, args...), ...);
-               }(std::make_index_sequence<N>{});
+      template <auto Opts, class... Args>
+         requires(has_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(auto&& value, [[maybe_unused]]is_context auto&& ctx, Args&&... args) noexcept
+      {
+         static constexpr auto N = reflect<T>::size;
+         [[maybe_unused]] decltype(auto) t = [&]() -> decltype(auto) {
+            if constexpr (reflectable<T>) {
+               return to_tie(value);
             }
             else {
-               [&]<size_t... I>(std::index_sequence<I...>) {
-                  (write<ERLANG>::op<Opts>(glz::get<I>(value), ctx, args...), ...);
-               }(std::make_index_sequence<N>{});
+               return nullptr;
             }
+         }();
+
+         // TODO propmap
+
+         // map layout
+         encode_map_header(N, ctx, std::forward<Args>(args)...);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
          }
-      };
 
-      template <writable_array_t T>
-      struct to<ERLANG, T> final
-      {
-         template <auto Opts, is_context Ctx, class... Args>
-         GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, Args&&... args) noexcept
-         {
-            const auto n = value.size();
-            encode_list_header(n, ctx, std::forward<Args>(args)...);
-            if (bool(ctx.error)) [[unlikely]] {
-               return;
-            }
+         invoke_table<N>([&]<size_t I>() {
+            static constexpr sv key = reflect<T>::keys[I];
+            serialize<ERLANG>::op<Opts>(key, ctx, std::forward<Args>(args)...);
 
-            for (auto& i : value) {
-               write<ERLANG>::op<Opts>(i, ctx, args...);
-            }
-
-            encode_list_tail(ctx, std::forward<Args>(args)...);
-         }
-      };
-
-      template <writable_map_t T>
-      struct to<ERLANG, T> final
-      {
-         template <auto Opts, is_context Ctx, class... Args>
-         GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, Args&&... args) noexcept
-         {
-            const auto n = value.size();
-            encode_map_header(n, ctx, std::forward<Args>(args)...);
-            if (bool(ctx.error)) [[unlikely]] {
-               return;
-            }
-
-            for (auto&& [k, v] : value) {
-               write<ERLANG>::op<Opts>(k, ctx, args...);
-               write<ERLANG>::op<Opts>(v, ctx, args...);
-            }
-         }
-      };
-
-      template <reflectable T>
-      struct to<ERLANG, T> final
-      {
-         template <auto Opts, is_context Ctx, class... Args>
-         GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, Args&&... args) noexcept
-         {
-            static constexpr auto N = reflect<T>::size;
-            [[maybe_unused]] decltype(auto) t = [&]() -> decltype(auto) {
+            decltype(auto) member = [&]() -> decltype(auto) {
                if constexpr (reflectable<T>) {
-                  return to_tuple(value);
+                  return get<I>(t);
                }
                else {
-                  return nullptr;
+                  return get<I>(reflect<T>::values);
                }
             }();
 
-            encode_map_header(N, ctx, std::forward<Args>(args)...);
-            if (bool(ctx.error)) [[unlikely]] {
-               return;
-            }
-
-            invoke_table<N>([&]<size_t I>() {
-               static constexpr sv key = reflect<T>::keys[I];
-               write<ERLANG>::op<Opts>(key, ctx, args...);
-
-               decltype(auto) member = [&]() -> decltype(auto) {
-                  if constexpr (reflectable<T>) {
-                     return get<I>(t);
-                  }
-                  else {
-                     return get<I>(reflect<T>::values);
-                  }
-               }();
-
-               write<ERLANG>::op<Opts>(get_member(value, member), ctx, args...);
-            });
-         }
-      };
-
-      template <class T>
-      struct to<ERLANG, T> final
-      {
-         // template <auto Opts, is_context Ctx, output_buffer B>
-         // GLZ_ALWAYS_INLINE static void op(T && /* value */, Ctx && /* ctx */, B && /* b */) noexcept
-         // {
-         // 	// std::cerr << "here\n";
-         // }
-      };
-
-   } // namespace detail
-
-   template <class T>
-   concept write_term_supported = requires { detail::to<ERLANG, std::remove_cvref_t<T>>{}; };
-
-   template <class T>
-   struct write_format_supported<ERLANG, T>
-   {
-      static const auto value = write_term_supported<T>;
+            serialize<ERLANG>::op<Opts>(get_member(value, member), ctx, std::forward<Args>(args)...);
+         });
+      }
    };
 
-   template <uint32_t layout = glz::map, write_term_supported T, output_buffer Buffer>
+   template <class T>
+   struct to<ERLANG, T> final
+   {
+      // empty for compilation error if use unsupported value type
+   };
+
+   template <uint32_t layout = glz::map, class T, output_buffer Buffer>
+      requires(write_supported<ERLANG, T>)
    [[nodiscard]] error_ctx write_term(T&& value, Buffer&& buffer) noexcept
    {
       return write<opts{.format = ERLANG, .layout = layout}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <uint32_t layout = glz::map, write_term_supported T, raw_buffer Buffer>
+   template <uint32_t layout = glz::map, class T, raw_buffer Buffer>
+      requires(write_supported<ERLANG, T>)
    [[nodiscard]] expected<size_t, error_ctx> write_term(T&& value, Buffer&& buffer) noexcept
    {
       return write<opts{.format = ERLANG, .layout = layout}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <write_term_supported T>
+   template <class T>
+      requires(write_supported<ERLANG, T>)
    [[nodiscard]] expected<std::string, error_ctx> write_term(T&& value) noexcept
    {
       return write<opts{.format = ERLANG}>(std::forward<T>(value));

--- a/include/glaze/eetf/write.hpp
+++ b/include/glaze/eetf/write.hpp
@@ -216,16 +216,16 @@ namespace glz
       static const auto value = write_term_supported<T>;
    };
 
-   template <write_term_supported T, output_buffer Buffer>
+   template <uint32_t layout = glz::map, write_term_supported T, output_buffer Buffer>
    [[nodiscard]] error_ctx write_term(T&& value, Buffer&& buffer) noexcept
    {
-      return write<opts{.format = ERLANG}>(std::forward<T>(value), std::forward<Buffer>(buffer));
+      return write<opts{.format = ERLANG, .layout = layout}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <write_term_supported T, raw_buffer Buffer>
+   template <uint32_t layout = glz::map, write_term_supported T, raw_buffer Buffer>
    [[nodiscard]] expected<size_t, error_ctx> write_term(T&& value, Buffer&& buffer) noexcept
    {
-      return write<opts{.format = ERLANG}>(std::forward<T>(value), std::forward<Buffer>(buffer));
+      return write<opts{.format = ERLANG, .layout = layout}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
    template <write_term_supported T>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,6 +80,9 @@ add_subdirectory(stencil)
 add_subdirectory(threading_test)
 add_subdirectory(toml_test)
 add_subdirectory(utility_formats)
+if(glaze_ERLANG_FORMAT)
+    add_subdirectory(eetf_test)
+endif(glaze_ERLANG_FORMAT)
 
 # We don't run find_package_test or glaze-install_test with MSVC/Windows, because the Github action runner often chokes
 # Don't run find_package on Clang, because Linux runs with Clang try to use GCC standard library and have errors before Clang 18

--- a/tests/eetf_test/CMakeLists.txt
+++ b/tests/eetf_test/CMakeLists.txt
@@ -1,0 +1,13 @@
+project(eetf_test)
+
+add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE glz_test_common)
+
+if (MINGW)
+    target_compile_options(${PROJECT_NAME} PRIVATE "-Wa,-mbig-obj")
+endif ()
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
+
+target_code_coverage(${PROJECT_NAME} AUTO ALL)

--- a/tests/eetf_test/eetf_test.cpp
+++ b/tests/eetf_test/eetf_test.cpp
@@ -179,6 +179,45 @@ suite etf_tests = [] {
       expect(s.hello == "Hello write meta");
    };
 
+   "write_proplist_term"_test = [] {
+      trace.begin("write_term");
+      my_struct sw{.i = 123, .d = 2.71827, .hello = "Hello write", .a = "qwe"_atom, .arr = {45, 67, 89}};
+      std::vector<std::uint8_t> buff;
+      auto ec = glz::write_term<glz::eetf::proplist_layout>(sw, buff);
+      trace.end("write_term");
+
+      expect(not ec) << glz::format_error(ec, "can't write");
+
+      my_struct s{};
+      ec = glz::read_term<glz::eetf::proplist_layout>(s, buff);
+      expect(not ec) << glz::format_error(ec, "can't read");
+
+      expect(s.a == "qwe");
+      expect(s.d == 2.71827);
+      expect(s.i == 123);
+      expect(s.arr == decltype(s.arr){45, 67, 89});
+      expect(s.hello == "Hello write");
+   };
+
+   "write_proplist_term_meta"_test = [] {
+      trace.begin("write_term");
+      my_struct_meta sw(123, 2.71827, "Hello write meta", {45, 67, 89});
+      std::vector<std::uint8_t> buff;
+      auto ec = glz::write_term<glz::eetf::proplist_layout>(sw, buff);
+      trace.end("write_term");
+
+      expect(not ec) << glz::format_error(ec, "can't write");
+
+      my_struct s{};
+      ec = glz::read_term<glz::eetf::proplist_layout>(s, buff);
+      expect(not ec) << glz::format_error(ec, "can't read");
+
+      expect(s.d == 2.71827);
+      expect(s.i == 123);
+      expect(s.arr == decltype(s.arr){45, 67, 89});
+      expect(s.hello == "Hello write meta");
+   };
+
    "read_write_string_as_atom"_test = [] {
       trace.begin("read_write_string_as_atom");
       atom_rw s{}, r{};

--- a/tests/eetf_test/eetf_test.cpp
+++ b/tests/eetf_test/eetf_test.cpp
@@ -8,7 +8,7 @@
 #include <string>
 
 #include "glaze/eetf/read.hpp"
-// #include "glaze/eetf/write.hpp"
+#include "glaze/eetf/write.hpp"
 #include "glaze/trace/trace.hpp"
 #include "ut/ut.hpp"
 
@@ -68,6 +68,7 @@ static_assert(glz::read_eetf_supported<my_struct_meta>);
 
 suite etf_tests = [] {
    "read_term"_test = [] {
+      trace.begin("read_term");
       my_struct s{};
       auto ec = glz::read_term(s, term001);
       expect(not ec) << glz::format_error(ec, "can't read");
@@ -76,9 +77,11 @@ suite etf_tests = [] {
       expect(s.i == 1);
       expect(s.arr == decltype(s.arr){9,8,7});
       expect(s.hello == "Hello Erlang Term");
+      trace.end("read_term");
    };
 
    "read_term_meta"_test = [] {
+      trace.begin("read_term_meta");
       my_struct_meta s{};
       auto ec = glz::read<glz::opts{.format = glz::ERLANG, .error_on_unknown_keys = false}>(s, term001);
       expect(not ec) << glz::format_error(ec, "can't read");
@@ -86,6 +89,27 @@ suite etf_tests = [] {
       expect(s.i == 1);
       expect(s.arr == decltype(s.arr){9,8,7});
       expect(s.hello == "Hello Erlang Term");
+      trace.end("read_term_meta");
+   };
+
+   "write_term"_test = [] {
+      trace.begin("write_term");
+      my_struct sw{.i = 123, .d = 2.71827, .hello = "Hello write", .a = "qwe"_atom, .arr = {45, 67, 89}};
+      std::vector<std::uint8_t> buff;
+      auto ec = glz::write_term(sw, buff);
+      trace.end("write_term");
+
+      expect(not ec) << glz::format_error(ec, "can't write");
+
+      my_struct s{};
+      ec = glz::read_term(s, buff);
+      expect(not ec) << glz::format_error(ec, "can't read");
+
+      expect(s.a == "qwe");
+      expect(s.d == 2.71827);
+      expect(s.i == 123);
+      expect(s.arr == decltype(s.arr){45,67,89});
+      expect(s.hello == "Hello write");
    };
 };
 

--- a/tests/eetf_test/eetf_test.cpp
+++ b/tests/eetf_test/eetf_test.cpp
@@ -1,0 +1,91 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#define UT_RUN_TIME_ONLY
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+#include "glaze/eetf/read.hpp"
+// #include "glaze/eetf/write.hpp"
+#include "glaze/trace/trace.hpp"
+#include "ut/ut.hpp"
+
+using namespace glz::eetf;
+
+using namespace ut;
+
+glz::trace trace{};
+suite start_trace = [] { trace.begin("eetf_test", "Full test suite duration."); };
+
+/*
+T = #{d=>3.1415926, hello=>"Hello Erlang Term", a=>atom_term, arr=>[9, 8, 7], i=>1}.
+io:format("~p", [erlang:term_to_binary(T)]).
+*/
+
+std::array<std::uint8_t, 81> term001{131, 116, 0,   0,   0,   5,   100, 0,   1,   97,  100, 0,   9,  97,  116, 111, 109,
+                                     95,  116, 101, 114, 109, 100, 0,   3,   97,  114, 114, 107, 0,  3,   9,   8,   7,
+                                     100, 0,   1,   100, 70,  64,  9,   33,  251, 77,  18,  216, 74, 100, 0,   5,   104,
+                                     101, 108, 108, 111, 107, 0,   17,  72,  101, 108, 108, 111, 32, 69,  114, 108, 97,
+                                     110, 103, 32,  84,  101, 114, 109, 100, 0,   1,   105, 97,  1};
+
+struct my_struct
+{
+   int i = 287;
+   double d = 3.14;
+   std::string hello = "Hello World";
+   glz::eetf::atom a = "elang_atom_field"_atom;
+   std::array<uint64_t, 3> arr = {1, 2, 3};
+};
+
+// static_assert(glz::write_eetf_supported<my_struct>);
+static_assert(glz::read_eetf_supported<my_struct>);
+
+struct my_struct_meta
+{
+   my_struct_meta() : i{287}, d{3.14}, hello{"Hello World"}, arr{1, 2, 3} {}
+
+   int i;
+   double d;
+   std::string hello;
+   std::array<uint64_t, 3> arr;
+};
+
+template <>
+struct glz::meta<my_struct_meta>
+{
+   using T = my_struct_meta;
+   static constexpr auto value = object("i", &T::i, //
+                                        "d", &T::d, //
+                                        "hello", &T::hello, //
+                                        "arr", &T::arr //
+   );
+};
+
+// static_assert(glz::write_eetf_supported<my_struct_meta>);
+static_assert(glz::read_eetf_supported<my_struct_meta>);
+
+suite etf_tests = [] {
+   "read_term"_test = [] {
+      my_struct s{};
+      auto ec = glz::read_term(s, term001);
+      expect(not ec) << glz::format_error(ec, "can't read");
+      expect(s.a == "atom_term");
+      expect(s.d == 3.1415926);
+      expect(s.i == 1);
+      expect(s.arr == decltype(s.arr){9,8,7});
+      expect(s.hello == "Hello Erlang Term");
+   };
+};
+
+int main()
+{
+   trace.end("eetf_test");
+   const auto ec = glz::write_file_json(trace, "eetf_test.trace.json", std::string{});
+   if (ec) {
+      std::cerr << "trace output failed\n";
+   }
+
+   return 0;
+}

--- a/tests/eetf_test/eetf_test.cpp
+++ b/tests/eetf_test/eetf_test.cpp
@@ -20,7 +20,7 @@ glz::trace trace{};
 suite start_trace = [] { trace.begin("eetf_test", "Full test suite duration."); };
 
 /*
-T = #{d=>3.1415926, hello=>"Hello Erlang Term", a=>atom_term, arr=>[9, 8, 7], i=>1}.
+T = #{a => atom_term, arr => [9,8,7], d => 3.1415926, hello => "Hello Erlang Term", i => 1}.
 io:format("~p", [erlang:term_to_binary(T)]).
 */
 
@@ -72,6 +72,16 @@ suite etf_tests = [] {
       auto ec = glz::read_term(s, term001);
       expect(not ec) << glz::format_error(ec, "can't read");
       expect(s.a == "atom_term");
+      expect(s.d == 3.1415926);
+      expect(s.i == 1);
+      expect(s.arr == decltype(s.arr){9,8,7});
+      expect(s.hello == "Hello Erlang Term");
+   };
+
+   "read_term_meta"_test = [] {
+      my_struct_meta s{};
+      auto ec = glz::read<glz::opts{.format = glz::ERLANG, .error_on_unknown_keys = false}>(s, term001);
+      expect(not ec) << glz::format_error(ec, "can't read");
       expect(s.d == 3.1415926);
       expect(s.i == 1);
       expect(s.arr == decltype(s.arr){9,8,7});


### PR DESCRIPTION
Add Erlang external term format parser and serializer.
This is "first" release of support with sets of features that enough for my purposes (an even more, but I don't think this is full set)

Use custom options for that format (great addition by the way)

This format supports only with `glaze_ERLANG_FORMAT` CMake options enabled (disabled by default) because I had to include erlang libs to parse this format.
