### PR TITLE
fix string parsing overwriting quote

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1004,13 +1004,15 @@ namespace glz
 
                      it = start;
                      while (it < end) [[likely]] {
-                        *p = *it;
                         if (*it == '"') {
                            value.resize(size_t(p - value.data()));
                            ++it;
                            return;
                         }
-                        else if (*it == '\\') {
+
+                        *p = *it;
+
+                        if (*it == '\\') {
                            ++it; // skip the escape
                            if (*it == 'u') {
                               ++it;

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -10704,6 +10704,25 @@ suite immutable_array_read_tests = [] {
    };
 };
 
+suite factor8_strings = [] {
+   // string parsing invokes separate path when there's >= 8 chars to parse.  There was a bug where
+   // inputs of exact factors of 8 chars caused overwriting, therefore not terminated correctly. 
+
+   "exactly 8"_test = [] {
+      const auto payload = R"("abcdefg")"; // 8 chars after open quote
+      const auto parsed = glz::read_json<std::string>(payload);
+      expect(parsed.has_value());
+      expect(*parsed->end() == '\0');
+   };
+
+   "factor of 8"_test = [] {
+      const auto payload = R"("abcdefghijklmno")"; // 16 chars after open quote
+      const auto parsed = glz::read_json<std::string>(payload);
+      expect(parsed.has_value());
+      expect(*parsed->end() == '\0');
+   };
+};
+
 int main()
 {
    trace.end("json_test");


### PR DESCRIPTION
## Issue
Parsing strings from input buffer lengths that are factors of 8 overwrites a quote (`"`) to the string's data, breaking the null-termination guarantee of strings. Subsequent code that reads the string as a c-string (`std::string::c_str`) therefore misinterprets it.

### Reproduction

```cpp
      const auto payload = R"("abcdefg")"; // 8 chars after open quote
      const auto parsed = glz::read_json<std::string>(payload);
      assert(parsed.has_value());
      assert(*parsed->end() == '\0'); // fails
```

## Explanation
Glaze's string parsing uses multiple paths based on the size of the remaining input buffer, where the threshold is 8 remaining chars: [link](https://github.com/stephenberry/glaze/blob/main/include/glaze/json/read.hpp#L933). Previously, the input buffer char was written to the output buffer before checking for the closing quote and ending string parsing. This often worked, as a subsequent `string::resize()`  would null-terminate again. However, when parsing to strings from an input buffer length that's a factor of 8, the output string would already be the correct size, causing `resize()` to have no effect, and the closing quote remains. 


This PR fixes this error and adds regression tests against it. This was hard to track down from the error behaviour, but a simple fix.