### PR TITLE
CSV improvements

### DIFF
--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -113,7 +113,7 @@ namespace glz
       uint32_t format = CSV;
       bool null_terminated = true; // Whether the input buffer is null terminated
       uint8_t layout = rowwise; // CSV row wise output/input
-      bool csv_write_headers = true; // Whether to write column/row headers in CSV format
+      bool use_headers = true; // Whether to write column/row headers in CSV format
       
       // INTERNAL OPTIONS
       uint32_t internal{}; // default should be 0
@@ -254,10 +254,10 @@ namespace glz
       }
    }
 
-   consteval bool check_csv_write_headers(auto&& Opts)
+   consteval bool check_use_headers(auto&& Opts)
    {
-      if constexpr (requires { Opts.csv_write_headers; }) {
-         return Opts.csv_write_headers;
+      if constexpr (requires { Opts.use_headers; }) {
+         return Opts.use_headers;
       }
       else {
          return true;

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -111,9 +111,10 @@ namespace glz
    struct opts_csv
    {
       uint32_t format = CSV;
-      bool null_terminated = true; // Whether the input buffer is null terminated
+      static constexpr bool null_terminated = true; // Whether the input buffer is null terminated
       uint8_t layout = rowwise; // CSV row wise output/input
       bool use_headers = true; // Whether to write column/row headers in CSV format
+      bool append_arrays = false; // When reading into an array the data will be appended if the type supports it
       
       // INTERNAL OPTIONS
       uint32_t internal{}; // default should be 0

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -9,7 +9,7 @@
 
 namespace glz
 {
-   // format
+   // Formats
    // Built in formats must be less than 65536
    // User defined formats can be 65536 to 4294967296
    inline constexpr uint32_t INVALID = 0;
@@ -89,8 +89,6 @@ namespace glz
       bool error_on_const_read =
          false; // Error if attempt is made to read into a const value, by default the value is skipped without error
 
-      uint8_t layout = rowwise; // CSV row wise output/input
-
       bool bools_as_numbers = false; // Read and write booleans with 1's and 0's
 
       bool quoted_num = false; // treat numbers as quoted or array-like types as having quoted numbers
@@ -106,6 +104,20 @@ namespace glz
       uint32_t internal{}; // default should be 0
 
       [[nodiscard]] constexpr bool operator==(const opts&) const noexcept = default;
+   };
+   
+   // CSV Format Options
+   // Note: You can always create your own options struct if you want to share it between formats
+   struct opts_csv : opts
+   {
+      uint32_t format = CSV;
+      uint8_t layout = rowwise; // CSV row wise output/input
+      bool csv_write_headers = true; // Whether to write column/row headers in CSV format
+      
+      // INTERNAL OPTIONS
+      uint32_t internal{}; // default should be 0
+      
+      [[nodiscard]] constexpr bool operator==(const opts_csv&) const noexcept = default;
    };
 
    // Add these fields to a custom options struct if you want to use them
@@ -238,6 +250,26 @@ namespace glz
       }
       else {
          return false;
+      }
+   }
+
+   consteval bool check_csv_write_headers(auto&& Opts)
+   {
+      if constexpr (requires { Opts.csv_write_headers; }) {
+         return Opts.csv_write_headers;
+      }
+      else {
+         return true;
+      }
+   }
+   
+   consteval uint8_t check_layout(auto&& Opts)
+   {
+      if constexpr (requires { Opts.layout; }) {
+         return Opts.layout;
+      }
+      else {
+         return rowwise;
       }
    }
 

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -108,9 +108,10 @@ namespace glz
    
    // CSV Format Options
    // Note: You can always create your own options struct if you want to share it between formats
-   struct opts_csv : opts
+   struct opts_csv
    {
       uint32_t format = CSV;
+      bool null_terminated = true; // Whether the input buffer is null terminated
       uint8_t layout = rowwise; // CSV row wise output/input
       bool csv_write_headers = true; // Whether to write column/row headers in CSV format
       

--- a/include/glaze/csv/read.hpp
+++ b/include/glaze/csv/read.hpp
@@ -275,7 +275,7 @@ namespace glz
       template <auto Opts, class It>
       static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end)
       {
-         if constexpr (Opts.layout == rowwise) {
+         if constexpr (check_layout(Opts) == rowwise) {
             while (it != end) {
                auto start = it;
                goto_delim<','>(it, end);
@@ -439,7 +439,7 @@ namespace glz
          static constexpr auto N = reflect<T>::size;
          static constexpr auto HashInfo = hash_info<T>;
 
-         if constexpr (Opts.layout == rowwise) {
+         if constexpr (check_layout(Opts) == rowwise) {
             while (it != end) {
                auto start = it;
                goto_delim<','>(it, end);
@@ -649,14 +649,14 @@ namespace glz
    template <uint32_t layout = rowwise, read_supported<CSV> T, class Buffer>
    [[nodiscard]] inline auto read_csv(T&& value, Buffer&& buffer)
    {
-      return read<opts{.format = CSV, .layout = layout}>(value, std::forward<Buffer>(buffer));
+      return read<opts_csv{.layout = layout}>(value, std::forward<Buffer>(buffer));
    }
 
    template <uint32_t layout = rowwise, read_supported<CSV> T, class Buffer>
    [[nodiscard]] inline auto read_csv(Buffer&& buffer)
    {
       T value{};
-      read<opts{.format = CSV, .layout = layout}>(value, std::forward<Buffer>(buffer));
+      read<opts_csv{.layout = layout}>(value, std::forward<Buffer>(buffer));
       return value;
    }
 
@@ -672,6 +672,6 @@ namespace glz
          return {ec};
       }
 
-      return read<opts{.format = CSV, .layout = layout}>(value, buffer, ctx);
+      return read<opts_csv{.layout = layout}>(value, buffer, ctx);
    }
 }

--- a/include/glaze/csv/read.hpp
+++ b/include/glaze/csv/read.hpp
@@ -428,6 +428,160 @@ namespace glz
          }
       }
    };
+   
+   // For types like std::vector<T> where T is a struct/object
+   template <readable_array_t T>
+      requires(glaze_object_t<typename T::value_type> || reflectable<typename T::value_type>)
+   struct from<CSV, T>
+   {
+      using U = typename T::value_type;
+      
+      template <auto Opts, class It>
+      static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end)
+      {
+         static constexpr auto N = reflect<U>::size;
+         static constexpr auto HashInfo = hash_info<U>;
+         
+         // Clear existing data if not appending
+         if constexpr (!Opts.append_arrays) {
+            value.clear();
+         }
+         
+         if constexpr (check_layout(Opts) == colwise)
+         {
+            // Read column headers
+            std::vector<size_t> member_indices;
+            
+            if constexpr (check_use_headers(Opts))
+            {
+               auto headers = read_column_wise_keys(ctx, it, end);
+               
+               if (bool(ctx.error)) [[unlikely]]
+               {
+                  return;
+               }
+               
+               if (csv_new_line(ctx, it))
+               {
+                  return;
+               }
+               
+               // Map header names to member indices
+               for (const auto& [key, idx] : headers)
+               {
+                  const auto member_idx = decode_hash_with_size<CSV, U, HashInfo, HashInfo.type>::op(
+                                                                                                     key.data(), key.data() + key.size(), key.size());
+                  
+                  if (member_idx >= N) [[unlikely]]
+                  {
+                     ctx.error = error_code::unknown_key;
+                     return;
+                  }
+                  
+                  member_indices.push_back(member_idx);
+               }
+            }
+            else
+            {
+               // Use default order of members
+               for (size_t i = 0; i < N; ++i)
+               {
+                  member_indices.push_back(i);
+               }
+            }
+            
+            const auto n_cols = member_indices.size();
+            
+            // Read rows
+            while (it != end)
+            {
+               U struct_value{};
+               
+               for (size_t i = 0; i < n_cols; ++i)
+               {
+                  const auto member_idx = member_indices[i];
+                  
+                  visit<N>([&]<size_t I>() {
+                     if (I == member_idx)
+                     {
+                        decltype(auto) member = [&]() -> decltype(auto) {
+                           if constexpr (reflectable<U>) {
+                              return get_member(struct_value, get<I>(to_tie(struct_value)));
+                           }
+                           else {
+                              return get_member(struct_value, get<I>(reflect<U>::values));
+                           }
+                        }();
+                        
+                        parse<CSV>::op<Opts>(member, ctx, it, end);
+                     }
+                  }, member_idx);
+                  
+                  if (bool(ctx.error)) [[unlikely]]
+                  {
+                     return;
+                  }
+                  
+                  if (i < n_cols - 1)
+                  {
+                     if (*it == ',')
+                     {
+                        ++it;
+                     }
+                     else [[unlikely]]
+                     {
+                        ctx.error = error_code::syntax_error;
+                        return;
+                     }
+                  }
+               }
+               
+               value.push_back(std::move(struct_value));
+               
+               if (it == end)
+               {
+                  break;
+               }
+               
+               // Handle newlines
+               if (*it == '\r')
+               {
+                  ++it;
+                  if (it != end && *it == '\n')
+                  {
+                     ++it;
+                  }
+                  else [[unlikely]]
+                  {
+                     ctx.error = error_code::syntax_error;
+                     return;
+                  }
+               }
+               else if (*it == '\n')
+               {
+                  ++it;
+               }
+               else [[unlikely]]
+               {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
+               
+               if (it == end)
+               {
+                  break;
+               }
+            }
+         }
+         else // rowwise layout
+         {
+            // Row-wise isn't a typical format for vector of structs in CSV
+            // But we could implement if needed
+            ctx.error = error_code::feature_not_supported;
+            return;
+         }
+      }
+   };
 
    template <class T>
       requires(glaze_object_t<T> || reflectable<T>)

--- a/include/glaze/csv/write.hpp
+++ b/include/glaze/csv/write.hpp
@@ -112,7 +112,7 @@ namespace glz
       {
          if constexpr (check_layout(Opts) == rowwise) {
             for (auto& [name, data] : value) {
-               if constexpr (check_csv_write_headers(Opts)) {
+               if constexpr (check_use_headers(Opts)) {
                   dump_maybe_empty(name, b, ix);
                   dump<','>(b, ix);
                }
@@ -129,7 +129,7 @@ namespace glz
          else {
             // dump titles
             const auto n = value.size();
-            if constexpr (check_csv_write_headers(Opts)) {
+            if constexpr (check_use_headers(Opts)) {
                size_t i = 0;
                for (auto& [name, data] : value) {
                   dump_maybe_empty(name, b, ix);
@@ -208,7 +208,7 @@ namespace glz
                   const auto count = member.size();
                   const auto size = member[0].size();
                   for (size_t i = 0; i < size; ++i) {
-                     if constexpr (check_csv_write_headers(Opts)) {
+                     if constexpr (check_use_headers(Opts)) {
                         dump<key>(b, ix);
                         dump<'['>(b, ix);
                         write_chars::op<Opts>(i, ctx, b, ix);
@@ -229,7 +229,7 @@ namespace glz
                   }
                }
                else {
-                  if constexpr (check_csv_write_headers(Opts)) {
+                  if constexpr (check_use_headers(Opts)) {
                      dump<key>(b, ix);
                      dump<','>(b, ix);
                   }
@@ -240,7 +240,7 @@ namespace glz
          }
          else {
             // write titles
-            if constexpr (check_csv_write_headers(Opts)) {
+            if constexpr (check_use_headers(Opts)) {
                for_each<N>([&](auto I) {
                   using X = refl_t<T, I>;
 
@@ -350,7 +350,7 @@ namespace glz
          static constexpr auto N = reflect<U>::size;
 
          // Write headers (field names) if enabled
-         if constexpr (check_csv_write_headers(Opts)) {
+         if constexpr (check_use_headers(Opts)) {
             for_each<N>([&](auto I) {
                static constexpr sv key = reflect<U>::keys[I];
                serialize<CSV>::op<Opts>(key, ctx, b, ix);

--- a/include/glaze/exceptions/csv_exceptions.hpp
+++ b/include/glaze/exceptions/csv_exceptions.hpp
@@ -22,7 +22,7 @@ namespace glz::ex
    template <uint32_t layout = rowwise, class T, class Buffer>
    inline auto read_csv(Buffer&& buffer)
    {
-      auto ex = glz::read<T, opts{.format = CSV, .layout = layout}>(std::forward<Buffer>(buffer));
+      auto ex = glz::read<T, opts_csv{.layout = layout}>(std::forward<Buffer>(buffer));
       if (ex) {
          throw std::runtime_error("read_csv error");
       }
@@ -44,7 +44,7 @@ namespace glz::ex
    template <class T, class Buffer>
    inline auto write_csv(T&& value, Buffer&& buffer)
    {
-      const auto ec = write<opts{.format = CSV}>(std::forward<T>(value), std::forward<Buffer>(buffer));
+      const auto ec = write<opts_csv{}>(std::forward<T>(value), std::forward<Buffer>(buffer));
       if (ec) {
          throw std::runtime_error("write_csv error");
       }

--- a/tests/csv_test/csv_test.cpp
+++ b/tests/csv_test/csv_test.cpp
@@ -678,7 +678,7 @@ suite csv_headers_control_tests = [] {
       csv_headers_struct obj{};
       std::string buffer{};
       
-      expect(not glz::write<glz::opts_csv{.csv_write_headers = true}>(obj, buffer));
+      expect(not glz::write<glz::opts_csv{.use_headers = true}>(obj, buffer));
       expect(buffer ==
              R"(num1,1,2,3
 num2,4,5,6
@@ -690,7 +690,7 @@ text,a,b,c
       csv_headers_struct obj{};
       std::string buffer{};
       
-      expect(not glz::write<glz::opts_csv{.csv_write_headers = false}>(obj, buffer));
+      expect(not glz::write<glz::opts_csv{.use_headers = false}>(obj, buffer));
       expect(buffer ==
              R"(1,2,3
 4,5,6
@@ -702,7 +702,7 @@ a,b,c
       csv_headers_struct obj{};
       std::string buffer{};
       
-      expect(not glz::write<glz::opts_csv{.layout = glz::colwise, .csv_write_headers = true}>(obj, buffer));
+      expect(not glz::write<glz::opts_csv{.layout = glz::colwise, .use_headers = true}>(obj, buffer));
       expect(buffer ==
              R"(num1,num2,text
 1,4,a
@@ -715,7 +715,7 @@ a,b,c
       csv_headers_struct obj{};
       std::string buffer{};
       
-      expect(not glz::write<glz::opts_csv{.layout = glz::colwise, .csv_write_headers = false}>(obj, buffer));
+      expect(not glz::write<glz::opts_csv{.layout = glz::colwise, .use_headers = false}>(obj, buffer));
       expect(buffer ==
              R"(1,4,a
 2,5,b
@@ -729,12 +729,12 @@ a,b,c
       std::string buffer;
       
       // First write with headers
-      expect(not glz::write<glz::opts_csv{.layout = glz::colwise, .csv_write_headers = true}>(obj, buffer));
+      expect(not glz::write<glz::opts_csv{.layout = glz::colwise, .use_headers = true}>(obj, buffer));
       result.append(buffer);
       
       // Subsequent write without headers
       buffer.clear();
-      expect(not glz::write<glz::opts_csv{.layout = glz::colwise, .csv_write_headers = false}>(obj, buffer));
+      expect(not glz::write<glz::opts_csv{.layout = glz::colwise, .use_headers = false}>(obj, buffer));
       result.append(buffer);
       
       expect(result ==
@@ -789,7 +789,7 @@ suite vector_struct_csv_tests = [] {
       };
       
       std::string buffer{};
-      expect(not glz::write<glz::opts_csv{.csv_write_headers = false}>(data, buffer));
+      expect(not glz::write<glz::opts_csv{.use_headers = false}>(data, buffer));
       
       expect(buffer ==
              R"(1,10.5,Point A

--- a/tests/csv_test/csv_test.cpp
+++ b/tests/csv_test/csv_test.cpp
@@ -843,4 +843,93 @@ suite vector_struct_csv_tests = [] {
    };
 };
 
+suite vector_struct_direct_read_tests = [] {
+   "read_vector_of_structs"_test = [] {
+      // Create test data
+      std::vector<data_point> original = {
+         {1, 10.5f, "Point A"},
+         {2, 20.3f, "Point B"},
+         {3, 15.7f, "Point C"}
+      };
+      
+      // Write to CSV string
+      std::string csv_str{};
+      expect(not glz::write<glz::opts_csv{}>(original, csv_str));
+      
+      // This is what the CSV looks like
+      expect(csv_str ==
+             R"(id,value,name
+1,10.5,Point A
+2,20.3,Point B
+3,15.7,Point C
+)");
+      
+      // Now read directly back into vector of structs
+      std::vector<data_point> read_back{};
+      expect(not glz::read<glz::opts_csv{.layout = glz::colwise}>(read_back, csv_str));
+      
+      // Verify the data was read correctly
+      expect(read_back.size() == 3);
+      
+      expect(read_back[0].id == 1);
+      expect(read_back[0].value == 10.5f);
+      expect(read_back[0].name == "Point A");
+      
+      expect(read_back[1].id == 2);
+      expect(read_back[1].value == 20.3f);
+      expect(read_back[1].name == "Point B");
+      
+      expect(read_back[2].id == 3);
+      expect(read_back[2].value == 15.7f);
+      expect(read_back[2].name == "Point C");
+   };
+   
+   "read_vector_of_structs_without_headers"_test = [] {
+      std::string csv_str =
+          R"(1,10.5,Point A
+2,20.3,Point B
+3,15.7,Point C)";
+      
+      std::vector<data_point> read_back{};
+      expect(not glz::read<glz::opts_csv{.layout = glz::colwise, .use_headers = false}>(read_back, csv_str));
+      
+      // Verify the data was read correctly
+      expect(read_back.size() == 3);
+      
+      expect(read_back[0].id == 1);
+      expect(read_back[0].value == 10.5f);
+      expect(read_back[0].name == "Point A");
+      
+      expect(read_back[1].id == 2);
+      expect(read_back[1].value == 20.3f);
+      expect(read_back[1].name == "Point B");
+      
+      expect(read_back[2].id == 3);
+      expect(read_back[2].value == 15.7f);
+      expect(read_back[2].name == "Point C");
+   };
+   
+   "append_to_vector"_test = [] {
+      // Initial vector with some data
+      std::vector<data_point> data = {
+         {1, 10.5f, "Point A"}
+      };
+      
+      // CSV with additional data
+      std::string csv_str =
+          R"(id,value,name
+2,20.3,Point B
+3,15.7,Point C)";
+      
+      // Append the new data
+      expect(not glz::read<glz::opts_csv{.layout = glz::colwise, .append_arrays = true}>(data, csv_str));
+      
+      // Verify combined data
+      expect(data.size() == 3);
+      expect(data[0].id == 1);
+      expect(data[1].id == 2);
+      expect(data[2].id == 3);
+   };
+};
+
 int main() { return 0; }

--- a/tests/csv_test/csv_test.cpp
+++ b/tests/csv_test/csv_test.cpp
@@ -71,7 +71,7 @@ suite csv_tests = [] {
 
       std::string out{};
 
-      expect(not glz::write<glz::opts{.format = glz::CSV, .layout = glz::colwise}>(obj, out));
+      expect(not glz::write<glz::opts_csv{.layout = glz::colwise}>(obj, out));
       expect(out ==
              R"(num1,num2,maybe,v3s[0],v3s[1],v3s[2]
 11,22,1,1,1,1
@@ -101,7 +101,7 @@ suite csv_tests = [] {
 
       std::string out{};
 
-      expect(not glz::write<glz::opts{.format = glz::CSV, .layout = glz::colwise}>(obj, out));
+      expect(not glz::write<glz::opts_csv{.layout = glz::colwise}>(obj, out));
       expect(out ==
              R"(num1,num2,maybe,v3s[0],v3s[1],v3s[2]
 11,22,1,1,1,1
@@ -136,7 +136,7 @@ suite csv_tests = [] {
 
       std::string out{};
 
-      expect(not glz::write<glz::opts{.format = glz::CSV, .layout = glz::colwise}>(obj, out));
+      expect(not glz::write<glz::opts_csv{.layout = glz::colwise}>(obj, out));
       expect(out ==
              R"(id,udl
 1,BRN
@@ -167,7 +167,7 @@ v3s[2],1,2,3,4)";
 
       std::string out{};
 
-      expect(not glz::write<glz::opts{.format = glz::CSV}>(obj, out));
+      expect(not glz::write<glz::opts_csv{}>(obj, out));
       expect(out ==
              R"(num1,11,33,55,77
 num2,22,44,66,88
@@ -193,7 +193,7 @@ v3s[2],1,2,3,4)");
 
       std::string out{};
 
-      expect(not glz::write<glz::opts{.format = glz::CSV}>(obj, out));
+      expect(not glz::write<glz::opts_csv{}>(obj, out));
       expect(out ==
              R"(num1,11,33,55,77
 num2,22,44,66,88
@@ -216,16 +216,16 @@ v3s[2],1,2,3,4)");
       }
 
       std::string out{};
-      expect(not glz::write<glz::opts{.format = glz::CSV}>(m, out));
+      expect(not glz::write<glz::opts_csv{}>(m, out));
       expect(out == R"(x,0,1,2,3,4,5,6,7,8,9
 y,1,2,3,4,5,6,7,8,9,10
 )");
 
       out.clear();
-      expect(not glz::write<glz::opts{.format = glz::CSV}>(m, out));
+      expect(not glz::write<glz::opts_csv{}>(m, out));
 
       m.clear();
-      expect(!glz::read<glz::opts{.format = glz::CSV}>(m, out));
+      expect(!glz::read<glz::opts_csv{}>(m, out));
 
       expect(m["x"] == std::vector<uint64_t>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
       expect(m["y"] == std::vector<uint64_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
@@ -242,7 +242,7 @@ y,1,2,3,4,5,6,7,8,9,10
       }
 
       std::string out{};
-      expect(not glz::write<glz::opts{.format = glz::CSV, .layout = glz::colwise}>(m, out));
+      expect(not glz::write<glz::opts_csv{.layout = glz::colwise}>(m, out));
       expect(out == R"(x,y
 0,1
 1,2
@@ -257,10 +257,10 @@ y,1,2,3,4,5,6,7,8,9,10
 )");
 
       out.clear();
-      expect(not glz::write<glz::opts{.format = glz::CSV, .layout = glz::colwise}>(m, out));
+      expect(not glz::write<glz::opts_csv{.layout = glz::colwise}>(m, out));
 
       m.clear();
-      expect(!glz::read<glz::opts{.format = glz::CSV, .layout = glz::colwise}>(m, out));
+      expect(!glz::read<glz::opts_csv{.layout = glz::colwise}>(m, out));
 
       expect(m["x"] == std::vector<uint64_t>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
       expect(m["y"] == std::vector<uint64_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
@@ -277,7 +277,7 @@ y,1,2,3,4,5,6,7,8,9,10
       }
 
       std::string out{};
-      expect(not glz::write<glz::opts{.format = glz::CSV}>(m, out));
+      expect(not glz::write<glz::opts_csv{}>(m, out));
       expect(out == R"(y,1,2,3,4,5,6,7,8,9,10
 x,0,1,2,3,4,5,6,7,8,9
 )" || out == R"(x,0,1,2,3,4,5,6,7,8,9
@@ -285,10 +285,10 @@ y,1,2,3,4,5,6,7,8,9,10
 )");
 
       out.clear();
-      expect(not glz::write<glz::opts{.format = glz::CSV}>(m, out));
+      expect(not glz::write<glz::opts_csv{}>(m, out));
 
       m.clear();
-      expect(!glz::read<glz::opts{.format = glz::CSV}>(m, out));
+      expect(!glz::read<glz::opts_csv{}>(m, out));
 
       expect(m["x"] == std::vector<uint64_t>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
       expect(m["y"] == std::vector<uint64_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
@@ -328,7 +328,7 @@ x,1,2,3,4,5)");
       }
 
       std::string s;
-      expect(not write<glz::opts{.format = glz::CSV, .layout = glz::colwise}>(recorder, s));
+      expect(not write<glz::opts_csv{.layout = glz::colwise}>(recorder, s));
       expect(s ==
              R"(t,x
 0,1
@@ -347,7 +347,7 @@ x,1,2,3,4,5)");
       glz::context ctx{};
       issue_768_test_struct value;
       glz::error_ctx glaze_err{
-         glz::read<glz::opts{.format = glz::CSV, .layout = glz::colwise}>(value, std::string{valid_record}, ctx)};
+         glz::read<glz::opts_csv{.layout = glz::colwise}>(value, std::string{valid_record}, ctx)};
       expect(!bool(glaze_err));
    };
    "issue 768 invalid_record 1"_test = [] {
@@ -360,7 +360,7 @@ x,1,2,3,4,5)");
       glz::context ctx{};
       issue_768_test_struct value;
       glz::error_ctx glaze_err{
-         glz::read<glz::opts{.format = glz::CSV, .layout = glz::colwise}>(value, std::string{invalid_record_1}, ctx)};
+         glz::read<glz::opts_csv{.layout = glz::colwise}>(value, std::string{invalid_record_1}, ctx)};
       expect(bool(glaze_err));
    };
 
@@ -374,7 +374,7 @@ x,1,2,3,4,5)");
       glz::context ctx{};
       issue_768_test_struct value;
       glz::error_ctx glaze_err{
-         glz::read<glz::opts{.format = glz::CSV, .layout = glz::colwise}>(value, std::string{invalid_record_2}, ctx)};
+         glz::read<glz::opts_csv{.layout = glz::colwise}>(value, std::string{invalid_record_2}, ctx)};
       expect(bool(glaze_err));
    };
 };
@@ -410,7 +410,7 @@ suite reflect_my_struct_test = [] {
 
       std::string out{};
 
-      expect(not glz::write<glz::opts{.format = glz::CSV, .layout = glz::colwise}>(obj, out));
+      expect(not glz::write<glz::opts_csv{.layout = glz::colwise}>(obj, out));
       expect(out ==
              R"(num1,num2,maybe,v3s[0],v3s[1],v3s[2]
 11,22,1,1,1,1
@@ -441,7 +441,7 @@ v3s[2],1,2,3,4)";
 
       std::string out{};
 
-      expect(not glz::write<glz::opts{.format = glz::CSV}>(obj, out));
+      expect(not glz::write<glz::opts_csv{}>(obj, out));
       expect(out ==
              R"(num1,11,33,55,77
 num2,22,44,66,88
@@ -642,6 +642,204 @@ suite currency_csv_test = [] {
       expect(not ec);
       ec = glz::read_file_csv(obj, "currency_rowwise.csv", buffer);
       expect(not ec) << glz::format_error(ec, buffer) << '\n';*/
+   };
+};
+
+struct csv_headers_struct
+{
+   std::vector<int> num1{1, 2, 3};
+   std::vector<float> num2{4.0f, 5.0f, 6.0f};
+   std::vector<std::string> text{"a", "b", "c"};
+};
+
+template <>
+struct glz::meta<csv_headers_struct>
+{
+   using T = csv_headers_struct;
+   static constexpr auto value = glz::object(&T::num1, &T::num2, &T::text);
+};
+
+struct data_point
+{
+   int id{};
+   float value{};
+   std::string name{};
+};
+
+template <>
+struct glz::meta<data_point>
+{
+   using T = data_point;
+   static constexpr auto value = glz::object(&T::id, &T::value, &T::name);
+};
+
+suite csv_headers_control_tests = [] {
+   "rowwise_with_headers"_test = [] {
+      csv_headers_struct obj{};
+      std::string buffer{};
+      
+      expect(not glz::write<glz::opts_csv{.csv_write_headers = true}>(obj, buffer));
+      expect(buffer ==
+             R"(num1,1,2,3
+num2,4,5,6
+text,a,b,c
+)");
+   };
+   
+   "rowwise_without_headers"_test = [] {
+      csv_headers_struct obj{};
+      std::string buffer{};
+      
+      expect(not glz::write<glz::opts_csv{.csv_write_headers = false}>(obj, buffer));
+      expect(buffer ==
+             R"(1,2,3
+4,5,6
+a,b,c
+)");
+   };
+   
+   "colwise_with_headers"_test = [] {
+      csv_headers_struct obj{};
+      std::string buffer{};
+      
+      expect(not glz::write<glz::opts_csv{.layout = glz::colwise, .csv_write_headers = true}>(obj, buffer));
+      expect(buffer ==
+             R"(num1,num2,text
+1,4,a
+2,5,b
+3,6,c
+)");
+   };
+   
+   "colwise_without_headers"_test = [] {
+      csv_headers_struct obj{};
+      std::string buffer{};
+      
+      expect(not glz::write<glz::opts_csv{.layout = glz::colwise, .csv_write_headers = false}>(obj, buffer));
+      expect(buffer ==
+             R"(1,4,a
+2,5,b
+3,6,c
+)");
+   };
+   
+   "incremental_writing"_test = [] {
+      csv_headers_struct obj{};
+      std::string result;
+      std::string buffer;
+      
+      // First write with headers
+      expect(not glz::write<glz::opts_csv{.layout = glz::colwise, .csv_write_headers = true}>(obj, buffer));
+      result.append(buffer);
+      
+      // Subsequent write without headers
+      buffer.clear();
+      expect(not glz::write<glz::opts_csv{.layout = glz::colwise, .csv_write_headers = false}>(obj, buffer));
+      result.append(buffer);
+      
+      expect(result ==
+             R"(num1,num2,text
+1,4,a
+2,5,b
+3,6,c
+1,4,a
+2,5,b
+3,6,c
+)");
+   };
+};
+
+// Read the CSV data into a struct with vectors
+struct csv_data {
+   std::vector<int> id{};
+   std::vector<float> value{};
+   std::vector<std::string> name{};
+   
+   struct glaze {
+      using T = csv_data;
+      static constexpr auto value = glz::object(&T::id, &T::value, &T::name);
+   };
+};
+
+// Test suite for the vector-of-structs feature
+suite vector_struct_csv_tests = [] {
+   "vector_of_structs_with_headers"_test = [] {
+      std::vector<data_point> data = {
+         {1, 10.5f, "Point A"},
+         {2, 20.3f, "Point B"},
+         {3, 15.7f, "Point C"}
+      };
+      
+      std::string buffer{};
+      expect(not glz::write<glz::opts_csv{}>(data, buffer));
+      
+      expect(buffer ==
+             R"(id,value,name
+1,10.5,Point A
+2,20.3,Point B
+3,15.7,Point C
+)");
+   };
+   
+   "vector_of_structs_without_headers"_test = [] {
+      std::vector<data_point> data = {
+         {1, 10.5f, "Point A"},
+         {2, 20.3f, "Point B"},
+         {3, 15.7f, "Point C"}
+      };
+      
+      std::string buffer{};
+      expect(not glz::write<glz::opts_csv{.csv_write_headers = false}>(data, buffer));
+      
+      expect(buffer ==
+             R"(1,10.5,Point A
+2,20.3,Point B
+3,15.7,Point C
+)");
+   };
+   
+   "empty_vector"_test = [] {
+      std::vector<data_point> data{};
+      
+      std::string buffer{};
+      expect(not glz::write<glz::opts_csv{}>(data, buffer));
+      
+      // Should only contain headers
+      expect(buffer == R"(id,value,name
+)");
+   };
+   
+   "vector_roundtrip"_test = [] {
+      // Create test data
+      std::vector<data_point> original = {
+         {1, 10.5f, "Point A"},
+         {2, 20.3f, "Point B"},
+         {3, 15.7f, "Point C"}
+      };
+      
+      // Write to CSV string
+      std::string csv_str{};
+      expect(not glz::write<glz::opts_csv{}>(original, csv_str));
+      
+      csv_data data{};
+      expect(not glz::read<glz::opts_csv{.layout = glz::colwise}>(data, csv_str));
+      
+      // Verify the data was read correctly
+      expect(data.id.size() == 3);
+      expect(data.value.size() == 3);
+      expect(data.name.size() == 3);
+      
+      expect(data.id[0] == 1);
+      expect(data.id[1] == 2);
+      expect(data.id[2] == 3);
+      
+      expect(data.value[0] == 10.5f);
+      expect(data.value[1] == 20.3f);
+      expect(data.value[2] == 15.7f);
+      
+      expect(data.name[0] == "Point A");
+      expect(data.name[1] == "Point B");
+      expect(data.name[2] == "Point C");
    };
 };
 


### PR DESCRIPTION
## Breaking Change
* Moved `layout` CSV option out of default `glz::opts`

## Improvements
* Added a new `glz::opts_csv`, with only the options that apply to the CSV format.
* Support for writing a CSV without headers.
* Support for array like types with structs as the value_type (reading/writing)

> This merge will not yet add reading without field names, as this needs further consideration.

```c++
struct csv_headers_struct
{
   std::vector<int> num1{1, 2, 3};
   std::vector<float> num2{4.0f, 5.0f, 6.0f};
   std::vector<std::string> text{"a", "b", "c"};
};

template <>
struct glz::meta<csv_headers_struct>
{
   using T = csv_headers_struct;
   static constexpr auto value = glz::object(&T::num1, &T::num2, &T::text);
};

struct data_point
{
   int id{};
   float value{};
   std::string name{};
};

template <>
struct glz::meta<data_point>
{
   using T = data_point;
   static constexpr auto value = glz::object(&T::id, &T::value, &T::name);
};

suite csv_headers_control_tests = [] {
   "rowwise_with_headers"_test = [] {
      csv_headers_struct obj{};
      std::string buffer{};
      
      expect(not glz::write<glz::opts_csv{.use_headers = true}>(obj, buffer));
      expect(buffer ==
             R"(num1,1,2,3
num2,4,5,6
text,a,b,c
)");
   };
   
   "rowwise_without_headers"_test = [] {
      csv_headers_struct obj{};
      std::string buffer{};
      
      expect(not glz::write<glz::opts_csv{.use_headers = false}>(obj, buffer));
      expect(buffer ==
             R"(1,2,3
4,5,6
a,b,c
)");
   };
   
   "colwise_with_headers"_test = [] {
      csv_headers_struct obj{};
      std::string buffer{};
      
      expect(not glz::write<glz::opts_csv{.layout = glz::colwise, .use_headers = true}>(obj, buffer));
      expect(buffer ==
             R"(num1,num2,text
1,4,a
2,5,b
3,6,c
)");
   };
   
   "colwise_without_headers"_test = [] {
      csv_headers_struct obj{};
      std::string buffer{};
      
      expect(not glz::write<glz::opts_csv{.layout = glz::colwise, .use_headers = false}>(obj, buffer));
      expect(buffer ==
             R"(1,4,a
2,5,b
3,6,c
)");
   };
   
   "incremental_writing"_test = [] {
      csv_headers_struct obj{};
      std::string result;
      std::string buffer;
      
      // First write with headers
      expect(not glz::write<glz::opts_csv{.layout = glz::colwise, .use_headers = true}>(obj, buffer));
      result.append(buffer);
      
      // Subsequent write without headers
      buffer.clear();
      expect(not glz::write<glz::opts_csv{.layout = glz::colwise, .use_headers = false}>(obj, buffer));
      result.append(buffer);
      
      expect(result ==
             R"(num1,num2,text
1,4,a
2,5,b
3,6,c
1,4,a
2,5,b
3,6,c
)");
   };
};

// Read the CSV data into a struct with vectors
struct csv_data {
   std::vector<int> id{};
   std::vector<float> value{};
   std::vector<std::string> name{};
   
   struct glaze {
      using T = csv_data;
      static constexpr auto value = glz::object(&T::id, &T::value, &T::name);
   };
};

// Test suite for the vector-of-structs feature
suite vector_struct_csv_tests = [] {
   "vector_of_structs_with_headers"_test = [] {
      std::vector<data_point> data = {
         {1, 10.5f, "Point A"},
         {2, 20.3f, "Point B"},
         {3, 15.7f, "Point C"}
      };
      
      std::string buffer{};
      expect(not glz::write<glz::opts_csv{}>(data, buffer));
      
      expect(buffer ==
             R"(id,value,name
1,10.5,Point A
2,20.3,Point B
3,15.7,Point C
)");
   };
   
   "vector_of_structs_without_headers"_test = [] {
      std::vector<data_point> data = {
         {1, 10.5f, "Point A"},
         {2, 20.3f, "Point B"},
         {3, 15.7f, "Point C"}
      };
      
      std::string buffer{};
      expect(not glz::write<glz::opts_csv{.use_headers = false}>(data, buffer));
      
      expect(buffer ==
             R"(1,10.5,Point A
2,20.3,Point B
3,15.7,Point C
)");
   };
   
   "empty_vector"_test = [] {
      std::vector<data_point> data{};
      
      std::string buffer{};
      expect(not glz::write<glz::opts_csv{}>(data, buffer));
      
      // Should only contain headers
      expect(buffer == R"(id,value,name
)");
   };
   
   "vector_roundtrip"_test = [] {
      // Create test data
      std::vector<data_point> original = {
         {1, 10.5f, "Point A"},
         {2, 20.3f, "Point B"},
         {3, 15.7f, "Point C"}
      };
      
      // Write to CSV string
      std::string csv_str{};
      expect(not glz::write<glz::opts_csv{}>(original, csv_str));
      
      csv_data data{};
      expect(not glz::read<glz::opts_csv{.layout = glz::colwise}>(data, csv_str));
      
      // Verify the data was read correctly
      expect(data.id.size() == 3);
      expect(data.value.size() == 3);
      expect(data.name.size() == 3);
      
      expect(data.id[0] == 1);
      expect(data.id[1] == 2);
      expect(data.id[2] == 3);
      
      expect(data.value[0] == 10.5f);
      expect(data.value[1] == 20.3f);
      expect(data.value[2] == 15.7f);
      
      expect(data.name[0] == "Point A");
      expect(data.name[1] == "Point B");
      expect(data.name[2] == "Point C");
   };
};

suite vector_struct_direct_read_tests = [] {
   "read_vector_of_structs"_test = [] {
      // Create test data
      std::vector<data_point> original = {
         {1, 10.5f, "Point A"},
         {2, 20.3f, "Point B"},
         {3, 15.7f, "Point C"}
      };
      
      // Write to CSV string
      std::string csv_str{};
      expect(not glz::write<glz::opts_csv{}>(original, csv_str));
      
      // This is what the CSV looks like
      expect(csv_str ==
             R"(id,value,name
1,10.5,Point A
2,20.3,Point B
3,15.7,Point C
)");
      
      // Now read directly back into vector of structs
      std::vector<data_point> read_back{};
      expect(not glz::read<glz::opts_csv{.layout = glz::colwise}>(read_back, csv_str));
      
      // Verify the data was read correctly
      expect(read_back.size() == 3);
      
      expect(read_back[0].id == 1);
      expect(read_back[0].value == 10.5f);
      expect(read_back[0].name == "Point A");
      
      expect(read_back[1].id == 2);
      expect(read_back[1].value == 20.3f);
      expect(read_back[1].name == "Point B");
      
      expect(read_back[2].id == 3);
      expect(read_back[2].value == 15.7f);
      expect(read_back[2].name == "Point C");
   };
   
   "read_vector_of_structs_without_headers"_test = [] {
      std::string csv_str =
          R"(1,10.5,Point A
2,20.3,Point B
3,15.7,Point C)";
      
      std::vector<data_point> read_back{};
      expect(not glz::read<glz::opts_csv{.layout = glz::colwise, .use_headers = false}>(read_back, csv_str));
      
      // Verify the data was read correctly
      expect(read_back.size() == 3);
      
      expect(read_back[0].id == 1);
      expect(read_back[0].value == 10.5f);
      expect(read_back[0].name == "Point A");
      
      expect(read_back[1].id == 2);
      expect(read_back[1].value == 20.3f);
      expect(read_back[1].name == "Point B");
      
      expect(read_back[2].id == 3);
      expect(read_back[2].value == 15.7f);
      expect(read_back[2].name == "Point C");
   };
   
   "append_to_vector"_test = [] {
      // Initial vector with some data
      std::vector<data_point> data = {
         {1, 10.5f, "Point A"}
      };
      
      // CSV with additional data
      std::string csv_str =
          R"(id,value,name
2,20.3,Point B
3,15.7,Point C)";
      
      // Append the new data
      expect(not glz::read<glz::opts_csv{.layout = glz::colwise, .append_arrays = true}>(data, csv_str));
      
      // Verify combined data
      expect(data.size() == 3);
      expect(data[0].id == 1);
      expect(data[1].id == 2);
      expect(data[2].id == 3);
   };
};

```