### PR TITLE
Reduce core glz::opts for smaller template definitions

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -21,9 +21,6 @@ The tables below list **all** compile time options, organized by category:
 | `bool skip_null_members` | `true` | Skip writing out members if their value is null |
 | `bool prettify` | `false` | Write out prettified JSON |
 | `bool minified` | `false` | Require minified input for faster read performance |
-| `char indentation_char` | `' '` | Prettified JSON indentation character |
-| `uint8_t indentation_width` | `3` | Prettified JSON indentation size |
-| `bool new_lines_in_arrays` | `true` | Whether prettified arrays have new lines per element |
 | `bool error_on_missing_keys` | `false` | Require all non-nullable keys to be present |
 | `bool quoted_num` | `false` | Treat numbers as quoted or arrays as having quoted numbers |
 | `bool number` | `false` | Treat string-like types as numbers |
@@ -50,6 +47,9 @@ These options are **not** in `glz::opts` by default. Add them to a custom option
 | `bool error_on_const_read` | `false` | Error when attempting to read into a const value |
 | `bool hide_non_invocable` | `true` | Hide non-invocable members from `cli_menu` |
 | `bool escape_control_characters` | `false` | Escape control characters as unicode sequences |
+| `char indentation_char` | `' '` | Prettified JSON indentation character |
+| `uint8_t indentation_width` | `3` | Prettified JSON indentation size |
+| `bool new_lines_in_arrays` | `true` | Whether prettified arrays have new lines per element |
 | `float_precision float_max_write_precision` | `full` | Maximum precision for writing floats |
 | `static constexpr std::string_view float_format` | (none) | Format string for float output using `std::format` (C++23) |
 | `bool skip_null_members_on_read` | `false` | Skip null values when reading (preserve existing value) |
@@ -197,11 +197,24 @@ When `true` (default), null values are omitted from JSON output. This applies to
 #### `prettify`
 When `true`, outputs formatted JSON with indentation and newlines.
 
-#### `indentation_char` / `indentation_width`
-Control prettified output formatting. Default is 3 spaces per level.
+#### `indentation_char` / `indentation_width` (Inheritable)
+Control prettified output formatting. Default is 3 spaces per level. These are inheritable options—define them in a custom opts struct:
+```cpp
+struct my_opts : glz::opts {
+   char indentation_char = '\t';  // use tabs
+   uint8_t indentation_width = 1; // one tab per level
+};
+glz::write<my_opts{.prettify = true}>(obj, json);
+```
 
-#### `new_lines_in_arrays`
-When `true` (default), prettified arrays have each element on its own line.
+#### `new_lines_in_arrays` (Inheritable)
+When `true` (default), prettified arrays have each element on its own line. Set to `false` for compact array output:
+```cpp
+struct compact_arrays : glz::opts {
+   bool new_lines_in_arrays = false;
+};
+glz::write<compact_arrays{.prettify = true}>(obj, json);
+```
 
 #### `raw` / `raw_string`
 Control string quoting and escape sequence handling. Useful for embedding pre-formatted content.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -201,8 +201,11 @@ auto error = glz::read<glz::opts{.error_on_unknown_keys = false}>(obj, json);
 // Require all keys to be present
 auto error = glz::read<glz::opts{.error_on_missing_keys = true}>(obj, json);
 
