### PR TITLE
Skip member functions when serializing.

### DIFF
--- a/docs/binary.md
+++ b/docs/binary.md
@@ -31,6 +31,12 @@ By default Glaze will handle structs as tagged objects, meaning that keys will b
 
 `glaze/binary/beve_to_json.hpp` provides `glz::beve_to_json`, which directly converts a buffer of BEVE data to a buffer of JSON data.
 
+### Member Function Pointers
+
+Objects that expose member function pointers through `glz::meta` are skipped by the BEVE writer by default. This mirrors JSON/TOML behaviour and avoids emitting unusable callable placeholders in binary payloads.
+
+If you want the key present, use `write_member_functions = true`.
+
 ## Partial Objects
 
 It is sometimes desirable to write out only a portion of an object. This is permitted via an array of JSON pointers, which indicate which parts of the object should be written out.

--- a/docs/json.md
+++ b/docs/json.md
@@ -164,6 +164,12 @@ struct glz::meta<Person> {
 // JSON output: {"full_name":"John","years_old":30,"interests":["reading"]}
 ```
 
+### Member Function Pointers in Metadata
+
+When a `glz::meta` definition references a member function (for example, to expose a computed field), Glaze skips that entry during JSON writes by default. This prevents unintentionally emitting empty values for callables.
+
+If you want the key to be emitted—you can opt back in by supplying a custom options type with `write_member_functions = true`:
+
 ## Error Handling
 
 Glaze provides comprehensive error handling with detailed error messages:

--- a/docs/options.md
+++ b/docs/options.md
@@ -115,6 +115,10 @@ The supported, but not default provided options are listed after `glz::opts` and
 bool validate_skipped = false;
 // If full validation should be performed on skipped values
 
+bool write_member_functions = false;
+// Serialize member function pointers referenced in glz::meta instead of skipping them
+// JSON/BEVE/TOML writers skip member function pointers by default for safety
+
 bool validate_trailing_whitespace = false;
 // If, after parsing a value, we want to validate the trailing whitespace
 

--- a/include/glaze/beve/write.hpp
+++ b/include/glaze/beve/write.hpp
@@ -809,7 +809,7 @@ namespace glz
          for_each<N>([&]<size_t I>() {
             using V = field_t<T, I>;
 
-            if constexpr (std::same_as<V, hidden> || std::same_as<V, skip>) {
+            if constexpr (std::same_as<V, hidden> || std::same_as<V, skip> || is_member_function_pointer<V>) {
                // do not serialize
                // not serializing is_includer<V> would be a breaking change
             }
@@ -839,7 +839,8 @@ namespace glz
          for_each<N>([&]<size_t I>() {
             using val_t = field_t<T, I>;
 
-            if constexpr (std::same_as<val_t, hidden> || std::same_as<val_t, skip>) {
+            if constexpr (std::same_as<val_t, hidden> || std::same_as<val_t, skip> ||
+                          is_member_function_pointer<val_t>) {
                return;
             }
             else {
@@ -877,7 +878,8 @@ namespace glz
          for_each<N>([&]<size_t I>() {
             using val_t = field_t<T, I>;
 
-            if constexpr (std::same_as<val_t, hidden> || std::same_as<val_t, skip>) {
+            if constexpr (std::same_as<val_t, hidden> || std::same_as<val_t, skip> ||
+                          is_member_function_pointer<val_t>) {
                return;
             }
             else {

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -337,8 +337,7 @@ namespace glz
       std::same_as<T, std::nullptr_t> || std::convertible_to<T, std::monostate> || std::same_as<T, std::nullopt_t>;
 
    template <class T>
-   concept always_skipped = is_includer<T> || std::same_as<T, hidden> || std::same_as<T, skip> ||
-      is_member_function_pointer<T>;
+   concept always_skipped = is_includer<T> || std::same_as<T, hidden> || std::same_as<T, skip>;
 
    template <class T>
    concept nullable_t = !meta_value_t<T> && !str_t<T> && requires(T t) {

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -337,7 +337,8 @@ namespace glz
       std::same_as<T, std::nullptr_t> || std::convertible_to<T, std::monostate> || std::same_as<T, std::nullopt_t>;
 
    template <class T>
-   concept always_skipped = is_includer<T> || std::same_as<T, hidden> || std::same_as<T, skip>;
+   concept always_skipped = is_includer<T> || std::same_as<T, hidden> || std::same_as<T, skip> ||
+      is_member_function_pointer<T>;
 
    template <class T>
    concept nullable_t = !meta_value_t<T> && !str_t<T> && requires(T t) {

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -140,6 +140,10 @@ namespace glz
    // If full validation should be performed on skipped values
 
    // ---
+   // bool write_member_functions = false;
+   // If member function pointers should be serialized when provided in glz::meta
+
+   // ---
    // bool validate_trailing_whitespace = false;
    // If, after parsing a value, we want to validate the trailing whitespace
 
@@ -179,6 +183,16 @@ namespace glz
    {
       if constexpr (requires { Opts.validate_skipped; }) {
          return Opts.validate_skipped;
+      }
+      else {
+         return false;
+      }
+   }
+
+   consteval bool check_write_member_functions(auto&& Opts)
+   {
+      if constexpr (requires { Opts.write_member_functions; }) {
+         return Opts.write_member_functions;
       }
       else {
          return false;

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -5,6 +5,7 @@
 
 #include "glaze/beve/header.hpp"
 #include "glaze/core/common.hpp"
+#include "glaze/core/opts.hpp"
 #include "glaze/core/wrappers.hpp"
 #include "glaze/util/primes_64.hpp"
 
@@ -225,14 +226,19 @@ namespace glz
          }
          else if constexpr (Opts.skip_null_members) {
             // if any type could be null then we might skip
-            return []<size_t... I>(std::index_sequence<I...>) {
-               return ((always_skipped<field_t<T, I>> || null_t<field_t<T, I>>) || ...);
+            constexpr bool write_member_functions = check_write_member_functions(Opts);
+            return [&]<size_t... I>(std::index_sequence<I...>) {
+               return ((always_skipped<field_t<T, I>> ||
+                        (!write_member_functions && is_member_function_pointer<field_t<T, I>>) ||
+                        null_t<field_t<T, I>>) || ...);
             }(std::make_index_sequence<N>{});
          }
          else {
             // if we have an always_skipped type then we return true
-            return []<size_t... I>(std::index_sequence<I...>) {
-               return ((always_skipped<field_t<T, I>>) || ...);
+            constexpr bool write_member_functions = check_write_member_functions(Opts);
+            return [&]<size_t... I>(std::index_sequence<I...>) {
+               return ((always_skipped<field_t<T, I>> ||
+                        (!write_member_functions && is_member_function_pointer<field_t<T, I>>)) || ...);
             }(std::make_index_sequence<N>{});
          }
       }

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1142,8 +1142,9 @@ namespace glz
             }
 
             using val_t = detail::iterator_second_type<T>; // the type of value in each [key, value] pair
-
-            if constexpr (not always_skipped<val_t>) {
+            constexpr bool write_member_functions = check_write_member_functions(Opts);
+            if constexpr (!always_skipped<val_t> &&
+                          (write_member_functions || !is_member_function_pointer<val_t>)) {
                if constexpr (null_t<val_t> && Opts.skip_null_members) {
                   auto write_first_entry = [&](auto&& it) {
                      auto&& [key, entry_val] = *it;
@@ -1605,7 +1606,8 @@ namespace glz
             }
 
             // skip
-            if constexpr (always_skipped<val_t>) {
+            constexpr bool write_member_functions = check_write_member_functions(Opts);
+            if constexpr (always_skipped<val_t> || (!write_member_functions && is_member_function_pointer<val_t>)) {
                return;
             }
             else {
@@ -1807,7 +1809,9 @@ namespace glz
                      if constexpr (meta<T>::skip(reflect<T>::keys[I], mctx)) return;
                   }
 
-                  if constexpr (always_skipped<val_t>) {
+                  constexpr bool write_member_functions = check_write_member_functions(Opts);
+                  if constexpr (always_skipped<val_t> ||
+                                (!write_member_functions && is_member_function_pointer<val_t>)) {
                      return;
                   }
                   else {

--- a/include/glaze/toml/write.hpp
+++ b/include/glaze/toml/write.hpp
@@ -308,7 +308,9 @@ namespace glz
          for_each<N>([&]<size_t I>() {
             using val_t = field_t<T, I>;
 
-            if constexpr (always_skipped<val_t>)
+            constexpr bool write_member_functions = check_write_member_functions(Options);
+            if constexpr (always_skipped<val_t> ||
+                          (!write_member_functions && is_member_function_pointer<val_t>))
                return;
             else {
                if constexpr (null_t<val_t>) {

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -2671,6 +2671,24 @@ suite member_function_pointer_beve_serialization = [] {
       expect(not glz::read_beve(output, buffer));
       expect(output.name == input.name);
    };
+
+   "member function pointer opt-in write encodes description key"_test = [] {
+      MemberFunctionThingBeve input{};
+      input.name = "test_item";
+
+      std::string buffer_default{};
+      expect(not glz::write_beve(input, buffer_default));
+      expect(buffer_default.find("description") == std::string::npos);
+
+      struct opts_with_member_functions : glz::opts
+      {
+         bool write_member_functions = true;
+      };
+
+      std::string buffer_opt_in{};
+      expect(not glz::write<glz::set_beve<opts_with_member_functions{}>()>(input, buffer_opt_in));
+      expect(buffer_opt_in.find("description") != std::string::npos);
+   };
 };
 
 int main()

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -2638,6 +2638,41 @@ suite explicit_string_view_support = [] {
    };
 };
 
+struct MemberFunctionThingBeve
+{
+   std::string name{};
+   auto get_description() const -> std::string
+   {
+      return "something";
+   }
+};
+
+namespace glz
+{
+   template <>
+   struct meta<MemberFunctionThingBeve>
+   {
+      using T = MemberFunctionThingBeve;
+      static constexpr auto value = object(
+         "name", &T::name,
+         "description", &T::get_description
+      );
+   };
+} // namespace glz
+
+suite member_function_pointer_beve_serialization = [] {
+   "member function pointer skipped in beve write"_test = [] {
+      MemberFunctionThingBeve input{};
+      input.name = "test_item";
+      std::string buffer{};
+      expect(not glz::write_beve(input, buffer));
+
+      MemberFunctionThingBeve output{};
+      expect(not glz::read_beve(output, buffer));
+      expect(output.name == input.name);
+   };
+};
+
 int main()
 {
    trace.begin("binary_test");

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -11729,6 +11729,20 @@ suite member_function_pointer_serialization = [] {
       expect(not glz::write_json(thing, buffer));
       expect(buffer == R"({"name":"test_item"})") << buffer;
    };
+
+   "member function pointer opt-in write produces legacy output"_test = [] {
+      MemberFunctionThing thing{};
+      thing.name = "test_item";
+
+      struct opts_with_member_functions : glz::opts
+      {
+         bool write_member_functions = true;
+      };
+
+      std::string buffer{};
+      expect(not glz::write<opts_with_member_functions{}>(thing, buffer));
+      expect(buffer == R"({"name":"test_item","description":})") << buffer;
+   };
 };
 
 int main()

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -126,6 +126,28 @@ struct Issue1866
    std::string parentName{};
 };
 
+struct MemberFunctionThing
+{
+   std::string name{};
+   auto get_description() const -> std::string
+   {
+      return "something";
+   }
+};
+
+namespace glz
+{
+   template <>
+   struct meta<MemberFunctionThing>
+   {
+      using T = MemberFunctionThing;
+      static constexpr auto value = object(
+         "name", &T::name,
+         "description", &T::get_description
+      );
+   };
+} // namespace glz
+
 suite starter = [] {
    "example"_test = [] {
       my_struct s{};
@@ -11696,6 +11718,16 @@ suite explicit_string_view_support = [] {
       buffer.clear();
       expect(not glz::write<glz::opts{.raw_string = true}>(value, buffer));
       expect(buffer == R"("explicit")");
+   };
+};
+
+suite member_function_pointer_serialization = [] {
+   "member function pointer skipped in json write"_test = [] {
+      MemberFunctionThing thing{};
+      thing.name = "test_item";
+      std::string buffer{};
+      expect(not glz::write_json(thing, buffer));
+      expect(buffer == R"({"name":"test_item"})") << buffer;
    };
 };
 


### PR DESCRIPTION
### Member Function Pointers in Metadata

When a `glz::meta` definition references a member function, Glaze skips that entry during JSON writes by default. This prevents unintentionally emitting empty values for callables.

If you want the key to be emitted—you can opt back in by supplying a custom options type with `write_member_functions = true`: