### PR TITLE
Fix MSVC errors

### DIFF
--- a/include/glaze/csv/write.hpp
+++ b/include/glaze/csv/write.hpp
@@ -271,7 +271,7 @@ namespace glz
                      serialize<CSV>::op<Opts>(key, ctx, b, ix);
                   }
 
-                  if (I != N - 1) {
+                  if constexpr (I != N - 1) {
                      dump<','>(b, ix);
                   }
                });

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -11,6 +11,8 @@
 #if !defined(GLZ_DISABLE_SIMD) && (defined(__x86_64__) || defined(_M_X64))
 #if defined(_MSC_VER)
 #include <intrin.h>
+#pragma warning(push)
+#pragma warning(disable:4702) // disable "unreachable code" warnings, which are often invalid due to constexpr branching
 #else
 #include <immintrin.h>
 #endif
@@ -18,9 +20,6 @@
 #if defined(__AVX2__)
 #define GLZ_USE_AVX2
 #endif
-
-#pragma warning(push)
-#pragma warning(disable:4702) // disable "unreachable code" warnings, which are often invalid due to constexpr branching
 #endif
 
 #include "glaze/core/opts.hpp"

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -18,6 +18,9 @@
 #if defined(__AVX2__)
 #define GLZ_USE_AVX2
 #endif
+
+#pragma warning(push)
+#pragma warning(disable:4702) // disable "unreachable code" warnings, which are often invalid due to constexpr branching
 #endif
 
 #include "glaze/core/opts.hpp"
@@ -2034,3 +2037,7 @@ namespace glz
       return {buffer_to_file(buffer, file_name)};
    }
 }
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -1019,7 +1019,7 @@ namespace glz
             // Call the streaming handler
             handler(req, stream_res);
          }
-         catch (const std::exception& e) {
+         catch (const std::exception&) {
             // If handler throws immediately, try to send an error response.
             if (!stream_conn->is_headers_sent()) {
                stream_conn->send_headers(500, {{"Content-Type", "text/plain"}});

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -22,6 +22,11 @@
 // Conditionally include SSL headers only when needed
 #ifdef GLZ_ENABLE_SSL
 #include <asio/ssl.hpp>
+
+// To deconflict Windows.h
+#ifdef DELETE
+#undef DELETE
+#endif
 #endif
 
 namespace glz

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -22,11 +22,11 @@
 // Conditionally include SSL headers only when needed
 #ifdef GLZ_ENABLE_SSL
 #include <asio/ssl.hpp>
+#endif
 
 // To deconflict Windows.h
 #ifdef DELETE
 #undef DELETE
-#endif
 #endif
 
 namespace glz

--- a/include/glaze/net/websocket_connection.hpp
+++ b/include/glaze/net/websocket_connection.hpp
@@ -147,7 +147,7 @@ namespace glz
             size_t i = 0;
             size_t j = (context->count[0] >> 3) & 63;
 
-            if ((context->count[0] += len << 3) < (len << 3)) context->count[1]++;
+            if ((context->count[0] += uint32_t(len << 3)) < (len << 3)) context->count[1]++;
             context->count[1] += (len >> 29);
 
             if ((j + len) > 63) {

--- a/include/glaze/reflection/get_name.hpp
+++ b/include/glaze/reflection/get_name.hpp
@@ -6,6 +6,7 @@
 // TODO: Use std::source_location when deprecating clang 14
 // #include <source_location>
 #include <array>
+#include <string>
 #include <string_view>
 
 #include "glaze/reflection/to_tuple.hpp"

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -1906,7 +1906,7 @@ suite bench = [] {
       trace.begin("json_ptr_bench");
       tstart = std::chrono::high_resolution_clock::now();
       for (size_t i{}; i < repeat; ++i) {
-         glz::get<std::string>(thing, "/thing_ptr/b");
+         std::ignore = glz::get<std::string>(thing, "/thing_ptr/b");
       }
       tend = std::chrono::high_resolution_clock::now();
       trace.end("json_ptr_bench", "JSON pointer benchmark");


### PR DESCRIPTION
This fixes some MSVC errors and warnings, but there are still compiler errors Glaze compile time options using member variable pointers. These were supposed to have been fixed, so it might be because the GitHub runner is using an older version of MSVC.