### PR TITLE
JSON Merge Patch

### DIFF
--- a/docs/design/json_merge_patch_rfc7386.md
+++ b/docs/design/json_merge_patch_rfc7386.md
@@ -1,0 +1,704 @@
+# RFC 7386 JSON Merge Patch Implementation Design
+
+## Overview
+
+This document outlines the design for implementing [RFC 7386 JSON Merge Patch](https://datatracker.ietf.org/doc/html/rfc7386) support in glaze. JSON Merge Patch provides a simpler alternative to JSON Patch (RFC 6902) for describing modifications to JSON documents.
+
+### Related Issue
+
+[GitHub Issue #975](https://github.com/stephenberry/glaze/issues/975) - Document current support and add more support for JSON Merge Patch
+
+### Goals
+
+1. **RFC 7386 Compliance** - Full support for the JSON Merge Patch algorithm
+2. **Idiomatic glaze API** - Follow patterns established by JSON Patch implementation
+3. **Performance** - Minimize allocations, support in-place modifications
+4. **Integration** - Work seamlessly with `glz::generic` and optionally typed structs
+
+### Non-Goals
+
+1. Three-way merge functionality (potential future enhancement)
+2. Conflict detection and resolution
+
+---
+
+## When to Use JSON Merge Patch vs JSON Patch
+
+| Use Case | Recommendation |
+|----------|----------------|
+| Partial update with simple values | Merge Patch |
+| Need to set explicit null values | JSON Patch |
+| Array element manipulation | JSON Patch |
+| Move/copy operations | JSON Patch |
+| Simple API for consumers | Merge Patch |
+| Conditional updates (test operation) | JSON Patch |
+| Maximum expressiveness | JSON Patch |
+
+### Format Comparison
+
+| Aspect | JSON Patch (RFC 6902) | JSON Merge Patch (RFC 7386) |
+|--------|----------------------|----------------------------|
+| Format | Array of operation objects | Single JSON value |
+| Null handling | Null is a value | Null means "remove" |
+| Array operations | Index-based add/remove | Full replacement only |
+| Complexity | More expressive | Simpler, more intuitive |
+| MIME type | `application/json-patch+json` | `application/merge-patch+json` |
+
+---
+
+## JSON Merge Patch Algorithm (RFC 7386 Section 2)
+
+```
+define MergePatch(Target, Patch):
+  if Patch is an Object:
+    if Target is not an Object:
+      Target = {} // Ignore the contents and set it to an empty Object
+    for each Name/Value pair in Patch:
+      if Value is null:
+        if Name exists in Target:
+          remove the Name/Value pair from Target
+      else:
+        Target[Name] = MergePatch(Target[Name], Value)
+    return Target
+  else:
+    return Patch
+```
+
+### Key Semantics
+
+1. **Objects are merged recursively** - Patch object members are applied to corresponding target members
+2. **Null removes members** - A null value in the patch removes that key from the target
+3. **Arrays are replaced entirely** - Unlike RFC 6902, there's no way to patch individual array elements
+4. **Non-object patches replace** - If the patch is not an object, it completely replaces the target
+5. **Non-object targets become objects** - If target isn't an object but patch is, target becomes an empty object first
+
+---
+
+## API Design
+
+### Core Functions
+
+```cpp
+namespace glz
+{
+   // ============================================================================
+   // RFC 7386 JSON Merge Patch
+   // ============================================================================
+
+   // Apply a merge patch to a JSON value (in-place modification)
+   [[nodiscard]] error_ctx merge_patch(
+      generic& target,
+      const generic& patch
+   );
+
+   // Apply a merge patch, returning a new value (non-mutating)
+   [[nodiscard]] expected<generic, error_ctx> merge_patched(
+      const generic& target,
+      const generic& patch
+   );
+
+   // Convenience overloads for JSON string input
+   [[nodiscard]] error_ctx merge_patch(
+      generic& target,
+      std::string_view patch_json
+   );
+
+   [[nodiscard]] expected<std::string, error_ctx> merge_patch_json(
+      std::string_view target_json,
+      std::string_view patch_json
+   );
+
+   // String-to-generic convenience (parse both, return generic result)
+   [[nodiscard]] expected<generic, error_ctx> merge_patched(
+      std::string_view target_json,
+      std::string_view patch_json
+   );
+
+   // Generate a merge patch that transforms 'source' into 'target'
+   // Note: Due to null semantics, this cannot perfectly round-trip if
+   // the target contains explicit null values (they would be interpreted as removals)
+   [[nodiscard]] expected<generic, error_ctx> merge_diff(
+      const generic& source,
+      const generic& target
+   );
+
+   // String overload - returns JSON string
+   [[nodiscard]] expected<std::string, error_ctx> merge_diff_json(
+      std::string_view source_json,
+      std::string_view target_json
+   );
+}
+```
+
+---
+
+## Error Handling
+
+### Possible Errors
+
+| Error Code | Description |
+|------------|-------------|
+| `parse_error` | Invalid JSON in string input |
+| `exceeded_max_recursive_depth` | Recursion depth exceeded the compile-time limit (256) |
+
+Note: Unlike JSON Patch (RFC 6902), merge patch operations cannot fail due to missing paths or type mismatches - the algorithm handles all cases by design. Parse errors occur only when using string-input convenience overloads.
+
+### Thread Safety
+
+- All functions are **thread-safe** for distinct target documents
+- Concurrent modification of the same `generic` instance requires external synchronization
+- The `patch` parameter is read-only and can be shared across threads
+
+---
+
+## Implementation Details
+
+### 1. Core Algorithm Implementation
+
+```cpp
+namespace glz::detail
+{
+   // Recursive merge patch implementation
+   // Modifies target in-place according to RFC 7386 algorithm
+   inline error_ctx apply_merge_patch_impl(
+      generic& target,
+      const generic& patch,
+      uint32_t depth = 0
+   )
+   {
+      if (depth >= max_recursive_depth_limit) [[unlikely]] {
+         return error_ctx{error_code::exceeded_max_recursive_depth};
+      }
+
+      if (patch.is_object()) {
+         // If target is not an object, replace with empty object
+         if (!target.is_object()) {
+            target.data = generic::object_t{};
+         }
+
+         auto& target_obj = target.get_object();
+         const auto& patch_obj = patch.get_object();
+
+         for (const auto& [key, value] : patch_obj) {
+            if (value.is_null()) {
+               // Null means remove
+               target_obj.erase(key);
+            }
+            else if (value.is_object()) {
+               // Recursively merge objects
+               // Use try_emplace to avoid double lookup
+               auto [it, inserted] = target_obj.try_emplace(key, generic{});
+               auto ec = apply_merge_patch_impl(it->second, value, depth + 1);
+               if (ec) {
+                  return ec;
+               }
+            }
+            else {
+               // Non-object value - direct assignment (no recursion needed)
+               target_obj[key] = value;
+            }
+         }
+      }
+      else {
+         // Non-object patch replaces target entirely
+         target = patch;
+      }
+
+      return {};
+   }
+}
+
+namespace glz
+{
+   [[nodiscard]] inline error_ctx merge_patch(
+      generic& target,
+      const generic& patch
+   )
+   {
+      return detail::apply_merge_patch_impl(target, patch);
+   }
+}
+```
+
+### 2. Merge Diff Algorithm
+
+Generating a merge patch from two documents requires special handling due to null semantics:
+
+```cpp
+namespace glz::detail
+{
+   inline void merge_diff_impl(
+      const generic& source,
+      const generic& target,
+      generic& patch
+   )
+   {
+      // If types differ or source is not an object, return target as patch
+      if (!source.is_object() || !target.is_object()) {
+         patch = target;
+         return;
+      }
+
+      // Both are objects - compute diff
+      patch.data = generic::object_t{};
+      auto& patch_obj = patch.get_object();
+      const auto& source_obj = source.get_object();
+      const auto& target_obj = target.get_object();
+
+      // Check for removed keys (in source but not in target)
+      for (const auto& [key, value] : source_obj) {
+         if (target_obj.find(key) == target_obj.end()) {
+            // Key was removed - emit null
+            patch_obj.emplace(key, nullptr);
+         }
+      }
+
+      // Check for added or modified keys
+      for (const auto& [key, target_value] : target_obj) {
+         auto source_it = source_obj.find(key);
+         if (source_it == source_obj.end()) {
+            // Key was added
+            patch_obj.emplace(key, target_value);
+         }
+         else if (!equal(source_it->second, target_value)) {
+            // Key was modified
+            if (source_it->second.is_object() && target_value.is_object()) {
+               // Both objects - recurse
+               generic child_patch;
+               merge_diff_impl(source_it->second, target_value, child_patch);
+               patch_obj.emplace(key, std::move(child_patch));
+            }
+            else {
+               // Different types or non-objects - replace
+               patch_obj.emplace(key, target_value);
+            }
+         }
+         // If equal, no patch entry needed
+      }
+   }
+}
+```
+
+### 3. Handling Edge Cases
+
+#### Null in Target Document
+
+RFC 7386 has a limitation: you cannot use merge patch to set a value to null, because null in the patch means "remove". This is documented in RFC 7386 Section 1:
+
+> "This design means that merge patch documents are suitable for describing modifications to JSON documents that primarily use objects for their structure and do not make use of explicit null values."
+
+**Design Decision**: Document this limitation clearly. For use cases requiring explicit null values, recommend using JSON Patch (RFC 6902) instead.
+
+#### Array Handling
+
+Arrays are replaced entirely. The algorithm does not attempt to merge array contents:
+
+```cpp
+// source: {"tags": ["a", "b", "c"]}
+// patch:  {"tags": ["x", "y"]}
+// result: {"tags": ["x", "y"]}  // Complete replacement
+```
+
+#### Root-Level Non-Object
+
+If the patch is not an object, it replaces the entire document:
+
+```cpp
+// source: {"a": 1, "b": 2}
+// patch:  42
+// result: 42
+```
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+1. **Basic merge operations**
+   - Add new key
+   - Modify existing key
+   - Remove key (null value)
+   - Nested object merge
+
+2. **Type coercion cases**
+   - Object target with non-object patch (replacement)
+   - Non-object target with object patch (becomes object)
+   - Array replacement
+
+3. **Edge cases**
+   - Empty patch `{}` (should be no-op)
+   - Empty target
+   - Patch removing all keys (result is empty object)
+   - Deep nesting (verify depth limit works)
+   - Unicode keys
+   - Empty string keys `{"": "value"}`
+   - Numeric string keys `{"0": "value", "1": "other"}`
+
+4. **Round-trip tests**
+   - `merge_patch(source, merge_diff(source, target))` should equal `target`
+   - Explicit test verifying null limitation behavior
+
+5. **Error cases**
+   - Exceeding max_recursive_depth_limit (256)
+   - Invalid JSON in string overloads
+
+6. **Performance tests** (optional)
+   - Large documents
+   - Deeply nested structures
+
+### Example Test Cases
+
+```cpp
+"merge_patch basic add"_test = [] {
+   auto target = glz::read_json<glz::generic>(R"({"a": 1})");
+   auto patch = glz::read_json<glz::generic>(R"({"b": 2})");
+
+   auto ec = glz::merge_patch(*target, *patch);
+   expect(!ec);
+
+   auto expected = glz::read_json<glz::generic>(R"({"a": 1, "b": 2})");
+   expect(glz::equal(*target, *expected));
+};
+
+"merge_patch remove with null"_test = [] {
+   auto target = glz::read_json<glz::generic>(R"({"a": 1, "b": 2})");
+   auto patch = glz::read_json<glz::generic>(R"({"b": null})");
+
+   auto ec = glz::merge_patch(*target, *patch);
+   expect(!ec);
+
+   auto expected = glz::read_json<glz::generic>(R"({"a": 1})");
+   expect(glz::equal(*target, *expected));
+};
+
+"merge_patch empty patch is no-op"_test = [] {
+   auto target = glz::read_json<glz::generic>(R"({"a": 1, "b": 2})");
+   auto original = *target;
+   auto patch = glz::read_json<glz::generic>(R"({})");
+
+   auto ec = glz::merge_patch(*target, *patch);
+   expect(!ec);
+   expect(glz::equal(*target, original));
+};
+
+"merge_patch remove all keys"_test = [] {
+   auto target = glz::read_json<glz::generic>(R"({"a": 1, "b": 2})");
+   auto patch = glz::read_json<glz::generic>(R"({"a": null, "b": null})");
+
+   auto ec = glz::merge_patch(*target, *patch);
+   expect(!ec);
+
+   auto expected = glz::read_json<glz::generic>(R"({})");
+   expect(glz::equal(*target, *expected));
+};
+
+"merge_patch nested merge"_test = [] {
+   auto target = glz::read_json<glz::generic>(R"({
+      "a": {"b": 1, "c": 2}
+   })");
+   auto patch = glz::read_json<glz::generic>(R"({
+      "a": {"b": 99, "d": 3}
+   })");
+
+   auto ec = glz::merge_patch(*target, *patch);
+   expect(!ec);
+
+   auto expected = glz::read_json<glz::generic>(R"({
+      "a": {"b": 99, "c": 2, "d": 3}
+   })");
+   expect(glz::equal(*target, *expected));
+};
+
+"merge_patch array replacement"_test = [] {
+   auto target = glz::read_json<glz::generic>(R"({"tags": [1, 2, 3]})");
+   auto patch = glz::read_json<glz::generic>(R"({"tags": ["x"]})");
+
+   auto ec = glz::merge_patch(*target, *patch);
+   expect(!ec);
+
+   auto expected = glz::read_json<glz::generic>(R"({"tags": ["x"]})");
+   expect(glz::equal(*target, *expected));
+};
+
+"merge_patch non-object replaces"_test = [] {
+   auto target = glz::read_json<glz::generic>(R"({"a": 1})");
+   auto patch = glz::read_json<glz::generic>(R"(42)");
+
+   auto ec = glz::merge_patch(*target, *patch);
+   expect(!ec);
+   expect(target->is_number());
+   expect(target->get_number() == 42.0);
+};
+
+"merge_patch empty string key"_test = [] {
+   auto target = glz::read_json<glz::generic>(R"({"": 1, "a": 2})");
+   auto patch = glz::read_json<glz::generic>(R"({"": 99})");
+
+   auto ec = glz::merge_patch(*target, *patch);
+   expect(!ec);
+
+   auto expected = glz::read_json<glz::generic>(R"({"": 99, "a": 2})");
+   expect(glz::equal(*target, *expected));
+};
+
+"merge_patch numeric string keys"_test = [] {
+   auto target = glz::read_json<glz::generic>(R"({"0": "a", "1": "b"})");
+   auto patch = glz::read_json<glz::generic>(R"({"1": "x", "2": "c"})");
+
+   auto ec = glz::merge_patch(*target, *patch);
+   expect(!ec);
+
+   auto expected = glz::read_json<glz::generic>(R"({"0": "a", "1": "x", "2": "c"})");
+   expect(glz::equal(*target, *expected));
+};
+
+"merge_patch max_depth exceeded"_test = [] {
+   // Create deeply nested structure exceeding max_recursive_depth_limit (256)
+   glz::generic target;
+   target.data = glz::generic::object_t{};
+
+   glz::generic patch;
+   patch.data = glz::generic::object_t{};
+
+   glz::generic* current = &patch;
+   for (size_t i = 0; i < glz::max_recursive_depth_limit + 10; ++i) {
+      current->get_object()["nested"].data = glz::generic::object_t{};
+      current = &current->get_object()["nested"];
+   }
+
+   auto ec = glz::merge_patch(target, patch);
+   expect(ec.ec == glz::error_code::exceeded_max_recursive_depth);
+};
+
+"merge_diff generates correct patch"_test = [] {
+   auto source = glz::read_json<glz::generic>(R"({"a": 1, "b": 2})");
+   auto target = glz::read_json<glz::generic>(R"({"a": 1, "c": 3})");
+
+   auto patch = glz::merge_diff(*source, *target);
+   expect(patch.has_value());
+
+   // patch should be {"b": null, "c": 3}
+   expect(patch->is_object());
+   expect(patch->get_object().size() == 2u);
+   expect((*patch)["b"].is_null());
+   expect((*patch)["c"].get_number() == 3.0);
+};
+
+"merge_diff round-trip"_test = [] {
+   auto source = glz::read_json<glz::generic>(R"({"a": 1, "b": {"x": 1}})");
+   auto target = glz::read_json<glz::generic>(R"({"a": 2, "b": {"y": 2}, "c": 3})");
+
+   auto patch = glz::merge_diff(*source, *target);
+   expect(patch.has_value());
+
+   auto result = *source;
+   auto ec = glz::merge_patch(result, *patch);
+   expect(!ec);
+   expect(glz::equal(result, *target));
+};
+
+"merge_diff null limitation"_test = [] {
+   // Demonstrate that explicit null in target cannot be preserved
+   auto source = glz::read_json<glz::generic>(R"({"a": 1})");
+   auto target = glz::read_json<glz::generic>(R"({"a": null})");
+
+   auto patch = glz::merge_diff(*source, *target);
+   expect(patch.has_value());
+
+   // The patch will contain {"a": null}, but this means "remove a"
+   // not "set a to null"
+   auto result = *source;
+   auto ec = glz::merge_patch(result, *patch);
+   expect(!ec);
+
+   // Result will NOT have "a" at all, not have "a": null
+   expect(!result.contains("a"));
+   // This is the documented limitation of RFC 7386
+};
+
+// RFC 7386 Appendix A example
+"rfc7386 appendix a example"_test = [] {
+   auto target = glz::read_json<glz::generic>(R"({
+      "title": "Goodbye!",
+      "author": {
+         "givenName": "John",
+         "familyName": "Doe"
+      },
+      "tags": ["example", "sample"],
+      "content": "This will be unchanged"
+   })");
+
+   auto patch = glz::read_json<glz::generic>(R"({
+      "title": "Hello!",
+      "phoneNumber": "+01-123-456-7890",
+      "author": {
+         "familyName": null
+      },
+      "tags": ["example"]
+   })");
+
+   auto ec = glz::merge_patch(*target, *patch);
+   expect(!ec);
+
+   auto expected = glz::read_json<glz::generic>(R"({
+      "title": "Hello!",
+      "author": {
+         "givenName": "John"
+      },
+      "tags": ["example"],
+      "content": "This will be unchanged",
+      "phoneNumber": "+01-123-456-7890"
+   })");
+   expect(glz::equal(*target, *expected));
+};
+```
+
+---
+
+## File Organization
+
+```
+include/glaze/json/
+├── patch.hpp           # Add merge patch functions (alongside existing JSON Patch)
+└── generic.hpp         # (existing) - no changes needed
+
+tests/json_test/
+├── json_patch_test.cpp          # Existing JSON Patch tests
+└── json_merge_patch_test.cpp    # New JSON Merge Patch tests
+
+docs/
+├── json-patch.md              # (existing) - add reference to merge patch
+└── json-merge-patch.md        # New documentation
+```
+
+### Header Integration
+
+Add to `patch.hpp` after the existing JSON Patch implementation:
+
+```cpp
+// ============================================================================
+// RFC 7386 JSON Merge Patch
+// ============================================================================
+
+// ... merge patch functions ...
+```
+
+---
+
+## Documentation
+
+### json-merge-patch.md Structure
+
+1. **Overview** - What is JSON Merge Patch, when to use it
+2. **Basic Usage** - Simple examples
+3. **Key Concepts**
+   - Null semantics
+   - Array replacement
+   - Recursive merging
+4. **API Reference** - All functions with examples
+5. **Limitations** - Cannot set explicit null values
+6. **HTTP Integration** - Using with `application/merge-patch+json` content type
+7. **Comparison with JSON Patch** - Decision matrix for when to use each
+8. **See Also** - Links to JSON Patch, generic JSON docs
+
+---
+
+## Implementation Steps
+
+### Phase 1: Core Implementation
+1. Add `merge_patch()` function for `glz::generic`
+2. Add `merge_patched()` non-mutating variant
+3. Add string convenience overloads
+4. Use `max_recursive_depth_limit` for stack overflow protection
+
+### Phase 2: Diff Generation
+5. Add `merge_diff()` function
+6. Add `merge_diff_json()` string convenience overload
+
+### Phase 3: Testing
+7. Create comprehensive test suite
+8. Include RFC 7386 examples from Appendix A
+9. Add depth limit tests
+
+### Phase 4: Documentation
+10. Create `json-merge-patch.md` documentation
+11. Update `json-patch.md` with cross-references
+12. Close GitHub issue #975
+
+---
+
+## Implemented Features
+
+### Typed Struct Support (Implemented)
+
+Merge patches can be applied directly to C++ structs:
+
+```cpp
+template <class T>
+error_ctx merge_patch(T& target, const generic& patch);
+
+template <class T>
+error_ctx merge_patch(T& target, std::string_view patch_json);
+
+template <class T>
+expected<T, error_ctx> merge_patched(const T& target, const generic& patch);
+
+template <class T>
+expected<generic, error_ctx> merge_diff(const T& source, const T& target);
+
+template <class T>
+expected<std::string, error_ctx> merge_diff_json(const T& source, const T& target);
+```
+
+This leverages existing reflection to apply partial updates to typed structs.
+
+---
+
+## Future Enhancements
+
+### 1. HTTP PATCH Support
+
+Integration with HTTP client for `application/merge-patch+json`:
+
+```cpp
+// Example HTTP client integration
+auto response = client.patch(url, merge_patch_document, {
+   {"Content-Type", "application/merge-patch+json"}
+});
+```
+
+### 2. Validation Options
+
+Option to reject patches that would create invalid states:
+
+```cpp
+struct merge_patch_opts
+{
+   bool strict_types = false;  // Reject type changes if true
+};
+```
+
+### 3. Preserve Nulls Mode (Non-Standard Extension)
+
+Option to treat null as a value instead of removal indicator:
+
+```cpp
+struct merge_patch_opts
+{
+   bool preserve_nulls = false;  // Non-standard: null becomes a value
+};
+```
+
+Note: This would be a non-standard extension and should be clearly documented as such.
+
+Note: Recursion depth protection is handled by the compile-time `max_recursive_depth_limit` constant (256).
+
+---
+
+## References
+
+- [RFC 7386 - JSON Merge Patch](https://datatracker.ietf.org/doc/html/rfc7386)
+- [RFC 6902 - JSON Patch](https://datatracker.ietf.org/doc/html/rfc6902) (existing implementation)
+- [GitHub Issue #975](https://github.com/stephenberry/glaze/issues/975)
+- MIME type: `application/merge-patch+json` (RFC 7386 Section 3)

--- a/docs/generic-json.md
+++ b/docs/generic-json.md
@@ -175,3 +175,9 @@ auto names_array = glz::get<std::array<std::string, 3>>(json, "/names");
 ```
 
 This works because `glz::generic` stores arrays as `std::vector<glz::generic>` and objects as `std::map<std::string, glz::generic>`. When you request a specific container type, Glaze deserializes the generic representation into your desired type.
+
+## See Also
+
+- [JSON Patch (RFC 6902)](./json-patch.md) - Apply structured patches to `glz::generic` documents
+- [JSON Merge Patch (RFC 7386)](./json-merge-patch.md) - Apply partial updates to `glz::generic` documents
+- [JSON Pointer Syntax](./json-pointer-syntax.md) - Path syntax for navigating JSON documents

--- a/docs/json-merge-patch.md
+++ b/docs/json-merge-patch.md
@@ -1,0 +1,426 @@
+# JSON Merge Patch (RFC 7386)
+
+Glaze provides full support for [JSON Merge Patch (RFC 7386)](https://datatracker.ietf.org/doc/html/rfc7386), a format for describing modifications to JSON documents. JSON Merge Patch works with [glz::generic](./generic-json.md) for runtime JSON manipulation.
+
+## Include
+
+```c++
+#include "glaze/json/patch.hpp"
+```
+
+## When to Use JSON Merge Patch
+
+JSON Merge Patch is simpler than [JSON Patch (RFC 6902)](./json-patch.md) but has some limitations:
+
+| Use Case | Recommendation |
+|----------|----------------|
+| Partial update with simple values | Merge Patch |
+| Need to set explicit null values | JSON Patch |
+| Array element manipulation | JSON Patch |
+| Move/copy operations | JSON Patch |
+| Simple API for consumers | Merge Patch |
+| Conditional updates (test operation) | JSON Patch |
+
+## Basic Usage
+
+### Applying a Merge Patch
+
+Use `glz::merge_patch()` to apply a merge patch to a JSON value:
+
+```c++
+auto target = glz::read_json<glz::generic>(R"({"a": 1, "b": 2})");
+
+auto patch = glz::read_json<glz::generic>(R"({"a": 99, "c": 3})");
+
+auto ec = glz::merge_patch(*target, *patch);
+if (!ec) {
+   // target is now {"a": 99, "b": 2, "c": 3}
+}
+```
+
+### Removing Keys with Null
+
+A `null` value in the patch removes the corresponding key:
+
+```c++
+auto target = glz::read_json<glz::generic>(R"({"a": 1, "b": 2, "c": 3})");
+
+auto patch = glz::read_json<glz::generic>(R"({"b": null})");
+
+glz::merge_patch(*target, *patch);
+// target is now {"a": 1, "c": 3}
+```
+
+### Generating a Merge Patch
+
+Use `glz::merge_diff()` to generate a merge patch that transforms one document into another:
+
+```c++
+auto source = glz::read_json<glz::generic>(R"({"a": 1, "b": 2})");
+auto target = glz::read_json<glz::generic>(R"({"a": 1, "c": 3})");
+
+auto patch = glz::merge_diff(*source, *target);
+if (patch) {
+   // patch is {"b": null, "c": 3}
+   // - "b": null means remove key "b"
+   // - "c": 3 means add key "c" with value 3
+}
+```
+
+## Using Merge Patch with C++ Structs
+
+In addition to working with `glz::generic`, merge patch can be applied directly to C++ structs. This leverages Glaze's automatic reflection to apply partial updates to your types.
+
+> **Implementation Note**: Glaze's `read_json` naturally has merge-patch semantics for structs—it only updates fields present in the JSON and leaves other fields unchanged. The `merge_patch` function for structs leverages this directly, making it highly efficient with no intermediate serialization or data structure conversions.
+
+### Basic Struct Patching
+
+```c++
+struct Person {
+   std::string name;
+   int age;
+   std::string city;
+};
+
+Person person{.name = "Alice", .age = 30, .city = "NYC"};
+
+// Apply a partial update - only change the age
+auto patch = glz::read_json<glz::generic>(R"({"age": 31})");
+auto ec = glz::merge_patch(person, *patch);
+
+if (!ec) {
+   // person.name is still "Alice"
+   // person.age is now 31
+   // person.city is still "NYC"
+}
+```
+
+### Patching from JSON String
+
+You can apply a patch directly from a JSON string:
+
+```c++
+Person person{.name = "Bob", .age = 25, .city = "LA"};
+
+auto ec = glz::merge_patch(person, R"({"city": "San Francisco"})");
+// person.city is now "San Francisco"
+```
+
+### Non-Mutating Struct Patching
+
+Use `glz::merge_patched()` to get a new struct without modifying the original:
+
+```c++
+Person original{.name = "Charlie", .age = 40, .city = "Boston"};
+
+auto result = glz::merge_patched(original, R"({"age": 41})");
+if (result) {
+   // original.age is still 40
+   // result->age is 41
+}
+```
+
+### Generating Patches Between Structs
+
+Use `glz::merge_diff()` to compute the difference between two struct instances:
+
+```c++
+Person before{.name = "Dave", .age = 35, .city = "Seattle"};
+Person after{.name = "Dave", .age = 36, .city = "Portland"};
+
+auto patch = glz::merge_diff(before, after);
+if (patch) {
+   // patch contains: {"age": 36, "city": "Portland"}
+   // "name" is not in the patch because it didn't change
+}
+
+// Get the patch as a JSON string
+auto patch_json = glz::merge_diff_json(before, after);
+// *patch_json is: {"age":36,"city":"Portland"}
+```
+
+### Round-Trip with Structs
+
+You can generate a patch and apply it to transform one struct into another:
+
+```c++
+struct Config {
+   std::string host = "localhost";
+   int port = 8080;
+   bool enabled = true;
+   std::vector<std::string> tags;
+};
+
+Config source{.host = "localhost", .port = 8080, .enabled = true, .tags = {"dev"}};
+Config target{.host = "production.example.com", .port = 443, .enabled = true, .tags = {"prod"}};
+
+// Generate patch
+auto patch = glz::merge_diff(source, target);
+
+// Apply patch to transform source into target
+Config result = source;
+glz::merge_patch(result, *patch);
+
+// result now matches target:
+// result.host == "production.example.com"
+// result.port == 443
+// result.tags == {"prod"}
+```
+
+### Nested Structs
+
+Merge patch works with nested structures:
+
+```c++
+struct Address {
+   std::string street;
+   std::string city;
+};
+
+struct Employee {
+   std::string name;
+   Address address;
+};
+
+Employee emp{
+   .name = "Eve",
+   .address = {.street = "123 Main St", .city = "Boston"}
+};
+
+// Update just the city in the nested address
+auto ec = glz::merge_patch(emp, R"({"address": {"city": "NYC"}})");
+
+// emp.address.street is still "123 Main St"
+// emp.address.city is now "NYC"
+```
+
+**Note**: When patching nested objects, the entire nested object in the patch is merged with the target. If you want to completely replace a nested object, include all its fields in the patch.
+
+### Struct API Reference
+
+```c++
+// Apply patch to struct (in-place)
+template <class T>
+[[nodiscard]] error_ctx merge_patch(T& target, const generic& patch);
+
+// Apply patch from JSON string to struct (in-place)
+template <class T>
+[[nodiscard]] error_ctx merge_patch(T& target, std::string_view patch_json);
+
+// Apply patch to struct (non-mutating)
+template <class T>
+[[nodiscard]] expected<T, error_ctx> merge_patched(const T& target, const generic& patch);
+
+// Apply patch from JSON string (non-mutating)
+template <class T>
+[[nodiscard]] expected<T, error_ctx> merge_patched(const T& target, std::string_view patch_json);
+
+// Generate patch between two structs
+template <class T>
+[[nodiscard]] expected<generic, error_ctx> merge_diff(const T& source, const T& target);
+
+// Generate patch between two structs as JSON string
+template <class T>
+[[nodiscard]] expected<std::string, error_ctx> merge_diff_json(const T& source, const T& target);
+```
+
+## Key Semantics
+
+### Objects Are Merged Recursively
+
+When both the target and patch have nested objects at the same key, they are merged recursively:
+
+```c++
+auto target = glz::read_json<glz::generic>(R"({
+   "user": {"name": "Alice", "age": 30}
+})");
+
+auto patch = glz::read_json<glz::generic>(R"({
+   "user": {"age": 31, "city": "NYC"}
+})");
+
+glz::merge_patch(*target, *patch);
+// target is now:
+// {"user": {"name": "Alice", "age": 31, "city": "NYC"}}
+```
+
+### Arrays Are Replaced Entirely
+
+Unlike JSON Patch, Merge Patch cannot modify individual array elements:
+
+```c++
+auto target = glz::read_json<glz::generic>(R"({"tags": ["a", "b", "c"]})");
+
+auto patch = glz::read_json<glz::generic>(R"({"tags": ["x"]})");
+
+glz::merge_patch(*target, *patch);
+// target is now {"tags": ["x"]} - complete replacement
+```
+
+### Non-Object Patches Replace the Target
+
+If the patch is not an object, it completely replaces the target:
+
+```c++
+auto target = glz::read_json<glz::generic>(R"({"a": 1, "b": 2})");
+
+auto patch = glz::read_json<glz::generic>(R"(42)");
+
+glz::merge_patch(*target, *patch);
+// target is now 42
+```
+
+## API Reference
+
+### merge_patch
+
+Apply a merge patch in-place:
+
+```c++
+[[nodiscard]] error_ctx merge_patch(
+   generic& target,
+   const generic& patch
+);
+```
+
+### merge_patched
+
+Apply a merge patch, returning a new value (non-mutating):
+
+```c++
+[[nodiscard]] expected<generic, error_ctx> merge_patched(
+   const generic& target,
+   const generic& patch
+);
+```
+
+### merge_diff
+
+Generate a merge patch that transforms source into target:
+
+```c++
+[[nodiscard]] expected<generic, error_ctx> merge_diff(
+   const generic& source,
+   const generic& target
+);
+```
+
+### Convenience Overloads
+
+```c++
+// Apply patch from JSON string
+[[nodiscard]] error_ctx merge_patch(
+   generic& target,
+   std::string_view patch_json
+);
+
+// Apply patch from strings, return JSON string
+[[nodiscard]] expected<std::string, error_ctx> merge_patch_json(
+   std::string_view target_json,
+   std::string_view patch_json
+);
+
+// Apply patch from strings, return generic
+[[nodiscard]] expected<generic, error_ctx> merge_patched(
+   std::string_view target_json,
+   std::string_view patch_json
+);
+
+// Generate patch from strings, return JSON string
+[[nodiscard]] expected<std::string, error_ctx> merge_diff_json(
+   std::string_view source_json,
+   std::string_view target_json
+);
+```
+
+## Limitations
+
+### Cannot Set Explicit Null Values
+
+RFC 7386 uses `null` to mean "remove this key", so you cannot use merge patch to set a value to `null`. This is documented in the RFC:
+
+> "This design means that merge patch documents are suitable for describing modifications to JSON documents that primarily use objects for their structure and do not make use of explicit null values."
+
+For use cases requiring explicit null values, use [JSON Patch (RFC 6902)](./json-patch.md) instead.
+
+### Round-Trip Limitation
+
+When generating a merge patch with `merge_diff()`, documents containing explicit null values cannot be perfectly reconstructed:
+
+```c++
+auto source = glz::read_json<glz::generic>(R"({"a": 1})");
+auto target = glz::read_json<glz::generic>(R"({"a": null})");
+
+auto patch = glz::merge_diff(*source, *target);
+// patch is {"a": null}
+
+auto result = *source;
+glz::merge_patch(result, *patch);
+// result is {} - the key "a" was removed, not set to null
+```
+
+## HTTP Integration
+
+When using JSON Merge Patch with HTTP, use the MIME type `application/merge-patch+json`:
+
+```c++
+// Example with HTTP client
+auto response = client.patch(url, patch_json, {
+   {"Content-Type", "application/merge-patch+json"}
+});
+```
+
+## RFC 7386 Appendix A Example
+
+This example from RFC 7386 demonstrates all key behaviors:
+
+```c++
+auto target = glz::read_json<glz::generic>(R"({
+   "title": "Goodbye!",
+   "author": {
+      "givenName": "John",
+      "familyName": "Doe"
+   },
+   "tags": ["example", "sample"],
+   "content": "This will be unchanged"
+})");
+
+auto patch = glz::read_json<glz::generic>(R"({
+   "title": "Hello!",
+   "phoneNumber": "+01-123-456-7890",
+   "author": {
+      "familyName": null
+   },
+   "tags": ["example"]
+})");
+
+glz::merge_patch(*target, *patch);
+
+// Result:
+// {
+//    "title": "Hello!",              // replaced
+//    "author": {
+//       "givenName": "John"          // preserved
+//                                    // familyName removed
+//    },
+//    "tags": ["example"],            // replaced entirely
+//    "content": "This will be unchanged",  // preserved
+//    "phoneNumber": "+01-123-456-7890"     // added
+// }
+```
+
+## Error Handling
+
+`glz::merge_patch()` returns an `error_ctx`. Possible errors:
+
+| Error Code | Description |
+|------------|-------------|
+| `parse_error` | Invalid JSON in string input |
+| `exceeded_max_recursive_depth` | Recursion depth exceeded the compile-time limit (256) |
+
+Unlike JSON Patch, merge patch operations cannot fail due to missing paths or type mismatches - the algorithm handles all cases by design.
+
+## See Also
+
+- [JSON Patch (RFC 6902)](./json-patch.md) - More expressive patching with explicit operations
+- [Generic JSON](./generic-json.md) - Working with `glz::generic`

--- a/docs/json-patch.md
+++ b/docs/json-patch.md
@@ -2,6 +2,8 @@
 
 Glaze provides full support for [JSON Patch (RFC 6902)](https://datatracker.ietf.org/doc/html/rfc6902), a format for describing changes to JSON documents. JSON Patch works with [glz::generic](./generic-json.md) for runtime JSON manipulation.
 
+> **See also:** [JSON Merge Patch (RFC 7386)](./json-merge-patch.md) for a simpler alternative when you don't need fine-grained control over array elements or explicit null values.
+
 ## Include
 
 ```c++
@@ -251,5 +253,6 @@ Patch operations serialize to standard RFC 6902 format:
 
 ## See Also
 
+- [JSON Merge Patch (RFC 7386)](./json-merge-patch.md) - Simpler patching for partial updates
 - [Generic JSON](./generic-json.md) - Working with `glz::generic`
 - [JSON Pointer Syntax](./json-pointer-syntax.md) - Path syntax used by JSON Patch

--- a/docs/json.md
+++ b/docs/json.md
@@ -74,6 +74,14 @@ if (result) {
 }
 ```
 
+**Partial Updates**: When reading into an existing object, `read_json` only updates fields present in the JSON—other fields retain their existing values. This makes `read_json` ideal for applying partial updates:
+
+```cpp
+Person person{.name = "Default", .age = 0, .hobbies = {}};
+glz::read_json(person, R"({"age": 25})");
+// person.name is still "Default", person.age is now 25
+```
+
 ### File I/O
 
 ```cpp
@@ -578,3 +586,11 @@ struct strict_opts : glz::opts {
 
 auto ec = glz::read<strict_opts>(obj, json_data);
 ```
+
+## See Also
+
+- [Generic JSON](./generic-json.md) - Working with `glz::generic` for dynamic JSON
+- [JSON Patch (RFC 6902)](./json-patch.md) - Apply structured patches to JSON documents
+- [JSON Merge Patch (RFC 7386)](./json-merge-patch.md) - Apply partial updates to JSON documents
+- [JSON Schema](./json-schema.md) - Generate JSON Schema from C++ types
+- [JSON Pointer Syntax](./json-pointer-syntax.md) - Path syntax for navigating JSON documents

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
    - JSON Pointer Syntax: json-pointer-syntax.md
    - Struct JSON Pointer Operations: struct-json-pointer.md
    - JSON Patch (RFC 6902): json-patch.md
+   - JSON Merge Patch (RFC 7386): json-merge-patch.md
    - JMESPath: JMESPath.md
    - JSON Schema: json-schema.md
    - Field Validation: field-validation.md

--- a/tests/json_test/CMakeLists.txt
+++ b/tests/json_test/CMakeLists.txt
@@ -109,3 +109,11 @@ add_executable(json_patch_test json_patch_test.cpp)
 target_link_libraries(json_patch_test PRIVATE glz_test_common)
 
 add_test(NAME json_patch_test COMMAND json_patch_test)
+
+## JSON Merge Patch test - RFC 7386
+
+add_executable(json_merge_patch_test json_merge_patch_test.cpp)
+
+target_link_libraries(json_merge_patch_test PRIVATE glz_test_common)
+
+add_test(NAME json_merge_patch_test COMMAND json_merge_patch_test)

--- a/tests/json_test/json_merge_patch_test.cpp
+++ b/tests/json_test/json_merge_patch_test.cpp
@@ -1,0 +1,771 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#include <cstdlib>
+
+#include "glaze/json/patch.hpp"
+#include "ut/ut.hpp"
+
+using namespace ut;
+
+suite json_merge_patch_tests = [] {
+   // ============================================================================
+   // Basic Merge Operations
+   // ============================================================================
+
+   "merge_patch basic add"_test = [] {
+      auto target = glz::read_json<glz::generic>(R"({"a": 1})");
+      auto patch = glz::read_json<glz::generic>(R"({"b": 2})");
+
+      expect(target.has_value() && patch.has_value());
+
+      auto ec = glz::merge_patch(*target, *patch);
+      expect(!ec);
+
+      auto expected = glz::read_json<glz::generic>(R"({"a": 1, "b": 2})");
+      expect(glz::equal(*target, *expected));
+   };
+
+   "merge_patch modify existing"_test = [] {
+      auto target = glz::read_json<glz::generic>(R"({"a": 1, "b": 2})");
+      auto patch = glz::read_json<glz::generic>(R"({"a": 99})");
+
+      expect(target.has_value() && patch.has_value());
+
+      auto ec = glz::merge_patch(*target, *patch);
+      expect(!ec);
+
+      auto expected = glz::read_json<glz::generic>(R"({"a": 99, "b": 2})");
+      expect(glz::equal(*target, *expected));
+   };
+
+   "merge_patch remove with null"_test = [] {
+      auto target = glz::read_json<glz::generic>(R"({"a": 1, "b": 2})");
+      auto patch = glz::read_json<glz::generic>(R"({"b": null})");
+
+      expect(target.has_value() && patch.has_value());
+
+      auto ec = glz::merge_patch(*target, *patch);
+      expect(!ec);
+
+      auto expected = glz::read_json<glz::generic>(R"({"a": 1})");
+      expect(glz::equal(*target, *expected));
+   };
+
+   "merge_patch nested merge"_test = [] {
+      auto target = glz::read_json<glz::generic>(R"({
+         "a": {"b": 1, "c": 2}
+      })");
+      auto patch = glz::read_json<glz::generic>(R"({
+         "a": {"b": 99, "d": 3}
+      })");
+
+      expect(target.has_value() && patch.has_value());
+
+      auto ec = glz::merge_patch(*target, *patch);
+      expect(!ec);
+
+      auto expected = glz::read_json<glz::generic>(R"({
+         "a": {"b": 99, "c": 2, "d": 3}
+      })");
+      expect(glz::equal(*target, *expected));
+   };
+
+   // ============================================================================
+   // Type Coercion Cases
+   // ============================================================================
+
+   "merge_patch array replacement"_test = [] {
+      auto target = glz::read_json<glz::generic>(R"({"tags": [1, 2, 3]})");
+      auto patch = glz::read_json<glz::generic>(R"({"tags": ["x"]})");
+
+      expect(target.has_value() && patch.has_value());
+
+      auto ec = glz::merge_patch(*target, *patch);
+      expect(!ec);
+
+      auto expected = glz::read_json<glz::generic>(R"({"tags": ["x"]})");
+      expect(glz::equal(*target, *expected));
+   };
+
+   "merge_patch non-object replaces"_test = [] {
+      auto target = glz::read_json<glz::generic>(R"({"a": 1})");
+      auto patch = glz::read_json<glz::generic>(R"(42)");
+
+      expect(target.has_value() && patch.has_value());
+
+      auto ec = glz::merge_patch(*target, *patch);
+      expect(!ec);
+      expect(target->is_number());
+      expect(target->get_number() == 42.0);
+   };
+
+   "merge_patch non-object target with object patch"_test = [] {
+      auto target = glz::read_json<glz::generic>(R"(42)");
+      auto patch = glz::read_json<glz::generic>(R"({"a": 1})");
+
+      expect(target.has_value() && patch.has_value());
+
+      auto ec = glz::merge_patch(*target, *patch);
+      expect(!ec);
+
+      auto expected = glz::read_json<glz::generic>(R"({"a": 1})");
+      expect(glz::equal(*target, *expected));
+   };
+
+   "merge_patch string target with object patch"_test = [] {
+      auto target = glz::read_json<glz::generic>(R"("hello")");
+      auto patch = glz::read_json<glz::generic>(R"({"a": 1})");
+
+      expect(target.has_value() && patch.has_value());
+
+      auto ec = glz::merge_patch(*target, *patch);
+      expect(!ec);
+
+      auto expected = glz::read_json<glz::generic>(R"({"a": 1})");
+      expect(glz::equal(*target, *expected));
+   };
+
+   "merge_patch array target with object patch"_test = [] {
+      auto target = glz::read_json<glz::generic>(R"([1, 2, 3])");
+      auto patch = glz::read_json<glz::generic>(R"({"a": 1})");
+
+      expect(target.has_value() && patch.has_value());
+
+      auto ec = glz::merge_patch(*target, *patch);
+      expect(!ec);
+
+      auto expected = glz::read_json<glz::generic>(R"({"a": 1})");
+      expect(glz::equal(*target, *expected));
+   };
+
+   // ============================================================================
+   // Edge Cases
+   // ============================================================================
+
+   "merge_patch empty patch is no-op"_test = [] {
+      auto target = glz::read_json<glz::generic>(R"({"a": 1, "b": 2})");
+      auto original = *target;
+      auto patch = glz::read_json<glz::generic>(R"({})");
+
+      expect(target.has_value() && patch.has_value());
+
+      auto ec = glz::merge_patch(*target, *patch);
+      expect(!ec);
+      expect(glz::equal(*target, original));
+   };
+
+   "merge_patch remove all keys"_test = [] {
+      auto target = glz::read_json<glz::generic>(R"({"a": 1, "b": 2})");
+      auto patch = glz::read_json<glz::generic>(R"({"a": null, "b": null})");
+
+      expect(target.has_value() && patch.has_value());
+
+      auto ec = glz::merge_patch(*target, *patch);
+      expect(!ec);
+
+      auto expected = glz::read_json<glz::generic>(R"({})");
+      expect(glz::equal(*target, *expected));
+   };
+
+   "merge_patch empty string key"_test = [] {
+      auto target = glz::read_json<glz::generic>(R"({"": 1, "a": 2})");
+      auto patch = glz::read_json<glz::generic>(R"({"": 99})");
+
+      expect(target.has_value() && patch.has_value());
+
+      auto ec = glz::merge_patch(*target, *patch);
+      expect(!ec);
+
+      auto expected = glz::read_json<glz::generic>(R"({"": 99, "a": 2})");
+      expect(glz::equal(*target, *expected));
+   };
+
+   "merge_patch numeric string keys"_test = [] {
+      auto target = glz::read_json<glz::generic>(R"({"0": "a", "1": "b"})");
+      auto patch = glz::read_json<glz::generic>(R"({"1": "x", "2": "c"})");
+
+      expect(target.has_value() && patch.has_value());
+
+      auto ec = glz::merge_patch(*target, *patch);
+      expect(!ec);
+
+      auto expected = glz::read_json<glz::generic>(R"({"0": "a", "1": "x", "2": "c"})");
+      expect(glz::equal(*target, *expected));
+   };
+
+   "merge_patch unicode keys"_test = [] {
+      auto target = glz::read_json<glz::generic>(R"({"日本語": 1, "中文": "hello"})");
+      auto patch = glz::read_json<glz::generic>(R"({"日本語": 2, "emoji": "test"})");
+
+      expect(target.has_value() && patch.has_value());
+
+      auto ec = glz::merge_patch(*target, *patch);
+      expect(!ec);
+
+      auto expected = glz::read_json<glz::generic>(R"({"日本語": 2, "中文": "hello", "emoji": "test"})");
+      expect(glz::equal(*target, *expected));
+   };
+
+   "merge_patch deeply nested"_test = [] {
+      auto target = glz::read_json<glz::generic>(R"({
+         "a": {"b": {"c": {"d": 1}}}
+      })");
+      auto patch = glz::read_json<glz::generic>(R"({
+         "a": {"b": {"c": {"d": 99, "e": 2}}}
+      })");
+
+      expect(target.has_value() && patch.has_value());
+
+      auto ec = glz::merge_patch(*target, *patch);
+      expect(!ec);
+
+      auto expected = glz::read_json<glz::generic>(R"({
+         "a": {"b": {"c": {"d": 99, "e": 2}}}
+      })");
+      expect(glz::equal(*target, *expected));
+   };
+
+   "merge_patch null target"_test = [] {
+      auto target = glz::read_json<glz::generic>(R"(null)");
+      auto patch = glz::read_json<glz::generic>(R"({"a": 1})");
+
+      expect(target.has_value() && patch.has_value());
+
+      auto ec = glz::merge_patch(*target, *patch);
+      expect(!ec);
+
+      auto expected = glz::read_json<glz::generic>(R"({"a": 1})");
+      expect(glz::equal(*target, *expected));
+   };
+
+   // ============================================================================
+   // Max Depth Protection
+   // ============================================================================
+
+   "merge_patch max_depth exceeded"_test = [] {
+      glz::generic target;
+      target.data = glz::generic::object_t{};
+
+      glz::generic patch;
+      patch.data = glz::generic::object_t{};
+
+      // Build a deeply nested patch exceeding max_recursive_depth_limit (256)
+      glz::generic* current = &patch;
+      for (size_t i = 0; i < glz::max_recursive_depth_limit + 10; ++i) {
+         current->get_object()["nested"].data = glz::generic::object_t{};
+         current = &current->get_object()["nested"];
+      }
+
+      auto ec = glz::merge_patch(target, patch);
+      expect(ec.ec == glz::error_code::exceeded_max_recursive_depth);
+   };
+
+   "merge_patch within max_depth"_test = [] {
+      auto target = glz::read_json<glz::generic>(R"({})");
+      auto patch = glz::read_json<glz::generic>(R"({"a": {"b": {"c": 1}}})");
+
+      expect(target.has_value() && patch.has_value());
+
+      auto ec = glz::merge_patch(*target, *patch);
+      expect(!ec);
+   };
+
+   // ============================================================================
+   // Merge Diff Tests
+   // ============================================================================
+
+   "merge_diff generates correct patch"_test = [] {
+      auto source = glz::read_json<glz::generic>(R"({"a": 1, "b": 2})");
+      auto target = glz::read_json<glz::generic>(R"({"a": 1, "c": 3})");
+
+      expect(source.has_value() && target.has_value());
+
+      auto patch = glz::merge_diff(*source, *target);
+      expect(patch.has_value());
+
+      // patch should contain {"b": null, "c": 3}
+      expect(patch->is_object());
+      auto& patch_obj = patch->get_object();
+      expect(patch_obj.size() == 2u);
+      expect(patch_obj.find("b") != patch_obj.end());
+      expect(patch_obj["b"].is_null());
+      expect(patch_obj.find("c") != patch_obj.end());
+      expect(patch_obj["c"].get_number() == 3.0);
+   };
+
+   "merge_diff round-trip"_test = [] {
+      auto source = glz::read_json<glz::generic>(R"({"a": 1, "b": {"x": 1}})");
+      auto target = glz::read_json<glz::generic>(R"({"a": 2, "b": {"y": 2}, "c": 3})");
+
+      expect(source.has_value() && target.has_value());
+
+      auto patch = glz::merge_diff(*source, *target);
+      expect(patch.has_value());
+
+      auto result = *source;
+      auto ec = glz::merge_patch(result, *patch);
+      expect(!ec);
+      expect(glz::equal(result, *target));
+   };
+
+   "merge_diff identical documents"_test = [] {
+      auto source = glz::read_json<glz::generic>(R"({"a": 1, "b": 2})");
+      auto target = glz::read_json<glz::generic>(R"({"a": 1, "b": 2})");
+
+      expect(source.has_value() && target.has_value());
+
+      auto patch = glz::merge_diff(*source, *target);
+      expect(patch.has_value());
+
+      // patch should be empty object
+      expect(patch->is_object());
+      expect(patch->get_object().empty());
+   };
+
+   "merge_diff nested objects"_test = [] {
+      auto source = glz::read_json<glz::generic>(R"({"a": {"b": 1, "c": 2}})");
+      auto target = glz::read_json<glz::generic>(R"({"a": {"b": 99, "d": 3}})");
+
+      expect(source.has_value() && target.has_value());
+
+      auto patch = glz::merge_diff(*source, *target);
+      expect(patch.has_value());
+
+      // Verify round-trip
+      auto result = *source;
+      auto ec = glz::merge_patch(result, *patch);
+      expect(!ec);
+      expect(glz::equal(result, *target));
+   };
+
+   "merge_diff type change"_test = [] {
+      auto source = glz::read_json<glz::generic>(R"({"a": 1})");
+      auto target = glz::read_json<glz::generic>(R"({"a": "string"})");
+
+      expect(source.has_value() && target.has_value());
+
+      auto patch = glz::merge_diff(*source, *target);
+      expect(patch.has_value());
+
+      auto result = *source;
+      auto ec = glz::merge_patch(result, *patch);
+      expect(!ec);
+      expect(glz::equal(result, *target));
+   };
+
+   "merge_diff null limitation"_test = [] {
+      // Demonstrate that explicit null in target cannot be preserved
+      auto source = glz::read_json<glz::generic>(R"({"a": 1})");
+      auto target = glz::read_json<glz::generic>(R"({"a": null})");
+
+      expect(source.has_value() && target.has_value());
+
+      auto patch = glz::merge_diff(*source, *target);
+      expect(patch.has_value());
+
+      // The patch will contain {"a": null}, but this means "remove a"
+      // not "set a to null"
+      auto result = *source;
+      auto ec = glz::merge_patch(result, *patch);
+      expect(!ec);
+
+      // Result will NOT have "a" at all, not have "a": null
+      expect(!result.contains("a"));
+      // This is the documented limitation of RFC 7386
+   };
+
+   // ============================================================================
+   // Non-Mutating API (merge_patched)
+   // ============================================================================
+
+   "merge_patched non-mutating"_test = [] {
+      auto target = glz::read_json<glz::generic>(R"({"a": 1})");
+      auto patch = glz::read_json<glz::generic>(R"({"b": 2})");
+
+      expect(target.has_value() && patch.has_value());
+
+      auto result = glz::merge_patched(*target, *patch);
+      expect(result.has_value());
+
+      // Original unchanged
+      expect(target->get_object()["a"].get_number() == 1.0);
+      expect(target->get_object().find("b") == target->get_object().end());
+
+      // Result has change
+      expect(result->get_object()["a"].get_number() == 1.0);
+      expect(result->get_object()["b"].get_number() == 2.0);
+   };
+
+   // ============================================================================
+   // Convenience String Functions
+   // ============================================================================
+
+   "merge_patch from string"_test = [] {
+      auto target = glz::read_json<glz::generic>(R"({"a": 1})");
+      expect(target.has_value());
+
+      auto ec = glz::merge_patch(*target, R"({"b": 2})");
+      expect(!ec);
+
+      auto expected = glz::read_json<glz::generic>(R"({"a": 1, "b": 2})");
+      expect(glz::equal(*target, *expected));
+   };
+
+   "merge_patch_json string to string"_test = [] {
+      auto result = glz::merge_patch_json(R"({"a": 1})", R"({"b": 2})");
+      expect(result.has_value());
+
+      auto parsed = glz::read_json<glz::generic>(*result);
+      expect(parsed.has_value());
+
+      auto expected = glz::read_json<glz::generic>(R"({"a": 1, "b": 2})");
+      expect(glz::equal(*parsed, *expected));
+   };
+
+   "merge_patched from strings"_test = [] {
+      auto result = glz::merge_patched(R"({"a": 1})", R"({"b": 2})");
+      expect(result.has_value());
+
+      auto expected = glz::read_json<glz::generic>(R"({"a": 1, "b": 2})");
+      expect(glz::equal(*result, *expected));
+   };
+
+   "merge_diff_json string to string"_test = [] {
+      auto result = glz::merge_diff_json(R"({"a": 1, "b": 2})", R"({"a": 1, "c": 3})");
+      expect(result.has_value());
+
+      auto parsed = glz::read_json<glz::generic>(*result);
+      expect(parsed.has_value());
+
+      // Should contain {"b": null, "c": 3}
+      expect(parsed->is_object());
+      expect((*parsed)["b"].is_null());
+      expect((*parsed)["c"].get_number() == 3.0);
+   };
+
+   "merge_patch invalid json"_test = [] {
+      auto target = glz::read_json<glz::generic>(R"({"a": 1})");
+      expect(target.has_value());
+
+      auto ec = glz::merge_patch(*target, R"({invalid json)");
+      expect(ec); // Should fail
+   };
+
+   "merge_patch_json invalid target json"_test = [] {
+      auto result = glz::merge_patch_json(R"({invalid)", R"({"b": 2})");
+      expect(!result.has_value());
+   };
+
+   "merge_patch_json invalid patch json"_test = [] {
+      auto result = glz::merge_patch_json(R"({"a": 1})", R"({invalid)");
+      expect(!result.has_value());
+   };
+
+   // ============================================================================
+   // RFC 7386 Appendix A Example
+   // ============================================================================
+
+   "rfc7386 appendix a example"_test = [] {
+      auto target = glz::read_json<glz::generic>(R"({
+         "title": "Goodbye!",
+         "author": {
+            "givenName": "John",
+            "familyName": "Doe"
+         },
+         "tags": ["example", "sample"],
+         "content": "This will be unchanged"
+      })");
+
+      auto patch = glz::read_json<glz::generic>(R"({
+         "title": "Hello!",
+         "phoneNumber": "+01-123-456-7890",
+         "author": {
+            "familyName": null
+         },
+         "tags": ["example"]
+      })");
+
+      expect(target.has_value() && patch.has_value());
+
+      auto ec = glz::merge_patch(*target, *patch);
+      expect(!ec);
+
+      // Verify the result matches RFC 7386 Appendix A expected output
+      expect(target->get_object()["title"].get_string() == "Hello!");
+      expect(target->get_object()["phoneNumber"].get_string() == "+01-123-456-7890");
+      expect(target->get_object()["content"].get_string() == "This will be unchanged");
+
+      // author should have givenName but not familyName
+      auto& author = target->get_object()["author"];
+      expect(author.is_object());
+      expect(author.get_object()["givenName"].get_string() == "John");
+      expect(author.get_object().find("familyName") == author.get_object().end());
+
+      // tags should be replaced entirely
+      auto& tags = target->get_object()["tags"];
+      expect(tags.is_array());
+      expect(tags.get_array().size() == 1u);
+      expect(tags.get_array()[0].get_string() == "example");
+   };
+
+   // ============================================================================
+   // Complex Round-Trip Tests
+   // ============================================================================
+
+   "complex round-trip"_test = [] {
+      auto source = glz::read_json<glz::generic>(R"({
+         "name": "test",
+         "values": [1, 2, 3],
+         "nested": {"a": 1, "b": 2},
+         "removed": "will be gone"
+      })");
+      auto target = glz::read_json<glz::generic>(R"({
+         "name": "modified",
+         "values": [4, 5],
+         "nested": {"a": 1, "c": 3},
+         "new_field": true
+      })");
+
+      expect(source.has_value() && target.has_value());
+
+      auto patch = glz::merge_diff(*source, *target);
+      expect(patch.has_value());
+
+      auto result = *source;
+      auto ec = glz::merge_patch(result, *patch);
+      expect(!ec);
+      expect(glz::equal(result, *target));
+   };
+
+   "deeply nested round-trip"_test = [] {
+      auto source = glz::read_json<glz::generic>(R"({
+         "l1": {"l2": {"l3": {"l4": {"value": 1}}}}
+      })");
+      auto target = glz::read_json<glz::generic>(R"({
+         "l1": {"l2": {"l3": {"l4": {"value": 2, "new": true}}}}
+      })");
+
+      expect(source.has_value() && target.has_value());
+
+      auto patch = glz::merge_diff(*source, *target);
+      expect(patch.has_value());
+
+      auto result = *source;
+      auto ec = glz::merge_patch(result, *patch);
+      expect(!ec);
+      expect(glz::equal(result, *target));
+   };
+};
+
+// ============================================================================
+// Struct-based Merge Patch Tests
+// ============================================================================
+
+struct Person
+{
+   std::string name{};
+   int age{};
+   std::string city{};
+};
+
+struct Config
+{
+   std::string host = "localhost";
+   int port = 8080;
+   bool enabled = true;
+   std::vector<std::string> tags{};
+};
+
+struct Nested
+{
+   std::string value{};
+   std::optional<int> count{};
+};
+
+struct Parent
+{
+   std::string id{};
+   Nested nested{};
+};
+
+suite struct_merge_patch_tests = [] {
+   "struct merge_patch basic"_test = [] {
+      Person person{.name = "Alice", .age = 30, .city = "NYC"};
+
+      auto patch = glz::read_json<glz::generic>(R"({"age": 31})");
+      expect(patch.has_value());
+
+      auto ec = glz::merge_patch(person, *patch);
+      expect(!ec);
+      expect(person.name == "Alice");
+      expect(person.age == 31);
+      expect(person.city == "NYC");
+   };
+
+   "struct merge_patch multiple fields"_test = [] {
+      Person person{.name = "Bob", .age = 25, .city = "LA"};
+
+      auto patch = glz::read_json<glz::generic>(R"({"name": "Robert", "city": "San Francisco"})");
+      expect(patch.has_value());
+
+      auto ec = glz::merge_patch(person, *patch);
+      expect(!ec);
+      expect(person.name == "Robert");
+      expect(person.age == 25);
+      expect(person.city == "San Francisco");
+   };
+
+   "struct merge_patch from string"_test = [] {
+      Person person{.name = "Charlie", .age = 40, .city = "Boston"};
+
+      auto ec = glz::merge_patch(person, R"({"age": 41, "city": "Chicago"})");
+      expect(!ec);
+      expect(person.name == "Charlie");
+      expect(person.age == 41);
+      expect(person.city == "Chicago");
+   };
+
+   "struct merge_patch array replacement"_test = [] {
+      Config config{.host = "localhost", .port = 8080, .enabled = true, .tags = {"dev", "test"}};
+
+      auto patch = glz::read_json<glz::generic>(R"({"tags": ["prod"]})");
+      expect(patch.has_value());
+
+      auto ec = glz::merge_patch(config, *patch);
+      expect(!ec);
+      expect(config.host == "localhost");
+      expect(config.port == 8080);
+      expect(config.enabled == true);
+      expect(config.tags.size() == 1u);
+      expect(config.tags[0] == "prod");
+   };
+
+   "struct merge_patch nested object"_test = [] {
+      Parent parent{.id = "123", .nested = {.value = "old", .count = 5}};
+
+      auto patch = glz::read_json<glz::generic>(R"({"nested": {"value": "new"}})");
+      expect(patch.has_value());
+
+      auto ec = glz::merge_patch(parent, *patch);
+      expect(!ec);
+      expect(parent.id == "123");
+      expect(parent.nested.value == "new");
+      // Note: count will be reset because the nested object is replaced
+   };
+
+   "struct merge_patched non-mutating"_test = [] {
+      Person original{.name = "Dave", .age = 35, .city = "Seattle"};
+
+      auto patch = glz::read_json<glz::generic>(R"({"age": 36})");
+      expect(patch.has_value());
+
+      auto result = glz::merge_patched(original, *patch);
+      expect(result.has_value());
+
+      // Original unchanged
+      expect(original.age == 35);
+
+      // Result has change
+      expect(result->name == "Dave");
+      expect(result->age == 36);
+      expect(result->city == "Seattle");
+   };
+
+   "struct merge_patched from string"_test = [] {
+      Config config{.host = "localhost", .port = 8080, .enabled = true, .tags = {}};
+
+      auto result = glz::merge_patched(config, R"({"port": 9000, "enabled": false})");
+      expect(result.has_value());
+
+      // Original unchanged
+      expect(config.port == 8080);
+      expect(config.enabled == true);
+
+      // Result has changes
+      expect(result->host == "localhost");
+      expect(result->port == 9000);
+      expect(result->enabled == false);
+   };
+
+   "struct merge_diff basic"_test = [] {
+      Person source{.name = "Eve", .age = 28, .city = "Miami"};
+      Person target{.name = "Eve", .age = 29, .city = "Miami"};
+
+      auto patch = glz::merge_diff(source, target);
+      expect(patch.has_value());
+
+      // Patch should only contain age change
+      expect(patch->is_object());
+      auto& obj = patch->get_object();
+      expect(obj.find("age") != obj.end());
+      expect(obj["age"].get_number() == 29.0);
+      // name and city should not be in patch (unchanged)
+      expect(obj.find("name") == obj.end());
+      expect(obj.find("city") == obj.end());
+   };
+
+   "struct merge_diff multiple changes"_test = [] {
+      Config source{.host = "localhost", .port = 8080, .enabled = true, .tags = {"a", "b"}};
+      Config target{.host = "production.example.com", .port = 443, .enabled = true, .tags = {"prod"}};
+
+      auto patch = glz::merge_diff(source, target);
+      expect(patch.has_value());
+
+      expect(patch->is_object());
+      auto& obj = patch->get_object();
+      expect(obj["host"].get_string() == "production.example.com");
+      expect(obj["port"].get_number() == 443.0);
+      // enabled is unchanged, should not be in patch
+      expect(obj.find("enabled") == obj.end());
+   };
+
+   "struct merge_diff_json"_test = [] {
+      Person source{.name = "Frank", .age = 50, .city = "Denver"};
+      Person target{.name = "Frank", .age = 51, .city = "Austin"};
+
+      auto patch_json = glz::merge_diff_json(source, target);
+      expect(patch_json.has_value());
+
+      // Parse and verify
+      auto patch = glz::read_json<glz::generic>(*patch_json);
+      expect(patch.has_value());
+      expect((*patch)["age"].get_number() == 51.0);
+      expect((*patch)["city"].get_string() == "Austin");
+   };
+
+   "struct round-trip"_test = [] {
+      Person source{.name = "Grace", .age = 45, .city = "Portland"};
+      Person target{.name = "Grace", .age = 46, .city = "Seattle"};
+
+      // Generate patch
+      auto patch = glz::merge_diff(source, target);
+      expect(patch.has_value());
+
+      // Apply patch to source
+      Person result = source;
+      auto ec = glz::merge_patch(result, *patch);
+      expect(!ec);
+
+      // Result should match target
+      expect(result.name == target.name);
+      expect(result.age == target.age);
+      expect(result.city == target.city);
+   };
+
+   "struct empty patch is no-op"_test = [] {
+      Person person{.name = "Henry", .age = 60, .city = "Phoenix"};
+      Person original = person;
+
+      auto patch = glz::read_json<glz::generic>(R"({})");
+      expect(patch.has_value());
+
+      auto ec = glz::merge_patch(person, *patch);
+      expect(!ec);
+      expect(person.name == original.name);
+      expect(person.age == original.age);
+      expect(person.city == original.city);
+   };
+};
+
+int main() { return 0; }


### PR DESCRIPTION
# JSON Merge Patch (RFC 7386) Support

Closes #975

## Summary

This PR adds full support for [JSON Merge Patch (RFC 7386)](https://datatracker.ietf.org/doc/html/rfc7386), a format for describing modifications to JSON documents. JSON Merge Patch provides a simpler alternative to JSON Patch (RFC 6902) for partial updates.

## Features

### Core API for `glz::generic`

```cpp
#include "glaze/json/patch.hpp"

// Apply merge patch in-place
error_ctx merge_patch(generic& target, const generic& patch);

// Apply merge patch, return new value (non-mutating)
expected<generic, error_ctx> merge_patched(const generic& target, const generic& patch);

// Generate merge patch that transforms source into target
expected<generic, error_ctx> merge_diff(const generic& source, const generic& target);
```

### Convenience Overloads

```cpp
// String input variants
error_ctx merge_patch(generic& target, std::string_view patch_json);
expected<std::string, error_ctx> merge_patch_json(std::string_view target_json, std::string_view patch_json);
expected<generic, error_ctx> merge_patched(std::string_view target_json, std::string_view patch_json);
expected<std::string, error_ctx> merge_diff_json(std::string_view source_json, std::string_view target_json);
```

### C++ Struct Support

Merge patches work directly with C++ structs, leveraging Glaze's reflection:

```cpp
struct Person {
   std::string name;
   int age;
   std::string city;
};

Person person{.name = "Alice", .age = 30, .city = "NYC"};

// Apply partial update - only changes specified fields
glz::merge_patch(person, R"({"age": 31})");
// person.name still "Alice", person.age now 31, person.city still "NYC"
```

This is highly efficient because Glaze's `read_json` naturally has merge-patch semantics—it only updates fields present in the JSON source.

## RFC 7386 Algorithm

The merge patch algorithm follows RFC 7386 precisely:

1. **Objects are merged recursively** - nested objects combine their keys
2. **`null` removes keys** - a null value in the patch removes the corresponding key from the target
3. **Arrays are replaced entirely** - no element-level array operations
4. **Non-object patches replace the target** - if the patch is not an object, it replaces the target completely

### Example (RFC 7386 Appendix A)

```cpp
auto target = glz::read_json<glz::generic>(R"({
   "title": "Goodbye!",
   "author": {"givenName": "John", "familyName": "Doe"},
   "tags": ["example", "sample"],
   "content": "This will be unchanged"
})");

auto patch = glz::read_json<glz::generic>(R"({
   "title": "Hello!",
   "phoneNumber": "+01-123-456-7890",
   "author": {"familyName": null},
   "tags": ["example"]
})");

