### PR TITLE
beve_peek_header_at

### DIFF
--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -5611,6 +5611,193 @@ suite beve_peek_header_tests = [] {
    };
 };
 
+// ============ beve_peek_header_at tests ============
+
+suite beve_peek_header_at_tests = [] {
+   "beve_peek_header_at basic offset"_test = [] {
+      // Create two concatenated BEVE values
+      int32_t val1 = 42;
+      std::string val2 = "hello";
+
+      auto buffer1 = glz::write_beve(val1).value();
+      auto buffer2 = glz::write_beve(val2).value();
+
+      // Concatenate them
+      std::string combined = buffer1 + buffer2;
+
+      // Peek at first value (offset 0)
+      auto result1 = glz::beve_peek_header_at(combined, 0);
+      expect(result1.has_value());
+      expect(result1->type == glz::tag::number);
+      expect(result1->count == 1u);
+
+      // Peek at second value (offset = size of first)
+      size_t offset = buffer1.size();
+      auto result2 = glz::beve_peek_header_at(combined, offset);
+      expect(result2.has_value());
+      expect(result2->type == glz::tag::string);
+      expect(result2->count == 5u); // "hello" has 5 characters
+   };
+
+   "beve_peek_header_at concatenated vectors"_test = [] {
+      std::vector<int> vec1{1, 2, 3};
+      std::vector<double> vec2{1.1, 2.2, 3.3, 4.4};
+
+      auto buffer1 = glz::write_beve(vec1).value();
+      auto buffer2 = glz::write_beve(vec2).value();
+
+      std::string combined = buffer1 + buffer2;
+
+      // Peek at first vector
+      auto result1 = glz::beve_peek_header_at(combined, 0);
+      expect(result1.has_value());
+      expect(result1->type == glz::tag::typed_array);
+      expect(result1->count == 3u);
+
+      // Peek at second vector
+      auto result2 = glz::beve_peek_header_at(combined, buffer1.size());
+      expect(result2.has_value());
+      expect(result2->type == glz::tag::typed_array);
+      expect(result2->count == 4u);
+   };
+
+   "beve_peek_header_at offset past end"_test = [] {
+      std::vector<int> val{1, 2, 3};
+      auto buffer = glz::write_beve(val).value();
+
+      // Offset equals buffer size - should fail
+      auto result = glz::beve_peek_header_at(buffer, buffer.size());
+      expect(!result.has_value());
+      expect(result.error().ec == glz::error_code::unexpected_end);
+
+      // Offset past buffer size - should fail
+      auto result2 = glz::beve_peek_header_at(buffer, buffer.size() + 10);
+      expect(!result2.has_value());
+      expect(result2.error().ec == glz::error_code::unexpected_end);
+   };
+
+   "beve_peek_header_at zero offset same as beve_peek_header"_test = [] {
+      std::map<std::string, int> val{{"a", 1}, {"b", 2}};
+      auto buffer = glz::write_beve(val).value();
+
+      auto result_at = glz::beve_peek_header_at(buffer, 0);
+      auto result_no_offset = glz::beve_peek_header(buffer);
+
+      expect(result_at.has_value());
+      expect(result_no_offset.has_value());
+      expect(result_at->type == result_no_offset->type);
+      expect(result_at->count == result_no_offset->count);
+      expect(result_at->header_size == result_no_offset->header_size);
+   };
+
+   "beve_peek_header_at raw pointer overload"_test = [] {
+      int32_t val1 = 100;
+      std::string val2 = "test";
+
+      auto buffer1 = glz::write_beve(val1).value();
+      auto buffer2 = glz::write_beve(val2).value();
+
+      std::string combined = buffer1 + buffer2;
+
+      // Use raw pointer overload
+      auto result = glz::beve_peek_header_at(combined.data(), combined.size(), buffer1.size());
+      expect(result.has_value());
+      expect(result->type == glz::tag::string);
+      expect(result->count == 4u); // "test" has 4 characters
+   };
+
+   "beve_peek_header_at raw pointer offset past end"_test = [] {
+      std::string buffer = "test";
+      auto result = glz::beve_peek_header_at(buffer.data(), buffer.size(), buffer.size());
+      expect(!result.has_value());
+      expect(result.error().ec == glz::error_code::unexpected_end);
+   };
+
+   "beve_peek_header_at iterate concatenated data"_test = [] {
+      // Demonstrate iterating through concatenated BEVE values
+      std::vector<int> vec{1, 2, 3, 4, 5};
+      std::string str = "hello world";
+      double num = 3.14159;
+
+      auto buffer1 = glz::write_beve(vec).value();
+      auto buffer2 = glz::write_beve(str).value();
+      auto buffer3 = glz::write_beve(num).value();
+
+      std::string combined = buffer1 + buffer2 + buffer3;
+
+      size_t offset = 0;
+
+      // First value: vector
+      auto header1 = glz::beve_peek_header_at(combined, offset);
+      expect(header1.has_value());
+      expect(header1->type == glz::tag::typed_array);
+      expect(header1->count == 5u);
+      offset += buffer1.size();
+
+      // Second value: string
+      auto header2 = glz::beve_peek_header_at(combined, offset);
+      expect(header2.has_value());
+      expect(header2->type == glz::tag::string);
+      expect(header2->count == 11u); // "hello world"
+      offset += buffer2.size();
+
+      // Third value: number
+      auto header3 = glz::beve_peek_header_at(combined, offset);
+      expect(header3.has_value());
+      expect(header3->type == glz::tag::number);
+      expect(header3->count == 1u);
+   };
+
+   "beve_peek_header_at with variant at offset"_test = [] {
+      int32_t val1 = 42;
+      std::variant<int, std::string> val2 = std::string("variant");
+
+      auto buffer1 = glz::write_beve(val1).value();
+      auto buffer2 = glz::write_beve(val2).value();
+
+      std::string combined = buffer1 + buffer2;
+
+      auto result = glz::beve_peek_header_at(combined, buffer1.size());
+      expect(result.has_value());
+      expect(result->type == glz::tag::extensions);
+      expect(result->ext_type == glz::extension::variant);
+      expect(result->count == 1u); // std::string is at index 1
+   };
+
+   "beve_peek_header_at with complex at offset"_test = [] {
+      std::string val1 = "prefix";
+      std::complex<double> val2{3.14, 2.71};
+
+      auto buffer1 = glz::write_beve(val1).value();
+      auto buffer2 = glz::write_beve(val2).value();
+
+      std::string combined = buffer1 + buffer2;
+
+      auto result = glz::beve_peek_header_at(combined, buffer1.size());
+      expect(result.has_value());
+      expect(result->type == glz::tag::extensions);
+      expect(result->ext_type == glz::extension::complex);
+      expect(result->count == 2u); // real + imag
+   };
+
+   "beve_peek_header_at truncated at offset"_test = [] {
+      // Create a combined buffer where the second value is truncated
+      int32_t val1 = 42;
+      std::vector<int> val2(100); // Needs multi-byte count encoding
+
+      auto buffer1 = glz::write_beve(val1).value();
+      auto buffer2 = glz::write_beve(val2).value();
+
+      // Combine, but truncate buffer2 to just the tag
+      std::string combined = buffer1;
+      combined += buffer2.substr(0, 1);
+
+      auto result = glz::beve_peek_header_at(combined, buffer1.size());
+      expect(!result.has_value());
+      expect(result.error().ec == glz::error_code::unexpected_end);
+   };
+};
+
 int main()
 {
    trace.begin("binary_test");


### PR DESCRIPTION
# Add `glz::beve_peek_header_at`

Adds `glz::beve_peek_header_at` function to peek at BEVE headers at arbitrary byte offsets without slicing or copying the buffer.

Closes #2222

## Changes

**New function in `include/glaze/beve/peek_header.hpp`:**

```cpp
// Template overload for buffers
template <class Buffer>
expected<beve_header, error_ctx> beve_peek_header_at(const Buffer& buffer, size_t offset) noexcept;

// Raw pointer overload
expected<beve_header, error_ctx> beve_peek_header_at(const void* data, size_t size, size_t offset) noexcept;
```

**Use cases:**
- Buffers with custom headers/prefixes before the BEVE data
- Memory-mapped files where you seek to specific positions
- Resuming parsing after partial reads
- Concatenated/delimited BEVE streams
- BEVE data embedded within larger binary structures

**Tests added:** 10 new tests in `tests/beve_test/beve_test.cpp`

**Documentation added:** New "Peek Header at Offset" section in `docs/binary.md`