### PR TITLE
Remove force inlining for YAML and TOML

### DIFF
--- a/include/glaze/toml/common.hpp
+++ b/include/glaze/toml/common.hpp
@@ -8,7 +8,7 @@ namespace glz
 {
    // Skip whitespace and comments
    template <class It, class End>
-   GLZ_ALWAYS_INLINE void skip_ws_and_comments(It&& it, End end) noexcept
+   inline void skip_ws_and_comments(It&& it, End end) noexcept
    {
       while (it != end) {
          if (*it == ' ' || *it == '\t') {
@@ -27,7 +27,7 @@ namespace glz
 
    // Skip to next line
    template <class Ctx, class It, class End>
-   GLZ_ALWAYS_INLINE bool skip_to_next_line(Ctx&, It&& it, End end) noexcept
+   inline bool skip_to_next_line(Ctx&, It&& it, End end) noexcept
    {
       while (it != end && *it != '\n' && *it != '\r') {
          ++it;

--- a/include/glaze/toml/read.hpp
+++ b/include/glaze/toml/read.hpp
@@ -26,14 +26,14 @@ namespace glz
    struct parse<TOML>
    {
       template <auto Opts, class T, is_context Ctx, class It0, class It1>
-      GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, It0&& it, It1 end)
+      static void op(T&& value, Ctx&& ctx, It0&& it, It1 end)
       {
          using V = std::remove_cvref_t<T>;
          from<TOML, V>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<It0>(it), end);
       }
    };
 
-   GLZ_ALWAYS_INLINE constexpr int toml_hex_to_int(const char c) noexcept
+   inline constexpr int toml_hex_to_int(const char c) noexcept
    {
       if (c >= '0' && c <= '9') return c - '0';
       if (c >= 'a' && c <= 'f') return 10 + (c - 'a');
@@ -42,7 +42,7 @@ namespace glz
    }
 
    template <class It, class End>
-   GLZ_ALWAYS_INLINE bool append_toml_unicode_escape_u(std::string& out, It& it, End end) noexcept
+   inline bool append_toml_unicode_escape_u(std::string& out, It& it, End end) noexcept
    {
       auto hex_it = it;
       ++hex_it; // first hex digit after 'u'
@@ -68,7 +68,7 @@ namespace glz
    }
 
    template <class It, class End>
-   GLZ_ALWAYS_INLINE bool append_toml_unicode_escape_U(std::string& out, It& it, End end) noexcept
+   inline bool append_toml_unicode_escape_U(std::string& out, It& it, End end) noexcept
    {
       auto hex_it = it;
       ++hex_it; // first hex digit after 'U'
@@ -102,7 +102,7 @@ namespace glz
    }
 
    template <class It, class End>
-   GLZ_ALWAYS_INLINE bool append_toml_basic_escape(std::string& out, It& it, End end) noexcept
+   inline bool append_toml_basic_escape(std::string& out, It& it, End end) noexcept
    {
       switch (*it) {
       case '"':
@@ -153,7 +153,7 @@ namespace glz
 
    // Parse TOML key (bare key or quoted key)
    template <class Ctx, class It, class End>
-   GLZ_ALWAYS_INLINE bool parse_toml_key(std::string& key, Ctx& ctx, It&& it, End end) noexcept
+   inline bool parse_toml_key(std::string& key, Ctx& ctx, It&& it, End end) noexcept
    {
       key.clear();
       skip_ws_and_comments(it, end);
@@ -225,7 +225,7 @@ namespace glz
    }
 
    template <class Ctx, class It, class End>
-   GLZ_ALWAYS_INLINE bool parse_toml_key(std::vector<std::string>& keys, Ctx& ctx, It& it, End end) noexcept
+   inline bool parse_toml_key(std::vector<std::string>& keys, Ctx& ctx, It& it, End end) noexcept
    {
       keys.clear();
       skip_ws_and_comments(it, end);
@@ -1001,7 +1001,7 @@ namespace glz
    struct from<TOML, T>
    {
       template <auto Opts, class It0, class It1>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, It0&& it, It1 end) noexcept
+      static void op(auto&& value, is_context auto&& ctx, It0&& it, It1 end) noexcept
       {
          using Rep = typename std::remove_cvref_t<T>::rep;
          Rep count{};
@@ -1368,7 +1368,7 @@ namespace glz
    struct from<TOML, T>
    {
       template <auto Opts, class It0, class It1>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, It0&& it, It1 end) noexcept
+      static void op(auto&& value, is_context auto&& ctx, It0&& it, It1 end) noexcept
       {
          using Duration = typename std::remove_cvref_t<T>::duration;
          using Rep = typename Duration::rep;
@@ -1386,7 +1386,7 @@ namespace glz
    struct from<TOML, T>
    {
       template <auto Opts, class It0, class It1>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, It0&& it, It1 end) noexcept
+      static void op(auto&& value, is_context auto&& ctx, It0&& it, It1 end) noexcept
       {
          // Treat like steady_clock - parse as count
          using Duration = typename std::remove_cvref_t<T>::duration;
@@ -1548,7 +1548,7 @@ namespace glz
    namespace detail
    {
       template <auto Opts, class T, class It, class End, class Ctx>
-      GLZ_ALWAYS_INLINE void parse_toml_object_members(T&& value, It&& it, End end, Ctx&& ctx, bool is_inline_table)
+      inline void parse_toml_object_members(T&& value, It&& it, End end, Ctx&& ctx, bool is_inline_table)
       {
          using U = std::remove_cvref_t<T>;
          static constexpr auto N = reflect<U>::size;
@@ -1698,7 +1698,7 @@ namespace glz
    }
 
    template <auto Opts, class T>
-   GLZ_ALWAYS_INLINE bool resolve_nested(T& root, std::span<std::string> path, auto& ctx, auto& it, auto& end)
+   inline bool resolve_nested(T& root, std::span<std::string> path, auto& ctx, auto& it, auto& end)
    {
       if constexpr (!(glz::reflectable<T> || glz::glaze_object_t<T>)) {
          return true;
@@ -1754,7 +1754,7 @@ namespace glz
    // Helper to resolve an array-of-tables path and emplace a new element
    // Returns true if successful, false if error
    template <auto Opts, class T>
-   GLZ_ALWAYS_INLINE bool resolve_array_of_tables(T& root, std::span<std::string> path, auto& ctx, auto& it, auto& end)
+   inline bool resolve_array_of_tables(T& root, std::span<std::string> path, auto& ctx, auto& it, auto& end)
    {
       if constexpr (!(glz::reflectable<T> || glz::glaze_object_t<T>)) {
          ctx.error = error_code::syntax_error;
@@ -1869,7 +1869,7 @@ namespace glz
 
       // Helper to resolve a dotted key path into a nested map, creating entries as needed
       // Returns a reference to the innermost value where data should be stored
-      // Note: Not GLZ_ALWAYS_INLINE because this function is recursive
+      // Note: Not inline because this function is recursive
       template <auto Opts, class T>
       bool resolve_nested_map(T& root, std::span<std::string> path, auto& ctx, auto& it, auto& end)
       {
@@ -1960,7 +1960,7 @@ namespace glz
 
       // Helper to ensure a path of nested maps exists (for table section headers)
       // This creates the nested map structure without parsing a value
-      // Note: Not GLZ_ALWAYS_INLINE because this function is recursive
+      // Note: Not inline because this function is recursive
       template <auto Opts, class T>
       bool ensure_map_path(T& root, std::span<std::string> path, auto& ctx)
       {
@@ -2106,7 +2106,7 @@ namespace glz
 
       // Parse inline table {...} into a map
       template <auto Opts, class T>
-      GLZ_ALWAYS_INLINE void parse_toml_inline_table_map(T& value, auto& it, auto& end, auto& ctx)
+      inline void parse_toml_inline_table_map(T& value, auto& it, auto& end, auto& ctx)
       {
          // Already consumed the opening '{'
          skip_ws_and_comments(it, end);

--- a/include/glaze/toml/skip.hpp
+++ b/include/glaze/toml/skip.hpp
@@ -7,7 +7,7 @@
 namespace glz::toml
 {
    template <class It, class End>
-   GLZ_ALWAYS_INLINE void skip_comment(It& it, End end) noexcept
+   inline void skip_comment(It& it, End end) noexcept
    {
       while (it != end && *it != '\n' && *it != '\r') {
          ++it;
@@ -229,7 +229,7 @@ namespace glz
    struct skip_value<TOML>
    {
       template <auto Opts>
-      GLZ_ALWAYS_INLINE static void op(is_context auto&& ctx, auto&& it, auto end) noexcept
+      static void op(is_context auto&& ctx, auto&& it, auto end) noexcept
       {
          toml::skip_value_impl<Opts>(ctx, it, end);
       }

--- a/include/glaze/toml/write.hpp
+++ b/include/glaze/toml/write.hpp
@@ -38,7 +38,7 @@ namespace glz
    struct serialize<TOML>
    {
       template <auto Opts, class T, is_context Ctx, class B, class IX>
-      GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
+      static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
       {
          to<TOML, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
                                                              std::forward<B>(b), std::forward<IX>(ix));
@@ -50,7 +50,7 @@ namespace glz
    struct to<TOML, T>
    {
       template <auto Opts, class Value, is_context Ctx, class B, class IX>
-      GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, B&& b, IX&& ix)
+      static void op(Value&& value, Ctx&& ctx, B&& b, IX&& ix)
       {
          using V = std::remove_cvref_t<decltype(get_member(std::declval<Value>(), meta_wrapper_v<T>))>;
          to<TOML, V>::template op<Opts>(get_member(std::forward<Value>(value), meta_wrapper_v<T>),
@@ -62,7 +62,7 @@ namespace glz
    struct to<TOML, T>
    {
       template <auto Opts>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& b, auto& ix)
+      static void op(auto&& value, is_context auto&& ctx, auto&& b, auto& ix)
       {
          if (value) {
             serialize<TOML>::op<Opts>(*value, ctx, b, ix);
@@ -77,7 +77,7 @@ namespace glz
    struct to<TOML, std::nullptr_t>
    {
       template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(std::nullptr_t, is_context auto&& ctx, B&& b, auto& ix)
+      static void op(std::nullptr_t, is_context auto&& ctx, B&& b, auto& ix)
       {
          // Write empty string as placeholder for null
          // Note: TOML doesn't support null natively
@@ -92,7 +92,7 @@ namespace glz
    struct to<TOML, T>
    {
       template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(const bool value, is_context auto&& ctx, B&& b, auto& ix)
+      static void op(const bool value, is_context auto&& ctx, B&& b, auto& ix)
       {
          static constexpr auto checked = not check_write_unchecked(Opts);
          if constexpr (checked) {
@@ -127,7 +127,7 @@ namespace glz
    struct to<TOML, T>
    {
       template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
       {
          // Numbers can be up to ~25 chars for doubles
          if (!ensure_space(ctx, b, ix + 32 + write_padding_bytes)) [[unlikely]] {
@@ -152,7 +152,7 @@ namespace glz
    struct to<TOML, T>
    {
       template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
       {
          const sv str = get_enum_name(value);
          if (!str.empty()) {
@@ -181,7 +181,7 @@ namespace glz
    struct to<TOML, T>
    {
       template <auto Opts, class... Args>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
+      static void op(auto&& value, is_context auto&& ctx, Args&&... args)
       {
          // serialize as underlying number
          serialize<TOML>::op<Opts>(static_cast<std::underlying_type_t<std::decay_t<T>>>(value), ctx,
@@ -199,7 +199,7 @@ namespace glz
    struct to<TOML, T>
    {
       template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix) noexcept
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix) noexcept
       {
          using Rep = typename std::remove_cvref_t<T>::rep;
          to<TOML, Rep>::template op<Opts>(value.count(), ctx, b, ix);
@@ -410,7 +410,7 @@ namespace glz
    struct to<TOML, T>
    {
       template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix) noexcept
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix) noexcept
       {
          using Duration = typename std::remove_cvref_t<T>::duration;
          using Rep = typename Duration::rep;
@@ -425,7 +425,7 @@ namespace glz
    struct to<TOML, T>
    {
       template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix) noexcept
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix) noexcept
       {
          // Treat like steady_clock - serialize as count since epoch is implementation-defined
          using Duration = typename std::remove_cvref_t<T>::duration;
@@ -602,7 +602,7 @@ namespace glz
 
    template <auto Opts, bool minified_check = true, class B>
       requires(Opts.format == TOML)
-   GLZ_ALWAYS_INLINE void write_array_entry_separator(is_context auto&& ctx, B&& b, auto& ix)
+   inline void write_array_entry_separator(is_context auto&& ctx, B&& b, auto& ix)
    {
       if constexpr (minified_check) {
          if (!ensure_space(ctx, b, ix + 2)) [[unlikely]] {
@@ -618,7 +618,7 @@ namespace glz
 
    template <auto Opts, bool minified_check = true, class B>
       requires(Opts.format == TOML)
-   GLZ_ALWAYS_INLINE void write_object_entry_separator(is_context auto&& ctx, B&& b, auto& ix)
+   inline void write_object_entry_separator(is_context auto&& ctx, B&& b, auto& ix)
    {
       if (!ensure_space(ctx, b, ix + 1)) [[unlikely]] {
          return;
@@ -1150,7 +1150,7 @@ namespace glz
 
       // Helper to write an array element - uses inline table format for objects when in inline mode
       template <auto Opts, class V, class B>
-      GLZ_ALWAYS_INLINE static void write_element(V&& element, is_context auto&& ctx, B&& b, auto& ix)
+      static void write_element(V&& element, is_context auto&& ctx, B&& b, auto& ix)
       {
          using val_t = std::remove_cvref_t<V>;
          constexpr bool is_object_type = glaze_object_t<val_t> || reflectable<val_t>;
@@ -1168,7 +1168,7 @@ namespace glz
       // --- Array-like container writer ---
       template <auto Opts, class B>
          requires(writable_array_t<T> && (map_like_array ? check_concatenate(Opts) == false : true))
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
       {
          if (empty_range(value)) {
             if (!ensure_space(ctx, b, ix + 2 + write_padding_bytes)) [[unlikely]] {
@@ -1276,7 +1276,7 @@ namespace glz
    struct to<TOML, T>
    {
       template <auto Opts, class V, size_t N, class... Args>
-      GLZ_ALWAYS_INLINE static void op(const V (&value)[N], is_context auto&& ctx, Args&&... args)
+      static void op(const V (&value)[N], is_context auto&& ctx, Args&&... args)
       {
          serialize<TOML>::op<Opts>(std::span{value, N}, ctx, std::forward<Args>(args)...);
       }
@@ -1337,7 +1337,7 @@ namespace glz
    struct to<TOML, T>
    {
       template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, B&& b, auto& ix)
+      static void op(auto&&, is_context auto&& ctx, B&& b, auto& ix)
       {
          if (!ensure_space(ctx, b, ix + 2 + write_padding_bytes)) [[unlikely]] {
             return;

--- a/include/glaze/yaml/common.hpp
+++ b/include/glaze/yaml/common.hpp
@@ -351,7 +351,7 @@ namespace glz::yaml
       unknown // Malformed tag (parse error)
    };
 
-   GLZ_ALWAYS_INLINE constexpr bool malformed_tag_token(std::string_view token) noexcept
+   inline constexpr bool malformed_tag_token(std::string_view token) noexcept
    {
       // Reject obviously malformed tag tokens used by conformance tests.
       // Unknown-but-well-formed tags are still ignored.
@@ -361,7 +361,7 @@ namespace glz::yaml
       return false;
    }
 
-   GLZ_ALWAYS_INLINE constexpr bool malformed_tag_termination(char c) noexcept
+   inline constexpr bool malformed_tag_termination(char c) noexcept
    {
       return !(c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '#' || c == ',' || c == ']' || c == '}');
    }
@@ -373,7 +373,7 @@ namespace glz::yaml
    // - Named: !mytag
    // Returns the tag type and advances iterator past the tag
    template <class It, class End>
-   GLZ_ALWAYS_INLINE yaml_tag parse_yaml_tag(It& it, End end, const bool allow_core_schema_secondary_handle) noexcept
+   inline yaml_tag parse_yaml_tag(It& it, End end, const bool allow_core_schema_secondary_handle) noexcept
    {
       if (it == end || *it != '!') {
          return yaml_tag::none;
@@ -486,62 +486,62 @@ namespace glz::yaml
    }
 
    template <class It, class End>
-   GLZ_ALWAYS_INLINE yaml_tag parse_yaml_tag(It& it, End end) noexcept
+   inline yaml_tag parse_yaml_tag(It& it, End end) noexcept
    {
       return parse_yaml_tag(it, end, true);
    }
 
    template <class It, class End, class Ctx>
-   GLZ_ALWAYS_INLINE yaml_tag parse_yaml_tag(It& it, End end, const Ctx& ctx) noexcept
+   inline yaml_tag parse_yaml_tag(It& it, End end, const Ctx& ctx) noexcept
    {
       return parse_yaml_tag(it, end, !ctx.secondary_tag_handle_overridden);
    }
 
    // Check if a tag is valid for string types
-   GLZ_ALWAYS_INLINE constexpr bool tag_valid_for_string(yaml_tag tag) noexcept
+   inline constexpr bool tag_valid_for_string(yaml_tag tag) noexcept
    {
       return tag == yaml_tag::none || tag == yaml_tag::str;
    }
 
    // Check if a tag is valid for integer types
-   GLZ_ALWAYS_INLINE constexpr bool tag_valid_for_int(yaml_tag tag) noexcept
+   inline constexpr bool tag_valid_for_int(yaml_tag tag) noexcept
    {
       return tag == yaml_tag::none || tag == yaml_tag::int_tag;
    }
 
    // Check if a tag is valid for floating-point types
-   GLZ_ALWAYS_INLINE constexpr bool tag_valid_for_float(yaml_tag tag) noexcept
+   inline constexpr bool tag_valid_for_float(yaml_tag tag) noexcept
    {
       return tag == yaml_tag::none || tag == yaml_tag::float_tag || tag == yaml_tag::int_tag;
    }
 
    // Check if a tag is valid for boolean types
-   GLZ_ALWAYS_INLINE constexpr bool tag_valid_for_bool(yaml_tag tag) noexcept
+   inline constexpr bool tag_valid_for_bool(yaml_tag tag) noexcept
    {
       return tag == yaml_tag::none || tag == yaml_tag::bool_tag;
    }
 
    // Check if a tag is valid for null/nullable types
-   GLZ_ALWAYS_INLINE constexpr bool tag_valid_for_null(yaml_tag tag) noexcept
+   inline constexpr bool tag_valid_for_null(yaml_tag tag) noexcept
    {
       return tag == yaml_tag::none || tag == yaml_tag::null_tag;
    }
 
    // Check if a tag is valid for sequence types
-   GLZ_ALWAYS_INLINE constexpr bool tag_valid_for_seq(yaml_tag tag) noexcept
+   inline constexpr bool tag_valid_for_seq(yaml_tag tag) noexcept
    {
       return tag == yaml_tag::none || tag == yaml_tag::seq;
    }
 
    // Check if a tag is valid for mapping types
-   GLZ_ALWAYS_INLINE constexpr bool tag_valid_for_map(yaml_tag tag) noexcept
+   inline constexpr bool tag_valid_for_map(yaml_tag tag) noexcept
    {
       return tag == yaml_tag::none || tag == yaml_tag::map;
    }
 
    // Skip inline whitespace (spaces and tabs only - NOT newlines)
    template <class It, class End>
-   GLZ_ALWAYS_INLINE void skip_inline_ws(It&& it, End end) noexcept
+   inline void skip_inline_ws(It&& it, End end) noexcept
    {
       while (it != end && (*it == ' ' || *it == '\t')) {
          ++it;
@@ -550,7 +550,7 @@ namespace glz::yaml
 
    // Skip a comment to end of line (does not consume the newline)
    template <class It, class End>
-   GLZ_ALWAYS_INLINE void skip_comment(It&& it, End end) noexcept
+   inline void skip_comment(It&& it, End end) noexcept
    {
       if (it != end && *it == '#') {
          while (it != end && *it != '\n' && *it != '\r') {
@@ -561,7 +561,7 @@ namespace glz::yaml
 
    // Skip inline whitespace and any trailing comment
    template <class It, class End>
-   GLZ_ALWAYS_INLINE void skip_ws_and_comment(It&& it, End end) noexcept
+   inline void skip_ws_and_comment(It&& it, End end) noexcept
    {
       skip_inline_ws(it, end);
       skip_comment(it, end);
@@ -569,7 +569,7 @@ namespace glz::yaml
 
    // Skip a newline sequence (handles \n, \r, \r\n)
    template <class It, class End>
-   GLZ_ALWAYS_INLINE bool skip_newline(It&& it, End end) noexcept
+   inline bool skip_newline(It&& it, End end) noexcept
    {
       if (it == end) return false;
 
@@ -589,7 +589,7 @@ namespace glz::yaml
 
    // Skip all whitespace including newlines (spaces, tabs, \n, \r)
    template <class It, class End>
-   GLZ_ALWAYS_INLINE void skip_ws_and_newlines(It&& it, End end) noexcept
+   inline void skip_ws_and_newlines(It&& it, End end) noexcept
    {
       while (it != end && (*it == ' ' || *it == '\t' || *it == '\n' || *it == '\r')) {
          if (*it == '\n' || *it == '\r') {
@@ -604,7 +604,7 @@ namespace glz::yaml
    // Skip all whitespace, newlines, and comments until reaching actual content
    // This is used at the start of parsing and between top-level elements
    template <class It, class End>
-   GLZ_ALWAYS_INLINE void skip_ws_newlines_comments(It&& it, End end) noexcept
+   inline void skip_ws_newlines_comments(It&& it, End end) noexcept
    {
       while (it != end) {
          if (*it == ' ' || *it == '\t') {
@@ -624,7 +624,7 @@ namespace glz::yaml
 
    // Check if at newline or end
    template <class It, class End>
-   GLZ_ALWAYS_INLINE bool at_newline_or_end(It&& it, End end) noexcept
+   inline bool at_newline_or_end(It&& it, End end) noexcept
    {
       return it == end || *it == '\n' || *it == '\r';
    }
@@ -632,7 +632,7 @@ namespace glz::yaml
    // Check if position starts with a document marker (--- or ...) followed by whitespace/newline/end.
    // Per YAML spec, these markers are only valid at the start of a line with zero indentation.
    template <class It, class End>
-   GLZ_ALWAYS_INLINE bool starts_with_document_marker(It src, End src_end) noexcept
+   inline bool starts_with_document_marker(It src, End src_end) noexcept
    {
       if (src >= src_end) return false;
       if ((src_end - src) >= 3) {
@@ -654,7 +654,7 @@ namespace glz::yaml
    // Validates indentation constraints and optionally reports the measured indent.
    // Returns false and sets ctx.error on indentation violations.
    template <class Ctx>
-   GLZ_ALWAYS_INLINE bool skip_folded_line_indent(const char*& src, const char* src_end, Ctx& ctx,
+   inline bool skip_folded_line_indent(const char*& src, const char* src_end, Ctx& ctx,
                                                   int* indent_out = nullptr) noexcept
    {
       bool saw_space = false;
@@ -682,7 +682,7 @@ namespace glz::yaml
    // Only scans to end of line (bounded by newline), so O(line length) not O(input).
    // Returns false for obvious non-mappings to avoid expensive full parse attempts.
    template <class It, class End>
-   GLZ_ALWAYS_INLINE bool line_could_be_block_mapping(It it, End end)
+   inline bool line_could_be_block_mapping(It it, End end)
    {
       bool prev_was_whitespace = true; // Start of value acts like after whitespace
       int flow_depth = 0;
@@ -756,7 +756,7 @@ namespace glz::yaml
    // - Documents with %YAML major version > 1 should be rejected
    // - Unknown directives should be ignored (with warning, but we silently skip)
    template <class It, class End, class Ctx>
-   GLZ_ALWAYS_INLINE void skip_document_start(It&& it, End end, Ctx& ctx) noexcept
+   inline void skip_document_start(It&& it, End end, Ctx& ctx) noexcept
    {
       ctx.secondary_tag_handle_overridden = false;
 
@@ -953,7 +953,7 @@ namespace glz::yaml
    // Check if at document start marker (---)
    // Returns true if at --- followed by whitespace/newline/end
    template <class It, class End>
-   GLZ_ALWAYS_INLINE bool at_document_start(It&& it, End end) noexcept
+   inline bool at_document_start(It&& it, End end) noexcept
    {
       if (end - it >= 3 && it[0] == '-' && it[1] == '-' && it[2] == '-') {
          auto after = it + 3;
@@ -965,7 +965,7 @@ namespace glz::yaml
    // Check if at document end marker (...)
    // Returns true if at ... followed by whitespace/newline/end
    template <class It, class End>
-   GLZ_ALWAYS_INLINE bool at_document_end(It&& it, End end) noexcept
+   inline bool at_document_end(It&& it, End end) noexcept
    {
       if (end - it >= 3 && it[0] == '.' && it[1] == '.' && it[2] == '.') {
          auto after = it + 3;
@@ -982,7 +982,7 @@ namespace glz::yaml
    // error_on_tab=false: only errors on tab at position 0 (pure tab indentation) — for block
    //   scalars where tabs after indentation spaces are valid content characters.
    template <bool error_on_tab = true, class It, class End, class Ctx>
-   GLZ_ALWAYS_INLINE int32_t measure_indent(It&& it, End end, Ctx& ctx) noexcept
+   inline int32_t measure_indent(It&& it, End end, Ctx& ctx) noexcept
    {
       int32_t indent = 0;
       while (it != end && *it == ' ') {
@@ -1007,7 +1007,7 @@ namespace glz::yaml
 
    // Skip to next line and return new indentation level
    template <class It, class End, class Ctx>
-   GLZ_ALWAYS_INLINE int32_t skip_to_next_content_line(It&& it, End end, Ctx& ctx) noexcept
+   inline int32_t skip_to_next_content_line(It&& it, End end, Ctx& ctx) noexcept
    {
       while (it != end) {
          // Skip to end of current line
@@ -1041,7 +1041,7 @@ namespace glz::yaml
    // Check for unsupported YAML features (anchors & and aliases *)
    // Returns true if an unsupported feature is detected and sets error
    template <class Ctx>
-   GLZ_ALWAYS_INLINE bool check_unsupported_feature(char c, Ctx& ctx) noexcept
+   inline bool check_unsupported_feature(char c, Ctx& ctx) noexcept
    {
       if (c == '&' || c == '*') {
          ctx.error = error_code::feature_not_supported;
@@ -1053,7 +1053,7 @@ namespace glz::yaml
    // Parse an anchor or alias name. Advances iterator past the name.
    // Anchor/alias names end at whitespace, flow indicators, or colon.
    template <class It, class End>
-   GLZ_ALWAYS_INLINE std::string_view parse_anchor_name(It& it, End end) noexcept
+   inline std::string_view parse_anchor_name(It& it, End end) noexcept
    {
       auto start = it;
       if (start == end) return {};
@@ -1071,7 +1071,7 @@ namespace glz::yaml
    }
 
    // Detect scalar style from first character
-   GLZ_ALWAYS_INLINE constexpr scalar_style detect_scalar_style(char c) noexcept
+   inline constexpr scalar_style detect_scalar_style(char c) noexcept
    {
       switch (c) {
       case '"':
@@ -1088,37 +1088,37 @@ namespace glz::yaml
    }
 
    // Check if character can start a plain scalar in flow context
-   GLZ_ALWAYS_INLINE constexpr bool can_start_plain_flow(char c) noexcept
+   inline constexpr bool can_start_plain_flow(char c) noexcept
    {
       return can_start_plain_flow_table[static_cast<uint8_t>(c)];
    }
 
    // Check if character can start a plain scalar in block context
-   GLZ_ALWAYS_INLINE constexpr bool can_start_plain_block(char c) noexcept
+   inline constexpr bool can_start_plain_block(char c) noexcept
    {
       return can_start_plain_block_table[static_cast<uint8_t>(c)];
    }
 
    // Check if string looks like a boolean
-   GLZ_ALWAYS_INLINE bool is_yaml_bool(std::string_view s) noexcept
+   inline bool is_yaml_bool(std::string_view s) noexcept
    {
       return s == "true" || s == "false" || s == "True" || s == "False" || s == "TRUE" || s == "FALSE";
    }
 
    // Check if string looks like null
-   GLZ_ALWAYS_INLINE bool is_yaml_null(std::string_view s) noexcept
+   inline bool is_yaml_null(std::string_view s) noexcept
    {
       return s == "null" || s == "Null" || s == "NULL" || s == "~" || s.empty();
    }
 
    // Check if character is a YAML indicator that needs quoting
-   GLZ_ALWAYS_INLINE constexpr bool is_yaml_indicator(char c) noexcept
+   inline constexpr bool is_yaml_indicator(char c) noexcept
    {
       return yaml_indicator_table[static_cast<uint8_t>(c)];
    }
 
    // Check if string needs quoting when written
-   GLZ_ALWAYS_INLINE bool needs_quoting(std::string_view s) noexcept
+   inline bool needs_quoting(std::string_view s) noexcept
    {
       if (s.empty()) return true;
 
@@ -1156,7 +1156,7 @@ namespace glz::yaml
 
    // Write indentation
    template <class B>
-   GLZ_ALWAYS_INLINE void write_indent(B&& b, auto& ix, int32_t level, uint8_t width = 2)
+   inline void write_indent(B&& b, auto& ix, int32_t level, uint8_t width = 2)
    {
       const int32_t spaces = level * width;
       for (int32_t i = 0; i < spaces; ++i) {

--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -25,7 +25,7 @@ namespace glz
    struct parse<YAML>
    {
       template <auto Opts, class T, is_context Ctx, class It0, class It1>
-      GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, It0&& it, It1 end)
+      static void op(T&& value, Ctx&& ctx, It0&& it, It1 end)
       {
          if constexpr (requires { ctx.stream_begin; }) {
             if (!ctx.stream_begin && it != end) {
@@ -189,7 +189,7 @@ namespace glz
    struct from<YAML, T>
    {
       template <auto Opts, class Value, is_context Ctx, class It0, class It1>
-      GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, It0&& it, It1 end)
+      static void op(Value&& value, Ctx&& ctx, It0&& it, It1 end)
       {
          using V = std::decay_t<decltype(get_member(std::declval<Value>(), meta_wrapper_v<T>))>;
          from<YAML, V>::template op<Opts>(get_member(std::forward<Value>(value), meta_wrapper_v<T>),
@@ -246,7 +246,7 @@ namespace glz
       }
 
       template <class It, class End>
-      GLZ_ALWAYS_INLINE bool alias_token_is_mapping_key(It it, End end) noexcept
+      inline bool alias_token_is_mapping_key(It it, End end) noexcept
       {
          if (it == end || *it != '*') return false;
          ++it; // skip '*'
@@ -283,7 +283,7 @@ namespace glz
       // Returns true when caller should stop (alias consumed, tolerated empty anchor, or syntax/error).
       template <auto Opts, node_property_policy Policy = node_property_policy{}, class T, class Ctx, class It,
                 class End>
-      GLZ_ALWAYS_INLINE bool parse_node_properties(T&& value, Ctx& ctx, It& it, End end,
+      inline bool parse_node_properties(T&& value, Ctx& ctx, It& it, End end,
                                                    node_property_state& state) noexcept
       {
          state.has_anchor = false;
@@ -331,7 +331,7 @@ namespace glz
       }
 
       template <class Ctx, class It>
-      GLZ_ALWAYS_INLINE void finalize_node_anchor(node_property_state& state, Ctx& ctx, It it) noexcept
+      inline void finalize_node_anchor(node_property_state& state, Ctx& ctx, It it) noexcept
       {
          if (state.has_anchor && !bool(ctx.error)) {
             ctx.anchors[std::move(state.anchor_name)] = {state.anchor_start, &*it, state.anchor_indent};
@@ -340,7 +340,7 @@ namespace glz
 
       template <auto Opts, node_property_policy PropertyPolicy = node_property_policy{}, bool AllowEmptyInput = false,
                 class T, class Ctx, class It, class End, class TagValidator>
-      GLZ_ALWAYS_INLINE bool parse_node_preamble(T&& value, Ctx& ctx, It& it, End end, node_preamble_state& preamble,
+      inline bool parse_node_preamble(T&& value, Ctx& ctx, It& it, End end, node_preamble_state& preamble,
                                                  TagValidator&& tag_validator) noexcept
       {
          skip_inline_ws(it, end);
@@ -381,7 +381,7 @@ namespace glz
       // SWAR-optimized double-quoted string parsing
       // Uses 8-byte chunks for fast scanning and copying
       template <class Ctx, class It, class End>
-      GLZ_ALWAYS_INLINE void parse_double_quoted_string(std::string& value, Ctx& ctx, It& it, End end)
+      inline void parse_double_quoted_string(std::string& value, Ctx& ctx, It& it, End end)
       {
          static constexpr size_t string_padding_bytes = 8;
 
@@ -624,7 +624,7 @@ namespace glz
       // Only escape is '' -> ' (doubled single quote)
       // Line breaks are folded: single newline -> space, blank line -> newline
       template <class Ctx, class It, class End>
-      GLZ_ALWAYS_INLINE void parse_single_quoted_string(std::string& value, Ctx& ctx, It& it, End end)
+      inline void parse_single_quoted_string(std::string& value, Ctx& ctx, It& it, End end)
       {
          static constexpr size_t string_padding_bytes = 8;
 
@@ -731,7 +731,7 @@ namespace glz
       }
 
       template <class Ctx, class It, class End>
-      GLZ_ALWAYS_INLINE void skip_flow_ws_and_newlines(Ctx& ctx, It& it, End end, bool* saw_line_break = nullptr)
+      inline void skip_flow_ws_and_newlines(Ctx& ctx, It& it, End end, bool* saw_line_break = nullptr)
       {
          bool at_line_start = false;
          bool saw_separation_ws = false;
@@ -809,7 +809,7 @@ namespace glz
       }
 
       template <class Ctx, class It, class End>
-      GLZ_ALWAYS_INLINE void validate_flow_node_adjacent_tail(Ctx& ctx, It& it, End end)
+      inline void validate_flow_node_adjacent_tail(Ctx& ctx, It& it, End end)
       {
          if (it == end) return;
          const char c = *it;
@@ -827,7 +827,7 @@ namespace glz
       // or stream separators (--- / ...). This catches malformed trailing content such as:
       // "[a] ]", "[a]#comment" (without separation), or "[a]\ntrailing".
       template <class Ctx, class It, class End>
-      GLZ_ALWAYS_INLINE void validate_root_flow_tail_after_close(Ctx& ctx, It& it, End end)
+      inline void validate_root_flow_tail_after_close(Ctx& ctx, It& it, End end)
       {
          auto is_document_start = [&](auto pos) {
             if (end - pos >= 3 && pos[0] == '-' && pos[1] == '-' && pos[2] == '-') {
@@ -881,7 +881,7 @@ namespace glz
 
       // Parse a plain scalar (unquoted)
       template <class Ctx, class It, class End>
-      GLZ_ALWAYS_INLINE void parse_plain_scalar(std::string& value, Ctx& ctx, It& it, End end, bool in_flow)
+      inline void parse_plain_scalar(std::string& value, Ctx& ctx, It& it, End end, bool in_flow)
       {
          value.clear();
 
@@ -970,7 +970,7 @@ namespace glz
       // - A single newline between lines becomes a single space
       // - Blank lines are preserved as literal newlines
       template <class Ctx, class It, class End>
-      GLZ_ALWAYS_INLINE void parse_plain_scalar_multiline(std::string& value, Ctx& ctx, It& it, End end,
+      inline void parse_plain_scalar_multiline(std::string& value, Ctx& ctx, It& it, End end,
                                                           int32_t base_indent)
       {
          value.clear();
@@ -1139,7 +1139,7 @@ namespace glz
 
       // Parse a block scalar (| or >)
       template <class Ctx, class It, class End>
-      GLZ_ALWAYS_INLINE void parse_block_scalar(std::string& value, Ctx& ctx, It& it, End end, int32_t base_indent)
+      inline void parse_block_scalar(std::string& value, Ctx& ctx, It& it, End end, int32_t base_indent)
       {
          if (it == end) [[unlikely]] {
             ctx.error = error_code::unexpected_end;
@@ -1348,7 +1348,7 @@ namespace glz
 
       // Parse a YAML key (unquoted or quoted)
       template <class Ctx, class It, class End>
-      GLZ_ALWAYS_INLINE bool parse_yaml_key(std::string& key, Ctx& ctx, It& it, End end, bool in_flow)
+      inline bool parse_yaml_key(std::string& key, Ctx& ctx, It& it, End end, bool in_flow)
       {
          key.clear();
          skip_inline_ws(it, end);
@@ -2242,7 +2242,7 @@ namespace glz
    {
       // Parse flow sequence [item, item, ...]
       template <auto Opts, class T, class Ctx, class It, class End>
-      GLZ_ALWAYS_INLINE void parse_flow_sequence(T&& value, Ctx& ctx, It& it, End end)
+      inline void parse_flow_sequence(T&& value, Ctx& ctx, It& it, End end)
       {
          using V = std::remove_cvref_t<T>;
          using value_type = typename V::value_type;
@@ -2251,7 +2251,7 @@ namespace glz
          {
             size_t index = 0;
 
-            GLZ_ALWAYS_INLINE bool fixed_capacity_reached(const V& container) const noexcept
+            inline bool fixed_capacity_reached(const V& container) const noexcept
             {
                if constexpr (!resizable<V>) {
                   return index >= container.size();
@@ -2262,9 +2262,9 @@ namespace glz
                }
             }
 
-            GLZ_ALWAYS_INLINE void commit_fixed_slot() noexcept { ++index; }
+            inline void commit_fixed_slot() noexcept { ++index; }
 
-            GLZ_ALWAYS_INLINE void append(V& container, value_type&& element) noexcept
+            inline void append(V& container, value_type&& element) noexcept
             {
                if constexpr (emplace_backable<V>) {
                   container.emplace_back(std::move(element));
@@ -2518,7 +2518,7 @@ namespace glz
 
       // Parse flow mapping {key: value, ...}
       template <auto Opts, class T, class Ctx, class It, class End>
-      GLZ_ALWAYS_INLINE void parse_flow_mapping(T&& value, Ctx& ctx, It& it, End end)
+      inline void parse_flow_mapping(T&& value, Ctx& ctx, It& it, End end)
       {
          using U = std::remove_cvref_t<T>;
          static constexpr auto N = reflect<U>::size;
@@ -2663,7 +2663,7 @@ namespace glz
       // Detects a plain "key: value" mapping indicator in an inline block-map
       // value segment, while ignoring quoted strings and nested flow collections.
       template <class It, class End>
-      GLZ_ALWAYS_INLINE bool inline_value_has_plain_mapping_indicator(It pos, End end) noexcept
+      inline bool inline_value_has_plain_mapping_indicator(It pos, End end) noexcept
       {
          int flow_depth = 0;
          while (pos != end) {
@@ -2707,7 +2707,7 @@ namespace glz
       // - item1
       // - item2
       template <auto Opts, class T, class Ctx, class It, class End>
-      GLZ_ALWAYS_INLINE void parse_block_sequence(T&& value, Ctx& ctx, It& it, End end, int32_t sequence_indent)
+      inline void parse_block_sequence(T&& value, Ctx& ctx, It& it, End end, int32_t sequence_indent)
       {
          using V = std::remove_cvref_t<T>;
          using value_type = typename V::value_type;
@@ -2716,7 +2716,7 @@ namespace glz
          {
             size_t index = 0;
 
-            GLZ_ALWAYS_INLINE bool fixed_capacity_reached(const V& container) const noexcept
+            inline bool fixed_capacity_reached(const V& container) const noexcept
             {
                if constexpr (!resizable<V>) {
                   return index >= container.size();
@@ -2727,9 +2727,9 @@ namespace glz
                }
             }
 
-            GLZ_ALWAYS_INLINE void commit_fixed_slot() noexcept { ++index; }
+            inline void commit_fixed_slot() noexcept { ++index; }
 
-            GLZ_ALWAYS_INLINE void append(V& container, value_type&& element) noexcept
+            inline void append(V& container, value_type&& element) noexcept
             {
                if constexpr (emplace_backable<V>) {
                   container.emplace_back(std::move(element));
@@ -3471,7 +3471,7 @@ namespace glz
       // key1: value1
       // key2: value2
       template <auto Opts, class T, class Ctx, class It, class End>
-      GLZ_ALWAYS_INLINE void parse_block_mapping(T&& value, Ctx& ctx, It& it, End end, int32_t mapping_indent)
+      inline void parse_block_mapping(T&& value, Ctx& ctx, It& it, End end, int32_t mapping_indent)
       {
          using U = std::remove_cvref_t<T>;
          static constexpr auto N = reflect<U>::size;
@@ -4813,7 +4813,7 @@ namespace glz
    // Quick check for implicit single-pair flow mappings used as sequence entries
    // (e.g. `"k":v`, `{k: v}:v`, `k: v`) up to the next top-level flow delimiter.
    template <class It, class End>
-   GLZ_ALWAYS_INLINE bool line_could_be_flow_mapping(It it, End end)
+   inline bool line_could_be_flow_mapping(It it, End end)
    {
       int flow_depth = 0;
       bool prev_was_whitespace = true;
@@ -4896,7 +4896,7 @@ namespace glz
    // fails with a syntax error, that error is propagated (not silently caught)
    // to avoid hiding malformed content.
    template <class Variant, auto Opts>
-   GLZ_ALWAYS_INLINE bool try_parse_block_mapping_into_variant(auto&& value, auto&& ctx, auto&& it, auto end)
+   inline bool try_parse_block_mapping_into_variant(auto&& value, auto&& ctx, auto&& it, auto end)
    {
       using counts = yaml_variant_type_count<Variant>;
       if constexpr (counts::n_object == 0) {
@@ -4939,7 +4939,7 @@ namespace glz
 #pragma warning(disable : 4702) // unreachable code from if constexpr
 #endif
    template <class Variant, auto Opts>
-   GLZ_ALWAYS_INLINE void parse_block_mapping_or_string(auto&& value, auto&& ctx, auto&& it, auto end)
+   inline void parse_block_mapping_or_string(auto&& value, auto&& ctx, auto&& it, auto end)
    {
       if constexpr (yaml::check_flow_context(Opts)) {
          // In flow context, only treat plain content as an implicit "key: value"

--- a/include/glaze/yaml/skip.hpp
+++ b/include/glaze/yaml/skip.hpp
@@ -429,7 +429,7 @@ namespace glz
    struct skip_value<YAML>
    {
       template <auto Opts>
-      GLZ_ALWAYS_INLINE static void op(is_context auto&& ctx, auto&& it, auto end) noexcept
+      static void op(is_context auto&& ctx, auto&& it, auto end) noexcept
       {
          yaml::skip_yaml_value<Opts>(ctx, it, end, 0, false);
       }

--- a/include/glaze/yaml/write.hpp
+++ b/include/glaze/yaml/write.hpp
@@ -24,7 +24,7 @@ namespace glz
    struct serialize<YAML>
    {
       template <auto Opts, class T, is_context Ctx, class B, class IX>
-      GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
+      static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
       {
          to<YAML, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
                                                              std::forward<B>(b), std::forward<IX>(ix));
@@ -37,7 +37,7 @@ namespace glz
    struct to<YAML, T>
    {
       template <auto Opts, class Value, is_context Ctx, class B, class IX>
-      GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, B&& b, IX&& ix)
+      static void op(Value&& value, Ctx&& ctx, B&& b, IX&& ix)
       {
          using V = std::remove_cvref_t<decltype(get_member(std::declval<Value>(), meta_wrapper_v<T>))>;
          to<YAML, V>::template op<Opts>(get_member(std::forward<Value>(value), meta_wrapper_v<T>),
@@ -50,7 +50,7 @@ namespace glz
    struct to<YAML, T>
    {
       template <auto Opts>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& b, auto& ix)
+      static void op(auto&& value, is_context auto&& ctx, auto&& b, auto& ix)
       {
          if (value) {
             serialize<YAML>::op<Opts>(*value, ctx, b, ix);
@@ -69,7 +69,7 @@ namespace glz
    struct to<YAML, std::nullptr_t>
    {
       template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(std::nullptr_t, is_context auto&& ctx, B&& b, auto& ix)
+      static void op(std::nullptr_t, is_context auto&& ctx, B&& b, auto& ix)
       {
          if (!ensure_space(ctx, b, ix + 8)) [[unlikely]] {
             return;
@@ -83,7 +83,7 @@ namespace glz
    struct to<YAML, T>
    {
       template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(const bool value, is_context auto&& ctx, B&& b, auto& ix)
+      static void op(const bool value, is_context auto&& ctx, B&& b, auto& ix)
       {
          if (!ensure_space(ctx, b, ix + 8)) [[unlikely]] {
             return;
@@ -115,7 +115,7 @@ namespace glz
    struct to<YAML, T>
    {
       template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
       {
          if (!ensure_space(ctx, b, ix + 32 + write_padding_bytes)) [[unlikely]] {
             return;
@@ -145,7 +145,7 @@ namespace glz
    struct to<YAML, T>
    {
       template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
       {
          if (!ensure_space(ctx, b, ix + 8)) [[unlikely]] {
             return;
@@ -160,7 +160,7 @@ namespace glz
    {
       // Write a YAML double-quoted string with proper escaping
       template <class B>
-      GLZ_ALWAYS_INLINE void write_double_quoted_string(std::string_view str, is_context auto&& ctx, B&& b, auto& ix)
+      inline void write_double_quoted_string(std::string_view str, is_context auto&& ctx, B&& b, auto& ix)
       {
          // Estimate max size: original + quotes + escapes
          if (!ensure_space(ctx, b, ix + str.size() * 2 + 3 + write_padding_bytes)) [[unlikely]] {
@@ -207,7 +207,7 @@ namespace glz
 
       // Write a YAML single-quoted string (only ' needs escaping as '')
       template <class B>
-      GLZ_ALWAYS_INLINE void write_single_quoted_string(std::string_view str, is_context auto&& ctx, B&& b, auto& ix)
+      inline void write_single_quoted_string(std::string_view str, is_context auto&& ctx, B&& b, auto& ix)
       {
          if (!ensure_space(ctx, b, ix + str.size() * 2 + 3 + write_padding_bytes)) [[unlikely]] {
             return;
@@ -227,7 +227,7 @@ namespace glz
 
       // Write a literal block scalar (|)
       template <class B>
-      GLZ_ALWAYS_INLINE void write_literal_block(std::string_view str, is_context auto&& ctx, B&& b, auto& ix,
+      inline void write_literal_block(std::string_view str, is_context auto&& ctx, B&& b, auto& ix,
                                                  int32_t indent_level, uint8_t indent_width, char chomping)
       {
          if (!ensure_space(ctx, b, ix + str.size() + 64 + write_padding_bytes)) [[unlikely]] {
@@ -280,7 +280,7 @@ namespace glz
 #pragma warning(disable : 4702) // unreachable code from if constexpr
 #endif
       template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE void write_yaml_string(std::string_view str, is_context auto&& ctx, B&& b, auto& ix,
+      inline void write_yaml_string(std::string_view str, is_context auto&& ctx, B&& b, auto& ix,
                                                int32_t indent_level = 0)
       {
          constexpr uint8_t indent_width = check_indent_width(yaml_opts{});
@@ -367,7 +367,7 @@ namespace glz
    struct to<YAML, T>
    {
       template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
       {
          const sv str{value};
          yaml::write_yaml_string<Opts>(str, ctx, b, ix);
@@ -380,7 +380,7 @@ namespace glz
    struct to<YAML, T>
    {
       template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
       {
          const sv str = get_enum_name(value);
          if (!str.empty()) {
@@ -399,7 +399,7 @@ namespace glz
    struct to<YAML, T>
    {
       template <auto Opts, class... Args>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, Args&&... args)
+      static void op(auto&& value, is_context auto&& ctx, Args&&... args)
       {
          serialize<YAML>::op<Opts>(static_cast<std::underlying_type_t<std::decay_t<T>>>(value), ctx,
                                    std::forward<Args>(args)...);
@@ -410,11 +410,11 @@ namespace glz
    {
       // Forward declarations for helpers used in block sequences
       template <auto Opts, class T, class B>
-      GLZ_ALWAYS_INLINE void write_block_mapping_nested(T&& value, is_context auto&& ctx, B&& b, auto& ix,
+      inline void write_block_mapping_nested(T&& value, is_context auto&& ctx, B&& b, auto& ix,
                                                         int32_t indent_level);
 
       template <auto Opts, class T, class B>
-      GLZ_ALWAYS_INLINE void write_block_mapping(T&& value, is_context auto&& ctx, B&& b, auto& ix,
+      inline void write_block_mapping(T&& value, is_context auto&& ctx, B&& b, auto& ix,
                                                  int32_t indent_level, bool skip_first_indent = false);
 
       // Helper to check if a type is "simple" (writes on same line)
@@ -427,7 +427,7 @@ namespace glz
 
       // Runtime check if a variant currently holds a simple type
       template <class T>
-      GLZ_ALWAYS_INLINE bool variant_holds_simple_type([[maybe_unused]] const T& value)
+      inline bool variant_holds_simple_type([[maybe_unused]] const T& value)
       {
          if constexpr (is_variant<T>) {
             return std::visit(
@@ -465,7 +465,7 @@ namespace glz
 
       // Write a variant's held value in block context, ensuring strings get correct indent_level.
       template <auto Opts, class T, class B>
-      GLZ_ALWAYS_INLINE void write_variant_value(T&& value, is_context auto&& ctx, B&& b, auto& ix,
+      inline void write_variant_value(T&& value, is_context auto&& ctx, B&& b, auto& ix,
                                                  int32_t indent_level)
       {
          using V = std::remove_cvref_t<T>;
@@ -495,7 +495,7 @@ namespace glz
 
       // Write block-style sequence
       template <auto Opts, class T, class B>
-      GLZ_ALWAYS_INLINE void write_block_sequence(T&& value, is_context auto&& ctx, B&& b, auto& ix,
+      inline void write_block_sequence(T&& value, is_context auto&& ctx, B&& b, auto& ix,
                                                   int32_t indent_level)
       {
          constexpr uint8_t indent_width = check_indent_width(yaml_opts{});
@@ -681,7 +681,7 @@ namespace glz
 
       // Write flow-style sequence
       template <auto Opts, class T, class B>
-      GLZ_ALWAYS_INLINE void write_flow_sequence(T&& value, is_context auto&& ctx, B&& b, auto& ix)
+      inline void write_flow_sequence(T&& value, is_context auto&& ctx, B&& b, auto& ix)
       {
          if (!ensure_space(ctx, b, ix + 8)) [[unlikely]] {
             return;
@@ -710,7 +710,7 @@ namespace glz
    struct to<YAML, T>
    {
       template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
       {
          if constexpr (yaml::check_flow_style(Opts) || yaml::check_flow_context(Opts)) {
             yaml::write_flow_sequence<Opts>(value, ctx, b, ix);
@@ -732,7 +732,7 @@ namespace glz
    struct to<YAML, T>
    {
       template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
       {
          static constexpr auto N = []() constexpr {
             if constexpr (glaze_array_t<std::decay_t<T>>) {
@@ -841,7 +841,7 @@ namespace glz
    struct to<YAML, T>
    {
       template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
       {
          const auto& [key, val] = value;
 
@@ -914,12 +914,12 @@ namespace glz
    {
       // Forward declaration for nested object helper
       template <auto Opts, class T, class B>
-      GLZ_ALWAYS_INLINE void write_block_mapping_nested(T&& value, is_context auto&& ctx, B&& b, auto& ix,
+      inline void write_block_mapping_nested(T&& value, is_context auto&& ctx, B&& b, auto& ix,
                                                         int32_t indent_level);
 
       // Write block-style mapping
       template <auto Opts, class T, class B>
-      GLZ_ALWAYS_INLINE void write_block_mapping(T&& value, is_context auto&& ctx, B&& b, auto& ix,
+      inline void write_block_mapping(T&& value, is_context auto&& ctx, B&& b, auto& ix,
                                                  int32_t indent_level, bool skip_first_indent)
       {
          using V = std::remove_cvref_t<T>;
@@ -1108,7 +1108,7 @@ namespace glz
 
       // Helper for nested objects
       template <auto Opts, class T, class B>
-      GLZ_ALWAYS_INLINE void write_block_mapping_nested(T&& value, is_context auto&& ctx, B&& b, auto& ix,
+      inline void write_block_mapping_nested(T&& value, is_context auto&& ctx, B&& b, auto& ix,
                                                         int32_t indent_level)
       {
          using V = std::remove_cvref_t<T>;
@@ -1237,7 +1237,7 @@ namespace glz
 
       // Write flow-style mapping
       template <auto Opts, class T, class B>
-      GLZ_ALWAYS_INLINE void write_flow_mapping(T&& value, is_context auto&& ctx, B&& b, auto& ix)
+      inline void write_flow_mapping(T&& value, is_context auto&& ctx, B&& b, auto& ix)
       {
          using V = std::remove_cvref_t<T>;
          constexpr auto N = reflect<V>::size;
@@ -1302,7 +1302,7 @@ namespace glz
    struct to<YAML, T>
    {
       template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
       {
          if constexpr (yaml::check_flow_style(Opts) || yaml::check_flow_context(Opts)) {
             yaml::write_flow_mapping<Opts>(value, ctx, b, ix);
@@ -1322,7 +1322,7 @@ namespace glz
    struct to<YAML, T>
    {
       template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
       {
          if constexpr (yaml::check_flow_style(Opts) || yaml::check_flow_context(Opts)) {
             // Flow style
@@ -1370,7 +1370,7 @@ namespace glz
    struct to<YAML, T>
    {
       template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
       {
          std::visit([&](auto&& v) { serialize<YAML>::op<Opts>(v, ctx, b, ix); }, value);
       }


### PR DESCRIPTION
Absolute peak performance is not needed for YAML and TOML, so for these formats we don't enable force inlining. This often improves compilation times and can reduce binary size.