### PR TITLE
Relax .as conversion for glz::json_t

### DIFF
--- a/include/glaze/json/json_t.hpp
+++ b/include/glaze/json/json_t.hpp
@@ -98,7 +98,7 @@ namespace glz
       }
 
       template <class T>
-         requires std::convertible_to<double, T>
+         requires (requires { static_cast<T>(std::declval<double>()); })
       [[nodiscard]] T as() const
       {
          // Can be used for int and the like


### PR DESCRIPTION
This allows enum conversions from `glz::json_t` with `value.as<Enum>()`