### PR TITLE
YAML skip unindented sequences properly

### DIFF
--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -3549,6 +3549,14 @@ namespace glz
                      if (it != end && !yaml::line_end_or_comment_table[static_cast<uint8_t>(*it)]) {
                         skip_yaml_value<Opts>(ctx, it, end, line_indent, false);
                      }
+                     else {
+                        // Value may be on the next line (block sequence, mapping, etc.)
+                        int32_t nested_indent = detect_nested_value_indent(ctx, it, end, line_indent);
+                        if (nested_indent >= 0) {
+                           skip_to_content(it, end);
+                           skip_yaml_value<Opts>(ctx, it, end, line_indent, false);
+                        }
+                     }
                   }
                }
 

--- a/include/glaze/yaml/skip.hpp
+++ b/include/glaze/yaml/skip.hpp
@@ -319,10 +319,19 @@ namespace glz::yaml
                break;
             }
 
-            // If dedented or not a sequence item, we're done
-            if (line_indent <= current_indent) {
+            // If dedented past current indent, we're done
+            if (line_indent < current_indent) {
                it = line_start;
                break;
+            }
+
+            // At current indent: continue only if it's another sequence item (indentless sequence)
+            if (line_indent == current_indent) {
+               if (!(*it == '-' &&
+                     ((it + 1) == end || *(it + 1) == ' ' || *(it + 1) == '\t' || *(it + 1) == '\n'))) {
+                  it = line_start;
+                  break;
+               }
             }
 
             // Continue with next line

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -3297,6 +3297,58 @@ extra: *a)";
       expect(obj.name == "skipped");
    };
 
+   // https://github.com/stephenberry/glaze/issues/2352
+   "skip_unknown_indentless_sequence"_test = [] {
+      // Unindented sequence under unknown key
+      {
+         std::string yaml = R"(---
+x: 1
+y: 1.0
+name: foo
+c:
+- baz
+...)";
+         simple_struct data{};
+         auto ec = glz::read_yaml<glz::yaml::yaml_opts{.error_on_unknown_keys = false}>(data, yaml);
+         expect(!ec) << glz::format_error(ec, yaml);
+         expect(data.x == 1);
+         expect(data.y == 1.0);
+         expect(data.name == "foo");
+      }
+
+      // Multiple items in unknown indentless sequence
+      {
+         std::string yaml = R"(x: 1
+c:
+- baz1
+- baz2
+y: 2.0
+name: bar)";
+         simple_struct data{};
+         auto ec = glz::read_yaml<glz::yaml::yaml_opts{.error_on_unknown_keys = false}>(data, yaml);
+         expect(!ec) << glz::format_error(ec, yaml);
+         expect(data.x == 1);
+         expect(data.y == 2.0);
+         expect(data.name == "bar");
+      }
+
+      // Unknown key with indented (normal) block sequence on next line
+      {
+         std::string yaml = R"(x: 1
+c:
+  - baz1
+  - baz2
+y: 2.0
+name: bar)";
+         simple_struct data{};
+         auto ec = glz::read_yaml<glz::yaml::yaml_opts{.error_on_unknown_keys = false}>(data, yaml);
+         expect(!ec) << glz::format_error(ec, yaml);
+         expect(data.x == 1);
+         expect(data.y == 2.0);
+         expect(data.name == "bar");
+      }
+   };
+
    "anchor_empty_node"_test = [] {
       std::string yaml = R"(a: &anchor
 b: *anchor)";


### PR DESCRIPTION
# Fix YAML unindented sequences not skipped for unknown keys (#2352)

When parsing YAML into a struct with `error_on_unknown_keys = false`, unknown keys whose values were block sequences on the next line caused a spurious `syntax_error`. This affected both indentless (unindented) and indented block sequences.

```yaml
a: foo
b:
- bar
c:       # unknown key
- baz    # <-- syntax_error here
```

## Problem

The unknown key handler in `parse_block_mapping` only skipped values on the **same line** as the key. If the character after the colon was a newline, `skip_yaml_value` was never called, leaving the sequence items in the stream where they were misinterpreted by the block mapping parser.

## Changes

### `include/glaze/yaml/read.hpp`

Added next-line value detection for unknown keys. When the value isn't on the same line, `detect_nested_value_indent` and `skip_to_content` (the same helpers used for known keys) locate the value, and then `skip_yaml_value` skips it.

### `include/glaze/yaml/skip.hpp`

Fixed `skip_yaml_value`'s block sequence skip loop. The old condition `line_indent <= current_indent` stopped too early for indentless sequences, where `- ` items sit at the same indent as the parent key. The new logic:

- `line_indent < current_indent` — dedented, stop.
- `line_indent == current_indent` — only continue if the line is another `- ` sequence item.

### `tests/yaml_test/yaml_test.cpp`

Added `skip_unknown_indentless_sequence` test covering:

- Unindented sequence under an unknown key (the exact reported case)
- Multi-item indentless sequence under an unknown key
- Indented block sequence under an unknown key