### PR TITLE
Support for read constraints

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -14,6 +14,7 @@
 #include "glaze/concepts/container_concepts.hpp"
 #include "glaze/core/array_apply.hpp"
 #include "glaze/core/context.hpp"
+#include "glaze/core/constraint.hpp"
 #include "glaze/core/feature_test.hpp"
 #include "glaze/core/meta.hpp"
 #include "glaze/util/bit_array.hpp"
@@ -604,6 +605,7 @@ struct glz::meta<glz::error_code>
                                     "invalid_variant_string",
                                     "no_matching_variant_type",
                                     "expected_true_or_false",
+                                    "constraint_violated",
                                     "key_not_found",
                                     "unknown_key",
                                     "missing_key",
@@ -668,6 +670,7 @@ struct glz::meta<glz::error_code>
                                      invalid_variant_string, //
                                      no_matching_variant_type, //
                                      expected_true_or_false, //
+                                     constraint_violated, //
                                      // Key errors
                                      key_not_found, //
                                      unknown_key, //

--- a/include/glaze/core/constraint.hpp
+++ b/include/glaze/core/constraint.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "glaze/core/opts.hpp"
+#include "glaze/util/string_literal.hpp"
 
 namespace glz
 {

--- a/include/glaze/core/constraint.hpp
+++ b/include/glaze/core/constraint.hpp
@@ -3,9 +3,7 @@
 
 #pragma once
 
-#include "glaze/core/read.hpp"
-#include "glaze/core/wrappers.hpp"
-#include "glaze/core/write.hpp"
+#include "glaze/core/opts.hpp"
 
 namespace glz
 {

--- a/include/glaze/core/constraint.hpp
+++ b/include/glaze/core/constraint.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "glaze/core/opts.hpp"
+#include "glaze/tuplet/tuple.hpp"
 #include "glaze/util/string_literal.hpp"
 
 namespace glz

--- a/include/glaze/core/constraint.hpp
+++ b/include/glaze/core/constraint.hpp
@@ -1,0 +1,200 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include "glaze/core/read.hpp"
+#include "glaze/core/wrappers.hpp"
+#include "glaze/core/write.hpp"
+
+namespace glz
+{
+   // read_constraint allows a user to register a contraint lambda or member function
+   // that returns a boolean, which indicates true for success and false for failure
+   // this allows arguments to be validated
+   template <class T, auto Target, auto Constraint, string_literal Message>
+   struct read_constraint_t
+   {
+      static constexpr auto glaze_reflect = false;
+      static constexpr std::string_view message = Message;
+      using target_t = decltype(Target);
+      using constraint_t = decltype(Constraint);
+      T& val;
+      static constexpr auto target = Target;
+      static constexpr auto constraint = Constraint;
+   };
+   
+   template <class T>
+   concept is_read_constraint = requires {
+      requires !T::glaze_reflect;
+      typename T::target_t;
+      typename T::constraint_t;
+   };
+   
+   template <uint32_t Format, is_read_constraint T>
+   struct from<Format, T>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         using V = std::decay_t<decltype(value)>;
+         using Constraint = typename V::constraint_t;
+         
+         auto assign_to_target = [&]<class Input>(Input&& input){
+            using Target = typename V::target_t;
+            if constexpr (std::is_member_object_pointer_v<Target>) {
+               (value.val).*(value.target) = std::forward<Input>(input);
+            }
+            else if constexpr (std::invocable<Target, decltype(value.val)>) {
+               std::invoke(value.target, value.val) = std::forward<Input>(input);
+            }
+            else {
+               static_assert(false_v<Target>,
+                             "expected invocable function or member object pointer, perhaps you need const qualified input on your lambda");
+            }
+         };
+
+         if constexpr (std::is_member_pointer_v<Constraint>) {
+            if constexpr (std::is_member_function_pointer_v<Constraint>) {
+               using Ret = typename return_type<Constraint>::type;
+               if constexpr (std::same_as<Ret, bool>) {
+                  using Tuple = typename inputs_as_tuple<Constraint>::type;
+                  if constexpr (glz::tuple_size_v<Tuple> == 1) {
+                     std::decay_t<glz::tuple_element_t<0, Tuple>> input{};
+                     parse<Format>::template op<Opts>(input, ctx, it, end);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                     auto success = (value.val.*(value.constraint))(input);
+                     if (not success) {
+                        ctx.error = error_code::constraint_violated;
+                        ctx.custom_error_message = V::message;
+                        return;
+                     }
+                     assign_to_target(std::move(input));
+                  }
+                  else {
+                     static_assert(false_v<T>, "function must have a single input");
+                  }
+               }
+               else {
+                  static_assert(false_v<T>, "function must return a boolean (true for success)");
+               }
+            }
+            else if constexpr (std::is_member_object_pointer_v<Constraint>) {
+               auto& constraint = value.val.*(value.constraint);
+               using Func = std::decay_t<decltype(constraint)>;
+               if constexpr (is_specialization_v<Func, std::function>) {
+                  using Ret = typename function_traits<Func>::result_type;
+                  
+                  if constexpr (std::same_as<Ret, bool>) {
+                     using Tuple = typename function_traits<Func>::arguments;
+                     if constexpr (glz::tuple_size_v<Tuple> == 1) {
+                        std::decay_t<glz::tuple_element_t<0, Tuple>> input{};
+                        parse<Format>::template op<Opts>(input, ctx, it, end);
+                        if (bool(ctx.error)) [[unlikely]]
+                           return;
+                        auto success = constraint(input);
+                        if (not success) {
+                           ctx.error = error_code::constraint_violated;
+                           ctx.custom_error_message = V::message;
+                           return;
+                        }
+                        assign_to_target(std::move(input));
+                     }
+                     else {
+                        static_assert(false_v<T>, "function must have a single input");
+                     }
+                  }
+                  else {
+                     static_assert(false_v<T>, "std::function must return a boolean (true for success)");
+                  }
+               }
+               else {
+                  static_assert(false_v<T>, "invalid type for read_constraint_t");
+               }
+            }
+            else {
+               static_assert(false_v<T>, "invalid type for read_constraint_t");
+            }
+         }
+         else {
+            if constexpr (is_invocable_concrete<Constraint>) {
+               using Ret = invocable_result_t<Constraint>;
+               if constexpr (std::same_as<Ret, bool>) {
+                  using Tuple = invocable_args_t<Constraint>;
+                  constexpr auto N = glz::tuple_size_v<Tuple>;
+                  if constexpr (N == 0) {
+                     static_assert(false_v<T>, "lambda must take in the class as the first argument and the type to deserialize as the second");
+                  }
+                  else if constexpr (N == 2) {
+                     std::decay_t<glz::tuple_element_t<1, Tuple>> input{};
+                     parse<Format>::template op<Opts>(input, ctx, it, end);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                     auto success = value.constraint(value.val, input);
+                     if (not success) {
+                        ctx.error = error_code::constraint_violated;
+                        ctx.custom_error_message = V::message;
+                        return;
+                     }
+                     assign_to_target(std::move(input));
+                  }
+                  else {
+                     static_assert(false_v<T>, "lambda must have two inputs, the class and the type to deserialize");
+                  }
+               }
+               else {
+                  static_assert(false_v<T>, "lambda must return a boolean (true for success)");
+               }
+            }
+            else {
+               static_assert(
+                  false_v<T>,
+                  "IMPORTANT: Two arguments are required in your lambda (e.g. [](my_struct&, const std::string& "
+                  "input)) you must make all the arguments concrete types. None of the inputs can be `auto`. Also, "
+                  "you probably cannot define these lambdas within a local `struct glaze`, but instead need to use "
+                  "`glz::meta` outside your class so that your lambda can operate on a defined class.");
+            }
+         }
+      }
+   };
+
+   template <uint32_t Format, is_read_constraint T>
+   struct to<Format, T>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&&... args)
+      {
+         using V = std::decay_t<decltype(value)>;
+         using Target = typename V::target_t;
+
+         if constexpr (std::is_member_pointer_v<Target>) {
+            if constexpr (std::is_member_object_pointer_v<Target>) {
+               auto& target = value.val.*(value.target);
+               serialize<Format>::template op<Opts>(target, ctx, args...);
+            }
+            else {
+               static_assert(false_v<T>, "invalid type for read_constraint_t");
+            }
+         }
+         else {
+            if constexpr (std::invocable<Target, decltype(value.val)>) {
+               serialize<Format>::template op<Opts>(std::invoke(value.target, value.val), ctx, args...);
+            }
+            else {
+               static_assert(false_v<Target>,
+                             "expected invocable function, perhaps you need const qualified input on your lambda");
+            }
+         }
+      }
+   };
+   
+   template <auto Target, auto Constraint, string_literal Message>
+   constexpr auto read_constraint_impl() noexcept
+   {
+      return [](auto&& v) { return read_constraint_t<std::remove_cvref_t<decltype(v)>, Target, Constraint, Message>{v}; };
+   }
+   
+   template <auto Target, auto Constraint, string_literal Message>
+   constexpr auto read_constraint = read_constraint_impl<Target, Constraint, Message>();
+}

