### PR TITLE
Fix hashing for sparse enums

### DIFF
--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -634,18 +634,22 @@ namespace glz
       offset, // Sequential values with offset: value - min_value
       power_of_two, // Powers of 2 (flags): countr_zero(value)
       small_range, // Sparse lookup table for small ranges
-      modular // Perfect hash: (value * seed) % table_size
+      modular, // Perfect hash: (value * seed) % table_size
+      modular_shifted // Perfect hash with shift: ((value >> shift) * seed) % table_size
    };
 
    template <size_t N, size_t TableSize>
    struct int_keys_info_t
    {
+      // Note: table must be first to work around Apple clang NTTP bug where
+      // arrays at the end of structs get corrupted when passed as template parameters
+      std::array<uint8_t, TableSize> table{}; // For small_range/modular: maps key → index
       int_hash_type type{};
       int64_t min_value{};
       int64_t max_value{};
       uint64_t seed{};
       size_t table_size{};
-      std::array<uint8_t, TableSize> table{}; // For small_range/modular: maps key → index
+      uint8_t shift{}; // Right shift to apply before modular hash (handles common power-of-2 factors)
    };
 
    // Specialization for when no table is needed
@@ -657,6 +661,7 @@ namespace glz
       int64_t max_value{};
       uint64_t seed{};
       size_t table_size{};
+      uint8_t shift{}; // Right shift to apply before modular hash (handles common power-of-2 factors)
    };
 
    template <class T>
@@ -776,6 +781,7 @@ namespace glz
          }
          else {
             // Strategy 4: Modular perfect hash (fallback)
+            // First try standard modular hash (faster lookup)
             constexpr auto modular_info = [&]() {
                for (const auto prime : primes_64) {
                   std::array<bool, table_size> used{};
@@ -797,17 +803,70 @@ namespace glz
                return std::pair{false, uint64_t{0}};
             }();
 
-            static_assert(modular_info.first, "Failed to find perfect hash seed for enum");
+            if constexpr (modular_info.first) {
+               // Standard modular hash works
+               int_keys_info_t<N, table_size> info{
+                  .type = int_hash_type::modular, .seed = modular_info.second, .table_size = table_size};
+               info.table.fill(static_cast<uint8_t>(N));
 
-            int_keys_info_t<N, table_size> info{
-               .type = int_hash_type::modular, .seed = modular_info.second, .table_size = table_size};
-            info.table.fill(static_cast<uint8_t>(N));
-
-            for (size_t i = 0; i < N; ++i) {
-               const auto h = (static_cast<uint64_t>(vals[i]) * info.seed) % table_size;
-               info.table[h] = static_cast<uint8_t>(i);
+               for (size_t i = 0; i < N; ++i) {
+                  const auto h = (static_cast<uint64_t>(vals[i]) * info.seed) % table_size;
+                  info.table[h] = static_cast<uint8_t>(i);
+               }
+               return info;
             }
-            return info;
+            else {
+               // Strategy 5: Modular hash with shift for sparse enums with common power-of-2 factors
+               constexpr uint8_t common_shift = [&]() -> uint8_t {
+                  uint8_t min_trailing = 64;
+                  for (const auto v : vals) {
+                     if (v != 0) {
+                        const auto trailing = static_cast<uint8_t>(std::countr_zero(static_cast<uint64_t>(v)));
+                        if (trailing < min_trailing) {
+                           min_trailing = trailing;
+                        }
+                     }
+                  }
+                  return min_trailing == 64 ? 0 : min_trailing;
+               }();
+
+               constexpr auto shifted_info = [&]() {
+                  for (const auto prime : primes_64) {
+                     std::array<bool, table_size> used{};
+                     bool collision = false;
+
+                     for (size_t i = 0; i < N; ++i) {
+                        const auto shifted = static_cast<uint64_t>(vals[i]) >> common_shift;
+                        const auto h = (shifted * prime) % table_size;
+                        if (used[h]) {
+                           collision = true;
+                           break;
+                        }
+                        used[h] = true;
+                     }
+
+                     if (!collision) {
+                        return std::pair{true, prime};
+                     }
+                  }
+                  return std::pair{false, uint64_t{0}};
+               }();
+
+               static_assert(shifted_info.first, "Failed to find perfect hash seed for enum");
+
+               int_keys_info_t<N, table_size> info{.type = int_hash_type::modular_shifted,
+                                                   .seed = shifted_info.second,
+                                                   .table_size = table_size,
+                                                   .shift = common_shift};
+               info.table.fill(static_cast<uint8_t>(N));
+
+               for (size_t i = 0; i < N; ++i) {
+                  const auto shifted = static_cast<uint64_t>(vals[i]) >> common_shift;
+                  const auto h = (shifted * info.seed) % table_size;
+                  info.table[h] = static_cast<uint8_t>(i);
+               }
+               return info;
+            }
          }
       }
    }
