### PR TITLE
Support for json_schema enum value description

### DIFF
--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -465,14 +465,33 @@ namespace glz
          {
             s.type = sv{"string"};
 
-            // TODO use oneOf instead of enum to handle doc comments
             static constexpr auto N = reflect<T>::size;
-            // s.enumeration = std::vector<std::string_view>(N);
-            // for_each<N>([&]<auto I>() {
-            //    static constexpr auto item = std::get<I>(meta_v<V>);
-            //    (*s.enumeration)[I] = std::get<0>(item);
-            // });
             s.oneOf = std::vector<schematic>(N);
+
+            // Apply json_schema attributes (e.g. description) to each enum value
+            if constexpr (json_schema_t<T>) {
+               static constexpr auto schema_size = reflect<json_schema_type<T>>::size;
+               if constexpr (schema_size > 0) {
+                  for_each<N>([&]<auto I>() {
+                     auto& enumeration = (*s.oneOf)[I];
+                     static constexpr sv enum_key = reflect<T>::keys[I];
+                     constexpr auto schema_index = [] {
+                        const auto& schema_keys = reflect<json_schema_type<T>>::keys;
+                        for (size_t i = 0; i < schema_size; ++i) {
+                           if (schema_keys[i] == enum_key) {
+                              return i;
+                           }
+                        }
+                        return schema_size;
+                     }();
+                     if constexpr (schema_index < schema_size) {
+                        static const auto schema_v = json_schema_type<T>{};
+                        enumeration.attributes = get<schema_index>(to_tie(schema_v));
+                     }
+                  });
+               }
+            }
+
             for_each<N>([&]<auto I>() {
                auto& enumeration = (*s.oneOf)[I];
                // Do not override if already set

--- a/tests/json_test/jsonschema_test.cpp
+++ b/tests/json_test/jsonschema_test.cpp
@@ -214,6 +214,24 @@ struct glz::meta<color>
    );
 };
 
+enum struct direction { up, down, left, right };
+
+template <>
+struct glz::meta<direction>
+{
+   using enum direction;
+   static constexpr auto value = enumerate(up, down, left, right);
+};
+
+template <>
+struct glz::json_schema<direction>
+{
+   schema up{.description = "Move upward"};
+   schema down{.description = "Move downward"};
+   schema left{.description = "Move left"};
+   schema right{.description = "Move right"};
+};
+
 struct const_one_enum
 {
    static constexpr color some_var{color::green};
@@ -397,12 +415,25 @@ suite schema_tests = [] {
       }
    };
 
-   "enum description"_test = [] {
-      std::string schema_str = glz::write_json_schema<color>().value_or("error");
+   "enum value description"_test = [] {
+      std::string schema_str = glz::write_json_schema<direction>().value_or("error");
       schematic_substitute obj{};
       auto err = read_json_ignore_unknown(obj, schema_str);
       expect(!err) << format_error(err, schema_str);
       expect[(obj.oneOf.has_value())];
+      auto& entries = obj.oneOf.value();
+      expect(entries.size() == 4);
+
+      std::array<std::string_view, 4> expected_keys{"up", "down", "left", "right"};
+      std::array<std::string_view, 4> expected_descs{"Move upward", "Move downward", "Move left", "Move right"};
+      for (size_t i = 0; i < 4; ++i) {
+         expect[(entries[i].attributes.constant.has_value())];
+         expect(std::get<std::string_view>(entries[i].attributes.constant.value()) == expected_keys[i]);
+         expect[(entries[i].attributes.title.has_value())];
+         expect(entries[i].attributes.title.value() == expected_keys[i]);
+         expect[(entries[i].attributes.description.has_value())];
+         expect(entries[i].attributes.description.value() == expected_descs[i]);
+      }
    };
 
    "fixed array has fixed size"_test = [] {


### PR DESCRIPTION
## JSON Schema: enum value descriptions

Closes #1339

Adds support for per-value descriptions (and other schema attributes) on enum types via `glz::json_schema` specialization, using the same pattern already available for struct members.

### Usage

```cpp
enum struct direction { up, down, left, right };

template <>
struct glz::meta<direction>
{
   using enum direction;
   static constexpr auto value = enumerate(up, down, left, right);
};

template <>
struct glz::json_schema<direction>
{
   schema up{.description = "Move upward"};
   schema down{.description = "Move downward"};
   schema left{.description = "Move left"};
   schema right{.description = "Move right"};
};
```

Produces:

```json
{
  "type": "string",
  "oneOf": [
    { "title": "up", "description": "Move upward", "const": "up" },
    { "title": "down", "description": "Move downward", "const": "down" },
    { "title": "left", "description": "Move left", "const": "left" },
    { "title": "right", "description": "Move right", "const": "right" }
  ]
}
```

### Changes

- `schema.hpp`: In the `to_json_schema` specialization for `glaze_enum_t`, look up `json_schema<T>` attributes by matching enum key names and apply them to each `oneOf` entry before setting default `const`/`title` values.
- `jsonschema_test.cpp`: Added test with a `direction` enum verifying that descriptions appear on each `oneOf` entry.