--- a/include/glaze/core/context.hpp
+++ b/include/glaze/core/context.hpp
@@ -50,6 +50,7 @@ namespace glz
       invalid_variant_string, //
       no_matching_variant_type, //
       expected_true_or_false, //
+      constraint_violated, //
       // Key errors
       key_not_found, //
       unknown_key, //

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -1978,6 +1978,7 @@ namespace glz
          error_str.append(pe.includer_error);
       }
       if (pe.custom_error_message.size()) {
+         error_str.append(" ");
          error_str.append(pe.custom_error_message.begin(), pe.custom_error_message.end());
       }
       return error_str;
@@ -1993,6 +1994,7 @@ namespace glz
          error_str.append(pe.includer_error);
       }
       if (pe.custom_error_message.size()) {
+         error_str.append(" ");
          error_str.append(pe.custom_error_message.begin(), pe.custom_error_message.end());
       }
       return error_str;

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -1973,7 +1973,14 @@ namespace glz
 
    [[nodiscard]] inline std::string format_error(const error_ctx& pe)
    {
-      return std::string{meta<error_code>::keys[uint32_t(pe.ec)]};
+      std::string error_str{meta<error_code>::keys[uint32_t(pe.ec)]};
+      if (pe.includer_error.size()) {
+         error_str.append(pe.includer_error);
+      }
+      if (pe.custom_error_message.size()) {
+         error_str.append(pe.custom_error_message.begin(), pe.custom_error_message.end());
+      }
+      return error_str;
    }
 
    [[nodiscard]] inline std::string format_error(const error_ctx& pe, const auto& buffer)
