### PR TITLE
Use ensure_space for always_null_t JSON

### DIFF
--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1644,14 +1644,12 @@ namespace glz
    template <always_null_t T>
    struct to<JSON, T>
    {
-      static constexpr bool can_error = false;
-
       template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&&, B&& b, auto& ix)
+      GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, B&& b, auto& ix)
       {
          if constexpr (not check_write_unchecked(Opts)) {
-            if (const auto k = ix + 4; k > b.size()) [[unlikely]] {
-               b.resize(2 * k);
+            if (!ensure_space(ctx, b, ix + 4)) [[unlikely]] {
+               return;
             }
          }
          if constexpr (std::endian::native == std::endian::big) {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -13701,6 +13701,27 @@ suite bounded_buffer_overflow_tests = [] {
       auto result = glz::write_json(obj, buffer);
       expect(result.ec == glz::error_code::buffer_overflow) << "long string should overflow";
    };
+
+   // Test: always_null_t (glz::generic null) to bounded buffer (issue #2362)
+   "always_null_t to bounded buffer"_test = [] {
+      glz::generic obj{}; // default constructed generic is null
+      std::array<char, 512> storage{};
+      std::span<char> buffer(storage);
+
+      auto result = glz::write_json(obj, buffer);
+      expect(not result) << "always_null_t write to span should succeed";
+      std::string_view json(buffer.data(), result.count);
+      expect(json == "null") << "should serialize as null";
+   };
+
+   "always_null_t to small bounded buffer"_test = [] {
+      glz::generic obj{}; // default constructed generic is null
+      std::array<char, 2> storage{};
+      std::span<char> buffer(storage);
+
+      auto result = glz::write_json(obj, buffer);
+      expect(result.ec == glz::error_code::buffer_overflow) << "should return buffer_overflow for too-small buffer";
+   };
 };
 
 int main()


### PR DESCRIPTION
# Fix `to<JSON, T>` for `always_null_t` with non-resizable buffers

Fixes #2362

## Problem

The `to<JSON, T>` specialization for `always_null_t` called `b.resize()` directly without checking whether the buffer supports resizing. This caused a compilation failure when writing to fixed-size buffers like `std::span<char>`.

## Changes

**`include/glaze/json/write.hpp`**
- Replaced the direct `b.resize(2 * k)` call with `ensure_space(ctx, b, ix + 4)`, which correctly handles all buffer types: resizable (grows the buffer), bounded (returns `buffer_overflow`), and raw pointers (trusts the caller).
- Removed `can_error = false` since the operation can now fail on bounded buffers. Without `can_error` declared, `write_can_error()` conservatively returns `true`, which is correct.

**`tests/json_test/json_test.cpp`**
- Added two tests: writing a `glz::generic` null to a `std::span<char>` with sufficient space (succeeds), and to a too-small span (returns `buffer_overflow`).