### PR TITLE
Nullable value write skipping

### DIFF
--- a/include/glaze/beve/write.hpp
+++ b/include/glaze/beve/write.hpp
@@ -1325,6 +1325,11 @@ namespace glz
                         ++member_count;
                      }
                   }
+                  else if constexpr (Options.skip_null_members && glaze_value_is_nullable<val_t>()) {
+                     if (!is_glaze_value_field_null<T, I>(value, t)) {
+                        ++member_count;
+                     }
+                  }
                   else {
                      ++member_count;
                   }
@@ -1394,6 +1399,11 @@ namespace glz
                   else if constexpr (is_specialization_v<val_t, custom_t> && Options.skip_null_members &&
                                      custom_getter_returns_nullable<val_t>()) {
                      if (is_custom_field_null<T, I>(value, t, ctx)) {
+                        return;
+                     }
+                  }
+                  else if constexpr (Options.skip_null_members && glaze_value_is_nullable<val_t>()) {
+                     if (is_glaze_value_field_null<T, I>(value, t)) {
                         return;
                      }
                   }

--- a/include/glaze/cbor/write.hpp
+++ b/include/glaze/cbor/write.hpp
@@ -688,6 +688,11 @@ namespace glz
                         ++member_count;
                      }
                   }
+                  else if constexpr (Opts.skip_null_members && glaze_value_is_nullable<val_t>()) {
+                     if (!is_glaze_value_field_null<T, I>(value, t)) {
+                        ++member_count;
+                     }
+                  }
                   else {
                      ++member_count;
                   }
@@ -742,6 +747,11 @@ namespace glz
                   else if constexpr (is_specialization_v<val_t, custom_t> && Opts.skip_null_members &&
                                      custom_getter_returns_nullable<val_t>()) {
                      if (is_custom_field_null<T, I>(value, t, ctx)) {
+                        return;
+                     }
+                  }
+                  else if constexpr (Opts.skip_null_members && glaze_value_is_nullable<val_t>()) {
+                     if (is_glaze_value_field_null<T, I>(value, t)) {
                         return;
                      }
                   }

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -429,6 +429,41 @@ namespace glz
       }
    }
 
+   // Check if a glaze_value_t wraps a nullable inner type (write side).
+   template <class V>
+   consteval bool glaze_value_is_nullable()
+   {
+      if constexpr (glaze_value_t<V>) {
+         return null_t<remove_meta_wrapper_t<V>>;
+      }
+      else {
+         return false;
+      }
+   }
+
+   // Runtime check: is a glaze_value_t field currently null?
+   template <class T, size_t I, class Value, class Tie>
+   bool is_glaze_value_field_null(Value&& value, Tie&& t)
+   {
+      using val_t = field_t<T, I>;
+      using Inner = remove_meta_wrapper_t<val_t>;
+      decltype(auto) element = [&]() -> decltype(auto) {
+         if constexpr (reflectable<T>) {
+            return get<I>(t);
+         }
+         else {
+            return get<I>(reflect<T>::values);
+         }
+      };
+      auto&& inner_val = get_member(get_member(value, element()), meta_wrapper_v<val_t>);
+      if constexpr (nullable_value_t<Inner>) {
+         return !inner_val.has_value();
+      }
+      else {
+         return !bool(inner_val);
+      }
+   }
+
    template <auto Opts, class T>
    inline constexpr bool maybe_skipped = [] {
       if constexpr (reflect<T>::size > 0) {
@@ -443,7 +478,8 @@ namespace glz
                return (
                   (always_skipped<field_t<T, I>> ||
                    (!write_function_pointers && is_member_function_pointer<field_t<T, I>>) || null_t<field_t<T, I>> ||
-                   (is_specialization_v<field_t<T, I>, custom_t> && custom_getter_returns_nullable<field_t<T, I>>())) ||
+                   (is_specialization_v<field_t<T, I>, custom_t> && custom_getter_returns_nullable<field_t<T, I>>()) ||
+                   glaze_value_is_nullable<field_t<T, I>>()) ||
                   ...);
             }(std::make_index_sequence<N>{});
          }

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -2196,6 +2196,9 @@ namespace glz
                                         custom_getter_returns_nullable<val_t>()) {
                         if (is_custom_field_null<T, I>(value, t, ctx)) return;
                      }
