### PR TITLE
YAML std::set parsing fix

### DIFF
--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -2749,7 +2749,8 @@ namespace glz
          int32_t pending_item_anchor_indent = sequence_indent;
 
          while (it != end) {
-            // For fixed-size arrays, stop when we've filled all elements
+            // For fixed-size arrays (e.g. std::array), stop when we've filled all elements.
+            // Exclude emplaceable types (e.g. std::set) which are not resizable but grow dynamically.
             if constexpr (!resizable<V> && !emplaceable<V>) {
                if (adapter.fixed_capacity_reached(value)) {
                   return;

--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -2750,7 +2750,7 @@ namespace glz
 
          while (it != end) {
             // For fixed-size arrays, stop when we've filled all elements
-            if constexpr (!resizable<V>) {
+            if constexpr (!resizable<V> && !emplaceable<V>) {
                if (adapter.fixed_capacity_reached(value)) {
                   return;
                }

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -73,6 +73,11 @@ struct seq_string_struct
    std::vector<std::string> items{};
 };
 
+struct set_string_struct
+{
+   std::set<std::string> items{};
+};
+
 template <>
 struct glz::meta<nested_struct>
 {
@@ -1864,6 +1869,42 @@ suite yaml_container_tests = [] {
       auto rec = glz::read_yaml(parsed, yaml);
       expect(!rec) << glz::format_error(rec, yaml);
       expect(parsed == original);
+   };
+
+   "set_block_sequence"_test = [] {
+      std::string yaml = R"(- 5
+- 3
+- 1
+- 4
+- 2
+)";
+      std::set<int> parsed{};
+      auto rec = glz::read_yaml(parsed, yaml);
+      expect(!rec) << glz::format_error(rec, yaml);
+      expect(parsed == std::set<int>{1, 2, 3, 4, 5});
+   };
+
+   "set_string_block_sequence"_test = [] {
+      std::string yaml = R"(- apple
+- banana
+- cherry
+)";
+      std::set<std::string> parsed{};
+      auto rec = glz::read_yaml(parsed, yaml);
+      expect(!rec) << glz::format_error(rec, yaml);
+      expect(parsed == std::set<std::string>{"apple", "banana", "cherry"});
+   };
+
+   "set_block_sequence_in_struct"_test = [] {
+      std::string yaml = R"(items:
+  - s1
+  - s2
+  - s3
+)";
+      set_string_struct parsed{};
+      auto rec = glz::read_yaml<glz::opts{.error_on_unknown_keys = false}>(parsed, yaml);
+      expect(!rec) << glz::format_error(rec, yaml);
+      expect(parsed.items == std::set<std::string>{"s1", "s2", "s3"});
    };
 
    "vector_of_vectors_flow"_test = [] {


### PR DESCRIPTION
# Fix YAML block sequence parsing for std::set

Closes #2502

## Problem

Parsing YAML block sequences into `std::set` (and `std::unordered_set`) silently produced empty containers. Flow sequences (`[a, b, c]`) worked correctly.

```yaml
set:
  - s1
```

```cpp
struct ConfigFile { std::set<std::string> set; };
// parsed.set was empty after read_yaml
```

## Root Cause

In `parse_block_sequence`, a fixed-capacity guard intended for `std::array` was checking `!resizable<V>`. Since `std::set` lacks `.resize()`, it matched this condition. An empty set has `size() == 0`, so `index (0) >= size (0)` evaluated to `true`, causing the parser to return immediately without reading any items.

## Fix

Added `&& !emplaceable<V>` to the guard so it only applies to truly fixed-size containers, excluding set-like types that grow dynamically via `.emplace()`:

```cpp
if constexpr (!resizable<V> && !emplaceable<V>) {
```

## Tests

Added three tests for block-style set parsing: standalone `std::set<int>`, standalone `std::set<std::string>`, and `std::set<std::string>` nested in a struct.