### PR TITLE
support for writing std::variant

### DIFF
--- a/include/glaze/eetf/eetf_to_json.hpp
+++ b/include/glaze/eetf/eetf_to_json.hpp
@@ -249,8 +249,8 @@ namespace glz
 
       context ctx{};
 
-      // skip magic version
-      const int version = (unsigned char)*it++;
+      // Check format version
+      const auto version = decode_version(ctx, it);
       if (eetf_magic_version != version) {
          return {1, error_code::version_mismatch};
       }

--- a/include/glaze/eetf/read.hpp
+++ b/include/glaze/eetf/read.hpp
@@ -102,9 +102,9 @@ namespace glz
          requires(not check_no_header(Opts))
       GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, It0&& it, It1 end) noexcept
       {
-         // TODO Check version
          const auto version = decode_version(ctx, it);
-         if (version != eetf_magic_version) { // TODO find in erlang files
+         // This version number is not in public headers - use as magic number
+         if (version != eetf_magic_version) {
             ctx.error = error_code::version_mismatch;
             return;
          }
@@ -408,6 +408,11 @@ namespace glz
          }
       }
    };
+
+   // is_variant
+   // Can't effectly parse into std::variant. Only if trying to parse all of underlying variant' types one by one. But
+   // this approach can (and would) add a place for errors - because undelying data can hold "similar" types in EETF
+   // terms
 
    template <uint8_t layout = glz::eetf::map_layout, read_supported<EETF> T, class Buffer>
    [[nodiscard]] inline error_ctx read_term(T&& value, Buffer&& buffer) noexcept

--- a/include/glaze/eetf/write.hpp
+++ b/include/glaze/eetf/write.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <glaze/core/buffer_traits.hpp>
-#include <glaze/core/reflect.hpp>
-#include <glaze/core/write.hpp>
-
 #include "defs.hpp"
 #include "ei.hpp"
+#include "glaze/core/buffer_traits.hpp"
+#include "glaze/core/reflect.hpp"
+#include "glaze/core/write.hpp"
+#include "glaze/util/variant.hpp"
 #include "opts.hpp"
 
 namespace glz
@@ -14,6 +14,14 @@ namespace glz
    template <>
    struct serialize<EETF>
    {
+      template <auto Opts, class T, class... Args>
+         requires(not check_no_header(Opts))
+      GLZ_ALWAYS_INLINE static void op(T&& value, Args&&... args) noexcept
+      {
+         encode_version(std::forward<Args>(args)...);
+         op<no_header_on<Opts>()>(std::forward<T>(value), std::forward<Args>(args)...);
+      }
+
       template <auto Opts, class T, class... Args>
          requires(check_no_header(Opts))
       GLZ_ALWAYS_INLINE static void op(T&& value, Args&&... args) noexcept
@@ -289,6 +297,16 @@ namespace glz
                flush_buffer(b, ix);
             }
          });
+      }
+   };
+
+   template <is_variant T>
+   struct to<EETF, T> final
+   {
+      template <auto Opts, class B>
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
+      {
+         std::visit([&](auto&& v) { serialize<EETF>::op<Opts>(v, ctx, b, ix); }, value);
       }
    };
 

--- a/tests/eetf_test/eetf_test.cpp
+++ b/tests/eetf_test/eetf_test.cpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <map>
 #include <string>
+#include <variant>
 
 #include "glaze/eetf/eetf_to_json.hpp"
 #include "glaze/eetf/read.hpp"
@@ -278,6 +279,23 @@ suite etf_tests = [] {
 
       expect(m == v);
       trace.end("roundtrip_map_as_proplist");
+   };
+
+   "write_variant"_test = [] {
+      using Doubles = std::vector<double>;
+      using V = std::variant<int, Doubles>;
+      V v = Doubles{1.2, 3.4, 5.6};
+      std::string buffer{};
+      expect(not glz::write_term(v, buffer));
+
+      // can't parse into std::variant (see comment in eetf/read.cpp)
+      Doubles res;
+      expect(not glz::read_term(res, buffer));
+      expect(res == std::get<Doubles>(v));
+
+      std::string json{};
+      expect(!glz::eetf_to_json(buffer, json));
+      expect(json == R"([1.2,3.4,5.6])") << json;
    };
 };
 


### PR DESCRIPTION
At the moment, I cannot support efficient reading into std::variant, because I cannot make relation between EETF format and undelying variant' types. Therefore, the only option is to attempt reading using all possible internal formats. However, this can lead to type collisions, since EETF does not distinguish, for example, between signed and unsigned types, 32-bit vs 64-bit representations, and so on.

So only writing std::variant support now