### PR TITLE
Runtime max length limits

### DIFF
--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -584,6 +584,12 @@ namespace glz
                return;
             }
          }
+         if constexpr (has_runtime_max_string_length<std::decay_t<decltype(ctx)>>) {
+            if (ctx.max_string_length > 0 && n > ctx.max_string_length) [[unlikely]] {
+               ctx.error = error_code::invalid_length;
+               return;
+            }
+         }
          value.resize(n);
          std::memcpy(value.data(), it, n);
          it += n;
@@ -615,6 +621,12 @@ namespace glz
          }
          if constexpr (check_max_string_length(Opts) > 0) {
             if (n > check_max_string_length(Opts)) [[unlikely]] {
+               ctx.error = error_code::invalid_length;
+               return;
+            }
+         }
+         if constexpr (has_runtime_max_string_length<std::decay_t<decltype(ctx)>>) {
+            if (ctx.max_string_length > 0 && n > ctx.max_string_length) [[unlikely]] {
                ctx.error = error_code::invalid_length;
                return;
             }
@@ -812,6 +824,12 @@ namespace glz
                   return;
                }
             }
+            if constexpr (has_runtime_max_array_size<std::decay_t<decltype(ctx)>>) {
+               if (ctx.max_array_size > 0 && n > ctx.max_array_size) [[unlikely]] {
+                  ctx.error = error_code::invalid_length;
+                  return;
+               }
+            }
 
             if constexpr (resizable<T>) {
                value.resize(n);
@@ -857,6 +875,12 @@ namespace glz
                }
                if constexpr (check_max_array_size(Opts) > 0) {
                   if (n > check_max_array_size(Opts)) [[unlikely]] {
+                     ctx.error = error_code::invalid_length;
+                     return 0;
+                  }
+               }
+               if constexpr (has_runtime_max_array_size<std::decay_t<decltype(ctx)>>) {
+                  if (ctx.max_array_size > 0 && n > ctx.max_array_size) [[unlikely]] {
                      ctx.error = error_code::invalid_length;
                      return 0;
                   }
@@ -1005,6 +1029,12 @@ namespace glz
                   return;
                }
             }
+            if constexpr (has_runtime_max_array_size<std::decay_t<decltype(ctx)>>) {
+               if (ctx.max_array_size > 0 && n > ctx.max_array_size) [[unlikely]] {
+                  ctx.error = error_code::invalid_length;
+                  return;
+               }
+            }
 
             if constexpr (resizable<T>) {
                value.resize(n);
@@ -1025,6 +1055,12 @@ namespace glz
                }
                if constexpr (check_max_string_length(Opts) > 0) {
                   if (length > check_max_string_length(Opts)) [[unlikely]] {
+                     ctx.error = error_code::invalid_length;
+                     return;
+                  }
+               }
+               if constexpr (has_runtime_max_string_length<std::decay_t<decltype(ctx)>>) {
+                  if (ctx.max_string_length > 0 && length > ctx.max_string_length) [[unlikely]] {
                      ctx.error = error_code::invalid_length;
                      return;
                   }
@@ -1076,6 +1112,12 @@ namespace glz
             }
             if constexpr (check_max_array_size(Opts) > 0) {
                if (n > check_max_array_size(Opts)) [[unlikely]] {
+                  ctx.error = error_code::invalid_length;
+                  return;
+               }
+            }
+            if constexpr (has_runtime_max_array_size<std::decay_t<decltype(ctx)>>) {
+               if (ctx.max_array_size > 0 && n > ctx.max_array_size) [[unlikely]] {
                   ctx.error = error_code::invalid_length;
                   return;
                }
@@ -1144,6 +1186,12 @@ namespace glz
             }
             if constexpr (check_max_array_size(Opts) > 0) {
                if (n > check_max_array_size(Opts)) [[unlikely]] {
+                  ctx.error = error_code::invalid_length;
+                  return;
+               }
+            }
+            if constexpr (has_runtime_max_array_size<std::decay_t<decltype(ctx)>>) {
+               if (ctx.max_array_size > 0 && n > ctx.max_array_size) [[unlikely]] {
                   ctx.error = error_code::invalid_length;
                   return;
                }
@@ -1308,6 +1356,12 @@ namespace glz
             // Check user-configured map size limit
             if constexpr (check_max_map_size(Opts) > 0) {
                if (n > check_max_map_size(Opts)) [[unlikely]] {
+                  ctx.error = error_code::invalid_length;
+                  return;
+               }
+            }
+            if constexpr (has_runtime_max_map_size<std::decay_t<decltype(ctx)>>) {
+               if (ctx.max_map_size > 0 && n > ctx.max_map_size) [[unlikely]] {
                   ctx.error = error_code::invalid_length;
                   return;
                }

--- a/include/glaze/cbor/read.hpp
+++ b/include/glaze/cbor/read.hpp
@@ -564,6 +564,12 @@ namespace glz
                   return;
                }
             }
+            if constexpr (has_runtime_max_string_length<std::decay_t<decltype(ctx)>>) {
+               if (ctx.max_string_length > 0 && length > ctx.max_string_length) [[unlikely]] {
+                  ctx.error = error_code::invalid_length;
+                  return;
+               }
+            }
 
             if constexpr (string_view_t<T>) {
                value = {reinterpret_cast<const char*>(it), static_cast<size_t>(length)};
@@ -665,6 +671,12 @@ namespace glz
                   return;
                }
             }
