### PR TITLE
JMESPath slicing support for tuples

### DIFF
--- a/tests/jmespath/jmespath.cpp
+++ b/tests/jmespath/jmespath.cpp
@@ -228,4 +228,44 @@ suite fuzz_findings_tests = [] {
    };
 };
 
+suite tuple_slice_tests = [] {
+   "mixed_type_array_tuple_deserialization_correct_slice"_test = [] {
+      std::string buffer = R"([1,"a","b",{"c":1}])";
+      std::tuple<int, std::string> target;
+
+      // Using [0:2] to get [1, "a"] which matches tuple<int, string>
+      auto ec = glz::read_jmespath<"[0:2]">(target, buffer);
+      expect(not ec) << "Error code: " << int(ec) << " " << glz::format_error(ec, buffer);
+      expect(std::get<0>(target) == 1);
+      expect(std::get<1>(target) == "a");
+   };
+
+   "mixed_type_array_tuple_deserialization_user_slice"_test = [] {
+      std::string buffer = R"([1,"a","b",{"c":1}])";
+      std::tuple<int, std::string> target;
+
+      // User used [0:1], which produces [1].
+      // This results in partial fill of the tuple.
+      auto ec = glz::read_jmespath<"[0:1]">(target, buffer);
+      expect(not ec) << "Error code: " << int(ec) << " " << glz::format_error(ec, buffer);
+      expect(std::get<0>(target) == 1);
+      expect(std::get<1>(target) == ""); // Default constructed string
+   };
+
+   "mixed_type_array_glz_tuple_deserialization"_test = [] {
+      std::string buffer = R"([1,"a","b",{"c":1}])";
+      glz::tuple<int, std::string> target;
+
+      static_assert(glz::tuple_t<decltype(target)>, "glz::tuple should satisfy tuple_t");
+      static_assert(glz::is_std_tuple<std::tuple<int, std::string>>,
+                    "std::tuple should satisfy is_std_tuple");
+
+      auto ec = glz::read_jmespath<"[0:2]">(target, buffer);
+      expect(not ec) << "Error code: " << int(ec) << " " << glz::format_error(ec, buffer);
+
+      expect(glz::get<0>(target) == 1);
+      expect(glz::get<1>(target) == "a");
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
- Added handle_slice overload for tuple types (std::tuple and glz::tuple) in JMESPath reading.
- Allows slicing operations (e.g. [0:2]) to work with tuple targets.
- Resolves issue #1843.
- Added regression tests in tests/jmespath/jmespath.cpp.