### PR TITLE
CSV: delimiter option with support for `,`  `\t`  `|`  `;`

### DIFF
--- a/docs/csv.md
+++ b/docs/csv.md
@@ -131,10 +131,53 @@ Options:
 - `validate_rectangular` — enforce equal column counts across rows on read.
   - On failure, `read` returns `constraint_violated` and sets a message in `ctx.custom_error_message`.
 
+## Custom Delimiters
+
+By default, Glaze uses a comma (`,`) as the field delimiter. You can change this via the `delimiter` option in `opts_csv` to support other common formats like TSV, pipe-delimited, or semicolon-delimited files.
+
+Supported delimiters: `,`  `\t`  `|`  `;`
+
+```c++
+// Semicolon-delimited (common in European locales)
+glz::read<glz::opts_csv{.delimiter = ';'}>(obj, input);
+glz::write<glz::opts_csv{.delimiter = ';'}>(obj, output);
+
+// Tab-separated (TSV)
+glz::read<glz::opts_csv{.delimiter = '\t'}>(obj, input);
+
+// Pipe-delimited
+glz::read<glz::opts_csv{.delimiter = '|'}>(obj, input);
+```
+
+The delimiter option works with all CSV features: structs, maps, 2D arrays, vectors of structs, quoting, and both row-wise and column-wise layouts.
+
+```c++
+// Semicolon-delimited column-wise struct
+std::string input =
+   R"(num1;num2;maybe
+11;22;1
+33;44;0)";
+
+my_struct obj{};
+glz::read<glz::opts_csv{.layout = glz::colwise, .delimiter = ';'}>(obj, input);
+
+// Pipe-delimited 2D array
+std::string tsv = "1|2|3\n4|5|6";
+std::vector<std::vector<int>> matrix;
+glz::read<glz::opts_csv{.use_headers = false, .delimiter = '|'}>(matrix, tsv);
+```
+
+Using an unsupported delimiter character produces a compile-time error:
+
+```c++
+// Compile error: CSV delimiter must be one of: ',' '\t' '|' ';'
+glz::write<glz::opts_csv{.delimiter = '.'}>(obj, out);
+```
+
 ## CSV Quoting and Special Values
 
 - Strings and chars are quoted when needed; embedded quotes are escaped by doubling them.
-- Quoted fields preserve commas, quotes, and newlines (handles both `\n` and `\r\n`).
+- Quoted fields preserve delimiters, quotes, and newlines (handles both `\n` and `\r\n`).
 - Empty fields are parsed as default values (e.g., `0` for numbers, empty string for strings, `false` for booleans).
 - Booleans accept `true`/`false` (case-insensitive) and `0`/`1`; empty boolean fields default to `false`.
 

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -114,6 +114,7 @@ namespace glz
       uint8_t layout = rowwise; // CSV row wise output/input
       bool use_headers = true; // Whether to write column/row headers in CSV format
       bool raw_string = false; // do not decode/encode escaped characters for strings (improves read/write performance)
+      char delimiter = ','; // field delimiter character (e.g. ',', ';', '|', '\t')
 
       // New options for headerless CSV support
       bool skip_header_row =
@@ -545,6 +546,32 @@ namespace glz
       }
       else {
          return false;
+      }
+   }
+
+   consteval bool is_valid_csv_delimiter(char c)
+   {
+      switch (c) {
+      case ',':
+      case '\t':
+      case '|':
+      case ';':
+         return true;
+      default:
+         return false;
+      }
+   }
+
+   template <auto Opts>
+   consteval char csv_delimiter()
+   {
+      if constexpr (requires { Opts.delimiter; }) {
+         static_assert(is_valid_csv_delimiter(Opts.delimiter),
+                       "CSV delimiter must be one of: ',' '\\t' '|' ';'");
+         return Opts.delimiter;
+      }
+      else {
+         return ',';
       }
    }
 

--- a/include/glaze/csv/read.hpp
+++ b/include/glaze/csv/read.hpp
@@ -190,8 +190,8 @@ namespace glz
                }
             }
 
