### PR TITLE
Fix enum hashed-lookup bounds check on truncated JSON strings

### DIFF
--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -2147,7 +2147,7 @@ namespace glz
             const auto* c = quote_memchr<HashInfo.min_length>(it, end);
             if (c) [[likely]] {
                const auto n = size_t(static_cast<std::decay_t<decltype(it)>>(c) - it);
-               if (n == 0 || n > HashInfo.max_length) [[unlikely]] {
+               if (n == 0 || n > HashInfo.max_length || HashInfo.unique_index >= size_t(end-it) ) [[unlikely]] {
                   return N; // error
                }
 

--- a/tests/json_reflection_test/json_reflection_test.cpp
+++ b/tests/json_reflection_test/json_reflection_test.cpp
@@ -1269,6 +1269,39 @@ struct glz::meta<rename_with_modify>
    static constexpr auto modify = glz::object("first_alias", &rename_with_modify::first);
 };
 
+enum class enum_fuzz_case {
+   aaaa,
+   aaa,
+   aab,
+   aac,
+};
+
+template <>
+struct glz::meta<enum_fuzz_case>
+{
+   using enum enum_fuzz_case;
+   static constexpr auto value = glz::enumerate("aaaa", aaaa, "aaa", aaa, "aab", aab, "aac", aac);
+};
+
+struct enum_container
+{
+   enum_fuzz_case enum_field{};
+};
+
+suite unique_index_sized_hash_bounds = [] {
+   "truncated enum payload does not read out of bounds"_test = [] {
+      enum_container obj{};
+
+      // Truncated quoted enum payload:
+      // {"enum_field":":
+      // (truncated immediately after the closing quote of enum string)
+      using namespace std::string_view_literals;
+      constexpr auto json = R"({"enum_field":":")"sv;
+      const auto ec = glz::read_json(obj, json);
+      expect(ec != glz::error_code::none);
+   };
+};
+
 suite rename_tests = [] {
    "rename"_test = [] {
       renamed_t obj{};


### PR DESCRIPTION
## Summary
This PR fixes a bounds issue in enum reflection parsing when using the sized-hash fast path on malformed/truncated JSON input.

## What changed
- Added an additional guard in `reflect.hpp` to ensure `HashInfo.unique_index` is within the remaining input span before indexing.
- Added a regression test in `json_reflection_test.cpp` that feeds a truncated enum payload and asserts parsing fails cleanly (instead of risking out-of-bounds access).

## Why
A truncated quoted enum value could pass earlier length checks but still allow an invalid index into the remaining buffer. The new condition prevents that read.
