### PR TITLE
Remove make_static

### DIFF
--- a/include/glaze/core/meta.hpp
+++ b/include/glaze/core/meta.hpp
@@ -767,8 +767,8 @@ namespace glz
       }
       else if constexpr (std::is_same_v<std::decay_t<decltype(ids[0])>, std::string_view>) {
          constexpr auto Len = detail::variant_ids_string_len<T>;
-         auto& static_arr = detail::make_static<detail::variant_ids_joined<T, Len>>::value;
-         return std::string_view{static_arr.data(), Len};
+         constexpr auto& arr = detail::variant_ids_joined<T, Len>;
+         return std::string_view{arr.data(), Len};
       }
       else {
          return std::string_view{};

--- a/include/glaze/json/escape_unicode.hpp
+++ b/include/glaze/json/escape_unicode.hpp
@@ -243,7 +243,7 @@ namespace glz
 {
    template <string_literal Str>
    inline constexpr auto escape_unicode = []() constexpr -> std::string_view {
-      constexpr auto escaped = []() constexpr {
+      static constexpr auto escaped = []() constexpr {
          constexpr auto len = detail::escaped_length(Str.sv());
          std::array<char, len + 1> result; // + 1 for null character
          const auto escaped = detail::escape_json_string(Str.sv(), len);
@@ -254,9 +254,7 @@ namespace glz
          return result;
       }();
 
-      // make_static here required for GCC 12, in the future just make escaped static
-      auto& arr = detail::make_static<escaped>::value;
-      return {arr.data(), arr.size() - 1};
+      return {escaped.data(), escaped.size() - 1};
    }();
 }
 

--- a/include/glaze/reflection/get_name.hpp
+++ b/include/glaze/reflection/get_name.hpp
@@ -300,12 +300,6 @@ namespace glz
    template <class T>
    struct meta;
 
-   template <std::pair V>
-   struct make_static
-   {
-      static constexpr auto value = V;
-   };
-
 #if GLZ_HAS_CONSTEXPR_STRING
    // Concept for when rename_key returns exactly std::string (allocates)
    // Requires constexpr std::string support (not available with _GLIBCXX_USE_CXX11_ABI=0)

--- a/include/glaze/util/string_literal.hpp
+++ b/include/glaze/util/string_literal.hpp
@@ -70,16 +70,10 @@ namespace glz
 
    namespace detail
    {
-      template <std::array V>
-      struct make_static
-      {
-         static constexpr auto value = V;
-      };
-
       template <const std::string_view&... Strs>
       inline constexpr std::string_view join()
       {
-         constexpr auto joined_arr = []() {
+         static constexpr auto joined_arr = []() {
             constexpr size_t len = (Strs.size() + ... + 0);
             std::array<char, len + 1> arr;
             auto append = [i = 0, &arr](const auto& s) mutable {
@@ -89,8 +83,7 @@ namespace glz
             arr[len] = '\0';
             return arr;
          }();
-         auto& static_arr = make_static<joined_arr>::value;
-         return {static_arr.data(), static_arr.size() - 1};
+         return {joined_arr.data(), joined_arr.size() - 1};
       }
    }
 
@@ -100,7 +93,7 @@ namespace glz
 
    template <const std::string_view& Key, bool Prettify = false>
    inline constexpr auto quoted_key_v = []() -> std::string_view {
-      constexpr auto quoted = [] {
+      static constexpr auto quoted = [] {
          constexpr auto N = Key.size();
          std::array<char, N + 4 + Prettify> result; // [quote, key, quote, colon, (prettify? space), null]
          result[0] = '"';
@@ -118,8 +111,6 @@ namespace glz
          }
          return result;
       }();
-      // TODO: make_static required by GCC 12
-      auto& static_arr = detail::make_static<quoted>::value;
-      return {static_arr.data(), static_arr.size() - 1};
+      return {quoted.data(), quoted.size() - 1};
    }();
 }


### PR DESCRIPTION
Since we've dropped support for GCC 12, we can now remove the intermediate `make_static` calls that just create additional template instantiations and slow down compile times.