### PR TITLE
Cleaner boolean reading

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -533,48 +533,26 @@ namespace glz
                }
             }
 
-            uint64_t c{};
-            static constexpr uint64_t u_true =
-               0b00000000'00000000'00000000'00000000'01100101'01110101'01110010'01110100;
-            static constexpr uint64_t u_false =
-               0b00000000'00000000'00000000'01100101'01110011'01101100'01100001'01100110;
-            if constexpr (Opts.null_terminated) {
-               // Note that because our buffer must be null terminated, we can read one more index without checking:
-               std::memcpy(&c, it, 5);
-               // We have to wipe the 5th character for true testing
-               if ((c & 0xFF'FF'FF'00'FF'FF'FF'FF) == u_true) {
-                  value = true;
-                  it += 4;
-               }
-               else {
-                  if (c != u_false) [[unlikely]] {
-                     ctx.error = error_code::expected_true_or_false;
-                     return;
-                  }
-                  value = false;
-                  it += 5;
-               }
+            uint32_t c;
+            static constexpr uint32_t u_true = 0b01100101'01110101'01110010'01110100;
+            static constexpr uint32_t u_fals = 0b01110011'01101100'01100001'01100110;
+            std::memcpy(&c, it, 4);
+            it += 4;
+            if (c == u_true) {
+               value = true;
+            }
+            else if (it == end) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
             }
             else {
-               std::memcpy(&c, it, 4);
-               if (c == u_true) {
-                  value = true;
-                  it += 4;
+               if (c == u_fals && (*it == 'e')) [[likely]] {
+                  value = false;
+                  ++it;
                }
-               else if (size_t(end - it) < 5) [[unlikely]] {
-                  ctx.error = error_code::unexpected_end;
+               else [[unlikely]] {
+                  ctx.error = error_code::expected_true_or_false;
                   return;
-               }
-               else {
-                  std::memcpy(&c, it, 5);
-                  if (c == u_false) [[likely]] {
-                     value = false;
-                     it += 5;
-                  }
-                  else [[unlikely]] {
-                     ctx.error = error_code::expected_true_or_false;
-                     return;
-                  }
                }
             }
          }

--- a/tests/json_test/json_t_test.cpp
+++ b/tests/json_test/json_t_test.cpp
@@ -537,4 +537,15 @@ suite json_pointer_extraction_tests = [] {
    };
 };
 
+suite fuzz_tests = [] {
+   "fuzz1"_test = [] {
+      std::string_view s = "[true,true,tur";
+      std::vector<char> buffer{s.data(), s.data() + s.size()};
+      buffer.push_back('\0');
+      glz::json_t json{};
+      auto ec = glz::read_json(json, buffer);
+      expect(bool(ec));
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
This avoids issues with std::vector<char> buffers that include null character in their size. It also moves away from the `null_terminated` option, which is a long term goal. And, it simplifies the code.