@@ -861,8 +920,13 @@ namespace glz
             }
             return Info.table[static_cast<size_t>(idx)]; // Returns N if slot is empty
          }
-         else { // modular
+         else if constexpr (Info.type == modular) {
             const auto h = (static_cast<uint64_t>(value) * Info.seed) % Info.table_size;
+            return Info.table[h]; // Returns N if slot is empty
+         }
+         else { // modular_shifted
+            const auto shifted = static_cast<uint64_t>(value) >> Info.shift;
+            const auto h = (shifted * Info.seed) % Info.table_size;
             return Info.table[h]; // Returns N if slot is empty
          }
       }
@@ -2537,6 +2601,8 @@ namespace glz
             return info;
          }
          else {
+            // Strategy 4: Modular perfect hash (fallback)
+            // First try standard modular hash (faster lookup)
             constexpr auto modular_info = [&]() {
                for (const auto prime : primes_64) {
                   std::array<bool, table_size> used{};
@@ -2558,17 +2624,70 @@ namespace glz
                return std::pair{false, uint64_t{0}};
             }();
 
-            static_assert(modular_info.first, "Failed to find perfect hash seed for variant int IDs");
+            if constexpr (modular_info.first) {
+               // Standard modular hash works
+               int_keys_info_t<N, table_size> info{
+                  .type = int_hash_type::modular, .seed = modular_info.second, .table_size = table_size};
+               info.table.fill(static_cast<uint8_t>(N));
 
-            int_keys_info_t<N, table_size> info{
-               .type = int_hash_type::modular, .seed = modular_info.second, .table_size = table_size};
-            info.table.fill(static_cast<uint8_t>(N));
-
-            for (size_t i = 0; i < N; ++i) {
-               const auto h = (static_cast<uint64_t>(vals[i]) * info.seed) % table_size;
-               info.table[h] = static_cast<uint8_t>(i);
+               for (size_t i = 0; i < N; ++i) {
+                  const auto h = (static_cast<uint64_t>(vals[i]) * info.seed) % table_size;
+                  info.table[h] = static_cast<uint8_t>(i);
+               }
+               return info;
             }
-            return info;
+            else {
+               // Strategy 5: Modular hash with shift for sparse values with common power-of-2 factors
+               constexpr uint8_t common_shift = [&]() -> uint8_t {
+                  uint8_t min_trailing = 64;
+                  for (const auto v : vals) {
+                     if (v != 0) {
+                        const auto trailing = static_cast<uint8_t>(std::countr_zero(static_cast<uint64_t>(v)));
+                        if (trailing < min_trailing) {
+                           min_trailing = trailing;
+                        }
+                     }
+                  }
+                  return min_trailing == 64 ? 0 : min_trailing;
+               }();
+
+               constexpr auto shifted_info = [&]() {
+                  for (const auto prime : primes_64) {
+                     std::array<bool, table_size> used{};
+                     bool collision = false;
+
+                     for (size_t i = 0; i < N; ++i) {
+                        const auto shifted = static_cast<uint64_t>(vals[i]) >> common_shift;
+                        const auto h = (shifted * prime) % table_size;
+                        if (used[h]) {
+                           collision = true;
+                           break;
+                        }
+                        used[h] = true;
+                     }
+
+                     if (!collision) {
+                        return std::pair{true, prime};
+                     }
+                  }
+                  return std::pair{false, uint64_t{0}};
+               }();
+
+               static_assert(shifted_info.first, "Failed to find perfect hash seed for variant int IDs");
+
+               int_keys_info_t<N, table_size> info{.type = int_hash_type::modular_shifted,
+                                                   .seed = shifted_info.second,
+                                                   .table_size = table_size,
+                                                   .shift = common_shift};
+               info.table.fill(static_cast<uint8_t>(N));
+
+               for (size_t i = 0; i < N; ++i) {
+                  const auto shifted = static_cast<uint64_t>(vals[i]) >> common_shift;
+                  const auto h = (shifted * info.seed) % table_size;
+                  info.table[h] = static_cast<uint8_t>(i);
+               }
+               return info;
+            }
          }
       }
    }
