### PR TITLE
Add static_cast to remove warning

### DIFF
--- a/include/glaze/stencil/stencil.hpp
+++ b/include/glaze/stencil/stencil.hpp
@@ -13,7 +13,7 @@ namespace glz
    inline std::string html_escape(const std::string& input)
    {
       std::string result;
-      result.reserve(input.size() * 1.1); // Reserve some extra space
+      result.reserve(static_cast<size_t>(input.size() * 1.1)); // Reserve some extra space
 
       for (char c : input) {
          switch (c) {


### PR DESCRIPTION
When compiling with VS 2022 (17.14.5) I get the warning:

glaze\include\glaze\stencil\stencil.hpp(16,35): warning C4244: 'argument': conversion from 'double' to 'const unsigned __int64', possible loss of data

I added a static_cast<size_t>.