### PR TITLE
Read toml tests fixes

### DIFF
--- a/include/glaze/toml/opts.hpp
+++ b/include/glaze/toml/opts.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <glaze/core/opts.hpp>
+
+namespace glz::toml
+{
+
+   enum struct opts_internal : uint32_t {
+      none = 0,
+      internal_struct = 1 << 0, // Currently in an inner struct
+   };
+
+   struct toml_opts
+   {
+      uint32_t format = TOML;
+      bool error_on_unknown_keys{true};
+
+      uint32_t internal{}; // default to 0
+   };
+
+   consteval bool check_is_internal(auto&& o) { return o.internal & uint32_t(opts_internal::internal_struct); }
+
+   template <auto Opts>
+   constexpr auto is_internal_on()
+   {
+      auto ret = Opts;
+      ret.internal &= ~uint32_t(opts_internal::internal_struct);
+      return ret;
+   }
+
+} // namespace glz::toml

--- a/include/glaze/toml/opts.hpp
+++ b/include/glaze/toml/opts.hpp
@@ -24,7 +24,7 @@ namespace glz::toml
    constexpr auto is_internal_on()
    {
       auto ret = Opts;
-      ret.internal &= ~uint32_t(opts_internal::internal_struct);
+      ret.internal |= uint32_t(opts_internal::internal_struct);
       return ret;
    }
 

--- a/tests/toml_test/toml_test.cpp
+++ b/tests/toml_test/toml_test.cpp
@@ -222,7 +222,7 @@ b = 2)");
    };
 
    // Test writing a nested structure.
-   "nested_struct"_test = [] {
+   "write_nested_struct"_test = [] {
       container c{};
       std::string buffer{};
       expect(not glz::write_toml(c, buffer));
@@ -230,7 +230,35 @@ b = 2)");
 x = 10
 y = "test"
 
-value = 5.5)");
+value = 5.5)"); // TODO: This is not the right format, we need to refactor the output to match TOML syntax.
+                // For now, I'll leave it as is, but it should be fixed in the future.
+   };
+
+   "read_wrong_format_nested"_test = [] {
+      container c{};
+      std::string buffer{R"([inner]
+x = 10
+y = "test"
+
+value = 5.5)"};
+      auto error = glz::read_toml(c, buffer);
+      expect(error); // Expect an error because the format is not correct for TOML. root value should be before nested
+                     // table.
+      expect(error == glz::error_code::syntax_error);
+   };
+
+   "read_nested_struct"_test = [] {
+      container c{};
+      std::string buffer{R"(value = 5.6
+
+[inner]
+x = 11
+y = "test1"
+)"};
+      expect(not glz::read_toml(c, buffer));
+      expect(c.inner.x == 11);
+      expect(c.inner.y == "test1");
+      expect(c.value == 5.6);
    };
 
    // Test writing a boolean value.

--- a/tests/toml_test/toml_test.cpp
+++ b/tests/toml_test/toml_test.cpp
@@ -34,6 +34,21 @@ struct advanced_container
    double value = 5.5;
 };
 
+struct level_one
+{
+   int value{0};
+};
+
+struct level_two
+{
+   level_one l1{};
+};
+
+struct dotted_access_struct
+{
+   level_two l2{};
+};
+
 struct optional_struct
 {
    std::optional<int> maybe = 99;
@@ -286,6 +301,13 @@ y = "test2"
       expect(ac.inner_two.x == 12);
       expect(ac.inner_two.y == "test2");
       expect(ac.value == 5.6);
+   };
+
+   "read_advanced_nested_struct"_test = [] {
+      dotted_access_struct dac{};
+      std::string buffer{R"(l2.l1.value = 1)"};
+      expect(not glz::read_toml(dac, buffer));
+      expect(dac.l2.l1.value == 1);
    };
 
    // Test writing a boolean value.


### PR DESCRIPTION
### Summary

This PR adds initial support for standard TOML tables (`[table]`) and dotted key access resolution. #1865

Introduced support for parsing and resolving `[table]` headers.
Implemented dotted key resolution during parsing, enabling nested object assignment.
Created a new `toml/opts.hpp` file to define custom parsing options. This allows toggling behavior based on context (e.g., whether parsing occurs in the root or within a table). I'm still not sure if that's the way...
```cpp
            else if (*it == '[') { // Normal table
               std::vector<std::string> path;

               if constexpr (toml::check_is_internal(Opts)) {
                  return; // since we are in internal table we need to return to root.
               }
               else {
                  ++it;
                  ...
```
* When encountering a `[table]`, the parser now returns root context, as required by the TOML spec.
* The function `resolve_nested` is currently used for path resolution. It returns a `bool` for now, though I originally intended it to return a reference to the resolved object but, couldn't figure it out, that'd be better and would remove unnecessary logic for this function when we'll need to add arrays, since for array table defining it like
`[able]`
is not right

### Notes

* This does **not** implement support for table arrays (`[[table_array]]`) yet.
* The ordering of values is still not as per the TOML spec. when writing and relies on struct layout
* Inline table handling (`{ key = value }`) is still based on the old logic and hasn't been refactored.

* The current implementation is functional, but likely not fully optimized.
* This also does not use the fixed size arrays for key length like I wanted [here](https://github.com/stephenberry/glaze/discussions/1865#discussioncomment-13819991)
