### PR TITLE
write_json_exclude

### DIFF
--- a/docs/partial-write.md
+++ b/docs/partial-write.md
@@ -1,9 +1,10 @@
 # Partial Write
 
-Glaze supports partial object writing, allowing you to serialize only specific fields. There are two approaches:
+Glaze supports partial object writing, allowing you to serialize only specific fields. There are three approaches:
 
 1. **Compile-time partial write** - Uses JSON pointers as template parameters (zero runtime overhead)
-2. **Runtime partial write** - Specify keys dynamically at runtime
+2. **Runtime partial write (whitelist)** - Specify keys to include at runtime
+3. **Runtime exclude write (blacklist)** - Specify keys to exclude at runtime
 
 ## Compile-Time Partial Write
 
@@ -174,22 +175,174 @@ glz::write_json_partial(obj, keys, buffer);
 // Result: {"field2":"test"}
 ```
 
-## Choosing Between Compile-Time and Runtime
+## Runtime Exclude Write (Blacklist)
 
-| Feature | Compile-Time (`write_json<partial>`) | Runtime (`write_json_partial`) |
-|---------|--------------------------------------|--------------------------------|
-| Key specification | `constexpr` JSON pointers | Runtime container |
-| Nested paths | Supported (`/animals/tiger`) | Top-level keys only |
-| Performance | Zero overhead | Hash lookup per key |
-| Use case | Fixed field sets | Dynamic field selection |
+Use `glz::write_json_exclude` to specify keys to **exclude** at runtime. This is useful when you want to serialize most fields but omit a few (e.g., sensitive data like passwords, internal IDs, or deprecated fields).
+
+### Basic Usage
+
+```c++
+struct my_struct
+{
+   int x = 10;
+   std::string name = "example";
+   double value = 3.14;
+   bool active = true;
+   std::string password = "secret";  // Don't serialize this!
+};
+
+my_struct obj{};
+std::string buffer;
+
+// Exclude specific keys at runtime
+std::vector<std::string> exclude = {"password"};
+auto ec = glz::write_json_exclude(obj, exclude, buffer);
+// Result: {"x":10,"name":"example","value":3.14,"active":true}
+```
+
+### Key Order
+
+The output key order matches the struct definition order (not the exclude list order):
+
+```c++
+std::vector<std::string> exclude = {"name"};
+glz::write_json_exclude(obj, exclude, buffer);
+// Result: {"x":10,"value":3.14,"active":true,"password":"secret"}
+// Keys appear in struct order: x, value, active, password (name excluded)
+```
+
+### Supported Key Containers
+
+Any range of string-like types works:
+
+```c++
+// std::vector<std::string>
+std::vector<std::string> exclude1 = {"password", "internal_id"};
+
+// std::vector<std::string_view>
+std::vector<std::string_view> exclude2 = {"password", "internal_id"};
+
+// std::array
+std::array<std::string_view, 2> exclude3 = {"password", "internal_id"};
+```
+
+### Error Handling
+
+If an exclude key doesn't exist in the struct, `error_code::unknown_key` is returned:
+
+```c++
+std::vector<std::string> exclude = {"nonexistent"};
+auto ec = glz::write_json_exclude(obj, exclude, buffer);
+if (ec.ec == glz::error_code::unknown_key) {
+    // Handle unknown key error
+}
+```
+
+### Empty Exclude List
+
+An empty exclude list writes all fields (equivalent to regular `write_json`):
+
+```c++
+std::vector<std::string> exclude = {};
+glz::write_json_exclude(obj, exclude, buffer);
+// Result: {"x":10,"name":"example","value":3.14,"active":true,"password":"secret"}
+```
+
+### Excluding All Keys
+
+Excluding all keys produces an empty JSON object:
+
+```c++
+std::vector<std::string> exclude = {"x", "name", "value", "active", "password"};
+glz::write_json_exclude(obj, exclude, buffer);
+// Result: {}
+```
+
+### Duplicate Exclude Keys
+
+Duplicate exclude keys are handled gracefully (the key is just excluded once):
+
+```c++
+std::vector<std::string> exclude = {"password", "password"};
+glz::write_json_exclude(obj, exclude, buffer);
+// Result: {"x":10,"name":"example","value":3.14,"active":true}
+```
+
+### Options Support
+
+Runtime exclude write supports standard Glaze options like `prettify`:
+
+```c++
+std::vector<std::string> exclude = {"password"};
+glz::write_json_exclude<glz::opts{.prettify = true}>(obj, exclude, buffer);
+// Result:
+// {
+//    "x": 10,
+//    "name": "example",
+//    "value": 3.14,
+//    "active": true
+// }
+```
+
+### Return Types
+
+Three overloads are available:
+
+```c++
+// 1. Write to resizable buffer (std::string, std::vector<char>)
+error_ctx write_json_exclude(T&& value, const Keys& exclude_keys, Buffer&& buffer);
+
+// 2. Write to raw buffer (char*)
+expected<size_t, error_ctx> write_json_exclude(T&& value, const Keys& exclude_keys, Buffer&& buffer);
+
+// 3. Return a new string
+expected<std::string, error_ctx> write_json_exclude(T&& value, const Keys& exclude_keys);
+```
+
+### Works with Reflectable Types
+
+Runtime exclude write works with both explicit Glaze metadata and pure reflection (C++ aggregates):
+
+```c++
+// No glz::meta needed - pure reflection
+struct reflectable_struct
+{
+   int field1 = 100;
+   std::string field2 = "test";
+   std::string internal = "hidden";
+};
+
+reflectable_struct obj{};
+std::vector<std::string> exclude = {"internal"};
+glz::write_json_exclude(obj, exclude, buffer);
+// Result: {"field1":100,"field2":"test"}
+```
+
+## Choosing Between Approaches
+
+| Feature | Compile-Time | Runtime Partial (Whitelist) | Runtime Exclude (Blacklist) |
+|---------|--------------|-----------------------------|-----------------------------|
+| Function | `write_json<partial>` | `write_json_partial` | `write_json_exclude` |
+| Key specification | `constexpr` JSON pointers | Runtime container | Runtime container |
+| Nested paths | Supported | Top-level keys only | Top-level keys only |
+| Performance | Zero overhead | Hash lookup per key | Hash lookup per exclude key |
+| Output order | Specified order | Input container order | Struct definition order |
+| Use case | Fixed field sets | Include specific fields | Exclude specific fields |
 
 Use **compile-time partial write** when:
 - The fields to serialize are known at compile time
 - You need nested JSON pointer paths
 - Maximum performance is critical
 
-Use **runtime partial write** when:
+Use **runtime partial write (whitelist)** when:
 - The fields to serialize depend on runtime conditions
 - Different message types need different field subsets
 - User configuration determines which fields to include
+- You want control over the output key order
+
+Use **runtime exclude write (blacklist)** when:
+- You want to serialize most fields but exclude a few
+- Excluding sensitive fields (passwords, tokens, internal IDs)
+- The set of excluded fields is smaller than the set of included fields
+- You want keys in struct definition order
 


### PR DESCRIPTION
# Add Blacklist Support for Partial Writing

Closes #1140

## Summary

This PR adds runtime blacklist (exclude) support for partial writing, complementing the existing whitelist approach. Users can now specify which fields to **exclude** from serialization rather than which fields to **include**.

- Add `glz::write_json_exclude` API for runtime field exclusion
- Add `to_runtime_exclude` implementation struct
- Add comprehensive test suite with 26 new tests
- Update documentation with blacklist examples and comparison table

## Motivation

The existing `write_json_partial` (whitelist) approach requires specifying all fields to include. This becomes cumbersome when you want to serialize most fields but exclude a few (e.g., sensitive data like passwords, API keys, or internal notes).

**Before (whitelist - verbose when excluding few fields):**
```cpp
// To exclude just "password", must list ALL other fields
std::vector<std::string> keys = {"name", "email", "age", "address", "phone", ...};
glz::write_json_partial(user, keys, buffer);
```

**After (blacklist - concise):**
```cpp
// Simply specify what to exclude
std::vector<std::string> exclude = {"password"};
glz::write_json_exclude(user, exclude, buffer);
```

## API

Three overloads mirror the existing `write_json_partial` API:

```cpp
// 1. Write to resizable buffer (std::string, std::vector<char>)
error_ctx write_json_exclude(T&& value, const Keys& exclude_keys, Buffer&& buffer);

