### PR TITLE
rename_key glz::meta utility

### DIFF
--- a/include/glaze/reflection/get_name.hpp
+++ b/include/glaze/reflection/get_name.hpp
@@ -129,6 +129,12 @@ namespace glz
       { glz::meta<std::remove_cvref_t<T>>::rename_key(s) } -> std::same_as<std::string>;
    };
    
+   template <std::pair V>
+   struct make_static
+   {
+      static constexpr auto value = V;
+   };
+   
    template <meta_has_rename_key_string T, size_t... I>
    [[nodiscard]] constexpr auto member_names_impl(std::index_sequence<I...>)
    {
@@ -153,7 +159,7 @@ namespace glz
 #else
             // GCC does not support constexpr designation on std::string
             // We therefore limit to a maximum of 64 characters on GCC for key transformations
-            static constexpr auto arr = [] {
+            constexpr auto arr_temp = [] {
                const auto str = glz::meta<std::remove_cvref_t<T>>::rename_key(member_nameof<I, T>);
                const size_t len = str.size();
                std::array<char, 65> arr{};
@@ -163,6 +169,8 @@ namespace glz
                arr[len] = '\0';
                return std::pair{arr, len};
             }();
+            // GCC 12 requires this make_static
+            auto& arr = make_static<arr_temp>::value;
             return {arr.first.data(), arr.second};
 #endif
          }()...};

--- a/include/glaze/reflection/get_name.hpp
+++ b/include/glaze/reflection/get_name.hpp
@@ -119,10 +119,29 @@ namespace glz
          return std::array{member_nameof<I, T>...};
       }
    }
-
+   
+   template <class T>
+   struct meta;
+   
+   template <class T>
+   concept meta_has_rename_key = requires(T t, const std::string_view s) {
+      { glz::meta<std::remove_cvref_t<T>>::rename_key(s) } -> std::convertible_to<std::string_view>;
+   };
+   
+   template <meta_has_rename_key T, size_t... I>
+   [[nodiscard]] constexpr auto member_names_impl(std::index_sequence<I...>)
+   {
+      if constexpr (sizeof...(I) == 0) {
+         return std::array<sv, 0>{};
+      }
+      else {
+         return std::array{glz::meta<std::remove_cvref_t<T>>::rename_key(member_nameof<I, T>)...};
+      }
+   }
+   
    template <class T>
    inline constexpr auto member_names =
-      [] { return member_names_impl<T>(std::make_index_sequence<detail::count_members<T>>{}); }();
+   [] { return member_names_impl<T>(std::make_index_sequence<detail::count_members<T>>{}); }();
 }
 
 // For member object pointers

--- a/include/glaze/reflection/get_name.hpp
+++ b/include/glaze/reflection/get_name.hpp
@@ -123,12 +123,43 @@ namespace glz
    template <class T>
    struct meta;
    
+   // Concept for when rename_key returns exactly std::string (allocates)
    template <class T>
