### PR TITLE
Mimic string pair fix

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2378,7 +2378,8 @@ namespace glz
             using V = std::decay_t<decltype(item)>;
 
             if constexpr (str_t<typename V::first_type> ||
-                          (std::is_enum_v<typename V::first_type> && glaze_t<typename V::first_type>)) {
+                          (std::is_enum_v<typename V::first_type> && glaze_t<typename V::first_type>) ||
+                          mimics_str_t<typename V::first_type>) {
                parse<JSON>::op<Opts>(item.first, ctx, it, end);
                if (bool(ctx.error)) [[unlikely]]
                   return;
@@ -2773,7 +2774,7 @@ namespace glz
          }
 
          using first_type = typename T::first_type;
-         if constexpr (str_t<first_type> || is_named_enum<first_type>) {
+         if constexpr (str_t<first_type> || is_named_enum<first_type> || mimics_str_t<first_type>) {
             parse<JSON>::op<Opts>(value.first, ctx, it, end);
             if (bool(ctx.error)) [[unlikely]]
                return;

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -6651,6 +6651,45 @@ suite mimics_string_key_tests = [] {
       static_assert(glz::mimics_str_t<mimics_string_key>);
       expect(true);
    };
+
+   // Test for issue #2285: mimic = std::string doesn't work in std::vector<std::pair<...>>
+   "mimics<T, std::string> in vector<pair> write"_test = [] {
+      std::vector<std::pair<mimics_string_key, mimics_string_key>> v{
+         {{"key1"}, {"value1"}}, {{"key2"}, {"value2"}}};
+
+      std::string buffer{};
+      expect(not glz::write_json(v, buffer));
+      expect(buffer == R"({"key1":"value1","key2":"value2"})") << buffer;
+   };
+
+   "mimics<T, std::string> in vector<pair> read"_test = [] {
+      std::vector<std::pair<mimics_string_key, mimics_string_key>> v;
+      std::string json = R"({"key1":"value1","key2":"value2"})";
+
+      expect(not glz::read_json(v, json));
+      expect(v.size() == 2);
+      expect(v[0].first.value == "key1");
+      expect(v[0].second.value == "value1");
+      expect(v[1].first.value == "key2");
+      expect(v[1].second.value == "value2");
+   };
+
+   "mimics<T, std::string> in vector<pair> roundtrip"_test = [] {
+      std::vector<std::pair<mimics_string_key, mimics_string_key>> original{
+         {{"key1"}, {"value1"}}, {{"key2"}, {"value2"}}};
+
+      std::string buffer{};
+      expect(not glz::write_json(original, buffer));
+
+      std::vector<std::pair<mimics_string_key, mimics_string_key>> parsed;
+      expect(not glz::read_json(parsed, buffer));
+
+      expect(parsed.size() == original.size());
+      for (size_t i = 0; i < original.size(); ++i) {
+         expect(parsed[i].first.value == original[i].first.value);
+         expect(parsed[i].second.value == original[i].second.value);
+      }
+   };
 };
 
 suite char_array = [] {


### PR DESCRIPTION
## Fix `mimic = std::string` not working in `std::vector<std::pair<...>>` (Issue #2285)

### Problem

When a custom type with `mimic = std::string` was used as a key in `std::vector<std::pair<...>>`, JSON writing worked correctly but reading failed with an `expected_quote` error.

```cpp
struct string_like {
    std::string str;
};

template<>
struct glz::meta<string_like> {
    using mimic = std::string;
    static constexpr auto value = &string_like::str;
};

std::vector<std::pair<string_like, string_like>> v;
// Writing produces: {"key1":"value1","key2":"value2"}
// Reading failed with: expected_quote
```

### Cause

The JSON read code was missing `mimics_str_t` checks in two locations where pair keys are parsed, while the write code correctly handled this case.

### Fix

Added `mimics_str_t` to the key type checks in `include/glaze/json/read.hpp`:

1. **Line 2776** - `from<JSON, pair_t<T>>` specialization
2. **Line 2382** - `from<JSON, readable_array_t<T>>` specialization for vector-of-pairs