### PR TITLE
CORS preflight requests succeed w/o user stubs

### DIFF
--- a/docs/networking/advanced-networking.md
+++ b/docs/networking/advanced-networking.md
@@ -81,7 +81,7 @@ server.get("/test-cors", [](const glz::request& req, glz::response& res) {
 
 ### Automatic Preflight Handling
 
-Glaze no longer requires empty `OPTIONS` routes. The server inspects sibling handlers, builds the `Allow` header dynamically, and runs middleware (including CORS) before returning a response. If the origin is denied the preflight receives `403`; otherwise the CORS middleware fills in the appropriate `Access-Control-Allow-*` headers.
+Glaze no longer requires empty `OPTIONS` routes. The server inspects sibling handlers, builds the `Allow` header dynamically, and runs middleware (including CORS) before returning a response. If the origin is denied the preflight receives `403`; if the browser asks for a verb that is not implemented the server answers with `405` (after running middleware so diagnostics still flow); otherwise the CORS middleware fills in the appropriate `Access-Control-Allow-*` headers.
 
 ### Extended CORS Configuration
 

--- a/docs/networking/advanced-networking.md
+++ b/docs/networking/advanced-networking.md
@@ -57,7 +57,8 @@ auto custom_cors = glz::create_cors_middleware({
     .allowed_origins_validator = [](std::string_view origin) {
         return origin.ends_with(".trusted-site.com");
     },
-    .allowed_headers = {"Content-Type"},
+    .allowed_methods = {"GET", "POST"},
+    .allowed_headers = {"Content-Type", "Authorization"},
     .allow_credentials = true,
     .max_age = 86400 // 24 hours
 });

--- a/docs/networking/advanced-networking.md
+++ b/docs/networking/advanced-networking.md
@@ -35,16 +35,14 @@ server.enable_cors(allowed_origins, true); // Allow credentials
 // Or use detailed configuration
 glz::cors_config config;
 config.allowed_origins = {"https://myapp.com", "https://app.myapp.com"};
-config.add_allowed_origin_pattern("https://*.partner.myapp.com");
-config.set_origin_validator([](std::string_view origin) {
-    return origin == "https://internal.myapp.local";
-});
+config.allowed_origins_validator = [](std::string_view origin) {
+    return origin.ends_with(".partner.myapp.com");
+};
 config.allowed_methods = {"GET", "POST", "PUT", "DELETE"};
 config.allowed_headers = {"Content-Type", "Authorization", "X-API-Key"};
 config.exposed_headers = {"X-Total-Count", "X-Page-Info"};
 config.allow_credentials = true;
 config.max_age = 3600; // 1 hour preflight cache
-config.allow_private_network = true;
 config.options_success_status = 200; // Use legacy-friendly 200 instead of 204
 
 server.enable_cors(config);
@@ -56,11 +54,12 @@ server.enable_cors(config);
 // Create custom CORS handler
 auto custom_cors = glz::create_cors_middleware({
     .allowed_origins = {"https://trusted-site.com"},
-    .allow_all_methods = true,                 // Reflect requested method
+    .allowed_origins_validator = [](std::string_view origin) {
+        return origin.ends_with(".trusted-site.com");
+    },
     .allowed_headers = {"Content-Type"},
-    .allow_all_headers = true,                 // Reflect requested headers when allowed
     .allow_credentials = true,
-    .max_age = 86400                           // 24 hours
+    .max_age = 86400 // 24 hours
 });
 
 server.use(custom_cors);
@@ -81,16 +80,12 @@ server.get("/test-cors", [](const glz::request& req, glz::response& res) {
 
 ### Automatic Preflight Handling
 
-Glaze no longer requires empty `OPTIONS` routes. The server inspects sibling handlers, builds the `Allow` header dynamically, and runs middleware (including CORS) before returning a response. If the origin is denied the preflight receives `403`; if the browser asks for a verb that is not implemented the server answers with `405` (after running middleware so diagnostics still flow); otherwise the CORS middleware fills in the appropriate `Access-Control-Allow-*` headers.
+The server builds the `Allow` header dynamically, and runs middleware (including CORS) before returning a response. If the origin is denied the preflight receives `403`; if the browser asks for a verb that is not implemented the server answers with `405` (after running middleware so diagnostics still flow); otherwise the CORS middleware fills in the appropriate `Access-Control-Allow-*` headers.
 
 ### Extended CORS Configuration
 
-- **Dynamic origins** – `add_allowed_origin_pattern`, `add_allowed_origin_regex`, and `set_origin_validator` let you accept wildcard domains or perform per-request checks.
-- **Convenience helpers** – `add_allowed_header`, `add_exposed_header`, `add_allowed_method`, and `add_allowed_origin` de-duplicate entries while you build a policy.
-- **Reflective allowances** – enable `allow_all_methods` and `allow_all_headers` to echo the browser's requested method/headers.
-- **Private network support** – set `allow_private_network` to emit `Access-Control-Allow-Private-Network` when the browser asks.
+- **Dynamic origins** – `allowed_origins_validator` let you accept wildcard domains or perform per-request checks.
 - **Custom preflight status** – override `options_success_status` if a client expects `200` instead of `204`.
-- **Credential safety** – when credentials are enabled alongside `*`, Glaze automatically echoes the request origin to keep browsers happy.
 
 ## WebSocket Support
 

--- a/include/glaze/net/cors.hpp
+++ b/include/glaze/net/cors.hpp
@@ -4,57 +4,13 @@
 #pragma once
 
 #include <algorithm>
-#include <atomic>
-#include <cstdio>
-#include <functional>
-#include <regex>
 #include <string>
-#include <unordered_set>
 #include <vector>
 
 #include "glaze/net/http_router.hpp"
 
 namespace glz
 {
-   inline std::string glob_to_regex(std::string_view pattern)
-   {
-      std::string regex;
-      regex.reserve(pattern.size() * 2 + 2);
-      regex.push_back('^');
-
-      for (char ch : pattern) {
-         switch (ch) {
-         case '*':
-            regex.append(".*");
-            break;
-         case '?':
-            regex.push_back('.');
-            break;
-         case '.':
-         case '+':
-         case '(': 
-         case ')': 
-         case '[':
-         case ']':
-         case '{':
-         case '}':
-         case '^':
-         case '$':
-         case '|':
-         case '\\':
-            regex.push_back('\\');
-            regex.push_back(ch);
-            break;
-         default:
-            regex.push_back(ch);
-            break;
-         }
-      }
-
-      regex.push_back('$');
-      return regex;
-   }
-
    /**
     * @brief Configuration for CORS (Cross-Origin Resource Sharing) support
     */
@@ -67,6 +23,11 @@ namespace glz
        * For credentials to work, you cannot use "*" - must specify exact origins
        */
       std::vector<std::string> allowed_origins = {"*"};
+
+      /**
+       * @brief Optional callback to dynamically validate origins
+       */
+      std::function<bool(std::string_view)> allowed_origins_validator{};
 
       /**
        * @brief List of allowed HTTP methods
@@ -105,105 +66,9 @@ namespace glz
       bool handle_preflight = true;
 
       /**
-       * @brief Optional regular expression matchers for origin validation
-       */
-      std::vector<std::string> allowed_origin_regexes{};
-
-      /**
-       * @brief Optional callback to dynamically validate origins
-       */
-      std::function<bool(std::string_view)> origin_validator{};
-
-      /**
-       * @brief Treat all methods as allowed when responding to preflight requests
-       */
-      bool allow_all_methods = false;
-
-      /**
-       * @brief Treat all request headers as allowed when responding to preflight requests
-       */
-      bool allow_all_headers = false;
-
-      /**
-       * @brief Include Access-Control-Allow-Private-Network when requested
-       */
-      bool allow_private_network = false;
-
-      /**
        * @brief HTTP status code to return for successful OPTIONS preflight responses
        */
       int options_success_status = 204;
-
-      /**
-       * @brief Helper to append an allowed header without duplicating entries
-       */
-      cors_config& add_allowed_header(std::string header)
-      {
-         if (std::find(allowed_headers.begin(), allowed_headers.end(), header) == allowed_headers.end()) {
-            allowed_headers.emplace_back(std::move(header));
-         }
-         return *this;
-      }
-
-      /**
-       * @brief Helper to append an exposed header without duplicating entries
-       */
-      cors_config& add_exposed_header(std::string header)
-      {
-         if (std::find(exposed_headers.begin(), exposed_headers.end(), header) == exposed_headers.end()) {
-            exposed_headers.emplace_back(std::move(header));
-         }
-         return *this;
-      }
-
-      /**
-       * @brief Helper to append an allowed origin without duplicating entries
-       */
-      cors_config& add_allowed_origin(std::string origin)
-      {
-         if (std::find(allowed_origins.begin(), allowed_origins.end(), origin) == allowed_origins.end()) {
-            allowed_origins.emplace_back(std::move(origin));
-         }
-         return *this;
-      }
-
-      /**
-       * @brief Helper to append an allowed method without duplicating entries
-       */
-      cors_config& add_allowed_method(std::string method)
-      {
-         if (std::find(allowed_methods.begin(), allowed_methods.end(), method) == allowed_methods.end()) {
-            allowed_methods.emplace_back(std::move(method));
-         }
-         return *this;
-      }
-
-      /**
-       * @brief Helper to append a glob pattern (e.g. https://\*.example.com) for origin validation
-       */
-      cors_config& add_allowed_origin_pattern(std::string pattern)
-      {
-         allowed_origin_regexes.emplace_back(glob_to_regex(pattern));
-         return *this;
-      }
-
-      /**
-       * @brief Helper to append a raw regular expression for origin validation
-       */
-      cors_config& add_allowed_origin_regex(std::string regex)
-      {
-         allowed_origin_regexes.emplace_back(std::move(regex));
-         return *this;
-      }
-
-      /**
-       * @brief Helper to register a dynamic origin validator
-       */
-      cors_config& set_origin_validator(std::function<bool(std::string_view)> validator)
-      {
-         origin_validator = std::move(validator);
-         return *this;
-      }
    };
 
    /**
@@ -213,16 +78,15 @@ namespace glz
     * @param origin The origin to check
     * @return true if the origin is allowed, false otherwise
     */
-   inline bool is_origin_allowed(const cors_config& config, std::string_view origin,
-                                 const std::vector<std::regex>& compiled_patterns)
+   inline bool is_origin_allowed(const cors_config& config, std::string_view origin)
    {
       if (origin.empty()) {
          return false;
       }
 
-      if (config.origin_validator) {
+      if (config.allowed_origins_validator) {
          try {
-            if (config.origin_validator(origin)) {
+            if (config.allowed_origins_validator(origin)) {
                return true;
             }
          }
@@ -231,19 +95,10 @@ namespace glz
          }
       }
 
-      for (const auto& pattern : compiled_patterns) {
-         if (std::regex_match(origin.begin(), origin.end(), pattern)) {
-            return true;
-         }
-      }
-
       // If no specific origins are configured or "*" is present, allow all
-      if (config.allowed_origins.empty()) {
-         if (compiled_patterns.empty() && !config.origin_validator) {
-            return true;
-         }
-      }
-      if (std::find(config.allowed_origins.begin(), config.allowed_origins.end(), "*") != config.allowed_origins.end()) {
+      if ((config.allowed_origins.empty() && !config.allowed_origins_validator) ||
+          std::find(config.allowed_origins.begin(), config.allowed_origins.end(), "*") !=
+             config.allowed_origins.end()) {
          return true;
       }
 
@@ -278,34 +133,7 @@ namespace glz
     */
    inline handler create_cors_middleware(const cors_config& config = {})
    {
-      std::vector<std::regex> compiled_origin_regexes;
-      compiled_origin_regexes.reserve(config.allowed_origin_regexes.size());
-      for (const auto& pattern : config.allowed_origin_regexes) {
-         try {
-            compiled_origin_regexes.emplace_back(pattern, std::regex::ECMAScript | std::regex::icase);
-         }
-         catch (const std::regex_error& e) {
-            std::fprintf(stderr, "CORS: invalid origin regex '%s': %s\n", pattern.c_str(), e.what());
-         }
-      }
-
-      const bool wildcard_with_credentials = config.allow_credentials &&
-                                             std::find(config.allowed_origins.begin(), config.allowed_origins.end(),
-                                                       "*") != config.allowed_origins.end();
-      if (wildcard_with_credentials) {
-         static std::atomic<bool> warning_emitted = false;
-         bool expected = false;
-         if (warning_emitted.compare_exchange_strong(expected, true)) {
-            std::fprintf(stderr,
-                         "glz::create_cors_middleware warning: allow_credentials=true with wildcard origin '*' "
-                         "is not permitted by browsers. Falling back to echoing the request origin.\n");
-         }
-      }
-
-      const bool has_dynamic_origin = config.origin_validator || !compiled_origin_regexes.empty();
-
-      return [config, compiled_origin_regexes = std::move(compiled_origin_regexes), has_dynamic_origin](
-                const request& req, response& res) {
+      return [config](const request& req, response& res) {
          // Get the origin from the request headers
          std::string origin;
          auto origin_it = req.headers.find("origin");
@@ -317,13 +145,18 @@ namespace glz
          bool is_preflight = (req.method == http_method::OPTIONS) &&
                              (req.headers.find("access-control-request-method") != req.headers.end());
 
+         if (is_preflight && config.handle_preflight) {
+            // Origin not allowed, but it's a preflight request - respond with 403
+            res.status(403).body("CORS: Origin not allowed");
+         }
+
          // Always add CORS headers if origin is allowed
-         if (!origin.empty() && is_origin_allowed(config, origin, compiled_origin_regexes)) {
+         if (!origin.empty() && is_origin_allowed(config, origin)) {
             // Determine which origin to send back
             std::string allowed_origin = "*";
-            const bool contains_wildcard =
-               std::find(config.allowed_origins.begin(), config.allowed_origins.end(), "*") != config.allowed_origins.end();
-            if (config.allow_credentials || !contains_wildcard || has_dynamic_origin) {
+            const bool contains_wildcard = std::find(config.allowed_origins.begin(), config.allowed_origins.end(),
+                                                     "*") != config.allowed_origins.end();
+            if (config.allow_credentials || !contains_wildcard || config.allowed_origins_validator) {
                allowed_origin = origin;
             }
 
@@ -334,13 +167,6 @@ namespace glz
                res.header("Access-Control-Allow-Credentials", "true");
             }
 
-            if (config.allow_private_network) {
-               auto private_network_it = req.headers.find("access-control-request-private-network");
-               if (private_network_it != req.headers.end()) {
-                  res.header("Access-Control-Allow-Private-Network", "true");
-               }
-            }
-
             // Add exposed headers if any
             if (!config.exposed_headers.empty()) {
                res.header("Access-Control-Expose-Headers", join_strings(config.exposed_headers, ", "));
@@ -349,24 +175,10 @@ namespace glz
             // Handle preflight requests
             if (is_preflight && config.handle_preflight) {
                // Add allowed methods
-               if (config.allow_all_methods) {
-                  auto method_header = req.headers.find("access-control-request-method");
-                  if (method_header != req.headers.end()) {
-                     res.header("Access-Control-Allow-Methods", method_header->second);
-                  }
-                  else {
-                     res.header("Access-Control-Allow-Methods", "*");
-                  }
-               }
-               else {
-                  res.header("Access-Control-Allow-Methods", join_strings(config.allowed_methods, ", "));
-               }
+               res.header("Access-Control-Allow-Methods", join_strings(config.allowed_methods, ", "));
 
                // Add allowed headers
-               if (config.allow_all_headers) {
-                  res.header("Access-Control-Allow-Headers", "*");
-               }
-               else if (!config.allowed_headers.empty()) {
+               if (!config.allowed_headers.empty()) {
                   res.header("Access-Control-Allow-Headers", join_strings(config.allowed_headers, ", "));
                }
                else if (auto requested_headers = req.headers.find("access-control-request-headers");
@@ -375,17 +187,11 @@ namespace glz
                }
 
                // Add max age
-               if (config.max_age > 0) {
-                  res.header("Access-Control-Max-Age", std::to_string(config.max_age));
-               }
+               res.header("Access-Control-Max-Age", std::to_string(config.max_age));
 
                // Set status to 204 (No Content) for preflight response
                res.status(config.options_success_status);
             }
-         }
-         else if (is_preflight && config.handle_preflight) {
-            // Origin not allowed, but it's a preflight request - respond with 403
-            res.status(403).body("CORS: Origin not allowed");
          }
       };
    }

--- a/include/glaze/net/cors.hpp
+++ b/include/glaze/net/cors.hpp
@@ -4,6 +4,10 @@
 #pragma once
 
 #include <algorithm>
+#include <atomic>
+#include <cstdio>
+#include <functional>
+#include <regex>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -12,6 +16,45 @@
 
 namespace glz
 {
+   inline std::string glob_to_regex(std::string_view pattern)
+   {
+      std::string regex;
+      regex.reserve(pattern.size() * 2 + 2);
+      regex.push_back('^');
+
+      for (char ch : pattern) {
+         switch (ch) {
+         case '*':
+            regex.append(".*");
+            break;
+         case '?':
+            regex.push_back('.');
+            break;
+         case '.':
+         case '+':
+         case '(': 
+         case ')': 
+         case '[':
+         case ']':
+         case '{':
+         case '}':
+         case '^':
+         case '$':
+         case '|':
+         case '\\':
+            regex.push_back('\\');
+            regex.push_back(ch);
+            break;
+         default:
+            regex.push_back(ch);
+            break;
+         }
+      }
+
+      regex.push_back('$');
+      return regex;
+   }
+
    /**
     * @brief Configuration for CORS (Cross-Origin Resource Sharing) support
     */
@@ -60,6 +103,107 @@ namespace glz
        * When true, the middleware will respond to OPTIONS requests with appropriate headers
        */
       bool handle_preflight = true;
+
+      /**
+       * @brief Optional regular expression matchers for origin validation
+       */
+      std::vector<std::string> allowed_origin_regexes{};
+
+      /**
+       * @brief Optional callback to dynamically validate origins
+       */
+      std::function<bool(std::string_view)> origin_validator{};
+
+      /**
+       * @brief Treat all methods as allowed when responding to preflight requests
+       */
+      bool allow_all_methods = false;
+
+      /**
+       * @brief Treat all request headers as allowed when responding to preflight requests
+       */
+      bool allow_all_headers = false;
+
+      /**
+       * @brief Include Access-Control-Allow-Private-Network when requested
+       */
+      bool allow_private_network = false;
+
+      /**
+       * @brief HTTP status code to return for successful OPTIONS preflight responses
+       */
+      int options_success_status = 204;
+
+      /**
+       * @brief Helper to append an allowed header without duplicating entries
+       */
+      cors_config& add_allowed_header(std::string header)
+      {
+         if (std::find(allowed_headers.begin(), allowed_headers.end(), header) == allowed_headers.end()) {
+            allowed_headers.emplace_back(std::move(header));
+         }
+         return *this;
+      }
+
+      /**
+       * @brief Helper to append an exposed header without duplicating entries
+       */
+      cors_config& add_exposed_header(std::string header)
+      {
+         if (std::find(exposed_headers.begin(), exposed_headers.end(), header) == exposed_headers.end()) {
+            exposed_headers.emplace_back(std::move(header));
+         }
+         return *this;
+      }
+
+      /**
+       * @brief Helper to append an allowed origin without duplicating entries
+       */
+      cors_config& add_allowed_origin(std::string origin)
+      {
+         if (std::find(allowed_origins.begin(), allowed_origins.end(), origin) == allowed_origins.end()) {
+            allowed_origins.emplace_back(std::move(origin));
+         }
+         return *this;
+      }
+
+      /**
+       * @brief Helper to append an allowed method without duplicating entries
+       */
+      cors_config& add_allowed_method(std::string method)
+      {
+         if (std::find(allowed_methods.begin(), allowed_methods.end(), method) == allowed_methods.end()) {
+            allowed_methods.emplace_back(std::move(method));
+         }
+         return *this;
+      }
+
+      /**
+       * @brief Helper to append a glob pattern (e.g. https://\*.example.com) for origin validation
+       */
+      cors_config& add_allowed_origin_pattern(std::string pattern)
+      {
+         allowed_origin_regexes.emplace_back(glob_to_regex(pattern));
+         return *this;
+      }
+
+      /**
+       * @brief Helper to append a raw regular expression for origin validation
+       */
+      cors_config& add_allowed_origin_regex(std::string regex)
+      {
+         allowed_origin_regexes.emplace_back(std::move(regex));
+         return *this;
+      }
+
+      /**
+       * @brief Helper to register a dynamic origin validator
+       */
+      cors_config& set_origin_validator(std::function<bool(std::string_view)> validator)
+      {
+         origin_validator = std::move(validator);
+         return *this;
+      }
    };
 
    /**
@@ -69,11 +213,37 @@ namespace glz
     * @param origin The origin to check
     * @return true if the origin is allowed, false otherwise
     */
-   inline bool is_origin_allowed(const cors_config& config, const std::string& origin)
+   inline bool is_origin_allowed(const cors_config& config, std::string_view origin,
+                                 const std::vector<std::regex>& compiled_patterns)
    {
+      if (origin.empty()) {
+         return false;
+      }
+
+      if (config.origin_validator) {
+         try {
+            if (config.origin_validator(origin)) {
+               return true;
+            }
+         }
+         catch (...) {
+            // If the validator throws, treat as not allowed.
+         }
+      }
+
+      for (const auto& pattern : compiled_patterns) {
+         if (std::regex_match(origin.begin(), origin.end(), pattern)) {
+            return true;
+         }
+      }
+
       // If no specific origins are configured or "*" is present, allow all
-      if (config.allowed_origins.empty() || std::find(config.allowed_origins.begin(), config.allowed_origins.end(),
-                                                      "*") != config.allowed_origins.end()) {
+      if (config.allowed_origins.empty()) {
+         if (compiled_patterns.empty() && !config.origin_validator) {
+            return true;
+         }
+      }
+      if (std::find(config.allowed_origins.begin(), config.allowed_origins.end(), "*") != config.allowed_origins.end()) {
          return true;
       }
 
@@ -108,7 +278,34 @@ namespace glz
     */
    inline handler create_cors_middleware(const cors_config& config = {})
    {
-      return [config](const request& req, response& res) {
+      std::vector<std::regex> compiled_origin_regexes;
+      compiled_origin_regexes.reserve(config.allowed_origin_regexes.size());
+      for (const auto& pattern : config.allowed_origin_regexes) {
+         try {
+            compiled_origin_regexes.emplace_back(pattern, std::regex::ECMAScript | std::regex::icase);
+         }
+         catch (const std::regex_error& e) {
+            std::fprintf(stderr, "CORS: invalid origin regex '%s': %s\n", pattern.c_str(), e.what());
+         }
+      }
+
+      const bool wildcard_with_credentials = config.allow_credentials &&
+                                             std::find(config.allowed_origins.begin(), config.allowed_origins.end(),
+                                                       "*") != config.allowed_origins.end();
+      if (wildcard_with_credentials) {
+         static std::atomic<bool> warning_emitted = false;
+         bool expected = false;
+         if (warning_emitted.compare_exchange_strong(expected, true)) {
+            std::fprintf(stderr,
+                         "glz::create_cors_middleware warning: allow_credentials=true with wildcard origin '*' "
+                         "is not permitted by browsers. Falling back to echoing the request origin.\n");
+         }
+      }
+
+      const bool has_dynamic_origin = config.origin_validator || !compiled_origin_regexes.empty();
+
+      return [config, compiled_origin_regexes = std::move(compiled_origin_regexes), has_dynamic_origin](
+                const request& req, response& res) {
          // Get the origin from the request headers
          std::string origin;
          auto origin_it = req.headers.find("origin");
@@ -121,11 +318,12 @@ namespace glz
                              (req.headers.find("access-control-request-method") != req.headers.end());
 
          // Always add CORS headers if origin is allowed
-         if (!origin.empty() && is_origin_allowed(config, origin)) {
+         if (!origin.empty() && is_origin_allowed(config, origin, compiled_origin_regexes)) {
             // Determine which origin to send back
             std::string allowed_origin = "*";
-            if (config.allow_credentials || std::find(config.allowed_origins.begin(), config.allowed_origins.end(),
-                                                      "*") == config.allowed_origins.end()) {
+            const bool contains_wildcard =
+               std::find(config.allowed_origins.begin(), config.allowed_origins.end(), "*") != config.allowed_origins.end();
+            if (config.allow_credentials || !contains_wildcard || has_dynamic_origin) {
                allowed_origin = origin;
             }
 
@@ -136,6 +334,13 @@ namespace glz
                res.header("Access-Control-Allow-Credentials", "true");
             }
 
+            if (config.allow_private_network) {
+               auto private_network_it = req.headers.find("access-control-request-private-network");
+               if (private_network_it != req.headers.end()) {
+                  res.header("Access-Control-Allow-Private-Network", "true");
+               }
+            }
+
             // Add exposed headers if any
             if (!config.exposed_headers.empty()) {
                res.header("Access-Control-Expose-Headers", join_strings(config.exposed_headers, ", "));
@@ -144,16 +349,38 @@ namespace glz
             // Handle preflight requests
             if (is_preflight && config.handle_preflight) {
                // Add allowed methods
-               res.header("Access-Control-Allow-Methods", join_strings(config.allowed_methods, ", "));
+               if (config.allow_all_methods) {
+                  auto method_header = req.headers.find("access-control-request-method");
+                  if (method_header != req.headers.end()) {
+                     res.header("Access-Control-Allow-Methods", method_header->second);
+                  }
+                  else {
+                     res.header("Access-Control-Allow-Methods", "*");
+                  }
+               }
+               else {
+                  res.header("Access-Control-Allow-Methods", join_strings(config.allowed_methods, ", "));
+               }
 
                // Add allowed headers
-               res.header("Access-Control-Allow-Headers", join_strings(config.allowed_headers, ", "));
+               if (config.allow_all_headers) {
+                  res.header("Access-Control-Allow-Headers", "*");
+               }
+               else if (!config.allowed_headers.empty()) {
+                  res.header("Access-Control-Allow-Headers", join_strings(config.allowed_headers, ", "));
+               }
+               else if (auto requested_headers = req.headers.find("access-control-request-headers");
+                        requested_headers != req.headers.end()) {
+                  res.header("Access-Control-Allow-Headers", requested_headers->second);
+               }
 
                // Add max age
-               res.header("Access-Control-Max-Age", std::to_string(config.max_age));
+               if (config.max_age > 0) {
+                  res.header("Access-Control-Max-Age", std::to_string(config.max_age));
+               }
 
                // Set status to 204 (No Content) for preflight response
-               res.status(204);
+               res.status(config.options_success_status);
             }
          }
          else if (is_preflight && config.handle_preflight) {

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <atomic>
 #include <charconv>
 #include <chrono>
@@ -1158,17 +1159,80 @@ namespace glz
          // Find a matching route using http_router::match which handles both exact and parameterized routes
          auto [handle, params] = root_router.match(method, target);
 
-         // Update the request with any extracted parameters
-         request.params = std::move(params);
+         // Create the response object up front so we can reuse it in fallback flows
+         response response;
 
          if (!handle) {
-            // No matching route found
+            if (method == http_method::OPTIONS) {
+               std::vector<http_method> allowed_methods;
+               std::unordered_map<std::string, std::string> preflight_params;
+
+               auto capture_first_params = [&](std::unordered_map<std::string, std::string>&& candidate_params) {
+                  if (preflight_params.empty()) {
+                     preflight_params = std::move(candidate_params);
+                  }
+               };
+
+               auto try_method = [&](http_method candidate) {
+                  if (candidate == http_method::OPTIONS) return;
+                  auto [candidate_handle, candidate_params] = root_router.match(candidate, target);
+                  if (candidate_handle) {
+                     allowed_methods.push_back(candidate);
+                     capture_first_params(std::move(candidate_params));
+                  }
+               };
+
+               try_method(http_method::GET);
+               try_method(http_method::POST);
+               try_method(http_method::PUT);
+               try_method(http_method::DELETE);
+               try_method(http_method::PATCH);
+               try_method(http_method::HEAD);
+
+               if (!allowed_methods.empty()) {
+                  request.params = std::move(preflight_params);
+
+                  if (std::none_of(allowed_methods.begin(), allowed_methods.end(),
+                                   [](http_method m) { return m == http_method::OPTIONS; })) {
+                     allowed_methods.push_back(http_method::OPTIONS);
+                  }
+
+                  std::string allow_header;
+                  allow_header.reserve(allowed_methods.size() * 8);
+                  for (size_t i = 0; i < allowed_methods.size(); ++i) {
+                     if (i > 0) allow_header.append(", ");
+                     allow_header.append(std::string(to_string(allowed_methods[i])));
+                  }
+                  response.header("Allow", allow_header);
+
+                  try {
+                     for (const auto& middleware : root_router.middlewares) {
+                        middleware(request, response);
+                     }
+                  }
+                  catch (const std::exception&) {
+                     error_handler(std::make_error_code(std::errc::invalid_argument),
+                                   std::source_location::current());
+                     send_error_response(socket, 500, "Internal Server Error");
+                     return;
+                  }
+
+                  if (response.status_code == 200 && response.response_body.empty()) {
+                     response.status(204);
+                  }
+
+                  send_response(socket, response);
+                  return;
+               }
+            }
+
+            // No matching route found (path or method)
             send_error_response(socket, 404, "Not Found");
             return;
          }
 
-         // Create the response object
-         response response;
+         // Update the request with any extracted parameters
+         request.params = std::move(params);
 
          try {
             // Apply middleware

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -1217,7 +1217,8 @@ namespace glz
                      return;
                   }
 
-                  if (response.status_code == 200 && response.response_body.empty()) {
+                  if (response.status_code == 200 && response.response_body.empty() &&
+                      response.response_headers.empty()) {
                      response.status(204);
                   }
 


### PR DESCRIPTION
- Implicitly handle preflight OPTIONS requests inside http_server, discovering sibling route methods and constructing the Allow header on the fly so that browsers receive a consistent view of which verbs are valid without developers wiring up placeholder handlers.
- Run the full middleware chain during these synthetic responses so CORS and other filters can stamp the preflight exchange, and tighten the logic to only return success when the requested verb is actually registered—mismatched methods now yield a proper 405.
- Grow the CORS feature surface with dynamic origin validation (callbacks and glob/regex helpers), allow-all conveniences for headers/methods, configurable success status and private-network support, credential safety warnings, and additive helpers for header exposure lists.
- Extend the HTTP client test harness to issue OPTIONS requests and add regression coverage for both the happy-path 2xx preflight and the new 405 safeguard, keeping the whole suite green.