### PR TITLE
Fix json_shema handling for glz::modify

### DIFF
--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -586,9 +586,24 @@ namespace glz
             std::sort(fields.begin(), fields.end());
 
             for (const auto& key : json_schema_names) {
-               if (!std::binary_search(fields.begin(), fields.end(), key)) {
-                  return false;
+               if (std::binary_search(fields.begin(), fields.end(), key)) {
+                  continue;
                }
+               // For types with modify, json_schema members may use original C++ member names
+               if constexpr (modify_t<std::decay_t<T>>) {
+                  constexpr auto& original_fields = member_names<std::decay_t<T>>;
+                  bool found = false;
+                  for (const auto& field : original_fields) {
+                     if (field == key) {
+                        found = true;
+                        break;
+                     }
+                  }
+                  if (found) {
+                     continue;
+                  }
+               }
+               return false;
             }
             return true;
          }
@@ -666,11 +681,21 @@ namespace glz
                   // Instead we just loop over the keys, looking for a match:
 
                   constexpr auto schema_index = [] {
-                     size_t i{};
                      const auto& schema_keys = reflect<json_schema_type<T>>::keys;
-                     for (; i < json_schema_size; ++i) {
+                     for (size_t i = 0; i < json_schema_size; ++i) {
                         if (schema_keys[i] == key) {
                            return i;
+                        }
+                     }
+                     // For modify types, try matching by original C++ member name
+                     if constexpr (modify_t<std::decay_t<T>> && I < count_members<std::decay_t<T>>) {
+                        constexpr sv original_name = member_names<std::decay_t<T>>[I];
+                        if constexpr (original_name != key) {
+                           for (size_t i = 0; i < json_schema_size; ++i) {
+                              if (schema_keys[i] == original_name) {
+                                 return i;
+                              }
+                           }
                         }
                      }
                      return json_schema_size;

--- a/tests/json_reflection_test/json_reflection_test.cpp
+++ b/tests/json_reflection_test/json_reflection_test.cpp
@@ -81,6 +81,28 @@ struct glz::meta<schema_modify_sample>
 
 static_assert(glz::glaze_object_t<schema_modify_sample>);
 
+struct modify_rename_schema_test
+{
+   int enum_{};
+   std::string class_{};
+};
+
+template <>
+struct glz::meta<modify_rename_schema_test>
+{
+   using T = modify_rename_schema_test;
+   static constexpr auto modify = glz::object(
+      "enum", &T::enum_,
+      "class", &T::class_);
+};
+
+template <>
+struct glz::json_schema<modify_rename_schema_test>
+{
+   glz::schema enum_{.description = "enum field"};
+   glz::schema class_{.description = "class field"};
+};
+
 struct modify_header
 {
    std::string id{"id"};
@@ -333,6 +355,16 @@ suite modify_json_schema = [] {
       expect(schema.find(R"("primary_alias")") != std::string::npos) << schema;
       expect(schema.find(R"("value")") == std::string::npos) << schema;
       expect(schema.find(R"("note")") != std::string::npos) << schema;
+   };
+
+   "json_schema with modify rename"_test = [] {
+      const auto schema = glz::write_json_schema<modify_rename_schema_test>().value_or("error");
+      // Keys should use the renamed names from modify
+      expect(schema.find(R"("enum")") != std::string::npos) << schema;
+      expect(schema.find(R"("class")") != std::string::npos) << schema;
+      // Schema descriptions should be applied
+      expect(schema.find(R"("enum field")") != std::string::npos) << schema;
+      expect(schema.find(R"("class field")") != std::string::npos) << schema;
    };
 };
 


### PR DESCRIPTION
## Fix `glz::json_schema` with `modify` rename (#2346)

When using `glz::meta::modify` to rename a field (e.g., `enum_` → `"enum"`), registering a `glz::json_schema` for that type failed with a `static_assert` because the json_schema member names (valid C++ identifiers like `enum_`) didn't match the renamed serialization keys (like `"enum"`).

### Changes

**`include/glaze/json/schema.hpp`**

- `json_schema_matches_object_keys()`: After checking against renamed serialization keys, also accept original C++ member names for `modify_t` types.
- Schema index lookup in `to_json_schema`: When the renamed key doesn't match any json_schema member, fall back to matching by the original C++ member name.

**`tests/json_reflection_test/json_reflection_test.cpp`**

- Added test struct `modify_rename_schema_test` that renames `enum_` → `"enum"` and `class_` → `"class"` via `modify`, with a `json_schema` using the original C++ member names.
- Added test verifying both the renamed keys and schema descriptions appear in the generated JSON schema.