glz::merge_patch(*target, *patch);

// Result:
// {
//    "title": "Hello!",              // replaced
//    "author": {"givenName": "John"}, // familyName removed
//    "tags": ["example"],             // replaced entirely
//    "content": "This will be unchanged",  // preserved
//    "phoneNumber": "+01-123-456-7890"     // added
// }
```

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| Uses `max_recursive_depth_limit` (256) | Consistent with other Glaze parsers; compile-time constant avoids runtime overhead |
| Struct merge_patch uses `read_json` directly | Glaze's read_json already has merge-patch semantics; avoids expensive intermediate conversions |
| Template constraints on `generic` overloads | Prevents ambiguity with string literals that could match both `generic` and `string_view` |
| Separate `merge_diff` and `merge_diff_json` | Follows existing API patterns; avoids overload ambiguity |

## When to Use JSON Merge Patch vs JSON Patch

| Use Case | Recommendation |
|----------|----------------|
| Partial update with simple values | Merge Patch |
| Need to set explicit null values | JSON Patch |
| Array element manipulation | JSON Patch |
| Move/copy operations | JSON Patch |
| Simple API for consumers | Merge Patch |
| Conditional updates (test operation) | JSON Patch |

## Testing

Added comprehensive test suite with 47 tests covering:

- Basic operations (add, replace, remove)
- Nested object merging
- Array replacement semantics
- Type coercion scenarios
- Edge cases (empty objects, root replacement)
- Max recursion depth protection
- `merge_diff` patch generation
- RFC 7386 Appendix A example
- Struct-based operations (12 tests)
- Round-trip verification

## Documentation

- Added `docs/json-merge-patch.md` - comprehensive user documentation
- Added `docs/design/json_merge_patch_rfc7386.md` - design document
- Updated `docs/json-patch.md` with cross-references
- Updated `docs/json.md` with partial update explanation and See Also link
- Updated `docs/generic-json.md` with See Also link
- Updated `mkdocs.yml` navigation

## Files Changed

- `include/glaze/json/patch.hpp` - implementation
- `tests/json_test/json_merge_patch_test.cpp` - test suite (new)
- `tests/json_test/CMakeLists.txt` - test target
- `docs/json-merge-patch.md` - user documentation (new)
- `docs/design/json_merge_patch_rfc7386.md` - design document (new)
- `docs/json-patch.md` - cross-references
- `docs/json.md` - partial update docs, See Also
- `docs/generic-json.md` - See Also
- `mkdocs.yml` - navigation

## HTTP Integration Note

When using JSON Merge Patch with HTTP APIs, use the MIME type `application/merge-patch+json` as specified in RFC 7386 Section 3.
