### PR TITLE
Add custom type handling for nullable fields in JSON serialization

### DIFF
--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -380,6 +380,9 @@ namespace glz
    template <class T, size_t I>
    using field_t = std::remove_cvref_t<refl_t<T, I>>;
 
+   template <class V>
+   consteval bool custom_to_is_nullable_or_false();
+
    template <auto Opts, class T>
    inline constexpr bool maybe_skipped = [] {
       if constexpr (reflect<T>::size > 0) {
@@ -393,7 +396,8 @@ namespace glz
             return [&]<size_t... I>(std::index_sequence<I...>) {
                return ((always_skipped<field_t<T, I>> ||
                         (!write_function_pointers && is_member_function_pointer<field_t<T, I>>) ||
-                        null_t<field_t<T, I>>) ||
+                        null_t<field_t<T, I>> ||
+                        is_specialization_v<field_t<T, I>, custom_t>) ||
                        ...);
             }(std::make_index_sequence<N>{});
          }
@@ -472,6 +476,74 @@ namespace glz
       }
 
       return false;
+   }
+
+   template <class V>
+   consteval bool custom_type_to_is_nullable()
+   {
+      using To = typename V::to_t;
+
+      if constexpr (std::is_member_pointer_v<To>) {
+         if constexpr (std::is_member_function_pointer_v<To>) {
+            using Ret = typename return_type<To>::type;
+            if constexpr (std::is_void_v<Ret>) {
+               return false;
+            }
+            else {
+               return bool(null_t<Ret>);
+            }
+         }
+         else if constexpr (std::is_member_object_pointer_v<To>) {
+            using Value = std::decay_t<decltype(std::declval<V>().val.*(std::declval<V>().to))>;
+            if constexpr (is_specialization_v<Value, std::function>) {
+               using Ret = typename function_traits<Value>::result_type;
+               if constexpr (std::is_void_v<Ret>) {
+                  return false;
+               }
+               else {
+                  return bool(null_t<Ret>);
+               }
+            }
+            else {
+               return bool(null_t<Value>);
+            }
+         }
+      }
+      else {
+         using Obj = decltype(std::declval<V>().val);
+         if constexpr (std::invocable<To, Obj>) {
+            using Ret = std::remove_cvref_t<decltype(std::invoke(std::declval<To>(), std::declval<Obj>()))>;
+            if constexpr (std::is_void_v<Ret>) {
+               return false;
+            }
+            else {
+               return bool(null_t<Ret>);
+            }
+         }
+         else if constexpr (std::invocable<To, Obj, context&>) {
+            using Ret = std::remove_cvref_t<
+               decltype(std::invoke(std::declval<To>(), std::declval<Obj>(), std::declval<context&>()))>;
+            if constexpr (std::is_void_v<Ret>) {
+               return false;
+            }
+            else {
+               return bool(null_t<Ret>);
+            }
+         }
+      }
+
+      return false;
+   }
+
+   template <class V>
+   consteval bool custom_to_is_nullable_or_false()
+   {
+      if constexpr (is_specialization_v<V, custom_t>) {
+         return custom_type_to_is_nullable<V>();
+      }
+      else {
+         return false;
+      }
    }
 
    template <class T, auto Opts>

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -2165,10 +2165,35 @@ namespace glz
                      return;
                   }
                   else {
-                     if constexpr (null_t<val_t> && Opts.skip_null_members) {
-                        if constexpr (always_null_t<val_t>)
-                           return;
-                        else {
+                     if constexpr (Opts.skip_null_members) {
+                        if constexpr (null_t<val_t>) {
+                           if constexpr (always_null_t<val_t>)
+                              return;
+                           else {
+                              const auto is_null = [&]() {
+                                 decltype(auto) element = [&]() -> decltype(auto) {
+                                    if constexpr (reflectable<T>) {
+                                       return get<I>(t);
+                                    }
+                                    else {
+                                       return get<I>(reflect<T>::values);
+                                    }
+                                 };
+
+                                 if constexpr (nullable_wrapper<val_t>) {
+                                    return !bool(element()(value).val);
+                                 }
+                                 else if constexpr (nullable_value_t<val_t>) {
+                                    return !get_member(value, element()).has_value();
+                                 }
+                                 else {
+                                    return !bool(get_member(value, element()));
+                                 }
+                              }();
+                              if (is_null) return;
+                           }
+                        }
+                        else if constexpr (is_specialization_v<val_t, custom_t>) {
                            const auto is_null = [&]() {
                               decltype(auto) element = [&]() -> decltype(auto) {
                                  if constexpr (reflectable<T>) {
@@ -2179,14 +2204,64 @@ namespace glz
                                  }
                               };
 
-                              if constexpr (nullable_wrapper<val_t>) {
-                                 return !bool(element()(value).val);
-                              }
-                              else if constexpr (nullable_value_t<val_t>) {
-                                 return !get_member(value, element()).has_value();
+                              auto&& custom = get_member(value, element());
+                              using CustomT = std::decay_t<decltype(custom)>;
+                              using To = typename CustomT::to_t;
+
+                              auto is_ret_null = [&](auto&& ret) {
+                                 using Ret = std::remove_cvref_t<decltype(ret)>;
+                                 if constexpr (null_t<Ret>) {
+                                    if constexpr (always_null_t<Ret>) {
+                                       return true;
+                                    }
+                                    else if constexpr (nullable_wrapper<Ret>) {
+                                       return !bool(ret.val);
+                                    }
+                                    else if constexpr (nullable_value_t<Ret>) {
+                                       return !ret.has_value();
+                                    }
+                                    else {
+                                       return !bool(ret);
+                                    }
+                                 }
+                                 else {
+                                    return false;
+                                 }
+                              };
+
+                              if constexpr (std::is_member_pointer_v<To>) {
+                                 if constexpr (std::is_member_function_pointer_v<To>) {
+                                    return is_ret_null((custom.val.*(custom.to))());
+                                 }
+                                 else if constexpr (std::is_member_object_pointer_v<To>) {
+                                    auto& to = custom.val.*(custom.to);
+                                    using Func = std::decay_t<decltype(to)>;
+                                    if constexpr (is_specialization_v<Func, std::function>) {
+                                       using Ret = typename function_traits<Func>::result_type;
+                                       static_assert(!std::is_void_v<Ret>,
+                                                     "conversion to JSON must return a value");
+                                       return is_ret_null(to());
+                                    }
+                                    else {
+                                       return is_ret_null(to);
+                                    }
+                                 }
+                                 else {
+                                    static_assert(false_v<To>, "invalid type for custom");
+                                 }
                               }
                               else {
-                                 return !bool(get_member(value, element()));
+                                 if constexpr (std::invocable<To, decltype(custom.val)>) {
+                                    return is_ret_null(std::invoke(custom.to, custom.val));
+                                 }
+                                 else if constexpr (std::invocable<To, decltype(custom.val), context&>) {
+                                    return is_ret_null(std::invoke(custom.to, custom.val, ctx));
+                                 }
+                                 else {
+                                    static_assert(false_v<To>,
+                                                  "expected invocable function, perhaps you need const qualified input "
+                                                  "on your lambda");
+                                 }
                               }
                            }();
                            if (is_null) return;

--- a/tests/json_test/nullable_lambda_test.cpp
+++ b/tests/json_test/nullable_lambda_test.cpp
@@ -109,4 +109,62 @@ suite nullable_lambda_optional_tests = [] {
    };
 };
 
+struct my_struct_custom_optional
+{
+   int value = 42;
+};
+
+template <>
+struct glz::meta<my_struct_custom_optional>
+{
+   using T = my_struct_custom_optional;
+
+   static constexpr auto set_status = [](T& s, std::optional<std::string> value) {
+      if (value.has_value())
+      {
+         s.value = 50;
+      }
+      else
+      {
+         s.value = 0;
+      }
+   };
+
+   static constexpr auto get_status = [](auto& s) -> std::optional<std::string> {
+      if (s.value > 50)
+      {
+         return "high";
+      }
+      else
+      {
+         return std::nullopt;
+      }
+   };
+
+   static constexpr auto value = glz::object("value", &T::value, "status",
+                                              glz::custom<set_status, get_status>);
+};
+
+suite nullable_lambda_custom_optional_tests = [] {
+   "glz::custom getter returns nullopt - should skip field"_test = [] {
+      my_struct_custom_optional obj{};
+      obj.value = 42;
+
+      std::string buffer;
+      expect(not glz::write_json(obj, buffer));
+
+      expect(buffer == R"({"value":42})") << "Got: " << buffer;
+   };
+
+   "glz::custom getter returns optional value - should write field"_test = [] {
+      my_struct_custom_optional obj{};
+      obj.value = 100;
+
+      std::string buffer;
+      expect(not glz::write_json(obj, buffer));
+
+      expect(buffer == R"({"value":100,"status":"high"})") << "Got: " << buffer;
+   };
+};
+
 int main() {}


### PR DESCRIPTION
### Summary

When a glz::object field uses glz::custom<setter, getter> and the getter returns std::optional<T> that is std::nullopt, Glaze currently serializes the field as "field": null instead of omitting the field (under skip_null_members=true). This PR adds a regression test and fixes the JSON writer so the field is skipped when the custom getter produces a null/empty optional.

### Changes

1. Fix skip logic for JSON serialization

- Updated the Opts.skip_null_members handling for fields whose value type is glz::custom_t.
- For glz::custom_t, the serializer now invokes the custom getter (supports member-function/member-object pointer and invocable forms), detects whether the getter result is “null” for nullable return types (notably std::optional / optional-like via existing nullable_* concepts) and skips writing the field when the getter result is empty (std::nullopt -> omitted field)

2. Ensure glz::custom_t is treated as a candidate for skipping

Expanded the maybe_skipped condition so that when skip_null_members=true, glz::custom_t fields are considered “potentially skippable”, allowing the runtime logic in json/write.hpp to run.

### Issue
https://github.com/stephenberry/glaze/issues/2386