### PR TITLE
make stream_request buffer size configurable + update docs

### DIFF
--- a/docs/networking/http-client.md
+++ b/docs/networking/http-client.md
@@ -182,45 +182,45 @@ void post_json_async(
 The HTTP client supports streaming requests, which allow you to receive data in chunks.
 
 ```cpp
-std::shared_ptr<http_stream_connection> stream_request(const stream_request_params& params);
+std::shared_ptr<http_stream_connection> stream_request_v2(const stream_request_params_v2& params);
 ```
 
-The `stream_request_params` struct contains the following fields:
+The `stream_request_params_v2` struct contains the following fields:
 
 ```cpp
-struct stream_request_params {
-    std::string url;
-    http_data_handler on_data;
-    http_error_handler on_error;
+struct stream_request_params_v2 {
     std::string method{"GET"};
+    std::string url;
+    std::chrono::seconds timeout{30s};
+    stream_read_strategy strategy{stream_read_strategy::bulk_transfer};
+    size_t max_buffer_size{1024 * 1024};
     std::string body;
     std::unordered_map<std::string, std::string> headers;
     http_connect_handler on_connect;
     http_disconnect_handler on_disconnect;
-    std::chrono::seconds timeout{30s};
-    stream_read_strategy strategy{stream_read_strategy::bulk_transfer};
-    std::function<bool(int)> status_is_error;
-    size_t max_buffer_size{1024 * 1024};
+    http_data_handler on_data;
+    http_error_handler on_error;
+    std::function<bool(int)> status_is_error{[](int status){ return status >= 400; }};
 };
 ```
 
--   `url`: The URL to request.
--   `on_data`: A callback that's called when data is received.
--   `on_error`: A callback that's called when an error occurs.
 -   `method`: The HTTP method to use. (default is "GET")
+-   `url`: The URL to request.
+-   `timeout`: Set connection timeout. (default is 30s)
+-   `strategy`: Can be `bulk_transfer` (default, larger chunks, better throughput) or `immediate_delivery` (smaller chunks, lower latency)
+-   `max_buffer_size`: Larger buffer can decrease dropouts and increase throughtput at cost of memory usage. (default is 1 MiB)
 -   `body`: The HTTP Body to send.
 -   `headers`: The HTTP headers to send.
 -   `on_connect`: A callback that's called when the connection is established and the headers are received.
 -   `on_disconnect`: A callback that's called when the connection is closed.
--   `timeout`: Set connection timeout. (default is 30s)
--   `strategy`: Can be `bulk_transfer` (default, larger chunks, better throughput) or `immediate_delivery` (smaller chunks, lower latency)
+-   `on_data`: A callback that's called when data is received.
+-   `on_error`: A callback that's called when an error occurs.
 -   `status_is_error`: Optional predicate to decide whether a status code should trigger `on_error` (defaults to checking for codes ≥ 400).
--   `max_buffer_size`: Larger buffer can decrease dropouts and increase throughtput at cost of memory usage. (default is 1 MiB)
 
 To override the default behaviour you can supply a predicate:
 
 ```cpp
-auto conn = client.stream_request({
+auto conn = client.stream_request_v2({
     .url = "http://localhost/typesense",
     .on_data = on_data,
     .on_error = on_error,

--- a/include/glaze/net/http_client.hpp
+++ b/include/glaze/net/http_client.hpp
@@ -589,8 +589,7 @@ namespace glz
 
       ~http_stream_connection() { disconnect(); }
    };
-
-   // Stream request parameters struct
+   // deprecated, use stream_request_params_v2 instead
    struct stream_request_params
    {
       std::string url;
@@ -603,8 +602,25 @@ namespace glz
       http_disconnect_handler on_disconnect{};
       std::chrono::seconds timeout{std::chrono::seconds{30}};
       stream_read_strategy strategy{stream_read_strategy::bulk_transfer};
-      std::function<bool(int)> status_is_error{}; // Custom predicate to decide whether a status code should fail
+      std::function<bool(int)> status_is_error{[](int status){ return status >= 400; }};
       size_t max_buffer_size{1024 * 1024};
+   };
+
+   // Stream request parameters struct
+   struct stream_request_params_v2
+   {
+      std::string method{"GET"};
+      std::string url;
+      std::chrono::seconds timeout{std::chrono::seconds{30}};
+      stream_read_strategy strategy{stream_read_strategy::bulk_transfer};
+      size_t max_buffer_size{1024 * 1024};
+      std::string body;
+      std::unordered_map<std::string, std::string> headers;
+      http_connect_handler on_connect;
+      http_disconnect_handler on_disconnect;
+      http_data_handler on_data;
+      http_error_handler on_error;
+      std::function<bool(int)> status_is_error{[](int status){ return status >= 400; }};
    };
 
    struct http_client
@@ -776,8 +792,21 @@ namespace glz
          return put(url, json_str, merged_headers);
       }
 
-      // New unified streaming request method
+      [[deprecated("use stream_request_v2 instead")]]
       std::shared_ptr<http_stream_connection> stream_request(const stream_request_params& params)
+      {
+         auto url_result = parse_url(params.url);
+         if (!url_result) {
+            asio::post(io_executor, [on_error = params.on_error, error = url_result.error()]() { on_error(error); });
+            return nullptr;
+         }
+
+         return perform_stream_request(params.method, *url_result, params.body, params.max_buffer_size, params.headers,
+                                       params.timeout, params.strategy, params.status_is_error, params.on_data,
+                                       params.on_error, params.on_connect, params.on_disconnect);
+      }
+
+      std::shared_ptr<http_stream_connection> stream_request_v2(const stream_request_params_v2& params)
       {
          auto url_result = parse_url(params.url);
          if (!url_result) {
@@ -960,9 +989,6 @@ namespace glz
          connection->is_https = use_https;
 
          connection->status_is_error = std::move(status_is_error);
-         if (!connection->status_is_error) {
-            connection->status_is_error = [](int status) { return status >= 400; };
-         }
 
          // Wrap the disconnect handler to return the socket to the pool
          auto internal_on_disconnect = [this, user_on_disconnect = std::move(on_disconnect), connection, url,


### PR DESCRIPTION
I was facing connections drops and slow speeds with default 1 MiB buffer when streaming data from metabase. Increasing buffer size to 8 MiB tripled my throughput and got rid of connection dropouts.

The max_buffer_size parameter was hardcoded earlier, this commit make it user configurable while keeping 1 MiB default. Also updated the out of date docs regarding `stream_request`

---

On the side note i must say, the order of members in `stream_request_params` is quite unfortunate, especially when you are using GCC and hence can't reorder designated initializers. perhaps we could do a `stream_request_v2` that takes params in different order, so that handlers and normal parameters don't interleave.