+            if constexpr (has_runtime_max_array_size<std::decay_t<decltype(ctx)>>) {
+               if (ctx.max_array_size > 0 && length > ctx.max_array_size) [[unlikely]] {
+                  ctx.error = error_code::invalid_length;
+                  return;
+               }
+            }
 
             value.resize(static_cast<size_t>(length));
             std::memcpy(value.data(), it, length);
@@ -760,6 +772,12 @@ namespace glz
                   return;
                }
             }
+            if constexpr (has_runtime_max_array_size<std::decay_t<decltype(ctx)>>) {
+               if (ctx.max_array_size > 0 && length > ctx.max_array_size) [[unlikely]] {
+                  ctx.error = error_code::invalid_length;
+                  return;
+               }
+            }
 
             value.resize(static_cast<size_t>(length));
             std::memcpy(value.data(), it, length);
@@ -838,6 +856,12 @@ namespace glz
                   // Check user-configured array size limit
                   if constexpr (check_max_array_size(Opts) > 0) {
                      if (count > check_max_array_size(Opts)) [[unlikely]] {
+                        ctx.error = error_code::invalid_length;
+                        return;
+                     }
+                  }
+                  if constexpr (has_runtime_max_array_size<std::decay_t<decltype(ctx)>>) {
+                     if (ctx.max_array_size > 0 && count > ctx.max_array_size) [[unlikely]] {
                         ctx.error = error_code::invalid_length;
                         return;
                      }
@@ -983,6 +1007,12 @@ namespace glz
                         return;
                      }
                   }
+                  if constexpr (has_runtime_max_array_size<std::decay_t<decltype(ctx)>>) {
+                     if (ctx.max_array_size > 0 && count > ctx.max_array_size) [[unlikely]] {
+                        ctx.error = error_code::invalid_length;
+                        return;
+                     }
+                  }
 
                   if constexpr (resizable<T>) {
                      value.resize(count);
@@ -1110,6 +1140,12 @@ namespace glz
                   return;
                }
             }
+            if constexpr (has_runtime_max_array_size<std::decay_t<decltype(ctx)>>) {
+               if (ctx.max_array_size > 0 && count > ctx.max_array_size) [[unlikely]] {
+                  ctx.error = error_code::invalid_length;
+                  return;
+               }
+            }
 
             if constexpr (resizable<T>) {
                value.resize(static_cast<size_t>(count));
@@ -1203,6 +1239,12 @@ namespace glz
             // Check user-configured map size limit
             if constexpr (check_max_map_size(Opts) > 0) {
                if (count > check_max_map_size(Opts)) [[unlikely]] {
+                  ctx.error = error_code::invalid_length;
+                  return;
+               }
+            }
+            if constexpr (has_runtime_max_map_size<std::decay_t<decltype(ctx)>>) {
+               if (ctx.max_map_size > 0 && count > ctx.max_map_size) [[unlikely]] {
                   ctx.error = error_code::invalid_length;
                   return;
                }

--- a/include/glaze/core/context.hpp
+++ b/include/glaze/core/context.hpp
@@ -131,4 +131,29 @@ namespace glz
       { ctx.error } -> std::same_as<error_code&>;
       { ctx.indentation_level } -> std::same_as<uint32_t&>;
    };
+
+   // Runtime constraint concepts
+   // These detect if a user-defined context has runtime constraint fields.
+   // Users can inherit from glz::context and add these fields for runtime limits:
+   //   struct my_context : glz::context {
+   //      size_t max_string_length = 1024;
+   //      size_t max_array_size = 100;
+   //      size_t max_map_size = 50;
+   //   };
+   // Use with if constexpr to ensure zero binary overhead when not used.
+
+   template <class Ctx>
+   concept has_runtime_max_string_length = requires(Ctx& ctx) {
+      { ctx.max_string_length } -> std::convertible_to<size_t>;
+   };
+
+   template <class Ctx>
+   concept has_runtime_max_array_size = requires(Ctx& ctx) {
+      { ctx.max_array_size } -> std::convertible_to<size_t>;
+   };
+
+   template <class Ctx>
+   concept has_runtime_max_map_size = requires(Ctx& ctx) {
+      { ctx.max_map_size } -> std::convertible_to<size_t>;
+   };
 }


### PR DESCRIPTION
# Runtime BEVE/CBOR Constraints

Adds support for runtime constraints when reading BEVE and CBOR formats. This complements the existing compile-time constraints (used with `glz::meta` and `max_length_t`).

## Changes

### `include/glaze/core/context.hpp`

Added three concepts to detect runtime constraint fields in user-defined contexts:

- `has_runtime_max_string_length`
- `has_runtime_max_array_size`
- `has_runtime_max_map_size`

### `include/glaze/beve/read.hpp`

Added runtime constraint checks at 9 locations (strings, arrays, maps) using `if constexpr` with the new concepts.

### `include/glaze/cbor/read.hpp`

Added runtime constraint checks at 7 locations (strings, arrays, maps) using `if constexpr` with the new concepts.

## Usage

Users inherit from `glz::context` and add constraint fields:

```cpp
struct my_context : glz::context {
   size_t max_string_length = 0;  // 0 = no limit
   size_t max_array_size = 0;
   size_t max_map_size = 0;
};

my_context ctx;
ctx.max_array_size = user_provided_limit;  // Set dynamically at runtime

glz::read<glz::opts{.format = glz::BEVE}>(output, buffer, ctx);
```

## Design

- **Zero binary overhead**: Uses `if constexpr` with concepts, so code is compiled out when using the base `glz::context`
- **Additive**: Runtime constraints work alongside compile-time constraints; either can reject
- **Consistent**: Same field names and semantics as compile-time options (0 = no limit)

Closes #2198