### PR TITLE
Fix Erlang format workflow

### DIFF
--- a/.github/workflows/clang-linux-erlang.yml
+++ b/.github/workflows/clang-linux-erlang.yml
@@ -49,11 +49,11 @@ jobs:
           -DCMAKE_CXX_COMPILER=${{env.CXX}} \
           -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
           -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++ -lc++abi" \
-          -Dglaze_ERLANG_FORMAT=ON
+          -Dglaze_EETF_FORMAT=ON
 
     - name: Build
-      run: cmake --build build -j $(nproc)
+      run: cmake --build build -j $(nproc) --target eetf_test
 
     - name: Test
       working-directory: build
-      run: ctest -j $(nproc) --output-on-failure
+      run: ctest -j $(nproc) --output-on-failure -R eetf_test

--- a/.github/workflows/gcc-erlang.yml
+++ b/.github/workflows/gcc-erlang.yml
@@ -44,10 +44,10 @@ jobs:
         CXXFLAGS="-g3" cmake -B ${{github.workspace}}/build \
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
           -DCMAKE_CXX_STANDARD=${{matrix.std}} \
-          -Dglaze_ERLANG_FORMAT=ON
+          -Dglaze_EETF_FORMAT=ON
 
     - name: Build
-      run: cmake --build build -j $(nproc)
+      run: cmake --build build -j $(nproc) --target eetf_test
 
     - name: Test
-      run: ctest --output-on-failure --test-dir ${{github.workspace}}/build
+      run: ctest --output-on-failure --test-dir ${{github.workspace}}/build -R eetf_test


### PR DESCRIPTION
The wrong CMake option name was being using, so eetf_tests was not being run. And, this update also restricts the EETF workflows to only testing the EETF format.