### PR TITLE
Simplify repe plugin init

### DIFF
--- a/include/glaze/rpc/repe/plugin.h
+++ b/include/glaze/rpc/repe/plugin.h
@@ -14,7 +14,7 @@ extern "C" {
 #include <stdint.h>
 
 // Current plugin interface version - increment when ABI changes
-#define REPE_PLUGIN_INTERFACE_VERSION 2
+#define REPE_PLUGIN_INTERFACE_VERSION 3
 
 // ABI-stable buffer for request/response data
 typedef struct repe_buffer
@@ -27,8 +27,7 @@ typedef struct repe_buffer
 typedef enum repe_result {
    REPE_OK = 0,
    REPE_ERROR_INIT_FAILED = 1,
-   REPE_ERROR_INVALID_CONFIG = 2,
-   REPE_ERROR_ALREADY_INITIALIZED = 3
+   REPE_ERROR_ALREADY_INITIALIZED = 2
 } repe_result;
 
 // Plugin metadata struct
@@ -79,12 +78,11 @@ const repe_plugin_data* repe_plugin_info(void);
 // Plugin Lifecycle (optional - may be NULL)
 // ---------------------------------------------------------------------------
 
-// Initialize the plugin with optional configuration.
+// Initialize the plugin.
 // Called once by the host before any calls to repe_plugin_call.
-// config/config_size: Optional JSON or REPE-formatted configuration (may be NULL/0)
 // Returns: REPE_OK on success, error code on failure
 // If not exported, the host assumes initialization is handled lazily.
-repe_result repe_plugin_init(const char* config, uint64_t config_size);
+repe_result repe_plugin_init(void);
 
 // Shutdown the plugin and release all resources.
 // Called once by the host before unloading the plugin.

--- a/tests/networking_tests/repe_plugin_test/repe_plugin_test.cpp
+++ b/tests/networking_tests/repe_plugin_test/repe_plugin_test.cpp
@@ -19,7 +19,7 @@ namespace repe = glz::repe;
 // =============================================================================
 
 suite c_interface_tests = [] {
-   "interface_version"_test = [] { expect(REPE_PLUGIN_INTERFACE_VERSION == 2); };
+   "interface_version"_test = [] { expect(REPE_PLUGIN_INTERFACE_VERSION == 3); };
 
    "repe_buffer_layout"_test = [] {
       repe_buffer buf{};
@@ -45,8 +45,7 @@ suite c_interface_tests = [] {
    "repe_result_values"_test = [] {
       expect(REPE_OK == 0);
       expect(REPE_ERROR_INIT_FAILED == 1);
-      expect(REPE_ERROR_INVALID_CONFIG == 2);
-      expect(REPE_ERROR_ALREADY_INITIALIZED == 3);
+      expect(REPE_ERROR_ALREADY_INITIALIZED == 2);
    };
 };
 


### PR DESCRIPTION
Removed `const char*, uint64_t` input for repe plugin `init`, as there was no standard way to use this. Instead, initializations that require data can use a `/init` RPC method or similar. Or, initialize internally at construction or with the now void input initialization function.