### PR TITLE
internal linkage for constexpr variables for module use

### DIFF
--- a/include/glaze/beve/header.hpp
+++ b/include/glaze/beve/header.hpp
@@ -59,43 +59,43 @@ namespace glz
 
 namespace glz::tag
 {
-   constexpr uint8_t null = 0;
-   constexpr uint8_t boolean = 0b00001'000;
-   constexpr uint8_t number = 1;
-   constexpr uint8_t string = 2;
-   constexpr uint8_t object = 3;
-   constexpr uint8_t typed_array = 4;
-   constexpr uint8_t generic_array = 5;
-   constexpr uint8_t extensions = 6;
+   inline constexpr uint8_t null = 0;
+   inline constexpr uint8_t boolean = 0b00001'000;
+   inline constexpr uint8_t number = 1;
+   inline constexpr uint8_t string = 2;
+   inline constexpr uint8_t object = 3;
+   inline constexpr uint8_t typed_array = 4;
+   inline constexpr uint8_t generic_array = 5;
+   inline constexpr uint8_t extensions = 6;
 
    // Data delimiter for separating multiple BEVE values in a stream/buffer
    // Used like NDJSON's newline delimiter - when converted to JSON outputs '\n'
-   constexpr uint8_t delimiter = 0b00000'110; // extensions type (6) with subtype 0
+   inline constexpr uint8_t delimiter = 0b00000'110; // extensions type (6) with subtype 0
 
-   constexpr uint8_t bool_false = 0b000'01'000;
-   constexpr uint8_t bool_true = 0b000'11'000;
+   inline constexpr uint8_t bool_false = 0b000'01'000;
+   inline constexpr uint8_t bool_true = 0b000'11'000;
 
-   constexpr uint8_t i8 = 0b000'01'001;
-   constexpr uint8_t i16 = 0b001'01'001;
-   constexpr uint8_t i32 = 0b010'01'001;
-   constexpr uint8_t i64 = 0b011'01'001;
-   constexpr uint8_t i128 = 0b100'01'001;
+   inline constexpr uint8_t i8 = 0b000'01'001;
+   inline constexpr uint8_t i16 = 0b001'01'001;
+   inline constexpr uint8_t i32 = 0b010'01'001;
+   inline constexpr uint8_t i64 = 0b011'01'001;
+   inline constexpr uint8_t i128 = 0b100'01'001;
 
-   constexpr uint8_t u8 = 0b000'10'001;
-   constexpr uint8_t u16 = 0b001'10'001;
-   constexpr uint8_t u32 = 0b010'10'001;
-   constexpr uint8_t u64 = 0b011'10'001;
-   constexpr uint8_t u128 = 0b100'10'001;
+   inline constexpr uint8_t u8 = 0b000'10'001;
+   inline constexpr uint8_t u16 = 0b001'10'001;
+   inline constexpr uint8_t u32 = 0b010'10'001;
+   inline constexpr uint8_t u64 = 0b011'10'001;
+   inline constexpr uint8_t u128 = 0b100'10'001;
 
-   constexpr uint8_t bf16 = 0b000'00'001; // brain float
-   constexpr uint8_t f16 = 0b001'00'001;
-   constexpr uint8_t f32 = 0b010'00'001;
-   constexpr uint8_t f64 = 0b011'00'001;
-   constexpr uint8_t f128 = 0b100'00'001;
+   inline constexpr uint8_t bf16 = 0b000'00'001; // brain float
+   inline constexpr uint8_t f16 = 0b001'00'001;
+   inline constexpr uint8_t f32 = 0b010'00'001;
+   inline constexpr uint8_t f64 = 0b011'00'001;
+   inline constexpr uint8_t f128 = 0b100'00'001;
 
    // Aligned typed array: category 3, sub-type 2 (bit 6 set, bits 5 and 7 clear)
    // Layout: ALIGNED_HEADER | NUMERIC_HEADER | SIZE | PADDING_LENGTH | PADDING | DATA
-   constexpr uint8_t aligned_typed_array = 0b010'11'100; // 0x5C
+   inline constexpr uint8_t aligned_typed_array = 0b010'11'100; // 0x5C
 }
 
 namespace glz

--- a/include/glaze/reflection/to_tuple.hpp
+++ b/include/glaze/reflection/to_tuple.hpp
@@ -104,7 +104,7 @@ namespace glz
          }
       }();
 
-      constexpr size_t max_pure_reflection_count = 128;
+      inline constexpr size_t max_pure_reflection_count = 128;
 #endif
    }
 

