### PR TITLE
Update Dockerfile to use official devcontainer image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # [Choice] bionic (18.04), focal (20.04), jammy (22.04), noble (24.04)
 ARG VARIANT="noble"
-FROM ubuntu:${VARIANT}
+FROM mcr.microsoft.com/devcontainers/cpp:${VARIANT}
 
 # Restate the variant to use it later on in the llvm and cmake installations
 ARG VARIANT

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,20 +15,10 @@
    },
    "features": {
       "ghcr.io/devcontainers/features/common-utils:2": {
-         "username": "user",
          "configureZshAsDefaultShell": true
       },
       "ghcr.io/devcontainers/features/git:1": {}
    },
-   // Needed when using a ptrace-based debugger like C++, Go, and Rust
-   "capAdd": [
-      "SYS_PTRACE"
-   ],
-   "securityOpt": [
-      "seccomp=unconfined"
-   ],
-   // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-   "remoteUser": "user",
    // Use 'postCreateCommand' to run commands after the container is created.
    "postCreateCommand": "id && git --version && gcc --version && clang --version && cmake --version && echo $CXX && openssl version && pkg-config --modversion openssl",
    // Configure tool-specific properties.


### PR DESCRIPTION
The prior image was using a generic Ubuntu image.  This change switches to using an official MSFT/GitHub image that is better set up for codespaces.  As a side effect, we no longer need to specify a custom user (which fixes a failing security check with newer git releases) and builds in all the needed security pieces for debugging.

Tested:
cmake --preset clang-debug
cmake --build --preset clang-debug -j $(nproc)
ctest --preset clang-debug