### PR TITLE
YAML: Complex variant types in block style

### DIFF
--- a/include/glaze/yaml/write.hpp
+++ b/include/glaze/yaml/write.hpp
@@ -546,27 +546,32 @@ namespace glz
             for (int32_t i = 0; i < spaces; ++i) {
                b[ix++] = ' ';
             }
-            dump("- ", b, ix);
+            dump('-', b, ix);
 
             if constexpr (str_t<element_t>) {
+               dump(' ', b, ix);
                write_yaml_string<Opts>(sv{element}, ctx, b, ix, indent_level);
                dump('\n', b, ix);
             }
             else if constexpr (is_simple_type<element_t>()) {
+               dump(' ', b, ix);
                serialize<YAML>::op<Opts>(element, ctx, b, ix);
                dump('\n', b, ix);
             }
             else if constexpr (nullable_like<element_t>) {
                using inner_t = std::remove_cvref_t<decltype(*element)>;
                if (!element) {
+                  dump(' ', b, ix);
                   dump("null", b, ix);
                   dump('\n', b, ix);
                }
                else if constexpr (str_t<inner_t>) {
+                  dump(' ', b, ix);
                   write_yaml_string<Opts>(sv{*element}, ctx, b, ix, indent_level);
                   dump('\n', b, ix);
                }
                else if constexpr (is_simple_type<inner_t>()) {
+                  dump(' ', b, ix);
                   serialize<YAML>::op<Opts>(*element, ctx, b, ix);
                   dump('\n', b, ix);
                }
@@ -575,20 +580,21 @@ namespace glz
                   bool wrote_empty = false;
                   if constexpr (writable_map_t<inner_t>) {
                      if (element->empty()) {
-                        dump("{}\n", b, ix);
+                        dump(" {}\n", b, ix);
                         wrote_empty = true;
                      }
                   }
                   else if constexpr (writable_array_t<inner_t>) {
                      if constexpr (requires { element->empty(); }) {
                         if (element->empty()) {
-                           dump("[]\n", b, ix);
+                           dump(" []\n", b, ix);
                            wrote_empty = true;
                         }
                      }
                   }
                   if (!wrote_empty) {
                      if constexpr (glaze_object_t<inner_t> || reflectable<inner_t>) {
+                        dump(' ', b, ix);
                         write_block_mapping<Opts>(*element, ctx, b, ix, indent_level + 1, true);
                      }
                      else {
@@ -601,6 +607,7 @@ namespace glz
             else if constexpr (is_or_wraps_variant<element_t>()) {
                // For variants, check at runtime if they hold a simple type
                if (variant_holds_simple_type(element)) {
+                  dump(' ', b, ix);
                   write_variant_value<Opts>(element, ctx, b, ix, indent_level);
                   dump('\n', b, ix);
                }
@@ -612,19 +619,20 @@ namespace glz
                            using inner_t = std::remove_cvref_t<decltype(inner)>;
                            if constexpr (glaze_object_t<inner_t> || reflectable<inner_t>) {
                               // Compact form: first key inline after dash
+                              dump(' ', b, ix);
                               write_block_mapping<Opts>(inner, ctx, b, ix, indent_level + 1, true);
                            }
                            else {
                               if constexpr (writable_map_t<inner_t>) {
                                  if (inner.empty()) {
-                                    dump("{}\n", b, ix);
+                                    dump(" {}\n", b, ix);
                                     return;
                                  }
                               }
                               else if constexpr (writable_array_t<inner_t>) {
                                  if constexpr (requires { inner.empty(); }) {
                                     if (inner.empty()) {
-                                       dump("[]\n", b, ix);
+                                       dump(" []\n", b, ix);
                                        return;
                                     }
                                  }
@@ -646,11 +654,13 @@ namespace glz
             }
             else if constexpr (glaze_object_t<element_t> || reflectable<element_t>) {
                // Compact form: first key inline after dash
+               dump(' ', b, ix);
                write_block_mapping<Opts>(element, ctx, b, ix, indent_level + 1, true);
             }
             else if constexpr (has_custom_meta_v<element_t>) {
                // Types with top-level custom serialization produce scalar output -
                // write inline after dash
+               dump(' ', b, ix);
                serialize<YAML>::op<Opts>(element, ctx, b, ix);
                dump('\n', b, ix);
             }
@@ -662,6 +672,7 @@ namespace glz
             }
             else {
                // Other types (pairs, tuples, etc.) - write inline after dash
+               dump(' ', b, ix);
                serialize<YAML>::op<Opts>(element, ctx, b, ix);
                dump('\n', b, ix);
             }

--- a/include/glaze/yaml/write.hpp
+++ b/include/glaze/yaml/write.hpp
@@ -463,6 +463,36 @@ namespace glz
          }
       }
 
+      // Write a variant's held value in block context, ensuring strings get correct indent_level.
+      template <auto Opts, class T, class B>
+      GLZ_ALWAYS_INLINE void write_variant_value(T&& value, is_context auto&& ctx, B&& b, auto& ix,
+                                                int32_t indent_level)
+      {
+         using V = std::remove_cvref_t<T>;
+         if constexpr (is_variant<V>) {
+            std::visit(
+               [&](auto&& inner) {
+                  using inner_t = std::remove_cvref_t<decltype(inner)>;
+                  if constexpr (str_t<inner_t>) {
+                     write_yaml_string<Opts>(sv{inner}, ctx, b, ix, indent_level);
+                  }
+                  else {
+                     serialize<YAML>::op<Opts>(inner, ctx, b, ix);
+                  }
+               },
+               value);
+         }
+         else if constexpr (glaze_value_t<V>) {
+            write_variant_value<Opts>(get_member(value, meta_wrapper_v<V>), ctx, b, ix, indent_level);
+         }
+         else if constexpr (str_t<V>) {
+            write_yaml_string<Opts>(sv{value}, ctx, b, ix, indent_level);
+         }
+         else {
+            serialize<YAML>::op<Opts>(value, ctx, b, ix);
+         }
+      }
+
       // Write block-style sequence
       template <auto Opts, class T, class B>
       GLZ_ALWAYS_INLINE void write_block_sequence(T&& value, is_context auto&& ctx, B&& b, auto& ix,
@@ -571,16 +601,47 @@ namespace glz
             else if constexpr (is_or_wraps_variant<element_t>()) {
                // For variants, check at runtime if they hold a simple type
                if (variant_holds_simple_type(element)) {
-                  serialize<YAML>::op<Opts>(element, ctx, b, ix);
+                  write_variant_value<Opts>(element, ctx, b, ix, indent_level);
                   dump('\n', b, ix);
                }
                else {
-                  // Complex variant content (maps/arrays) uses flow style ({...}, [...]) rather than
-                  // block style. This is a pragmatic choice: proper block-style output would require
-                  // tracking indentation context through the variant visitor, which adds significant
-                  // complexity. Flow style produces valid, parseable YAML that round-trips correctly.
-                  serialize<YAML>::op<flow_context_on<Opts>()>(element, ctx, b, ix);
-                  dump('\n', b, ix);
+                  // Complex variant content (maps/arrays/objects) - write in block style
+                  if constexpr (is_variant<element_t>) {
+                     std::visit(
+                        [&](auto&& inner) {
+                           using inner_t = std::remove_cvref_t<decltype(inner)>;
+                           if constexpr (glaze_object_t<inner_t> || reflectable<inner_t>) {
+                              // Compact form: first key inline after dash
+                              write_block_mapping<Opts>(inner, ctx, b, ix, indent_level + 1, true);
+                           }
+                           else {
+                              if constexpr (writable_map_t<inner_t>) {
+                                 if (inner.empty()) {
+                                    dump("{}\n", b, ix);
+                                    return;
+                                 }
+                              }
+                              else if constexpr (writable_array_t<inner_t>) {
+                                 if constexpr (requires { inner.empty(); }) {
+                                    if (inner.empty()) {
+                                       dump("[]\n", b, ix);
+                                       return;
+                                    }
+                                 }
+                              }
+                              dump('\n', b, ix);
+                              write_block_mapping_nested<Opts>(inner, ctx, b, ix, indent_level + 1);
+                           }
+                        },
+                        element);
+                  }
+                  else {
+                     // glaze_value_t wrapping a variant — simple types were already
+                     // handled by variant_holds_simple_type above, so the held value
+                     // is guaranteed to be a complex type (map/array/object).
+                     dump('\n', b, ix);
+                     write_block_mapping_nested<Opts>(element, ctx, b, ix, indent_level + 1);
+                  }
                }
             }
             else if constexpr (glaze_object_t<element_t> || reflectable<element_t>) {
@@ -990,7 +1051,7 @@ namespace glz
                // Variants and variant-wrappers (e.g., glz::generic) may hold simple values
                if (variant_holds_simple_type(member)) {
                   dump(' ', b, ix);
-                  serialize<YAML>::op<Opts>(member, ctx, b, ix);
+                  write_variant_value<Opts>(member, ctx, b, ix, indent_level);
                   dump('\n', b, ix);
                }
                else {
@@ -1134,7 +1195,7 @@ namespace glz
                   // check at runtime if they hold a simple type
                   if (variant_holds_simple_type(v)) {
                      dump(' ', b, ix);
-                     serialize<YAML>::op<Opts>(v, ctx, b, ix);
+                     write_variant_value<Opts>(v, ctx, b, ix, indent_level);
                      dump('\n', b, ix);
                   }
                   else {

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -6108,7 +6108,10 @@ suite yaml_variant_block_style = [] {
       std::string yaml;
       auto wec = glz::write_yaml(original, yaml);
       expect(!wec);
-      expect(yaml == "- \n  a: 1\n  b: 2\n") << yaml;
+            expect(yaml == R"(-
+  a: 1
+  b: 2
+)") << yaml;
 
       std::vector<var_t> parsed;
       auto rec = glz::read_yaml(parsed, yaml);
@@ -6127,7 +6130,11 @@ suite yaml_variant_block_style = [] {
       std::string yaml;
       auto wec = glz::write_yaml(original, yaml);
       expect(!wec);
-      expect(yaml == "- \n  - 10\n  - 20\n  - 30\n") << yaml;
+            expect(yaml == R"(-
+  - 10
+  - 20
+  - 30
+)") << yaml;
 
       std::vector<var_t> parsed;
       auto rec = glz::read_yaml(parsed, yaml);
@@ -6190,7 +6197,11 @@ suite yaml_variant_block_style = [] {
       std::string yaml;
       auto wec = glz::write_yaml(original, yaml);
       expect(!wec);
-      expect(yaml == "- 42\n- \n  key: 99\n- hello\n") << yaml;
+            expect(yaml == R"(- 42
+-
+  key: 99
+- hello
+)") << yaml;
 
       std::vector<var_t> parsed;
       auto rec = glz::read_yaml(parsed, yaml);
@@ -6212,7 +6223,10 @@ suite yaml_variant_block_style = [] {
       std::string yaml;
       auto wec = glz::write_yaml(original, yaml);
       expect(!wec);
-      expect(yaml == "- \n  name: test\n  value: 42\n") << yaml;
+            expect(yaml == R"(-
+  name: test
+  value: 42
+)") << yaml;
 
       std::vector<glz::generic> parsed;
       auto rec = glz::read_yaml(parsed, yaml);

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -6097,6 +6097,183 @@ suite yaml_variant_edge_cases = [] {
    };
 };
 
+suite yaml_variant_block_style = [] {
+   // Tests for issue #2447: complex variants in sequences should use block style
+
+   "variant_map_in_sequence_block_style"_test = [] {
+      using var_t = std::variant<int, std::map<std::string, int>>;
+      std::vector<var_t> original;
+      original.emplace_back(std::map<std::string, int>{{"a", 1}, {"b", 2}});
+
+      std::string yaml;
+      auto wec = glz::write_yaml(original, yaml);
+      expect(!wec);
+      expect(yaml == "- \n  a: 1\n  b: 2\n") << yaml;
+
+      std::vector<var_t> parsed;
+      auto rec = glz::read_yaml(parsed, yaml);
+      expect(!rec) << glz::format_error(rec, yaml);
+      expect(parsed.size() == 1u);
+      auto& m = std::get<std::map<std::string, int>>(parsed[0]);
+      expect(m["a"] == 1);
+      expect(m["b"] == 2);
+   };
+
+   "variant_array_in_sequence_block_style"_test = [] {
+      using var_t = std::variant<int, std::vector<int>>;
+      std::vector<var_t> original;
+      original.emplace_back(std::vector<int>{10, 20, 30});
+
+      std::string yaml;
+      auto wec = glz::write_yaml(original, yaml);
+      expect(!wec);
+      expect(yaml == "- \n  - 10\n  - 20\n  - 30\n") << yaml;
+
+      std::vector<var_t> parsed;
+      auto rec = glz::read_yaml(parsed, yaml);
+      expect(!rec) << glz::format_error(rec, yaml);
+      auto& v = std::get<std::vector<int>>(parsed[0]);
+      expect(v == std::vector<int>{10, 20, 30});
+   };
+
+   "variant_object_in_sequence_block_style"_test = [] {
+      using var_t = std::variant<int, simple_struct>;
+      std::vector<var_t> original;
+      original.emplace_back(simple_struct{.x = 5, .y = 3.14, .name = "test"});
+
+      std::string yaml;
+      auto wec = glz::write_yaml(original, yaml);
+      expect(!wec);
+      expect(yaml == R"(- x: 5
+  y: 3.14
+  name: test
+)") << yaml;
+
+      std::vector<var_t> parsed;
+      auto rec = glz::read_yaml(parsed, yaml);
+      expect(!rec) << glz::format_error(rec, yaml);
+      auto& s = std::get<simple_struct>(parsed[0]);
+      expect(s.x == 5);
+      expect(s.y == 3.14);
+      expect(s.name == "test");
+   };
+
+   "variant_empty_map_in_sequence"_test = [] {
+      using var_t = std::variant<int, std::map<std::string, int>>;
+      std::vector<var_t> original;
+      original.emplace_back(std::map<std::string, int>{});
+
+      std::string yaml;
+      auto wec = glz::write_yaml(original, yaml);
+      expect(!wec);
+      expect(yaml == "- {}\n") << yaml;
+   };
+
+   "variant_empty_array_in_sequence"_test = [] {
+      using var_t = std::variant<int, std::vector<int>>;
+      std::vector<var_t> original;
+      original.emplace_back(std::vector<int>{});
+
+      std::string yaml;
+      auto wec = glz::write_yaml(original, yaml);
+      expect(!wec);
+      expect(yaml == "- []\n") << yaml;
+   };
+
+   "variant_mixed_simple_and_complex_in_sequence"_test = [] {
+      using var_t = std::variant<int, std::string, std::map<std::string, int>>;
+      std::vector<var_t> original;
+      original.emplace_back(42);
+      original.emplace_back(std::map<std::string, int>{{"key", 99}});
+      original.emplace_back(std::string("hello"));
+
+      std::string yaml;
+      auto wec = glz::write_yaml(original, yaml);
+      expect(!wec);
+      expect(yaml == "- 42\n- \n  key: 99\n- hello\n") << yaml;
+
+      std::vector<var_t> parsed;
+      auto rec = glz::read_yaml(parsed, yaml);
+      expect(!rec) << glz::format_error(rec, yaml);
+      expect(parsed.size() == 3u);
+      expect(std::get<int>(parsed[0]) == 42);
+      expect(std::get<std::map<std::string, int>>(parsed[1])["key"] == 99);
+      expect(std::get<std::string>(parsed[2]) == "hello");
+   };
+
+   "generic_complex_in_sequence_block_style"_test = [] {
+      // glz::generic wrapping a variant - tests the glaze_value_t path
+      std::vector<glz::generic> original;
+      glz::generic obj;
+      obj["name"] = "test";
+      obj["value"] = 42.0;
+      original.emplace_back(std::move(obj));
+
+      std::string yaml;
+      auto wec = glz::write_yaml(original, yaml);
+      expect(!wec);
+      expect(yaml == "- \n  name: test\n  value: 42\n") << yaml;
+
+      std::vector<glz::generic> parsed;
+      auto rec = glz::read_yaml(parsed, yaml);
+      expect(!rec) << glz::format_error(rec, yaml);
+      auto& obj2 = std::get<glz::generic::object_t>(parsed[0].data);
+      expect(std::get<std::string>(obj2.at("name").data) == "test");
+      expect(std::get<double>(obj2.at("value").data) == 42.0);
+   };
+
+   "variant_multiline_string_in_mapping"_test = [] {
+      // Tests write_variant_value indent_level fix for variant values in mappings
+      glz::generic doc;
+      doc["script"] = "echo hello\n./run --port=8080";
+      doc["name"] = "service-1";
+
+      std::string yaml;
+      auto wec = glz::write_yaml(doc, yaml);
+      expect(!wec);
+      expect(yaml == R"(script: |-
+  echo hello
+  ./run --port=8080
+
+name: service-1
+)") << yaml;
+
+      glz::generic parsed;
+      auto rec = glz::read_yaml(parsed, yaml);
+      expect(!rec) << glz::format_error(rec, yaml);
+      auto& obj = std::get<glz::generic::object_t>(parsed.data);
+      expect(std::get<std::string>(obj.at("script").data) == "echo hello\n./run --port=8080");
+      expect(std::get<std::string>(obj.at("name").data) == "service-1");
+   };
+
+   "variant_multiline_string_in_nested_mapping"_test = [] {
+      // Tests indent_level propagation through nested variant mappings
+      glz::generic doc;
+      doc["outer"]["script"] = "line one\nline two\nline three";
+      doc["outer"]["count"] = 42.0;
+
+      std::string yaml;
+      auto wec = glz::write_yaml(doc, yaml);
+      expect(!wec);
+      expect(yaml == R"(outer:
+  script: |-
+    line one
+    line two
+    line three
+
+  count: 42
+)") << yaml;
+
+      glz::generic parsed;
+      auto rec = glz::read_yaml(parsed, yaml);
+      expect(!rec) << glz::format_error(rec, yaml);
+      auto& root = std::get<glz::generic::object_t>(parsed.data);
+      auto& outer = std::get<glz::generic::object_t>(root.at("outer").data);
+      expect(std::get<std::string>(outer.at("script").data) == "line one\nline two\nline three");
+      expect(std::get<double>(outer.at("count").data) == 42.0);
+   };
+};
+
 suite generic_colon_in_value_tests = [] {
    "generic_time_format_hhmm"_test = [] {
       // Time format HH:MM should parse as string, not fail as number


### PR DESCRIPTION
# YAML block style for complex variants in sequences

Closes #2447

Complex variants (maps, arrays, objects) inside YAML block sequences previously used flow style (`{...}`, `[...]`). They now use block style with proper indentation, matching the readability of JSON pretty-printing.

## Before

```yaml
- {a: 1, b: 2}
- [10, 20, 30]
```

## After

```yaml
- 
  a: 1
  b: 2
- 
  - 10
  - 20
  - 30
```

Struct variants get compact form (first key inline after the dash):

```yaml
- x: 5
  y: 3.14
  name: test
```

## Changes

**`include/glaze/yaml/write.hpp`**

- Replaced the `flow_context_on` fallback in `write_block_sequence` with block-style output. Direct variants dispatch through `std::visit` to choose compact form for objects or nested block style for maps/arrays. `glaze_value_t` wrappers (e.g. `glz::generic`) delegate to `write_block_mapping_nested`. Empty maps and arrays produce inline `{}` / `[]`.
- Added `write_variant_value` helper that unwraps variant/`glaze_value_t` types and writes strings with the correct `indent_level` for literal block scalars. Without this, multiline strings serialized through `serialize<YAML>::op` would get `indent_level = 0`, producing malformed block scalars when nested. Applied in `write_block_sequence`, `write_block_mapping`, and `write_block_mapping_nested`.

**`tests/yaml_test/yaml_test.cpp`**

- 9 new tests: map, array, object, empty map, empty array, mixed sequence, `glz::generic` wrapper, multiline string in mapping, and multiline string in nested mapping. Tests compare against exact expected YAML and verify round-trip correctness.