### PR TITLE
Remove non asio tests for boost-asio CI

### DIFF
--- a/.github/workflows/boost-asio.yml
+++ b/.github/workflows/boost-asio.yml
@@ -95,4 +95,4 @@ jobs:
 
       - name: Test
         working-directory: build
-        run: ctest -j $(nproc) --output-on-failure
+        run: ctest -j $(nproc) --output-on-failure -R "^(asio_repe|http_examples|http_router_test|http_client_test|http_server_api_tests|https_test|jsonrpc_registry_test|openapi_test|repe_buffer_test|repe_plugin_test|repe_test|registry_view_test|repe_to_jsonrpc_test|websocket_close_test|websocket_client_test|utf8_test|shared_context_bug_test|wss_test)$"

--- a/.github/workflows/standalone-asio.yml
+++ b/.github/workflows/standalone-asio.yml
@@ -79,4 +79,4 @@ jobs:
           wss_test
 
     - name: Test
-      run: ctest --output-on-failure --test-dir "$GITHUB_WORKSPACE/build"
+      run: ctest --output-on-failure --test-dir "$GITHUB_WORKSPACE/build" -R "^(asio_repe|http_examples|http_router_test|http_client_test|http_server_api_tests|https_test|jsonrpc_registry_test|openapi_test|repe_buffer_test|repe_plugin_test|repe_test|registry_view_test|repe_to_jsonrpc_test|websocket_close_test|websocket_client_test|utf8_test|shared_context_bug_test|wss_test)$"


### PR DESCRIPTION
No reason to run non asio tests on Boost asio CI, which will speed up CI.