### PR TITLE
check_null_terminated to fix glz::custom for yaml_opts

### DIFF
--- a/include/glaze/core/cast.hpp
+++ b/include/glaze/core/cast.hpp
@@ -65,7 +65,7 @@ namespace glz
          Cast temp{};
          parse<Format>::template op<Opts>(temp, ctx, it, end);
          if (bool(ctx.error)) [[unlikely]] {
-            if constexpr (Opts.null_terminated) {
+            if constexpr (check_null_terminated(Opts)) {
                return;
             }
             else if (ctx.error != error_code::end_reached) {
@@ -86,7 +86,7 @@ namespace glz
          Cast temp{};
          parse<Format>::template op<Opts>(temp, tag, ctx, it, end);
          if (bool(ctx.error)) [[unlikely]] {
-            if constexpr (Opts.null_terminated) {
+            if constexpr (check_null_terminated(Opts)) {
                return;
             }
             else if (ctx.error != error_code::end_reached) {

--- a/include/glaze/core/custom.hpp
+++ b/include/glaze/core/custom.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "glaze/core/context.hpp"
+#include "glaze/core/opts.hpp"
 #include "glaze/core/read.hpp"
 #include "glaze/core/wrappers.hpp"
 #include "glaze/core/write.hpp"
@@ -37,7 +38,7 @@ namespace glz
                   else if constexpr (glz::tuple_size_v<Tuple> == 1) {
                      std::decay_t<glz::tuple_element_t<0, Tuple>> input{};
                      parse<Format>::template op<Opts>(input, ctx, it, end);
-                     if constexpr (Opts.null_terminated) {
+                     if constexpr (check_null_terminated(Opts)) {
                         if (bool(ctx.error)) [[unlikely]]
                            return;
                      }
@@ -72,7 +73,7 @@ namespace glz
                      else if constexpr (glz::tuple_size_v<Tuple> == 1) {
                         std::decay_t<glz::tuple_element_t<0, Tuple>> input{};
                         parse<Format>::template op<Opts>(input, ctx, it, end);
-                        if constexpr (Opts.null_terminated) {
+                        if constexpr (check_null_terminated(Opts)) {
                            if (bool(ctx.error)) [[unlikely]]
                               return;
                         }
@@ -116,7 +117,7 @@ namespace glz
                   else if constexpr (N > 1) {
                      std::decay_t<glz::tuple_element_t<1, Tuple>> input{};
                      parse<Format>::template op<Opts>(input, ctx, it, end);
-                     if constexpr (Opts.null_terminated) {
+                     if constexpr (check_null_terminated(Opts)) {
                         if (bool(ctx.error)) [[unlikely]]
                            return;
                      }

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -388,6 +388,16 @@ namespace glz
       }
    }
 
+   consteval bool check_null_terminated(auto&& Opts)
+   {
+      if constexpr (requires { Opts.null_terminated; }) {
+         return Opts.null_terminated;
+      }
+      else {
+         return false;
+      }
+   }
+
    consteval bool check_partial_read(auto&& Opts)
    {
       if constexpr (requires { Opts.partial_read; }) {

--- a/include/glaze/core/read.hpp
+++ b/include/glaze/core/read.hpp
@@ -154,7 +154,9 @@ namespace glz
       // For streaming, we need null_terminated = false to track depth
       static constexpr auto StreamingOpts = [] {
          auto o = is_padded_off<Opts>();
-         o.null_terminated = false;
+         if constexpr (requires { o.null_terminated = false; }) {
+            o.null_terminated = false;
+         }
          return o;
       }();
 


### PR DESCRIPTION
## Summary

Fix YAML compile failures when using `glz::custom` (issue #2310) by making `null_terminated` optional in core option handling.

## Changes from `main`

- `include/glaze/core/opts.hpp`
  - Added `check_null_terminated(...)` in the same style as existing `check_*` option probes.
  - Default behavior is `false` when an opts type does not define `null_terminated`.

- `include/glaze/core/custom.hpp`
  - Replaced direct `Opts.null_terminated` usage with `check_null_terminated(Opts)` in custom read paths.
  - This allows formats like YAML opts to omit `null_terminated` entirely.

- `include/glaze/core/cast.hpp`
  - Replaced direct `Opts.null_terminated` checks with `check_null_terminated(Opts)` for consistency and compatibility.

- `include/glaze/core/read.hpp`
  - Guarded streaming opts mutation with `requires { o.null_terminated = false; }` so opts types with non-mutable/static option fields still compile.

- `tests/yaml_test/yaml_test.cpp`
  - Added a regression test (`read_custom_meta_field`) that exercises `glz::read_yaml` with a `glz::custom` field.