### PR TITLE
Add CI jobs for big-endian builds

### DIFF
--- a/.github/workflows/clang-linux-big-endian.yml
+++ b/.github/workflows/clang-linux-big-endian.yml
@@ -1,0 +1,110 @@
+name: clang-linux-big-endian
+
+on:
+  push:
+    branches:
+      - main
+      - feature/*
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        clang: [17, 18]
+        build_type: [Debug]
+        std: [23]
+        target: [
+          { arch: s390x, triple: s390x-unknown-linux-gnu }
+        ]
+
+    env:
+      CC: clang-${{matrix.clang}}
+      CXX: clang++-${{matrix.clang}}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Discover Ubuntu release codename
+      id: discover-ubuntu-codename
+      run: echo "codename=$(lsb_release -cs)" >> $GITHUB_OUTPUT
+
+    - name: Add target architecture with dpkg
+      run: sudo dpkg --add-architecture ${{ matrix.target.arch }}
+
+    - name: Prepare APT sources for target architecture
+      run: |
+        sudo cp /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu-${{ matrix.target.arch }}.sources
+        sudo sed -i'' -E 's@^(URIs:.*)$@URIs: http://ports.ubuntu.com/ubuntu-ports@' /etc/apt/sources.list.d/ubuntu-${{ matrix.target.arch }}.sources
+        sudo sed -i'' -E 's@^(Signed-By:.*)$@Architectures: ${{ matrix.target.arch }}\n\1@' /etc/apt/sources.list.d/ubuntu-${{ matrix.target.arch }}.sources
+        echo "/etc/apt/sources.list.d/ubuntu-${{ matrix.target.arch }}.sources:"
+        cat /etc/apt/sources.list.d/ubuntu-${{ matrix.target.arch }}.sources
+
+    - name: Prepare APT sources for host architecture
+      run: |
+        sudo sed -i'' -E 's@^(Signed-By:.*)$@Architectures: amd64 i386\n\1@' /etc/apt/sources.list.d/ubuntu.sources
+        echo "/etc/apt/sources.list.d/ubuntu.sources:"
+        cat /etc/apt/sources.list.d/ubuntu.sources
+
+    - name: Prepare APT sources for latest CMake
+      run: |
+        sudo apt remove --purge --auto-remove cmake
+        sudo apt update
+        sudo apt install -y software-properties-common lsb-release
+        wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+        sudo apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main"
+
+    - name: Prepare APT for installing target libc++
+      run: |
+        sudo apt remove --purge --auto-remove libc++-dev libc++abi-dev
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          cmake \
+          ninja-build \
+          qemu-user-static \
+          mold \
+          libc6:${{ matrix.target.arch }} \
+          libc6-dev:${{ matrix.target.arch }} \
+          libgcc-13-dev:${{ matrix.target.arch }} \
+          libgcc-s1:${{ matrix.target.arch }} \
+          libstdc++-13-dev:${{ matrix.target.arch }} \
+          libc++-dev:${{ matrix.target.arch }} \
+          libc++abi-dev:${{ matrix.target.arch }}
+
+    - name: Configure CMake
+      run: |
+        cmake \
+          -B ${{github.workspace}}/build \
+          -G Ninja \
+          -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
+          -DCMAKE_CXX_STANDARD=${{matrix.std}} \
+          -DCMAKE_C_COMPILER=${{env.CC}} \
+          -DCMAKE_C_COMPILER_TARGET=${{ matrix.target.triple }} \
+          -DCMAKE_CXX_COMPILER=${{env.CXX}} \
+          -DCMAKE_CXX_COMPILER_TARGET=${{ matrix.target.triple }} \
+          -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
+          -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++ -lc++abi" \
+          -DCMAKE_LINKER_TYPE=MOLD \
+          -DCMAKE_SYSTEM_NAME=Linux
+
+    - name: Build
+      run: cmake --build build -j $(nproc)
+
+    - name: Test
+      working-directory: build
+      run: ctest -j $(nproc) --output-on-failure

--- a/.github/workflows/gcc-linux-big-endian.yml
+++ b/.github/workflows/gcc-linux-big-endian.yml
@@ -1,0 +1,61 @@
+name: gcc-linux-big-endian
+
+on:
+  push:
+    branches:
+      - main
+      - feature/*
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug]
+        std: [23]
+        target: [
+          { arch: s390x, triple: s390x-unknown-linux-gnu }
+        ]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          cmake \
+          ninja-build \
+          qemu-user-static \
+          binutils-${{ matrix.target.arch }}-linux-gnu \
+          g++-${{ matrix.target.arch }}-linux-gnu
+
+    - name: Configure CMake
+      run: |
+        cmake \
+          -B ${{github.workspace}}/build \
+          -G Ninja \
+          -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
+          -DCMAKE_CXX_STANDARD=${{matrix.std}} \
+          -DCMAKE_C_COMPILER=${{ matrix.target.arch }}-linux-gnu-gcc \
+          -DCMAKE_CXX_COMPILER=${{ matrix.target.arch }}-linux-gnu-g++ \
+          -DCMAKE_SYSTEM_NAME=Linux
+
+    - name: Build
+      run: cmake --build build -j $(nproc)
+
+    - name: Test
+      working-directory: build
+      run: ctest -j $(nproc) --output-on-failure


### PR DESCRIPTION
Related: https://github.com/stephenberry/glaze/issues/1675

This PR adds CI jobs for big-endian builds to help development of big-endian support.

The build target is `s390x-unknown-linux-gnu` since this is the only big-endian target easy to set up on GitHub actions without resorting to containers or other virtualization options. Although Ubuntu lists `powerpc` (32-bit) as a supported big-endian target, it is apparently no longer an officially maintained platform and has no recent releases.

The `clang-linux-big-endian` job uses `clang` and `libc++` and targets `s390x-unknown-linux-gnu`. It uses `mold` as the linker because `lld` does not support `s390x` and using GNU `ld` would require setting up a different compiler toolchain (which we do in the other job). This job also installs the latest CMake since version `>= 3.29` is needed (with support for `CMAKE_LINKER_TYPE`) to configure the linker easily for cross-compilation.

The `gcc-linux-big-endian` job uses a standard GNU cross-compiling toolchain configuration with the `s390x-linux-gnu-` prefix.

Both jobs also install `qemu-user-static` which automatically configures `binfmt` so any `s390x` binaries can be run from the shell without manually invoking qemu. This can also be configured separately through CMake for CTest via the `CMAKE_CROSSCOMPILING_EMULATOR` variable.

Both jobs successfully begin compilation but fail as expected on the little-endianness assertions.