-            // After closing quote, expect comma, newline, or end of input
-            if (it != end && *it != ',' && *it != '\n' && *it != '\r') {
+            // After closing quote, expect delimiter, newline, or end of input
+            if (it != end && *it != csv_delimiter<Opts>() && *it != '\n' && *it != '\r') {
                // Invalid character after closing quote
                ctx.error = error_code::syntax_error;
                return;
@@ -199,7 +199,7 @@ namespace glz
          }
          else {
             // Unquoted field
-            while (it != end && *it != ',' && *it != '\n' && *it != '\r') {
+            while (it != end && *it != csv_delimiter<Opts>() && *it != '\n' && *it != '\r') {
                value.push_back(*it);
                ++it;
             }
@@ -259,14 +259,14 @@ namespace glz
             --closing;
             field = std::string_view(content_begin, static_cast<std::size_t>(closing - content_begin));
 
-            if (it != end && *it != ',' && *it != '\n' && *it != '\r') {
+            if (it != end && *it != csv_delimiter<Opts>() && *it != '\n' && *it != '\r') {
                ctx.error = error_code::syntax_error;
                return;
             }
          }
          else {
             auto content_begin = it;
-            while (it != end && *it != ',' && *it != '\n' && *it != '\r') {
+            while (it != end && *it != csv_delimiter<Opts>() && *it != '\n' && *it != '\r') {
                ++it;
             }
             field = std::string_view(content_begin, static_cast<std::size_t>(it - content_begin));
@@ -397,8 +397,8 @@ namespace glz
 
          auto start = it;
 
-         // Skip to end of field (comma, newline, or end)
-         while (it != end && *it != ',' && *it != '\n' && *it != '\r') {
+         // Skip to end of field (delimiter, newline, or end)
+         while (it != end && *it != csv_delimiter<Opts>() && *it != '\n' && *it != '\r') {
             ++it;
          }
 
@@ -459,7 +459,7 @@ namespace glz
    };
 
    // Utility to quickly count cells in a row for pre-allocation
-   template <class It>
+   template <char delim = ',', class It>
    inline size_t count_csv_cells(It start, It end) noexcept
    {
       if (start == end) {
@@ -473,7 +473,7 @@ namespace glz
          if (*start == '"') {
             in_quotes = !in_quotes;
          }
-         else if (*start == ',' && !in_quotes) {
+         else if (*start == delim && !in_quotes) {
             ++count;
          }
          else if ((*start == '\n' || *start == '\r') && !in_quotes) {
@@ -555,11 +555,11 @@ namespace glz
 
                   // Check for field separator or end of row
                   if (it != end) {
-                     if (*it == ',') {
+                     if (*it == csv_delimiter<Opts>()) {
                         ++it;
-                        // Handle trailing comma
+                        // Handle trailing delimiter
                         if (it == end || *it == '\n' || *it == '\r') {
-                           // Add empty value for trailing comma
+                           // Add empty value for trailing delimiter
                            if (col_index >= temp_cols.size()) {
                               temp_cols.resize(col_index + 1);
                            }
@@ -672,7 +672,7 @@ namespace glz
                while (row_end != end && *row_end != '\n' && *row_end != '\r') {
                   ++row_end;
                }
-               const auto estimated_cells = count_csv_cells(row_start, row_end);
+               const auto estimated_cells = count_csv_cells<csv_delimiter<Opts>()>(row_start, row_end);
                if (estimated_cells > 0) {
                   row.reserve(estimated_cells);
                }
@@ -726,9 +726,9 @@ namespace glz
                   break;
                }
 
-               if (*it == ',') {
+               if (*it == csv_delimiter<Opts>()) {
                   ++it;
-                  // Handle trailing comma by adding empty value
+                  // Handle trailing delimiter by adding empty value
                   if (it == end || *it == '\n' || *it == '\r') {
                      Value empty_value{};
                      if constexpr (emplace_backable<Row>) {
@@ -813,6 +813,7 @@ namespace glz
       }
    }
 
+   template <char delim = ','>
    inline auto read_column_wise_keys(auto&& ctx, auto&& it, auto end)
    {
       std::vector<std::pair<sv, size_t>> keys;
@@ -839,7 +840,7 @@ namespace glz
 
       auto start = it;
       while (it != end) {
-         if (*it == ',') {
+         if (*it == delim) {
             read_key(start, it);
             ++it;
             start = it;
@@ -879,7 +880,7 @@ namespace glz
          if constexpr (check_layout(Opts) == rowwise) {
             while (it != end) {
                auto start = it;
-               goto_delim<','>(it, end);
+               goto_delim<csv_delimiter<Opts>()>(it, end);
                sv key{start, static_cast<size_t>(it - start)};
 
                size_t csv_index{};
@@ -896,7 +897,7 @@ namespace glz
                   }
                }
 
-               if (it == end || *it != ',') [[unlikely]] {
+               if (it == end || *it != csv_delimiter<Opts>()) [[unlikely]] {
                   ctx.error = error_code::syntax_error;
                   return;
                }
@@ -943,7 +944,7 @@ namespace glz
                         break;
                      }
 
-                     if (*it == ',') {
+                     if (*it == csv_delimiter<Opts>()) {
                         ++it;
                      }
                      else {
@@ -972,7 +973,7 @@ namespace glz
                         break;
                      }
 
-                     if (*it == ',') {
+                     if (*it == csv_delimiter<Opts>()) {
                         ++it;
                      }
                      else {
@@ -985,7 +986,7 @@ namespace glz
          }
          else // column wise
          {
-            const auto keys = read_column_wise_keys(ctx, it, end);
+            const auto keys = read_column_wise_keys<csv_delimiter<Opts>()>(ctx, it, end);
 
             if (bool(ctx.error)) {
                return;
@@ -1031,7 +1032,7 @@ namespace glz
                      parse<CSV>::op<Opts>(member, ctx, it, end);
                   }
 
-                  if (it != end && *it == ',') {
+                  if (it != end && *it == csv_delimiter<Opts>()) {
                      ++it;
                   }
                }
@@ -1081,7 +1082,7 @@ namespace glz
             std::vector<size_t> member_indices;
 
             if constexpr (check_use_headers(Opts)) {
-               auto headers = read_column_wise_keys(ctx, it, end);
+               auto headers = read_column_wise_keys<csv_delimiter<Opts>()>(ctx, it, end);
 
                if (bool(ctx.error)) [[unlikely]] {
                   return;
@@ -1142,7 +1143,7 @@ namespace glz
                   }
 
                   if (i < n_cols - 1) {
-                     if (it == end || *it != ',') [[unlikely]] {
+                     if (it == end || *it != csv_delimiter<Opts>()) [[unlikely]] {
                         ctx.error = error_code::syntax_error;
                         return;
                      }
@@ -1239,7 +1240,7 @@ namespace glz
 
                      // Handle field separator
                      if constexpr (I < N - 1) {
-                        if (it != end && *it == ',') {
+                        if (it != end && *it == csv_delimiter<Opts>()) {
                            ++it;
                         }
                         else if (it == end || *it == '\n' || *it == '\r') {
@@ -1267,7 +1268,7 @@ namespace glz
                      else if (*it == '\n') {
                         ++it;
                      }
-                     else if (*it == ',') {
+                     else if (*it == csv_delimiter<Opts>()) {
                         // Extra fields in row - error
                         ctx.error = error_code::syntax_error;
                         return;
@@ -1297,7 +1298,7 @@ namespace glz
          if constexpr (check_layout(Opts) == rowwise) {
             while (it != end) {
                auto start = it;
-               goto_delim<','>(it, end);
+               goto_delim<csv_delimiter<Opts>()>(it, end);
                sv key{start, static_cast<size_t>(it - start)};
 
                size_t csv_index{};
@@ -1314,7 +1315,7 @@ namespace glz
                   }
                }
 
-               if (it == end || *it != ',') [[unlikely]] {
+               if (it == end || *it != csv_delimiter<Opts>()) [[unlikely]] {
                   ctx.error = error_code::syntax_error;
                   return;
                }
@@ -1380,7 +1381,7 @@ namespace glz
                                  break;
                               }
 
-                              if (*it == ',') [[likely]] {
+                              if (*it == csv_delimiter<Opts>()) [[likely]] {
                                  ++it;
                               }
                               else [[unlikely]] {
@@ -1413,7 +1414,7 @@ namespace glz
                                  break;
                               }
 
-                              if (*it == ',') [[likely]] {
+                              if (*it == csv_delimiter<Opts>()) [[likely]] {
                                  ++it;
                               }
                               else [[unlikely]] {
@@ -1437,7 +1438,7 @@ namespace glz
          }
          else // column wise
          {
-            const auto keys = read_column_wise_keys(ctx, it, end);
+            const auto keys = read_column_wise_keys<csv_delimiter<Opts>()>(ctx, it, end);
 
             if (bool(ctx.error)) [[unlikely]] {
                return;
@@ -1511,7 +1512,7 @@ namespace glz
                      }
 
                      at_end = it == end;
-                     if (!at_end && *it == ',') {
+                     if (!at_end && *it == csv_delimiter<Opts>()) {
                         ++it;
                         at_end = it == end;
                      }

--- a/include/glaze/csv/skip.hpp
+++ b/include/glaze/csv/skip.hpp
@@ -36,7 +36,7 @@ namespace glz
                      continue;
                   }
 
-                  if (*it == ',' || *it == '\n' || *it == '\r') {
+                  if (*it == csv_delimiter<Opts>() || *it == '\n' || *it == '\r') {
                      return;
                   }
 
@@ -50,7 +50,7 @@ namespace glz
          else {
             while (it != end) {
                const auto ch = *it;
-               if (ch == ',' || ch == '\n' || ch == '\r') {
+               if (ch == csv_delimiter<Opts>() || ch == '\n' || ch == '\r') {
                   return;
                }
                ++it;

--- a/include/glaze/csv/write.hpp
+++ b/include/glaze/csv/write.hpp
@@ -112,7 +112,7 @@ namespace glz
                      if (!ensure_space(ctx, b, ix + 1 + write_padding_bytes)) [[unlikely]] {
                         return;
                      }
-                     dump(',', b, ix);
+                     dump(csv_delimiter<Opts>(), b, ix);
                      if constexpr (is_output_streaming<B>) {
                         flush_buffer(b, ix);
                      }
@@ -135,7 +135,7 @@ namespace glz
                   if (!ensure_space(ctx, b, ix + 1 + write_padding_bytes)) [[unlikely]] {
                      return;
                   }
-                  dump(',', b, ix);
+                  dump(csv_delimiter<Opts>(), b, ix);
                   if constexpr (is_output_streaming<B>) {
                      flush_buffer(b, ix);
                   }
@@ -173,7 +173,7 @@ namespace glz
                      if (!ensure_space(ctx, b, ix + 1 + write_padding_bytes)) [[unlikely]] {
                         return;
                      }
-                     dump(',', b, ix);
+                     dump(csv_delimiter<Opts>(), b, ix);
                      if constexpr (is_output_streaming<B>) {
                         flush_buffer(b, ix);
                      }
@@ -227,7 +227,7 @@ namespace glz
                      if (!ensure_space(ctx, b, ix + 1 + write_padding_bytes)) [[unlikely]] {
                         return;
                      }
-                     dump(',', b, ix);
+                     dump(csv_delimiter<Opts>(), b, ix);
                      if constexpr (is_output_streaming<B>) {
                         flush_buffer(b, ix);
                      }
@@ -257,11 +257,11 @@ namespace glz
    };
 
    // Helper function to check if a string needs CSV quoting
-   template <class Str>
+   template <char delim = ',', class Str>
    inline bool needs_csv_quoting(const Str& str)
    {
       for (const auto c : str) {
-         if (c == ',' || c == '"' || c == '\n' || c == '\r') {
+         if (c == delim || c == '"' || c == '\n' || c == '\r') {
             return true;
          }
       }
@@ -269,10 +269,10 @@ namespace glz
    }
 
    // Dump a CSV string with proper quoting and escaping
-   template <class B>
+   template <char delim = ',', class B>
    inline void dump_csv_string(is_context auto& ctx, const sv str, B& b, size_t& ix)
    {
-      if (needs_csv_quoting(str)) {
+      if (needs_csv_quoting<delim>(str)) {
          // Need to quote this string - worst case: every char is a quote (doubled) plus surrounding quotes
          if (!ensure_space(ctx, b, ix + str.size() * 2 + 2 + write_padding_bytes)) [[unlikely]] {
             return;
@@ -304,7 +304,7 @@ namespace glz
    }
 
    // Dump a single character with CSV quoting if needed
-   template <class B>
+   template <char delim = ',', class B>
    inline void dump_csv_char(is_context auto& ctx, const char c, B& b, size_t& ix)
    {
       // Worst case: quoted double-quote = 4 chars (""")
@@ -312,7 +312,7 @@ namespace glz
          return;
       }
 
-      if (c == ',' || c == '"' || c == '\n' || c == '\r') {
+      if (c == delim || c == '"' || c == '\n' || c == '\r') {
          dump('"', b, ix);
          if (c == '"') {
             dump('"', b, ix);
@@ -338,10 +338,10 @@ namespace glz
       static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
       {
          if constexpr (char_t<T>) {
-            dump_csv_char(ctx, value, b, ix);
+            dump_csv_char<csv_delimiter<Opts>()>(ctx, value, b, ix);
          }
          else {
-            dump_csv_string(ctx, value, b, ix);
+            dump_csv_string<csv_delimiter<Opts>()>(ctx, value, b, ix);
          }
       }
    };
@@ -359,7 +359,7 @@ namespace glz
                      return;
                   }
                   dump_maybe_empty(name, b, ix);
-                  dump(',', b, ix);
+                  dump(csv_delimiter<Opts>(), b, ix);
                }
                const auto n = data.size();
                for (size_t i = 0; i < n; ++i) {
@@ -371,7 +371,7 @@ namespace glz
                      if (!ensure_space(ctx, b, ix + 1 + write_padding_bytes)) [[unlikely]] {
                         return;
                      }
-                     dump(',', b, ix);
+                     dump(csv_delimiter<Opts>(), b, ix);
                      if constexpr (is_output_streaming<B>) {
                         flush_buffer(b, ix);
                      }
@@ -398,7 +398,7 @@ namespace glz
                   dump_maybe_empty(name, b, ix);
                   ++i;
                   if (i < n) {
-                     dump(',', b, ix);
+                     dump(csv_delimiter<Opts>(), b, ix);
                      if constexpr (is_output_streaming<B>) {
                         flush_buffer(b, ix);
                      }
@@ -432,7 +432,7 @@ namespace glz
                      if (!ensure_space(ctx, b, ix + 1 + write_padding_bytes)) [[unlikely]] {
                         return;
                      }
-                     dump(',', b, ix);
+                     dump(csv_delimiter<Opts>(), b, ix);
                      if constexpr (is_output_streaming<B>) {
                         flush_buffer(b, ix);
                      }
@@ -506,7 +506,7 @@ namespace glz
                         dump('[', b, ix);
                         write_chars::op<Opts>(i, ctx, b, ix);
                         dump(']', b, ix);
-                        dump(',', b, ix);
+                        dump(csv_delimiter<Opts>(), b, ix);
                      }
 
                      for (size_t j = 0; j < count; ++j) {
@@ -518,7 +518,7 @@ namespace glz
                            if (!ensure_space(ctx, b, ix + 1 + write_padding_bytes)) [[unlikely]] {
                               return;
                            }
-                           dump(',', b, ix);
+                           dump(csv_delimiter<Opts>(), b, ix);
                         }
                      }
 
@@ -536,7 +536,7 @@ namespace glz
                         return;
                      }
                      dump<key>(b, ix);
-                     dump(',', b, ix);
+                     dump(csv_delimiter<Opts>(), b, ix);
                   }
                   serialize<CSV>::op<Opts>(get_member(value, mem), ctx, b, ix);
                   if (bool(ctx.error)) [[unlikely]] {
@@ -580,7 +580,7 @@ namespace glz
                         write_chars::op<Opts>(i, ctx, b, ix);
                         dump(']', b, ix);
                         if (i != size - 1) {
-                           dump(',', b, ix);
+                           dump(csv_delimiter<Opts>(), b, ix);
                         }
                      }
                   }
@@ -592,7 +592,7 @@ namespace glz
                      if (!ensure_space(ctx, b, ix + 1 + write_padding_bytes)) [[unlikely]] {
                         return;
                      }
-                     dump(',', b, ix);
+                     dump(csv_delimiter<Opts>(), b, ix);
                   }
                });
 
@@ -638,7 +638,7 @@ namespace glz
                            if (!ensure_space(ctx, b, ix + 1 + write_padding_bytes)) [[unlikely]] {
                               return;
                            }
-                           dump(',', b, ix);
+                           dump(csv_delimiter<Opts>(), b, ix);
                         }
                      }
                   }
@@ -658,7 +658,7 @@ namespace glz
                         if (!ensure_space(ctx, b, ix + 1 + write_padding_bytes)) [[unlikely]] {
                            return;
                         }
-                        dump(',', b, ix);
+                        dump(csv_delimiter<Opts>(), b, ix);
                      }
                   }
                });
@@ -703,7 +703,7 @@ namespace glz
                   if (!ensure_space(ctx, b, ix + 1 + write_padding_bytes)) [[unlikely]] {
                      return;
                   }
-                  dump(',', b, ix);
+                  dump(csv_delimiter<Opts>(), b, ix);
                }
             });
 
@@ -740,7 +740,7 @@ namespace glz
                   if (!ensure_space(ctx, b, ix + 1 + write_padding_bytes)) [[unlikely]] {
                      return;
                   }
-                  dump(',', b, ix);
+                  dump(csv_delimiter<Opts>(), b, ix);
                }
             });
 

--- a/tests/csv_test/csv_test.cpp
+++ b/tests/csv_test/csv_test.cpp
@@ -2399,4 +2399,165 @@ normal,")" + long_text + R"(")";
    };
 };
 
+struct csv_delim_point
+{
+   int x{};
+   int y{};
+};
+
+struct csv_delim_simple
+{
+   std::vector<int> num1{};
+   std::deque<float> num2{};
+   std::vector<bool> maybe{};
+};
+
+suite csv_delimiter_tests = [] {
+   "pipe delimiter colwise struct"_test = [] {
+      std::string input =
+         R"(num1|num2|maybe|v3s[0]|v3s[1]|v3s[2]
+11|22|1|1|1|1
+33|44|1|2|2|2
+55|66|0|3|3|3)";
+
+      my_struct obj{};
+      expect(!glz::read<glz::opts_csv{.layout = glz::colwise, .delimiter = '|'}>(obj, input));
+
+      expect(obj.num1[0] == 11);
+      expect(obj.num1[1] == 33);
+      expect(obj.num2[0] == 22.0f);
+      expect(obj.maybe[0] == true);
+      expect(obj.maybe[2] == false);
+      expect(obj.v3s[0] == std::array{1, 1, 1});
+
+      std::string out{};
+      expect(not glz::write<glz::opts_csv{.layout = glz::colwise, .delimiter = '|'}>(obj, out));
+      expect(out ==
+             R"(num1|num2|maybe|v3s[0]|v3s[1]|v3s[2]
+11|22|1|1|1|1
+33|44|1|2|2|2
+55|66|0|3|3|3
+)");
+   };
+
+   "semicolon delimiter rowwise struct"_test = [] {
+      std::string input =
+         R"(num1;1;2;3
+num2;4.5;5.5;6.5
+maybe;1;0;1)";
+
+      csv_delim_simple obj{};
+      expect(!glz::read<glz::opts_csv{.layout = glz::rowwise, .delimiter = ';'}>(obj, input));
+
+      expect(obj.num1[0] == 1);
+      expect(obj.num1[1] == 2);
+      expect(obj.num1[2] == 3);
+      expect(obj.num2[0] == 4.5f);
+      expect(obj.maybe[1] == false);
+
+      std::string out{};
+      expect(not glz::write<glz::opts_csv{.layout = glz::rowwise, .delimiter = ';'}>(obj, out));
+      expect(out ==
+             R"(num1;1;2;3
+num2;4.5;5.5;6.5
+maybe;1;0;1
+)");
+   };
+
+   "tab delimiter 2d array"_test = [] {
+      std::string input = "1\t2\t3\n4\t5\t6";
+
+      std::vector<std::vector<int>> matrix;
+      expect(!glz::read<glz::opts_csv{.use_headers = false, .delimiter = '\t'}>(matrix, input));
+
+      expect(matrix.size() == 2);
+      expect(matrix[0][0] == 1);
+      expect(matrix[0][2] == 3);
+      expect(matrix[1][1] == 5);
+
+      std::string out{};
+      expect(not glz::write<glz::opts_csv{.use_headers = false, .delimiter = '\t'}>(matrix, out));
+      expect(out == "1\t2\t3\n4\t5\t6\n");
+   };
+
+   "pipe delimiter 2d array single row"_test = [] {
+      std::string input = "10|20|30|40";
+
+      std::vector<std::vector<int>> arr;
+      expect(!glz::read<glz::opts_csv{.use_headers = false, .delimiter = '|'}>(arr, input));
+
+      expect(arr.size() == 1);
+      expect(arr[0].size() == 4);
+      expect(arr[0][0] == 10);
+      expect(arr[0][3] == 40);
+
+      std::string out{};
+      expect(not glz::write<glz::opts_csv{.use_headers = false, .delimiter = '|'}>(arr, out));
+      expect(out == "10|20|30|40\n");
+   };
+
+   "semicolon delimiter map"_test = [] {
+      std::map<std::string, std::vector<int>> map;
+      map["x"] = {1, 2, 3};
+      map["y"] = {4, 5, 6};
+
+      std::string out{};
+      expect(not glz::write<glz::opts_csv{.layout = glz::rowwise, .delimiter = ';'}>(map, out));
+      expect(out ==
+             R"(x;1;2;3
+y;4;5;6
+)");
+
+      std::map<std::string, std::vector<int>> map2;
+      expect(!glz::read<glz::opts_csv{.layout = glz::rowwise, .delimiter = ';'}>(map2, out));
+      expect(map2["x"] == std::vector{1, 2, 3});
+      expect(map2["y"] == std::vector{4, 5, 6});
+   };
+
+   "pipe delimiter string quoting"_test = [] {
+      std::string input = R"("hello|world"|simple|"has""quote")";
+
+      std::vector<std::vector<std::string>> arr;
+      expect(!glz::read<glz::opts_csv{.use_headers = false, .delimiter = '|'}>(arr, input));
+
+      expect(arr.size() == 1);
+      expect(arr[0].size() == 3);
+      expect(arr[0][0] == "hello|world");
+      expect(arr[0][1] == "simple");
+      expect(arr[0][2] == "has\"quote");
+   };
+
+   "semicolon delimiter vector of structs"_test = [] {
+      std::vector<csv_delim_point> original = {{1, 2}, {3, 4}, {5, 6}};
+
+      std::string out{};
+      expect(not glz::write<glz::opts_csv{.delimiter = ';'}>(original, out));
+      expect(out ==
+             R"(x;y
+1;2
+3;4
+5;6
+)");
+
+      std::vector<csv_delim_point> points;
+      expect(!glz::read<glz::opts_csv{.layout = glz::colwise, .delimiter = ';'}>(points, out));
+
+      expect(points.size() == 3);
+      expect(points[0].x == 1);
+      expect(points[0].y == 2);
+      expect(points[2].x == 5);
+      expect(points[2].y == 6);
+   };
+
+   "default delimiter unchanged"_test = [] {
+      std::string input = "1,2,3";
+      std::vector<std::vector<int>> arr;
+      expect(!glz::read<glz::opts_csv{.use_headers = false}>(arr, input));
+      expect(arr.size() == 1);
+      expect(arr[0].size() == 3);
+      expect(arr[0][0] == 1);
+      expect(arr[0][2] == 3);
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
# CSV: Configurable Field Delimiter

Adds a `delimiter` option to `opts_csv` so CSV reading and writing can use characters other than `,`. Previously the delimiter was hardcoded, which prevented Glaze from handling TSV, pipe-delimited, or semicolon-delimited files (common in European locales).

## Supported Delimiters

`,` &nbsp; `\t` &nbsp; `|` &nbsp; `;`

Any other character fails to compile via `static_assert`.

## Usage

```cpp
glz::read<glz::opts_csv{.delimiter = ';'}>(obj, input);
glz::write<glz::opts_csv{.delimiter = '\t'}>(obj, output);
```

Composes with all existing CSV features (headers, quoting, row/column layout, rectangular validation).

## Changes

- **`include/glaze/core/opts.hpp`** — Adds `char delimiter = ','` to the CSV options. Introduces `is_valid_csv_delimiter()` and `csv_delimiter<Opts>()` helpers that enforce the allowed set at compile time.
- **`include/glaze/csv/read.hpp`, `write.hpp`, `skip.hpp`** — Replaces hardcoded `','` with the compile-time delimiter from options throughout the CSV read/write/skip paths.
- **`docs/csv.md`** — Documents the new option with examples for TSV, pipe, and semicolon delimiters.
- **`tests/csv_test/csv_test.cpp`** — Adds tests covering each supported delimiter across row-wise, column-wise, struct, map, and 2D array cases.