### PR TITLE
Remove use_hash_comparison

### DIFF
--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -77,7 +77,6 @@ namespace glz
       bool comments = false; // Support reading in JSONC style comments
       bool error_on_unknown_keys = true; // Error when an unknown key is encountered
       bool skip_null_members = true; // Skip writing out params in an object if the value is null
-      bool use_hash_comparison = true; // Will replace some string equality checks with hash checks
       bool prettify = false; // Write out prettified JSON
       bool minified = false; // Require minified input for JSON, which results in faster read performance
       char indentation_char = ' '; // Prettified JSON indentation char


### PR DESCRIPTION
Removes the compile time option: `use_hash_comparison`

This option used to affect more of the hashing code and was defaulted to true. It would compare hashes rather than the actual key strings. This was valid for nearly all cases, because Glaze uses perfect hash maps. This means there cannot be collisions between known keys.

The problem with this is that an invalid key could hash as a valid key. In an extreme corner case this could allow an attacker to find some nefarious key that hashes to the same value as a valid key and pass through some bad key without Glaze catching it.

The optimization does not affect the core object hashing in Glaze anymore, as it only applies to the old hash map that is used in only a few places, such as for variants.

This is a small regression in performance for some corners of Glaze, but it makes the hashing have no weird edge cases and it removes a compile time option, which simplifies the core glz::opts and results in cleaner build errors and a simpler interface for users.