### PR TITLE
Make REST router more like a map and allow overwriting routes

### DIFF
--- a/docs/networking/rest-registry.md
+++ b/docs/networking/rest-registry.md
@@ -228,26 +228,28 @@ private:
 
 ### Service Composition
 
+Multiple services can be registered on a single registry. Each service's member endpoints are registered under the mount path, while the root endpoint reflects the last registered service.
+
 ```cpp
 int main() {
     glz::http_server server;
-    
+
     // Multiple service instances
     UserService userService;
     ProductService productService;
     OrderService orderService;
-    
+
     // Single registry for all services
     glz::registry<glz::opts{}, glz::REST> registry;
-    
+
     // Register all services
     registry.on(userService);
-    registry.on(productService);  
+    registry.on(productService);
     registry.on(orderService);
-    
+
     // All endpoints available under /api
     server.mount("/api", registry.endpoints);
-    
+
     server.bind(8080).with_signals();
     server.start();
     server.wait_for_signal();
@@ -256,6 +258,15 @@ int main() {
 
 Each registered service in this setup (`UserService`, `ProductService`, `OrderService`) needs its own
 `glz::meta<...>::value = glz::object(...)` declaration.
+
+> [!NOTE]
+>
+> When composing multiple services, the root endpoint (e.g. `GET /api`) returns only the last registered service's data. If you need a combined root endpoint that merges all services into a single view, use `glz::merge` instead:
+>
+> ```cpp
+> auto merged = glz::merge{userService, productService, orderService};
+> registry.on(merged);
+> ```
 
 ## Customization
 

--- a/docs/rpc/jsonrpc-registry.md
+++ b/docs/rpc/jsonrpc-registry.md
@@ -314,9 +314,11 @@ Function pointers support:
 
 > **Note:** Function pointers with more than one parameter are not supported. Use a struct parameter for multiple values.
 
-## Using with `glz::merge`
+## Service Composition
 
-Multiple objects can be merged into a single registry:
+Multiple services can be registered on a single registry by calling `on()` multiple times. Each service's member endpoints are all registered, while the root endpoint reflects the last registered service.
+
+To combine multiple objects into a single merged view at the root path, use `glz::merge`:
 
 ```cpp
 struct sensors_t {

--- a/docs/rpc/repe-rpc.md
+++ b/docs/rpc/repe-rpc.md
@@ -104,7 +104,7 @@ See [REPE Buffer Handling](repe-buffer.md) for detailed documentation of these t
 
 ## Registering Multiple Objects with `glz::merge`
 
-By default, when you register an object with `server.on(obj)`, the root path `""` returns that object's JSON representation. If you call `server.on()` multiple times with different objects, only the last registered object will be returned at the root path `""`.
+By default, when you register an object with `server.on(obj)`, the root path `""` returns that object's JSON representation. If you call `server.on()` multiple times with different objects, the last registered object will be returned at the root path `""`. Each service's member endpoints are all registered regardless.
 
 To combine multiple objects into a single merged view at the root path, use `glz::merge`:
 

--- a/include/glaze/net/http_router.hpp
+++ b/include/glaze/net/http_router.hpp
@@ -770,15 +770,7 @@ namespace glz
 
          // Optimization: for non-parameterized routes, store them directly
          if (path_str.find(':') == std::string::npos && path_str.find('*') == std::string::npos) {
-            // Check for conflicts first
-            auto& method_handlers = direct_routes[path_str];
-            if (method_handlers.find(method) != method_handlers.end()) {
-               throw std::runtime_error("Route conflict: handler already exists for " + std::string(to_string(method)) +
-                                        " " + path_str);
-            }
-
-            // Store the route directly
-            method_handlers[method] = handle;
+            direct_routes[path_str][method] = handle;
             return;
          }
 
@@ -854,12 +846,6 @@ namespace glz
 
                current = current->static_children[segment].get();
             }
-         }
-
-         // Check for route conflict
-         if (current->is_endpoint && current->handlers.find(method) != current->handlers.end()) {
-            throw std::runtime_error("Route conflict: handler already exists for " + std::string(to_string(method)) +
-                                     " " + path_str);
          }
 
          // Mark as endpoint and set handler

--- a/tests/networking_tests/http_router_test/http_router_test.cpp
+++ b/tests/networking_tests/http_router_test/http_router_test.cpp
@@ -2,6 +2,7 @@
 // For the license information refer to glaze.hpp
 
 #include "glaze/net/http_router.hpp"
+#include "glaze/rpc/registry.hpp"
 
 #include <cassert>
 #include <regex>
