### PR TITLE
fix use after move in websocket handshake method

### DIFF
--- a/include/glaze/net/websocket_connection.hpp
+++ b/include/glaze/net/websocket_connection.hpp
@@ -422,25 +422,24 @@ namespace glz
 
          auto self = shared_from_this();
 
-         asio::async_write(socket_, asio::buffer(response_str),
-                           [self, req, response_str = std::move(response_str)](std::error_code ec, std::size_t) {
-                              if (ec) {
-                                 if (self->server_) {
-                                    self->server_->notify_error(self, ec);
-                                 }
-                                 return;
-                              }
+         asio::async_write(socket_, asio::buffer(response_str), [self, req](std::error_code ec, std::size_t) {
+            if (ec) {
+               if (self->server_) {
+                  self->server_->notify_error(self, ec);
+               }
+               return;
+            }
 
-                              self->handshake_complete_ = true;
+            self->handshake_complete_ = true;
 
-                              // Notify server of successful connection
-                              if (self->server_) {
-                                 self->server_->notify_open(self, req);
-                              }
+            // Notify server of successful connection
+            if (self->server_) {
+               self->server_->notify_open(self, req);
+            }
 
-                              // Start reading frames
-                              self->start_read();
-                           });
+            // Start reading frames
+            self->start_read();
+         });
       }
 
       inline void start_read()


### PR DESCRIPTION
This fixes an issue in which the socket would never return the response string during the handshake phase of a websocket connection initialization.

This was due to the fact that the response_str variable was moved into the capture scope of the WriteHandler lambda passed as the third argument to async_write.

Since this variable isn' used within the context of the lambda, there doesn't seem to be need for it anyhow.