### PR TITLE
glz::get support for generic_i64 and generic_u64

### DIFF
--- a/tests/json_test/generic_int_test.cpp
+++ b/tests/json_test/generic_int_test.cpp
@@ -69,6 +69,24 @@ suite generic_i64_tests = [] {
       expect(json["value"].get<double>() == 3.14);
    };
 
+   "i64_json_ptr_get_and_get_if"_test = [] {
+      glz::generic_i64 json{};
+      std::string buffer = R"({"Example":{"enabled":true,"name":"test"}})";
+      expect(glz::read_json(json, buffer) == glz::error_code::none);
+
+      auto enabled = glz::get<bool>(json, "/Example/enabled");
+      expect(enabled.has_value());
+      expect(enabled->get() == true);
+
+      auto name = glz::get<std::string>(json, "/Example/name");
+      expect(name.has_value());
+      expect(name->get() == "test");
+
+      auto* name_if = glz::get_if<std::string>(json, "/Example/name");
+      expect(name_if != nullptr);
+      expect(*name_if == "test");
+   };
+
    "i64_in_array"_test = [] {
       glz::generic_i64 json{};
       std::string buffer = "[1, 2, 3, 4, 5]";
@@ -301,6 +319,24 @@ suite generic_u64_tests = [] {
       // value should be double
       expect(json["value"].is_double());
       expect(json["value"].get<double>() == 3.14);
+   };
+
+   "u64_json_ptr_get_and_get_if"_test = [] {
+      glz::generic_u64 json{};
+      std::string buffer = R"({"Example":{"enabled":true,"name":"test"}})";
+      expect(glz::read_json(json, buffer) == glz::error_code::none);
+
+      auto enabled = glz::get<bool>(json, "/Example/enabled");
+      expect(enabled.has_value());
+      expect(enabled->get() == true);
+
+      auto name = glz::get<std::string>(json, "/Example/name");
+      expect(name.has_value());
+      expect(name->get() == "test");
+
+      auto* name_if = glz::get_if<std::string>(json, "/Example/name");
+      expect(name_if != nullptr);
+      expect(*name_if == "test");
    };
 
    "u64_as_conversion"_test = [] {


### PR DESCRIPTION
## Summary

Fixes JSON pointer lookups for `glz::generic_i64` and `glz::generic_u64` when using `glz::get<>` and `glz::get_if<>` (issue #2315).

## Changes from `main`

- `include/glaze/json/generic.hpp`
  - Generalized `seek_op` specialization from `glz::generic` to `glz::generic_json<Mode>`.
  - Generalized `navigate_to` overloads to support all generic number modes.
  - Generalized container-deserializing `glz::get` overloads to support all `generic_json<Mode>` types.
- `tests/json_test/generic_int_test.cpp`
  - Added regression tests for JSON pointer access on both `generic_i64` and `generic_u64`:
    - `glz::get<bool>(..., "/Example/enabled")`
    - `glz::get<std::string>(..., "/Example/name")`
    - `glz::get_if<std::string>(..., "/Example/name")`