### PR TITLE
CSV parser properly handles quoted strings

### DIFF
--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -114,6 +114,7 @@ namespace glz
       uint8_t layout = rowwise; // CSV row wise output/input
       bool use_headers = true; // Whether to write column/row headers in CSV format
       bool append_arrays = false; // When reading into an array the data will be appended if the type supports it
+      bool raw_string = false; // do not decode/encode escaped characters for strings (improves read/write performance)
 
       // INTERNAL OPTIONS
       uint32_t internal{}; // default should be 0
@@ -261,6 +262,16 @@ namespace glz
       }
       else {
          return true;
+      }
+   }
+
+   consteval bool check_raw_string(auto&& Opts)
+   {
+      if constexpr (requires { Opts.raw_string; }) {
+         return Opts.raw_string;
+      }
+      else {
+         return false;
       }
    }
 

--- a/include/glaze/csv/read.hpp
+++ b/include/glaze/csv/read.hpp
@@ -159,28 +159,52 @@ namespace glz
          if (*it == '"') {
             // Quoted field
             ++it; // Skip the opening quote
-            while (it != end) {
-               if (*it == '"') {
-                  ++it; // Skip the quote
-                  if (it == end) {
-                     // End of input after closing quote
-                     break;
-                  }
+            
+            if constexpr (check_raw_string(Opts)) {
+               // Raw string mode: don't process escape sequences
+               while (it != end) {
                   if (*it == '"') {
-                     // Escaped quote
+                     ++it; // Skip the quote
+                     if (it == end || *it != '"') {
+                        // Single quote - end of field
+                        break;
+                     }
+                     // Double quote - add one quote and continue
                      value.push_back('"');
                      ++it;
                   }
                   else {
-                     // Closing quote
-                     break;
+                     value.push_back(*it);
+                     ++it;
                   }
                }
-               else {
-                  value.push_back(*it);
-                  ++it;
+            }
+            else {
+               // Normal mode: process escape sequences properly
+               while (it != end) {
+                  if (*it == '"') {
+                     ++it; // Skip the quote
+                     if (it == end) {
+                        // End of input after closing quote
+                        break;
+                     }
+                     if (*it == '"') {
+                        // Escaped quote
+                        value.push_back('"');
+                        ++it;
+                     }
+                     else {
+                        // Closing quote
+                        break;
+                     }
+                  }
+                  else {
+                     value.push_back(*it);
+                     ++it;
+                  }
                }
             }
+            
             // After closing quote, expect comma, newline, or end of input
             if (it != end && *it != ',' && *it != '\n' && *it != '\r') {
                // Invalid character after closing quote


### PR DESCRIPTION
CSV parsing now handles quoted strings when they contain characters like commas:

```c++
std::string csv_data = R"(Entity,Currency,AlphabeticCode,NumericCode,MinorUnit,WithdrawalDate
"MOLDOVA, REPUBLIC OF",Russian Ruble,RUR,810,,1993-12
"FALKLAND ISLANDS (THE) [MALVINAS]",Falkland Islands Pound,FKP,238,2,
"BONAIRE, SINT EUSTATIUS AND SABA",US Dollar,USD,840,2,)";

CurrencyCSV obj{};
auto ec = glz::read<glz::opts_csv{.layout = glz::colwise}>(obj, csv_data);
```

The `raw_string` compile time option can be set to `true` to not handle delimiters within quotes and just parse the entire string.