### PR TITLE
fixed compile error when including both toml and json

### DIFF
--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -469,20 +469,6 @@ namespace glz
       }
    };
 
-   inline constexpr std::array<uint16_t, 256> char_escape_table = [] {
-      auto combine = [](const char chars[2]) -> uint16_t { return uint16_t(chars[0]) | (uint16_t(chars[1]) << 8); };
-
-      std::array<uint16_t, 256> t{};
-      t['\b'] = combine(R"(\b)");
-      t['\t'] = combine(R"(\t)");
-      t['\n'] = combine(R"(\n)");
-      t['\f'] = combine(R"(\f)");
-      t['\r'] = combine(R"(\r)");
-      t['\"'] = combine(R"(\")");
-      t['\\'] = combine(R"(\\)");
-      return t;
-   }();
-
    template <class T>
       requires str_t<T> || char_t<T>
    struct to<JSON, T>

--- a/include/glaze/toml/write.hpp
+++ b/include/glaze/toml/write.hpp
@@ -106,20 +106,6 @@ namespace glz
       }
    };
 
-   constexpr std::array<uint16_t, 256> char_escape_table = [] {
-      auto combine = [](const char chars[2]) -> uint16_t { return uint16_t(chars[0]) | (uint16_t(chars[1]) << 8); };
-
-      std::array<uint16_t, 256> t{};
-      t['\b'] = combine(R"(\b)");
-      t['\t'] = combine(R"(\t)");
-      t['\n'] = combine(R"(\n)");
-      t['\f'] = combine(R"(\f)");
-      t['\r'] = combine(R"(\r)");
-      t['\"'] = combine(R"(\")");
-      t['\\'] = combine(R"(\\)");
-      return t;
-   }();
-
    template <class T>
       requires str_t<T> || char_t<T>
    struct to<TOML, T>

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -116,6 +116,20 @@ namespace glz
       return t;
    }();
 
+   inline constexpr std::array<uint16_t, 256> char_escape_table = [] {
+      auto combine = [](const char chars[2]) -> uint16_t { return uint16_t(chars[0]) | (uint16_t(chars[1]) << 8); };
+
+      std::array<uint16_t, 256> t{};
+      t['\b'] = combine(R"(\b)");
+      t['\t'] = combine(R"(\t)");
+      t['\n'] = combine(R"(\n)");
+      t['\f'] = combine(R"(\f)");
+      t['\r'] = combine(R"(\r)");
+      t['\"'] = combine(R"(\")");
+      t['\\'] = combine(R"(\\)");
+      return t;
+   }();
+
    consteval uint32_t repeat_byte4(const auto repeat) { return uint32_t(0x01010101u) * uint8_t(repeat); }
 
    consteval uint64_t repeat_byte8(const uint8_t repeat) { return 0x0101010101010101ull * repeat; }


### PR DESCRIPTION
A small fix to where char_escape_table is defined for both json and toml, before including both `glaze.hpp` and `toml.hpp` would not compile because of double declaration.

I removed it from `write.hpp` from both `json/` and `toml/` put it into a `util/parse.hpp`, it seemed as best fit there.