### PR TITLE
Support Byte Arrays in Glaze

### DIFF
--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -42,6 +42,23 @@ namespace glz
       T& val;
    };
 
+   // Wrapper to treat character arrays as fixed-size byte arrays instead of null-terminated strings
+   template <class T>
+   struct byte_array final
+   {
+      static constexpr bool glaze_wrapper = true;
+      static constexpr bool glaze_byte_array = true;
+      static constexpr auto glaze_reflect = false; // Exclude from reflection
+      using value_type = T;
+      T& val;
+   };
+
+   template <class T>
+   byte_array(T&) -> byte_array<T>;
+
+   template <class T>
+   concept is_byte_array = requires { requires T::glaze_byte_array == true; };
+
    template <class... T>
    struct obj final
    {


### PR DESCRIPTION
Add byte_array wrapper for explicit fixed-size character array serialization.  This introduces glz::byte_array.

Currently:
char arr[4] = {0, 0, 1, 0};
std::string json;
glz::write_json(arr, json);
// Previously: json == "\"\""  (empty string - WRONG) // Expected: json == "\"\\u0000\\u0000\\u0001\\u0000\""  (desired behavior)

This happens because there's no way to distinguish between a regular character array and a byte array in C/C++.

This introduces:

char arr[4] = {0, 0, 1, 0};

// Traditional behavior (unchanged)
glz::write_json(arr, json);                    // → ""

// NEW: Explicit byte array behavior
glz::write_json(glz::byte_array{arr}, json);   // → "\u0000\u0000\u0001\u0000"

Tested:
Null-only arrays: glz::byte_array{char[3]{0,0,0}} → "\u0000\u0000\u0000" Mixed content: glz::byte_array{char[4]{'a',0,'b','\n'}} → "a\u0000b\n" Normal strings: glz::byte_array{char[5]{'h','e','l','l','o'}} → "hello" Round-trip: Full serialization and deserialization support