### PR TITLE
(feat): enable avx2 for mac arm chipset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,18 @@ option(glaze_DISABLE_SIMD_WHEN_SUPPORTED
        "disable SIMD optimizations even when targets support it (e.g. AVX2)" OFF)
 if(glaze_DISABLE_SIMD_WHEN_SUPPORTED)
   target_compile_definitions(glaze_glaze INTERFACE GLZ_DISABLE_SIMD)
+else ()
+  if(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
+    if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm64")
+      list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+      find_package(simde REQUIRED)
+      target_link_libraries(
+              glaze_glaze ${warning_guard}
+              INTERFACE
+              simde
+      )
+    endif ()
+  endif ()
 endif()
 
 option(glaze_BUILD_EXAMPLES "Build GLAZE examples" OFF)

--- a/cmake/Findsimde.cmake
+++ b/cmake/Findsimde.cmake
@@ -1,0 +1,19 @@
+# Add the FetchContent module
+include(FetchContent)
+
+# Define the simde dependency
+FetchContent_Declare(
+        simde
+        GIT_REPOSITORY https://github.com/simd-everywhere/simde.git
+#        GIT_TAG v0.8.2
+        GIT_TAG master
+)
+
+# Populate the dependency
+FetchContent_MakeAvailable(simde)
+
+add_library(simde INTERFACE IMPORTED GLOBAL)
+target_include_directories(simde INTERFACE "${simde_SOURCE_DIR}")
+
+# Enables native aliases. Not ideal but makes it easier to convert old code.
+target_compile_definitions(simde INTERFACE SIMDE_ENABLE_NATIVE_ALIASES)

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -20,6 +20,12 @@
 #endif
 #endif
 
+
+#if !defined(GLZ_DISABLE_SIMD) && defined(__aarch64__) || defined(_M_ARM64)
+#define GLZ_USE_AVX2
+#include <simde/x86/avx2.h>
+#endif
+
 #include "glaze/core/opts.hpp"
 #include "glaze/core/reflect.hpp"
 #include "glaze/core/to.hpp"
@@ -684,7 +690,6 @@ namespace glz
                      }
                   }
 #endif
-
                   if (n > 7) {
                      for (const auto end_m7 = e - 7; c < end_m7;) {
                         std::memcpy(data, c, 8);


### PR DESCRIPTION
* Add `simde` for Mac Arm to take advantage of `AVX2` 