### PR TITLE
fedora ci test timeout

### DIFF
--- a/util/glaze.spec
+++ b/util/glaze.spec
@@ -78,7 +78,7 @@ done <<<"${macros_ff}"
 %cmake_install
 
 %check
-%ctest
+%ctest --timeout 120
 
 %files devel
 %license LICENSE


### PR DESCRIPTION
Trying to figure out why rpm-build:fedora-rawhide-s390x always hangs in CI. Was having runner issues, but I'm thinking this might be a Glaze issue.