### PR TITLE
Fix reinitialization in glz::asio_client

### DIFF
--- a/include/glaze/ext/glaze_asio.hpp
+++ b/include/glaze/ext/glaze_asio.hpp
@@ -330,10 +330,13 @@ namespace glz
       [[nodiscard]] error_code init()
       {
          ctx = std::make_shared<asio::io_context>(concurrency);
-         socket_pool->ctx = ctx;
-         socket_pool->host = host;
-         socket_pool->service = service;
-         is_connected = socket_pool->is_connected;
+         {
+            std::unique_lock lock{socket_pool->mtx}; // lock the socket_pool when setting up
+            socket_pool->ctx = ctx;
+            socket_pool->host = host;
+            socket_pool->service = service;
+            is_connected = socket_pool->is_connected;
+         }
 
          unique_socket socket{socket_pool.get()};
          if (socket) {

--- a/include/glaze/ext/glaze_asio.hpp
+++ b/include/glaze/ext/glaze_asio.hpp
@@ -334,9 +334,9 @@ namespace glz
 
       [[nodiscard]] error_code init()
       {
-         ctx = std::make_shared<asio::io_context>(concurrency);
          {
             std::unique_lock lock{socket_pool->mtx}; // lock the socket_pool when setting up
+            ctx = std::make_shared<asio::io_context>(concurrency);
             socket_pool->ctx = ctx;
             socket_pool->host = host;
             socket_pool->service = service;

--- a/include/glaze/ext/glaze_asio.hpp
+++ b/include/glaze/ext/glaze_asio.hpp
@@ -323,7 +323,7 @@ namespace glz
       };
 
       std::shared_ptr<asio::io_context> ctx{};
-      std::shared_ptr<glz::socket_pool> socket_pool = std::make_shared<glz::socket_pool>();
+      std::shared_ptr<glz::socket_pool> socket_pool{};
       std::shared_ptr<glz::memory_pool<repe::message>> message_pool =
          std::make_shared<glz::memory_pool<repe::message>>();
 
@@ -334,6 +334,11 @@ namespace glz
 
       [[nodiscard]] error_code init()
       {
+         *is_connected = false;
+         // create a new socket_pool if we are initilaizing, this is needed because the sockets hold references to the io_context
+         // which is being recreated with init()
+         socket_pool = std::make_shared<glz::socket_pool>();
+         
          {
             std::unique_lock lock{socket_pool->mtx}; // lock the socket_pool when setting up
             ctx = std::make_shared<asio::io_context>(concurrency);


### PR DESCRIPTION
If `init()` was called again on asio_client the sockets in the socket pool could still have references to the old context. This fixes that issue by rebuilding the socket_pool on reinitialization.