### PR TITLE
Fix glz::seek for invalid path to maps by using find

### DIFF
--- a/include/glaze/core/seek.hpp
+++ b/include/glaze/core/seek.hpp
@@ -201,7 +201,11 @@ namespace glz
             }
          }
          else {
-            return seek(std::forward<F>(func), value[key], json_ptr);
+            auto it = value.find(key);
+            if (it == value.end()) {
+               return false;
+            }
+            return seek(std::forward<F>(func), it->second, json_ptr);
          }
       }
    };

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -1841,6 +1841,12 @@ suite large_length_range = [] {
    };
 };
 
+// Test struct for issue #2124
+struct RecursiveNode
+{
+   std::unordered_map<std::string, RecursiveNode> children;
+};
+
 suite json_pointer = [] {
    using namespace ut;
 
@@ -1942,6 +1948,15 @@ suite json_pointer = [] {
       auto maybe_id = glz::get_sv_json<"/data/1/id">(json);
       expect(maybe_id.has_value());
       expect(maybe_id.value() == "88") << maybe_id.value();
+   };
+
+   "seek_nonexistent_key_in_map"_test = [] {
+      // Test for issue #2124: seek should not modify the map when key doesn't exist
+      RecursiveNode root;
+      bool found = glz::seek([](auto&) {}, root, "/children/does_not_exist/children/does_not_exist_as_well");
+
+      expect(found == false) << "seek should return false for non-existent path";
+      expect(root.children.empty()) << "seek should not modify the map";
    };
 };
 


### PR DESCRIPTION
Use `find` rather than `[]` operator so that invalid paths do not get allocated and return true.