-// Write with custom indentation
-auto error = glz::write<glz::opts{.prettify = true, .indentation_width = 2}>(obj, json);
+// Write with custom indentation (use a custom opts struct for indentation settings)
+struct indent2 : glz::opts {
+   uint8_t indentation_width = 2;
+};
+auto error = glz::write<indent2{.prettify = true}>(obj, json);
 ```
 
 ## Performance Tips

--- a/include/glaze/beve/beve_to_json.hpp
+++ b/include/glaze/beve/beve_to_json.hpp
@@ -166,9 +166,9 @@ namespace glz
 
             dump('{', out, ix);
             if constexpr (Opts.prettify) {
-               ctx.depth += Opts.indentation_width;
+               ctx.depth += check_indentation_width(Opts);
                dump('\n', out, ix);
-               dumpn(Opts.indentation_char, ctx.depth, out, ix);
+               dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
             }
             else {
                ++ctx.depth;
@@ -209,7 +209,7 @@ namespace glz
                      dump(',', out, ix);
                      if constexpr (Opts.prettify) {
                         dump('\n', out, ix);
-                        dumpn(Opts.indentation_char, ctx.depth, out, ix);
+                        dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
                      }
                   }
                }
@@ -245,7 +245,7 @@ namespace glz
                      dump(',', out, ix);
                      if constexpr (Opts.prettify) {
                         dump('\n', out, ix);
-                        dumpn(Opts.indentation_char, ctx.depth, out, ix);
+                        dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
                      }
                   }
                }
@@ -258,9 +258,9 @@ namespace glz
             }
 
             if constexpr (Opts.prettify) {
-               ctx.depth -= Opts.indentation_width;
+               ctx.depth -= check_indentation_width(Opts);
                dump('\n', out, ix);
-               dumpn(Opts.indentation_char, ctx.depth, out, ix);
+               dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
             }
             else {
                --ctx.depth;
@@ -472,9 +472,9 @@ namespace glz
 
                dump('{', out, ix);
                if constexpr (Opts.prettify) {
-                  ctx.depth += Opts.indentation_width;
+                  ctx.depth += check_indentation_width(Opts);
                   dump('\n', out, ix);
-                  dumpn(Opts.indentation_char, ctx.depth, out, ix);
+                  dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
                }
                else {
                   ++ctx.depth;
@@ -493,7 +493,7 @@ namespace glz
                dump(',', out, ix);
                if constexpr (Opts.prettify) {
                   dump('\n', out, ix);
-                  dumpn(Opts.indentation_char, ctx.depth, out, ix);
+                  dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
                }
 
                if constexpr (Opts.prettify) {
@@ -511,7 +511,7 @@ namespace glz
                dump(',', out, ix);
                if constexpr (Opts.prettify) {
                   dump('\n', out, ix);
-                  dumpn(Opts.indentation_char, ctx.depth, out, ix);
+                  dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
                }
 
                if constexpr (Opts.prettify) {
@@ -527,9 +527,9 @@ namespace glz
                }
 
                if constexpr (Opts.prettify) {
-                  ctx.depth -= Opts.indentation_width;
+                  ctx.depth -= check_indentation_width(Opts);
                   dump('\n', out, ix);
-                  dumpn(Opts.indentation_char, ctx.depth, out, ix);
+                  dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
                }
                else {
                   --ctx.depth;

--- a/include/glaze/cbor/cbor_to_json.hpp
+++ b/include/glaze/cbor/cbor_to_json.hpp
@@ -315,7 +315,7 @@ namespace glz
          case major::map: {
             dump('{', out, ix);
             if constexpr (Opts.prettify) {
-               ctx.depth += Opts.indentation_width;
+               ctx.depth += check_indentation_width(Opts);
             }
 
             if (additional_info == info::indefinite) {
@@ -339,7 +339,7 @@ namespace glz
                   }
                   if constexpr (Opts.prettify) {
                      dump('\n', out, ix);
-                     dumpn(Opts.indentation_char, ctx.depth, out, ix);
+                     dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
                   }
                   first = false;
 
@@ -372,7 +372,7 @@ namespace glz
                   }
                   if constexpr (Opts.prettify) {
                      dump('\n', out, ix);
-                     dumpn(Opts.indentation_char, ctx.depth, out, ix);
+                     dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
                   }
 
                   // Key
@@ -395,10 +395,10 @@ namespace glz
             }
 
             if constexpr (Opts.prettify) {
-               ctx.depth -= Opts.indentation_width;
+               ctx.depth -= check_indentation_width(Opts);
                if (additional_info != 0 || additional_info == info::indefinite) {
                   dump('\n', out, ix);
-                  dumpn(Opts.indentation_char, ctx.depth, out, ix);
+                  dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
                }
             }
             dump('}', out, ix);

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -91,9 +91,6 @@ namespace glz
       bool skip_null_members = true; // Skip writing out params in an object if the value is null
       bool prettify = false; // Write out prettified JSON
       bool minified = false; // Require minified input for JSON, which results in faster read performance
-      char indentation_char = ' '; // Prettified JSON indentation char
-      uint8_t indentation_width = 3; // Prettified JSON indentation size
-      bool new_lines_in_arrays = true; // Whether prettified arrays should have new lines for each element
       bool error_on_missing_keys = false; // Require all non nullable keys to be present in the object. Use
                                           // skip_null_members = false to require nullable members
 
@@ -238,6 +235,19 @@ namespace glz
    // without any known way to delete the memory, making memory leaks easy.
    // Enable this option only when you are prepared to manually manage the allocated memory.
    // Works with JSON, BEVE, CBOR, and MSGPACK formats.
+
+   // ---
+   // char indentation_char = ' ';
+   // Prettified JSON indentation character. Use '\t' for tabs.
+
+   // ---
+   // uint8_t indentation_width = 3;
+   // Prettified JSON indentation size (number of indentation_char per level).
+
+   // ---
+   // bool new_lines_in_arrays = true;
+   // Whether prettified arrays should have new lines for each element.
+   // Set to false for more compact array output.
 
    struct append_arrays_opt_tag
    {};
@@ -425,6 +435,36 @@ namespace glz
       }
       else {
          return rowwise;
+      }
+   }
+
+   consteval char check_indentation_char(auto&& Opts)
+   {
+      if constexpr (requires { Opts.indentation_char; }) {
+         return Opts.indentation_char;
+      }
+      else {
+         return ' ';
+      }
+   }
+
+   consteval uint8_t check_indentation_width(auto&& Opts)
+   {
+      if constexpr (requires { Opts.indentation_width; }) {
+         return Opts.indentation_width;
+      }
+      else {
+         return 3;
+      }
+   }
+
+   consteval bool check_new_lines_in_arrays(auto&& Opts)
+   {
+      if constexpr (requires { Opts.new_lines_in_arrays; }) {
+         return Opts.new_lines_in_arrays;
+      }
+      else {
+         return true;
       }
    }
 

--- a/include/glaze/json/prettify.hpp
+++ b/include/glaze/json/prettify.hpp
@@ -14,8 +14,8 @@ namespace glz
       template <auto Opts>
       inline void prettify_json(is_context auto&& ctx, auto&& it, auto&& end, auto&& b, auto& ix)
       {
-         constexpr bool use_tabs = Opts.indentation_char == '\t';
-         constexpr auto indent_width = Opts.indentation_width;
+         constexpr bool use_tabs = check_indentation_char(Opts) == '\t';
+         constexpr auto indent_width = check_indentation_width(Opts);
 
          using enum json_type;
 
@@ -32,7 +32,7 @@ namespace glz
             case Comma: {
                dump(',', b, ix);
                ++it;
-               if constexpr (Opts.new_lines_in_arrays) {
+               if constexpr (check_new_lines_in_arrays(Opts)) {
                   append_new_line<use_tabs, indent_width>(b, ix, indent);
                }
                else {
@@ -77,7 +77,7 @@ namespace glz
                   }
                }
                state[indent] = Array_Start;
-               if constexpr (Opts.new_lines_in_arrays) {
+               if constexpr (check_new_lines_in_arrays(Opts)) {
                   if constexpr (not Opts.null_terminated) {
                      if (it != end && *it != ']') {
                         append_new_line<use_tabs, indent_width>(b, ix, indent);
@@ -97,7 +97,7 @@ namespace glz
                   ctx.error = error_code::syntax_error;
                   return;
                }
-               if constexpr (Opts.new_lines_in_arrays) {
+               if constexpr (check_new_lines_in_arrays(Opts)) {
                   if (it[-1] != '[') {
                      append_new_line<use_tabs, indent_width>(b, ix, indent);
                   }

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -93,7 +93,7 @@ namespace glz
          }
          std::memcpy(&b[ix], ",\n", 2);
          ix += 2;
-         std::memset(&b[ix], Opts.indentation_char, ctx.depth);
+         std::memset(&b[ix], check_indentation_char(Opts), ctx.depth);
          ix += ctx.depth;
       }
       else {
@@ -121,9 +121,9 @@ namespace glz
          if constexpr (!check_opening_handled(Opts)) {
             dump('{', b, ix);
             if constexpr (Opts.prettify) {
-               ctx.depth += Opts.indentation_width;
+               ctx.depth += check_indentation_width(Opts);
                dump('\n', b, ix);
-               dumpn(Opts.indentation_char, ctx.depth, b, ix);
+               dumpn(check_indentation_char(Opts), ctx.depth, b, ix);
             }
          }
 
@@ -223,9 +223,9 @@ namespace glz
          if constexpr (!check_opening_handled(Opts)) {
             dump('{', b, ix);
             if constexpr (Opts.prettify) {
-               ctx.depth += Opts.indentation_width;
+               ctx.depth += check_indentation_width(Opts);
                dump('\n', b, ix);
-               dumpn(Opts.indentation_char, ctx.depth, b, ix);
+               dumpn(check_indentation_char(Opts), ctx.depth, b, ix);
             }
          }
 
@@ -314,9 +314,9 @@ namespace glz
          }
 
          if constexpr (Opts.prettify) {
-            ctx.depth -= Opts.indentation_width;
+            ctx.depth -= check_indentation_width(Opts);
             dump('\n', b, ix);
-            dumpn(Opts.indentation_char, ctx.depth, b, ix);
+            dumpn(check_indentation_char(Opts), ctx.depth, b, ix);
          }
 
          if (not bool(ctx.error)) [[likely]] {
@@ -337,9 +337,9 @@ namespace glz
          if constexpr (!check_opening_handled(Opts)) {
             dump('{', b, ix);
             if constexpr (Opts.prettify) {
-               ctx.depth += Opts.indentation_width;
+               ctx.depth += check_indentation_width(Opts);
                dump('\n', b, ix);
-               dumpn(Opts.indentation_char, ctx.depth, b, ix);
+               dumpn(check_indentation_char(Opts), ctx.depth, b, ix);
             }
          }
 
@@ -436,9 +436,9 @@ namespace glz
          }
 
          if constexpr (Opts.prettify) {
-            ctx.depth -= Opts.indentation_width;
+            ctx.depth -= check_indentation_width(Opts);
             dump('\n', b, ix);
-            dumpn(Opts.indentation_char, ctx.depth, b, ix);
+            dumpn(check_indentation_char(Opts), ctx.depth, b, ix);
          }
 
          if (not bool(ctx.error)) [[likely]] {
@@ -1138,10 +1138,10 @@ namespace glz
          if (!ensure_space(ctx, b, ix + ctx.depth + write_padding_bytes)) [[unlikely]] {
             return;
          }
-         if constexpr (Opts.new_lines_in_arrays) {
+         if constexpr (check_new_lines_in_arrays(Opts)) {
             std::memcpy(&b[ix], ",\n", 2);
             ix += 2;
-            std::memset(&b[ix], Opts.indentation_char, ctx.depth);
+            std::memset(&b[ix], check_indentation_char(Opts), ctx.depth);
             ix += ctx.depth;
          }
          else {
@@ -1216,8 +1216,8 @@ namespace glz
                static constexpr auto value_padding = required_padding<typename T::value_type>();
 
                if constexpr (Opts.prettify) {
-                  if constexpr (Opts.new_lines_in_arrays) {
-                     ctx.depth += Opts.indentation_width;
+                  if constexpr (check_new_lines_in_arrays(Opts)) {
+                     ctx.depth += check_indentation_width(Opts);
                   }
 
                   // add space for '\n' and ',' characters for each element, hence `+ 2`
@@ -1227,10 +1227,10 @@ namespace glz
                      return;
                   }
 
-                  if constexpr (Opts.new_lines_in_arrays) {
+                  if constexpr (check_new_lines_in_arrays(Opts)) {
                      std::memcpy(&b[ix], "[\n", 2);
                      ix += 2;
-                     std::memset(&b[ix], Opts.indentation_char, ctx.depth);
+                     std::memset(&b[ix], check_indentation_char(Opts), ctx.depth);
                      ix += ctx.depth;
                   }
                   else {
@@ -1255,10 +1255,10 @@ namespace glz
                ++it;
                for (const auto fin = std::end(value); it != fin; ++it) {
                   if constexpr (Opts.prettify) {
-                     if constexpr (Opts.new_lines_in_arrays) {
+                     if constexpr (check_new_lines_in_arrays(Opts)) {
                         std::memcpy(&b[ix], ",\n", 2);
                         ix += 2;
-                        std::memset(&b[ix], Opts.indentation_char, ctx.depth);
+                        std::memset(&b[ix], check_indentation_char(Opts), ctx.depth);
                         ix += ctx.depth;
                      }
                      else {
@@ -1276,11 +1276,11 @@ namespace glz
 
                   to<JSON, val_t>::template op<write_unchecked_on<Opts>()>(*it, ctx, b, ix);
                }
-               if constexpr (Opts.prettify && Opts.new_lines_in_arrays) {
-                  ctx.depth -= Opts.indentation_width;
+               if constexpr (Opts.prettify && check_new_lines_in_arrays(Opts)) {
+                  ctx.depth -= check_indentation_width(Opts);
                   std::memcpy(&b[ix], "\n", 1);
                   ++ix;
-                  std::memset(&b[ix], Opts.indentation_char, ctx.depth);
+                  std::memset(&b[ix], check_indentation_char(Opts), ctx.depth);
                   ix += ctx.depth;
                }
 
@@ -1291,18 +1291,18 @@ namespace glz
                // we either can't get the size (std::forward_list) or we cannot compute the allocation size
 
                if constexpr (Opts.prettify) {
-                  if constexpr (Opts.new_lines_in_arrays) {
-                     ctx.depth += Opts.indentation_width;
+                  if constexpr (check_new_lines_in_arrays(Opts)) {
+                     ctx.depth += check_indentation_width(Opts);
                   }
 
                   if (!ensure_space(ctx, b, ix + ctx.depth + write_padding_bytes)) [[unlikely]] {
                      return;
                   }
 
-                  if constexpr (Opts.new_lines_in_arrays) {
+                  if constexpr (check_new_lines_in_arrays(Opts)) {
                      std::memcpy(&b[ix], "[\n", 2);
                      ix += 2;
-                     std::memset(&b[ix], Opts.indentation_char, ctx.depth);
+                     std::memset(&b[ix], check_indentation_char(Opts), ctx.depth);
                      ix += ctx.depth;
                   }
                   else {
@@ -1345,10 +1345,10 @@ namespace glz
                      }
 
                      if constexpr (Opts.prettify) {
-                        if constexpr (Opts.new_lines_in_arrays) {
+                        if constexpr (check_new_lines_in_arrays(Opts)) {
                            std::memcpy(&b[ix], ",\n", 2);
                            ix += 2;
-                           std::memset(&b[ix], Opts.indentation_char, ctx.depth);
+                           std::memset(&b[ix], check_indentation_char(Opts), ctx.depth);
                            ix += ctx.depth;
                         }
                         else {
@@ -1374,9 +1374,9 @@ namespace glz
                      }
                   }
                }
-               if constexpr (Opts.prettify && Opts.new_lines_in_arrays) {
-                  ctx.depth -= Opts.indentation_width;
-                  dump_newline_indent(Opts.indentation_char, ctx.depth, b, ix);
+               if constexpr (Opts.prettify && check_new_lines_in_arrays(Opts)) {
+                  ctx.depth -= check_indentation_width(Opts);
+                  dump_newline_indent(check_indentation_char(Opts), ctx.depth, b, ix);
                }
 
                dump(']', b, ix);
@@ -1395,13 +1395,13 @@ namespace glz
          if (!empty_range(value)) {
             if constexpr (!check_opening_handled(Opts)) {
                if constexpr (Opts.prettify) {
-                  ctx.depth += Opts.indentation_width;
+                  ctx.depth += check_indentation_width(Opts);
                   if (!ensure_space(ctx, b, ix + ctx.depth + write_padding_bytes)) [[unlikely]] {
                      return;
                   }
                   std::memcpy(&b[ix], "\n", 1);
                   ++ix;
-                  std::memset(&b[ix], Opts.indentation_char, ctx.depth);
+                  std::memset(&b[ix], check_indentation_char(Opts), ctx.depth);
                   ix += ctx.depth;
                }
             }
@@ -1471,13 +1471,13 @@ namespace glz
 
             if constexpr (!check_closing_handled(Opts)) {
                if constexpr (Opts.prettify) {
-                  ctx.depth -= Opts.indentation_width;
+                  ctx.depth -= check_indentation_width(Opts);
                   if (!ensure_space(ctx, b, ix + ctx.depth + write_padding_bytes)) [[unlikely]] {
                      return;
                   }
                   std::memcpy(&b[ix], "\n", 1);
                   ++ix;
-                  std::memset(&b[ix], Opts.indentation_char, ctx.depth);
+                  std::memset(&b[ix], check_indentation_char(Opts), ctx.depth);
                   ix += ctx.depth;
                }
             }
@@ -1501,12 +1501,12 @@ namespace glz
          }
 
          if constexpr (Opts.prettify) {
-            ctx.depth += Opts.indentation_width;
+            ctx.depth += check_indentation_width(Opts);
             if (!ensure_space(ctx, b, ix + ctx.depth + 2)) [[unlikely]] {
                return;
             }
             dump<false>("{\n", b, ix);
-            std::memset(&b[ix], Opts.indentation_char, ctx.depth);
+            std::memset(&b[ix], check_indentation_char(Opts), ctx.depth);
             ix += ctx.depth;
          }
          else {
@@ -1519,8 +1519,8 @@ namespace glz
          }
 
          if constexpr (Opts.prettify) {
-            ctx.depth -= Opts.indentation_width;
-            dump_newline_indent(Opts.indentation_char, ctx.depth, b, ix);
+            ctx.depth -= check_indentation_width(Opts);
+            dump_newline_indent(check_indentation_char(Opts), ctx.depth, b, ix);
             dump<false>('}', b, ix);
          }
          else {
@@ -1640,8 +1640,8 @@ namespace glz
                   // must first write out type
                   if constexpr (Opts.prettify) {
                      dump("{\n", b, ix);
-                     ctx.depth += Opts.indentation_width;
-                     dumpn(Opts.indentation_char, ctx.depth, b, ix);
+                     ctx.depth += check_indentation_width(Opts);
+                     dumpn(check_indentation_char(Opts), ctx.depth, b, ix);
                      dump('"', b, ix);
                      dump_maybe_empty(tag_v<T>, b, ix);
 
@@ -1652,7 +1652,7 @@ namespace glz
                         serialize<JSON>::op<Opts>(ids_v<T>[value.index()], ctx, b, ix);
                         if constexpr (N > 0) {
                            dump(",\n", b, ix);
-                           dumpn(Opts.indentation_char, ctx.depth, b, ix);
+                           dumpn(check_indentation_char(Opts), ctx.depth, b, ix);
                         }
                      }
                      else {
@@ -1663,7 +1663,7 @@ namespace glz
                         }
                         else {
                            dump("\",\n", b, ix);
-                           dumpn(Opts.indentation_char, ctx.depth, b, ix);
+                           dumpn(check_indentation_char(Opts), ctx.depth, b, ix);
                         }
                      }
                   }
@@ -1709,13 +1709,13 @@ namespace glz
                   }
 
                   if constexpr (Opts.prettify) {
-                     ctx.depth -= Opts.indentation_width;
+                     ctx.depth -= check_indentation_width(Opts);
                      if (!ensure_space(ctx, b, ix + ctx.depth + write_padding_bytes)) [[unlikely]] {
                         return;
                      }
                      std::memcpy(&b[ix], "\n", 1);
                      ++ix;
-                     std::memset(&b[ix], Opts.indentation_char, ctx.depth);
+                     std::memset(&b[ix], check_indentation_char(Opts), ctx.depth);
                      ix += ctx.depth;
                      std::memcpy(&b[ix], "}", 1);
                      ++ix;
@@ -1741,19 +1741,19 @@ namespace glz
          auto& value = wrapper.value;
          dump('[', args...);
          if constexpr (Opts.prettify) {
-            ctx.depth += Opts.indentation_width;
-            dump_newline_indent(Opts.indentation_char, ctx.depth, args...);
+            ctx.depth += check_indentation_width(Opts);
+            dump_newline_indent(check_indentation_char(Opts), ctx.depth, args...);
          }
          dump('"', args...);
          dump_maybe_empty(ids_v<T>[value.index()], args...);
          dump("\",", args...);
          if constexpr (Opts.prettify) {
-            dump_newline_indent(Opts.indentation_char, ctx.depth, args...);
+            dump_newline_indent(check_indentation_char(Opts), ctx.depth, args...);
          }
          std::visit([&](auto&& v) { serialize<JSON>::op<Opts>(v, ctx, args...); }, value);
          if constexpr (Opts.prettify) {
-            ctx.depth -= Opts.indentation_width;
-            dump_newline_indent(Opts.indentation_char, ctx.depth, args...);
+            ctx.depth -= check_indentation_width(Opts);
+            dump_newline_indent(check_indentation_char(Opts), ctx.depth, args...);
          }
          dump(']', args...);
       }
@@ -1771,9 +1771,9 @@ namespace glz
 
          dump('[', args...);
          if constexpr (N > 0 && Opts.prettify) {
-            if constexpr (Opts.new_lines_in_arrays) {
-               ctx.depth += Opts.indentation_width;
-               dump_newline_indent(Opts.indentation_char, ctx.depth, args...);
+            if constexpr (check_new_lines_in_arrays(Opts)) {
+               ctx.depth += check_indentation_width(Opts);
+               dump_newline_indent(check_indentation_char(Opts), ctx.depth, args...);
             }
          }
          for_each<N>([&]<size_t I>() {
@@ -1789,9 +1789,9 @@ namespace glz
             }
          });
          if constexpr (N > 0 && Opts.prettify) {
-            if constexpr (Opts.new_lines_in_arrays) {
-               ctx.depth -= Opts.indentation_width;
-               dump_newline_indent(Opts.indentation_char, ctx.depth, args...);
+            if constexpr (check_new_lines_in_arrays(Opts)) {
+               ctx.depth -= check_indentation_width(Opts);
+               dump_newline_indent(check_indentation_char(Opts), ctx.depth, args...);
             }
          }
          dump(']', args...);
@@ -1816,9 +1816,9 @@ namespace glz
 
          dump('[', args...);
          if constexpr (N > 0 && Opts.prettify) {
-            if constexpr (Opts.new_lines_in_arrays) {
-               ctx.depth += Opts.indentation_width;
-               dump_newline_indent(Opts.indentation_char, ctx.depth, args...);
+            if constexpr (check_new_lines_in_arrays(Opts)) {
+               ctx.depth += check_indentation_width(Opts);
+               dump_newline_indent(check_indentation_char(Opts), ctx.depth, args...);
             }
          }
          using V = std::decay_t<T>;
@@ -1840,9 +1840,9 @@ namespace glz
             }
          });
          if constexpr (N > 0 && Opts.prettify) {
-            if constexpr (Opts.new_lines_in_arrays) {
-               ctx.depth -= Opts.indentation_width;
-               dump_newline_indent(Opts.indentation_char, ctx.depth, args...);
+            if constexpr (check_new_lines_in_arrays(Opts)) {
+               ctx.depth -= check_indentation_width(Opts);
+               dump_newline_indent(check_indentation_char(Opts), ctx.depth, args...);
             }
          }
          dump(']', args...);
@@ -1878,9 +1878,9 @@ namespace glz
          if constexpr (!check_opening_handled(Options)) {
             dump('{', b, ix);
             if constexpr (Options.prettify) {
-               ctx.depth += Options.indentation_width;
+               ctx.depth += check_indentation_width(Options);
                dump('\n', b, ix);
-               dumpn(Options.indentation_char, ctx.depth, b, ix);
+               dumpn(check_indentation_char(Options), ctx.depth, b, ix);
             }
          }
 
@@ -1934,9 +1934,9 @@ namespace glz
 
          if constexpr (!check_closing_handled(Options)) {
             if constexpr (Options.prettify) {
-               ctx.depth -= Options.indentation_width;
+               ctx.depth -= check_indentation_width(Options);
                dump('\n', b, ix);
-               dumpn(Options.indentation_char, ctx.depth, b, ix);
+               dumpn(check_indentation_char(Options), ctx.depth, b, ix);
             }
             dump('}', b, ix);
          }
@@ -1953,9 +1953,9 @@ namespace glz
          if constexpr (!check_opening_handled(Options)) {
             dump('{', b, ix);
             if constexpr (Options.prettify) {
-               ctx.depth += Options.indentation_width;
+               ctx.depth += check_indentation_width(Options);
                dump('\n', b, ix);
-               dumpn(Options.indentation_char, ctx.depth, b, ix);
+               dumpn(check_indentation_char(Options), ctx.depth, b, ix);
             }
          }
 
@@ -1984,9 +1984,9 @@ namespace glz
          }
 
          if constexpr (Options.prettify) {
-            ctx.depth -= Options.indentation_width;
+            ctx.depth -= check_indentation_width(Options);
             dump('\n', b, ix);
-            dumpn(Options.indentation_char, ctx.depth, b, ix);
+            dumpn(check_indentation_char(Options), ctx.depth, b, ix);
          }
          dump('}', b, ix);
       }
@@ -2063,13 +2063,13 @@ namespace glz
 
             if constexpr (not check_opening_handled(Options)) {
                if constexpr (Options.prettify) {
-                  ctx.depth += Options.indentation_width;
+                  ctx.depth += check_indentation_width(Options);
                   if (!ensure_space(ctx, b, ix + ctx.depth + write_padding_bytes)) [[unlikely]] {
                      return;
                   }
                   std::memcpy(&b[ix], "{\n", 2);
                   ix += 2;
-                  std::memset(&b[ix], Opts.indentation_char, ctx.depth);
+                  std::memset(&b[ix], check_indentation_char(Opts), ctx.depth);
                   ix += ctx.depth;
                }
                else {
@@ -2167,7 +2167,7 @@ namespace glz
                         if constexpr (Opts.prettify) {
                            std::memcpy(&b[ix], ",\n", 2);
                            ix += 2;
-                           std::memset(&b[ix], Opts.indentation_char, ctx.depth);
+                           std::memset(&b[ix], check_indentation_char(Opts), ctx.depth);
                            ix += ctx.depth;
                         }
                         else {
@@ -2225,7 +2225,7 @@ namespace glz
                   if constexpr (I != 0 && Opts.prettify) {
                      std::memcpy(&b[ix], ",\n", 2);
                      ix += 2;
-                     std::memset(&b[ix], Opts.indentation_char, ctx.depth);
+                     std::memset(&b[ix], check_indentation_char(Opts), ctx.depth);
                      ix += ctx.depth;
                   }
 
@@ -2276,13 +2276,13 @@ namespace glz
             // Options is required here, because it must be the top level
             if constexpr (not check_closing_handled(Options)) {
                if constexpr (Options.prettify) {
-                  ctx.depth -= Options.indentation_width;
+                  ctx.depth -= check_indentation_width(Options);
                   if (!ensure_space(ctx, b, ix + ctx.depth + write_padding_bytes)) [[unlikely]] {
                      return;
                   }
                   std::memcpy(&b[ix], "\n", 1);
                   ++ix;
-                  std::memset(&b[ix], Opts.indentation_char, ctx.depth);
+                  std::memset(&b[ix], check_indentation_char(Opts), ctx.depth);
                   ix += ctx.depth;
                   std::memcpy(&b[ix], "}", 1);
                   ++ix;

--- a/include/glaze/record/recorder.hpp
+++ b/include/glaze/record/recorder.hpp
@@ -74,9 +74,9 @@ namespace glz
          dump('{', std::forward<Args>(args)...);
 
          if constexpr (Opts.prettify) {
-            ctx.depth += Opts.indentation_width;
+            ctx.depth += check_indentation_width(Opts);
             dump('\n', args...);
-            dumpn(Opts.indentation_char, ctx.depth, args...);
+            dumpn(check_indentation_char(Opts), ctx.depth, args...);
          }
 
          const size_t n = value.data.size();
@@ -96,14 +96,14 @@ namespace glz
 
             if constexpr (Opts.prettify) {
                dump('\n', args...);
-               dumpn(Opts.indentation_char, ctx.depth, args...);
+               dumpn(check_indentation_char(Opts), ctx.depth, args...);
             }
          }
 
          if constexpr (Opts.prettify) {
-            ctx.depth -= Opts.indentation_width;
+            ctx.depth -= check_indentation_width(Opts);
             dump('\n', args...);
-            dumpn(Opts.indentation_char, ctx.depth, args...);
+            dumpn(check_indentation_char(Opts), ctx.depth, args...);
          }
          dump('}', args...);
       }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -41,6 +41,18 @@
 
 using namespace ut;
 
+// Custom opts for prettify without newlines in arrays
+struct opts_no_array_newlines : glz::opts
+{
+   bool new_lines_in_arrays = false;
+};
+
+struct opts_prettify_no_array_newlines : glz::opts
+{
+   bool prettify = true;
+   bool new_lines_in_arrays = false;
+};
+
 glz::trace trace{};
 
 struct jsonc_comment_config
@@ -226,7 +238,7 @@ suite starter = [] {
    ]
 })") << pretty;
 
-      pretty = glz::prettify_json<glz::opts{.new_lines_in_arrays = false}>(buffer);
+      pretty = glz::prettify_json<opts_no_array_newlines{}>(buffer);
       expect(pretty == R"({
    "i": 287,
    "d": 3.14,
@@ -1503,7 +1515,7 @@ suite user_types = [] {
    "complex user obect opts prettify, new_lines_in_arrays = false"_test = [] {
       Thing obj{};
       std::string buffer{};
-      expect(not glz::write<glz::opts{.prettify = true, .new_lines_in_arrays = false}>(obj, buffer));
+      expect(not glz::write<opts_prettify_no_array_newlines{}>(obj, buffer));
       std::string_view thing_pretty = R"({
    "thing": {
       "a": 3.14,


### PR DESCRIPTION
# Remove prettify options from `glz::opts` to reduce template sizes

## Summary

Moved `indentation_char`, `indentation_width`, and `new_lines_in_arrays` out of `glz::opts` into inheritable options. This reduces template instantiation sizes since these options are rarely customized.

## Changes

### Core changes (opts.hpp)
- Removed from `struct opts`:
  - `char indentation_char = ' '`
  - `uint8_t indentation_width = 3`
  - `bool new_lines_in_arrays = true`
- Added `check_*` functions that return defaults when options aren't present:
  - `check_indentation_char(Opts)` - defaults to `' '`
  - `check_indentation_width(Opts)` - defaults to `3`
  - `check_new_lines_in_arrays(Opts)` - defaults to `true`

### Library updates
Updated all usages to use the new check functions:
- `json/write.hpp`
- `json/prettify.hpp`
- `beve/beve_to_json.hpp`
- `cbor/cbor_to_json.hpp`
- `record/recorder.hpp`

### Documentation updates
- `docs/options.md`: Moved options from Core Options table to Inheritable Options table, added usage examples
- `docs/quick-start.md`: Updated custom indentation example to use inheritable pattern

## Migration

Users who customize these options should define them in a custom opts struct:

```cpp
struct my_opts : glz::opts {
   char indentation_char = '\t';
   uint8_t indentation_width = 1;
   bool new_lines_in_arrays = false;
};

glz::write<my_opts{.prettify = true}>(obj, buffer);
```