### PR TITLE
Error handling for glz::custom

### DIFF
--- a/include/glaze/core/custom.hpp
+++ b/include/glaze/core/custom.hpp
@@ -100,15 +100,18 @@ namespace glz
                         return;
                      value.from(value.val);
                   }
-                  else if constexpr (N == 2) {
+                  else if constexpr (N > 1) {
                      std::decay_t<glz::tuple_element_t<1, Tuple>> input{};
                      parse<Format>::template op<Opts>(input, ctx, it, end);
                      if (bool(ctx.error)) [[unlikely]]
                         return;
-                     value.from(value.val, std::move(input));
-                  }
-                  else {
-                     static_assert(false_v<T>, "lambda cannot have more than two inputs");
+                     if constexpr (N == 2) {
+                        value.from(value.val, std::move(input));
+                     }
+                     else {
+                        // Version that passes the glz::context for custom error handling
+                        value.from(value.val, std::move(input), ctx);
+                     }
                   }
                }
                else {
@@ -117,6 +120,9 @@ namespace glz
             }
             else if constexpr (std::invocable<From, decltype(value.val)>) {
                parse<Format>::template op<Opts>(value.from(value.val), ctx, it, end);
+            }
+            else if constexpr (std::invocable<From, decltype(value.val), context&>) {
+               parse<Format>::template op<Opts>(value.from(value.val, ctx), ctx, it, end);
             }
             else {
                static_assert(
@@ -180,6 +186,9 @@ namespace glz
          else {
             if constexpr (std::invocable<To, decltype(value.val)>) {
                serialize<Format>::template op<Opts>(std::invoke(value.to, value.val), ctx, args...);
+            }
+            else if constexpr (std::invocable<To, decltype(value.val), context&>) {
+               serialize<Format>::template op<Opts>(std::invoke(value.to, value.val, ctx), ctx, args...);
             }
             else {
                static_assert(false_v<To>,

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -7038,7 +7038,7 @@ struct glz::meta<age_custom_error_obj>
    using T = age_custom_error_obj;
    static constexpr auto read_x = [](T& s, int age, glz::context& ctx) {
       if (age < 21) {
-         ctx.error = glz::error_code::syntax_error;
+         ctx.error = glz::error_code::constraint_violated;
          ctx.custom_error_message = "age too young";
       }
       else {
@@ -7055,7 +7055,8 @@ suite custom_error_tests = [] {
       auto ec = glz::read_json(obj, s);
       auto err_msg = glz::format_error(ec, s);
       expect(bool(ec)) << err_msg;
-      expect(err_msg == R"("1:10: syntax_error\n   {\"age\":18}\n            ^ age too young")");
+      //std::cout << err_msg << '\n';
+      expect(err_msg == "1:10: constraint_violated\n   {\"age\":18}\n            ^ age too young");
       
       expect(not glz::write_json(obj, s));
       expect(s == R"({"age":0})");


### PR DESCRIPTION
Developers can throw errors within `glz::custom`, but this adds support for handling the `glz::context` for errors when working with `glz::custom`. This allows complex error handling with `glz::custom` even on platforms with exceptions disabled.

Example:
```c++
struct age_custom_error_obj
{
   int age{};
};

template <>
struct glz::meta<age_custom_error_obj>
{
   using T = age_custom_error_obj;
   static constexpr auto read_x = [](T& s, int age, glz::context& ctx) {
      if (age < 21) {
         ctx.error = glz::error_code::constraint_violated;
         ctx.custom_error_message = "age too young";
      }
      else {
         s.age = age;
      }
   };
   static constexpr auto value = object("age", glz::custom<read_x, &T::age>);
};
```

In use:
```c++
age_custom_error_obj obj{};
std::string s = R"({"age":18})";
auto ec = glz::read_json(obj, s);
auto err_msg = glz::format_error(ec, s);
std::cout << err_msg << '\n';
```

Output:
```
1:10: constraint_violated
   {"age":18}
            ^ age too young
```