### PR TITLE
Cleaner nullable concept usage and guarding nullable_t from fn pointers

### DIFF
--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -1736,8 +1736,7 @@ namespace glz
       }
    };
 
-   template <nullable_t T>
-      requires(!std::is_array_v<T> && not is_expected<T>)
+   template <nullable_like T>
    struct from<BEVE, T> final
    {
       template <auto Opts>

--- a/include/glaze/beve/size.hpp
+++ b/include/glaze/beve/size.hpp
@@ -390,8 +390,7 @@ namespace glz
       }
    };
 
-   template <nullable_t T>
-      requires(!std::is_array_v<T>)
+   template <nullable_like T>
    struct calculate_size<BEVE, T>
    {
       template <auto Opts>
@@ -461,7 +460,7 @@ namespace glz
          if constexpr (std::same_as<V, hidden> || std::same_as<V, skip>) {
             return true;
          }
-         else if constexpr (is_member_function_pointer<V>) {
+         else if constexpr (is_any_function_ptr<V>) {
             return !check_write_function_pointers(Opts);
          }
          else {
@@ -528,7 +527,7 @@ namespace glz
          if constexpr (std::same_as<V, hidden> || std::same_as<V, skip>) {
             return true;
          }
-         else if constexpr (is_member_function_pointer<V>) {
+         else if constexpr (is_any_function_ptr<V>) {
             return !check_write_function_pointers(Opts);
          }
          else {

--- a/include/glaze/beve/write.hpp
+++ b/include/glaze/beve/write.hpp
@@ -1079,8 +1079,7 @@ namespace glz
       }
    };
 
-   template <nullable_t T>
-      requires(!std::is_array_v<T> && not is_expected<T>)
+   template <nullable_like T>
    struct to<BEVE, T> final
    {
       template <auto Opts, class B>

--- a/include/glaze/cbor/read.hpp
+++ b/include/glaze/cbor/read.hpp
@@ -1671,8 +1671,7 @@ namespace glz
    };
 
    // Nullable types
-   template <nullable_t T>
-      requires(!std::is_array_v<T> && not is_expected<T>)
+   template <nullable_like T>
    struct from<CBOR, T> final
    {
       template <auto Opts>

--- a/include/glaze/cbor/write.hpp
+++ b/include/glaze/cbor/write.hpp
@@ -612,7 +612,7 @@ namespace glz
          if constexpr (std::same_as<V, hidden> || std::same_as<V, skip>) {
             return true;
          }
-         else if constexpr (is_member_function_pointer<V>) {
+         else if constexpr (is_any_function_ptr<V>) {
             return !check_write_function_pointers(Opts);
          }
          else {
@@ -900,8 +900,7 @@ namespace glz
    };
 
    // Nullable types (std::optional, std::unique_ptr, std::shared_ptr)
-   template <nullable_t T>
-      requires(!std::is_array_v<T> && not is_expected<T>)
+   template <nullable_like T>
    struct to<CBOR, T> final
    {
       template <auto Opts>

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -396,12 +396,6 @@ namespace glz
    template <class T>
    concept always_skipped = is_includer<T> || std::same_as<T, hidden> || std::same_as<T, skip>;
 
-   template <class T>
-   concept nullable_t = !meta_value_t<T> && !str_t<T> && requires(T t) {
-      bool(t);
-      { *t };
-   };
-
    // Detect function pointers and function references (which should not be treated as nullable)
    template <class T>
    concept is_function_ptr_or_ref =
@@ -414,7 +408,13 @@ namespace glz
    concept is_any_function_ptr = is_member_function_pointer<T> || is_function_ptr_or_ref<T>;
 
    template <class T>
-   concept nullable_like = nullable_t<T> && !is_expected<T> && !std::is_array_v<T> && !is_function_ptr_or_ref<T>;
+   concept nullable_t = !meta_value_t<T> && !str_t<T> && !is_function_ptr_or_ref<T> && requires(T t) {
+      bool(t);
+      { *t };
+   };
+
+   template <class T>
+   concept nullable_like = nullable_t<T> && !is_expected<T> && !std::is_array_v<T>;
 
    // For optional like types that cannot overload `operator bool()`
    template <class T>

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -297,6 +297,14 @@ namespace glz
                skip_value<JSON>::op<Opts>(ctx, it, end);
             }
          }
+         else if constexpr (is_function_ptr_or_ref<V>) {
+            // Function pointers cannot be deserialized from JSON.
+            // When write_function_pointers is enabled the writer emits a type-name string,
+            // but there is nothing meaningful to reconstruct on read — just skip the value.
+            // When write_function_pointers is off the key is never written, so this branch
+            // is unreachable in that case.
+            skip_value<JSON>::op<Opts>(ctx, it, end);
+         }
          else {
             if constexpr (glaze_object_t<T>) {
                from<JSON, std::remove_cvref_t<V>>::template op<ws_handled<Opts>()>(
@@ -4529,8 +4537,9 @@ namespace glz
    };
 
    template <class T>
-      requires((nullable_t<T> || nullable_value_t<T>) && not is_expected<T> && not std::is_array_v<T> &&
-               not custom_read<T>)
+      requires((nullable_like<T> || nullable_value_t<T>) && not is_expected<T> && not std::is_array_v<T> &&
+               not custom_read<T>) // is_expected and is_array_v are redundant with nullable_like but needed for
+                                   // nullable_value_t
    struct from<JSON, T>
    {
       template <auto Options>


### PR DESCRIPTION
## Fix -Waddress and -Wnonnull-compare warnings for function pointer members

Closes #2485

### Problem

Function pointers and function references (e.g. `std::string(*)()`) satisfied the `nullable_t` concept because they support `bool(t)` and `*t`. This caused GCC to emit `-Waddress` and `-Wnonnull-compare` warnings when deserializing structs with function pointer members, since `if (!value)` on a function reference is always false. Worse, dereferencing a function pointer yields a function reference that also matches `nullable_t`, leading to infinite recursion at runtime.

### Fix

**`nullable_t` now excludes function pointers at the concept level.** The `is_function_ptr_or_ref` check was moved into `nullable_t` itself rather than only being in `nullable_like`. This prevents function pointers from ever being treated as nullable, fixing the warnings and the infinite recursion. `nullable_like` is simplified accordingly.

**Additional changes:**

- Non-array `from`/`to` specializations across JSON, BEVE, and CBOR now use `nullable_like` instead of `nullable_t` with ad-hoc constraints, consistent with the JSON write path which already did this.
- JSON `decode_index` now skips function pointer members rather than attempting to deserialize them (matching write-side behavior).
- CBOR and BEVE `should_skip_field` updated from `is_member_function_pointer` to `is_any_function_ptr`, so non-member function pointers are correctly skipped during write and size calculation.