### PR TITLE
Move float_max_write_precision out of glz::opts

### DIFF
--- a/docs/wrappers.md
+++ b/docs/wrappers.md
@@ -388,11 +388,19 @@ struct write_precision_t
 };
 ```
 
+> [!IMPORTANT]
+>
+> The `glz::float_precision float_max_write_precision` is not a core option in `glz::opts`. You must create an options structure that adds this field to enable float precision control. The example below shows this user defined options struct that inherits from `glz::opts`.
+
 In use:
 
 ```c++
+struct float_opts : glz::opts {
+   glz::float_precision float_max_write_precision{};
+};
+
 write_precision_t obj{};
-std::string json_float = glz::write_json(obj);
+std::string json_float = glz::write<float_opts{}>(obj);
 expect(json_float == R"({"pi":3.1415927})") << json_float;
 ```
 

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -87,9 +87,6 @@ namespace glz
 
       uint8_t layout = rowwise; // CSV row wise output/input
 
-      // The maximum precision type used for writing floats, higher precision floats will be cast down to this precision
-      float_precision float_max_write_precision{};
-
       bool bools_as_numbers = false; // Read and write booleans with 1's and 0's
 
       bool quoted_num = false; // treat numbers as quoted or array-like types as having quoted numbers
@@ -145,6 +142,10 @@ namespace glz
    // (embedding nulls can cause issues, especially with C APIs)
    // Glaze will error when parsing non-escaped control character (per the JSON spec)
    // This option allows escaping control characters to avoid such errors.
+   
+   // ---
+   // The maximum precision type used for writing floats, higher precision floats will be cast down to this precision
+   // float_precision float_max_write_precision{};
 
    consteval bool check_validate_skipped(auto&& Opts)
    {
@@ -233,6 +234,16 @@ namespace glz
       }
       else {
          return false;
+      }
+   }
+   
+   consteval float_precision check_float_max_write_precision(auto&& Opts)
+   {
+      if constexpr (requires { Opts.float_max_write_precision; }) {
+         return Opts.float_max_write_precision;
+      }
+      else {
+         return {};
       }
    }
 

--- a/include/glaze/core/write_chars.hpp
+++ b/include/glaze/core/write_chars.hpp
@@ -64,16 +64,16 @@ namespace glz
          using V = std::decay_t<decltype(value)>;
 
          if constexpr (std::floating_point<V>) {
-            if constexpr (uint8_t(Opts.float_max_write_precision) > 0 &&
-                          uint8_t(Opts.float_max_write_precision) < sizeof(V)) {
+            if constexpr (uint8_t(check_float_max_write_precision(Opts)) > 0 &&
+                          uint8_t(check_float_max_write_precision(Opts)) < sizeof(V)) {
                // we cast to a lower precision floating point value before writing out
-               if constexpr (uint8_t(Opts.float_max_write_precision) == 8) {
+               if constexpr (uint8_t(check_float_max_write_precision(Opts)) == 8) {
                   const auto reduced = static_cast<double>(value);
                   const auto start = reinterpret_cast<char*>(&b[ix]);
                   const auto end = glz::to_chars(start, reduced);
                   ix += size_t(end - start);
                }
-               else if constexpr (uint8_t(Opts.float_max_write_precision) == 4) {
+               else if constexpr (uint8_t(check_float_max_write_precision(Opts)) == 4) {
                   const auto reduced = static_cast<float>(value);
                   const auto start = reinterpret_cast<char*>(&b[ix]);
                   const auto end = glz::to_chars(start, reduced);

--- a/include/glaze/json/max_write_precision.hpp
+++ b/include/glaze/json/max_write_precision.hpp
@@ -63,7 +63,7 @@ namespace glz
       template <auto Opts>
       GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
       {
-         static constexpr auto O = set_opt<Opts, &opts::float_max_write_precision>(float_precision::float32);
+         static constexpr auto O = set_opt<Opts, &decltype(Opts)::float_max_write_precision>(float_precision::float32);
          using Value = core_t<decltype(value.val)>;
          to<JSON, Value>::template op<O>(value.val, ctx, args...);
       }
@@ -75,7 +75,7 @@ namespace glz
       template <auto Opts>
       GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
       {
-         static constexpr auto O = set_opt<Opts, &opts::float_max_write_precision>(float_precision::float64);
+         static constexpr auto O = set_opt<Opts, &decltype(Opts)::float_max_write_precision>(float_precision::float64);
          using Value = core_t<decltype(value.val)>;
          to<JSON, Value>::template op<O>(value.val, ctx, args...);
       }
@@ -87,7 +87,7 @@ namespace glz
       template <auto Opts>
       GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&&... args) noexcept
       {
-         static constexpr auto O = set_opt<Opts, &opts::float_max_write_precision>(float_precision::full);
+         static constexpr auto O = set_opt<Opts, &decltype(Opts)::float_max_write_precision>(float_precision::full);
          using Value = core_t<decltype(value.val)>;
          to<JSON, Value>::template op<O>(value.val, ctx, args...);
       }

--- a/tests/example_json/example_json.cpp
+++ b/tests/example_json/example_json.cpp
@@ -432,12 +432,17 @@ struct FloatPrecision
    double val{3.141592653589793};
 };
 
+struct float_opts : glz::opts
+{
+   glz::float_precision float_max_write_precision{};
+};
+
 suite float_precision_test = [] {
    "float_precision"_test = [] {
       FloatPrecision fp{};
       std::string json;
       // limit float precision to float32
-      expect(not glz::write<glz::opts{.float_max_write_precision = glz::float_precision::float32}>(fp, json));
+      expect(not glz::write<float_opts{{}, glz::float_precision::float32}>(fp, json));
       // This should produce fewer decimal places.
       expect(json.find("3.1415927") != std::string::npos); // approximate float32 rounding
    };

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -9005,12 +9005,17 @@ struct write_precision_t
    };
 };
 
+struct float_opts : glz::opts
+{
+   glz::float_precision float_max_write_precision{};
+};
+
 suite max_write_precision_tests = [] {
    "max_write_precision"_test = [] {
       double pi = std::numbers::pi_v<double>;
       std::string json_double = glz::write_json(pi).value_or("error");
 
-      constexpr glz::opts options{.float_max_write_precision = glz::float_precision::float32};
+      constexpr float_opts options{{}, glz::float_precision::float32};
       std::string json_float = glz::write<options>(pi).value_or("error");
       expect(json_double != json_float);
       expect(json_float == glz::write_json(std::numbers::pi_v<float>));
@@ -9026,7 +9031,7 @@ suite max_write_precision_tests = [] {
 
    "write_precision_t"_test = [] {
       write_precision_t obj{};
-      std::string json_float = glz::write_json(obj).value_or("error");
+      std::string json_float = glz::write<float_opts{}>(obj).value_or("error");
       expect(json_float == R"({"pi":3.1415927})") << json_float;
    };
 };


### PR DESCRIPTION
## Breaking Change

Moved `glz::float_precision` out of the default `glz::opts` fields. This change does not remove any functionality from Glaze.

The `glz::float_precision` enum is not widely used, but had the greatest impact on the length of the template parameter name printed by compilers when compile time errors occur. By moving this out of the default `glz::opts` we shorten compilation errors and make compilation hashes faster.

This change requires a user to add their own option type with the field:
```c++
struct float_opts : glz::opts {
   glz::float_precision float_max_write_precision{};
};
```