### PR TITLE
Additional websocket handshake header support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ out/
 CMakeUserPresets.json
 **/CMakeFiles/
 **/CMakeCache.txt
+**/Testing/
 
 # IDE files
 .idea/


### PR DESCRIPTION
## Summary

Adds configurable WebSocket client handshake headers for authenticated endpoints, with strict header validation and clearer error reporting.

## Changes from `main`

- `include/glaze/net/websocket_client.hpp`
  - Added `set_header()`, `clear_headers()`, and `last_header_error()`.
  - Added `header_validation_error` for rejected header diagnostics.
  - Stores extra request headers and appends them to the opening handshake.
  - Rejects reserved handshake headers (`Host`, `Upgrade`, `Connection`, `Sec-WebSocket-*`), invalid names, and invalid values (e.g. CR/LF injection).
  - Uses ASCII-only header token validation and case-insensitive header replacement.
- `tests/networking_tests/websocket_test/websocket_client_test.cpp`
  - Added an auth-gated WebSocket test server helper.
  - Added coverage for valid auth header usage, clearing headers, replacement behavior, persistence across reconnects, and rejection cases (`empty_name`, `reserved_name`, `invalid_name`, `invalid_value`, non-ASCII names).
- `docs/networking/websocket-client.md`
  - Documented the new header APIs and validation behavior.
  - Added an authenticated client example.
  - Clarified that `clear_headers()` does not reset `last_header_error()`.
- `.gitignore`
  - Added `**/Testing/` to ignore CTest temporary output.