### PR TITLE
Fix CSV parsing for signed integral min and named enums

### DIFF
--- a/include/glaze/csv/read.hpp
+++ b/include/glaze/csv/read.hpp
@@ -104,26 +104,10 @@ namespace glz
                value = static_cast<V>(i);
             }
             else {
-               uint64_t i{};
-               int sign = 1;
-               if (*it == '-') {
-                  sign = -1;
-                  ++it;
-                  if (it == end) [[unlikely]] {
-                     ctx.error = error_code::unexpected_end;
-                     return;
-                  }
-               }
-               if (not glz::atoi(i, it, end)) [[unlikely]] {
+               if (not glz::atoi(value, it, end)) [[unlikely]] {
                   ctx.error = error_code::parse_number_failure;
                   return;
                }
-
-               if (i > (std::numeric_limits<V>::max)()) [[unlikely]] {
-                  ctx.error = error_code::parse_number_failure;
-                  return;
-               }
-               value = sign * static_cast<V>(i);
             }
          }
          else {
@@ -218,6 +202,60 @@ namespace glz
                value.push_back(*it);
                ++it;
             }
+         }
+      }
+   };
+
+   template <class T>
+      requires(is_named_enum<T>)
+   struct from<CSV, T>
+   {
+      template <auto Opts, class It>
+      static void op(auto&& value, is_context auto&& ctx, It&& it, auto&& end)
+      {
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+
+         if (it == end) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return;
+         }
+
+         std::string field{};
+         parse<CSV>::op<Opts>(field, ctx, it, end);
+
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+
+         sv key{field.data(), field.size()};
+
+         constexpr auto N = reflect<T>::size;
+
+         if constexpr (N == 0) {
+            ctx.error = error_code::unexpected_enum;
+            return;
+         }
+         else if constexpr (N == 1) {
+            if (key == get<0>(reflect<T>::keys)) {
+               value = get<0>(reflect<T>::values);
+            }
+            else {
+               ctx.error = error_code::unexpected_enum;
+            }
+         }
+         else {
+            static constexpr auto HashInfo = hash_info<T>;
+            const auto index = decode_hash_with_size<CSV, T, HashInfo, HashInfo.type>::op(
+               key.data(), key.data() + key.size(), key.size());
+
+            if (index >= N || reflect<T>::keys[index] != key) [[unlikely]] {
+               ctx.error = error_code::unexpected_enum;
+               return;
+            }
+
+            visit<N>([&]<size_t I>() { value = get<I>(reflect<T>::values); }, index);
          }
       }
    };

--- a/tests/csv_test/csv_test.cpp
+++ b/tests/csv_test/csv_test.cpp
@@ -1,4 +1,6 @@
+#include <cstdint>
 #include <deque>
+#include <limits>
 #include <map>
 #include <unordered_map>
 
@@ -47,6 +49,45 @@ struct glz::meta<string_elements>
 {
    using T = string_elements;
    static constexpr auto value = glz::object("id", &T::id, &T::udl);
+};
+
+struct signed_min_columns
+{
+   std::vector<std::int8_t> i8{};
+   std::vector<std::int32_t> i32{};
+};
+
+template <>
+struct glz::meta<signed_min_columns>
+{
+   using T = signed_min_columns;
+   static constexpr auto value = glz::object("i8", &T::i8, "i32", &T::i32);
+};
+
+enum struct csv_color : std::uint8_t
+{
+   red = 0,
+   green = 1,
+   blue = 2,
+};
+
+template <>
+struct glz::meta<csv_color>
+{
+   using enum csv_color;
+   static constexpr auto value = enumerate("rouge", red, "vert", green, "bleu", blue);
+};
+
+struct enum_column_struct
+{
+   std::vector<csv_color> colors{};
+};
+
+template <>
+struct glz::meta<enum_column_struct>
+{
+   using T = enum_column_struct;
+   static constexpr auto value = glz::object("colors", &T::colors);
 };
 
 suite csv_tests = [] {
@@ -147,6 +188,36 @@ suite csv_tests = [] {
 )");
 
       expect(!glz::write_file_csv<glz::colwise>(obj, "csv_test_colwise.csv", std::string{}));
+   };
+
+   "signed minimum integers"_test = [] {
+      std::string input =
+         R"(i8,i32
+-128,-2147483648)";
+
+      signed_min_columns obj{};
+      expect(!glz::read_csv<glz::colwise>(obj, input));
+
+      expect(obj.i8.size() == 1);
+      expect(obj.i32.size() == 1);
+      expect(obj.i8[0] == std::numeric_limits<std::int8_t>::min());
+      expect(obj.i32[0] == std::numeric_limits<std::int32_t>::min());
+   };
+
+   "named enum column wise"_test = [] {
+      std::string input =
+         R"(colors
+rouge
+vert
+bleu)";
+
+      enum_column_struct obj{};
+      expect(!glz::read_csv<glz::colwise>(obj, input));
+
+      expect(obj.colors.size() == 3);
+      expect(obj.colors[0] == csv_color::red);
+      expect(obj.colors[1] == csv_color::green);
+      expect(obj.colors[2] == csv_color::blue);
    };
 
    "read/write row wise"_test = [] {


### PR DESCRIPTION
- Fixed CSV parsing for signed integrals by parsing directly into the destination value with `glz::atoi`, allowing `std::numeric_limits<T>::min()` to succeed without overflow workarounds.
- Extended CSV parsing to support named enums (those declared with Glaze meta keys/enumerate), hashing the decoded
field and assigning the corresponding enum constant.
- Added column-wise tests covering signed minimum values and named enum fields to csv_test.