### PR TITLE
Swap read/write supported template parameters

### DIFF
--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -1536,15 +1536,13 @@ namespace glz
       }
    };
 
-   template <class T, class Buffer>
-      requires(read_supported<BEVE, T>)
+   template <read_supported<BEVE> T, class Buffer>
    [[nodiscard]] inline error_ctx read_beve(T&& value, Buffer&& buffer)
    {
       return read<opts{.format = BEVE}>(value, std::forward<Buffer>(buffer));
    }
 
-   template <class T, class Buffer>
-      requires(read_supported<BEVE, T>)
+   template <read_supported<BEVE> T, class Buffer>
    [[nodiscard]] inline expected<T, error_ctx> read_beve(Buffer&& buffer)
    {
       T value{};
@@ -1555,8 +1553,7 @@ namespace glz
       return value;
    }
 
-   template <auto Opts = opts{}, class T>
-      requires(read_supported<BEVE, T>)
+   template <auto Opts = opts{}, read_supported<BEVE> T>
    [[nodiscard]] inline error_ctx read_file_beve(T& value, const sv file_name, auto&& buffer)
    {
       context ctx{};
@@ -1571,16 +1568,14 @@ namespace glz
       return read<set_beve<Opts>()>(value, buffer, ctx);
    }
 
-   template <class T, class Buffer>
-      requires(read_supported<BEVE, T>)
+   template <read_supported<BEVE> T, class Buffer>
    [[nodiscard]] inline error_ctx read_binary_untagged(T&& value, Buffer&& buffer)
    {
       return read<opts{.format = BEVE, .structs_as_arrays = true}>(std::forward<T>(value),
                                                                    std::forward<Buffer>(buffer));
    }
 
-   template <class T, class Buffer>
-      requires(read_supported<BEVE, T>)
+   template <read_supported<BEVE> T, class Buffer>
    [[nodiscard]] inline expected<T, error_ctx> read_binary_untagged(Buffer&& buffer)
    {
       T value{};
@@ -1591,8 +1586,7 @@ namespace glz
       return value;
    }
 
-   template <auto Opts = opts{}, class T>
-      requires(read_supported<BEVE, T>)
+   template <auto Opts = opts{}, read_supported<BEVE> T>
    [[nodiscard]] inline error_ctx read_file_beve_untagged(T& value, const std::string& file_name, auto&& buffer)
    {
       return read_file_beve<opt_true<Opts, &opts::structs_as_arrays>>(value, file_name, buffer);

--- a/include/glaze/beve/write.hpp
+++ b/include/glaze/beve/write.hpp
@@ -906,30 +906,26 @@ namespace glz
       }
    };
 