+                     else if constexpr (Opts.skip_null_members && glaze_value_is_nullable<val_t>()) {
+                        if (is_glaze_value_field_null<T, I>(value, t)) return;
+                     }
 
                      if constexpr (Opts.prettify) {
                         if (!ensure_space(ctx, b, ix + padding + ctx.depth)) [[unlikely]] {

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -389,6 +389,21 @@ struct outer_skip_struct
    std::optional<bool> outer_opt2{};
 };
 
+struct beve_glaze_value_nullable_field
+{
+   std::optional<int> my_val;
+   struct glaze
+   {
+      static constexpr auto value{&beve_glaze_value_nullable_field::my_val};
+   };
+};
+
+struct beve_glaze_value_nullable_obj
+{
+   beve_glaze_value_nullable_field field_name{};
+   std::string required_field{};
+};
+
 void write_tests()
 {
    using namespace ut;
@@ -712,6 +727,33 @@ void write_tests()
          expect(json_obj3.nested.inner_opt2 == beve_obj3.nested.inner_opt2);
          expect(json_obj3.nested.inner_opt2.value() == 3.14159);
       }
+   };
+
+   "glaze_value_t nullable skip_null_members beve round-trip"_test = [] {
+      // Null field should be skipped in BEVE output, then read back as default
+      beve_glaze_value_nullable_obj obj{};
+      obj.required_field = "hello";
+
+      std::vector<char> buffer;
+      auto write_err = glz::write_beve(obj, buffer);
+      expect(!write_err);
+
+      beve_glaze_value_nullable_obj obj2{};
+      auto read_err = glz::read_beve(obj2, buffer);
+      expect(!read_err);
+      expect(!obj2.field_name.my_val.has_value());
+      expect(obj2.required_field == "hello");
+
+      // With value present
+      obj.field_name.my_val = 42;
+      buffer.clear();
+      write_err = glz::write_beve(obj, buffer);
+      expect(!write_err);
+
+      read_err = glz::read_beve(obj2, buffer);
+      expect(!read_err);
+      expect(obj2.field_name.my_val.has_value());
+      expect(obj2.field_name.my_val.value() == 42);
    };
 
    "map"_test = [] {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -12915,6 +12915,23 @@ struct glaze_value_nullable_obj
    std::string required_field{};
 };
 
