### PR TITLE
Fix boost asio error_code handling

### DIFF
--- a/tests/networking_tests/http_chunked_test/http_chunked_test.cpp
+++ b/tests/networking_tests/http_chunked_test/http_chunked_test.cpp
@@ -13,6 +13,14 @@
 #include "glaze/net/http_server.hpp"
 #include "ut/ut.hpp"
 
+#if defined(GLZ_USING_BOOST_ASIO)
+namespace asio
+{
+   using namespace boost::asio;
+   using error_code = boost::system::error_code;
+}
+#endif
+
 using namespace ut;
 
 // --------------------------------------------------------------------------
@@ -84,7 +92,8 @@ struct chunked_test_server
    void setup_routes()
    {
       server_.on_error([this](std::error_code ec, std::source_location) {
-         if (running_ && ec != asio::error::eof && ec != asio::error::operation_aborted) {
+         if (running_ && ec != make_error_code(asio::error::eof) &&
+             ec != make_error_code(asio::error::operation_aborted)) {
             std::fprintf(stderr, "Server error: %s\n", ec.message().c_str());
          }
       });

--- a/tests/networking_tests/http_client_no_ssl_executor_test/http_client_no_ssl_executor_test.cpp
+++ b/tests/networking_tests/http_client_no_ssl_executor_test/http_client_no_ssl_executor_test.cpp
@@ -12,6 +12,14 @@
 #include "glaze/net/http_client.hpp"
 #include "ut/ut.hpp"
 
+#if defined(GLZ_USING_BOOST_ASIO)
+namespace asio
+{
+   using namespace boost::asio;
+   using error_code = boost::system::error_code;
+}
+#endif
+
 using namespace ut;
 
 suite http_client_no_ssl_executor_tests = [] {

--- a/tests/networking_tests/http_client_ssl_test/http_client_ssl_test.cpp
+++ b/tests/networking_tests/http_client_ssl_test/http_client_ssl_test.cpp
@@ -245,11 +245,11 @@ struct TestResponse
 // Helper to suppress expected errors
 bool should_suppress_error(const std::error_code& ec)
 {
-   if (ec == asio::error::eof) return true;
-   if (ec == asio::error::connection_reset) return true;
-   if (ec == asio::error::operation_aborted) return true;
-   if (ec == asio::error::bad_descriptor) return true;
-   if (ec == asio::error::broken_pipe) return true;
+   if (ec == make_error_code(asio::error::eof)) return true;
+   if (ec == make_error_code(asio::error::connection_reset)) return true;
+   if (ec == make_error_code(asio::error::operation_aborted)) return true;
+   if (ec == make_error_code(asio::error::bad_descriptor)) return true;
+   if (ec == make_error_code(asio::error::broken_pipe)) return true;
    return false;
 }
 


### PR DESCRIPTION
# Fix Boost.ASIO test build failures (#2470)

## Problem

Three networking tests fail to compile when using Boost.ASIO (e.g. Ubuntu 24.04 with Boost 1.83):

- `http_chunked_test`
- `http_client_ssl_test`
- `http_client_no_ssl_executor_test`

Two issues:

1. These tests reference the bare `asio::` namespace, which doesn't exist outside the `glz` namespace when using Boost.ASIO (only `boost::asio` and `glz::asio` are available).

2. Comparisons like `ec == asio::error::eof` fail when `ec` is `std::error_code`. With standalone ASIO this works because `std::is_error_code_enum` is specialized for ASIO error enums, enabling implicit conversion. With Boost.ASIO the specialization is on `boost::system::is_error_code_enum` instead, so `std::error_code` has no matching `operator==` for these enums.

## Fix

- Added `#if defined(GLZ_USING_BOOST_ASIO)` namespace alias blocks to `http_chunked_test` and `http_client_no_ssl_executor_test` (matching the pattern already used by `http_client_ssl_test` and `http_server_api_tests`).

- Wrapped bare enum comparisons with `make_error_code()`, converting the enum to an error code object before comparing (matching the pattern already used by `http_client_test` and `http_server_api_tests`):

```cpp
// Before:
ec != asio::error::eof

// After:
ec != make_error_code(asio::error::eof)
```