--- a/include/glaze/util/fast_float.hpp
+++ b/include/glaze/util/fast_float.hpp
@@ -185,8 +185,8 @@ namespace glz::fast_float {
 enum class chars_format : uint64_t;
 
 namespace detail {
-constexpr chars_format basic_json_fmt = chars_format(1 << 5);
-constexpr chars_format basic_fortran_fmt = chars_format(1 << 6);
+inline constexpr chars_format basic_json_fmt = chars_format(1 << 5);
+inline constexpr chars_format basic_fortran_fmt = chars_format(1 << 6);
 } // namespace detail
 
 enum class chars_format : uint64_t {
@@ -577,10 +577,10 @@ struct adjusted_mantissa {
 };
 
 // Bias so we can get the real exponent with an invalid adjusted_mantissa.
-constexpr static int32_t invalid_am_bias = -0x8000;
+inline constexpr int32_t invalid_am_bias = -0x8000;
 
 // used for binary_format_lookup_tables<T>::max_mantissa
-constexpr uint64_t constant_55555 = 5 * 5 * 5 * 5 * 5;
+inline constexpr uint64_t constant_55555 = 5 * 5 * 5 * 5 * 5;
 
 template <typename T, typename U = void> struct binary_format_lookup_tables;
 
@@ -1167,7 +1167,7 @@ template <typename UC> constexpr bool is_space(UC c) {
   return c < 256 && space_lut<>::value[uint8_t(c)];
 }
 
-template <typename UC> static constexpr uint64_t int_cmp_zeros() {
+template <typename UC> constexpr uint64_t int_cmp_zeros() {
   static_assert((sizeof(UC) == 1) || (sizeof(UC) == 2) || (sizeof(UC) == 4),
                 "Unsupported character size");
   return (sizeof(UC) == 1) ? 0x3030303030303030
@@ -1177,7 +1177,7 @@ template <typename UC> static constexpr uint64_t int_cmp_zeros() {
              : (uint64_t(UC('0')) << 32 | UC('0'));
 }
 
-template <typename UC> static constexpr int int_cmp_len() {
+template <typename UC> constexpr int int_cmp_len() {
   return sizeof(uint64_t) / sizeof(UC);
 }
 
@@ -2980,11 +2980,11 @@ namespace glz::fast_float {
 #if defined(GLZ_FASTFLOAT_64BIT) && !defined(__sparc)
 #define GLZ_FASTFLOAT_64BIT_LIMB 1
 typedef uint64_t limb;
-constexpr size_t limb_bits = 64;
+inline constexpr size_t limb_bits = 64;
 #else
 #define GLZ_FASTFLOAT_32BIT_LIMB
 typedef uint32_t limb;
-constexpr size_t limb_bits = 32;
+inline constexpr size_t limb_bits = 32;
 #endif
 
 typedef span<limb> limb_span;
@@ -2993,8 +2993,8 @@ typedef span<limb> limb_span;
 // of bits required to store the largest bigint, which is
 // `log2(10**(digits + max_exp))`, or `log2(10**(767 + 342))`, or
 // ~3600 bits, so we round to 4000.
-constexpr size_t bigint_bits = 4000;
-constexpr size_t bigint_limbs = bigint_bits / limb_bits;
+inline constexpr size_t bigint_bits = 4000;
+inline constexpr size_t bigint_limbs = bigint_bits / limb_bits;
 
 // vector-like type that is allocated on the stack. the entire
 // buffer is pre-allocated, and only the length changes.
@@ -3610,7 +3610,7 @@ struct bigint : pow5_tables<> {
 namespace glz::fast_float {
 
 // 1e0 to 1e19
-constexpr static uint64_t powers_of_ten_uint64[] = {1UL,
+inline constexpr uint64_t powers_of_ten_uint64[] = {1UL,
                                                     10UL,
                                                     100UL,
                                                     1000UL,

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -269,16 +269,16 @@ namespace glz
 
    namespace unicode
    {
-      constexpr uint32_t generic_surrogate_mask = 0xF800;
-      constexpr uint32_t generic_surrogate_value = 0xD800;
+      inline constexpr uint32_t generic_surrogate_mask = 0xF800;
+      inline constexpr uint32_t generic_surrogate_value = 0xD800;
 
-      constexpr uint32_t surrogate_mask = 0xFC00;
-      constexpr uint32_t high_surrogate_value = 0xD800;
-      constexpr uint32_t low_surrogate_value = 0xDC00;
+      inline constexpr uint32_t surrogate_mask = 0xFC00;
+      inline constexpr uint32_t high_surrogate_value = 0xD800;
+      inline constexpr uint32_t low_surrogate_value = 0xDC00;
 
-      constexpr uint32_t surrogate_codepoint_offset = 0x10000;
-      constexpr uint32_t surrogate_codepoint_mask = 0x03FF;
-      constexpr uint32_t surrogate_codepoint_bits = 10;
+      inline constexpr uint32_t surrogate_codepoint_offset = 0x10000;
+      inline constexpr uint32_t surrogate_codepoint_mask = 0x03FF;
+      inline constexpr uint32_t surrogate_codepoint_bits = 10;
    }
 
    template <class SrcChar, class DstChar = SrcChar>

--- a/include/glaze/util/simple_float.hpp
+++ b/include/glaze/util/simple_float.hpp
@@ -33,8 +33,8 @@ namespace glz::simple_float
          int32_t exp10{};
       };
 
-      static constexpr int32_t max_exp10 = 400;
-      static constexpr int32_t min_exp10 = -400;
+      inline constexpr int32_t max_exp10 = 400;
+      inline constexpr int32_t min_exp10 = -400;
 
       // Strict JSON-compliant number parser
       // JSON number format (RFC 8259):


### PR DESCRIPTION
Added inline to namespace-scope constexpr variables (giving them external linkage), and removed static from function templates.

---

constexpr functions are implicitly inline, but constexpr variables are not — they're implicitly const, and const at namespace scope has internal linkage in C++.

So:

```c++
// Internal linkage (each TU gets its own copy)
constexpr int x = 42;

// External linkage (one definition shared across TUs)
inline constexpr int x = 42;
```

This distinction doesn't matter in traditional header-based code — each TU gets its own identical copy and the linker is fine with it. But with C++ modules, GCC 15 enforces [basic.link]/[module.reach]: a module interface unit must not expose entities with internal linkage (TU-local entities) in any reachable declaration. Since templates and inline functions in the module interface reference these constants, the internal-linkage variables "leak" through, and GCC rightfully rejects it.