### PR TITLE
Fix read_constraint optional handling with missing-key option

### DIFF
--- a/include/glaze/beve.hpp
+++ b/include/glaze/beve.hpp
@@ -9,4 +9,5 @@
 #include "glaze/beve/wrappers.hpp"
 #include "glaze/beve/write.hpp"
 #include "glaze/core/as_array_wrapper.hpp"
+#include "glaze/core/wrapper_traits.hpp"
 #include "glaze/thread/atomic.hpp"

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -14,7 +14,6 @@
 #include "glaze/concepts/container_concepts.hpp"
 #include "glaze/core/array_apply.hpp"
 #include "glaze/core/cast.hpp"
-#include "glaze/core/constraint.hpp"
 #include "glaze/core/context.hpp"
 #include "glaze/core/error_category.hpp"
 #include "glaze/core/feature_test.hpp"

--- a/include/glaze/core/constraint.hpp
+++ b/include/glaze/core/constraint.hpp
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include <utility>
+
+#include "glaze/core/common.hpp"
 #include "glaze/core/context.hpp"
 #include "glaze/core/opts.hpp"
 #include "glaze/tuplet/tuple.hpp"
@@ -16,10 +19,13 @@ namespace glz
    template <class T, auto Target, auto Constraint, string_literal Message>
    struct read_constraint_t
    {
+      static constexpr bool glaze_wrapper = true;
       static constexpr auto glaze_reflect = false;
       static constexpr std::string_view message = Message;
       using target_t = decltype(Target);
       using constraint_t = decltype(Constraint);
+      using value_type = std::remove_cvref_t<member_t<T, target_t>>;
+
       T& val;
       static constexpr auto target = Target;
       static constexpr auto constraint = Constraint;
@@ -217,6 +223,7 @@ namespace glz
    template <class T>
    concept is_self_constraint = requires(T t) {
       requires !T::glaze_reflect;
+      requires (!is_read_constraint<T>);
       typename T::constraint_t;
       typename T::value_type;
       t.val;

--- a/include/glaze/core/wrapper_traits.hpp
+++ b/include/glaze/core/wrapper_traits.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#include "glaze/core/constraint.hpp"
+#include "glaze/core/wrappers.hpp"

--- a/include/glaze/csv.hpp
+++ b/include/glaze/csv.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "glaze/core/as_array_wrapper.hpp"
+#include "glaze/core/wrapper_traits.hpp"
 #include "glaze/csv/read.hpp"
 #include "glaze/csv/skip.hpp"
 #include "glaze/csv/write.hpp"

--- a/include/glaze/json.hpp
+++ b/include/glaze/json.hpp
@@ -5,6 +5,7 @@
 
 #include "glaze/core/as_array_wrapper.hpp"
 #include "glaze/core/manage.hpp"
+#include "glaze/core/wrapper_traits.hpp"
 #include "glaze/json/escape_unicode.hpp"
 #include "glaze/json/generic.hpp"
 #include "glaze/json/invoke.hpp"

--- a/include/glaze/toml.hpp
+++ b/include/glaze/toml.hpp
@@ -4,5 +4,6 @@
 #pragma once
 
 #include "glaze/core/as_array_wrapper.hpp"
+#include "glaze/core/wrapper_traits.hpp"
 #include "glaze/toml/read.hpp"
 #include "glaze/toml/write.hpp"


### PR DESCRIPTION
- Marks read_constraint_t as a Glaze wrapper and exposes its target value type so optional members are treated as nullable when error_on_missing_keys is enabled
- Improves the self_constraint concept so the constraint wrappers don’t collide with it
- Introduces glaze/core/wrapper_traits.hpp and updates the public format headers to include it, so that wrapper utilities stay available