-   template <class T, class Buffer>
-      requires(write_supported<BEVE, T>)
+   template <write_supported<BEVE> T, class Buffer>
    [[nodiscard]] error_ctx write_beve(T&& value, Buffer&& buffer)
    {
       return write<opts{.format = BEVE}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <auto Opts = opts{}, class T>
-      requires(write_supported<BEVE, T>)
+   template <auto Opts = opts{}, write_supported<BEVE> T>
    [[nodiscard]] glz::expected<std::string, error_ctx> write_beve(T&& value)
    {
       return write<set_beve<Opts>()>(std::forward<T>(value));
    }
 
-   template <auto& Partial, class T, class Buffer>
-      requires(write_supported<BEVE, T>)
+   template <auto& Partial, write_supported<BEVE> T, class Buffer>
    [[nodiscard]] error_ctx write_beve(T&& value, Buffer&& buffer)
    {
       return write<Partial, opts{.format = BEVE}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
    // requires file_name to be null terminated
-   template <auto Opts = opts{}, class T>
-      requires(write_supported<BEVE, T>)
+   template <auto Opts = opts{}, write_supported<BEVE> T>
    [[nodiscard]] error_ctx write_file_beve(T&& value, const sv file_name, auto&& buffer)
    {
       static_assert(sizeof(decltype(*buffer.data())) == 1);
@@ -951,23 +947,20 @@ namespace glz
       return {};
    }
 
-   template <class T, class Buffer>
-      requires(write_supported<BEVE, T>)
+   template <write_supported<BEVE> T, class Buffer>
    [[nodiscard]] error_ctx write_beve_untagged(T&& value, Buffer&& buffer)
    {
       return write<opts{.format = BEVE, .structs_as_arrays = true}>(std::forward<T>(value),
                                                                     std::forward<Buffer>(buffer));
    }
 
-   template <class T>
-      requires(write_supported<BEVE, T>)
+   template <write_supported<BEVE> T>
    [[nodiscard]] error_ctx write_beve_untagged(T&& value)
    {
       return write<opts{.format = BEVE, .structs_as_arrays = true}>(std::forward<T>(value));
    }
 
-   template <auto Opts = opts{}, class T>
-      requires(write_supported<BEVE, T>)
+   template <auto Opts = opts{}, write_supported<BEVE> T>
    [[nodiscard]] error_ctx write_file_beve_untagged(T&& value, const std::string& file_name, auto&& buffer)
    {
       return write_file_beve<opt_true<Opts, &opts::structs_as_arrays>>(std::forward<T>(value), file_name, buffer);

--- a/include/glaze/core/feature_test.hpp
+++ b/include/glaze/core/feature_test.hpp
@@ -5,6 +5,9 @@
 
 // Glaze Feature Test Macros for breaking changes
 
+// v5.1.0 swaps the template parameters of read_supported/write_supported to enable cleaner concepts and usage
+#define glaze_v5_1_0_supported_swap
+
 // v5.0.0 removes many internal functions and concepts out of the detail namespace to enable cleaner customization
 #define glaze_v5_0_0
 // v5.0.0 moves to more generic read_supported and write_supported concepts

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -435,10 +435,10 @@ namespace glz
    template <uint32_t Format = INVALID>
    struct skip_value;
 
-   template <uint32_t Format, class T>
+   template <class T, uint32_t Format>
    concept write_supported = requires { to<Format, std::remove_cvref_t<T>>{}; };
 
-   template <uint32_t Format, class T>
+   template <class T, uint32_t Format>
    concept read_supported = requires { from<Format, std::remove_cvref_t<T>>{}; };
 
    // These templates save typing by determining the core type used to select the proper to/from specialization

--- a/include/glaze/core/read.hpp
+++ b/include/glaze/core/read.hpp
@@ -30,7 +30,7 @@ namespace glz
    }
 
    template <auto Opts, class T>
-      requires read_supported<Opts.format, T>
+      requires read_supported<T, Opts.format>
    [[nodiscard]] error_ctx read(T& value, contiguous auto&& buffer, is_context auto&& ctx)
    {
       static_assert(sizeof(decltype(*buffer.data())) == 1);
@@ -107,7 +107,7 @@ namespace glz
    }
 
    template <auto Opts, class T>
-      requires read_supported<Opts.format, T>
+      requires read_supported<T, Opts.format>
    [[nodiscard]] error_ctx read(T& value, contiguous auto&& buffer)
    {
       context ctx{};
@@ -122,7 +122,7 @@ namespace glz
 
    // for char array input
    template <auto Opts, class T, c_style_char_buffer Buffer>
-      requires read_supported<Opts.format, T>
+      requires read_supported<T, Opts.format>
    [[nodiscard]] error_ctx read(T& value, Buffer&& buffer, auto&& ctx)
    {
       const auto str = std::string_view{std::forward<Buffer>(buffer)};
@@ -133,7 +133,7 @@ namespace glz
    }
 
    template <auto Opts, class T, c_style_char_buffer Buffer>
-      requires read_supported<Opts.format, T>
+      requires read_supported<T, Opts.format>
    [[nodiscard]] error_ctx read(T& value, Buffer&& buffer)
    {
       context ctx{};

--- a/include/glaze/core/write.hpp
+++ b/include/glaze/core/write.hpp
@@ -12,7 +12,7 @@ namespace glz
 {
    // For writing to a std::string, std::vector<char>, std::deque<char> and the like
    template <auto Opts, class T, output_buffer Buffer>
-      requires write_supported<Opts.format, T>
+      requires write_supported<T, Opts.format>
    [[nodiscard]] error_ctx write(T&& value, Buffer& buffer, is_context auto&& ctx)
    {
       if constexpr (resizable<Buffer>) {
@@ -31,7 +31,7 @@ namespace glz
    }
 
    template <auto& Partial, auto Opts, class T, output_buffer Buffer>
-      requires write_supported<Opts.format, T>
+      requires write_supported<T, Opts.format>
    [[nodiscard]] error_ctx write(T&& value, Buffer& buffer)
    {
       if constexpr (resizable<Buffer>) {
@@ -50,7 +50,7 @@ namespace glz
    }
 
    template <auto& Partial, auto Opts, class T, raw_buffer Buffer>
-      requires write_supported<Opts.format, T>
+      requires write_supported<T, Opts.format>
    [[nodiscard]] glz::expected<size_t, error_ctx> write(T&& value, Buffer& buffer)
    {
       context ctx{};
@@ -63,7 +63,7 @@ namespace glz
    }
 
    template <auto Opts, class T, output_buffer Buffer>
-      requires write_supported<Opts.format, T>
+      requires write_supported<T, Opts.format>
    [[nodiscard]] error_ctx write(T&& value, Buffer& buffer)
    {
       context ctx{};
@@ -71,7 +71,7 @@ namespace glz
    }
 
    template <auto Opts, class T>
-      requires write_supported<Opts.format, T>
+      requires write_supported<T, Opts.format>
    [[nodiscard]] glz::expected<std::string, error_ctx> write(T&& value)
    {
       std::string buffer{};
@@ -84,7 +84,7 @@ namespace glz
    }
 
    template <auto Opts, class T, raw_buffer Buffer>
-      requires write_supported<Opts.format, T>
+      requires write_supported<T, Opts.format>
    [[nodiscard]] glz::expected<size_t, error_ctx> write(T&& value, Buffer&& buffer, is_context auto&& ctx)
    {
       size_t ix = 0;
@@ -96,7 +96,7 @@ namespace glz
    }
 
    template <auto Opts, class T, raw_buffer Buffer>
-      requires write_supported<Opts.format, T>
+      requires write_supported<T, Opts.format>
    [[nodiscard]] glz::expected<size_t, error_ctx> write(T&& value, Buffer&& buffer)
    {
       context ctx{};

--- a/include/glaze/csv/read.hpp
+++ b/include/glaze/csv/read.hpp
@@ -646,15 +646,13 @@ namespace glz
       }
    };
 
-   template <uint32_t layout = rowwise, class T, class Buffer>
-      requires(read_supported<CSV, T>)
+   template <uint32_t layout = rowwise, read_supported<CSV> T, class Buffer>
    [[nodiscard]] inline auto read_csv(T&& value, Buffer&& buffer)
    {
       return read<opts{.format = CSV, .layout = layout}>(value, std::forward<Buffer>(buffer));
    }
 
-   template <uint32_t layout = rowwise, class T, class Buffer>
-      requires(read_supported<CSV, T>)
+   template <uint32_t layout = rowwise, read_supported<CSV> T, class Buffer>
    [[nodiscard]] inline auto read_csv(Buffer&& buffer)
    {
       T value{};
@@ -662,8 +660,7 @@ namespace glz
       return value;
    }
 
-   template <uint32_t layout = rowwise, class T, is_buffer Buffer>
-      requires(read_supported<CSV, T>)
+   template <uint32_t layout = rowwise, read_supported<CSV> T, is_buffer Buffer>
    [[nodiscard]] inline error_ctx read_file_csv(T& value, const sv file_name, Buffer&& buffer)
    {
       context ctx{};

--- a/include/glaze/csv/write.hpp
+++ b/include/glaze/csv/write.hpp
@@ -328,22 +328,19 @@ namespace glz
       }
    };
 
-   template <uint32_t layout = rowwise, class T, class Buffer>
-      requires(write_supported<CSV, T>)
+   template <uint32_t layout = rowwise, write_supported<CSV> T, class Buffer>
    [[nodiscard]] auto write_csv(T&& value, Buffer&& buffer)
    {
       return write<opts{.format = CSV, .layout = layout}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <uint32_t layout = rowwise, class T>
-      requires(write_supported<CSV, T>)
+   template <uint32_t layout = rowwise, write_supported<CSV> T>
    [[nodiscard]] expected<std::string, error_ctx> write_csv(T&& value)
    {
       return write<opts{.format = CSV, .layout = layout}>(std::forward<T>(value));
    }
 
-   template <uint32_t layout = rowwise, class T>
-      requires(write_supported<CSV, T>)
+   template <uint32_t layout = rowwise, write_supported<CSV> T>
    [[nodiscard]] error_ctx write_file_csv(T&& value, const std::string& file_name, auto&& buffer)
    {
       const auto ec = write<opts{.format = CSV, .layout = layout}>(std::forward<T>(value), buffer);

--- a/include/glaze/eetf/read.hpp
+++ b/include/glaze/eetf/read.hpp
@@ -369,15 +369,13 @@ namespace glz
       }
    };
 
-   template <uint8_t layout = glz::eetf::map_layout, class T, class Buffer>
-      requires(read_supported<EETF, T>)
+   template <uint8_t layout = glz::eetf::map_layout, read_supported<EETF> T, class Buffer>
    [[nodiscard]] inline error_ctx read_term(T&& value, Buffer&& buffer) noexcept
    {
       return read<eetf::eetf_opts{.format = EETF, .layout = layout}>(value, std::forward<Buffer>(buffer));
    }
 
-   template <uint8_t layout = glz::eetf::map_layout, class T, is_buffer Buffer>
-      requires(read_supported<EETF, T>)
+   template <uint8_t layout = glz::eetf::map_layout, read_supported<EETF> T, is_buffer Buffer>
    [[nodiscard]] expected<T, error_ctx> read_term(Buffer&& buffer) noexcept
    {
       T value{};

--- a/include/glaze/eetf/write.hpp
+++ b/include/glaze/eetf/write.hpp
@@ -276,24 +276,21 @@ namespace glz
       // empty for compilation error if use unsupported value type
    };
 
-   template <uint8_t layout = glz::eetf::map_layout, class T, output_buffer Buffer>
-      requires(write_supported<EETF, T>)
+   template <uint8_t layout = glz::eetf::map_layout, write_supported<EETF> T, output_buffer Buffer>
    [[nodiscard]] error_ctx write_term(T&& value, Buffer&& buffer) noexcept
    {
       return write<eetf::eetf_opts{.format = EETF, .layout = layout}>(std::forward<T>(value),
                                                                       std::forward<Buffer>(buffer));
    }
 
-   template <uint8_t layout = glz::eetf::map_layout, class T, raw_buffer Buffer>
-      requires(write_supported<EETF, T>)
+   template <uint8_t layout = glz::eetf::map_layout, write_supported<EETF> T, raw_buffer Buffer>
    [[nodiscard]] expected<size_t, error_ctx> write_term(T&& value, Buffer&& buffer) noexcept
    {
       return write<eetf::eetf_opts{.format = EETF, .layout = layout}>(std::forward<T>(value),
                                                                       std::forward<Buffer>(buffer));
    }
 
-   template <class T>
-      requires(write_supported<EETF, T>)
+   template <write_supported<EETF> T>
    [[nodiscard]] expected<std::string, error_ctx> write_term(T&& value) noexcept
    {
       return write<eetf::eetf_opts{.format = EETF}>(std::forward<T>(value));

--- a/include/glaze/exceptions/core_exceptions.hpp
+++ b/include/glaze/exceptions/core_exceptions.hpp
@@ -11,7 +11,7 @@
 namespace glz::ex
 {
    template <auto Opts, class T>
-      requires read_supported<Opts.format, T>
+      requires read_supported<T, Opts.format>
    void read(T&& value, auto&& buffer)
    {
       const auto ec = glz::read<Opts>(std::forward<T>(value), buffer);
@@ -25,7 +25,7 @@ namespace glz::ex
 {
    // For writing to a std::string, std::vector<char>, std::deque<char> and the like
    template <auto Opts, class T, output_buffer Buffer>
-      requires write_supported<Opts.format, T>
+      requires write_supported<T, Opts.format>
    void write(T&& value, Buffer& buffer, is_context auto&& ctx)
    {
       const auto ec = glz::write<Opts>(std::forward<T>(value), buffer, ctx);
@@ -35,7 +35,7 @@ namespace glz::ex
    }
 
    template <auto& Partial, auto Opts, class T, output_buffer Buffer>
-      requires write_supported<Opts.format, T>
+      requires write_supported<T, Opts.format>
    void write(T&& value, Buffer& buffer)
    {
       const auto ec = glz::write(std::forward<T>(value), buffer);
@@ -45,7 +45,7 @@ namespace glz::ex
    }
 
    template <auto Opts, class T, output_buffer Buffer>
-      requires write_supported<Opts.format, T>
+      requires write_supported<T, Opts.format>
    void write(T&& value, Buffer& buffer)
    {
       glz::context ctx{};
@@ -53,7 +53,7 @@ namespace glz::ex
    }
 
    template <auto Opts, class T>
-      requires write_supported<Opts.format, T>
+      requires write_supported<T, Opts.format>
    [[nodiscard]] std::string write(T&& value)
    {
       const auto e = glz::write<Opts>(std::forward<T>(value));
@@ -64,7 +64,7 @@ namespace glz::ex
    }
 
    template <auto Opts, class T, raw_buffer Buffer>
-      requires write_supported<Opts.format, T>
+      requires write_supported<T, Opts.format>
    [[nodiscard]] size_t write(T&& value, Buffer&& buffer)
    {
       const auto e = write<Opts>(std::forward<T>(value), std::forward<Buffer>(buffer));

--- a/include/glaze/json/json_t.hpp
+++ b/include/glaze/json/json_t.hpp
@@ -363,7 +363,7 @@ namespace glz
    // These functions allow a json_t value to be read/written to a C++ struct
 
    template <auto Opts, class T>
-      requires read_supported<Opts.format, T>
+      requires read_supported<T, Opts.format>
    [[nodiscard]] error_ctx read(T& value, const json_t& source)
    {
       auto buffer = source.dump();
@@ -376,8 +376,7 @@ namespace glz
       }
    }
 
-   template <class T>
-      requires(read_supported<JSON, T>)
+   template <read_supported<JSON> T>
    [[nodiscard]] error_ctx read_json(T& value, const json_t& source)
    {
       auto buffer = source.dump();
@@ -389,8 +388,7 @@ namespace glz
       }
    }
 
-   template <class T>
-      requires(read_supported<JSON, T>)
+   template <read_supported<JSON> T>
    [[nodiscard]] expected<T, error_ctx> read_json(const json_t& source)
    {
       auto buffer = source.dump();

--- a/include/glaze/json/ndjson.hpp
+++ b/include/glaze/json/ndjson.hpp
@@ -254,16 +254,14 @@ namespace glz
       }
    };
 
-   template <class T, class Buffer>
-      requires(read_supported<NDJSON, T>)
+   template <read_supported<NDJSON> T, class Buffer>
    [[nodiscard]] auto read_ndjson(T& value, Buffer&& buffer)
    {
       context ctx{};
       return read<opts{.format = NDJSON}>(value, std::forward<Buffer>(buffer), ctx);
    }
 
-   template <class T, class Buffer>
-      requires(read_supported<NDJSON, T>)
+   template <read_supported<NDJSON> T, class Buffer>
    [[nodiscard]] expected<T, error_ctx> read_ndjson(Buffer&& buffer)
    {
       T value{};
@@ -275,8 +273,7 @@ namespace glz
       return unexpected(ec);
    }
 
-   template <auto Opts = opts{.format = NDJSON}, class T>
-      requires(read_supported<NDJSON, T>)
+   template <auto Opts = opts{.format = NDJSON}, read_supported<NDJSON> T>
    [[nodiscard]] error_ctx read_file_ndjson(T& value, const sv file_name)
    {
       context ctx{};
@@ -293,22 +290,19 @@ namespace glz
       return read<Opts>(value, buffer, ctx);
    }
 
-   template <class T, class Buffer>
-      requires(write_supported<NDJSON, T>)
+   template <write_supported<NDJSON> T, class Buffer>
    [[nodiscard]] error_ctx write_ndjson(T&& value, Buffer&& buffer)
    {
       return write<opts{.format = NDJSON}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <class T>
-      requires(write_supported<NDJSON, T>)
+   template <write_supported<NDJSON> T>
    [[nodiscard]] expected<std::string, error_ctx> write_ndjson(T&& value)
    {
       return write<opts{.format = NDJSON}>(std::forward<T>(value));
    }
 
-   template <class T>
-      requires(write_supported<NDJSON, T>)
+   template <write_supported<NDJSON> T>
    [[nodiscard]] error_ctx write_file_ndjson(T&& value, const std::string& file_name, auto&& buffer)
    {
       write<opts{.format = NDJSON}>(std::forward<T>(value), buffer);

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -3241,16 +3241,14 @@ namespace glz
       return read<opts_validate{{opts{.comments = true}}}>(skip_value, std::forward<Buffer>(buffer), ctx);
    }
 
-   template <class T, is_buffer Buffer>
-      requires(read_supported<JSON, T>)
+   template <read_supported<JSON> T, is_buffer Buffer>
    [[nodiscard]] error_ctx read_json(T& value, Buffer&& buffer)
    {
       context ctx{};
       return read<opts{}>(value, std::forward<Buffer>(buffer), ctx);
    }
 
-   template <class T, is_buffer Buffer>
-      requires(read_supported<JSON, T>)
+   template <read_supported<JSON> T, is_buffer Buffer>
    [[nodiscard]] expected<T, error_ctx> read_json(Buffer&& buffer)
    {
       T value{};
@@ -3262,16 +3260,14 @@ namespace glz
       return value;
    }
 
-   template <class T, is_buffer Buffer>
-      requires(read_supported<JSON, T>)
+   template <read_supported<JSON> T, is_buffer Buffer>
    [[nodiscard]] error_ctx read_jsonc(T& value, Buffer&& buffer)
    {
       context ctx{};
       return read<opts{.comments = true}>(value, std::forward<Buffer>(buffer), ctx);
    }
 
-   template <class T, is_buffer Buffer>
-      requires(read_supported<JSON, T>)
+   template <read_supported<JSON> T, is_buffer Buffer>
    [[nodiscard]] expected<T, error_ctx> read_jsonc(Buffer&& buffer)
    {
       T value{};
@@ -3283,8 +3279,7 @@ namespace glz
       return value;
    }
 
-   template <auto Opts = opts{}, class T, is_buffer Buffer>
-      requires(read_supported<JSON, T>)
+   template <auto Opts = opts{}, read_supported<JSON> T, is_buffer Buffer>
    [[nodiscard]] error_ctx read_file_json(T& value, const sv file_name, Buffer&& buffer)
    {
       context ctx{};
@@ -3299,8 +3294,7 @@ namespace glz
       return read<set_json<Opts>()>(value, buffer, ctx);
    }
 
-   template <auto Opts = opts{}, class T, is_buffer Buffer>
-      requires(read_supported<JSON, T>)
+   template <auto Opts = opts{}, read_supported<JSON> T, is_buffer Buffer>
    [[nodiscard]] error_ctx read_file_jsonc(T& value, const sv file_name, Buffer&& buffer)
    {
       context ctx{};

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1956,57 +1956,49 @@ namespace glz
       }
    };
 
-   template <class T, output_buffer Buffer>
-      requires(write_supported<JSON, T>)
+   template <write_supported<JSON> T, output_buffer Buffer>
    [[nodiscard]] error_ctx write_json(T&& value, Buffer&& buffer)
    {
       return write<opts{}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <class T, raw_buffer Buffer>
-      requires(write_supported<JSON, T>)
+   template <write_supported<JSON> T, raw_buffer Buffer>
    [[nodiscard]] glz::expected<size_t, error_ctx> write_json(T&& value, Buffer&& buffer)
    {
       return write<opts{}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <class T>
-      requires(write_supported<JSON, T>)
+   template <write_supported<JSON> T>
    [[nodiscard]] glz::expected<std::string, error_ctx> write_json(T&& value)
    {
       return write<opts{}>(std::forward<T>(value));
    }
 
-   template <auto& Partial, class T, output_buffer Buffer>
-      requires(write_supported<JSON, T>)
+   template <auto& Partial, write_supported<JSON> T, output_buffer Buffer>
    [[nodiscard]] error_ctx write_json(T&& value, Buffer&& buffer)
    {
       return write<Partial, opts{}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <auto& Partial, class T, raw_buffer Buffer>
-      requires(write_supported<JSON, T>)
+   template <auto& Partial, write_supported<JSON> T, raw_buffer Buffer>
    [[nodiscard]] glz::expected<size_t, error_ctx> write_json(T&& value, Buffer&& buffer)
    {
       return write<Partial, opts{}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <class T, class Buffer>
-      requires(write_supported<JSON, T>)
+   template <write_supported<JSON> T, class Buffer>
    [[nodiscard]] error_ctx write_jsonc(T&& value, Buffer&& buffer)
    {
       return write<opts{.comments = true}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <class T>
-      requires(write_supported<JSON, T>)
+   template <write_supported<JSON> T>
    [[nodiscard]] glz::expected<std::string, error_ctx> write_jsonc(T&& value)
    {
       return write<opts{.comments = true}>(std::forward<T>(value));
    }
 
-   template <auto Opts = opts{}, class T>
-      requires(write_supported<JSON, T>)
+   template <auto Opts = opts{}, write_supported<JSON> T>
    [[nodiscard]] error_ctx write_file_json(T&& value, const sv file_name, auto&& buffer)
    {
       const auto ec = write<set_json<Opts>()>(std::forward<T>(value), buffer);

--- a/include/glaze/toml/write.hpp
+++ b/include/glaze/toml/write.hpp
@@ -551,29 +551,25 @@ namespace glz
       }
    };
 
-   template <class T, output_buffer Buffer>
-      requires(write_supported<TOML, T>)
+   template <write_supported<TOML> T, output_buffer Buffer>
    [[nodiscard]] error_ctx write_toml(T&& value, Buffer&& buffer)
    {
       return write<opts{.format = TOML}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <class T, raw_buffer Buffer>
-      requires(write_supported<TOML, T>)
+   template <write_supported<TOML> T, raw_buffer Buffer>
    [[nodiscard]] glz::expected<size_t, error_ctx> write_toml(T&& value, Buffer&& buffer)
    {
       return write<opts{.format = TOML}>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
-   template <class T>
-      requires(write_supported<TOML, T>)
+   template <write_supported<TOML> T>
    [[nodiscard]] glz::expected<std::string, error_ctx> write_toml(T&& value)
    {
       return write<opts{.format = TOML}>(std::forward<T>(value));
    }
 
-   template <auto Opts = opts{.format = TOML}, class T>
-      requires(write_supported<TOML, T>)
+   template <auto Opts = opts{.format = TOML}, write_supported<TOML> T>
    [[nodiscard]] error_ctx write_file_toml(T&& value, const sv file_name, auto&& buffer)
    {
       const auto ec = write<set_toml<Opts>()>(std::forward<T>(value), buffer);

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -46,8 +46,8 @@ struct glz::meta<my_struct>
    );
 };
 
-static_assert(glz::write_supported<glz::BEVE, my_struct>);
-static_assert(glz::read_supported<glz::BEVE, my_struct>);
+static_assert(glz::write_supported<my_struct, glz::BEVE>);
+static_assert(glz::read_supported<my_struct, glz::BEVE>);
 
 struct sub_thing
 {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -61,8 +61,8 @@ struct glz::meta<my_struct>
    );
 };
 
-static_assert(glz::write_supported<glz::JSON, my_struct>);
-static_assert(glz::read_supported<glz::JSON, my_struct>);
+static_assert(glz::write_supported<my_struct, glz::JSON>);
+static_assert(glz::read_supported<my_struct, glz::JSON>);
 
 suite starter = [] {
    "example"_test = [] {


### PR DESCRIPTION
# Breaking Change

This change allows us to write:
```c++
template <read_supported<JSON> T>
```

Rather than requiring:
```c++
template <class T>
requires read_supported<JSON, T>
```