### PR TITLE
fix invalid control code in string

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1508,6 +1508,11 @@ namespace glz
                            return;
                         }
 
+                        if ((*it & 0b11100000) == 0) [[unlikely]] {
+                           ctx.error = error_code::syntax_error;
+                           return;
+                        }
+
                         *p = *it;
 
                         if (*it == '\\') {
@@ -1588,6 +1593,9 @@ namespace glz
                            ++p;
                            ++it;
                         }
+                     } else if ((*it & 0b11100000) == 0) [[unlikely]] {
+                        ctx.error = error_code::syntax_error;
+                        return;
                      }
                      else {
                         ++it;

--- a/tests/json_conformance/json_conformance.cpp
+++ b/tests/json_conformance/json_conformance.cpp
@@ -230,6 +230,43 @@ inline void should_fail()
       }
    };
 
+   "illegal control code u8string short tail"_test = [] {
+      constexpr sv s = "[\"ab\r\nd\"]";
+      {
+         std::vector<std::u8string> v;
+         expect(glz::read_json(v, s));
+      }
+   };
+
+   "illegal control code u8string middle tail"_test = [] {
+      constexpr sv s = "[\"ab\r\nd\",\"ab\"]";
+      {
+         std::vector<std::u8string> v;
+         expect(glz::read_json(v, s));
+      }
+   };
+
+   "illegal control code u8string long tail"_test = [] {
+      constexpr sv s = "[\"ab\r\nd\",\"abcdefghji\"]";
+      {
+         std::vector<std::u8string> v;
+         expect(glz::read_json(v, s));
+      }
+   };
+
+   "illegal control code non-null-terminated"_test = [] {
+      std::string input = "\"a\rb\"";
+      std::string_view s{input.data(), input.size()};
+      {
+         std::string v;
+         expect(glz::read<glz::opts{.null_terminated = false}>(v, s));
+      }
+      {
+         std::u8string v;
+         expect(glz::read<glz::opts{.null_terminated = false}>(v, s));
+      }
+   };
+
    "illegal backslash escape: \017"_test = [] {
       constexpr sv s = R"(["Illegal backslash escape: \017"])";
       {


### PR DESCRIPTION
Fixes parsing of strings that contain an invalid control character sequence. Currently, only the test with long tail will succeed while the tests with short/middle tail fail.