@@ -2636,8 +2755,13 @@ namespace glz
             }
             return Info.table[static_cast<size_t>(idx)];
          }
-         else { // modular
+         else if constexpr (Info.type == modular) {
             const auto h = (static_cast<uint64_t>(id) * Info.seed) % Info.table_size;
+            return Info.table[h];
+         }
+         else { // modular_shifted
+            const auto shifted = static_cast<uint64_t>(id) >> Info.shift;
+            const auto h = (shifted * Info.seed) % Info.table_size;
             return Info.table[h];
          }
       }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -349,6 +349,141 @@ suite enum_tests = [] {
    };
 };
 
+// Issue #2246: Sparse enums with huge values that share common power-of-2 factors
+// These enums previously failed to compile with "Failed to find perfect hash seed for enum"
+// because values like 0 and 400,000,000 both hash to 0 with standard modular hash.
+// The fix adds a modular_shifted hash type that removes common trailing zeros before hashing.
+
+enum class SparseEnum : int {
+   Zero = 0,
+   FourHundredMillion = 400000000
+};
+
+template <>
+struct glz::meta<SparseEnum>
+{
+   using enum SparseEnum;
+   static constexpr auto value = enumerate(Zero, FourHundredMillion);
+};
+
+// Another sparse enum with values that have common factors
+enum class SparseEnumMillions : int {
+   A = 0,
+   B = 1000000,
+   C = 2000000
+};
+
+template <>
+struct glz::meta<SparseEnumMillions>
+{
+   using enum SparseEnumMillions;
+   static constexpr auto value = enumerate(A, B, C);
+};
+
+// Sparse enum with power-of-2 gaps (tests that standard modular still works when possible)
+enum class SparseEnumPow2 : int {
+   X = 1,
+   Y = 1024,
+   Z = 65536
+};
+
+template <>
+struct glz::meta<SparseEnumPow2>
+{
+   using enum SparseEnumPow2;
+   static constexpr auto value = enumerate(X, Y, Z);
+};
+
+// Test struct for sparse enum in object test
+struct SparseEnumTestStruct
+{
+   SparseEnum e1{SparseEnum::Zero};
+   SparseEnum e2{SparseEnum::FourHundredMillion};
+};
+
+suite sparse_enum_tests = [] {
+   "sparse_enum_serialization"_test = [] {
+      // Test issue #2246: enum values 0 and 400,000,000
+      SparseEnum e = SparseEnum::Zero;
+      std::string json;
+      expect(not glz::write_json(e, json));
+      expect(json == "\"Zero\"") << json;
+
+      e = SparseEnum::FourHundredMillion;
+      json.clear();
+      expect(not glz::write_json(e, json));
+      expect(json == "\"FourHundredMillion\"") << json;
+   };
+
+   "sparse_enum_deserialization"_test = [] {
+      SparseEnum e;
+      expect(not glz::read_json(e, R"("Zero")"));
+      expect(e == SparseEnum::Zero);
+
+      expect(not glz::read_json(e, R"("FourHundredMillion")"));
+      expect(e == SparseEnum::FourHundredMillion);
+   };
+
+   "sparse_enum_roundtrip"_test = [] {
+      for (auto val : {SparseEnum::Zero, SparseEnum::FourHundredMillion}) {
+         std::string json;
+         expect(not glz::write_json(val, json));
+
+         SparseEnum parsed;
+         expect(not glz::read_json(parsed, json));
+         expect(parsed == val);
+      }
+   };
+
+   "sparse_enum_millions_roundtrip"_test = [] {
+      for (auto val : {SparseEnumMillions::A, SparseEnumMillions::B, SparseEnumMillions::C}) {
+         std::string json;
+         expect(not glz::write_json(val, json));
+
+         SparseEnumMillions parsed;
+         expect(not glz::read_json(parsed, json));
+         expect(parsed == val);
+      }
+   };
+
+   "sparse_enum_pow2_roundtrip"_test = [] {
+      for (auto val : {SparseEnumPow2::X, SparseEnumPow2::Y, SparseEnumPow2::Z}) {
+         std::string json;
+         expect(not glz::write_json(val, json));
+
+         SparseEnumPow2 parsed;
+         expect(not glz::read_json(parsed, json));
+         expect(parsed == val);
+      }
+   };
+
+   "sparse_enum_get_name"_test = [] {
+      expect(glz::get_enum_name(SparseEnum::Zero) == "Zero");
+      expect(glz::get_enum_name(SparseEnum::FourHundredMillion) == "FourHundredMillion");
+      expect(glz::get_enum_name(SparseEnumMillions::A) == "A");
+      expect(glz::get_enum_name(SparseEnumMillions::B) == "B");
+      expect(glz::get_enum_name(SparseEnumMillions::C) == "C");
+   };
+
+   "sparse_enum_invalid_value"_test = [] {
+      // Test that invalid enum values return empty string
+      auto invalid = static_cast<SparseEnum>(12345);
+      expect(glz::get_enum_name(invalid).empty());
+   };
+
+   "sparse_enum_in_struct"_test = [] {
+      SparseEnumTestStruct obj;
+      std::string json;
+      expect(not glz::write_json(obj, json));
+      expect(json == R"({"e1":"Zero","e2":"FourHundredMillion"})") << json;
+
+      SparseEnumTestStruct parsed;
+      expect(not glz::read_json(parsed, json));
+      expect(parsed.e1 == SparseEnum::Zero);
+      expect(parsed.e2 == SparseEnum::FourHundredMillion);
+   };
+};
+
 static constexpr auto MY_ARRAY_MAX = 2;
 
 struct MyArrayStruct


### PR DESCRIPTION
## Problem

Sparse enums with values that share common power-of-2 factors failed to compile with:
```
Failed to find perfect hash seed for enum
```

Example that previously failed:
```cpp
enum class SparseEnum : int {
   Zero = 0,
   FourHundredMillion = 400000000
};
```

Both values are divisible by 2^10 (1024), so `value % table_size` produces the same hash bucket for any table size that's a power of 2.

## Solution

Added a new `modular_shifted` hash type that removes common trailing zeros before hashing:

1. **Hash selection order:**
   - First try standard `modular` hash (faster lookup)
   - Fall back to `modular_shifted` only when standard modular fails

2. **How `modular_shifted` works:**
   - Calculate the minimum trailing zeros across all enum values
   - Right-shift values by that amount before applying modular hash
   - For `{0, 400000000}`: shift by 10 gives `{0, 390625}`, which hash to different buckets

3. **Struct layout fix:**
   - Moved `table` array to beginning of `int_keys_info_t` to work around Apple clang NTTP bug

- `tests/json_test/json_test.cpp`:
  - Added 8 unit tests for sparse enum support