### PR TITLE
Remove bad unit test causing GCC 15 failure

### DIFF
--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -176,12 +176,6 @@ void tests()
    };
 
    "unordered type name"_test = [] {
-      // GCC 15 has a compiler bug with this code
-      // We're commenting this out because it was just an example test and not used anywhere
-      //{
-      //   std::string_view u = glz::name_v<std::unordered_set<std::vector<std::string>>>;
-      //   expect(u == "std::unordered_set<std::vector<std::string>>");
-      //}
       {
          std::string_view u = glz::name_v<std::unordered_map<uint64_t, std::string_view>>;
          expect(u == "std::unordered_map<uint64_t,std::string_view>");

--- a/tests/lib_test/lib_test.cpp
+++ b/tests/lib_test/lib_test.cpp
@@ -53,12 +53,6 @@ void tests()
    };
 
    "unordered type name"_test = [] {
-      // GCC 15 has a compiler bug with this code
-      // We're commenting this out because it was just an example test and not used anywhere
-      //{
-      //   std::string_view u = glz::name_v<std::unordered_set<std::vector<std::string>>>;
-      //   expect(u == "std::unordered_set<std::vector<std::string>>");
-      //}
       {
          std::string_view u = glz::name_v<std::unordered_map<uint64_t, std::string_view>>;
          expect(u == "std::unordered_map<uint64_t,std::string_view>");


### PR DESCRIPTION
`std::vector` is not required to have a `std::hash` specialization. This test used a std::unordered_set containing a std::vector, which required the hash specialization. Therefore, GCC 15 wouldn't build. Removed the test because it was just a type name test and not relevant to any other code in Glaze.