### PR TITLE
undef Windows.h DELETE macro

### DIFF
--- a/include/glaze/net/http.hpp
+++ b/include/glaze/net/http.hpp
@@ -11,6 +11,11 @@
 #include <string_view>
 #include <system_error>
 
+// To deconflict Windows.h
+#ifdef DELETE
+#undef DELETE
+#endif
+
 namespace glz
 {
    enum struct http_method { GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS };

--- a/include/glaze/net/websocket_connection.hpp
+++ b/include/glaze/net/websocket_connection.hpp
@@ -18,6 +18,11 @@
 #if defined(GLZ_ENABLE_OPENSSL) && __has_include(<openssl/sha.h>)
 #include <openssl/sha.h>
 #define GLZ_HAS_OPENSSL
+
+// To deconflict Windows.h
+#ifdef DELETE
+#undef DELETE
+#endif
 #endif
 
 #include "glaze/base64/base64.hpp"

--- a/tests/networking_tests/https_test/https_test.cpp
+++ b/tests/networking_tests/https_test/https_test.cpp
@@ -29,6 +29,10 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 
+#ifdef DELETE
+#undef DELETE
+#endif
+
 #include <asio.hpp>
 
 using namespace ut;


### PR DESCRIPTION
We aren't renaming this enum because we want it to match the actual HTTP spec for future pure reflection.