### PR TITLE
Fix GLZ_ALWAYS_INLINE for clang-cl: use __attribute__((always_inline)) instead of [[msvc::forceinline]]

### DIFF
--- a/include/glaze/util/inline.hpp
+++ b/include/glaze/util/inline.hpp
@@ -11,7 +11,7 @@
 
 #if defined(GLZ_USE_ALWAYS_INLINE) && defined(NDEBUG)
 #ifndef GLZ_ALWAYS_INLINE
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
 #define GLZ_ALWAYS_INLINE [[msvc::forceinline]] inline
 #else
 #define GLZ_ALWAYS_INLINE inline __attribute__((always_inline))


### PR DESCRIPTION
## Issue
When trying to build a project that uses glaze with the clang-cl compiler, the following warning appears:
```
[build] In file included from C:\artem\cpp\stripped-project-name\src\main.cpp:1:
[build] In file included from C:\artem\cpp\stripped-project-name\vendor\glaze\include\glaze/glaze.hpp:35:
[build] In file included from C:\artem\cpp\stripped-project-name\vendor\glaze\include\glaze/beve.hpp:6:
[build] C:\artem\cpp\stripped-project-name\vendor\glaze\include\glaze/beve/header.hpp(18,4): warning: unknown attribute 'forceinline' ignored [-Wunknown-attributes]
[build]    18 |    GLZ_ALWAYS_INLINE bool invalid_end(is_context auto& ctx, auto&& it, auto&& end) noexcept
[build]       |    ^~~~~~~~~~~~~~~~~
[build] C:\artem\cpp\stripped-project-name\vendor\glaze\include\glaze/util/inline.hpp(15,29): note: expanded from macro 'GLZ_ALWAYS_INLINE'
[build]    15 | #define GLZ_ALWAYS_INLINE [[msvc::forceinline]] inline
[build]       |                             ^~~~~~~~~~~~~~~~~
...
200+ identical warnings in different places
```
As a result, library does not provide the compiler with a strong inlining hint using the `GLZ_ALWAYS_INLINE` attribute on the clang-cl compiler, resulting in the function being treated as a regular `inline`, which is not a strong inlining directive

## Details
Although clang-cl supports msvc-like attributes (e.g. [[[msvc::noinline]]](https://clang.llvm.org/docs/AttributeReference.html#noinline)), unfortunately it does not specifically support the `[[msvc::forceinline]]` attribute, which can be seen in clang's attribute documentation: https://clang.llvm.org/docs/AttributeReference.html#always-inline-force-inline

## Fix
It is sufficient to check for two defines at the same time, these are `__clang__` to check if the compiler belongs to the clang ecosystem and `_MSC_VER` to check if MSVC compatibility is emulated.
That is, it should be enough to replace `#if defined(_MSC_VER)` with `#if defined(_MSC_VER) && !defined(__clang__)` in the code below:

```
#if defined(GLZ_USE_ALWAYS_INLINE) && defined(NDEBUG)
#ifndef GLZ_ALWAYS_INLINE
#if defined(_MSC_VER)
#define GLZ_ALWAYS_INLINE [[msvc::forceinline]] inline
#else
#define GLZ_ALWAYS_INLINE inline __attribute__((always_inline))
#endif
#endif
#endif
```