### PR TITLE
Increase strictness of time_point parsing

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -4669,19 +4669,21 @@ namespace glz
                }
                ++pos;
             }
+            if (digits == 0) [[unlikely]] {
+               ctx.error = error_code::parse_error;
+               return;
+            }
             // Scale to nanoseconds
             static constexpr int64_t scale[] = {1000000000, 100000000, 10000000, 1000000, 100000,
                                                 10000,      1000,      100,      10,      1};
-            if (digits > 0 && digits <= 9) {
-               subsec_nanos = frac * scale[digits];
-            }
+            subsec_nanos = frac * scale[digits];
          }
 
          // Parse timezone: Z or +HH:MM or -HH:MM (defaults to UTC if missing)
          int tz_offset_seconds = 0;
          if (pos < n) {
             if (s[pos] == 'Z') {
-               // UTC
+               ++pos; // consume 'Z'
             }
             else if (s[pos] == '+' || s[pos] == '-') {
                // +05:00 means local is ahead of UTC, so subtract to get UTC (multiply by -1)
@@ -4699,7 +4701,11 @@ namespace glz
                }
                pos += 2;
                int tz_min = 0;
-               if (pos < n && s[pos] == ':') ++pos;
+               bool has_tz_colon = false;
+               if (pos < n && s[pos] == ':') {
+                  ++pos;
+                  has_tz_colon = true;
+               }
                if (pos + 2 <= n) {
                   const int m = parse_digits(pos, 2);
                   if (m < 0 || m > 59) [[unlikely]] {
@@ -4709,8 +4715,19 @@ namespace glz
                   tz_min = m;
                   pos += 2;
                }
+               else if (has_tz_colon) [[unlikely]] {
+                  // Colon present but minutes missing or incomplete
+                  ctx.error = error_code::parse_error;
+                  return;
+               }
                tz_offset_seconds = utc_adjustment * (tz_hour * 3600 + tz_min * 60);
             }
+         }
+
+         // Reject trailing characters
+         if (pos != n) [[unlikely]] {
+            ctx.error = error_code::parse_error;
+            return;
          }
 
          // Construct time_point using std::chrono calendar types

--- a/tests/chrono_test/chrono_test.cpp
+++ b/tests/chrono_test/chrono_test.cpp
@@ -602,6 +602,77 @@ suite chrono_timezone_tests = [] {
    };
 };
 
+suite chrono_strict_parsing_tests = [] {
+   "reject_trailing_characters_after_Z"_test = [] {
+      std::chrono::system_clock::time_point tp;
+      expect(bool(glz::read_json(tp, R"("2024-12-13T15:30:45Zfoobar")")));
+   };
+
+   "reject_trailing_characters_after_offset"_test = [] {
+      std::chrono::system_clock::time_point tp;
+      expect(bool(glz::read_json(tp, R"("2024-12-13T15:30:45+05:00extra")")));
+   };
+
+   "reject_trailing_digits_after_Z"_test = [] {
+      std::chrono::system_clock::time_point tp;
+      expect(bool(glz::read_json(tp, R"("2024-12-13T15:30:45Z0")")));
+   };
+
+   "reject_trailing_characters_no_timezone"_test = [] {
+      std::chrono::system_clock::time_point tp;
+      expect(bool(glz::read_json(tp, R"("2024-12-13T15:30:45abc")")));
+   };
+
+   "reject_bare_decimal_point"_test = [] {
+      std::chrono::system_clock::time_point tp;
+      expect(bool(glz::read_json(tp, R"("2024-12-13T15:30:45.Z")")));
+   };
+
+   "reject_bare_decimal_point_no_timezone"_test = [] {
+      std::chrono::system_clock::time_point tp;
+      expect(bool(glz::read_json(tp, R"("2024-12-13T15:30:45.")")));
+   };
+
+   "reject_timezone_colon_without_minutes"_test = [] {
+      std::chrono::system_clock::time_point tp;
+      expect(bool(glz::read_json(tp, R"("2024-12-13T15:30:45+05:")")));
+   };
+
+   "reject_timezone_colon_with_one_minute_digit"_test = [] {
+      std::chrono::system_clock::time_point tp;
+      expect(bool(glz::read_json(tp, R"("2024-12-13T15:30:45+05:3")")));
+   };
+
+   "reject_timezone_colon_with_negative_incomplete"_test = [] {
+      std::chrono::system_clock::time_point tp;
+      expect(bool(glz::read_json(tp, R"("2024-12-13T15:30:45-08:")")));
+   };
+
+   "accept_hour_only_timezone_offset"_test = [] {
+      using namespace std::chrono;
+
+      // Hour-only offset is valid ISO 8601 (no colon, no minutes)
+      sys_time<seconds> tp;
+      auto err = glz::read_json(tp, R"("2024-12-13T15:30:45+05")");
+      expect(!err);
+
+      auto json = glz::write_json(tp);
+      expect(json.value() == R"("2024-12-13T10:30:45Z")") << json.value();
+   };
+
+   "accept_valid_fractional_seconds"_test = [] {
+      using namespace std::chrono;
+
+      // Single fractional digit should still work
+      sys_time<milliseconds> tp;
+      auto err = glz::read_json(tp, R"("2024-12-13T15:30:45.1Z")");
+      expect(!err);
+
+      auto json = glz::write_json(tp);
+      expect(json.value() == R"("2024-12-13T15:30:45.100Z")") << json.value();
+   };
+};
+
 suite chrono_roundtrip_1000_tests = [] {
    "duration_roundtrip_1000"_test = [] {
       // Test 1000 different duration values


### PR DESCRIPTION
## Increase strictness of `time_point` parsing

Tightens the ISO 8601 `time_point` JSON parser to reject malformed inputs that were previously silently accepted.

### Changes

- **Reject trailing characters** after a fully parsed timestamp (e.g. `"2024-12-13T15:30:45Zfoobar"`, `"2024-12-13T15:30:45+05:00extra"`)
- **Reject bare decimal point** with no fractional digits (e.g. `"2024-12-13T15:30:45."`, `"2024-12-13T15:30:45.Z"`)
- **Reject incomplete timezone minutes** when a colon is present after the hour offset (e.g. `"2024-12-13T15:30:45+05:"`, `"2024-12-13T15:30:45+05:3"`)
- **Consume the `Z` character** so trailing-character validation works correctly
- Hour-only timezone offsets (e.g. `+05`) remain valid per ISO 8601

### Tests

Added `chrono_strict_parsing_tests` suite with 11 new test cases covering all rejection and acceptance scenarios.