### PR TITLE
Add support for the Boost version of Asio

### DIFF
--- a/include/glaze/ext/glaze_asio.hpp
+++ b/include/glaze/ext/glaze_asio.hpp
@@ -104,7 +104,10 @@ namespace glz
    }
 
 #if defined(GLZ_USING_BOOST_ASIO)
-   namespace asio = boost::asio;
+   namespace asio {
+      using namespace boost::asio;
+      using error_code = boost::system::error_code;
+   }
 #endif
    inline void send_buffer(asio::ip::tcp::socket& socket, repe::message& msg)
    {

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -174,15 +174,15 @@ namespace glz
             std::string final_chunk = "0\r\n\r\n";
             auto buffer = std::make_shared<std::string>(std::move(final_chunk));
 
-            asio::async_write(*socket_, asio::buffer(*buffer), [self, buffer, handler](std::error_code, std::size_t) {
+            asio::async_write(*socket_, asio::buffer(*buffer), [self, buffer, handler](asio::error_code, std::size_t) {
                if (handler) handler();
-               std::error_code close_ec;
+               asio::error_code close_ec;
                self->socket_->close(close_ec);
             });
          }
          else {
             if (handler) handler();
-            std::error_code ec;
+            asio::error_code ec;
             socket_->close(ec);
          }
       }
@@ -755,7 +755,7 @@ namespace glz
 
          asio::async_read_until(
             *socket_ptr, *buffer, "\r\n\r\n",
-            [this, socket_ptr, buffer, remote_endpoint](std::error_code ec, std::size_t /*bytes_transferred*/) {
+            [this, socket_ptr, buffer, remote_endpoint](asio::error_code ec, std::size_t /*bytes_transferred*/) {
                if (ec) {
                   // EOF is a normal disconnect, not a server error
                   if (ec != asio::error::eof) {

--- a/include/glaze/net/websocket_connection.hpp
+++ b/include/glaze/net/websocket_connection.hpp
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <array>
-#include <asio.hpp>
 #include <chrono>
 #include <cstring>
 #include <functional>
@@ -22,6 +21,7 @@
 #endif
 
 #include "glaze/base64/base64.hpp"
+#include "glaze/ext/glaze_asio.hpp"
 #include "glaze/net/http_router.hpp"
 
 namespace glz
@@ -766,7 +766,7 @@ namespace glz
             server_->notify_close(shared_from_this());
          }
 
-         std::error_code ec;
+         asio::error_code ec;
          socket_.close(ec);
       }
 


### PR DESCRIPTION
Hi,

This PR adds support for the Boost version of Asio.

`asio::error_code` is is the main difference between the two versions for our usage.

In standalone, it's just a typedef to `std::error_code` but in the Boost version they use `boost::system::error_code` which is it's own class. 
It's convertible to/from std::error_code but since they use reference the conversion can't work without changing our code.

I have verified these changes compile with Asio 1.34.2 and with Boost.Asio 1.88.0.