### PR TITLE
Integer IDs for std::variant support

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -409,17 +409,31 @@ namespace glz
    };
 
    template <is_variant T, size_t... I>
-   constexpr auto make_variant_id_map_impl(std::index_sequence<I...>, auto&& variant_ids)
+   constexpr auto make_variant_sv_id_map_impl(std::index_sequence<I...>, auto&& variant_ids)
    {
       return normal_map<sv, size_t, std::variant_size_v<T>>(std::array{pair<sv, size_t>{sv(variant_ids[I]), I}...});
+   }
+   
+   template <is_variant T, size_t... I>
+   constexpr auto make_variant_id_map_impl(std::index_sequence<I...>, auto&& variant_ids)
+   {
+      using id_type = std::decay_t<decltype(ids_v<T>[0])>;
+      return normal_map<id_type, size_t, std::variant_size_v<T>>(std::array{pair{variant_ids[I], I}...});
    }
 
    template <is_variant T>
    constexpr auto make_variant_id_map()
    {
       constexpr auto indices = std::make_index_sequence<std::variant_size_v<T>>{};
-
-      return make_variant_id_map_impl<T>(indices, ids_v<T>);
+      
+      using id_type = std::decay_t<decltype(ids_v<T>[0])>;
+      
+      if constexpr (std::integral<id_type>) {
+         return make_variant_id_map_impl<T>(indices, ids_v<T>);
+      }
+      else {
+         return make_variant_sv_id_map_impl<T>(indices, ids_v<T>);
+      }
    }
 
    /**

--- a/include/glaze/core/meta.hpp
+++ b/include/glaze/core/meta.hpp
@@ -262,9 +262,21 @@ namespace glz
    namespace detail
    {
       template <class T, size_t N>
-      inline constexpr std::array<std::string_view, N> convert_ids_to_array_of_sv(const std::array<T, N>& arr)
+      requires (not std::integral<T>)
+      inline constexpr auto convert_ids_to_array(const std::array<T, N>& arr)
       {
          std::array<std::string_view, N> result;
+         for (size_t i = 0; i < N; ++i) {
+            result[i] = arr[i];
+         }
+         return result;
+      }
+      
+      template <class T, size_t N>
+      requires (std::integral<T>)
+      inline constexpr auto convert_ids_to_array(const std::array<T, N>& arr)
+      {
+         std::array<T, N> result;
          for (size_t i = 0; i < N; ++i) {
             result[i] = arr[i];
          }
@@ -276,10 +288,10 @@ namespace glz
    inline constexpr auto ids_v = [] {
       if constexpr (ided<T>) {
          if constexpr (local_meta_t<T>) {
-            return detail::convert_ids_to_array_of_sv(std::decay_t<T>::glaze::ids);
+            return detail::convert_ids_to_array(std::decay_t<T>::glaze::ids);
          }
          else {
-            return detail::convert_ids_to_array_of_sv(meta<std::decay_t<T>>::ids);
+            return detail::convert_ids_to_array(meta<std::decay_t<T>>::ids);
          }
       }
       else {

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2704,8 +2704,16 @@ namespace glz
                               if (parse_ws_colon<Opts>(ctx, it, end)) {
                                  return;
                               }
-                              sv type_id{};
-                              from<JSON, sv>::template op<ws_handled<Opts>()>(type_id, ctx, it, end);
+                              
+                              using id_type = std::decay_t<decltype(ids_v<T>[0])>;
+                              
+                              std::conditional_t<std::integral<id_type>, id_type, sv> type_id{};
+                              if constexpr (std::integral<id_type>) {
+                                 from<JSON, id_type>::template op<ws_handled<Opts>()>(type_id, ctx, it, end);
+                              }
+                              else {
+                                 from<JSON, sv>::template op<ws_handled<Opts>()>(type_id, ctx, it, end);
+                              }
                               if (bool(ctx.error)) [[unlikely]]
                                  return;
                               if (skip_ws<Opts>(ctx, it, end)) {

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1365,26 +1365,54 @@ namespace glz
                      dumpn<Opts.indentation_char>(ctx.indentation_level, b, ix);
                      dump<'"'>(b, ix);
                      dump_maybe_empty(tag_v<T>, b, ix);
-                     dump<"\": \"">(b, ix);
-                     dump_maybe_empty(ids_v<T>[value.index()], b, ix);
-                     if constexpr (N == 0) {
-                        dump<"\"\n">(b, ix);
+                     
+                     using id_type = std::decay_t<decltype(ids_v<T>[value.index()])>;
+                     
+                     if constexpr (std::integral<id_type>) {
+                        dump<"\": ">(b, ix);
+                        serialize<JSON>::op<Opts>(ids_v<T>[value.index()], ctx, b, ix);
+                        if constexpr (N == 0) {
+                           dump<"\n">(b, ix);
+                        }
+                        else {
+                           dump<",\n">(b, ix);
+                        }
+                        dumpn<Opts.indentation_char>(ctx.indentation_level, b, ix);
                      }
                      else {
-                        dump<"\",\n">(b, ix);
+                        dump<"\": \"">(b, ix);
+                        dump_maybe_empty(ids_v<T>[value.index()], b, ix);
+                        if constexpr (N == 0) {
+                           dump<"\"\n">(b, ix);
+                        }
+                        else {
+                           dump<"\",\n">(b, ix);
+                        }
+                        dumpn<Opts.indentation_char>(ctx.indentation_level, b, ix);
                      }
-                     dumpn<Opts.indentation_char>(ctx.indentation_level, b, ix);
                   }
                   else {
+                     using id_type = std::decay_t<decltype(ids_v<T>[value.index()])>;
+                     
                      dump<"{\"">(b, ix);
                      dump_maybe_empty(tag_v<T>, b, ix);
-                     dump<"\":\"">(b, ix);
-                     dump_maybe_empty(ids_v<T>[value.index()], b, ix);
-                     if constexpr (N == 0) {
-                        dump<R"(")">(b, ix);
+                     
+                     if constexpr (std::integral<id_type>) {
+                        dump<"\":">(b, ix);
+                        serialize<JSON>::op<Opts>(ids_v<T>[value.index()], ctx, b, ix);
+                        if constexpr (N > 0) {
+                           dump<R"(,)">(b, ix);
+                        }
                      }
                      else {
-                        dump<R"(",)">(b, ix);
+                        dump<"\":\"">(b, ix);
+                        dump_maybe_empty(ids_v<T>[value.index()], b, ix);
+                        if constexpr (N == 0) {
+                           dump<R"(")">(b, ix);
+                        }
+                        else {
+                           dump<R"(",)">(b, ix);
+                        }
                      }
                   }
                   to<JSON, V>::template op<opening_and_closing_handled<Opts>()>(val, ctx, b, ix);

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -10869,6 +10869,53 @@ suite cast_tests = [] {
    };
 };
 
+struct Command401
+{
+   int code{};
+   int indent{};
+   std::vector<std::string> parameters{};
+};
+
+struct Command250Params
+{
+   std::string name{};
+   int volume{};
+   int pitch{};
+   int pan{};
+};
+
+struct Command250
+{
+   int code{};
+   int indent{};
+   std::vector<Command250Params> parameters{};
+};
+
+using CommandVariant = std::variant<Command250, Command401>;
+
+template <>
+struct glz::meta<CommandVariant>
+{
+   static constexpr std::string_view tag = "code";
+   static constexpr std::array ids = {250, 401};
+};
+
+suite integer_id_variant_tests = [] {
+   "command variant"_test = [] {
+      std::vector<CommandVariant> v{};
+      
+      std::string buffer = R"([{"code":401,"indent":0,"parameters":["You light the torch."]},{"code":250,"indent":0,"parameters":[{"name":"fnh_book1","volume":90,"pitch":100,"pan":0}]}])";
+      
+      auto ec = glz::read_json(v, buffer);
+      expect(not ec) << glz::format_error(ec, buffer);
+      
+      std::string out{};
+      expect(not glz::write_json(v, out));
+      
+      expect(out == buffer) << out;
+   };
+};
+
 int main()
 {
    trace.end("json_test");


### PR DESCRIPTION
Adds support for using integers as variant tag IDs rather than just strings:

```c++
struct Command401
{
   int code{};
   int indent{};
   std::vector<std::string> parameters{};
};

struct Command250Params
{
   std::string name{};
   int volume{};
   int pitch{};
   int pan{};
};

struct Command250
{
   int code{};
   int indent{};
   std::vector<Command250Params> parameters{};
};

using CommandVariant = std::variant<Command250, Command401>;

template <>
struct glz::meta<CommandVariant>
{
   static constexpr std::string_view tag = "code";
   static constexpr std::array ids = {250, 401};
};

suite integer_id_variant_tests = [] {
   "command variant"_test = [] {
      std::vector<CommandVariant> v{};
      
      std::string buffer = R"([{"code":401,"indent":0,"parameters":["You light the torch."]},{"code":250,"indent":0,"parameters":[{"name":"fnh_book1","volume":90,"pitch":100,"pan":0}]}])";
      
      auto ec = glz::read_json(v, buffer);
      expect(not ec) << glz::format_error(ec, buffer);
      
      std::string out{};
      expect(not glz::write_json(v, out));
      
      expect(out == buffer) << out;
   };
};
```