### PR TITLE
glz::custom support for error_on_missing_keys and nullable fields

### DIFF
--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -249,6 +249,55 @@ namespace glz
          return reflect<T>::keys[I];
       }
    }();
+   
+   template <class V, class From>
+   consteval bool custom_type_is_nullable()
+   {
+      if constexpr (std::is_member_pointer_v<From>) {
+         if constexpr (std::is_member_function_pointer_v<From>) {
+            using Ret = typename return_type<From>::type;
+            if constexpr (std::is_void_v<Ret>) {
+               using Tuple = typename inputs_as_tuple<From>::type;
+               if constexpr (glz::tuple_size_v<Tuple> == 1) {
+                  using Input = std::decay_t<glz::tuple_element_t<0, Tuple>>;
+                  return bool(null_t<Input>);
+               }
+            }
+         }
+         else if constexpr (std::is_member_object_pointer_v<From>) {
+            using Value = std::decay_t<decltype(std::declval<V>().val.*(std::declval<V>().from))>;
+            if constexpr (is_specialization_v<Value, std::function>) {
+               using Ret = typename function_traits<Value>::result_type;
+               
+               if constexpr (std::is_void_v<Ret>) {
+                  using Tuple = typename function_traits<Value>::arguments;
+                  if constexpr (glz::tuple_size_v<Tuple> == 1) {
+                     using Input = std::decay_t<glz::tuple_element_t<0, Tuple>>;
+                     return bool(null_t<Input>);
+                  }
+               }
+            }
+            else {
+               return bool(null_t<Value>);
+            }
+         }
+      }
+      else {
+         if constexpr (is_invocable_concrete<From>) {
+            using Ret = invocable_result_t<From>;
+            if constexpr (std::is_void_v<Ret>) {
+               using Tuple = invocable_args_t<From>;
+               constexpr auto N = glz::tuple_size_v<Tuple>;
+               if constexpr (N == 2) {
+                  using Input = std::decay_t<glz::tuple_element_t<1, Tuple>>;
+                  return bool(null_t<Input>);
+               }
+            }
+         }
+      }
+      
+      return false;
+   }
 
    template <class T, auto Opts>
    constexpr auto required_fields()
@@ -260,56 +309,11 @@ namespace glz
          for_each<N>([&](auto I) constexpr {
             using V = std::decay_t<refl_t<T, I>>;
             if constexpr (is_specialization_v<V, custom_t>) {
-               // If we are reading a glz::custom_t, we must deduce the input argument and not require the key if it is optional
-               // This allows error_on_missing_keys to work properly with glz::custom_t wrapping optional types
                using From = typename V::from_t;
                
-               constexpr bool nullable_in_custom = []{
-                  if constexpr (std::is_member_pointer_v<From>) {
-                     if constexpr (std::is_member_function_pointer_v<From>) {
-                        using Ret = typename return_type<From>::type;
-                        if constexpr (std::is_void_v<Ret>) {
-                           using Tuple = typename inputs_as_tuple<From>::type;
-                           if constexpr (glz::tuple_size_v<Tuple> == 1) {
-                              using Input = std::decay_t<glz::tuple_element_t<0, Tuple>>;
-                              return bool(null_t<Input>);
-                           }
-                        }
-                     }
-                     else if constexpr (std::is_member_object_pointer_v<From>) {
-                        using Value = std::decay_t<decltype(std::declval<V>().val.*(std::declval<V>().from))>;
-                        if constexpr (is_specialization_v<Value, std::function>) {
-                           using Ret = typename function_traits<Value>::result_type;
-                           
-                           if constexpr (std::is_void_v<Ret>) {
-                              using Tuple = typename function_traits<Value>::arguments;
-                              if constexpr (glz::tuple_size_v<Tuple> == 1) {
-                                 using Input = std::decay_t<glz::tuple_element_t<0, Tuple>>;
-                                 return bool(null_t<Input>);
-                              }
-                           }
-                        }
-                        else {
-                           return bool(null_t<Value>);
-                        }
-                     }
-                  }
-                  else {
-                     if constexpr (is_invocable_concrete<From>) {
-                        using Ret = invocable_result_t<From>;
-                        if constexpr (std::is_void_v<Ret>) {
-                           using Tuple = invocable_args_t<From>;
-                           constexpr auto N = glz::tuple_size_v<Tuple>;
-                           if constexpr (N == 2) {
-                              using Input = std::decay_t<glz::tuple_element_t<1, Tuple>>;
-                              return bool(null_t<Input>);
-                           }
-                        }
-                     }
-                  }
-                  
-                  return false;
-               }();
+               // If we are reading a glz::custom_t, we must deduce the input argument and not require the key if it is optional
+               // This allows error_on_missing_keys to work properly with glz::custom_t wrapping optional types
+               constexpr bool nullable_in_custom = custom_type_is_nullable<V, From>;
                
                fields[I] = !Opts.skip_null_members || !(std::same_as<From, skip> || nullable_in_custom);
             }

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -313,7 +313,7 @@ namespace glz
                
                // If we are reading a glz::custom_t, we must deduce the input argument and not require the key if it is optional
                // This allows error_on_missing_keys to work properly with glz::custom_t wrapping optional types
-               constexpr bool nullable_in_custom = custom_type_is_nullable<V, From>;
+               constexpr bool nullable_in_custom = custom_type_is_nullable<V, From>();
                
                fields[I] = !Opts.skip_null_members || !(std::same_as<From, skip> || nullable_in_custom);
             }

--- a/include/glaze/core/wrappers.hpp
+++ b/include/glaze/core/wrappers.hpp
@@ -46,8 +46,8 @@ namespace glz
       };
    }
 
-   // custom_t allows a user to register member functions (and std::function members) to implement custom reading and
-   // writing
+   // custom_t allows a user to register member functions, std::function members, and member variables
+   // to implement custom reading and writing
    template <class T, class From, class To>
    struct custom_t final
    {

--- a/tests/exceptions_test/exceptions_test.cpp
+++ b/tests/exceptions_test/exceptions_test.cpp
@@ -696,4 +696,59 @@ suite async_tests = [] {
    };
 };
 
+struct times
+{
+   uint64_t time;
+   std::optional<uint64_t> time1;
+   
+   void read_time(uint64_t timeValue)
+   {
+      time = timeValue;
+   }
+   
+   void read_time1(std::optional<uint64_t> time1Value)
+   {
+      time1 = time1Value;
+   }
+};
+
+struct date
+{
+   times t;
+};
+
+template <>
+struct glz::meta<times>
+{
+   using T = times;
+   static constexpr auto value = object(
+                                        "time", glz::custom<&T::read_time, nullptr>,
+                                        "time1", glz::custom<&T::read_time1, nullptr>
+                                        );
+};
+
+template <>
+struct glz::meta<date>
+{
+   using T = date;
+   static constexpr auto value = object("date", &T::t);
+};
+
+suite custom_tests = [] {
+   "glz::custom"_test = [] {
+      constexpr std::string_view onlyTimeJson = R"({"date":{"time":1}})";
+      
+      date d{};
+      
+      try
+      {
+         glz::ex::read<glz::opts{.error_on_missing_keys = true}>(d, onlyTimeJson);
+      }
+      catch (std::exception const& error)
+      {
+         expect(false) << error.what() << '\n';
+      }
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
This allows `error_on_missing_keys` to work properly with `glz::custom` wrapping nullable types like `std::optional`. It will not require fields that wrap nullable values.