### PR TITLE
glz::trace better input argument order and fix for async_scope

### DIFF
--- a/docs/time-trace.md
+++ b/docs/time-trace.md
@@ -49,11 +49,21 @@ trace.begin("my event name", "My event description");
 trace.end("my event name");
 ```
 
-## Disabling trace
+## Runtime Disabling Trace
 
 ```c++
 trace.disabled = true; // no data will be collected
 ```
+
+## Compile Time Disabling Trace
+
+A boolean template parameter `Enabled` defaults to `true`, but can be set to `false` to compile time disable tracing and thus remove the binary when compiled.
+
+```c++
+glz::trace<false> trace{};
+```
+
+When disabled, writing `glz::trace` as JSON will result in an empty JSON object: `{}`
 
 ## Scoped Tracing
 

--- a/docs/time-trace.md
+++ b/docs/time-trace.md
@@ -47,9 +47,9 @@ trace.disabled = true; // no data will be collected
 
 ## Scoped Tracing
 
-`trace.scope("event name")` automatically ends the event when it goes out of scope.
+`auto scoper = trace.scope("event name");` automatically ends the event when it goes out of scope.
 
-`trace.async_scope("event name")` automatically ends the async event when it goes out of scope.
+`auto scoper = trace.async_scope("event name");` automatically ends the async event when it goes out of scope.
 
 ## Global tracing
 

--- a/docs/time-trace.md
+++ b/docs/time-trace.md
@@ -13,11 +13,21 @@ An example of the API in use:
 
 glz::trace trace{}; // make a structure to store a trace
 
-trace.begin("my event name")
+trace.begin("my event name");
 // compute something here
-trace.end("my event name")
+trace.end("my event name");
   
 auto ec = glz::write_file_json(trace, "trace.json", std::string{});
+```
+
+Or, for async events:
+
+```c++
+glz::trace trace{}; // make a structure to store a trace
+
+trace.async_begin("my event name");
+// compute something here
+trace.async_end("my event name");
 ```
 
 ## Args (metadata)
@@ -47,9 +57,25 @@ trace.disabled = true; // no data will be collected
 
 ## Scoped Tracing
 
-`auto scoper = trace.scope("event name");` automatically ends the event when it goes out of scope.
+Automatically ends the event when it goes out of scope:
 
-`auto scoper = trace.async_scope("event name");` automatically ends the async event when it goes out of scope.
+```c++
+{
+  auto scoper = trace.scope("event name"); // trace.begin("event name") called
+  // run event
+}
+// end("event name") automatically called when leaving scope
+```
+
+Automatically ends the async event when it goes out of scope:
+
+```c++
+{
+  auto scoper = trace.async_scope("event name"); // trace.async_begin("event name") called
+  // run event
+}
+// trace.async_end("event name") automatically called when leaving scope
+```
 
 ## Global tracing
 

--- a/include/glaze/trace/trace.hpp
+++ b/include/glaze/trace/trace.hpp
@@ -57,12 +57,10 @@ namespace glz
 
    struct trace
    {
-      std::deque<trace_event> traceEvents{};
-      display_time_unit displayTimeUnit = display_time_unit::ms;
-
-      std::optional<std::chrono::time_point<std::chrono::steady_clock>> t0{}; // the time of the first event
-
       std::atomic<bool> disabled = false;
+      display_time_unit displayTimeUnit = display_time_unit::ms;
+      std::deque<trace_event> traceEvents{};
+      std::optional<std::chrono::time_point<std::chrono::steady_clock>> t0{}; // the time of the first event
       std::mutex mtx{};
 
       template <class... Args>

--- a/include/glaze/trace/trace.hpp
+++ b/include/glaze/trace/trace.hpp
@@ -184,13 +184,13 @@ namespace glz
          async_scoper(trace& tr, const std::string_view name) noexcept : tr(tr), name(name)
          {
             if (not tr.disabled) {
-               tr.begin(name);
+               tr.async_begin(name);
             }
          }
          ~async_scoper() noexcept
          {
             if (not tr.disabled) {
-               tr.end(name);
+               tr.async_end(name);
             }
          }
 

--- a/include/glaze/trace/trace.hpp
+++ b/include/glaze/trace/trace.hpp
@@ -63,6 +63,10 @@ namespace glz
       std::deque<trace_event> traceEvents{};
       std::optional<std::chrono::time_point<std::chrono::steady_clock>> t0{}; // the time of the first event
       std::mutex mtx{};
+      
+      void clear() {
+         traceEvents.clear();
+      }
 
       template <class... Args>
          requires(sizeof...(Args) <= 1)


### PR DESCRIPTION
Better ordering of `glz::trace` arguments for brace initialization and fixed issue with async_scope not registering async events.