### PR TITLE
Accept ISO 8601 format strings without timezone information

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -4615,8 +4615,8 @@ namespace glz
          if (bool(ctx.error)) [[unlikely]]
             return;
 
-         // Minimum: YYYY-MM-DDTHH:MM:SSZ = 20 chars
-         if (str.size() < 20) [[unlikely]] {
+         // Minimum: YYYY-MM-DDTHH:MM:SS = 19 chars (timezone is optional, defaults to UTC)
+         if (str.size() < 19) [[unlikely]] {
             ctx.error = error_code::parse_error;
             return;
          }

--- a/tests/chrono_test/chrono_test.cpp
+++ b/tests/chrono_test/chrono_test.cpp
@@ -372,6 +372,30 @@ suite chrono_edge_case_tests = [] {
       expect(json.value() == "\"1900-01-01T00:00:00Z\"") << json.value();
    };
 
+   "no_timezone_defaults_to_utc"_test = [] {
+      using namespace std::chrono;
+
+      // ISO 8601 without timezone information should default to UTC
+      sys_time<seconds> tp;
+      auto err = glz::read_json(tp, "\"2024-12-13T15:30:45\"");
+      expect(!err);
+
+      auto json = glz::write_json(tp);
+      expect(json.value() == "\"2024-12-13T15:30:45Z\"") << json.value();
+   };
+
+   "no_timezone_with_fractional_seconds"_test = [] {
+      using namespace std::chrono;
+
+      // ISO 8601 without timezone but with fractional seconds
+      sys_time<milliseconds> tp;
+      auto err = glz::read_json(tp, "\"2024-12-13T15:30:45.123\"");
+      expect(!err);
+
+      auto json = glz::write_json(tp);
+      expect(json.value() == "\"2024-12-13T15:30:45.123Z\"") << json.value();
+   };
+
    "timezone_offset_with_minutes"_test = [] {
       using namespace std::chrono;
 


### PR DESCRIPTION
## Accept ISO 8601 timestamps without timezone information

Closes #2361

### Problem

Glaze rejected valid ISO 8601 timestamps that omit timezone information, such as `"2024-12-13T15:30:45"`. The minimum string length check required 20 characters (for `YYYY-MM-DDTHH:MM:SSZ`), causing 19-character timestamps without a timezone suffix to fail parsing.

### Fix

- Lowered the minimum length check in `read.hpp` from 20 to 19 characters
- No other code changes needed — the timezone parsing already defaulted to UTC when no timezone was present

### Tests

Added two new test cases in `chrono_test.cpp`:
- `no_timezone_defaults_to_utc` — parses `"2024-12-13T15:30:45"` and verifies it roundtrips as `"2024-12-13T15:30:45Z"`
- `no_timezone_with_fractional_seconds` — parses `"2024-12-13T15:30:45.123"` without timezone

This is a non-breaking change. All existing formats continue to work as before.