### PR TITLE
Fix incorrect error message on missing required key 

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2243,7 +2243,7 @@ namespace glz
                         constexpr auto req_fields = required_fields<T, Opts>();
                         if ((req_fields & fields) != req_fields) {
                            for (size_t i = 0; i < num_members; ++i) {
-                              if (not fields[i]) {
+                              if (not fields[i] && req_fields[i]) {
                                  ctx.custom_error_message = reflect<T>::keys[i];
                                  // We just return the first missing key in order to avoid heap allocations
                                  break;

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -63,6 +63,16 @@ struct glz::meta<my_struct>
 static_assert(glz::write_supported<my_struct, glz::JSON>);
 static_assert(glz::read_supported<my_struct, glz::JSON>);
 
+struct Issue1866
+{
+   std::string uniqueName;
+   std::string name{};
+   std::string description{};
+   bool codexSecret{};
+   std::optional<bool> excludeFromCodex{};
+   std::string parentName{};
+};
+
 suite starter = [] {
    "example"_test = [] {
       my_struct s{};
@@ -5841,6 +5851,22 @@ suite required_keys = [] {
    [{"i":287,"d":0.0,"arr":[1,2,3]}]
                                   ^ hello)")
          << err_msg;
+   };
+
+   "required_keys_format_error_issue1866"_test = [] {
+      std::vector<Issue1866> exports;
+      std::vector<Issue1866> gen;
+      std::string buffer{
+         R"([{"uniqueName": "/Lotus/Characters/TwinQueens","name": "Twin Queens","description": "Rulers of the Grineer with their own banner.","codexSecret": false,"parentName": "/Lotus/Characters"}])"};
+
+      std::string buffer1{
+         R"([{"uniqueName": "/Lotus/Characters/TwinQueens","name": "Twin Queens","description": "Rulers of the Grineer with their own banner.","codexSecret": false}])"};
+      auto er = glz::read<glz::opts{.error_on_missing_keys = true}>(exports, buffer);
+      expect(!er);
+
+      auto er1 = glz::read<glz::opts{.error_on_missing_keys = true}>(gen, buffer1);
+      expect(er1);
+      expect(er1.custom_error_message == "parentName");
    };
 };
 


### PR DESCRIPTION
Check if key is actually required when generating error message.

What puzzles me a little is that I couldn't reproduce the issue by simply adding an optional one of the existing test cases. Probably has to do with the hashing of the keys and thus the resulting order. Hence, I added the test case from the issue.

Fixes #1866