### PR TITLE
Report the first missing key in format_error

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2235,6 +2235,14 @@ namespace glz
                      if constexpr ((glaze_object_t<T> || reflectable<T>) && Opts.error_on_missing_keys) {
                         constexpr auto req_fields = required_fields<T, Opts>();
                         if ((req_fields & fields) != req_fields) {
+                           for (size_t i = 0; i < num_members; ++i) {
+                              if (not fields[i]) {
+                                 ctx.custom_error_message = reflect<T>::keys[i];
+                                 // We just return the first missing key in order to avoid heap allocations
+                                 break;
+                              }
+                           }
+                           
                            ctx.error = error_code::missing_key;
                            return;
                         }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -6059,8 +6059,22 @@ suite required_keys = [] {
       my_struct obj{};
       std::string buffer = R"({"i":287,"hello":"Hello World","arr":[1,2,3]})";
       auto err = glz::read<glz::opts{.error_on_missing_keys = true}>(obj, buffer);
-      expect(err != glz::error_code::none);
-      expect(glz::format_error(err, buffer) == "index 45: missing_key") << glz::format_error(err, buffer);
+      expect(bool(err));
+      auto err_msg = glz::format_error(err, buffer);
+      expect(err_msg == "index 45: missing_key d") << err_msg;
+      
+      buffer = R"({"i":287,"d":0.0,"arr":[1,2,3]})";
+      err = glz::read<glz::opts{.error_on_missing_keys = true}>(obj, buffer);
+      expect(bool(err));
+      err_msg = glz::format_error(err, buffer);
+      expect(err_msg == "index 31: missing_key hello") << err_msg;
+      
+      std::vector<my_struct> vec{};
+      buffer = R"([{"i":287,"d":0.0,"arr":[1,2,3]}])";
+      err = glz::read<glz::opts{.error_on_missing_keys = true}>(vec, buffer);
+      expect(bool(err));
+      err_msg = glz::format_error(err, buffer);
+      expect(err_msg == "1:33: missing_key\n   [{\"i\":287,\"d\":0.0,\"arr\":[1,2,3]}]\n                                   ^ hello") << err_msg;
    };
 };
 


### PR DESCRIPTION
We now report the first missing key when calling `glz::format_error`. Previously there was no indication of what key was missing.

Console output for missing key "hello"
```
1:33: missing_key
   [{"i":287,"d":0.0,"arr":[1,2,3]}]
                                   ^ hello
```
> The `^` points just after the object with the missing key, because we can't know any keys are missing until we have parsed the entire object.

This approach requires minimal additional executable binary and performs no heap allocations within the read_json call.

In the future this can be improved, but this is a huge step up from not getting any feedback about what key is missing.