### PR TITLE
Proper JSON Schema for Glaze value metadata

### DIFF
--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -339,7 +339,7 @@ namespace glz
          {
             // &T::member
             if constexpr (glaze_t<T> && std::is_member_object_pointer_v<meta_wrapper_t<T>>) {
-               using val_t = member_t<T, meta_wrapper_t<T>>;
+               using val_t = std::remove_cvref_t<member_t<T, meta_wrapper_t<T>>>;
                to_json_schema<val_t>::template op<Opts>(s, defs);
                if constexpr (json_schema_t<T>) {
                   static constexpr auto schema_size = reflect<json_schema_type<T>>::size;
@@ -362,7 +362,7 @@ namespace glz
                }
             }
             else if constexpr (glaze_const_value_t<T>) { // &T::constexpr_member
-               using constexpr_val_t = member_t<T, meta_wrapper_t<T>>;
+               using constexpr_val_t = std::remove_cvref_t<member_t<T, meta_wrapper_t<T>>>;
                static constexpr auto val_v{*glz::meta_wrapper_v<T>};
                if constexpr (glz::glaze_enum_t<constexpr_val_t>) {
                   s.attributes.constant = glz::enum_name_v<val_v>;

--- a/tests/json_test/jsonschema_test.cpp
+++ b/tests/json_test/jsonschema_test.cpp
@@ -651,4 +651,109 @@ suite vector_pair_schema_test = [] {
    };
 };
 
+// Issue #2459: meta value types should produce correct schema
+struct holds_bool
+{
+   bool value;
+};
+
+template <>
+struct glz::meta<holds_bool>
+{
+   static constexpr auto value = &holds_bool::value;
+};
+
+struct holds_int
+{
+   int value;
+};
+
+template <>
+struct glz::meta<holds_int>
+{
+   static constexpr auto value = &holds_int::value;
+};
+
+struct holds_string
+{
+   std::string value;
+};
+
+template <>
+struct glz::meta<holds_string>
+{
+   static constexpr auto value = &holds_string::value;
+};
+
+struct holds_optional
+{
+   std::optional<bool> value;
+};
+
+template <>
+struct glz::meta<holds_optional>
+{
+   static constexpr auto value = &holds_optional::value;
+};
+
+// glaze_const_value_t: constexpr pointer to static const member
+struct const_value_wrapper
+{
+   static constexpr std::uint64_t const_v{42};
+   struct glaze
+   {
+      static constexpr auto value{&const_value_wrapper::const_v};
+   };
+};
+static_assert(glz::glaze_const_value_t<const_value_wrapper>);
+
+suite meta_value_schema_test = [] {
+   "holds_bool schema"_test = [] {
+      auto schema = glz::write_json_schema<holds_bool>().value();
+      auto obj = glz::read_json<glz::detail::schematic>(schema);
+      expect(obj.has_value()) << "failed to parse schema";
+      if (!obj) return;
+      expect(obj->type.has_value());
+      expect(std::get<std::string_view>(*obj->type) == "boolean") << schema;
+   };
+
+   "holds_int schema"_test = [] {
+      auto schema = glz::write_json_schema<holds_int>().value();
+      auto obj = glz::read_json<glz::detail::schematic>(schema);
+      expect(obj.has_value()) << "failed to parse schema";
+      if (!obj) return;
+      expect(obj->type.has_value());
+      expect(std::get<std::string_view>(*obj->type) == "integer") << schema;
+   };
+
+   "holds_string schema"_test = [] {
+      auto schema = glz::write_json_schema<holds_string>().value();
+      auto obj = glz::read_json<glz::detail::schematic>(schema);
+      expect(obj.has_value()) << "failed to parse schema";
+      if (!obj) return;
+      expect(obj->type.has_value());
+      expect(std::get<std::string_view>(*obj->type) == "string") << schema;
+   };
+
+   "holds_optional schema"_test = [] {
+      auto schema = glz::write_json_schema<holds_optional>().value();
+      auto obj = glz::read_json<glz::detail::schematic>(schema);
+      expect(obj.has_value()) << "failed to parse schema";
+      if (!obj) return;
+      expect(obj->type.has_value());
+      auto& types = std::get<std::vector<std::string_view>>(*obj->type);
+      expect(std::find(types.begin(), types.end(), "boolean") != types.end()) << "missing boolean";
+      expect(std::find(types.begin(), types.end(), "null") != types.end()) << "missing null";
+   };
+
+   "const_value_wrapper schema"_test = [] {
+      auto schema = glz::write_json_schema<const_value_wrapper>().value();
+      auto obj = glz::read_json<glz::detail::schematic>(schema);
+      expect(obj.has_value()) << "failed to parse schema";
+      if (!obj) return;
+      expect(obj->type.has_value());
+      expect(std::get<std::string_view>(*obj->type) == "integer") << schema;
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
## Fix JSON Schema for meta value types

Closes #2459

When a struct uses `glz::meta` to map directly to a member (e.g., `static constexpr auto value = &HoldsBool::value;`), the generated JSON schema incorrectly fell back to all types (`"type": ["number","string","boolean","object","array","null"]`) instead of the member's actual type (e.g., `"type": "boolean"`).

**Root cause:** `member_t<T, meta_wrapper_t<T>>` resolves to a reference type (e.g., `bool&`), and `to_json_schema<bool&>` doesn't match the `bool` specialization because `std::same_as<bool&, bool>` is false. The same issue existed for the `glaze_const_value_t` branch.

### Changes

- `include/glaze/json/schema.hpp` — Wrapped `member_t` with `std::remove_cvref_t` in both the member-pointer and const-value branches of the primary `to_json_schema` template.
- `tests/json_test/jsonschema_test.cpp` — Added tests for meta value types: `bool`, `int`, `std::string`, `std::optional<bool>`, and `glaze_const_value_t`.