### PR TITLE
devcontainer version updates

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] bionic (18.04), focal (20.04), jammy (22.04)
-ARG VARIANT="jammy"
+# [Choice] bionic (18.04), focal (20.04), jammy (22.04), noble (24.04)
+ARG VARIANT="noble"
 FROM ubuntu:${VARIANT}
 
 # Restate the variant to use it later on in the llvm and cmake installations
@@ -11,11 +11,12 @@ RUN apt-get update -qq && export DEBIAN_FRONTEND=noninteractive && \
         lsb-release software-properties-common \
         wget apt-utils file zip \
         openssh-client gnupg gpg-agent socat rsync \
-        make ninja-build
+        make ninja-build \
+        ca-certificates pkg-config libssl-dev
 
 # User-settable versions:
 # This Dockerfile should support gcc-[7, 8, 9, 10, 11, 12, 13] and clang-[10, 11, 12, 13. 14, 15, 16, 17]
-ARG GCC_VER="13"
+ARG GCC_VER="14"
 # Add gcc-${GCC_VER}
 RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
 RUN apt-get update -qq && export DEBIAN_FRONTEND=noninteractive && \
@@ -26,12 +27,15 @@ RUN apt-get update -qq && export DEBIAN_FRONTEND=noninteractive && \
 RUN update-alternatives --install /usr/bin/gcc gcc $(which gcc-${GCC_VER}) 100
 RUN update-alternatives --install /usr/bin/g++ g++ $(which g++-${GCC_VER}) 100
 
-ARG LLVM_VER="17"
+ARG LLVM_VER="18"
 # Add clang-${LLVM_VER}
 ARG LLVM_URL="http://apt.llvm.org/${VARIANT}/"
 ARG LLVM_PKG="llvm-toolchain-${VARIANT}-${LLVM_VER}"
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - 2>/dev/null
-RUN add-apt-repository -y "deb ${LLVM_URL} ${LLVM_PKG} main"
+# Use keyrings and signed-by (apt-key is removed in Ubuntu noble)
+RUN mkdir -p /etc/apt/keyrings && \
+    wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm-snapshot.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/llvm-snapshot.gpg] ${LLVM_URL} ${LLVM_PKG} main" \
+    > /etc/apt/sources.list.d/llvm-${LLVM_VER}.list
 RUN apt-get update -qq && export DEBIAN_FRONTEND=noninteractive && \
     apt-get install -y --no-install-recommends \
         clang-${LLVM_VER} lldb-${LLVM_VER} lld-${LLVM_VER} \
@@ -55,12 +59,13 @@ RUN update-alternatives --install /usr/bin/clang-format clang-format $(which cla
 # Set the default clangd, so IDEs can find it
 RUN update-alternatives --install /usr/bin/clangd clangd $(which clangd-${LLVM_VER}) 1
 
-# Add current cmake/ccmake, from Kitware
+# Add current cmake/ccmake, from Kitware (keyrings + signed-by)
 ARG CMAKE_URL="https://apt.kitware.com/ubuntu/"
 ARG CMAKE_PKG=${VARIANT}
-RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
-   | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
-RUN apt-add-repository -y "deb ${CMAKE_URL} ${CMAKE_PKG} main"
+RUN mkdir -p /etc/apt/keyrings && \
+    wget -qO- https://apt.kitware.com/keys/kitware-archive-latest.asc | gpg --dearmor -o /etc/apt/keyrings/kitware-archive.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/kitware-archive.gpg] ${CMAKE_URL} ${CMAKE_PKG} main" \
+    > /etc/apt/sources.list.d/kitware.list
 RUN apt-get update -qq && export DEBIAN_FRONTEND=noninteractive && \
     apt-get install -y --no-install-recommends cmake cmake-curses-gui
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,14 +2,14 @@
    "name": "C++",
    "build": {
       "dockerfile": "Dockerfile",
-      // Update 'VARIANT' to pick an Ubuntu OS version. Options: [bionic, focal, jammy]. Default: jammy
-      // Update 'GCC_VER' to pick a gcc and g++ version. Options: [7, 8, 9, 10, 11, 12, 13]. Default: 13
-      // Update 'LLVM_VER' to pick clang version. Options: [10, 11, 12, 13, 14, 15, 16, 17]. Default: 17
+      // Update 'VARIANT' to pick an Ubuntu OS version. Options: [bionic, focal, jammy, noble]. Default: noble
+      // Update 'GCC_VER' to pick a gcc and g++ version.
+      // Update 'LLVM_VER' to pick clang version.
       // Update 'USE_CLANG' to set clang as the default C and C++ compiler. Options: [1, null]. Default null
       "args": {
-         "VARIANT": "jammy",
-         "GCC_VER": "13",
-         "LLVM_VER": "17",
+         "VARIANT": "noble",
+         "GCC_VER": "14",
+         "LLVM_VER": "18",
          "USE_CLANG": "1"
       }
    },
@@ -30,7 +30,7 @@
    // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
    "remoteUser": "user",
    // Use 'postCreateCommand' to run commands after the container is created.
-   "postCreateCommand": "id && git --version && gcc --version && clang --version && cmake --version && echo $CXX",
+   "postCreateCommand": "id && git --version && gcc --version && clang --version && cmake --version && echo $CXX && openssl version && pkg-config --modversion openssl",
    // Configure tool-specific properties.
    "customizations": {
       // Configure properties specific to VS Code.

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,7 +18,11 @@
                 "CMAKE_CXX_COMPILER": "/usr/bin/clang++",
                 "CMAKE_EXPORT_COMPILE_COMMANDS": true,
                 "glaze_DEVELOPER_MODE": true,
-                "BUILD_TESTING": true
+                "BUILD_TESTING": true,
+                "CMAKE_CXX_FLAGS": "-stdlib=libc++",
+                "CMAKE_EXE_LINKER_FLAGS": "-stdlib=libc++",
+                "CMAKE_SHARED_LINKER_FLAGS": "-stdlib=libc++",
+                "CMAKE_MODULE_LINKER_FLAGS": "-stdlib=libc++"
             }
         },
         {
@@ -33,7 +37,11 @@
                 "CMAKE_CXX_COMPILER": "/usr/bin/clang++",
                 "CMAKE_EXPORT_COMPILE_COMMANDS": true,
                 "glaze_DEVELOPER_MODE": true,
-                "BUILD_TESTING": true
+                "BUILD_TESTING": true,
+                "CMAKE_CXX_FLAGS": "-stdlib=libc++",
+                "CMAKE_EXE_LINKER_FLAGS": "-stdlib=libc++",
+                "CMAKE_SHARED_LINKER_FLAGS": "-stdlib=libc++",
+                "CMAKE_MODULE_LINKER_FLAGS": "-stdlib=libc++"
             }
         },
         {


### PR DESCRIPTION
Update devcontainer for newer Ubuntu, LLVM and GCC releases.  This prepares for future work to add C++ module support to the build which needs a newer ninja and newer clang.

This also forces the use of libc++ on clang.  The libstdc++ version linked from the apt.llvm.org sources doesn't have the needed support for C++23.

Tested:
Rebuilt container.
Built with clang-debug
Ran ctest with clang-debug