### PR TITLE
meta_context and skip documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ Thumbs.db
 # Allow mock test data
 !tests/mock_json_test/json/*.json
 alabastar.beve
+*.jsonc

--- a/docs/skip-keys.md
+++ b/docs/skip-keys.md
@@ -18,7 +18,7 @@ struct my_struct_t {
 
 template <>
 struct glz::meta<my_struct_t> {
-    static constexpr bool skip(const std::string_view key) {
+    static constexpr bool skip(const std::string_view key, const meta_context&) {
         // Return true to skip the key, false to include it
         return key == "internal_member";
     }
@@ -38,7 +38,7 @@ struct skipped_t {
 
 template <>
 struct glz::meta<skipped_t> {
-    static constexpr bool skip(const std::string_view key) {
+    static constexpr bool skip(const std::string_view key, const meta_context&) {
         if (key == "secret_info") {
             return true; // Skip this field
         }
@@ -78,7 +78,7 @@ struct prefixed_skipped_t {
 
 template <>
 struct glz::meta<prefixed_skipped_t> {
-    static constexpr bool skip(const std::string_view key) { 
+    static constexpr bool skip(const std::string_view key, const meta_context&) { 
         return key.starts_with("temp_"); // Skip keys starting with "temp_"
     }
 };

--- a/docs/skip-keys.md
+++ b/docs/skip-keys.md
@@ -2,6 +2,9 @@
 
 The `skip` functionality in Glaze allows you to conditionally skip struct members during JSON serialization at compile time. This feature operates at compile time.
 
+> [!NOTE]
+> Currently the `glz::meta::skip` function only works for skipping on serialization, but support for skipping when reading will be added in the future.
+
 ## Overview
 
 By default, Glaze serializes all public C++ struct members to JSON. However, you may need to omit certain fields from your JSON output.
@@ -56,13 +59,6 @@ std::string buffer{};
 // Writing JSON
 glz::write_json(obj, buffer);
 // Output: {"name":"John Doe","age":30}
-
-// Reading JSON (skipped fields are ignored if present in input)
-buffer = R"({"name":"Jane Doe","age":25,"secret_info":"Should be ignored"})";
-glz::read_json(obj, buffer);
-// obj.name == "Jane Doe"
-// obj.age == 25
-// obj.secret_info == "My Top Secret" (original value, not overwritten)
 ```
 
 ## Example 2: Skipping Based on Prefix/Suffix

--- a/docs/skip-keys.md
+++ b/docs/skip-keys.md
@@ -1,0 +1,96 @@
+# Skip Keys
+
+The `skip` functionality in Glaze allows you to conditionally skip struct members during JSON serialization at compile time. This feature operates at compile time.
+
+## Overview
+
+By default, Glaze serializes all public C++ struct members to JSON. However, you may need to omit certain fields from your JSON output.
+
+## Basic Usage
+
+To use `skip`, specialize the `glz::meta` template for your struct and implement a `skip` function:
+
+```cpp
+struct my_struct_t {
+    std::string public_member{};
+    std::string internal_member{};
+};
+
+template <>
+struct glz::meta<my_struct_t> {
+    static constexpr bool skip(const std::string_view key) {
+        // Return true to skip the key, false to include it
+        return key == "internal_member";
+    }
+};
+```
+
+## Example 1: Skipping Specific Keys
+
+Omit specific member names from the JSON output:
+
+```cpp
+struct skipped_t {
+    std::string name{};
+    int age{};
+    std::string secret_info{};
+};
+
+template <>
+struct glz::meta<skipped_t> {
+    static constexpr bool skip(const std::string_view key) {
+        if (key == "secret_info") {
+            return true; // Skip this field
+        }
+        return false; // Include other fields
+    }
+};
+```
+
+**Usage:**
+
+```cpp
+skipped_t obj{"John Doe", 30, "My Top Secret"};
+std::string buffer{};
+
+// Writing JSON
+glz::write_json(obj, buffer);
+// Output: {"name":"John Doe","age":30}
+
+// Reading JSON (skipped fields are ignored if present in input)
+buffer = R"({"name":"Jane Doe","age":25,"secret_info":"Should be ignored"})";
+glz::read_json(obj, buffer);
+// obj.name == "Jane Doe"
+// obj.age == 25
+// obj.secret_info == "My Top Secret" (original value, not overwritten)
+```
+
+## Example 2: Skipping Based on Prefix/Suffix
+
+Apply systematic skipping based on key patterns using compile-time string manipulation:
+
+```cpp
+struct prefixed_skipped_t {
+    std::string user_id{};
+    std::string user_name{};
+    std::string temp_data{};
+};
+
+template <>
+struct glz::meta<prefixed_skipped_t> {
+    static constexpr bool skip(const std::string_view key) { 
+        return key.starts_with("temp_"); // Skip keys starting with "temp_"
+    }
+};
+```
+
+**Usage:**
+
+```cpp
+prefixed_skipped_t obj{"123", "Alice", "temporary value"};
+std::string buffer{};
+
+// Writing JSON
+glz::write_json(obj, buffer);
+// Output: {"user_id":"123","user_name":"Alice"}
+```

--- a/docs/skip-keys.md
+++ b/docs/skip-keys.md
@@ -1,13 +1,29 @@
 # Skip Keys
 
-The `skip` functionality in Glaze allows you to conditionally skip struct members during JSON serialization at compile time. This feature operates at compile time.
-
-> [!NOTE]
-> Currently the `glz::meta::skip` function only works for skipping on serialization, but support for skipping when reading will be added in the future.
+The `skip` functionality in Glaze allows you to conditionally skip struct members during JSON serialization and parsing at compile time. This feature operates at compile time and can differentiate between serialize and parse operations.
 
 ## Overview
 
-By default, Glaze serializes all public C++ struct members to JSON. However, you may need to omit certain fields from your JSON output.
+By default, Glaze serializes all public C++ struct members to JSON. However, you may need to omit certain fields from your JSON output or input processing.
+
+## Meta Context
+
+The `skip` function receives a `meta_context` parameter that provides compile-time information about the current operation:
+
+```cpp
+namespace glz {
+    enum struct operation {
+        serialize,  // Writing/serializing to JSON
+        parse      // Reading/parsing from JSON
+    };
+
+    struct meta_context {
+        operation op = operation::serialize;
+    };
+}
+```
+
+This allows you to implement different skipping logic for serialization versus parsing operations.
 
 ## Basic Usage
 
@@ -89,4 +105,50 @@ std::string buffer{};
 // Writing JSON
 glz::write_json(obj, buffer);
 // Output: {"user_id":"123","user_name":"Alice"}
+```
+
+## Example 3: Operation-Specific Skipping
+
+Use the `meta_context` to implement different skipping behavior for serialization versus parsing:
+
+```cpp
+struct versioned_data_t {
+    std::string name{};
+    int version{};
+    std::string computed_field{};
+    std::string input_only_field{};
+};
+
+template <>
+struct glz::meta<versioned_data_t> {
+    static constexpr bool skip(const std::string_view key, const meta_context& ctx) {
+        // Skip computed_field during parsing (reading) - it should only be written
+        if (key == "computed_field" && ctx.op == glz::operation::parse) {
+            return true;
+        }
+        
+        // Skip input_only_field during serialization (writing) - it should only be read
+        if (key == "input_only_field" && ctx.op == glz::operation::serialize) {
+            return true;
+        }
+        
+        return false;
+    }
+};
+```
+
+**Usage:**
+
+```cpp
+versioned_data_t obj{"TestData", 1, "computed_value", "input_value"};
+std::string buffer{};
+
+// Writing JSON - skips input_only_field
+glz::write_json(obj, buffer);
+// Output: {"name":"TestData","version":1,"computed_field":"computed_value"}
+
+// Reading JSON - skips computed_field
+const char* json = R"({"name":"NewData","version":2,"computed_field":"ignored","input_only_field":"new_input"})";
+glz::read_json(obj, json);
+// obj.computed_field retains "computed_value", obj.input_only_field becomes "new_input"
 ```

--- a/include/glaze/core/meta.hpp
+++ b/include/glaze/core/meta.hpp
@@ -257,6 +257,12 @@ namespace glz
    template <class T>
    concept ided = requires { meta<std::decay_t<T>>::ids; } || requires { std::decay_t<T>::glaze::ids; };
 
+   // Concept when skip is specified for the type
+   template <class T>
+   concept meta_has_skip = requires(T t, const std::string_view s, const meta_context& mctx) {
+      { glz::meta<std::remove_cvref_t<T>>::skip(s, mctx) } -> std::same_as<bool>;
+   };
+
    template <class T>
    inline constexpr std::string_view tag_v = [] {
       if constexpr (tagged<T>) {

--- a/include/glaze/core/meta.hpp
+++ b/include/glaze/core/meta.hpp
@@ -15,6 +15,19 @@
 
 namespace glz
 {
+   enum struct operation
+   {
+      serialize,
+      parse
+   };
+
+   // The meta_context provides compile time data about the serialization context.
+   // This include whether we are serializing or parsing.
+   struct meta_context
+   {
+      operation op = operation::serialize;
+   };
+
    template <class T>
    struct meta;
 

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -174,6 +174,19 @@ namespace glz
             return;
          }
 
+         // Check for operation-specific skipping
+         if constexpr (meta_has_skip<std::remove_cvref_t<T>>) {
+            if constexpr (meta<std::remove_cvref_t<T>>::skip(Key, {glz::operation::parse})) {
+               skip_value<JSON>::op<Opts>(ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]]
+                  return; // Propagate error from skip_value
+               if constexpr (Opts.error_on_missing_keys || Opts.partial_read) {
+                  ((selected_index = I), ...); // Mark as handled even if skipped
+               }
+               return;
+            }
+         }
+
          using V = refl_t<T, I>;
 
          if constexpr (const_value_v<V>) {

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1813,7 +1813,8 @@ namespace glz
                   using val_t = field_t<T, I>;
 
                   if constexpr (meta_has_skip<T>) {
-                     if constexpr (meta<T>::skip(reflect<T>::keys[I])) return;
+                     static constexpr meta_context mctx{.op = operation::serialize};
+                     if constexpr (meta<T>::skip(reflect<T>::keys[I], mctx)) return;
                   }
 
                   if constexpr (always_skipped<val_t>) {

--- a/include/glaze/reflection/get_name.hpp
+++ b/include/glaze/reflection/get_name.hpp
@@ -123,10 +123,12 @@ namespace glz
    template <class T>
    struct meta;
 
+   struct meta_context;
+
    // Concept when skip is specified for the type
    template <class T>
-   concept meta_has_skip = requires(T t, const std::string_view s) {
-      { glz::meta<std::remove_cvref_t<T>>::skip(s) } -> std::same_as<bool>;
+   concept meta_has_skip = requires(T t, const std::string_view s, const meta_context& mctx) {
+      { glz::meta<std::remove_cvref_t<T>>::skip(s, mctx) } -> std::same_as<bool>;
    };
 
    // Concept for when rename_key returns exactly std::string (allocates)

--- a/include/glaze/reflection/get_name.hpp
+++ b/include/glaze/reflection/get_name.hpp
@@ -123,14 +123,6 @@ namespace glz
    template <class T>
    struct meta;
 
-   struct meta_context;
-
-   // Concept when skip is specified for the type
-   template <class T>
-   concept meta_has_skip = requires(T t, const std::string_view s, const meta_context& mctx) {
-      { glz::meta<std::remove_cvref_t<T>>::skip(s, mctx) } -> std::same_as<bool>;
-   };
-
    // Concept for when rename_key returns exactly std::string (allocates)
    template <class T>
    concept meta_has_rename_key_string = requires(T t, const std::string_view s) {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
    - Compile Time Options: options.md
    - Optimizing Performance: optimizing-performance.md
    - Rename Keys: rename-keys.md
+   - Skip Keys: skip-keys.md
    - Generic JSON: generic-json.md
  - Reflection:
    - Pure Reflection: pure-reflection.md

--- a/tests/json_reflection_test/json_reflection_test.cpp
+++ b/tests/json_reflection_test/json_reflection_test.cpp
@@ -27,7 +27,7 @@ struct test_skip
 template <>
 struct glz::meta<test_skip>
 {
-   static constexpr bool skip(const std::string_view) { return true; }
+   static constexpr bool skip(const std::string_view, const meta_context&) { return true; }
 };
 
 static_assert(glz::meta_has_skip<test_skip>);

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -9114,7 +9114,7 @@ struct specify_only_skip_obj
 template <>
 struct glz::meta<specify_only_skip_obj>
 {
-   static constexpr bool skip(const std::string_view key) { return key == "j"; }
+   static constexpr bool skip(const std::string_view key, const meta_context&) { return key == "j"; }
 };
 
 suite specify_only_skip_obj_tests = [] {
@@ -9135,7 +9135,10 @@ struct skip_hidden_elements
 template <>
 struct glz::meta<skip_hidden_elements>
 {
-   static constexpr bool skip(const std::string_view key) { return key.starts_with(std::string_view{"hidden"}); }
+   static constexpr bool skip(const std::string_view key, const meta_context&)
+   {
+      return key.starts_with(std::string_view{"hidden"});
+   }
 };
 
 suite skip_hidden_elements_tests = [] {
@@ -9156,7 +9159,7 @@ struct skip_first_and_last
 template <>
 struct glz::meta<skip_first_and_last>
 {
-   static constexpr bool skip(const std::string_view key) { return key == "i" || key == "l"; }
+   static constexpr bool skip(const std::string_view key, const meta_context&) { return key == "i" || key == "l"; }
 };
 
 suite skip_first_and_last_tests = [] {


### PR DESCRIPTION
@Yaraslaut, when creating documentation for this new skip functionality, I realized that what we implemented only currently affects writing.

Skipping can also apply to reading. And, I think in some cases we want to only skip writing or only skip reading.

Here are the two approaches I'm thinking of taking.

First option is to simply name the function `skip_write` and a `skip_read` could be added later.
```c++
static constexpr bool skip_write(const std::string_view key) {
    return key == "internal_member";
}
```

> The downside of this approach is that if we wanted to skip both reading and writing then we'd need to implement both functions or have a third function just called `skip`, but having three separate functions complicates the internals of Glaze.

The second option is to make the skip function templated on whether it is a read or write:
```c++
template <bool IsRead>
static constexpr bool skip(const std::string_view key) {
    if (not IsRead) {
       return key == "internal_member";
    }
    return false;
}
```

I'm leaning towards this second option. What are your thoughts?