@@ -1984,6 +1991,9 @@ namespace glz
       auto error_str = detail::generate_error_string(error_type_str, info);
       if (pe.includer_error.size()) {
          error_str.append(pe.includer_error);
+      }
+      if (pe.custom_error_message.size()) {
+         error_str.append(pe.custom_error_message.begin(), pe.custom_error_message.end());
       }
       return error_str;
    }

--- a/include/glaze/core/wrappers.hpp
+++ b/include/glaze/core/wrappers.hpp
@@ -63,7 +63,7 @@ namespace glz
    custom_t(T&, From, To) -> custom_t<T, From, To>;
 
    template <auto From, auto To>
-   inline constexpr auto custom_impl() noexcept
+   constexpr auto custom_impl() noexcept
    {
       return [](auto&& v) { return custom_t{v, From, To}; };
    }
@@ -92,6 +92,7 @@ namespace glz
    template <auto MemPtr>
    constexpr auto partial_read = opts_wrapper<MemPtr, &opts::partial_read>();
 
+   // Customize reading and writing
    template <auto From, auto To>
    constexpr auto custom = custom_impl<From, To>();
 }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -7021,6 +7021,9 @@ suite constraint_tests = []
       expect(bool(ec));
       error_message = glz::format_error(ec, buffer);
       expect(error_message == "1:35: constraint_violated\n   {\"age\": 10, \"name\": \"Abra Cadabra\"}\n                                     ^ Name is too long") << error_message << '\n';
