### PR TITLE
Support for static function pointers

### DIFF
--- a/docs/binary.md
+++ b/docs/binary.md
@@ -253,11 +253,11 @@ By default Glaze will handle structs as tagged objects, meaning that keys will b
 
 `glaze/binary/beve_to_json.hpp` provides `glz::beve_to_json`, which directly converts a buffer of BEVE data to a buffer of JSON data.
 
-### Member Function Pointers
+### Function Pointers
 
-Objects that expose member function pointers through `glz::meta` are skipped by the BEVE writer by default. This mirrors JSON/TOML behaviour and avoids emitting unusable callable placeholders in binary payloads.
+Objects that expose function pointers (both member and non-member) through `glz::meta` are skipped by the BEVE writer by default. This mirrors JSON/TOML behaviour and avoids emitting unusable callable placeholders in binary payloads.
 
-If you want the key present, use `write_member_functions = true`.
+If you want the key present, use `write_function_pointers = true`.
 
 ## Custom Map Keys
 

--- a/docs/json.md
+++ b/docs/json.md
@@ -172,11 +172,11 @@ struct glz::meta<Person> {
 // JSON output: {"full_name":"John","years_old":30,"interests":["reading"]}
 ```
 
-### Member Function Pointers in Metadata
+### Function Pointers in Metadata
 
-When a `glz::meta` definition references a member function (for example, to expose a computed field), Glaze skips that entry during JSON writes by default. This prevents unintentionally emitting empty values for callables.
+When a `glz::meta` definition references a function pointer (member or non-member), Glaze skips that entry during JSON writes by default. This prevents unintentionally emitting empty values for callables.
 
-If you want the key to be emitted—you can opt back in by supplying a custom options type with `write_member_functions = true`:
+If you want the key to be emitted—you can opt back in by supplying a custom options type with `write_function_pointers = true`:
 
 ## Error Handling
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -41,7 +41,7 @@ These options are **not** in `glz::opts` by default. Add them to a custom option
 | `bool validate_skipped` | `false` | Perform full validation on skipped values |
 | `bool validate_trailing_whitespace` | `false` | Validate whitespace after parsing completes |
 | `bool bools_as_numbers` | `false` | Read/write booleans as `1` and `0` |
-| `bool write_member_functions` | `false` | Serialize member function pointers in `glz::meta` (off by default for safety) |
+| `bool write_function_pointers` | `false` | Serialize function pointers (both member and non-member) in `glz::meta` as their type name (off by default) |
 | `bool concatenate` | `true` | Concatenate ranges of `std::pair` into single objects |
 | `bool allow_conversions` | `true` | Allow type conversions in BEVE (e.g., `double` → `float`) |
 | `bool write_type_info` | `true` | Write type info for meta objects in variants |

--- a/include/glaze/beve/size.hpp
+++ b/include/glaze/beve/size.hpp
@@ -450,7 +450,7 @@ namespace glz
             return true;
          }
          else if constexpr (is_member_function_pointer<V>) {
-            return !check_write_member_functions(Opts);
+            return !check_write_function_pointers(Opts);
          }
          else {
             return false;
@@ -516,7 +516,7 @@ namespace glz
             return true;
          }
          else if constexpr (is_member_function_pointer<V>) {
-            return !check_write_member_functions(Opts);
+            return !check_write_function_pointers(Opts);
          }
          else {
             return false;

--- a/include/glaze/beve/write.hpp
+++ b/include/glaze/beve/write.hpp
@@ -428,6 +428,16 @@ namespace glz
       {}
    };
 
+   // Handle function pointers and function references (no-op like member function pointers)
+   template <class T>
+      requires is_function_ptr_or_ref<T>
+   struct to<BEVE, T>
+   {
+      template <auto Opts, class... Args>
+      GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, Args&&...) noexcept
+      {}
+   };
+
    // write includers as empty strings
    template <is_includer T>
    struct to<BEVE, T>
@@ -1097,8 +1107,8 @@ namespace glz
          if constexpr (std::same_as<V, hidden> || std::same_as<V, skip>) {
             return true;
          }
-         else if constexpr (is_member_function_pointer<V>) {
-            return !check_write_member_functions(Opts);
+         else if constexpr (is_any_function_ptr<V>) {
+            return !check_write_function_pointers(Opts);
          }
          else {
             return false;
@@ -1170,8 +1180,8 @@ namespace glz
          if constexpr (std::same_as<V, hidden> || std::same_as<V, skip>) {
             return true;
          }
-         else if constexpr (is_member_function_pointer<V>) {
-            return !check_write_member_functions(Opts);
+         else if constexpr (is_any_function_ptr<V>) {
+            return !check_write_function_pointers(Opts);
          }
          else {
             return false;

--- a/include/glaze/cbor/write.hpp
+++ b/include/glaze/cbor/write.hpp
@@ -613,7 +613,7 @@ namespace glz
             return true;
          }
          else if constexpr (is_member_function_pointer<V>) {
-            return !check_write_member_functions(Opts);
+            return !check_write_function_pointers(Opts);
          }
          else {
             return false;

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -376,8 +376,20 @@ namespace glz
       { *t };
    };
 
+   // Detect function pointers and function references (which should not be treated as nullable)
    template <class T>
-   concept nullable_like = nullable_t<T> && (!is_expected<T> && !std::is_array_v<T>);
+   concept is_function_ptr_or_ref =
+      std::is_function_v<std::remove_cvref_t<T>> || // function reference: void(&)(int)
+      (std::is_pointer_v<std::remove_cvref_t<T>> &&
+       std::is_function_v<std::remove_pointer_t<std::remove_cvref_t<T>>>); // function pointer: void(*)(int)
+
+   // Combined concept for any function pointer type (member or non-member)
+   template <class T>
+   concept is_any_function_ptr = is_member_function_pointer<T> || is_function_ptr_or_ref<T>;
+
+   template <class T>
+   concept nullable_like =
+      nullable_t<T> && !is_expected<T> && !std::is_array_v<T> && !is_function_ptr_or_ref<T>;
 
    // For optional like types that cannot overload `operator bool()`
    template <class T>

--- a/include/glaze/core/feature_test.hpp
+++ b/include/glaze/core/feature_test.hpp
@@ -21,7 +21,12 @@ namespace glz
 
 // Glaze Feature Test Macros for breaking changes
 
-// v6.6.0 renames context::indentation_level to context::depth
+// v7.0.0 renames write_member_functions to write_function_pointers
+//
+// Options:
+// - 'write_member_functions' renamed to 'write_function_pointers'
+// - This option now controls serialization of both member and non-member function pointers
+// - check_write_member_functions() renamed to check_write_function_pointers()
 //
 // context struct:
 // - 'indentation_level' renamed to 'depth'
@@ -30,7 +35,8 @@ namespace glz
 //
 // is_context concept:
 // - Now checks for 'depth' member instead of 'indentation_level'
-#define glaze_v6_6_0_depth
+#define glaze_v7_0_0_write_function_pointers
+#define glaze_v7_0_0_depth
 
 // v6.5.0 unified error_ctx and streaming I/O support
 //

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -145,8 +145,8 @@ namespace glz
    // If full validation should be performed on skipped values
 
    // ---
-   // bool write_member_functions = false;
-   // If member function pointers should be serialized when provided in glz::meta
+   // bool write_function_pointers = false;
+   // If function pointers (member and non-member) should be serialized when provided in glz::meta
 
    // ---
    // bool validate_trailing_whitespace = false;
@@ -288,10 +288,10 @@ namespace glz
       }
    }
 
-   consteval bool check_write_member_functions(auto&& Opts)
+   consteval bool check_write_function_pointers(auto&& Opts)
    {
-      if constexpr (requires { Opts.write_member_functions; }) {
-         return Opts.write_member_functions;
+      if constexpr (requires { Opts.write_function_pointers; }) {
+         return Opts.write_function_pointers;
       }
       else {
          return false;

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -376,20 +376,20 @@ namespace glz
          }
          else if constexpr (Opts.skip_null_members) {
             // if any type could be null then we might skip
-            constexpr bool write_member_functions = check_write_member_functions(Opts);
+            constexpr bool write_function_pointers = check_write_function_pointers(Opts);
             return [&]<size_t... I>(std::index_sequence<I...>) {
                return ((always_skipped<field_t<T, I>> ||
-                        (!write_member_functions && is_member_function_pointer<field_t<T, I>>) ||
+                        (!write_function_pointers && is_member_function_pointer<field_t<T, I>>) ||
                         null_t<field_t<T, I>>) ||
                        ...);
             }(std::make_index_sequence<N>{});
          }
          else {
             // if we have an always_skipped type then we return true
-            constexpr bool write_member_functions = check_write_member_functions(Opts);
+            constexpr bool write_function_pointers = check_write_function_pointers(Opts);
             return [&]<size_t... I>(std::index_sequence<I...>) {
                return ((always_skipped<field_t<T, I>> ||
-                        (!write_member_functions && is_member_function_pointer<field_t<T, I>>)) ||
+                        (!write_function_pointers && is_member_function_pointer<field_t<T, I>>)) ||
                        ...);
             }(std::make_index_sequence<N>{});
          }

--- a/include/glaze/rpc/registry.hpp
+++ b/include/glaze/rpc/registry.hpp
@@ -162,6 +162,16 @@ namespace glz
 
                impl::template register_param_function_endpoint<Func, Params>(full_key, func, *this);
             }
+            else if constexpr (is_function_ptr_invocable<std::remove_cvref_t<Func>>) {
+               // Handle function pointers with arguments (e.g., void(*)(int))
+               using Tuple = function_ptr_args_t<std::remove_cvref_t<Func>>;
+               constexpr auto N = glz::tuple_size_v<Tuple>;
+               static_assert(N == 1, "Only one input is allowed for your function pointer");
+
+               using Params = glz::tuple_element_t<0, Tuple>;
+
+               impl::template register_param_function_endpoint<Func, Params>(full_key, func, *this);
+            }
             else if constexpr (std::is_pointer_v<std::remove_cvref_t<Func>> &&
                                (glaze_object_t<std::remove_pointer_t<std::remove_cvref_t<Func>>> ||
                                 reflectable<std::remove_pointer_t<std::remove_cvref_t<Func>>>)) {

--- a/include/glaze/toml/write.hpp
+++ b/include/glaze/toml/write.hpp
@@ -732,8 +732,8 @@ namespace glz
          using val_t = field_t<Type, I>;
 
          // Skip member function pointers unless explicitly enabled
-         constexpr bool write_member_functions = check_write_member_functions(Options);
-         if constexpr (always_skipped<val_t> || (!write_member_functions && is_member_function_pointer<val_t>)) {
+         constexpr bool write_function_pointers = check_write_function_pointers(Options);
+         if constexpr (always_skipped<val_t> || (!write_function_pointers && is_member_function_pointer<val_t>)) {
             return;
          }
 
@@ -855,8 +855,8 @@ namespace glz
       // Helper lambda to check if a field should be skipped
       auto should_skip_field = [&]<size_t I>() constexpr {
          using val_t = field_t<T, I>;
-         constexpr bool write_member_functions = check_write_member_functions(Options);
-         return always_skipped<val_t> || (!write_member_functions && is_member_function_pointer<val_t>);
+         constexpr bool write_function_pointers = check_write_function_pointers(Options);
+         return always_skipped<val_t> || (!write_function_pointers && is_member_function_pointer<val_t>);
       };
 
       // Helper lambda to check if nullable field is null

--- a/include/glaze/util/type_traits.hpp
+++ b/include/glaze/util/type_traits.hpp
@@ -303,6 +303,36 @@ namespace glz
       using object_type = T;
    };
 
+   // Function pointer specializations
+   template <class R, class... Args>
+   struct invocable_traits<R (*)(Args...)> : std::true_type
+   {
+      using result_type = R;
+      using arguments = std::tuple<Args...>;
+   };
+
+   template <class R, class... Args>
+   struct invocable_traits<R (*)(Args...) noexcept> : std::true_type
+   {
+      using result_type = R;
+      using arguments = std::tuple<Args...>;
+   };
+
+   // Function type specializations (for function references)
+   template <class R, class... Args>
+   struct invocable_traits<R(Args...)> : std::true_type
+   {
+      using result_type = R;
+      using arguments = std::tuple<Args...>;
+   };
+
+   template <class R, class... Args>
+   struct invocable_traits<R(Args...) noexcept> : std::true_type
+   {
+      using result_type = R;
+      using arguments = std::tuple<Args...>;
+   };
+
    template <class T>
    using invocable_args_t = typename invocable_traits<decltype(&T::operator())>::arguments;
 
@@ -312,6 +342,18 @@ namespace glz
    // checks if type is a lambda with all known arguments
    template <class T>
    concept is_invocable_concrete = requires { typename invocable_traits<decltype(&T::operator())>::result_type; };
+
+   // checks if type is a function pointer with known arguments
+   template <class T>
+   concept is_function_ptr_invocable =
+      std::is_pointer_v<std::decay_t<T>> && std::is_function_v<std::remove_pointer_t<std::decay_t<T>>> &&
+      requires { typename invocable_traits<std::decay_t<T>>::result_type; };
+
+   template <class T>
+   using function_ptr_args_t = typename invocable_traits<std::decay_t<T>>::arguments;
+
+   template <class T>
+   using function_ptr_result_t = typename invocable_traits<std::decay_t<T>>::result_type;
 
    template <class T>
    using decay_keep_volatile_t = std::remove_const_t<std::remove_reference_t<T>>;

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -3148,13 +3148,13 @@ suite member_function_pointer_beve_serialization = [] {
       expect(not glz::write_beve(input, buffer_default));
       expect(buffer_default.find("description") == std::string::npos);
 
-      struct opts_with_member_functions : glz::opts
+      struct opts_with_function_pointers : glz::opts
       {
-         bool write_member_functions = true;
+         bool write_function_pointers = true;
       };
 
       std::string buffer_opt_in{};
-      expect(not glz::write<glz::set_beve<opts_with_member_functions{}>()>(input, buffer_opt_in));
+      expect(not glz::write<glz::set_beve<opts_with_function_pointers{}>()>(input, buffer_opt_in));
       expect(buffer_opt_in.find("description") != std::string::npos);
    };
 };

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -12903,17 +12903,17 @@ suite member_function_pointer_serialization = [] {
       expect(buffer == R"({"name":"test_item"})") << buffer;
    };
 
-   "member function pointer explicitly skipped when write_member_functions = false"_test = [] {
+   "member function pointer explicitly skipped when write_function_pointers = false"_test = [] {
       MemberFunctionThing thing{};
       thing.name = "test_item";
 
-      struct opts_without_member_functions : glz::opts
+      struct opts_without_function_pointers : glz::opts
       {
-         bool write_member_functions = false;
+         bool write_function_pointers = false;
       };
 
       std::string buffer{};
-      expect(not glz::write<opts_without_member_functions{}>(thing, buffer));
+      expect(not glz::write<opts_without_function_pointers{}>(thing, buffer));
       expect(buffer == R"({"name":"test_item"})") << buffer;
    };
 
@@ -12921,13 +12921,13 @@ suite member_function_pointer_serialization = [] {
       MemberFunctionThing thing{};
       thing.name = "test_item";
 
-      struct opts_with_member_functions : glz::opts
+      struct opts_with_function_pointers : glz::opts
       {
-         bool write_member_functions = true;
+         bool write_function_pointers = true;
       };
 
       std::string buffer{};
-      expect(not glz::write<opts_with_member_functions{}>(thing, buffer));
+      expect(not glz::write<opts_with_function_pointers{}>(thing, buffer));
 #if defined(__GNUC__) && !defined(__clang__)
 #if defined(_GLIBCXX_USE_CXX11_ABI) && _GLIBCXX_USE_CXX11_ABI == 0
       // Old ABI uses std::basic_string<char> without __cxx11 namespace
@@ -12954,13 +12954,13 @@ suite member_function_pointer_serialization = [] {
       expect(not glz::write_json(s, buffer1));
       expect(buffer1 == R"({})") << buffer1;
 
-      struct opts_with_member_functions : glz::opts
+      struct opts_with_function_pointers : glz::opts
       {
-         bool write_member_functions = true;
+         bool write_function_pointers = true;
       };
 
       std::string buffer2{};
-      expect(not glz::write<opts_with_member_functions{}>(s, buffer2));
+      expect(not glz::write<opts_with_function_pointers{}>(s, buffer2));
       expect(buffer2 == R"({"f1":"unsigned char (struct_t::*)() const noexcept"})") << buffer2;
    };
 };

--- a/tests/networking_tests/repe_test/repe_test.cpp
+++ b/tests/networking_tests/repe_test/repe_test.cpp
@@ -297,12 +297,12 @@ suite structs_of_functions = [] {
    };
 
    "volatile_member_functions_test"_test = [] {
-      struct opts_with_write_member_functions : glz::opts
+      struct opts_with_write_function_pointers : glz::opts
       {
-         bool write_member_functions = true;
+         bool write_function_pointers = true;
       };
 
-      glz::registry<opts_with_write_member_functions{}> server{};
+      glz::registry<opts_with_write_function_pointers{}> server{};
       VolatileData obj{};
 
       server.on(obj);
@@ -323,7 +323,7 @@ suite structs_of_functions = [] {
       response = call_json(server, {"/i"});
       expect(response.body == "11");
 
-      // Test empty query with write_member_functions=true
+      // Test empty query with write_function_pointers=true
       response = call_json(server, {""});
       expect(
          response.body ==
@@ -869,13 +869,13 @@ suite deeply_nested_tests = [] {
       expect(response.body == R"({"middle":{"inner":{"val":99},"name":"modified_mid"},"score":1.23})") << response.body;
    };
 
-   "nested_mix_write_member_functions_test"_test = [] {
-      struct opts_with_write_member_functions : glz::opts
+   "nested_mix_write_function_pointers_test"_test = [] {
+      struct opts_with_write_function_pointers : glz::opts
       {
-         bool write_member_functions = true;
+         bool write_function_pointers = true;
       };
 
-      glz::registry<opts_with_write_member_functions{}> server{};
+      glz::registry<opts_with_write_function_pointers{}> server{};
       outer_t obj{};
       server.on(obj);
 
@@ -893,12 +893,12 @@ suite deeply_nested_tests = [] {
    };
 
    "museum_member_functions_test"_test = [] {
-      struct opts_with_write_member_functions : glz::opts
+      struct opts_with_write_function_pointers : glz::opts
       {
-         bool write_member_functions = true;
+         bool write_function_pointers = true;
       };
 
-      glz::registry<opts_with_write_member_functions{}> server{};
+      glz::registry<opts_with_write_function_pointers{}> server{};
       Museum museum{};
       museum.name = "The Louvre";
       museum.main_exhibit = {"Mona Lisa", 1503};


### PR DESCRIPTION
# Function Pointer Support & Option Rename

## Summary

- Fixes #2221: Stack overflow when registering JSON-RPC methods with static member function pointers
- Adds support for non-member function pointers across all serialization formats
- Renames `write_member_functions` to `write_function_pointers` (breaking change for v7.0.0)

## Changes

### Bug Fix

Static member functions like `&MyClass::method` create regular function pointers (`void(*)(int)`), not member function pointers. These incorrectly matched the `nullable_like` concept, causing infinite recursion when the serializer tried to dereference them.

**Fix:** Added `is_function_ptr_or_ref` concept to exclude function pointers from `nullable_like`.

### New Features

- Function pointers are now supported in `glz::meta` definitions and JSON-RPC registries
- Added `is_any_function_ptr` concept combining member and non-member function pointer detection
- Function pointers serialize to their type signature string (e.g., `"void (*)(int)"`) when `write_function_pointers = true`

### Breaking Change (v7.0.0)

Renamed option and check function:
- `write_member_functions` → `write_function_pointers`
- `check_write_member_functions()` → `check_write_function_pointers()`

This better reflects that the option controls serialization of both member and non-member function pointers.

## Files Modified

- `include/glaze/core/common.hpp` - Added function pointer concepts
- `include/glaze/core/opts.hpp` - Renamed option
- `include/glaze/util/type_traits.hpp` - Added `invocable_traits` for function pointers
- `include/glaze/rpc/registry.hpp` - Added function pointer endpoint registration
- `include/glaze/json/write.hpp` - Added function pointer serialization
- `include/glaze/beve/write.hpp` - Added function pointer serialization
- `include/glaze/beve/size.hpp` - Updated skip logic
- `include/glaze/cbor/write.hpp` - Updated skip logic
- `include/glaze/toml/write.hpp` - Updated skip logic
- `include/glaze/core/reflect.hpp` - Updated to use new option name
- `include/glaze/core/feature_test.hpp` - Documented breaking change
- `docs/options.md`, `docs/json.md`, `docs/binary.md`, `docs/rpc/jsonrpc-registry.md` - Updated documentation