### PR TITLE
Remove unneeded CMake VS Code extension from devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -59,7 +59,6 @@
          "ms-vscode.cpptools",
          "ms-vscode.cpptools-themes",
          "ms-vscode.cmake-tools",
-         "twxs.cmake",
          "llvm-vs-code-extensions.vscode-clangd",
          "eamodio.gitlens",
          "mhutchie.git-graph",


### PR DESCRIPTION
This PR removes the deprecated/unnecessary `twxs.cmake` VS Code extension from `.devcontainer/devcontainer.json`.

Rationale:
- We already use `ms-vscode.cmake-tools` and `clangd`, which cover CMake support and language features.
- Keeping extensions minimal reduces container build time and avoids conflicts.

Change details:
- Delete `twxs.cmake` from the `customizations.vscode.extensions` list in the devcontainer.

No functional changes to the codebase; devcontainer image only.

Testing:
- Container still provisions and relevant tools versions print via `postCreateCommand`.