+      
+      expect(not glz::write_json(obj, buffer));
+      expect(buffer == R"({"age":10,"name":"José"})") << buffer;
    };
 };
 

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -6989,17 +6989,11 @@ struct glz::meta<constrained_object>
 {
    using T = constrained_object;
    static constexpr auto limit_age = [](const T&, int age) {
-      if (age < 0 || age > 120) {
-         return false;
-      }
-      return true;
+      return (age >= 0 && age <= 120);
    };
    
    static constexpr auto limit_name = [](const T&, const std::string& name) {
-      if (name.size() > 8) {
-         return false;
-      }
-      return true;
+      return name.size() <= 8;
    };
    
    static constexpr auto value = object("age", read_constraint<&T::age, limit_age, "Age out of range">, //
@@ -7019,14 +7013,14 @@ suite constraint_tests = []
       auto ec = glz::read_json(obj, buffer);
       expect(bool(ec));
       auto error_message = glz::format_error(ec, buffer);
-      expect(error_message == R"()") << error_message;
+      expect(error_message == "1:11: constraint_violated\n   {\"age\": -1, \"name\": \"Victor\"}\n             ^ Age out of range") << error_message << '\n';
       
       buffer = R"({"age": 10, "name": "Abra Cadabra"})";
       ec = glz::read_json(obj, buffer);
       expect(obj.age == 10);
       expect(bool(ec));
       error_message = glz::format_error(ec, buffer);
-      expect(error_message == R"()") << error_message;
+      expect(error_message == "1:35: constraint_violated\n   {\"age\": 10, \"name\": \"Abra Cadabra\"}\n                                     ^ Name is too long") << error_message << '\n';
    };
 };
 


### PR DESCRIPTION
This adds a `read_constraint` wrapper that enables complex constraints to be defined within a glz::meta or using member functions. Parsing is short circuited upon violating a constraint and a nicely formatted error can be produced with a custom error message.

Example constraint violation outputs:
```
1:11: constraint_violated
   {"age": -1, "name": "Victor"}
             ^ Age out of range
```

```
1:35: constraint_violated
   {"age": 10, "name": "Abra Cadabra"}
                                     ^ Name is too long
```

Source:
```c++
struct constrained_object
{
   int age{};
   std::string name{};
};

template <>
struct glz::meta<constrained_object>
{
   using T = constrained_object;
   static constexpr auto limit_age = [](const T&, int age) {
      return (age >= 0 && age <= 120);
   };
   
   static constexpr auto limit_name = [](const T&, const std::string& name) {
      return name.size() <= 8;
   };
   
   static constexpr auto value = object("age", read_constraint<&T::age, limit_age, "Age out of range">, //
                                        "name", read_constraint<&T::name, limit_name, "Name is too long">);
};

suite constraint_tests = []
{
   "constrained_object"_test = [] {
      constrained_object obj{};
      
      expect(not glz::read_json(obj, R"({"age": 25, "name": "José"})"));
      expect(obj.age == 25);
      expect(obj.name == "José");
      
      std::string buffer = R"({"age": -1, "name": "Victor"})";
      auto ec = glz::read_json(obj, buffer);
      expect(bool(ec));
      auto error_message = glz::format_error(ec, buffer);
      expect(error_message == R"(1:11: constraint_violated
             {"age": -1, "name": "Victor"}
             ^ Age out of range)") << error_message << '\n';
      
      buffer = R"({"age": 10, "name": "Abra Cadabra"})";
      ec = glz::read_json(obj, buffer);
      expect(obj.age == 10);
      expect(bool(ec));
      error_message = glz::format_error(ec, buffer);
      expect(error_message == R"(1:35: constraint_violated
                                     {"age": 10, "name": "Abra Cadabra"}
                                     ^ Name is too long)") << error_message << '\n';
   };
};
```