### PR TITLE
Use Windows runners with Visual Studio 2026 for MSVC workflow

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     timeout-minutes: 10
 
     strategy:


### PR DESCRIPTION
This pull request changes the Windows runner to `windows-2025-vs2026`, which contains Visual Studio 2026, with the latest (19.50) version of MSVC. We can return to `windows-latest` when Visual Studio 2026 gets integrated into it with the GA on 4 May. For details, see [this blog post](https://github.blog/changelog/2026-02-05-github-actions-early-february-2026-updates/#windows-server-2025-with-visual-studio-2026-image-now-available-for-github-hosted-runners). 