@@ -429,6 +430,153 @@ suite path_param_decoding_tests = [] {
       auto [handler, params] = router.match(glz::http_method::GET, "/files/my%20docs/file%20name.txt");
       expect(handler != nullptr);
       expect(params["path"] == "my docs/file name.txt");
+   };
+};
+
+// Service composition test types (GitHub issue #2401)
+
+struct Task
+{
+   int id{};
+   std::string title{};
+};
+
+class TaskService
+{
+   std::vector<Task> tasks_;
+
+  public:
+   std::vector<Task> getAllTasks() { return tasks_; }
+};
+
+template <>
+struct glz::meta<TaskService>
+{
+   using T = TaskService;
+   static constexpr auto value = object(&T::getAllTasks);
+};
+
+struct Post
+{
+   int id{};
+   std::string title{};
+};
+
+class PostService
+{
+   std::vector<Post> posts_;
+
+  public:
+   std::vector<Post> getAllPosts() { return posts_; }
+};
+
+template <>
+struct glz::meta<PostService>
+{
+   using T = PostService;
+   static constexpr auto value = object(&T::getAllPosts);
+};
+
+struct Config
+{
+   int id{};
+   std::string title{};
+};
+
+class ConfigService
+{
+   std::vector<Config> configs_;
+
+  public:
+   std::vector<Config> getAllConfigs() { return configs_; }
+};
+
+template <>
+struct glz::meta<ConfigService>
+{
+   using T = ConfigService;
+   static constexpr auto value = object(&T::getAllConfigs);
+};
+
+suite route_replacement_tests = [] {
+   "duplicate_direct_route_replaces_handler"_test = [] {
+      glz::http_router router;
+
+      router.get("", [](const glz::request&, glz::response& res) { res.body("first"); });
+      router.get("", [](const glz::request&, glz::response& res) { res.body("second"); });
+
+      auto [handler, params] = router.match(glz::http_method::GET, "");
+      expect(handler != nullptr);
+
+      glz::request req{.method = glz::http_method::GET, .target = ""};
+      glz::response res;
+      handler(req, res);
+      expect(res.response_body == "second") << "Last registered handler should win";
+   };
+
+   "duplicate_route_different_methods_coexist"_test = [] {
+      glz::http_router router;
+
+      router.get("/path", [](const glz::request&, glz::response& res) { res.body("get"); });
+      router.put("/path", [](const glz::request&, glz::response& res) { res.body("put"); });
+      router.get("/path", [](const glz::request&, glz::response& res) { res.body("get2"); });
+
+      auto [get_handler, get_params] = router.match(glz::http_method::GET, "/path");
+      auto [put_handler, put_params] = router.match(glz::http_method::PUT, "/path");
+      expect(get_handler != nullptr);
+      expect(put_handler != nullptr);
+
+      glz::request req{.method = glz::http_method::GET, .target = "/path"};
+      glz::response get_res, put_res;
+      get_handler(req, get_res);
+      put_handler(req, put_res);
+      expect(get_res.response_body == "get2") << "Replaced GET should use new handler";
+      expect(put_res.response_body == "put") << "PUT should be unchanged";
+   };
+};
+
+suite service_composition_tests = [] {
+   "multiple_services_on_single_registry"_test = [] {
+      TaskService taskService;
+      PostService postService;
+      ConfigService configService;
+
+      glz::registry<glz::opts{}, glz::REST> registry;
+
+      // Registering multiple services should not produce errors
+      registry.on(taskService);
+      registry.on(postService);
+      registry.on(configService);
+
+      auto check = [&](const std::string& path, bool should_exist) {
+         auto [handler, params] = registry.endpoints.match(glz::http_method::GET, path);
+         expect((handler != nullptr) == should_exist) << path;
+      };
+
+      // Each service's endpoints should be accessible
+      check("/getAllTasks", true);
+      check("/getAllPosts", true);
+      check("/getAllConfigs", true);
+
+      // Root endpoint should exist (last registered service wins)
+      check("", true);
+   };
+
+   "single_service_root_endpoint_works"_test = [] {
+      TaskService taskService;
+
+      glz::registry<glz::opts{}, glz::REST> registry;
+      registry.on(taskService);
+
+      // Root should have both GET and PUT
+      auto [get_handler, get_params] = registry.endpoints.match(glz::http_method::GET, "");
+      auto [put_handler, put_params] = registry.endpoints.match(glz::http_method::PUT, "");
+      expect(get_handler != nullptr);
+      expect(put_handler != nullptr);
+
+      // Sub-endpoint should work
+      auto [tasks_handler, tasks_params] = registry.endpoints.match(glz::http_method::GET, "/getAllTasks");
+      expect(tasks_handler != nullptr);
    };
 };
 


### PR DESCRIPTION
# Fix route conflict error on REST service composition (#2401)

Registering multiple services on a single `glz::registry<opts, REST>` via separate `on()` calls produced spurious "Route conflict" errors on stderr. Each service tried to register GET/PUT handlers at the root path, and the HTTP router threw on duplicates.

## Changes

**`include/glaze/net/http_router.hpp`** — Allow route replacement (last writer wins) instead of throwing on duplicate method+path registrations. This applies to both direct routes and parameterized radix tree routes, making the router consistent with the map-based storage used by REPE and JSONRPC protocols.

**`tests/.../http_router_test.cpp`** — Added tests for route replacement behavior and a service composition test reproducing the exact scenario from the issue (three services on one registry).

**`docs/`** — Updated REST, JSONRPC, and REPE registry docs to document service composition behavior: all member endpoints are registered, the root endpoint reflects the last registered service, and `glz::merge` is recommended for a combined root view.