### PR TITLE
Support variant determination via parsability

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2673,7 +2673,14 @@ namespace glz
                   }
                });
                if (!found_match) {
-                  ctx.error = error_code::no_matching_variant_type;
+                  // If we only tried one type and it failed with a specific error, preserve that error
+                  // Otherwise, use the generic no_matching_variant_type
+                  if constexpr (glz::tuple_size_v<non_const_types> == 1) {
+                     // Keep the specific error from the single type we tried
+                  }
+                  else {
+                     ctx.error = error_code::no_matching_variant_type;
+                  }
                }
             }
             else {

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2575,7 +2575,7 @@ namespace glz
    };
 
    template <class Tuple>
-   struct process_arithmetic_boolean_string_or_array
+   struct process_variant_alternatives
    {
       template <auto Options>
       static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
@@ -2617,10 +2617,33 @@ namespace glz
             }
 
             using non_const_types = typename tuple_types<Tuple>::glaze_non_const_types;
-            if constexpr (glz::tuple_size_v < non_const_types >> 0) {
-               using V = glz::tuple_element_t<0, non_const_types>;
-               if (!std::holds_alternative<V>(value)) value = V{};
-               parse<JSON>::op<ws_handled<Options>()>(std::get<V>(value), ctx, it, end);
+            if constexpr (glz::tuple_size_v<non_const_types> > 0) {
+               bool found_match{};
+               for_each<glz::tuple_size_v<non_const_types>>([&]<size_t I>() {
+                  if (found_match) {
+                     return;
+                  }
+                  using V = glz::tuple_element_t<I, non_const_types>;
+                  auto copy_it{it};
+                  if (!std::holds_alternative<V>(value)) {
+                     value = V{};
+                  }
+                  parse<JSON>::op<ws_handled<Options>()>(std::get<V>(value), ctx, it, end);
+                  if (!bool(ctx.error)) {
+                     found_match = true;
+                  }
+                  else {
+                     // Reset iterator for next attempt
+                     it = copy_it;
+                     // Reset error to try next type (unless we're at the last type)
+                     if constexpr (I + 1 < glz::tuple_size_v<non_const_types>) {
+                        ctx.error = error_code::none;
+                     }
+                  }
+               });
+               if (!found_match) {
+                  ctx.error = error_code::no_matching_variant_type;
+               }
             }
             else {
                ctx.error = error_code::no_matching_variant_type;
@@ -3022,20 +3045,20 @@ namespace glz
                   // Depth counting is done at the object level when not null terminated
                   ++ctx.indentation_level;
                }
-               process_arithmetic_boolean_string_or_array<array_types>::template op<Opts>(value, ctx, it, end);
+               process_variant_alternatives<array_types>::template op<Opts>(value, ctx, it, end);
                if constexpr (Opts.null_terminated) {
                   --ctx.indentation_level;
                }
                break;
             case '"': {
                using string_types = typename variant_types<T>::string_types;
-               process_arithmetic_boolean_string_or_array<string_types>::template op<Opts>(value, ctx, it, end);
+               process_variant_alternatives<string_types>::template op<Opts>(value, ctx, it, end);
                break;
             }
             case 't':
             case 'f': {
                using bool_types = typename variant_types<T>::bool_types;
-               process_arithmetic_boolean_string_or_array<bool_types>::template op<Opts>(value, ctx, it, end);
+               process_variant_alternatives<bool_types>::template op<Opts>(value, ctx, it, end);
                break;
             }
             case 'n':
@@ -3052,12 +3075,39 @@ namespace glz
             default: {
                // Not bool, string, object, or array so must be number or null
                using number_types = typename variant_types<T>::number_types;
-               process_arithmetic_boolean_string_or_array<number_types>::template op<Opts>(value, ctx, it, end);
+               process_variant_alternatives<number_types>::template op<Opts>(value, ctx, it, end);
             }
             }
          }
          else {
-            std::visit([&](auto&& v) { parse<JSON>::op<Options>(v, ctx, it, end); }, value);
+            // For non-auto-deducible variants, try each type until one succeeds
+            constexpr auto N = std::variant_size_v<T>;
+            bool parsed = false;
+            
+            for_each<N>([&]<size_t I>() {
+               if (parsed) return;
+               
+               auto copy_it = it;
+               auto saved_error = ctx.error;
+               
+               // Try parsing as this type
+               if (value.index() != I) {
+                  value = runtime_variant_map<T>()[I];
+               }
+               
+               std::visit([&](auto&& v) { parse<JSON>::op<Options>(v, ctx, it, end); }, value);
+               
+               if (!bool(ctx.error)) {
+                  parsed = true;
+               }
+               else {
+                  // Reset for next attempt (unless this is the last type)
+                  it = copy_it;
+                  if constexpr (I + 1 < N) {
+                     ctx.error = saved_error;
+                  }
+               }
+            });
          }
       }
    };

--- a/tests/reflection/reflection.cpp
+++ b/tests/reflection/reflection.cpp
@@ -640,4 +640,108 @@ suite embedded_tag_variants = [] {
    };
 };
 
