### PR TITLE
Guard fixed_padding for prettify

### DIFF
--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -2250,7 +2250,7 @@ namespace glz
                });
             }
             else {
-               static constexpr size_t fixed_max_size = fixed_padding<T>;
+               static constexpr size_t fixed_max_size = Opts.prettify ? 0 : fixed_padding<T>;
                if constexpr (fixed_max_size && not check_write_unchecked(Options)) {
                   if (!ensure_space(ctx, b, ix + fixed_max_size)) [[unlikely]] {
                      return;

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -433,6 +433,14 @@ suite glz_enum_test = [] {
 
 enum class TestData : uint8_t { None, A, B, C, D, ERROR_E = 0xFF };
 
+// Issue #2455: structs with many fields to test fixed_padding + prettify
+struct issue2455_data {
+   int a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v;
+};
+struct issue2455_wrapper {
+   issue2455_data d;
+};
+
 struct DummyData
 {
    uint32_t id{0};
@@ -13989,6 +13997,17 @@ suite bounded_buffer_overflow_tests = [] {
 
       auto result = glz::write_json(obj, buffer);
       expect(result.ec == glz::error_code::buffer_overflow) << "should return buffer_overflow for too-small buffer";
+   };
+
+   // Regression test for issue #2455: out-of-bounds write with prettify + quoted_num
+   "prettify with fixed_padding struct"_test = [] {
+      issue2455_wrapper w{};
+      std::memset(&w, 128, sizeof(w));
+      std::string buffer;
+      constexpr auto opts = glz::opt_on<glz::opts{.prettify = true}, glz::quoted_num_opt_tag{}>();
+      auto ec = glz::write<opts>(w, buffer);
+      expect(not ec) << "prettify with many fields should not crash";
+      expect(buffer.size() > 0) << "output should not be empty";
    };
 };
 


### PR DESCRIPTION
## Fix out-of-bounds write with `.prettify` option (#2455)

`fixed_padding<T>` computes a pre-allocation size for object serialization that assumes non-prettified output — it does not account for newlines, indentation, or extra spaces. However, the object write path used `fixed_padding<T>` unconditionally, even when `Opts.prettify` is true. This caused the buffer to be undersized, leading to an out-of-bounds write.

### Fix

Set `fixed_max_size` to zero when prettifying, so the code falls through to per-field `ensure_space` checks that correctly account for indentation depth:

```cpp
// Before
static constexpr size_t fixed_max_size = fixed_padding<T>;
// After
static constexpr size_t fixed_max_size = Opts.prettify ? 0 : fixed_padding<T>;
```

### Regression test

Added a test that serializes a struct with many `int` fields using `prettify = true` and `quoted_num`, the combination that most closely approaches the `fixed_padding` limit and triggered the crash.