// 2. Write to raw buffer (char*)
expected<size_t, error_ctx> write_json_exclude(T&& value, const Keys& exclude_keys, Buffer&& buffer);

// 3. Return a new string
expected<std::string, error_ctx> write_json_exclude(T&& value, const Keys& exclude_keys);
```

## Usage Examples

### Basic Usage
```cpp
struct my_struct {
   int x = 10;
   std::string name = "example";
   std::string password = "secret";
};

my_struct obj{};
std::vector<std::string> exclude = {"password"};
auto ec = glz::write_json_exclude(obj, exclude, buffer);
// Result: {"x":10,"name":"example"}
```

### With Prettify
```cpp
glz::write_json_exclude<glz::opts{.prettify = true}>(obj, exclude, buffer);
```

### Empty Exclude List
```cpp
std::vector<std::string> exclude = {};
glz::write_json_exclude(obj, exclude, buffer);
// Result: all fields serialized (equivalent to write_json)
```

### Error Handling
```cpp
std::vector<std::string> exclude = {"nonexistent_field"};
auto ec = glz::write_json_exclude(obj, exclude, buffer);
// ec.ec == glz::error_code::unknown_key
```

## Key Differences from Whitelist

| Feature | `write_json_partial` (Whitelist) | `write_json_exclude` (Blacklist) |
|---------|----------------------------------|----------------------------------|
| Specify | Fields to include | Fields to exclude |
| Output order | Input container order | Struct definition order |
| Use case | Include specific fields | Exclude specific fields |
| Best for | Few fields needed | Few fields to hide |

## Implementation Details

- Uses hash-based lookup for O(1) key validation (same as `write_json_partial`)
- Builds a bitset of excluded indices, then iterates struct fields in definition order
- Validates all exclude keys exist before writing (returns `unknown_key` error if not)
- Supports both `glaze_object_t` types (with metadata) and `reflectable` types (pure C++ aggregates)
- Duplicate exclude keys are handled gracefully (key excluded once)