### PR TITLE
Checking for Opts.comments when skipping ws to fix JSONC parse issue

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1539,7 +1539,7 @@ namespace glz
                if (*it == ',') {
                   ++it;
 
-                  if constexpr (!Opts.minified) {
+                  if constexpr (!Opts.minified && !Opts.comments) {
                      if (ws_size && ws_size < size_t(end - it)) {
                         skip_matching_ws(ws_start, it, ws_size);
                      }
@@ -1596,7 +1596,7 @@ namespace glz
                   if (*it == ',') [[likely]] {
                      ++it;
 
-                     if constexpr (!Opts.minified) {
+                     if constexpr (!Opts.minified && !Opts.comments) {
                         if (ws_size && ws_size < size_t(end - it)) {
                            skip_matching_ws(ws_start, it, ws_size);
                         }
@@ -2334,7 +2334,8 @@ namespace glz
                      }
                   }
 
-                  if constexpr ((not Opts.minified) && (num_members > 1 || not Opts.error_on_unknown_keys)) {
+                  if constexpr ((not Opts.minified) && (num_members > 1 || not Opts.error_on_unknown_keys) &&
+                                (!Opts.comments)) {
                      if (ws_size && ws_size < size_t(end - it)) {
                         skip_matching_ws(ws_start, it, ws_size);
                      }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -38,6 +38,13 @@
 using namespace ut;
 
 glz::trace trace{};
+
+struct jsonc_comment_config
+{
+   std::vector<int> array_1{};
+   std::vector<int> array_2{};
+};
+
 suite start_trace = [] { trace.begin("json_test", "Full test suite duration."); };
 
 // Regression test: empty JSON string to char should yield '\0'
@@ -2264,6 +2271,18 @@ suite read_tests = [] {
          expect(glz::read_jsonc(a, b) == glz::error_code::none);
          expect(a[0] == 100);
          expect(a[1] == 20);
+      }
+      {
+         std::string json = R"({
+    // Comment 1
+    "array_1": [],
+    // Comment 2
+    "array_2": []
+})";
+         jsonc_comment_config cfg{};
+         expect(glz::read_jsonc(cfg, json) == glz::error_code::none);
+         expect(cfg.array_1.empty());
+         expect(cfg.array_2.empty());
       }
    };
 


### PR DESCRIPTION
Turns off the fast whitespace skipping optimization whenever comments are enabled, so we never try to “fast reuse” whitespace that may hide comment content.