### PR TITLE
Fix clang build with structs embedding vector of incomparable variants

### DIFF
--- a/include/glaze/tuplet/tuple.hpp
+++ b/include/glaze/tuplet/tuple.hpp
@@ -113,17 +113,6 @@ namespace glz
          constexpr decltype(auto) operator[](tag<I>) && { return (std::move(*this).value); }
          auto operator<=>(const tuple_elem&) const = default;
          bool operator==(const tuple_elem&) const = default;
-         // Implements comparison for tuples containing reference types
-         constexpr auto operator<=>(const tuple_elem& other) const noexcept(noexcept(value <=> other.value))
-            requires(std::is_reference_v<T> && ordered<T>)
-         {
-            return value <=> other.value;
-         }
-         constexpr bool operator==(const tuple_elem& other) const noexcept(noexcept(value == other.value))
-            requires(std::is_reference_v<T> && equality_comparable<T>)
-         {
-            return value == other.value;
-         }
       };
    } // namespace tuplet
 

--- a/tests/json_test/json_variant_support_test.cpp
+++ b/tests/json_test/json_variant_support_test.cpp
@@ -334,6 +334,13 @@ suite variant_tests = [] {
    };
 };
 
+struct incomparable_struct {
+   bool operator<=>(const incomparable_struct&) const = delete;
+};
+struct struct_with_incomparable_variant {
+   std::vector<std::variant<incomparable_struct>> vec;
+};
+
 // Tests for std::vector<std::variant<...>> with purely reflected structs
 struct reflected_person
 {
@@ -540,6 +547,13 @@ suite vector_variant_reflection_tests = [] {
       expect(read_items.size() == 2);
       expect(std::holds_alternative<reflected_person>(read_items[0]));
       expect(std::holds_alternative<reflected_animal>(read_items[1]));
+   };
+
+   "struct with vector of incomparable variant"_test = [] {
+      struct_with_incomparable_variant obj;
+
+      std::string json;
+      expect(!glz::write_json(obj, json));
    };
 };
 


### PR DESCRIPTION
Hello

Those `tuple_elem` comparison operators specializations make clang build fail. I guess the two previous default operators already cover such cases so the specializations are not needed.

See https://godbolt.org/z/3z5zrTs3K

If I understand correctly, it is actually a GCC oversight that such code compiles with it. Clang eagerly instantiates template, but instead of expected SFINAE behavior, we are getting a compilation error as it believes that the program is ill-formed.