### PR TITLE
JSON Schema specialization for void

### DIFF
--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -388,6 +388,16 @@ namespace glz
          }
       };
 
+      template <>
+      struct to_json_schema<void>
+      {
+         template <auto Opts>
+         static void op(auto& s, auto&)
+         {
+            s.type = sv{"null"};
+         }
+      };
+
       template <class T>
          requires(std::same_as<T, bool> || std::same_as<T, std::vector<bool>::reference> ||
                   std::same_as<T, std::vector<bool>::const_reference>)

--- a/tests/json_test/jsonschema_test.cpp
+++ b/tests/json_test/jsonschema_test.cpp
@@ -756,4 +756,12 @@ suite meta_value_schema_test = [] {
    };
 };
 
+// Issue #2467: void should produce null type, not all types
+suite void_schema_test = [] {
+   "void schema is null"_test = [] {
+      auto schema = glz::write_json_schema<void>().value();
+      expect(schema == R"({"type":"null","$defs":{},"title":"void"})") << schema;
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
## Fix JSON Schema for `void` type

Closes #2467

`write_json_schema<void>()` produced a schema allowing all JSON types:

```json
{"type":["number","string","boolean","object","array","null"]}
```

This happened because `void` matched no `if constexpr` branches in the primary `to_json_schema` template and fell through to the catch-all default.

Added an explicit `to_json_schema<void>` specialization that produces `{"type":"null"}`, the natural JSON representation of "no value."

### Changes

- `include/glaze/json/schema.hpp` — Added `to_json_schema<void>` specialization
- `tests/json_test/jsonschema_test.cpp` — Added test for void schema output