### PR TITLE
JSON schema value support

### DIFF
--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -338,6 +338,25 @@ namespace glz
             if constexpr (glaze_t<T> && std::is_member_object_pointer_v<meta_wrapper_t<T>>) {
                using val_t = member_t<T, meta_wrapper_t<T>>;
                to_json_schema<val_t>::template op<Opts>(s, defs);
+               if constexpr (json_schema_t<T>) {
+                  static constexpr auto schema_size = reflect<json_schema_type<T>>::size;
+                  if constexpr (schema_size > 0) {
+                     static constexpr sv member_name = get_name<meta_wrapper_v<T>>();
+                     constexpr auto schema_index = [] {
+                        const auto& schema_keys = reflect<json_schema_type<T>>::keys;
+                        for (size_t i = 0; i < schema_size; ++i) {
+                           if (schema_keys[i] == member_name) {
+                              return i;
+                           }
+                        }
+                        return schema_size;
+                     }();
+                     if constexpr (schema_index < schema_size) {
+                        static const auto schema_v = json_schema_type<T>{};
+                        s.attributes = get<schema_index>(to_tie(schema_v));
+                     }
+                  }
+               }
             }
             else if constexpr (glaze_const_value_t<T>) { // &T::constexpr_member
                using constexpr_val_t = member_t<T, meta_wrapper_t<T>>;

--- a/tests/json_test/jsonschema_test.cpp
+++ b/tests/json_test/jsonschema_test.cpp
@@ -474,4 +474,41 @@ suite schema_tests = [] {
    };
 };
 
+struct identifier
+{
+   std::string value;
+};
+
+template <>
+struct glz::meta<identifier>
+{
+   static constexpr auto value{&identifier::value};
+};
+
+template <>
+struct glz::json_schema<identifier>
+{
+   schema value{.description = "C++ identifier"};
+};
+
+struct cpp_class
+{
+   identifier name;
+};
+
+suite value_type_schema = [] {
+   "value_type_json_schema"_test = [] {
+      auto s = glz::write_json_schema<cpp_class>().value();
+      auto obj = glz::read_json<glz::detail::schematic>(s);
+      expect(obj.has_value()) << "Failed to parse schema";
+
+      // The $defs/identifier definition should have the description from json_schema<identifier>
+      expect(obj->defs.has_value());
+      auto it = obj->defs->find("identifier");
+      expect(it != obj->defs->end());
+      expect(it->second.attributes.description.has_value());
+      expect(*it->second.attributes.description == "C++ identifier");
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
# Support `json_schema` metadata for value types

Fixes #2349

## Problem

Types that use `glz::meta<T>::value` as a single member pointer (value types / newtypes) had no way to attach JSON schema metadata like `description` or `deprecated`. The schema generator delegated to the wrapped type but never checked for a `glz::json_schema<T>` specialization, so any metadata was silently ignored.

## Solution

After generating the schema for the wrapped type, the value type code path now checks for a `json_schema<T>` specialization. It extracts the member name from the member pointer via `get_name<meta_wrapper_v<T>>()`, matches it against the field names in the `json_schema` struct, and applies the matching schema attributes to the definition.

This allows users to write:

```cpp
struct identifier {
   std::string value;
};

template <>
struct glz::meta<identifier> {
   static constexpr auto value{ &identifier::value };
};

template <>
struct glz::json_schema<identifier> {
   schema value{ .description = "C++ identifier" };
};
```

Which produces a `$defs` entry with the metadata included:

```json
"identifier": {
   "type": ["string"],
   "description": "C++ identifier"
}
```

## Changes

- **`include/glaze/json/schema.hpp`**: Added `json_schema<T>` lookup in the value type (`&T::member`) branch of `to_json_schema`, matching by member name for correctness.
- **`tests/json_test/jsonschema_test.cpp`**: Added test verifying that `json_schema` metadata appears in the generated schema for a value type.