### PR TITLE
Support for tagged variants with default case

### DIFF
--- a/docs/variant-handling.md
+++ b/docs/variant-handling.md
@@ -277,9 +277,9 @@ suite tagged_variant_tests = [] {
 };
 ```
 
-### Tagged Variants with Embedded Tags (New!)
+### Tagged Variants with Embedded Tags
 
-Recent improvements allow variant tags to be embedded within the structs themselves, making the discriminator accessible at runtime without using `std::visit`. This provides cleaner, more maintainable code:
+Variant tags may be embedded within the structs themselves, making the discriminator accessible at runtime without using `std::visit`. This provides cleaner, more maintainable code:
 
 ```c++
 // String-based embedded tags

--- a/docs/variant-handling.md
+++ b/docs/variant-handling.md
@@ -415,6 +415,102 @@ auto error = glz::read_json(e3, R"({"species":"Lion","type":"person","weight":19
 // Error: no_matching_variant_type (tag says "person" but fields match Animal)
 ```
 
+### Default Variant Types (Catch-All Handler)
+
+When working with tagged variants, you may encounter unknown tag values that aren't in your predefined list. Glaze supports a default/catch-all variant type by making the `ids` array shorter than the number of variant alternatives. The first unlabeled type (without a corresponding ID) becomes the default handler for unknown tags.
+
+```c++
+struct CreateAction {
+   std::string action{"CREATE"};  // Embedded tag field
+   std::string resource;
+   std::map<std::string, std::string> attributes;
+};
+
+struct UpdateAction {
+   std::string action{"UPDATE"};  // Embedded tag field
+   std::string id;
+   std::map<std::string, std::string> changes;
+};
+
+// Default handler for unknown action types
+struct UnknownAction {
+   std::string action;  // Will be populated with the actual tag value
+   std::optional<std::string> id;
+   std::optional<std::string> resource;
+   std::optional<std::string> target;
+   // Can add more optional fields to handle various unknown formats
+};
+
+using ActionVariant = std::variant<CreateAction, UpdateAction, UnknownAction>;
+
+template <>
+struct glz::meta<ActionVariant> {
+   static constexpr std::string_view tag = "action";
+   // Note: Only 2 IDs for 3 variant types - UnknownAction becomes the default
+   static constexpr auto ids = std::array{"CREATE", "UPDATE"};
+};
+
+// Known actions work as expected
+std::string_view json = R"({"action":"CREATE","resource":"user","attributes":{"name":"Alice"}})";
+ActionVariant av;
+glz::read_json(av, json);
+// av holds CreateAction with action == "CREATE"
+
+// Unknown actions route to the default type
+json = R"({"action":"DELETE","id":"123","target":"resource"})";
+glz::read_json(av, json);
+// av holds UnknownAction with action == "DELETE"
+if (std::holds_alternative<UnknownAction>(av)) {
+   auto& unknown = std::get<UnknownAction>(av);
+   std::cout << "Unknown action: " << unknown.action << std::endl;  // Prints: DELETE
+}
+```
+
+This feature is particularly useful for:
+- **Forward compatibility**: Handle future action types without breaking existing code
+- **API versioning**: Gracefully handle newer message types from updated clients
+- **Error recovery**: Capture and log unknown operations instead of failing
+- **Plugin systems**: Allow extensions to define custom actions
+
+The default type works with both string and numeric tags:
+
+```c++
+struct TypeA {
+   int type{1};
+   std::string data;
+};
+
+struct TypeB {
+   int type{2};
+   double value;
+};
+
+struct TypeDefault {
+   int type;  // Will contain the actual numeric tag value
+   std::optional<std::string> data;
+   std::optional<double> value;
+};
+
+using NumericVariant = std::variant<TypeA, TypeB, TypeDefault>;
+
+template <>
+struct glz::meta<NumericVariant> {
+   static constexpr std::string_view tag = "type";
+   static constexpr auto ids = std::array{1, 2};  // TypeDefault handles all other values
+};
+
+// Type 99 is unknown, routes to TypeDefault
+std::string_view json = R"({"type":99,"data":"unknown"})";
+NumericVariant nv;
+glz::read_json(nv, json);
+// nv holds TypeDefault with type == 99
+```
+
+**Important notes:**
+- The default type must be the last type in the variant that doesn't have a corresponding ID
+- The tag field in the default type will be populated with the actual tag value from the JSON
+- Only the first unlabeled type serves as the default (you can only have one default handler)
+
 ## BEVE to JSON
 
 BEVE uses the variant index to denote the type in a variant. When calling `glz::beve_to_json`, variants will be written in JSON with `"index"` and `"value"` keys. The index indicates the type, which would correspond to a `std::variant` `index()` method.

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -412,20 +412,24 @@ namespace glz
    template <is_variant T, size_t... I>
    constexpr auto make_variant_sv_id_map_impl(std::index_sequence<I...>, auto&& variant_ids)
    {
-      return normal_map<sv, size_t, std::variant_size_v<T>>(std::array{pair<sv, size_t>{sv(variant_ids[I]), I}...});
+      // Use the actual size of the ids array, not the variant size
+      return normal_map<sv, size_t, sizeof...(I)>(std::array{pair<sv, size_t>{sv(variant_ids[I]), I}...});
    }
 
    template <is_variant T, size_t... I>
    constexpr auto make_variant_id_map_impl(std::index_sequence<I...>, auto&& variant_ids)
    {
       using id_type = std::decay_t<decltype(ids_v<T>[0])>;
-      return normal_map<id_type, size_t, std::variant_size_v<T>>(std::array{pair{variant_ids[I], I}...});
+      // Use the actual size of the ids array, not the variant size
+      return normal_map<id_type, size_t, sizeof...(I)>(std::array{pair{variant_ids[I], I}...});
    }
 
    template <is_variant T>
    constexpr auto make_variant_id_map()
    {
-      constexpr auto indices = std::make_index_sequence<std::variant_size_v<T>>{};
+      // Use the size of the ids array, not the variant size
+      // This allows unlabeled variant types to serve as defaults
+      constexpr auto indices = std::make_index_sequence<ids_v<T>.size()>{};
 
       using id_type = std::decay_t<decltype(ids_v<T>[0])>;
 

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2872,8 +2872,59 @@ namespace glz
                                  return; // we've decoded our target type
                               }
                               else [[unlikely]] {
-                                 ctx.error = error_code::no_matching_variant_type;
-                                 return;
+                                 // Check if we have a default type (ids array shorter than variant)
+                                 constexpr auto ids_size = ids_v<T>.size();
+                                 constexpr auto variant_size = std::variant_size_v<T>;
+                                 if constexpr (ids_size < variant_size) {
+                                    // Use the first unlabeled type as the default
+                                    const auto type_index = ids_size;
+                                    
+                                    it = start; // we restart our object parsing now that we know the target type
+                                    tag_specified_index = type_index; // Store the default type index
+                                    if (value.index() != type_index) value = runtime_variant_map<T>()[type_index];
+                                    std::visit(
+                                       [&](auto&& v) {
+                                          using V = std::decay_t<decltype(v)>;
+                                          constexpr bool is_object = glaze_object_t<V> || reflectable<V>;
+                                          if constexpr (is_object) {
+                                             from<JSON, V>::template op<opening_handled<Opts>()>(v, ctx, it, end);
+                                          }
+                                          else if constexpr (is_memory_object<V>) {
+                                             if (!v) {
+                                                if constexpr (is_specialization_v<V, std::optional>) {
+                                                   if constexpr (requires { v.emplace(); }) {
+                                                      v.emplace();
+                                                   }
+                                                   else {
+                                                      v = typename V::value_type{};
+                                                   }
+                                                }
+                                                else if constexpr (is_specialization_v<V, std::unique_ptr>)
+                                                   v = std::make_unique<typename V::element_type>();
+                                                else if constexpr (is_specialization_v<V, std::shared_ptr>)
+                                                   v = std::make_shared<typename V::element_type>();
+                                                else if constexpr (constructible<V>) {
+                                                   v = meta_construct_v<V>();
+                                                }
+                                                else {
+                                                   ctx.error = error_code::invalid_nullable_read;
+                                                   return;
+                                                }
+                                             }
+                                             from<JSON, memory_type<V>>::template op<opening_handled<Opts>()>(*v, ctx, it, end);
+                                          }
+                                       },
+                                       value);
+
+                                    if constexpr (Opts.null_terminated) {
+                                       --ctx.indentation_level;
+                                    }
+                                    return;
+                                 }
+                                 else {
+                                    ctx.error = error_code::no_matching_variant_type;
+                                    return;
+                                 }
                               }
                            }
                         }
@@ -2912,8 +2963,21 @@ namespace glz
                               return;
                            }
                            else {
-                              ctx.error = error_code::no_matching_variant_type;
-                              return;
+                              // Check if we have a default type (ids array shorter than variant)
+                              constexpr auto ids_size = ids_v<T>.size();
+                              constexpr auto variant_size = std::variant_size_v<T>;
+                              if constexpr (ids_size < variant_size) {
+                                 // Use the first unlabeled type as the default
+                                 it = start;
+                                 const auto type_index = ids_size;
+                                 tag_specified_index = type_index; // Store the default type index
+                                 if (value.index() != type_index) value = runtime_variant_map<T>()[type_index];
+                                 return;
+                              }
+                              else {
+                                 ctx.error = error_code::no_matching_variant_type;
+                                 return;
+                              }
                            }
                         }
                         else if constexpr (Opts.error_on_unknown_keys) {

--- a/tests/json_test/variant_ambiguous_test.cpp
+++ b/tests/json_test/variant_ambiguous_test.cpp
@@ -899,4 +899,197 @@ suite variant_ambiguous_tests = [] {
    };
 };
 
+// ============================================================================
+// Default variant tests - variants with unlabeled default types
+// ============================================================================
+
+// Test structs for default variant functionality
+struct CreateAction {
+   std::string action{"CREATE"};  // Embedded tag field
+   std::string resource{};
+   std::map<std::string, std::string> attributes{};
+};
+
+struct UpdateAction {
+   std::string action{"UPDATE"};  // Embedded tag field
+   std::string id{};
+   std::map<std::string, std::string> changes{};
+};
+
+// Default handler for unknown action types
+struct UnknownAction {
+   std::string action{};  // Will be populated with the actual tag value
+   std::optional<std::string> id{};
+   std::optional<std::string> resource{};
+   std::optional<std::string> target{};
+   std::optional<std::string> data{};
+};
+
+using ActionVariant = std::variant<CreateAction, UpdateAction, UnknownAction>;
+
+template <>
+struct glz::meta<ActionVariant> {
+   static constexpr std::string_view tag = "action";
+   // Note: Only 2 IDs for 3 variant types - UnknownAction becomes the default
+   static constexpr auto ids = std::array{"CREATE", "UPDATE"};
+};
+
+// Test with numeric IDs
+struct TypeNumA {
+   int type{1};
+   std::string data{};
+};
+
+struct TypeNumB {
+   int type{2};
+   double value{};
+};
+
+struct TypeNumUnknown {
+   int type{};
+   std::optional<std::string> data{};
+   std::optional<double> value{};
+};
+
+using NumericVariant = std::variant<TypeNumA, TypeNumB, TypeNumUnknown>;
+
+template <>
+struct glz::meta<NumericVariant> {
+   static constexpr std::string_view tag = "type";
+   static constexpr auto ids = std::array{1, 2};  // TypeNumUnknown handles all other values
+};
+
+suite variant_default_tests = [] {
+   "default variant - known CREATE action"_test = [] {
+      std::string_view json = R"({"action":"CREATE","resource":"user","attributes":{"name":"Alice","role":"admin"}})";
+      ActionVariant av{};
+      auto ec = glz::read_json(av, json);
+      expect(!ec) << glz::format_error(ec, json);
+      expect(std::holds_alternative<CreateAction>(av));
+      
+      auto& create = std::get<CreateAction>(av);
+      expect(create.action == "CREATE");
+      expect(create.resource == "user");
+      expect(create.attributes["name"] == "Alice");
+      expect(create.attributes["role"] == "admin");
+   };
+   
+   "default variant - known UPDATE action"_test = [] {
+      std::string_view json = R"({"action":"UPDATE","id":"123","changes":{"status":"active","priority":"high"}})";
+      ActionVariant av{};
+      auto ec = glz::read_json(av, json);
+      expect(!ec) << glz::format_error(ec, json);
+      expect(std::holds_alternative<UpdateAction>(av));
+      
+      auto& update = std::get<UpdateAction>(av);
+      expect(update.action == "UPDATE");
+      expect(update.id == "123");
+      expect(update.changes["status"] == "active");
+      expect(update.changes["priority"] == "high");
+   };
+   
+   "default variant - unknown DELETE action"_test = [] {
+      // DELETE is not in the ids array, should route to UnknownAction
+      std::string_view json = R"({"action":"DELETE","id":"456","target":"resource"})";
+      ActionVariant av{};
+      auto ec = glz::read_json(av, json);
+      expect(!ec) << glz::format_error(ec, json);
+      expect(std::holds_alternative<UnknownAction>(av));
+      
+      auto& unknown = std::get<UnknownAction>(av);
+      expect(unknown.action == "DELETE");
+      expect(unknown.id.has_value());
+      expect(unknown.id.value() == "456");
+      expect(unknown.target.has_value());
+      expect(unknown.target.value() == "resource");
+   };
+   
+   "default variant - unknown PATCH action"_test = [] {
+      // PATCH is not in the ids array, should route to UnknownAction
+      std::string_view json = R"({"action":"PATCH","data":"some_data","resource":"item"})";
+      ActionVariant av{};
+      auto ec = glz::read_json(av, json);
+      expect(!ec) << glz::format_error(ec, json);
+      expect(std::holds_alternative<UnknownAction>(av));
+      
+      auto& unknown = std::get<UnknownAction>(av);
+      expect(unknown.action == "PATCH");
+      expect(unknown.data.has_value());
+      expect(unknown.data.value() == "some_data");
+      expect(unknown.resource.has_value());
+      expect(unknown.resource.value() == "item");
+   };
+   
+   "default variant - unknown custom action"_test = [] {
+      // Custom action type not in the ids array
+      std::string_view json = R"({"action":"ARCHIVE","id":"789"})";
+      ActionVariant av{};
+      auto ec = glz::read_json(av, json);
+      expect(!ec) << glz::format_error(ec, json);
+      expect(std::holds_alternative<UnknownAction>(av));
+      
+      auto& unknown = std::get<UnknownAction>(av);
+      expect(unknown.action == "ARCHIVE");
+      expect(unknown.id.has_value());
+      expect(unknown.id.value() == "789");
+   };
+   
+   "default variant - fields order with known action"_test = [] {
+      // Test with fields in different order
+      std::string_view json = R"({"resource":"product","action":"CREATE","attributes":{"price":"99.99"}})";
+      ActionVariant av{};
+      auto ec = glz::read_json(av, json);
+      expect(!ec) << glz::format_error(ec, json);
+      expect(std::holds_alternative<CreateAction>(av));
+      
+      auto& create = std::get<CreateAction>(av);
+      expect(create.action == "CREATE");
+      expect(create.resource == "product");
+      expect(create.attributes["price"] == "99.99");
+   };
+   
+   "default variant - fields order with unknown action"_test = [] {
+      // Test unknown action with fields before action tag
+      std::string_view json = R"({"id":"111","target":"db","action":"PURGE"})";
+      ActionVariant av{};
+      auto ec = glz::read_json(av, json);
+      expect(!ec) << glz::format_error(ec, json);
+      expect(std::holds_alternative<UnknownAction>(av));
+      
+      auto& unknown = std::get<UnknownAction>(av);
+      expect(unknown.action == "PURGE");
+      expect(unknown.id.has_value());
+      expect(unknown.id.value() == "111");
+      expect(unknown.target.has_value());
+      expect(unknown.target.value() == "db");
+   };
+
+   "default variant - numeric known type"_test = [] {
+      std::string_view json = R"({"type":1,"data":"test"})";
+      NumericVariant nv{};
+      auto ec = glz::read_json(nv, json);
+      expect(!ec) << glz::format_error(ec, json);
+      expect(std::holds_alternative<TypeNumA>(nv));
+      
+      auto& a = std::get<TypeNumA>(nv);
+      expect(a.type == 1);
+      expect(a.data == "test");
+   };
+   
+   "default variant - numeric unknown type"_test = [] {
+      std::string_view json = R"({"type":99,"data":"unknown","value":3.14})";
+      NumericVariant nv{};
+      auto ec = glz::read_json(nv, json);
+      expect(!ec) << glz::format_error(ec, json);
+      expect(std::holds_alternative<TypeNumUnknown>(nv));
+      
+      auto& unknown = std::get<TypeNumUnknown>(nv);
+      expect(unknown.type == 99);
+      expect(unknown.data.has_value());
+      expect(unknown.data.value() == "unknown");
+      expect(unknown.value.has_value());
+      expect(unknown.value.value() == 3.14);
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
### Default Variant Types (Catch-All Handler)

When working with tagged variants, you may encounter unknown tag values that aren't in your predefined list. Glaze supports a default/catch-all variant type by making the `ids` array shorter than the number of variant alternatives. The first unlabeled type (without a corresponding ID) becomes the default handler for unknown tags.

```c++
struct CreateAction {
   std::string action{"CREATE"};  // Embedded tag field
   std::string resource;
   std::map<std::string, std::string> attributes;
};

struct UpdateAction {
   std::string action{"UPDATE"};  // Embedded tag field
   std::string id;
   std::map<std::string, std::string> changes;
};

// Default handler for unknown action types
struct UnknownAction {
   std::string action;  // Will be populated with the actual tag value
   std::optional<std::string> id;
   std::optional<std::string> resource;
   std::optional<std::string> target;
   // Can add more optional fields to handle various unknown formats
};

using ActionVariant = std::variant<CreateAction, UpdateAction, UnknownAction>;

template <>
struct glz::meta<ActionVariant> {
   static constexpr std::string_view tag = "action";
   // Note: Only 2 IDs for 3 variant types - UnknownAction becomes the default
   static constexpr auto ids = std::array{"CREATE", "UPDATE"};
};

// Known actions work as expected
std::string_view json = R"({"action":"CREATE","resource":"user","attributes":{"name":"Alice"}})";
ActionVariant av;
glz::read_json(av, json);
// av holds CreateAction with action == "CREATE"

// Unknown actions route to the default type
json = R"({"action":"DELETE","id":"123","target":"resource"})";
glz::read_json(av, json);
// av holds UnknownAction with action == "DELETE"
if (std::holds_alternative<UnknownAction>(av)) {
   auto& unknown = std::get<UnknownAction>(av);
   std::cout << "Unknown action: " << unknown.action << std::endl;  // Prints: DELETE
}
```

This feature is particularly useful for:
- **Forward compatibility**: Handle future action types without breaking existing code
- **API versioning**: Gracefully handle newer message types from updated clients
- **Error recovery**: Capture and log unknown operations instead of failing
- **Plugin systems**: Allow extensions to define custom actions

The default type works with both string and numeric tags:

```c++
struct TypeA {
   int type{1};
   std::string data;
};

struct TypeB {
   int type{2};
   double value;
};

struct TypeDefault {
   int type;  // Will contain the actual numeric tag value
   std::optional<std::string> data;
   std::optional<double> value;
};

using NumericVariant = std::variant<TypeA, TypeB, TypeDefault>;

template <>
struct glz::meta<NumericVariant> {
   static constexpr std::string_view tag = "type";
   static constexpr auto ids = std::array{1, 2};  // TypeDefault handles all other values
};

// Type 99 is unknown, routes to TypeDefault
std::string_view json = R"({"type":99,"data":"unknown"})";
NumericVariant nv;
glz::read_json(nv, json);
// nv holds TypeDefault with type == 99
```

**Important notes:**
- The default type must be the last type in the variant that doesn't have a corresponding ID
- The tag field in the default type will be populated with the actual tag value from the JSON
- Only the first unlabeled type serves as the default (you can only have one default handler)