### PR TITLE
format_context to support specifying YAML in opts format field

### DIFF
--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -1439,6 +1439,17 @@ namespace glz
    struct serialize
    {};
 
+   // Default context type for a format.
+   // Formats that need a richer context (e.g. YAML) specialize this.
+   template <uint32_t Format>
+   struct format_context
+   {
+      using type = context;
+   };
+
+   template <uint32_t Format>
+   using format_context_t = typename format_context<Format>::type;
+
    template <uint32_t Format>
    struct serialize_partial
    {};

--- a/include/glaze/core/read.hpp
+++ b/include/glaze/core/read.hpp
@@ -120,7 +120,7 @@ namespace glz
       requires read_supported<T, Opts.format>
    [[nodiscard]] error_ctx read(T& value, contiguous auto&& buffer)
    {
-      context ctx{};
+      format_context_t<Opts.format> ctx{};
       return read<Opts>(value, buffer, ctx);
    }
 
@@ -146,7 +146,7 @@ namespace glz
       requires read_supported<T, Opts.format>
    [[nodiscard]] error_ctx read(T& value, Buffer&& buffer)
    {
-      context ctx{};
+      format_context_t<Opts.format> ctx{};
       return read<Opts>(value, std::forward<Buffer>(buffer), ctx);
    }
 

--- a/include/glaze/yaml/common.hpp
+++ b/include/glaze/yaml/common.hpp
@@ -115,7 +115,16 @@ namespace glz::yaml
          return c;
       }
    };
+} // namespace glz::yaml
 
+template <>
+struct glz::format_context<glz::YAML>
+{
+   using type = glz::yaml::yaml_context;
+};
+
+namespace glz::yaml
+{
    // Lookup table for characters that can start a plain scalar in flow context
    // In flow context, these are NOT allowed: [ ] { } , : # ' " | > @ ` \n \r
    inline constexpr std::array<bool, 256> can_start_plain_flow_table = [] {

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -7763,4 +7763,43 @@ suite nullable_empty_container_in_collections_tests = [] {
    };
 };
 
+// Test that glz::read with opts{.format = YAML} works (issue #2380)
+suite generic_read_yaml_format = [] {
+   "glz::read with format YAML"_test = [] {
+      constexpr auto options = glz::opts{.format = glz::YAML};
+
+      std::string yaml = R"(name: John
+age: 30)";
+
+      std::map<std::string, glz::generic> obj;
+      auto ec = glz::read<options>(obj, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(obj.size() == 2u);
+   };
+
+   "glz::read generic with format YAML"_test = [] {
+      constexpr auto options = glz::opts{.format = glz::YAML};
+
+      std::string yaml = "hello";
+
+      glz::generic obj;
+      auto ec = glz::read<options>(obj, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+   };
+
+   "glz::read with format YAML vector"_test = [] {
+      constexpr auto options = glz::opts{.format = glz::YAML};
+
+      std::string yaml = R"(- 1
+- 2
+- 3)";
+
+      std::vector<int> obj;
+      auto ec = glz::read<options>(obj, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(obj.size() == 3u);
+      expect(obj == std::vector<int>{1, 2, 3});
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
# Fix `glz::read` with YAML format (Issue #2380)

`glz::read<opts{.format = glz::YAML}>(obj, buffer)` failed to compile because the generic `read` overloads created a plain `context`, but YAML parsing requires `yaml::yaml_context` (for indent tracking, anchors, etc.).

## Changes

- **`include/glaze/core/opts.hpp`**: Added `format_context` trait and `format_context_t` alias. Defaults to `context`; formats that need a richer context specialize this.
- **`include/glaze/core/read.hpp`**: The two-argument `read` overloads now create `format_context_t<Opts.format>` instead of a hardcoded `context`.
- **`include/glaze/yaml/common.hpp`**: Specializes `format_context<YAML>` to `yaml_context`.
- **`tests/yaml_test/yaml_test.cpp`**: Added tests for `glz::read<opts{.format = YAML}>` with maps, generics, and vectors.