### PR TITLE
Finalize read_into context for partial reading with lazy_json

### DIFF
--- a/include/glaze/beve/lazy.hpp
+++ b/include/glaze/beve/lazy.hpp
@@ -231,6 +231,7 @@ namespace glz
          auto it = data_;
          auto end = beve_end();
          parse<BEVE>::op<Opts>(value, ctx, it, end);
+         finalize_read_context<Opts>(ctx);
          if (bool(ctx.error)) {
             return error_ctx{static_cast<size_t>(it - data_), ctx.error};
          }

--- a/include/glaze/core/read.hpp
+++ b/include/glaze/core/read.hpp
@@ -31,6 +31,25 @@ namespace glz
       return std::pair{it, end};
    }
 
+   template <auto Opts, is_context Ctx>
+   GLZ_ALWAYS_INLINE void finalize_read_context(Ctx&& ctx) noexcept
+   {
+      // We don't do depth validation for partial reading
+      if constexpr (check_partial_read(Opts)) {
+         if (ctx.error == error_code::partial_read_complete) [[likely]] {
+            ctx.error = error_code::none;
+         }
+         else if (ctx.error == error_code::end_reached && ctx.depth == 0) {
+            ctx.error = error_code::none;
+         }
+      }
+      else {
+         if (ctx.error == error_code::end_reached && ctx.depth == 0) {
+            ctx.error = error_code::none;
+         }
+      }
+   }
+
    template <auto Opts, class T>
       requires read_supported<T, Opts.format>
    [[nodiscard]] error_ctx read(T& value, contiguous auto&& buffer, is_context auto&& ctx)
@@ -87,20 +106,7 @@ namespace glz
       }
 
    finish:
-      // We don't do depth validation for partial reading
-      if constexpr (check_partial_read(Opts)) {
-         if (ctx.error == error_code::partial_read_complete) [[likely]] {
-            ctx.error = error_code::none;
-         }
-         else if (ctx.error == error_code::end_reached && ctx.depth == 0) {
-            ctx.error = error_code::none;
-         }
-      }
-      else {
-         if (ctx.error == error_code::end_reached && ctx.depth == 0) {
-            ctx.error = error_code::none;
-         }
-      }
+      finalize_read_context<Opts>(ctx);
 
       if constexpr (use_padded) {
          // Restore the original buffer state
@@ -185,11 +191,7 @@ namespace glz
       const size_t final_consumed = static_cast<size_t>(it - ctx.stream.data());
       consume_buffer(buffer, final_consumed);
 
-      // Handle end_reached as success when parsing completed at depth 0
-      // (same logic as non-streaming read)
-      if (ctx.error == error_code::end_reached && ctx.depth == 0) {
-         ctx.error = error_code::none;
-      }
+      finalize_read_context<StreamingOpts>(ctx);
 
       if (bool(ctx.error)) {
          return {buffer.bytes_consumed(), ctx.error, ctx.custom_error_message};

--- a/include/glaze/json/lazy.hpp
+++ b/include/glaze/json/lazy.hpp
@@ -260,6 +260,7 @@ namespace glz
          auto it = data_;
          auto end = json_end();
          parse<JSON>::op<Opts>(value, ctx, it, end);
+         finalize_read_context<Opts>(ctx);
          if (bool(ctx.error)) {
             return error_ctx{static_cast<size_t>(it - data_), ctx.error};
          }

--- a/tests/json_test/lazy_test.cpp
+++ b/tests/json_test/lazy_test.cpp
@@ -857,6 +857,22 @@ suite lazy_json_tests = [] {
       expect(user.name == "Alice");
    };
 
+   "lazy_json_read_into_partial_read_clears_error"_test = [] {
+      std::string buffer = R"({
+         "user": {"name": "Alice", "ignored": 42}
+      })";
+
+      auto result = glz::lazy_json<glz::opts{.partial_read = true}>(buffer);
+      expect(result.has_value());
+
+      MinimalUser user{};
+      auto ec = (*result)["user"].read_into(user);
+
+      expect(!ec) << glz::format_error(ec, buffer);
+      expect(ec == glz::error_code::none);
+      expect(user.name == "Alice");
+   };
+
    "lazy_json_read_into_nested"_test = [] {
       std::string buffer = R"({
          "people": [


### PR DESCRIPTION
## Fix `partial_read` cleanup for `lazy_json::read_into`

Fixes issue #2369, where deserializing from `lazy_json` with `partial_read = true` could return a non-empty `error_ctx` even when parsing completed successfully.

### Changes

- Extract the read finalization logic in [read.hpp](/Users/stephenberry/Develop/repos/glaze/include/glaze/core/read.hpp) into a shared helper so direct parse entrypoints normalize internal completion states consistently
- Apply that finalization in [lazy.hpp](/Users/stephenberry/Develop/repos/glaze/include/glaze/json/lazy.hpp) so `lazy_json_view::read_into()` clears `partial_read_complete` the same way as the normal `glz::read` path
- Apply the same cleanup in [lazy.hpp](/Users/stephenberry/Develop/repos/glaze/include/glaze/beve/lazy.hpp) for consistency with the lazy BEVE read path
- Add a regression test in [lazy_test.cpp](/Users/stephenberry/Develop/repos/glaze/tests/json_test/lazy_test.cpp) covering `lazy_json<opts{.partial_read = true}>`

### Tests

- `cmake --build build --target lazy_test -j4`
- `ctest --test-dir build -R lazy_test --output-on-failure`