### PR TITLE
max_recursive_depth_limit for glz::prettify_json

### DIFF
--- a/include/glaze/core/context.hpp
+++ b/include/glaze/core/context.hpp
@@ -10,7 +10,7 @@
 
 namespace glz
 {
-   constexpr size_t max_recursive_depth_limit = 256;
+   inline constexpr size_t max_recursive_depth_limit = 256;
 
    enum struct error_code : uint32_t {
       // REPE compliant error codes

--- a/include/glaze/json/prettify.hpp
+++ b/include/glaze/json/prettify.hpp
@@ -16,6 +16,8 @@ namespace glz
       {
          constexpr bool use_tabs = Opts.indentation_char == '\t';
          constexpr auto indent_width = Opts.indentation_width;
+         
+         static constexpr size_t maximum_nested_depth = 256;
 
          using enum json_type;
 
@@ -71,6 +73,10 @@ namespace glz
                ++indent;
                if (size_t(indent) >= state.size()) [[unlikely]] {
                   state.resize(state.size() * 2);
+                  if (state.size() >= max_recursive_depth_limit) [[unlikely]] {
+                     ctx.error = error_code::exceeded_max_recursive_depth;
+                     return;
+                  }
                }
                state[indent] = Array_Start;
                if constexpr (Opts.new_lines_in_arrays) {
@@ -125,6 +131,10 @@ namespace glz
                ++indent;
                if (size_t(indent) >= state.size()) [[unlikely]] {
                   state.resize(state.size() * 2);
+                  if (state.size() >= max_recursive_depth_limit) [[unlikely]] {
+                     ctx.error = error_code::exceeded_max_recursive_depth;
+                     return;
+                  }
                }
                state[indent] = Object_Start;
                if constexpr (not Opts.null_terminated) {

--- a/include/glaze/json/prettify.hpp
+++ b/include/glaze/json/prettify.hpp
@@ -16,8 +16,6 @@ namespace glz
       {
          constexpr bool use_tabs = Opts.indentation_char == '\t';
          constexpr auto indent_width = Opts.indentation_width;
-         
-         static constexpr size_t maximum_nested_depth = 256;
 
          using enum json_type;
 


### PR DESCRIPTION
Limits the depth of prettifying JSON. Avoids massive memory allocation for prettified text like: `[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[...`

This would be an unlikely attack vector that merely uses lots of memory. Typically this would be caught on a parse and wouldn't be generated on a server. This fix is really to avoid fuzz testing failures on glz::prettify_json.