+// Tests for nested array variants parsing
+suite nested_array_variant_tests = [] {
+   "nested array variant - vector<double>"_test = [] {
+      using NestedArrayVariant = std::variant<std::vector<double>, std::vector<std::vector<double>>>;
+      NestedArrayVariant var;
+      std::string json = "[1.0, 2.0, 3.0]";
+      auto ec = glz::read_json(var, json);
+      expect(!ec) << glz::format_error(ec, json);
+      expect(std::holds_alternative<std::vector<double>>(var));
+      auto& vec = std::get<std::vector<double>>(var);
+      expect(vec.size() == 3);
+      expect(vec[0] == 1.0);
+      expect(vec[1] == 2.0);
+      expect(vec[2] == 3.0);
+   };
+   
+   "nested array variant - vector<vector<double>>"_test = [] {
+      using NestedArrayVariant = std::variant<std::vector<double>, std::vector<std::vector<double>>>;
+      NestedArrayVariant var;
+      std::string json = "[[1.0, 1.0], [2.0, 2.0]]";
+      auto ec = glz::read_json(var, json);
+      expect(!ec) << glz::format_error(ec, json);
+      expect(std::holds_alternative<std::vector<std::vector<double>>>(var));
+      auto& vec = std::get<std::vector<std::vector<double>>>(var);
+      expect(vec.size() == 2);
+      expect(vec[0].size() == 2);
+      expect(vec[0][0] == 1.0);
+      expect(vec[0][1] == 1.0);
+      expect(vec[1][0] == 2.0);
+      expect(vec[1][1] == 2.0);
+   };
+   
+   "nested array variant - integer vectors"_test = [] {
+      // Test with integers that should work as doubles too
+      using NestedArrayVariant = std::variant<std::vector<double>, std::vector<std::vector<double>>>;
+      NestedArrayVariant var;
+      std::string json = "[[1, 1], [2, 2]]";
+      auto ec = glz::read_json(var, json);
+      expect(!ec) << glz::format_error(ec, json);
+      expect(std::holds_alternative<std::vector<std::vector<double>>>(var));
+      auto& vec = std::get<std::vector<std::vector<double>>>(var);
+      expect(vec.size() == 2);
+      expect(vec[0][0] == 1.0);
+      expect(vec[1][1] == 2.0);
+   };
+   
+   "nested array variant - round trip"_test = [] {
+      using NestedArrayVariant = std::variant<std::vector<double>, std::vector<std::vector<double>>>;
+      
+      // Test vector<double> round trip
+      {
+         NestedArrayVariant original = std::vector<double>{1.5, 2.5, 3.5};
+         auto json = glz::write_json(original);
+         expect(json.has_value());
+         
+         NestedArrayVariant restored;
+         auto ec = glz::read_json(restored, json.value());
+         expect(!ec);
+         expect(std::holds_alternative<std::vector<double>>(restored));
+         auto& vec = std::get<std::vector<double>>(restored);
+         expect(vec.size() == 3);
+         expect(vec[0] == 1.5);
+      }
+      
+      // Test vector<vector<double>> round trip
+      {
+         NestedArrayVariant original = std::vector<std::vector<double>>{{1.5, 2.5}, {3.5, 4.5}};
+         auto json = glz::write_json(original);
+         expect(json.has_value());
+         
+         NestedArrayVariant restored;
+         auto ec = glz::read_json(restored, json.value());
+         expect(!ec);
+         expect(std::holds_alternative<std::vector<std::vector<double>>>(restored));
+         auto& vec = std::get<std::vector<std::vector<double>>>(restored);
+         expect(vec.size() == 2);
+         expect(vec[0][0] == 1.5);
+         expect(vec[1][1] == 4.5);
+      }
+   };
+   
+   "nested array variant - empty arrays"_test = [] {
+      using NestedArrayVariant = std::variant<std::vector<double>, std::vector<std::vector<double>>>;
+      
+      // Empty outer array should parse as vector<double>
+      NestedArrayVariant var;
+      std::string json = "[]";
+      auto ec = glz::read_json(var, json);
+      expect(!ec) << glz::format_error(ec, json);
+      expect(std::holds_alternative<std::vector<double>>(var));
+      expect(std::get<std::vector<double>>(var).empty());
+      
+      // Array with empty inner arrays should parse as vector<vector<double>>
+      json = "[[], []]";
+      ec = glz::read_json(var, json);
+      expect(!ec) << glz::format_error(ec, json);
+      expect(std::holds_alternative<std::vector<std::vector<double>>>(var));
+      auto& vec = std::get<std::vector<std::vector<double>>>(var);
+      expect(vec.size() == 2);
+      expect(vec[0].empty());
+      expect(vec[1].empty());
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
`process_arithmetic_boolean_string_or_array` is now `process_variant_alternatives`, and it attempts to parse variant types in sequence until one is satisfied. See `variant-handling.md` for more documentation.