### PR TITLE
Avoid erroring on nullable value types

### DIFF
--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -619,6 +619,10 @@ namespace glz
                      using CastType = typename V::cast_type;
                      return null_t<CastType>;
                   }
+                  else if constexpr (glaze_value_t<V>) {
+                     using Inner = remove_meta_wrapper_t<V>;
+                     return null_t<Inner>;
+                  }
                   else {
                      return null_t<V>;
                   }
@@ -638,6 +642,11 @@ namespace glz
                // Handle cast_t by checking if the cast type is nullable
                using CastType = typename V::cast_type;
                fields[I] = !Opts.skip_null_members || !null_t<CastType>;
+            }
+            else if constexpr (glaze_value_t<V>) {
+               // Handle value types (structs with glaze::value) by checking the underlying type
+               using Inner = remove_meta_wrapper_t<V>;
+               fields[I] = !Opts.skip_null_members || !null_t<Inner>;
             }
             else {
                fields[I] = !Opts.skip_null_members || !null_t<V>;

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -12900,6 +12900,20 @@ struct glz::meta<cast_obj>
                                         "indirect", cast<[](T& s) -> auto& { return s.integer; }, double>);
 };
 
+struct glaze_value_nullable_field
+{
+   std::optional<int> my_val;
+   struct glaze {
+      static constexpr auto value{&glaze_value_nullable_field::my_val};
+   };
+};
+
+struct glaze_value_nullable_obj
+{
+   glaze_value_nullable_field field_name{};
+   std::string required_field{};
+};
+
 struct cast_nullable_obj
 {
    std::optional<double> a;
@@ -12960,6 +12974,33 @@ suite cast_tests = [] {
 
       // Test missing required field
       data = R"({"a":null})";
+      ec = glz::read<opts>(obj, data);
+      expect(ec == glz::error_code::missing_key);
+   };
+
+   "glaze_value_t nullable with error_on_missing_keys"_test = [] {
+      constexpr auto opts = glz::opts{
+         .format = glz::JSON,
+         .error_on_missing_keys = true,
+      };
+
+      // Missing nullable value-type field should not error
+      std::string_view data = R"({"required_field":"hello"})";
+      glaze_value_nullable_obj obj{};
+      auto ec = glz::read<opts>(obj, data);
+      expect(!ec) << glz::format_error(ec, data);
+      expect(!obj.field_name.my_val.has_value());
+      expect(obj.required_field == "hello");
+
+      // With value present
+      data = R"({"field_name":42,"required_field":"world"})";
+      ec = glz::read<opts>(obj, data);
+      expect(!ec) << glz::format_error(ec, data);
+      expect(obj.field_name.my_val.has_value());
+      expect(obj.field_name.my_val.value() == 42);
+
+      // Missing required (non-nullable) field should still error
+      data = R"({"field_name":42})";
       ec = glz::read<opts>(obj, data);
       expect(ec == glz::error_code::missing_key);
    };


### PR DESCRIPTION
## Fix `error_on_missing_keys` for value types wrapping nullable types

Fixes #2389

When a struct uses `glaze::value` to serialize as one of its members (a "value type"), and that member is nullable (e.g. `std::optional`), `error_on_missing_keys` incorrectly treated the field as required. This is because `required_fields()` checked nullability on the outer struct rather than the underlying type it serializes as.

### Changes

**`include/glaze/core/reflect.hpp`** — Added a `glaze_value_t` branch to `required_fields()` that unwraps the value type via `remove_meta_wrapper_t` and checks nullability on the inner type. Applied in both the `meta_has_requires_key` path and the default path.

**`tests/json_test/json_test.cpp`** — Added a test verifying that a missing value-type field backed by `std::optional` does not produce a `missing_key` error, while non-nullable required fields still do.