### PR TITLE
Fix BEVE serialization for empty arrays

### DIFF
--- a/include/glaze/beve/write.hpp
+++ b/include/glaze/beve/write.hpp
@@ -578,8 +578,10 @@ namespace glz
                      }
                   }
                   else {
-                     std::memcpy(&b[ix], value.data(), n);
-                     ix += n;
+                     if (n) {
+                        std::memcpy(&b[ix], value.data(), n);
+                        ix += n;
+                     }
                   }
                };
 


### PR DESCRIPTION
There was a missing check for the size of the array when using `std::memcpy`, which is UB until I think recent changes to the C spec. This adds the proper check and I also looked for other similar issues and did not find any.