### PR TITLE
Check for to_chars support

### DIFF
--- a/include/glaze/core/write_chars.hpp
+++ b/include/glaze/core/write_chars.hpp
@@ -125,6 +125,8 @@ namespace glz
                const auto end = glz::to_chars(start, value);
                ix += size_t(end - start);
             }
+// float128_t requires std::to_chars for floating-point, unavailable on older Apple platforms (iOS < 16.3)
+#if !defined(_LIBCPP_VERSION) || defined(_LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT)
             else if constexpr (is_float128<V>) {
                const auto start = reinterpret_cast<char*>(&b[ix]);
                const auto [ptr, ec] = std::to_chars(start, &b[0] + b.size(), value, std::chars_format::general);
@@ -134,6 +136,7 @@ namespace glz
                }
                ix += size_t(ptr - start);
             }
+#endif
             else {
                static_assert(false_v<V>, "type is not supported");
             }

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -834,6 +834,8 @@ namespace glz
             }
          }
          else {
+// float128_t requires std::from_chars for floating-point, unavailable on older Apple platforms (iOS < 16.3)
+#if !defined(_LIBCPP_VERSION) || defined(_LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT)
             if constexpr (is_float128<V>) {
                auto [ptr, ec] = std::from_chars(it, end, value);
                if (ec != std::errc()) {
@@ -842,7 +844,9 @@ namespace glz
                }
                it = ptr;
             }
-            else {
+            else
+#endif
+            {
                if constexpr (std::is_volatile_v<std::remove_reference_t<decltype(value)>>) {
                   // Hardware may interact with value changes, so we parse into a temporary and assign in one
                   // place


### PR DESCRIPTION
Request to avoid using `std::to_chars` when not supported on older iOS: https://github.com/organicmaps/organicmaps/issues/11934