### PR TITLE
Update deprecated CI dependencies

### DIFF
--- a/.github/workflows/armv7.yml
+++ b/.github/workflows/armv7.yml
@@ -22,7 +22,7 @@ jobs:
     name: GCC armv7 (NEON, cross-compiled)
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install cross-compiler and QEMU
       run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,7 +18,7 @@ jobs:
       CXX: g++-14
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Verify AVX2 support
       run: grep -q avx2 /proc/cpuinfo && echo "AVX2 is available"
@@ -52,7 +52,7 @@ jobs:
       CXX: g++-14
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Verify AVX2 support
       run: grep -q avx2 /proc/cpuinfo && echo "AVX2 is available"

--- a/.github/workflows/big-endian.yml
+++ b/.github/workflows/big-endian.yml
@@ -22,7 +22,7 @@ jobs:
     name: GCC s390x (big-endian, cross-compiled)
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install cross-compiler and QEMU
       run: |

--- a/.github/workflows/boost-asio.yml
+++ b/.github/workflows/boost-asio.yml
@@ -33,7 +33,7 @@ jobs:
       CXX: ${{ matrix.compiler.name == 'gcc' && 'g++' || 'clang++' }}-${{matrix.compiler.version}}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install clang
         if: matrix.compiler.name == 'clang'

--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -30,7 +30,7 @@ jobs:
         cpp_version: [23]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Configure CMake
       run: |

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: DoozyX/clang-format-lint-action@v0.20
       with:
         source: '.'

--- a/.github/workflows/clang-linux-erlang.yml
+++ b/.github/workflows/clang-linux-erlang.yml
@@ -32,7 +32,7 @@ jobs:
       CXX: clang++-${{matrix.clang}}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/clang-linux-latest.yml
+++ b/.github/workflows/clang-linux-latest.yml
@@ -36,7 +36,7 @@ jobs:
       LLVM_VERSION: ${{matrix.clang}}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install latest clang
       run: |

--- a/.github/workflows/clang-linux.yml
+++ b/.github/workflows/clang-linux.yml
@@ -32,7 +32,7 @@ jobs:
       CXX: clang++-${{matrix.clang}}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0 # Fetch all history for git diff
         token: ${{ secrets.GITHUB_TOKEN }} # Use GITHUB_TOKEN for pushing changes

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - uses: maxim-lobanov/setup-xcode@v1
       with:

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     
     - name: Set up environment
       run: |

--- a/.github/workflows/disable-always-inline.yml
+++ b/.github/workflows/disable-always-inline.yml
@@ -45,7 +45,7 @@ jobs:
           python3
         update-ca-certificates
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Configure CMake
       run: |
@@ -77,7 +77,7 @@ jobs:
       LLVM_VERSION: 19
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install Clang 19
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/exhaustive_float.yml
+++ b/.github/workflows/exhaustive_float.yml
@@ -32,7 +32,7 @@ jobs:
       CXX: clang++-${{matrix.clang}}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/exhaustive_int.yml
+++ b/.github/workflows/exhaustive_int.yml
@@ -32,7 +32,7 @@ jobs:
       CXX: clang++-${{matrix.clang}}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/gcc-erlang.yml
+++ b/.github/workflows/gcc-erlang.yml
@@ -37,7 +37,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install erlang-dev
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Configure CMake
       run: |

--- a/.github/workflows/gcc-old-abi.yml
+++ b/.github/workflows/gcc-old-abi.yml
@@ -32,7 +32,7 @@ jobs:
       CXX: g++-${{matrix.gcc}}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Configure CMake
       run: |
@@ -73,7 +73,7 @@ jobs:
           python3
         update-ca-certificates
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Prepare build directory
       run: cmake -E make_directory "$GITHUB_WORKSPACE/build"

--- a/.github/workflows/gcc-p2996-reflection.yml
+++ b/.github/workflows/gcc-p2996-reflection.yml
@@ -44,7 +44,7 @@ jobs:
         apt-get update
         apt-get install -y gcc-16 g++-16
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Verify GCC version and reflection support
       run: |

--- a/.github/workflows/gcc-x86.yml
+++ b/.github/workflows/gcc-x86.yml
@@ -32,7 +32,7 @@ jobs:
          CXX: g++-${{matrix.gcc}}
 
       steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@v6
 
          - name: Setup environment
            run: |

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -32,7 +32,7 @@ jobs:
       CXX: g++-${{matrix.gcc}}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Configure CMake
       run: |
@@ -73,7 +73,7 @@ jobs:
           python3
         update-ca-certificates
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Prepare build directory
       run: cmake -E make_directory "$GITHUB_WORKSPACE/build"

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -30,7 +30,7 @@ jobs:
         cpp_version: [23]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_STANDARD=${{matrix.cpp_version}}

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -21,7 +21,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: msys2/setup-msys2@v2
       with:
         update: true

--- a/.github/workflows/p2996-reflection.yml
+++ b/.github/workflows/p2996-reflection.yml
@@ -25,7 +25,7 @@ jobs:
     name: P2996 Reflection Tests
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Pull P2996 Docker image
       run: docker pull ${{ env.P2996_IMAGE }}

--- a/.github/workflows/quickfuzz.yml
+++ b/.github/workflows/quickfuzz.yml
@@ -32,7 +32,7 @@ jobs:
       CXX: clang++-${{matrix.clang}}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -46,7 +46,7 @@ jobs:
           python3
         update-ca-certificates
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Configure CMake
       run: |

--- a/.github/workflows/simple_float.yml
+++ b/.github/workflows/simple_float.yml
@@ -32,7 +32,7 @@ jobs:
       CXX: clang++-${{matrix.clang}}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install dependencies
       run: |
@@ -71,7 +71,7 @@ jobs:
       CXX: g++-${{matrix.gcc}}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Configure CMake
       run: |

--- a/.github/workflows/standalone-asio.yml
+++ b/.github/workflows/standalone-asio.yml
@@ -47,7 +47,7 @@ jobs:
           python3
         update-ca-certificates
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Configure CMake
       run: |

--- a/.github/workflows/yaml-conformance-data-gcc.yml
+++ b/.github/workflows/yaml-conformance-data-gcc.yml
@@ -32,7 +32,7 @@ jobs:
       CXX: g++-${{matrix.gcc}}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Configure CMake
       run: |


### PR DESCRIPTION
### Issue
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

You can read more [here](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)
You will see warnings if you open "Annotations" dropdown in [any glaze workflow run](https://github.com/stephenberry/glaze/actions/runs/23657543310/job/68918793812)

### Fix
This PR resolves this issue by replacing `checkout/v4`, which runs on Node.js 20, with `checkout/v6`, whose runtime uses Node.js 24. `v5` also uses Node.js 24, but I figured that since the opportunity was there and it wouldn’t break anything, why not upgrade to the latest version?