+struct glaze_value_ptr_field
+{
+   std::unique_ptr<int> ptr;
+   struct glaze
+   {
+      static constexpr auto value{&glaze_value_ptr_field::ptr};
+   };
+};
+
+struct glaze_value_nullable_multi_obj
+{
+   glaze_value_nullable_field a{};
+   glaze_value_ptr_field b{};
+   std::string c{};
+   glaze_value_nullable_field d{};
+};
+
 struct cast_nullable_obj
 {
    std::optional<double> a;
@@ -12977,6 +12994,83 @@ suite cast_tests = [] {
       data = R"({"a":null})";
       ec = glz::read<opts>(obj, data);
       expect(ec == glz::error_code::missing_key);
+   };
+
+   "glaze_value_t nullable skip_null_members write"_test = [] {
+      // When skip_null_members is enabled (default), writing a glaze_value_t
+      // wrapping a nullable type should skip the field when the inner value is null
+      glaze_value_nullable_obj obj{};
+      obj.required_field = "hello";
+      // field_name.my_val is std::nullopt by default
+
+      auto result = glz::write_json(obj);
+      expect(result.has_value());
+      expect(result.value() == R"({"required_field":"hello"})") << result.value();
+
+      // With value present, the field should be written
+      obj.field_name.my_val = 42;
+      result = glz::write_json(obj);
+      expect(result.has_value());
+      expect(result.value() == R"({"field_name":42,"required_field":"hello"})") << result.value();
+   };
+
+   "glaze_value_t nullable unique_ptr inner type"_test = [] {
+      glaze_value_nullable_multi_obj obj{};
+      obj.c = "hello";
+      // a (optional) and b (unique_ptr) and d (optional) are all null
+
+      auto result = glz::write_json(obj);
+      expect(result.has_value());
+      expect(result.value() == R"({"c":"hello"})") << result.value();
+
+      // Set only the unique_ptr field
+      obj.b.ptr = std::make_unique<int>(99);
+      result = glz::write_json(obj);
+      expect(result.has_value());
+      expect(result.value() == R"({"b":99,"c":"hello"})") << result.value();
+
+      // Set all fields
+      obj.a.my_val = 1;
+      obj.d.my_val = 4;
+      result = glz::write_json(obj);
+      expect(result.has_value());
+      expect(result.value() == R"({"a":1,"b":99,"c":"hello","d":4})") << result.value();
+   };
+
+   "glaze_value_t nullable skip_null_members false"_test = [] {
+      constexpr auto opts = glz::opts{.format = glz::JSON, .skip_null_members = false};
+
+      glaze_value_nullable_obj obj{};
+      obj.required_field = "hello";
+
+      auto result = glz::write<opts>(obj);
+      expect(result.has_value());
+      expect(result.value() == R"({"field_name":null,"required_field":"hello"})") << result.value();
+   };
+
+   "glaze_value_t nullable write then read round-trip"_test = [] {
+      // Round-trip with null field: field is skipped, reading into default object preserves nullopt
+      glaze_value_nullable_obj obj{};
+      obj.required_field = "hello";
+
+      auto json = glz::write_json(obj);
+      expect(json.has_value());
+
+      glaze_value_nullable_obj obj2{};
+      auto ec = glz::read_json(obj2, json.value());
+      expect(!ec) << glz::format_error(ec, json.value());
+      expect(!obj2.field_name.my_val.has_value());
+      expect(obj2.required_field == "hello");
+
+      // Round-trip with value present
+      obj.field_name.my_val = 42;
+      json = glz::write_json(obj);
+      expect(json.has_value());
+
+      ec = glz::read_json(obj2, json.value());
+      expect(!ec) << glz::format_error(ec, json.value());
+      expect(obj2.field_name.my_val.has_value());
+      expect(obj2.field_name.my_val.value() == 42);
    };
 
    "glaze_value_t nullable with error_on_missing_keys"_test = [] {


### PR DESCRIPTION
## Fix `skip_null_members` for `glaze_value_t` wrapping nullable types

Fixes #2397

When a struct field uses `glaze::value` to expose a nullable inner type (e.g. `std::optional`, `std::unique_ptr`), the `skip_null_members` option was not skipping the field during writing. The null check was only performed on the outer wrapper type, which is not itself nullable.

### Changes

**`include/glaze/core/reflect.hpp`**
- Added `glaze_value_is_nullable<V>()` — compile-time check for whether a `glaze_value_t` wraps a nullable inner type.
- Added `is_glaze_value_field_null<T, I>(value, t)` — runtime null check that unwraps the value type and tests the inner value.
- Updated `maybe_skipped` to recognize nullable value types so the skip code path is entered.

**`include/glaze/json/write.hpp`**, **`cbor/write.hpp`**, **`beve/write.hpp`**
- Added an `else if` branch in each object-member write loop that calls the new helpers to skip null value-type fields. CBOR and BEVE each have two sites (member-count pass and write pass).

### Tests

- `std::optional<int>` inner type — null skipped, non-null written
- `std::unique_ptr<int>` inner type — exercises the `!bool()` null-check path
- Multiple nullable value-type fields with mixed null/non-null
- `skip_null_members = false` — null explicitly written as `null`
- JSON and BEVE round-trip (write then read back)