-   concept meta_has_rename_key = requires(T t, const std::string_view s) {
-      { glz::meta<std::remove_cvref_t<T>>::rename_key(s) } -> std::convertible_to<std::string_view>;
+   concept meta_has_rename_key_string = requires(T t, const std::string_view s) {
+      { glz::meta<std::remove_cvref_t<T>>::rename_key(s) } -> std::same_as<std::string>;
    };
    
-   template <meta_has_rename_key T, size_t... I>
+   template <meta_has_rename_key_string T, size_t... I>
+   [[nodiscard]] constexpr auto member_names_impl(std::index_sequence<I...>)
+   {
+      if constexpr (sizeof...(I) == 0) {
+         return std::array<sv, 0>{};
+      }
+      else {
+         return std::array{[]() -> sv {
+            // Need to move allocation into a new static buffer
+            static constexpr auto arr = []() {
+               constexpr auto str = glz::meta<std::remove_cvref_t<T>>::rename_key(member_nameof<I, T>);
+               constexpr size_t len = str.size();
+               std::array<char, len + 1> arr;
+               for (size_t i = 0; i < len; ++i) {
+                  arr[i] = str[i];
+               }
+               arr[len] = '\0';
+               return arr;
+            }();
+            return {arr.data(), arr.size() - 1};
+         }()...};
+      }
+   }
+   
+   // Concept for when rename_key returns anything convertible to std::string_view EXCEPT std::string (non-allocating)
+   template <class T>
+   concept meta_has_rename_key_convertible = requires(T t, const std::string_view s) {
+      { glz::meta<std::remove_cvref_t<T>>::rename_key(s) } -> std::convertible_to<std::string_view>;
+   } && !meta_has_rename_key_string<T>;
+   
+   template <meta_has_rename_key_convertible T, size_t... I>
    [[nodiscard]] constexpr auto member_names_impl(std::index_sequence<I...>)
    {
       if constexpr (sizeof...(I) == 0) {

--- a/tests/json_reflection_test/json_reflection_test.cpp
+++ b/tests/json_reflection_test/json_reflection_test.cpp
@@ -913,4 +913,41 @@ suite enum_pair_tests = [] {
    };
 };
 
+struct renamed_t
+{
+   std::string first_name{};
+   std::string last_name{};
+   int age{};
+};
+
+template <>
+struct glz::meta<renamed_t>
+{
+   static constexpr std::string_view rename_key(const std::string_view key) {
+      if (key == "first_name") {
+         return "firstName";
+      }
+      else if (key == "last_name") {
+         return "lastName";
+      }
+      return key;
+   }
+};
+
+suite rename_tests = [] {
+   "rename"_test = [] {
+      renamed_t obj{};
+      std::string buffer{};
+      expect(not glz::write_json(obj, buffer));
+      expect(buffer == R"({"firstName":"","lastName":"","age":0})") << buffer;
+      
+      buffer = R"({"firstName":"Kira","lastName":"Song","age":29})";
+      
+      expect(not glz::read_json(obj, buffer));
+      expect(obj.first_name == "Kira");
+      expect(obj.last_name == "Song");
+      expect(obj.age == 29);
+   };
+};
+
 int main() { return 0; }

--- a/tests/json_reflection_test/json_reflection_test.cpp
+++ b/tests/json_reflection_test/json_reflection_test.cpp
@@ -934,6 +934,21 @@ struct glz::meta<renamed_t>
    }
 };
 
+// This example shows how we use dynamic memory at compile time for string transformations
+struct suffixed_keys_t
+{
+   std::string first{};
+   std::string last{};
+};
+
+template <>
+struct glz::meta<suffixed_keys_t>
+{
+   static constexpr std::string rename_key(const auto key) {
+      return std::string(key) + "_name";
+   }
+};
+
 suite rename_tests = [] {
    "rename"_test = [] {
       renamed_t obj{};
@@ -947,6 +962,19 @@ suite rename_tests = [] {
       expect(obj.first_name == "Kira");
       expect(obj.last_name == "Song");
       expect(obj.age == 29);
+   };
+   
+   "suffixed keys"_test = [] {
+      suffixed_keys_t obj{};
+      std::string buffer{};
+      expect(not glz::write_json(obj, buffer));
+      expect(buffer == R"({"first_name":"","last_name":""})") << buffer;
+      
+      buffer = R"({"first_name":"Kira","last_name":"Song"})";
+      
+      expect(not glz::read_json(obj, buffer));
+      expect(obj.first == "Kira");
+      expect(obj.last == "Song");
    };
 };
 


### PR DESCRIPTION
Enables an easy approach to rename specific keys at compile time for reflected structs:

```c++
struct renamed_t
{
   std::string first_name{};
   std::string last_name{};
   int age{};
};

template <>
struct glz::meta<renamed_t>
{
   static constexpr std::string_view rename_key(const std::string_view key) {
      if (key == "first_name") {
         return "firstName";
      }
      else if (key == "last_name") {
         return "lastName";
      }
      return key;
   }
};

"rename"_test = [] {
  renamed_t obj{};
  std::string buffer{};
  expect(not glz::write_json(obj, buffer));
  expect(buffer == R"({"firstName":"","lastName":"","age":0})") << buffer;
  
  buffer = R"({"firstName":"Kira","lastName":"Song","age":29})";
  
  expect(not glz::read_json(obj, buffer));
  expect(obj.first_name == "Kira");
  expect(obj.last_name == "Song");
  expect(obj.age == 29);
};
```

Even more powerful the the ability to use std::string at compile time for dynamic key transformations:
```c++
struct suffixed_keys_t
{
   std::string first{};
   std::string last{};
};

template <>
struct glz::meta<suffixed_keys_t>
{
   static constexpr std::string rename_key(const auto key) {
      return std::string(key) + "_name";
   }
};

"suffixed keys"_test = [] {
  suffixed_keys_t obj{};
  std::string buffer{};
  expect(not glz::write_json(obj, buffer));
  expect(buffer == R"({"first_name":"","last_name":""})") << buffer;
  
  buffer = R"({"first_name":"Kira","last_name":"Song"})";
  
  expect(not glz::read_json(obj, buffer));
  expect(obj.first == "Kira");
  expect(obj.last == "Song");
};
```