### PR TITLE
Fix BEVE static size array constexpr bug

### DIFF
--- a/include/glaze/beve/write.hpp
+++ b/include/glaze/beve/write.hpp
@@ -551,10 +551,11 @@ namespace glz
 
             // booleans must be dumped using single bits
             if constexpr (has_static_size<T>) {
-               constexpr auto num_bytes = (value.size() + 7) / 8;
+               constexpr auto N = std::tuple_size_v<std::decay_t<T>>;
+               constexpr auto num_bytes = (N + 7) / 8;
                std::array<uint8_t, num_bytes> bytes{};
                for (size_t byte_i{}, i{}; byte_i < num_bytes; ++byte_i) {
-                  for (size_t bit_i = 7; bit_i < 8 && i < value.size(); --bit_i, ++i) {
+                  for (size_t bit_i = 7; bit_i < 8 && i < N; --bit_i, ++i) {
                      bytes[byte_i] |= uint8_t(value[i]) << uint8_t(bit_i);
                   }
                }

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -1473,6 +1473,64 @@ suite bitset = [] {
    };
 };
 
+suite array_bool_tests = [] {
+   "array_bool_13"_test = [] {
+      std::array<bool, 13> arr = {true, false, true, true, false, false, true, false, true, false, true, true, false};
+
+      std::string s{};
+      expect(not glz::write_beve(arr, s));
+
+      std::array<bool, 13> arr2{};
+      expect(!glz::read_beve(arr2, s));
+      expect(arr == arr2);
+   };
+
+   "array_bool_8"_test = [] {
+      std::array<bool, 8> arr = {true, false, true, false, true, false, true, false};
+
+      std::string s{};
+      expect(not glz::write_beve(arr, s));
+
+      std::array<bool, 8> arr2{};
+      expect(!glz::read_beve(arr2, s));
+      expect(arr == arr2);
+   };
+
+   "array_bool_1"_test = [] {
+      std::array<bool, 1> arr = {true};
+
+      std::string s{};
+      expect(not glz::write_beve(arr, s));
+
+      std::array<bool, 1> arr2{};
+      expect(!glz::read_beve(arr2, s));
+      expect(arr == arr2);
+   };
+};
+
+struct nested_bool_array
+{
+   int id{};
+   std::array<bool, 13> flags{};
+   std::string name{};
+
+   bool operator==(const nested_bool_array&) const = default;
+};
+
+suite nested_array_bool_tests = [] {
+   "nested_array_bool"_test = [] {
+      nested_bool_array obj{42, {true, false, true, true, false, false, true, false, true, false, true, true, false},
+                            "test"};
+
+      std::string s{};
+      expect(not glz::write_beve(obj, s));
+
+      nested_bool_array obj2{};
+      expect(!glz::read_beve(obj2, s));
+      expect(obj == obj2);
+   };
+};
+
 struct key_reflection
 {
    int i = 287;


### PR DESCRIPTION
## Fix `std::array<bool, N>` BEVE serialization compile error

Fixes #2170

### Problem

Serializing `std::array<bool, N>` with BEVE format failed to compile with:

> "constexpr variable 'num_bytes' must be initialized by a constant expression"

The issue was in `include/glaze/beve/write.hpp` where `value.size()` was called in a `constexpr` context. While `std::array::size()` is a `constexpr` member function, calling it on a function parameter (`value`) is not a constant expression.

### Fix

Use `std::tuple_size_v<std::decay_t<T>>` to get the array size from the type at compile time instead of calling `.size()` on the runtime value.

```cpp
// Before
constexpr auto num_bytes = (value.size() + 7) / 8;

// After
constexpr auto N = std::tuple_size_v<std::decay_t<T>>;
constexpr auto num_bytes = (N + 7) / 8;
```