### PR TITLE
Add glz::cast wrapper

### DIFF
--- a/include/glaze/core/cast.hpp
+++ b/include/glaze/core/cast.hpp
@@ -1,0 +1,95 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include "glaze/core/context.hpp"
+#include "glaze/core/opts.hpp"
+#include "glaze/tuplet/tuple.hpp"
+
+namespace glz
+{
+   // `cast` allows a user to register a type that Glaze will deserialize/serialize to
+   // and then cast to the underlying value
+   // glz::cast<&T::integer, double>
+   // ^^^ This example would read and write the integer as a double
+   template <class T, auto Target, class CastType>
+   struct cast_t
+   {
+      static constexpr auto glaze_reflect = false;
+      using target_t = decltype(Target);
+      using cast_type = CastType;
+      T& val;
+      static constexpr auto target = Target;
+   };
+   
+   template <class T>
+   concept is_cast = requires {
+      requires !T::glaze_reflect;
+      typename T::target_t;
+      typename T::cast_type;
+   };
+   
+   template <uint32_t Format, is_cast T>
+   struct from<Format, T>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
+      {
+         using V = std::decay_t<decltype(value)>;
+         using Target = typename V::target_t;
+         using Cast = typename V::cast_type;
+         
+         Cast temp{};
+         parse<Format>::template op<Opts>(temp, ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+         
+         if constexpr (std::is_member_object_pointer_v<Target>) {
+            auto& field = value.val.*(value.target);
+            using Field = std::remove_cvref_t<decltype(field)>;
+            field = static_cast<Field>(temp);
+         }
+         else if constexpr (std::invocable<Target, decltype(value.val)>) {
+            auto& field = value.target(value.val);
+            using Field = std::remove_cvref_t<decltype(field)>;
+            field = static_cast<Field>(temp);
+         }
+         else {
+            static_assert(false_v<Target>, "invalid type for cast_t");
+         }
+      }
+   };
+   
+   template <uint32_t Format, is_cast T>
+   struct to<Format, T>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&&... args)
+      {
+         using V = std::decay_t<decltype(value)>;
+         using Target = typename V::target_t;
+         using Cast = typename V::cast_type;
+         
+         if constexpr (std::is_member_object_pointer_v<Target>) {
+            serialize<Format>::template op<Opts>(static_cast<Cast>(value.val.*(value.target)), ctx, args...);
+         }
+         else if constexpr (std::invocable<Target, decltype(value.val)>) {
+            serialize<Format>::template op<Opts>(static_cast<Cast>(value.target(value.val)), ctx, args...);
+         }
+         else {
+            static_assert(false_v<T>, "invalid type for cast_t");
+         }
+      }
+   };
+   
+   template <auto Target, class CastType>
+   constexpr auto cast_impl() noexcept
+   {
+      return
+      [](auto&& v) { return cast_t<std::remove_cvref_t<decltype(v)>, Target, CastType>{v}; };
+   }
+   
+   template <auto Target, class CastType>
+   constexpr auto cast = cast_impl<Target, CastType>();
+}

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -13,6 +13,7 @@
 
 #include "glaze/concepts/container_concepts.hpp"
 #include "glaze/core/array_apply.hpp"
+#include "glaze/core/cast.hpp"
 #include "glaze/core/constraint.hpp"
 #include "glaze/core/context.hpp"
 #include "glaze/core/feature_test.hpp"

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -10842,7 +10842,8 @@ template <>
 struct glz::meta<cast_obj>
 {
    using T = cast_obj;
-   static constexpr auto value = object("integer", cast<&T::integer, double>);
+   static constexpr auto value = object("integer", cast<&T::integer, double>, //
+                                        "indirect", cast<[](T& s) -> auto& { return s.integer; }, double>);
 };
 
 suite cast_tests = []
@@ -10857,8 +10858,15 @@ suite cast_tests = []
       
       obj.integer = 77;
       expect(not glz::write_json(obj, buffer));
+      expect(buffer == R"({"integer":77,"indirect":77})");
       
-      expect(buffer == R"({"integer":77})");
+      buffer = R"({"indirect":33.5})";
+      expect(not glz::read_json(obj, buffer));
+      expect(obj.integer == 33);
+      
+      obj.integer = 77;
+      expect(not glz::write_json(obj, buffer));
+      expect(buffer == R"({"integer":77,"indirect":77})");
    };
 };
 

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -10833,6 +10833,36 @@ suite factor8_strings = [] {
    };
 };
 
+struct cast_obj
+{
+   int integer{};
+};
+
+template <>
+struct glz::meta<cast_obj>
+{
+   using T = cast_obj;
+   static constexpr auto value = object("integer", cast<&T::integer, double>);
+};
+
+suite cast_tests = []
+{
+   "cast"_test = [] {
+      cast_obj obj{};
+      
+      std::string buffer = R"({"integer":5.7})";
+      expect(not glz::read_json(obj, buffer));
+      
+      expect(obj.integer == 5);
+      
+      obj.integer = 77;
+      expect(not glz::write_json(obj, buffer));
+      
+      expect(buffer == R"({"integer":77})");
+   };
+};
+
+
 int main()
 {
    trace.end("json_test");


### PR DESCRIPTION
`glz::cast` is a simple wrapper that will serialize and deserialize the cast type rather than underlying type. This enables the user to parse JSON for a floating point value into an integer, or perform similar `static_cast` behaviors.

```c++
struct cast_obj
{
   int integer{};
};

template <>
struct glz::meta<cast_obj>
{
   using T = cast_obj;
   static constexpr auto value = object("integer", cast<&T::integer, double>);
};
```

In use:

```c++
cast_obj obj{};
std::string buffer = R"({"integer":5.7})";
expect(not glz::read_json(obj, buffer));
expect(obj.integer == 5);
```