### PR TITLE
BSON Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Formats Supported:
 - [BEVE](https://github.com/beve-org/beve) (Binary Efficient Versatile Encoding) | `glaze/beve.hpp`
 - [CBOR](https://stephenberry.github.io/glaze/cbor/) (Concise Binary Object Representation) | `glaze/cbor.hpp`
 - [JSONB](https://stephenberry.github.io/glaze/jsonb/) (SQLite Binary JSON) | `glaze/jsonb.hpp`
+- [BSON](https://stephenberry.github.io/glaze/bson/) (MongoDB Binary JSON) | `glaze/bson.hpp`
 - [CSV](https://stephenberry.github.io/glaze/csv/) (Comma Separated Value) | `glaze/csv.hpp`
 - [MessagePack](https://stephenberry.github.io/glaze/msgpack/) | `glaze/msgpack.hpp`
 - [Stencil/Mustache](https://stephenberry.github.io/glaze/stencil-mustache/) (string interpolation) | `glaze/stencil/stencil.hpp`

--- a/docs/bson.md
+++ b/docs/bson.md
@@ -75,6 +75,21 @@ BSON has two integer element types. Glaze picks between them by the target's ran
 
 On read, both int32 and int64 wire tags are accepted for any integer target and range-checked at runtime; mismatched sizes return `error_code::parse_number_failure`. Integer wire tags are also accepted into `float`/`double` targets as a widening conversion.
 
+## Strings
+
+BSON string values (element type 0x02) deserialize into either an owning or a non-owning target:
+
+- **`std::string`** — the reader copies the wire bytes into the target. The decoded value outlives the input buffer.
+- **`std::string_view`** — the reader sets the target to a view that **aliases into the input buffer**. No allocation, no copy. This is a performance win when the input is long-lived (e.g., a memory-mapped file), but it comes with a lifetime rule: **the input buffer must outlive every `std::string_view` that was decoded from it**. Destroying the buffer dangles the view, and any subsequent access is undefined behavior. Prefer `std::string` unless you specifically need to avoid the copy and can guarantee the buffer's lifetime.
+
+```cpp
+// Copy into owning string — safe regardless of buffer lifetime.
+struct record_owned { std::string name{}; };
+
+// Alias into the input buffer — buffer must outlive the record.
+struct record_view { std::string_view name{}; };
+```
+
 ## `glz::bson::object_id`
 
 Opaque 12-byte ObjectId. Glaze treats it as a fixed-size blob — MongoDB assigns meaning to the bytes (timestamp, random, counter) but the library does not generate them.

--- a/docs/bson.md
+++ b/docs/bson.md
@@ -1,0 +1,283 @@
+# BSON
+
+Glaze ships with first-class BSON support. Any type that already reflects for JSON — aggregate-initializable structs, `glz::meta`-annotated classes, STL containers, `std::optional`, `std::variant` (see [Variants](#variants) for requirements), custom types — serializes to and from BSON without additional metadata.
+
+## Specification Compliance
+
+Glaze implements the [BSON 1.1 specification](https://bsonspec.org/spec.html). Element types supported:
+
+| Code | Type | C++ mapping |
+|------|------|-------------|
+| 0x01 | double | `float`, `double`, `long double` |
+| 0x02 | UTF-8 string | `std::string`, `std::string_view`, `const char*` |
+| 0x03 | embedded document | reflected struct, `glz::meta`-annotated class, `std::map<std::string, T>` |
+| 0x04 | array | `std::vector`, `std::array`, `std::list`, any `writable_array_t` |
+| 0x05 | binary | `glz::bson::binary<Bytes>`, `glz::uuid` (subtype 0x04) |
+| 0x07 | ObjectId | `glz::bson::object_id` |
+| 0x08 | boolean | `bool` |
+| 0x09 | UTC datetime | `glz::bson::datetime`, `std::chrono::system_clock::time_point` |
+| 0x0A | null | `std::optional`, `std::nullptr_t`, empty pointers |
+| 0x0B | regex | `glz::bson::regex` |
+| 0x0D | JavaScript | `glz::bson::javascript` |
+| 0x10 | int32 | 8-, 16-, and 32-bit integers (signed or unsigned <32-bit) |
+| 0x11 | timestamp | `glz::bson::timestamp` |
+| 0x12 | int64 | 64-bit integers, `uint32_t`, `uint64_t` (with range check) |
+| 0x13 | decimal128 | `glz::bson::decimal128` (opaque 16-byte wrapper) |
+| 0x7F / 0xFF | MinKey / MaxKey | `glz::bson::max_key` / `glz::bson::min_key` |
+
+Deprecated element types (0x06 undefined, 0x0C DBPointer, 0x0E symbol, 0x0F code-with-scope) are skipped on read and cannot be written.
+
+## Quick Start
+
+```cpp
+#include "glaze/bson.hpp"
+
+struct point
+{
+   double x{};
+   double y{};
+};
+
+point p{.x = 4.2, .y = 1.3};
+
+// Write into a std::string (or std::vector<char> / std::vector<std::byte>)
+auto encoded = glz::write_bson(p);
+if (!encoded) {
+   // glz::format_error(encoded.error()) for a message
+}
+
+// Read the buffer back
+point decoded{};
+auto ec = glz::read_bson(decoded, std::string_view{encoded.value()});
+if (ec) {
+   const auto message = glz::format_error(ec, encoded.value());
+}
+```
+
+`glz::write_bson` and `glz::read_bson` mirror the JSON helpers:
+
+- They work with any reflected type, STL container, map with string keys, or custom specialization.
+- Overloads exist for output buffers (`std::string`, `std::vector<char>`, `std::vector<std::byte>`, etc.).
+- Write functions return an `error_ctx` whose `count` field records bytes written; read functions return the same type.
+- Success is the falsy case: `if (!ec) { /* ok */ }`.
+
+BSON's top-level value is always a document. Primitives (`int`, `std::string`, `double`, …) are rejected at the call site with a `no matching function for call to 'write_bson'` compile error. Wrap them in a struct or map if you need to ship a single value.
+
+## Integer Encoding
+
+BSON has two integer element types. Glaze picks between them by the target's range, not the runtime value, so the encoding is deterministic from the schema alone:
+
+| C++ type | BSON element |
+|---|---|
+| `int8_t`, `int16_t`, `int32_t`, `uint8_t`, `uint16_t` | int32 (0x10) |
+| `int64_t`, `uint32_t`, `long`, `long long` | int64 (0x12) |
+| `uint64_t` | int64 (0x12) with range check — values above `INT64_MAX` fail with `error_code::invalid_length` on write |
+
+On read, both int32 and int64 wire tags are accepted for any integer target and range-checked at runtime; mismatched sizes return `error_code::parse_number_failure`. Integer wire tags are also accepted into `float`/`double` targets as a widening conversion.
+
+## `glz::bson::object_id`
+
+Opaque 12-byte ObjectId. Glaze treats it as a fixed-size blob — MongoDB assigns meaning to the bytes (timestamp, random, counter) but the library does not generate them.
+
+```cpp
+struct document
+{
+   glz::bson::object_id _id{};
+   std::string name{};
+};
+```
+
+## `glz::bson::datetime` and `std::chrono::system_clock::time_point`
+
+BSON's UTC datetime is a signed int64 holding milliseconds since the Unix epoch. Two C++ types map to it:
+
+- `glz::bson::datetime` — direct wrapper over `int64_t ms_since_epoch` for code that wants the raw value.
+- `std::chrono::system_clock::time_point` — auto-mapped on read and write. Precisions finer than milliseconds are truncated via `duration_cast<milliseconds>`.
+
+```cpp
+struct event
+{
+   std::string name{};
+   std::chrono::system_clock::time_point when{};
+};
+
+event e{"login", std::chrono::system_clock::now()};
+auto encoded = glz::write_bson(e);
+```
+
+## `glz::bson::timestamp`
+
+MongoDB-internal timestamp used for replication and sharding. Distinct from `datetime`: the wire format is a uint64 with the low 32 bits holding an increment counter and the high 32 bits seconds since epoch.
+
+```cpp
+glz::bson::timestamp ts{.increment = 7, .seconds = 1700000000};
+```
+
+## `glz::bson::regex`, `glz::bson::javascript`
+
+```cpp
+glz::bson::regex re{.pattern = "^glaze", .options = "i"};    // case-insensitive
+glz::bson::javascript js{.code = "function(x) { return x; }"};
+```
+
+Regex options follow MongoDB convention (alphabetical, single characters): `i` case-insensitive, `l` locale-dependent, `m` multiline, `s` dotall, `u` Unicode, `x` verbose.
+
+## `glz::bson::decimal128`
+
+Opaque 16-byte IEEE 754-2008 decimal128. This is **not** the same encoding as `std::float128_t` — that type is binary128 (`§3.6`), whereas BSON decimal128 is `§3.5` (decimal significand, base-10 exponent). The wrapper carries the raw bytes for round-trip interop; arithmetic and string conversion are out of scope.
+
+## `glz::bson::binary`
+
+Arbitrary binary data plus a subtype byte.
+
+```cpp
+glz::bson::binary<std::vector<std::byte>> payload{
+   .data = {std::byte{0xDE}, std::byte{0xAD}, std::byte{0xBE}, std::byte{0xEF}},
+   .subtype = glz::bson::binary_subtype::generic,
+};
+```
+
+Subtype constants (from `glz::bson::binary_subtype`):
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `generic` | 0x00 | Default |
+| `function` | 0x01 | Function data |
+| `uuid_old` | 0x03 | Deprecated UUID encoding |
+| `uuid` | 0x04 | RFC 9562 UUID (canonical byte order) |
+| `md5` | 0x05 | MD5 hash |
+| `encrypted` | 0x06 | Encrypted value |
+| `column` | 0x07 | Compressed BSON column |
+| `sensitive` | 0x08 | Sensitive data |
+| `vector` | 0x09 | Dense numeric vector |
+| `user_defined_min` | 0x80 | First reserved user-defined code |
+
+The container type is your choice — `std::vector<std::byte>`, `std::vector<uint8_t>`, `std::string`, etc.
+
+## `glz::uuid`
+
+`glz::uuid` is a general-purpose 16-byte UUID (RFC 9562) that lives in `glaze/util/uuid.hpp` and works with every Glaze format. In BSON it auto-maps to binary subtype 0x04 (canonical UUID). The reader also accepts subtype 0x03 (`uuid_old`) for interop with older drivers; the writer always emits 0x04.
+
+```cpp
+#include "glaze/util/uuid.hpp"
+
+glz::uuid id{};
+glz::parse_uuid("550e8400-e29b-41d4-a716-446655440000", id);
+
+struct record { glz::uuid id{}; std::string name{}; };
+record r{id, "example"};
+auto encoded = glz::write_bson(r);
+```
+
+The canonical textual representation is the hyphenated 8-4-4-4-12 hex form; parsing accepts upper- and lower-case hex digits and `glz::to_string(uuid)` always emits lower-case.
+
+## Arrays
+
+BSON encodes arrays as documents whose keys are the decimal strings `"0"`, `"1"`, `"2"`, … in order. Glaze handles the key generation internally; from user code, an `std::vector<int>` round-trips like any other container.
+
+```cpp
+std::vector<int32_t> xs{1, 2, 3};
+auto encoded = glz::write_bson(xs);
+// total length | 04 '0' 00 <i32> | 04 '1' 00 <i32> | 04 '2' 00 <i32> | 00
+```
+
+## Optionals and Missing Keys
+
+Empty `std::optional<T>` fields follow Glaze's standard `skip_null_members` behavior:
+
+- **Default** (`skip_null_members = true`): the key is omitted entirely from the document.
+- **Explicit null** (`skip_null_members = false`): the key is written with element type 0x0A (null).
+
+On read, a missing key leaves the target's optional at whatever it already was; an explicit `null` on the wire resets it.
+
+```cpp
+struct profile { std::string name{}; std::optional<int> age{}; };
+
+profile p{"alice", std::nullopt};
+auto encoded = glz::write_bson(p);    // omits "age" entirely
+```
+
+## Unknown Keys
+
+By default Glaze errors on unknown keys (`error_code::unknown_key`). To tolerate extra fields — e.g., when reading documents produced by a newer writer — pass a permissive opts:
+
+```cpp
+constexpr auto permissive = glz::opts{.error_on_unknown_keys = false};
+auto ec = glz::read_bson<permissive>(value, buffer);
+```
+
+## Variants
+
+`std::variant<...>` is auto-deduced on read from the element's BSON type byte — no wrapper or tag field is added to the wire format. The writer serializes the active alternative directly; the reader maps the incoming tag to the first alternative of the matching BSON category.
+
+Each BSON category (null, bool, int, float, string, document, array, binary, uuid, object_id, datetime, timestamp, regex, javascript, decimal128, min_key, max_key) may contain **at most one** variant alternative. This is enforced at compile time with a `static_assert`.
+
+```cpp
+struct message
+{
+   std::variant<int32_t, std::string> payload{};
+};
+
+struct maybe
+{
+   std::variant<std::monostate, int32_t> count{};   // monostate → null on the wire
+};
+
+struct record
+{
+   std::variant<double, std::vector<int32_t>> value{};
+};
+```
+
+Notes:
+
+- `std::monostate` (and `std::nullptr_t`, `std::nullopt_t`) count as the **null** category — the writer emits BSON `null` (0x0A).
+- `std::optional<T>` in a variant only matches the null category, not `T`'s category. For "maybe an int or a string," prefer `std::variant<std::monostate, int, std::string>`.
+- `int` is widened to a `float` alternative when the variant has only float (not vice versa).
+- `glz::uuid` and `glz::bson::binary<Bytes>` may coexist in one variant; the reader prefers `binary<Bytes>` because its wire subtype check is permissive.
+- Rejected at compile time: two alternatives in the same category, e.g., `std::variant<int32_t, int64_t>` or `std::variant<struct_a, struct_b>`. The writer and reader cannot tell them apart from the wire tag alone. A tagged-variant convention (as in JSON) is a planned follow-up.
+
+## Maps
+
+Maps with string-like keys round-trip as BSON documents. Non-string key types are rejected at compile time — BSON keys are cstrings on the wire, and silent lossy key conversion is undesirable.
+
+```cpp
+std::map<std::string, int32_t> m{{"a", 1}, {"b", 2}};
+auto encoded = glz::write_bson(m);
+```
+
+## File Helpers
+
+```cpp
+std::vector<std::byte> buffer{};
+glz::write_file_bson(value, "payload.bson", buffer);
+
+decltype(value) restored{};
+glz::read_file_bson(restored, "payload.bson", buffer);
+```
+
+## Interop Example
+
+The canonical `{"hello": "world"}` document from the spec:
+
+```
+16 00 00 00                       // total length = 22
+02 68 65 6C 6C 6F 00              // string element, key "hello"
+06 00 00 00 77 6F 72 6C 64 00     // string length = 6, "world\0"
+00                                // document terminator
+```
+
+Glaze produces exactly this sequence:
+
+```cpp
+struct hello_t { std::string hello{}; };
+hello_t h{"world"};
+auto encoded = glz::write_bson(h);
+// *encoded equals the 22 bytes above, byte-for-byte.
+```
+
+## Unsupported / Future Work
+
+- **MongoDB Extended JSON** (canonical / relaxed modes) — follow-up; this documentation covers the binary wire format only.
+- **Decimal128 arithmetic and string conversion** — `glz::bson::decimal128` is currently an opaque byte buffer. A future version may add lossless text parsing.
+- **Deprecated element types** — 0x06 undefined, 0x0C DBPointer, 0x0E symbol, 0x0F code-with-scope — are skipped on read to preserve forward compatibility but cannot be written.

--- a/docs/bson.md
+++ b/docs/bson.md
@@ -156,7 +156,9 @@ The container type is your choice — `std::vector<std::byte>`, `std::vector<uin
 
 ## `glz::uuid`
 
-`glz::uuid` is a general-purpose 16-byte UUID (RFC 9562) that lives in `glaze/util/uuid.hpp` and works with every Glaze format. In BSON it auto-maps to binary subtype 0x04 (canonical UUID). The reader also accepts subtype 0x03 (`uuid_old`) for interop with older drivers; the writer always emits 0x04.
+`glz::uuid` is a 16-byte UUID (RFC 9562) defined in `glaze/util/uuid.hpp`. Today a custom serializer exists only for BSON: on write it emits binary subtype 0x04 (canonical RFC 9562 byte order); on read it accepts 0x04 and rejects 0x03 (`uuid_old`) with `error_code::syntax_error`. 0x03 is refused deliberately — its byte layout is driver-dependent (Java, C#, and Python historically laid the same UUID out in incompatible orders), so decoding without knowing the origin driver would silently scramble the bytes. To consume legacy 0x03 data, re-encode to 0x04 at the source, or read the field as `glz::bson::binary<...>` and reorder the bytes yourself.
+
+In other Glaze formats (JSON, BEVE, CBOR, JSONB, MsgPack, …) `glz::uuid` has no dedicated specialization — it falls through to aggregate reflection over its 16-byte array and serializes as `{"bytes":[...]}`. Round-trips work, but the wire shape is not the canonical hyphenated string. If you need the textual form in those formats, use `glz::to_string(uuid)` / `glz::parse_uuid` around a `std::string` field.
 
 ```cpp
 #include "glaze/util/uuid.hpp"

--- a/include/glaze/base64/base64.hpp
+++ b/include/glaze/base64/base64.hpp
@@ -4,9 +4,15 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
+#include <cstring>
 #include <string>
 #include <string_view>
-#include <vector>
+#include <type_traits>
+
+#include "glaze/core/buffer_traits.hpp"
+#include "glaze/core/context.hpp"
+#include "glaze/core/opts.hpp"
 
 namespace glz
 {
@@ -41,25 +47,68 @@ namespace glz
       return decoded_data;
    }
 
+   // 12-bit → two-character table. 4096 × 2 B = 8 KB, fits in L1D.
+   // Halves the per-triple lookup count from 4 to 2 vs. the obvious
+   // byte-at-a-time version.
+   inline constexpr auto base64_pair_table = [] {
+      std::array<char[2], 4096> t{};
+      for (size_t i = 0; i < 4096; ++i) {
+         t[i][0] = base64_chars[(i >> 6) & 0x3F];
+         t[i][1] = base64_chars[i & 0x3F];
+      }
+      return t;
+   }();
+
+   // RFC 4648 base64, no line breaks. `=` padding only.
+   // Writes directly into a caller-supplied output buffer at offset `ix`.
+   // The buffer's value_type must be byte-sized.
+   template <class B>
+   inline void write_base64_to(is_context auto& ctx, const uint8_t* bytes, size_t n, B& out, size_t& ix) noexcept
+   {
+      using V = typename std::decay_t<B>::value_type;
+      static_assert(sizeof(V) == 1, "write_base64_to requires a byte-sized output buffer");
+      const size_t full_triples = n / 3;
+      const size_t rem = n % 3;
+      const size_t out_len = 4 * (full_triples + (rem ? 1 : 0));
+      if (!ensure_space(ctx, out, ix + out_len + write_padding_bytes)) return;
+
+      if (full_triples) {
+         char* dst = reinterpret_cast<char*>(&out[ix]);
+         for (size_t i = 0; i < full_triples; ++i) {
+            const uint8_t b0 = bytes[3 * i];
+            const uint8_t b1 = bytes[3 * i + 1];
+            const uint8_t b2 = bytes[3 * i + 2];
+            std::memcpy(dst, base64_pair_table[(uint32_t(b0) << 4) | (b1 >> 4)], 2);
+            std::memcpy(dst + 2, base64_pair_table[(uint32_t(b1 & 0x0F) << 8) | b2], 2);
+            dst += 4;
+         }
+         ix += 4 * full_triples;
+      }
+
+      if (rem == 1) {
+         const uint8_t b0 = bytes[3 * full_triples];
+         out[ix++] = static_cast<V>(base64_chars[b0 >> 2]);
+         out[ix++] = static_cast<V>(base64_chars[(b0 & 0x03) << 4]);
+         out[ix++] = static_cast<V>('=');
+         out[ix++] = static_cast<V>('=');
+      }
+      else if (rem == 2) {
+         const uint8_t b0 = bytes[3 * full_triples];
+         const uint8_t b1 = bytes[3 * full_triples + 1];
+         std::memcpy(&out[ix], base64_pair_table[(uint32_t(b0) << 4) | (b1 >> 4)], 2);
+         ix += 2;
+         out[ix++] = static_cast<V>(base64_chars[(b1 & 0x0F) << 2]);
+         out[ix++] = static_cast<V>('=');
+      }
+   }
+
    inline std::string write_base64(const std::string_view input)
    {
-      std::string encoded_data;
-
-      int val = 0, valb = -6;
-      for (unsigned char c : input) {
-         val = (val << 8) + c;
-         valb += 8;
-         while (valb >= 0) {
-            encoded_data.push_back(base64_chars[(val >> valb) & 0x3F]);
-            valb -= 6;
-         }
-      }
-      if (valb > -6) {
-         encoded_data.push_back(base64_chars[((val << 8) >> (valb + 8)) & 0x3F]);
-      }
-      while (encoded_data.size() % 4) {
-         encoded_data.push_back('=');
-      }
-      return encoded_data;
+      std::string out;
+      size_t ix{};
+      context ctx{};
+      write_base64_to(ctx, reinterpret_cast<const uint8_t*>(input.data()), input.size(), out, ix);
+      out.resize(ix);
+      return out;
    }
 }

--- a/include/glaze/beve/write.hpp
+++ b/include/glaze/beve/write.hpp
@@ -1014,6 +1014,8 @@ namespace glz
       static auto op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
       {
          using Key = typename T::key_type;
+         using val_t = std::remove_cvref_t<detail::iterator_second_type<T>>;
+         constexpr bool may_skip = null_t<val_t> && Opts.skip_null_members;
 
          constexpr uint8_t tag = beve_key_traits<Key>::header;
          dump_type(ctx, tag, b, ix);
@@ -1021,11 +1023,23 @@ namespace glz
             return;
          }
 
-         dump_compressed_int(ctx, value.size(), b, ix);
+         size_t count = value.size();
+         if constexpr (may_skip) {
+            count = 0;
+            for (auto&& [k, v] : value) {
+               (void)k;
+               if (!skip_member<Opts>(v)) ++count;
+            }
+         }
+
+         dump_compressed_int(ctx, count, b, ix);
          if (bool(ctx.error)) [[unlikely]] {
             return;
          }
          for (auto&& [k, v] : value) {
+            if constexpr (may_skip) {
+               if (skip_member<Opts>(v)) continue;
+            }
             serialize<BEVE>::no_header<Opts>(k, ctx, b, ix);
             if (bool(ctx.error)) [[unlikely]] {
                return;

--- a/include/glaze/bson.hpp
+++ b/include/glaze/bson.hpp
@@ -1,0 +1,10 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include "glaze/bson/bson_to_json.hpp"
+#include "glaze/bson/header.hpp"
+#include "glaze/bson/read.hpp"
+#include "glaze/bson/skip.hpp"
+#include "glaze/bson/write.hpp"

--- a/include/glaze/bson/bson_to_json.hpp
+++ b/include/glaze/bson/bson_to_json.hpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <string_view>
 
+#include "glaze/base64/base64.hpp"
 #include "glaze/bson/header.hpp"
 #include "glaze/bson/read.hpp"
 #include "glaze/core/opts.hpp"
@@ -61,8 +62,9 @@ namespace glz
       template <class B>
       GLZ_ALWAYS_INLINE void emit_char(is_context auto& ctx, B& out, size_t& ix, char c) noexcept
       {
+         using V = typename std::decay_t<B>::value_type;
          if (!ensure_space(ctx, out, ix + 1 + write_padding_bytes)) return;
-         out[ix++] = static_cast<typename std::decay_t<B>::value_type>(c);
+         out[ix++] = static_cast<V>(c);
       }
 
       template <auto Opts, class B>
@@ -75,49 +77,13 @@ namespace glz
       template <class B>
       inline void emit_hex_bytes(is_context auto& ctx, const uint8_t* bytes, size_t n, B& out, size_t& ix) noexcept
       {
+         using V = typename std::decay_t<B>::value_type;
          static constexpr char digits[] = "0123456789abcdef";
          if (!ensure_space(ctx, out, ix + 2 * n + write_padding_bytes)) return;
          for (size_t i = 0; i < n; ++i) {
             const uint8_t b = bytes[i];
-            out[ix++] = static_cast<typename std::decay_t<B>::value_type>(digits[b >> 4]);
-            out[ix++] = static_cast<typename std::decay_t<B>::value_type>(digits[b & 0x0F]);
-         }
-      }
-
-      // RFC 4648 base64, no line breaks. `=` padding only.
-      template <class B>
-      inline void emit_base64(is_context auto& ctx, const uint8_t* bytes, size_t n, B& out, size_t& ix) noexcept
-      {
-         static constexpr char alphabet[] =
-            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-         const size_t full_triples = n / 3;
-         const size_t rem = n % 3;
-         const size_t out_len = 4 * (full_triples + (rem ? 1 : 0));
-         if (!ensure_space(ctx, out, ix + out_len + write_padding_bytes)) return;
-
-         for (size_t i = 0; i < full_triples; ++i) {
-            const uint8_t b0 = bytes[3 * i];
-            const uint8_t b1 = bytes[3 * i + 1];
-            const uint8_t b2 = bytes[3 * i + 2];
-            out[ix++] = static_cast<typename std::decay_t<B>::value_type>(alphabet[b0 >> 2]);
-            out[ix++] = static_cast<typename std::decay_t<B>::value_type>(alphabet[((b0 & 0x03) << 4) | (b1 >> 4)]);
-            out[ix++] = static_cast<typename std::decay_t<B>::value_type>(alphabet[((b1 & 0x0F) << 2) | (b2 >> 6)]);
-            out[ix++] = static_cast<typename std::decay_t<B>::value_type>(alphabet[b2 & 0x3F]);
-         }
-         if (rem == 1) {
-            const uint8_t b0 = bytes[3 * full_triples];
-            out[ix++] = static_cast<typename std::decay_t<B>::value_type>(alphabet[b0 >> 2]);
-            out[ix++] = static_cast<typename std::decay_t<B>::value_type>(alphabet[(b0 & 0x03) << 4]);
-            out[ix++] = static_cast<typename std::decay_t<B>::value_type>('=');
-            out[ix++] = static_cast<typename std::decay_t<B>::value_type>('=');
-         }
-         else if (rem == 2) {
-            const uint8_t b0 = bytes[3 * full_triples];
-            const uint8_t b1 = bytes[3 * full_triples + 1];
-            out[ix++] = static_cast<typename std::decay_t<B>::value_type>(alphabet[b0 >> 2]);
-            out[ix++] = static_cast<typename std::decay_t<B>::value_type>(alphabet[((b0 & 0x03) << 4) | (b1 >> 4)]);
-            out[ix++] = static_cast<typename std::decay_t<B>::value_type>(alphabet[(b1 & 0x0F) << 2]);
-            out[ix++] = static_cast<typename std::decay_t<B>::value_type>('=');
+            out[ix++] = static_cast<V>(digits[b >> 4]);
+            out[ix++] = static_cast<V>(digits[b & 0x0F]);
          }
       }
 
@@ -253,7 +219,7 @@ namespace glz
 
             emit_literal(ctx, out, ix, R"({"$binary":{"base64":")");
             if (bool(ctx.error)) return;
-            emit_base64(ctx, payload, static_cast<size_t>(payload_len), out, ix);
+            write_base64_to(ctx, payload, static_cast<size_t>(payload_len), out, ix);
             if (bool(ctx.error)) return;
             emit_literal(ctx, out, ix, R"(","subType":")");
             if (bool(ctx.error)) return;

--- a/include/glaze/bson/bson_to_json.hpp
+++ b/include/glaze/bson/bson_to_json.hpp
@@ -1,0 +1,479 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <string_view>
+
+#include "glaze/bson/header.hpp"
+#include "glaze/bson/read.hpp"
+#include "glaze/core/opts.hpp"
+#include "glaze/json/write.hpp"
+
+// BSON → JSON converter.
+//
+// Output uses MongoDB Canonical Extended JSON v2 conventions for types that
+// have no native JSON representation:
+//   - object_id  → {"$oid":"<24 hex chars>"}
+//   - datetime   → {"$date":{"$numberLong":"<int64 ms as string>"}}
+//   - timestamp  → {"$timestamp":{"t":<sec>,"i":<inc>}}
+//   - binary     → {"$binary":{"base64":"...","subType":"XX"}}
+//   - regex      → {"$regularExpression":{"pattern":"...","options":"..."}}
+//   - javascript → {"$code":"..."}
+//   - min_key / max_key → {"$minKey":1} / {"$maxKey":1}
+//   - symbol     → {"$symbol":"..."}
+//   - undefined  → {"$undefined":true}
+//   - db_pointer / code_w_scope → syntax_error (deprecated; rare in practice)
+//
+// Asymmetry with the struct-read skip path: when reading BSON into a C++
+// struct, unknown or unused fields (including db_pointer and code_w_scope) are
+// skipped — the caller didn't ask for them, so silently advancing past the
+// bytes is correct. The converter cannot do the same: callers expect the
+// output JSON to reflect the entire document, so silently dropping fields
+// would misrepresent the contents. These deprecated types therefore fail
+// loudly here rather than being elided.
+//
+// decimal128 has no native parser in Glaze, so the 16-byte payload is emitted
+// under a non-`$` wrapper — {"decimal128Hex":"<32 hex chars>"} — to preserve
+// the value for round trip without masquerading as a real Extended JSON
+// $numberDecimal (which requires a decimal string, not hex bytes).
+
+namespace glz
+{
+   namespace bson_detail
+   {
+      // --- small emit helpers ------------------------------------------------
+
+      template <class B, size_t N>
+      GLZ_ALWAYS_INLINE void emit_literal(is_context auto& ctx, B& out, size_t& ix, const char (&lit)[N]) noexcept
+      {
+         constexpr size_t n = N - 1; // exclude the trailing NUL
+         if (!ensure_space(ctx, out, ix + n + write_padding_bytes)) return;
+         std::memcpy(&out[ix], lit, n);
+         ix += n;
+      }
+
+      template <class B>
+      GLZ_ALWAYS_INLINE void emit_char(is_context auto& ctx, B& out, size_t& ix, char c) noexcept
+      {
+         if (!ensure_space(ctx, out, ix + 1 + write_padding_bytes)) return;
+         out[ix++] = static_cast<typename std::decay_t<B>::value_type>(c);
+      }
+
+      template <auto Opts, class B>
+      GLZ_ALWAYS_INLINE void emit_json_string(is_context auto& ctx, std::string_view s, B& out, size_t& ix) noexcept
+      {
+         to<JSON, std::string_view>::template op<Opts>(s, ctx, out, ix);
+      }
+
+      // Emit `n` payload bytes as a lowercase hex literal (no quotes, no prefix).
+      template <class B>
+      inline void emit_hex_bytes(is_context auto& ctx, const uint8_t* bytes, size_t n, B& out, size_t& ix) noexcept
+      {
+         static constexpr char digits[] = "0123456789abcdef";
+         if (!ensure_space(ctx, out, ix + 2 * n + write_padding_bytes)) return;
+         for (size_t i = 0; i < n; ++i) {
+            const uint8_t b = bytes[i];
+            out[ix++] = static_cast<typename std::decay_t<B>::value_type>(digits[b >> 4]);
+            out[ix++] = static_cast<typename std::decay_t<B>::value_type>(digits[b & 0x0F]);
+         }
+      }
+
+      // RFC 4648 base64, no line breaks. `=` padding only.
+      template <class B>
+      inline void emit_base64(is_context auto& ctx, const uint8_t* bytes, size_t n, B& out, size_t& ix) noexcept
+      {
+         static constexpr char alphabet[] =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+         const size_t full_triples = n / 3;
+         const size_t rem = n % 3;
+         const size_t out_len = 4 * (full_triples + (rem ? 1 : 0));
+         if (!ensure_space(ctx, out, ix + out_len + write_padding_bytes)) return;
+
+         for (size_t i = 0; i < full_triples; ++i) {
+            const uint8_t b0 = bytes[3 * i];
+            const uint8_t b1 = bytes[3 * i + 1];
+            const uint8_t b2 = bytes[3 * i + 2];
+            out[ix++] = static_cast<typename std::decay_t<B>::value_type>(alphabet[b0 >> 2]);
+            out[ix++] = static_cast<typename std::decay_t<B>::value_type>(alphabet[((b0 & 0x03) << 4) | (b1 >> 4)]);
+            out[ix++] = static_cast<typename std::decay_t<B>::value_type>(alphabet[((b1 & 0x0F) << 2) | (b2 >> 6)]);
+            out[ix++] = static_cast<typename std::decay_t<B>::value_type>(alphabet[b2 & 0x3F]);
+         }
+         if (rem == 1) {
+            const uint8_t b0 = bytes[3 * full_triples];
+            out[ix++] = static_cast<typename std::decay_t<B>::value_type>(alphabet[b0 >> 2]);
+            out[ix++] = static_cast<typename std::decay_t<B>::value_type>(alphabet[(b0 & 0x03) << 4]);
+            out[ix++] = static_cast<typename std::decay_t<B>::value_type>('=');
+            out[ix++] = static_cast<typename std::decay_t<B>::value_type>('=');
+         }
+         else if (rem == 2) {
+            const uint8_t b0 = bytes[3 * full_triples];
+            const uint8_t b1 = bytes[3 * full_triples + 1];
+            out[ix++] = static_cast<typename std::decay_t<B>::value_type>(alphabet[b0 >> 2]);
+            out[ix++] = static_cast<typename std::decay_t<B>::value_type>(alphabet[((b0 & 0x03) << 4) | (b1 >> 4)]);
+            out[ix++] = static_cast<typename std::decay_t<B>::value_type>(alphabet[(b1 & 0x0F) << 2]);
+            out[ix++] = static_cast<typename std::decay_t<B>::value_type>('=');
+         }
+      }
+
+      // --- value / document / array dispatchers ------------------------------
+
+      template <auto Opts, class It, class End, class B>
+      void bson_to_json_value(uint8_t tag, is_context auto& ctx, It& it, const End& end, B& out, size_t& ix) noexcept;
+
+      template <auto Opts, class It, class B>
+      void bson_to_json_document_body(is_context auto& ctx, It& it, const It& stop, B& out, size_t& ix) noexcept
+      {
+         depth_guard guard{ctx};
+         if (!guard) return;
+
+         emit_char(ctx, out, ix, '{');
+         if (bool(ctx.error)) return;
+
+         bool first = true;
+         read_document_elements(ctx, it, stop, [&](uint8_t element_tag, std::string_view key) {
+            if (!first) {
+               emit_char(ctx, out, ix, ',');
+               if (bool(ctx.error)) return;
+            }
+            first = false;
+
+            emit_json_string<Opts>(ctx, key, out, ix);
+            if (bool(ctx.error)) return;
+            emit_char(ctx, out, ix, ':');
+            if (bool(ctx.error)) return;
+
+            bson_to_json_value<Opts>(element_tag, ctx, it, stop, out, ix);
+         });
+         if (bool(ctx.error)) return;
+
+         emit_char(ctx, out, ix, '}');
+      }
+
+      template <auto Opts, class It, class B>
+      void bson_to_json_array_body(is_context auto& ctx, It& it, const It& stop, B& out, size_t& ix) noexcept
+      {
+         depth_guard guard{ctx};
+         if (!guard) return;
+
+         emit_char(ctx, out, ix, '[');
+         if (bool(ctx.error)) return;
+
+         bool first = true;
+         read_document_elements(ctx, it, stop, [&](uint8_t element_tag, std::string_view /*key*/) {
+            if (!first) {
+               emit_char(ctx, out, ix, ',');
+               if (bool(ctx.error)) return;
+            }
+            first = false;
+            bson_to_json_value<Opts>(element_tag, ctx, it, stop, out, ix);
+         });
+         if (bool(ctx.error)) return;
+
+         emit_char(ctx, out, ix, ']');
+      }
+
+      template <auto Opts, class It, class End, class B>
+      void bson_to_json_value(uint8_t tag, is_context auto& ctx, It& it, const End& end, B& out, size_t& ix) noexcept
+      {
+         using namespace bson;
+         switch (tag) {
+         case type::double_: {
+            double d{};
+            if (!read_le_double(ctx, it, end, d)) return;
+            to<JSON, double>::template op<Opts>(d, ctx, out, ix);
+            return;
+         }
+         case type::string: {
+            int32_t len{};
+            if (!read_le<int32_t>(ctx, it, end, len)) return;
+            if (len < 1) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            if (static_cast<int64_t>(end - it) < len) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+            // len includes the trailing null byte.
+            const auto n = static_cast<size_t>(len) - 1;
+            std::string_view s{reinterpret_cast<const char*>(&*it), n};
+            emit_json_string<Opts>(ctx, s, out, ix);
+            it += len;
+            return;
+         }
+         case type::document: {
+            It stop{};
+            if (!read_document_stop(ctx, it, end, stop)) return;
+            bson_to_json_document_body<Opts>(ctx, it, stop, out, ix);
+            return;
+         }
+         case type::array: {
+            It stop{};
+            if (!read_document_stop(ctx, it, end, stop)) return;
+            bson_to_json_array_body<Opts>(ctx, it, stop, out, ix);
+            return;
+         }
+         case type::binary: {
+            int32_t outer_len{};
+            if (!read_le<int32_t>(ctx, it, end, outer_len)) return;
+            if (outer_len < 0) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            if (static_cast<int64_t>(end - it) < static_cast<int64_t>(1) + outer_len) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+            const uint8_t subtype = static_cast<uint8_t>(*it++);
+            int32_t payload_len = outer_len;
+            if (subtype == bson::binary_subtype::binary_old) [[unlikely]] {
+               // Spec: 0x02 wraps the payload in a redundant inner int32
+               // length. Strip it so $binary base64 reflects only the real
+               // data bytes.
+               if (outer_len < 4) [[unlikely]] {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
+               int32_t inner_len{};
+               if (!read_le<int32_t>(ctx, it, end, inner_len)) return;
+               if (inner_len < 0 || inner_len != outer_len - 4) [[unlikely]] {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
+               payload_len = inner_len;
+            }
+            const uint8_t* payload = reinterpret_cast<const uint8_t*>(&*it);
+            it += payload_len;
+
+            emit_literal(ctx, out, ix, R"({"$binary":{"base64":")");
+            if (bool(ctx.error)) return;
+            emit_base64(ctx, payload, static_cast<size_t>(payload_len), out, ix);
+            if (bool(ctx.error)) return;
+            emit_literal(ctx, out, ix, R"(","subType":")");
+            if (bool(ctx.error)) return;
+            emit_hex_bytes(ctx, &subtype, 1, out, ix);
+            if (bool(ctx.error)) return;
+            emit_literal(ctx, out, ix, R"("}})");
+            return;
+         }
+         case type::undefined:
+            emit_literal(ctx, out, ix, R"({"$undefined":true})");
+            return;
+         case type::object_id: {
+            if (static_cast<int64_t>(end - it) < 12) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+            const uint8_t* payload = reinterpret_cast<const uint8_t*>(&*it);
+            emit_literal(ctx, out, ix, R"({"$oid":")");
+            if (bool(ctx.error)) return;
+            emit_hex_bytes(ctx, payload, 12, out, ix);
+            if (bool(ctx.error)) return;
+            emit_literal(ctx, out, ix, R"("})");
+            it += 12;
+            return;
+         }
+         case type::boolean: {
+            if (it == end) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+            const uint8_t b = static_cast<uint8_t>(*it++);
+            if (b == 0) {
+               emit_literal(ctx, out, ix, "false");
+            }
+            else {
+               emit_literal(ctx, out, ix, "true");
+            }
+            return;
+         }
+         case type::datetime: {
+            int64_t ms{};
+            if (!read_le<int64_t>(ctx, it, end, ms)) return;
+            // Canonical Extended JSON v2: always wrap in {"$numberLong":"..."}
+            // (Relaxed uses ISO-8601 for in-range values, which Glaze has no
+            // formatter for; canonical form is valid in both modes.)
+            emit_literal(ctx, out, ix, R"({"$date":{"$numberLong":")");
+            if (bool(ctx.error)) return;
+            to<JSON, int64_t>::template op<Opts>(ms, ctx, out, ix);
+            if (bool(ctx.error)) return;
+            emit_literal(ctx, out, ix, R"("}})");
+            return;
+         }
+         case type::null:
+            emit_literal(ctx, out, ix, "null");
+            return;
+         case type::regex: {
+            std::string_view pattern{};
+            if (!read_cstring(ctx, it, end, pattern)) return;
+            std::string_view options{};
+            if (!read_cstring(ctx, it, end, options)) return;
+            emit_literal(ctx, out, ix, R"({"$regularExpression":{"pattern":)");
+            if (bool(ctx.error)) return;
+            emit_json_string<Opts>(ctx, pattern, out, ix);
+            if (bool(ctx.error)) return;
+            emit_literal(ctx, out, ix, R"(,"options":)");
+            if (bool(ctx.error)) return;
+            emit_json_string<Opts>(ctx, options, out, ix);
+            if (bool(ctx.error)) return;
+            emit_literal(ctx, out, ix, "}}");
+            return;
+         }
+         case type::javascript: {
+            int32_t len{};
+            if (!read_le<int32_t>(ctx, it, end, len)) return;
+            if (len < 1) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            if (static_cast<int64_t>(end - it) < len) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+            const auto n = static_cast<size_t>(len) - 1;
+            std::string_view s{reinterpret_cast<const char*>(&*it), n};
+            emit_literal(ctx, out, ix, R"({"$code":)");
+            if (bool(ctx.error)) return;
+            emit_json_string<Opts>(ctx, s, out, ix);
+            if (bool(ctx.error)) return;
+            emit_char(ctx, out, ix, '}');
+            it += len;
+            return;
+         }
+         case type::symbol: {
+            int32_t len{};
+            if (!read_le<int32_t>(ctx, it, end, len)) return;
+            if (len < 1) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            if (static_cast<int64_t>(end - it) < len) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+            const auto n = static_cast<size_t>(len) - 1;
+            std::string_view s{reinterpret_cast<const char*>(&*it), n};
+            emit_literal(ctx, out, ix, R"({"$symbol":)");
+            if (bool(ctx.error)) return;
+            emit_json_string<Opts>(ctx, s, out, ix);
+            if (bool(ctx.error)) return;
+            emit_char(ctx, out, ix, '}');
+            it += len;
+            return;
+         }
+         case type::int32: {
+            int32_t v{};
+            if (!read_le<int32_t>(ctx, it, end, v)) return;
+            to<JSON, int32_t>::template op<Opts>(v, ctx, out, ix);
+            return;
+         }
+         case type::timestamp: {
+            uint32_t increment{};
+            uint32_t seconds{};
+            if (!read_le<uint32_t>(ctx, it, end, increment)) return;
+            if (!read_le<uint32_t>(ctx, it, end, seconds)) return;
+            emit_literal(ctx, out, ix, R"({"$timestamp":{"t":)");
+            if (bool(ctx.error)) return;
+            to<JSON, uint32_t>::template op<Opts>(seconds, ctx, out, ix);
+            if (bool(ctx.error)) return;
+            emit_literal(ctx, out, ix, R"(,"i":)");
+            if (bool(ctx.error)) return;
+            to<JSON, uint32_t>::template op<Opts>(increment, ctx, out, ix);
+            if (bool(ctx.error)) return;
+            emit_literal(ctx, out, ix, "}}");
+            return;
+         }
+         case type::int64: {
+            int64_t v{};
+            if (!read_le<int64_t>(ctx, it, end, v)) return;
+            to<JSON, int64_t>::template op<Opts>(v, ctx, out, ix);
+            return;
+         }
+         case type::decimal128: {
+            if (static_cast<int64_t>(end - it) < 16) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+            const uint8_t* payload = reinterpret_cast<const uint8_t*>(&*it);
+            // Extended JSON v2 $numberDecimal requires a decimal string, which
+            // Glaze has no decimal128 formatter for. Emit under a non-`$`
+            // wrapper so this doesn't masquerade as real $numberDecimal.
+            emit_literal(ctx, out, ix, R"({"decimal128Hex":")");
+            if (bool(ctx.error)) return;
+            emit_hex_bytes(ctx, payload, 16, out, ix);
+            if (bool(ctx.error)) return;
+            emit_literal(ctx, out, ix, R"("})");
+            it += 16;
+            return;
+         }
+         case type::min_key:
+            emit_literal(ctx, out, ix, R"({"$minKey":1})");
+            return;
+         case type::max_key:
+            emit_literal(ctx, out, ix, R"({"$maxKey":1})");
+            return;
+         case type::db_pointer:
+         case type::code_w_scope:
+         default:
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+      }
+   } // namespace bson_detail
+
+   // Convert a BSON document (top-level) to JSON text.
+   template <auto Opts = glz::opts{}, class BSONBuffer, class JSONBuffer>
+   [[nodiscard]] inline error_ctx bson_to_json(const BSONBuffer& input, JSONBuffer& out)
+   {
+      size_t ix{};
+      context ctx{};
+
+      const char* it = reinterpret_cast<const char*>(std::data(input));
+      const char* const end = it + std::size(input);
+
+      if (end - it < 5) {
+         return {0, error_code::unexpected_end};
+      }
+
+      const char* stop{};
+      if (!bson_detail::read_document_stop(ctx, it, end, stop)) {
+         return {0, ctx.error};
+      }
+
+      bson_detail::bson_to_json_document_body<Opts>(ctx, it, stop, out, ix);
+      if (bool(ctx.error)) {
+         return {ix, ctx.error, ctx.custom_error_message};
+      }
+      if (it != stop) {
+         return {ix, error_code::syntax_error};
+      }
+      // Trailing bytes beyond the advertised document length are silently
+      // permitted by a literal read of `stop`, but a well-formed input must
+      // consume the whole buffer (matches read_bson's exact-fill behavior).
+      if (stop != end) {
+         return {ix, error_code::syntax_error};
+      }
+
+      if constexpr (resizable<JSONBuffer>) {
+         out.resize(ix);
+      }
+      return {};
+   }
+
+   template <auto Opts = glz::opts{}, class BSONBuffer>
+   [[nodiscard]] inline expected<std::string, error_ctx> bson_to_json(const BSONBuffer& input)
+   {
+      std::string out;
+      auto ec = bson_to_json<Opts>(input, out);
+      if (ec) {
+         return unexpected(ec);
+      }
+      return out;
+   }
+}

--- a/include/glaze/bson/bson_to_json.hpp
+++ b/include/glaze/bson/bson_to_json.hpp
@@ -423,7 +423,7 @@ namespace glz
       // permitted by a literal read of `stop`, but a well-formed input must
       // consume the whole buffer (matches read_bson's exact-fill behavior).
       if (stop != end) {
-         return {ix, error_code::syntax_error};
+         return {ix, error_code::syntax_error, "trailing bytes after document terminator"};
       }
 
       if constexpr (resizable<JSONBuffer>) {

--- a/include/glaze/bson/header.hpp
+++ b/include/glaze/bson/header.hpp
@@ -1,0 +1,167 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include <array>
+#include <compare>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "glaze/concepts/container_concepts.hpp"
+#include "glaze/util/inline.hpp"
+
+// BSON - https://bsonspec.org/spec.html
+//
+// A BSON document is the top-level container and is encoded as:
+//     int32 length | e_list | 0x00
+// The int32 length includes itself and the terminating null byte. All
+// multi-byte integers and floats on the wire are little-endian.
+//
+// Each element in e_list is:
+//     byte type | cstring key | value...
+// where cstring is a UTF-8 byte sequence terminated by 0x00.
+//
+// BSON arrays are encoded as documents whose keys are the decimal string
+// representations of their indices ("0", "1", "2", ...), in order.
+
+namespace glz::bson
+{
+   // Element type codes. These identify the wire format of a document value.
+   namespace type
+   {
+      inline constexpr uint8_t double_ = 0x01; // IEEE 754 binary64
+      inline constexpr uint8_t string = 0x02; // int32 length (bytes+1) | UTF-8 | 0x00
+      inline constexpr uint8_t document = 0x03; // embedded BSON document
+      inline constexpr uint8_t array = 0x04; // document with integer-string keys
+      inline constexpr uint8_t binary = 0x05; // int32 length | subtype | bytes
+      inline constexpr uint8_t undefined = 0x06; // DEPRECATED (read-only support)
+      inline constexpr uint8_t object_id = 0x07; // 12 bytes
+      inline constexpr uint8_t boolean = 0x08; // 0x00 = false, 0x01 = true
+      inline constexpr uint8_t datetime = 0x09; // int64 ms since Unix epoch, UTC
+      inline constexpr uint8_t null = 0x0A; // no value bytes
+      inline constexpr uint8_t regex = 0x0B; // cstring pattern | cstring options
+      inline constexpr uint8_t db_pointer = 0x0C; // DEPRECATED (read-only support)
+      inline constexpr uint8_t javascript = 0x0D; // string (length-prefixed)
+      inline constexpr uint8_t symbol = 0x0E; // DEPRECATED (read-only support)
+      inline constexpr uint8_t code_w_scope = 0x0F; // DEPRECATED (read-only support)
+      inline constexpr uint8_t int32 = 0x10;
+      inline constexpr uint8_t timestamp = 0x11; // uint64: low 32 increment, high 32 seconds
+      inline constexpr uint8_t int64 = 0x12;
+      inline constexpr uint8_t decimal128 = 0x13; // IEEE 754-2008 decimal128 (opaque)
+      inline constexpr uint8_t min_key = 0xFF; // compares lower than all other values
+      inline constexpr uint8_t max_key = 0x7F; // compares higher than all other values
+   }
+
+   // Binary data subtype codes, carried in the byte immediately after the
+   // length of a type::binary element.
+   namespace binary_subtype
+   {
+      inline constexpr uint8_t generic = 0x00;
+      inline constexpr uint8_t function = 0x01;
+      inline constexpr uint8_t binary_old = 0x02; // DEPRECATED
+      inline constexpr uint8_t uuid_old = 0x03; // DEPRECATED
+      inline constexpr uint8_t uuid = 0x04; // RFC 9562 UUID, canonical byte order
+      inline constexpr uint8_t md5 = 0x05;
+      inline constexpr uint8_t encrypted = 0x06;
+      inline constexpr uint8_t column = 0x07; // compressed BSON column
+      inline constexpr uint8_t sensitive = 0x08;
+      inline constexpr uint8_t vector = 0x09;
+      inline constexpr uint8_t user_defined_min = 0x80; // 0x80..0xFF reserved for users
+   }
+
+   // Opaque 12-byte MongoDB ObjectId. MongoDB assigns meaning to the bytes
+   // (timestamp, random, counter) but the BSON wire format treats it as a
+   // fixed-size blob. Glaze does the same — generation is left to the user.
+   struct object_id
+   {
+      std::array<uint8_t, 12> bytes{};
+
+      [[nodiscard]] constexpr bool operator==(const object_id&) const noexcept = default;
+      [[nodiscard]] constexpr auto operator<=>(const object_id&) const noexcept = default;
+   };
+
+   // Wire representation of a BSON UTC datetime: signed milliseconds since
+   // the Unix epoch. Users usually prefer std::chrono::system_clock::time_point,
+   // which the BSON codec auto-maps to this type.
+   struct datetime
+   {
+      int64_t ms_since_epoch{};
+
+      [[nodiscard]] constexpr bool operator==(const datetime&) const noexcept = default;
+      [[nodiscard]] constexpr auto operator<=>(const datetime&) const noexcept = default;
+   };
+
+   // MongoDB-internal timestamp used for replication and sharding. Distinct
+   // from `datetime` — on the wire it is a uint64 whose low 32 bits hold an
+   // increment counter and whose high 32 bits hold seconds since epoch.
+   struct timestamp
+   {
+      uint32_t increment{};
+      uint32_t seconds{};
+
+      [[nodiscard]] constexpr bool operator==(const timestamp&) const noexcept = default;
+      [[nodiscard]] constexpr auto operator<=>(const timestamp&) const noexcept = default;
+   };
+
+   // PCRE-style regular expression. Options are ASCII flag characters in
+   // alphabetical order per spec: 'i' case-insensitive, 'l' locale-dependent,
+   // 'm' multiline, 's' dotall, 'u' Unicode, 'x' verbose.
+   struct regex
+   {
+      std::string pattern;
+      std::string options;
+
+      [[nodiscard]] bool operator==(const regex&) const noexcept = default;
+   };
+
+   struct javascript
+   {
+      std::string code;
+
+      [[nodiscard]] bool operator==(const javascript&) const noexcept = default;
+   };
+
+   // Opaque 16-byte IEEE 754-2008 decimal128. This is not the same encoding
+   // as std::float128_t (binary128); the formats share width and parent spec
+   // but not bit layout. Arithmetic and string conversion are out of scope
+   // for now — this type carries the raw bytes for round-trip interop.
+   struct decimal128
+   {
+      std::array<uint8_t, 16> bytes{};
+
+      [[nodiscard]] constexpr bool operator==(const decimal128&) const noexcept = default;
+   };
+
+   // Comparison sentinels used primarily in MongoDB queries. They have no
+   // associated value and compare lower/higher than every other BSON value.
+   struct min_key
+   {
+      [[nodiscard]] constexpr bool operator==(const min_key&) const noexcept = default;
+   };
+
+   struct max_key
+   {
+      [[nodiscard]] constexpr bool operator==(const max_key&) const noexcept = default;
+   };
+
+   // Binary payload carrying a subtype byte. The container type is left to
+   // the user; common choices are std::vector<std::byte>, std::vector<uint8_t>,
+   // and std::string. The subtype defaults to `generic` (0x00).
+   //
+   // Constrained to resizable containers because the reader calls `.resize()`
+   // with the wire-provided length. Fixed-size targets (e.g., std::array) would
+   // write but not read, so the constraint is enforced at the type level to
+   // keep write and read symmetric.
+   template <class Bytes = std::vector<std::byte>>
+      requires(resizable<Bytes>)
+   struct binary
+   {
+      Bytes data{};
+      uint8_t subtype = binary_subtype::generic;
+
+      [[nodiscard]] bool operator==(const binary&) const noexcept = default;
+   };
+}

--- a/include/glaze/bson/header.hpp
+++ b/include/glaze/bson/header.hpp
@@ -114,14 +114,14 @@ namespace glz::bson
       std::string pattern;
       std::string options;
 
-      [[nodiscard]] bool operator==(const regex&) const noexcept = default;
+      [[nodiscard]] constexpr bool operator==(const regex&) const noexcept = default;
    };
 
    struct javascript
    {
       std::string code;
 
-      [[nodiscard]] bool operator==(const javascript&) const noexcept = default;
+      [[nodiscard]] constexpr bool operator==(const javascript&) const noexcept = default;
    };
 
    // Opaque 16-byte IEEE 754-2008 decimal128. This is not the same encoding
@@ -162,6 +162,6 @@ namespace glz::bson
       Bytes data{};
       uint8_t subtype = binary_subtype::generic;
 
-      [[nodiscard]] bool operator==(const binary&) const noexcept = default;
+      [[nodiscard]] constexpr bool operator==(const binary&) const noexcept = default;
    };
 }

--- a/include/glaze/bson/read.hpp
+++ b/include/glaze/bson/read.hpp
@@ -1,0 +1,1284 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include <array>
+#include <bit>
+#include <charconv>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <string_view>
+
+#include "glaze/bson/header.hpp"
+#include "glaze/bson/skip.hpp"
+#include "glaze/core/opts.hpp"
+#include "glaze/core/read.hpp"
+#include "glaze/core/reflect.hpp"
+#include "glaze/core/to.hpp"
+#include "glaze/file/file_ops.hpp"
+#include "glaze/util/for_each.hpp"
+#include "glaze/util/uuid.hpp"
+#include "glaze/util/variant.hpp"
+
+// BSON reader — https://bsonspec.org/spec.html
+//
+// BSON values do not carry a self-describing tag byte; the element type lives
+// one level up, in the containing document. The document reader therefore
+// reads `type_byte | cstring key | value` triples and supplies the tag to the
+// per-type parser via `from<BSON, T>::op(value, tag, ctx, it, end)`.
+
+namespace glz
+{
+   namespace bson_detail
+   {
+      // RAII guard bumping ctx.depth on entry to a document/array reader and
+      // popping on exit. Errors with exceeded_max_recursive_depth before the
+      // stack can overflow on adversarial input — pathologically nested BSON
+      // (e.g. `{"a": {"a": {...}}}`) is cheap to produce and a real DoS vector.
+      template <class Ctx>
+      struct depth_guard
+      {
+         Ctx& ctx;
+         bool entered = false;
+
+         depth_guard(Ctx& c) noexcept : ctx(c)
+         {
+            if (ctx.depth >= max_recursive_depth_limit) [[unlikely]] {
+               ctx.error = error_code::exceeded_max_recursive_depth;
+               return;
+            }
+            ++ctx.depth;
+            entered = true;
+         }
+         ~depth_guard()
+         {
+            if (entered) --ctx.depth;
+         }
+         explicit operator bool() const noexcept { return entered; }
+      };
+
+      // --- Little-endian readers ----------------------------------------------
+      //
+      // On little-endian hosts these compile to a single aligned load. On big-
+      // endian hosts we byteswap first.
+
+      template <std::integral T, class It, class End>
+      GLZ_ALWAYS_INLINE bool read_le(is_context auto& ctx, It& it, const End& end, T& out) noexcept
+      {
+         if (static_cast<size_t>(end - it) < sizeof(T)) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return false;
+         }
+         T v{};
+         std::memcpy(&v, it, sizeof(T));
+         if constexpr (std::endian::native == std::endian::big) {
+            v = static_cast<T>(std::byteswap(static_cast<std::make_unsigned_t<T>>(v)));
+         }
+         it += sizeof(T);
+         out = v;
+         return true;
+      }
+
+      template <class It, class End>
+      GLZ_ALWAYS_INLINE bool read_le_double(is_context auto& ctx, It& it, const End& end, double& out) noexcept
+      {
+         uint64_t bits{};
+         if (!read_le<uint64_t>(ctx, it, end, bits)) return false;
+         out = std::bit_cast<double>(bits);
+         return true;
+      }
+
+      // Return a string_view over a cstring in the buffer. Advances `it` to
+      // just past the trailing 0x00.
+      template <class It, class End>
+      GLZ_ALWAYS_INLINE bool read_cstring(is_context auto& ctx, It& it, const End& end, std::string_view& out) noexcept
+      {
+         auto start = it;
+         while (it < end) {
+            if (*it == 0) {
+               out = std::string_view{reinterpret_cast<const char*>(static_cast<const void*>(start)),
+                                      static_cast<size_t>(it - start)};
+               ++it;
+               return true;
+            }
+            ++it;
+         }
+         ctx.error = error_code::unexpected_end;
+         return false;
+      }
+
+      // Read a BSON string value: int32(len) | UTF-8 | 0x00. `out` points into
+      // the input buffer; lifetime matches the buffer.
+      template <class It, class End>
+      GLZ_ALWAYS_INLINE bool read_bson_string(is_context auto& ctx, It& it, const End& end,
+                                              std::string_view& out) noexcept
+      {
+         int32_t len{};
+         if (!read_le<int32_t>(ctx, it, end, len)) return false;
+         if (len < 1) [[unlikely]] {
+            // Length must include the trailing null.
+            ctx.error = error_code::syntax_error;
+            return false;
+         }
+         const size_t payload_bytes = static_cast<size_t>(len) - 1; // Drop the trailing null.
+         if (static_cast<size_t>(end - it) < static_cast<size_t>(len)) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return false;
+         }
+         if (it[payload_bytes] != 0) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return false;
+         }
+         out = std::string_view{reinterpret_cast<const char*>(static_cast<const void*>(it)), payload_bytes};
+         it += len;
+         return true;
+      }
+
+      // Helper — read a BSON document's 4-byte length and compute the
+      // terminating position (`stop`) such that a correct document consumes
+      // exactly `stop - doc_start` bytes ending in 0x00 at `stop - 1`.
+      template <class It, class End>
+      GLZ_ALWAYS_INLINE bool read_document_stop(is_context auto& ctx, It& it, const End& end, It& stop) noexcept
+      {
+         auto doc_start = it;
+         int32_t len{};
+         if (!read_le<int32_t>(ctx, it, end, len)) return false;
+         if (len < 5) [[unlikely]] {
+            // Minimum legal document: 4-byte length + 0x00 terminator.
+            ctx.error = error_code::syntax_error;
+            return false;
+         }
+         if (static_cast<size_t>(end - doc_start) < static_cast<size_t>(len)) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return false;
+         }
+         stop = doc_start + len;
+         return true;
+      }
+
+      // Confirm the trailing 0x00 of a document is where we expect it, then
+      // advance past it.
+      template <class It, class End>
+      GLZ_ALWAYS_INLINE bool finish_document(is_context auto& ctx, It& it, const End& /*end*/, It stop) noexcept
+      {
+         // Caller guarantees it <= stop. After the element loop the document
+         // reader expects the null terminator at `stop - 1` and `it` pointing
+         // there.
+         if (it != stop - 1) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return false;
+         }
+         if (*it != 0) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return false;
+         }
+         ++it;
+         return true;
+      }
+   } // namespace bson_detail
+
+   // Top-level dispatcher. BSON's top-level is always a document, so the
+   // implicit tag is bson::type::document. Per-element dispatch inside a
+   // document is handled by the struct/array reader calling `from<BSON,
+   // Member>::op` directly with the element's tag.
+   template <>
+   struct parse<BSON>
+   {
+      template <auto Opts, class T, is_context Ctx, class It, class End>
+      GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, It& it, const End& end) noexcept
+      {
+         if constexpr (const_value_v<T>) {
+            if constexpr (check_error_on_const_read(Opts)) {
+               ctx.error = error_code::attempt_const_read;
+            }
+            else {
+               skip_value<BSON>::template op<Opts>(bson::type::document, ctx, it, end);
+            }
+            return;
+         }
+         using V = std::remove_cvref_t<T>;
+         // Top-level BSON has no element tag byte on the wire; a top-level
+         // array is byte-for-byte identical to a document. Dispatch with the
+         // tag the target type's reader expects so array-shaped top-level
+         // targets (std::array, std::vector, std::tuple, glaze_array_t) route
+         // to the array reader instead of tripping its tag check.
+         constexpr uint8_t top_tag =
+            (writable_array_t<V> || glaze_array_t<V>) ? bson::type::array : bson::type::document;
+         from<BSON, V>::template op<Opts>(std::forward<T>(value), top_tag, ctx, it, end);
+      }
+   };
+
+   // ==========================================================================
+   // Primitive readers. Each from<BSON, T> receives the element tag from the
+   // enclosing document and reads the corresponding value bytes.
+   // ==========================================================================
+
+   // --- Boolean --------------------------------------------------------------
+   template <>
+   struct from<BSON, bool>
+   {
+      template <auto Opts, class It, class End>
+      GLZ_ALWAYS_INLINE static void op(bool& value, uint8_t tag, is_context auto& ctx, It& it, const End& end) noexcept
+      {
+         if (tag != bson::type::boolean) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         if (it >= end) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return;
+         }
+         value = (*it++ != 0);
+      }
+   };
+
+   // --- Integers -------------------------------------------------------------
+   //
+   // Accept both int32 (0x10) and int64 (0x12) tags regardless of the C++
+   // target width — the usual coercion rules apply: error on out-of-range.
+   template <class T>
+      requires(std::integral<T> && !std::same_as<T, bool>)
+   struct from<BSON, T>
+   {
+      template <auto Opts, class It, class End>
+      static void op(T& value, uint8_t tag, is_context auto& ctx, It& it, const End& end) noexcept
+      {
+         if (tag == bson::type::int32) {
+            int32_t v{};
+            if (!bson_detail::read_le<int32_t>(ctx, it, end, v)) return;
+            // Reject negative wire values into any unsigned target (covers
+            // uint32_t, uint64_t, and the smaller widths uniformly).
+            if constexpr (!std::is_signed_v<T>) {
+               if (v < 0) [[unlikely]] {
+                  ctx.error = error_code::parse_number_failure;
+                  return;
+               }
+            }
+            // Narrowing bounds check only when T is strictly narrower than
+            // int32. For sizeof(T) == 4 && unsigned (uint32_t), the non-negative
+            // check above plus the int32 input width guarantee the value fits.
+            if constexpr (sizeof(T) < 4) {
+               if (v < static_cast<int32_t>(std::numeric_limits<T>::min()) ||
+                   v > static_cast<int32_t>(std::numeric_limits<T>::max())) [[unlikely]] {
+                  ctx.error = error_code::parse_number_failure;
+                  return;
+               }
+            }
+            value = static_cast<T>(v);
+            return;
+         }
+         if (tag == bson::type::int64) {
+            int64_t v{};
+            if (!bson_detail::read_le<int64_t>(ctx, it, end, v)) return;
+            // Narrow to T with range check. uint64_t target: accept only
+            // non-negative values.
+            if constexpr (std::is_same_v<T, uint64_t>) {
+               if (v < 0) [[unlikely]] {
+                  ctx.error = error_code::parse_number_failure;
+                  return;
+               }
+               value = static_cast<uint64_t>(v);
+               return;
+            }
+            else if constexpr (sizeof(T) <= 8) {
+               if constexpr (std::is_signed_v<T>) {
+                  if (v < static_cast<int64_t>(std::numeric_limits<T>::min()) ||
+                      v > static_cast<int64_t>(std::numeric_limits<T>::max())) [[unlikely]] {
+                     ctx.error = error_code::parse_number_failure;
+                     return;
+                  }
+               }
+               else {
+                  if (v < 0 || static_cast<uint64_t>(v) > static_cast<uint64_t>(std::numeric_limits<T>::max()))
+                     [[unlikely]] {
+                     ctx.error = error_code::parse_number_failure;
+                     return;
+                  }
+               }
+               value = static_cast<T>(v);
+               return;
+            }
+         }
+         ctx.error = error_code::syntax_error;
+      }
+   };
+
+   // --- Floating point -------------------------------------------------------
+   //
+   // BSON double (0x01) is the native mapping; integer tags are accepted as a
+   // widening conversion so `double x` can read an int32/int64 field.
+   template <std::floating_point T>
+   struct from<BSON, T>
+   {
+      template <auto Opts, class It, class End>
+      static void op(T& value, uint8_t tag, is_context auto& ctx, It& it, const End& end) noexcept
+      {
+         if (tag == bson::type::double_) {
+            double d{};
+            if (!bson_detail::read_le_double(ctx, it, end, d)) return;
+            value = static_cast<T>(d);
+            return;
+         }
+         if (tag == bson::type::int32) {
+            int32_t v{};
+            if (!bson_detail::read_le<int32_t>(ctx, it, end, v)) return;
+            value = static_cast<T>(v);
+            return;
+         }
+         if (tag == bson::type::int64) {
+            int64_t v{};
+            if (!bson_detail::read_le<int64_t>(ctx, it, end, v)) return;
+            value = static_cast<T>(v);
+            return;
+         }
+         ctx.error = error_code::syntax_error;
+      }
+   };
+
+   // --- Enums ----------------------------------------------------------------
+   template <class T>
+      requires(std::is_enum_v<T>)
+   struct from<BSON, T>
+   {
+      template <auto Opts, class It, class End>
+      GLZ_ALWAYS_INLINE static void op(T& value, uint8_t tag, is_context auto& ctx, It& it, const End& end) noexcept
+      {
+         using U = std::underlying_type_t<T>;
+         U u{};
+         from<BSON, U>::template op<Opts>(u, tag, ctx, it, end);
+         if (bool(ctx.error)) return;
+         value = static_cast<T>(u);
+      }
+   };
+
+   // --- Strings --------------------------------------------------------------
+   template <str_t T>
+   struct from<BSON, T>
+   {
+      template <auto Opts, class It, class End>
+      static void op(auto& value, uint8_t tag, is_context auto& ctx, It& it, const End& end) noexcept
+      {
+         if (tag != bson::type::string) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         std::string_view sv{};
+         if (!bson_detail::read_bson_string(ctx, it, end, sv)) return;
+         if constexpr (requires { value.assign(sv.data(), sv.size()); }) {
+            value.assign(sv.data(), sv.size());
+         }
+         else {
+            value = sv;
+         }
+      }
+   };
+
+   // --- Nullable / optional --------------------------------------------------
+   template <nullable_like T>
+   struct from<BSON, T>
+   {
+      template <auto Opts, class It, class End>
+      static void op(auto& value, uint8_t tag, is_context auto& ctx, It& it, const End& end) noexcept
+      {
+         if (tag == bson::type::null) {
+            if constexpr (requires { value.reset(); }) {
+               value.reset();
+            }
+            else {
+               value = T{};
+            }
+            return;
+         }
+         if (!value) {
+            if constexpr (requires { value.emplace(); }) {
+               value.emplace();
+            }
+            else if constexpr (std::is_constructible_v<typename T::value_type>) {
+               value = typename T::value_type{};
+            }
+            else {
+               ctx.error = error_code::invalid_nullable_read;
+               return;
+            }
+         }
+         using Inner = std::remove_cvref_t<decltype(*value)>;
+         from<BSON, Inner>::template op<Opts>(*value, tag, ctx, it, end);
+      }
+   };
+
+   // --- always_null_t (std::monostate, std::nullptr_t, std::nullopt_t) -------
+   //
+   // These carry no state and never appear as top-level BSON values, but are
+   // reachable as variant alternatives. The tag is always bson::type::null
+   // when the variant reader routes here; anything else is a wire error.
+   template <always_null_t T>
+   struct from<BSON, T>
+   {
+      template <auto Opts, class It, class End>
+      GLZ_ALWAYS_INLINE static void op(auto&&, uint8_t tag, is_context auto& ctx, It&, const End&) noexcept
+      {
+         if (tag != bson::type::null) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+         }
+      }
+   };
+
+   // --- BSON-native helper types --------------------------------------------
+
+   template <>
+   struct from<BSON, bson::object_id>
+   {
+      template <auto Opts, class It, class End>
+      GLZ_ALWAYS_INLINE static void op(bson::object_id& value, uint8_t tag, is_context auto& ctx, It& it,
+                                       const End& end) noexcept
+      {
+         if (tag != bson::type::object_id) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         if (static_cast<size_t>(end - it) < 12) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return;
+         }
+         std::memcpy(value.bytes.data(), it, 12);
+         it += 12;
+      }
+   };
+
+   template <>
+   struct from<BSON, bson::datetime>
+   {
+      template <auto Opts, class It, class End>
+      GLZ_ALWAYS_INLINE static void op(bson::datetime& value, uint8_t tag, is_context auto& ctx, It& it,
+                                       const End& end) noexcept
+      {
+         if (tag != bson::type::datetime) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         (void)bson_detail::read_le<int64_t>(ctx, it, end, value.ms_since_epoch);
+      }
+   };
+
+   template <>
+   struct from<BSON, bson::timestamp>
+   {
+      template <auto Opts, class It, class End>
+      GLZ_ALWAYS_INLINE static void op(bson::timestamp& value, uint8_t tag, is_context auto& ctx, It& it,
+                                       const End& end) noexcept
+      {
+         if (tag != bson::type::timestamp) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         if (!bson_detail::read_le<uint32_t>(ctx, it, end, value.increment)) return;
+         (void)bson_detail::read_le<uint32_t>(ctx, it, end, value.seconds);
+      }
+   };
+
+   template <>
+   struct from<BSON, bson::regex>
+   {
+      template <auto Opts, class It, class End>
+      static void op(bson::regex& value, uint8_t tag, is_context auto& ctx, It& it, const End& end) noexcept
+      {
+         if (tag != bson::type::regex) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         std::string_view pat{};
+         std::string_view opt{};
+         if (!bson_detail::read_cstring(ctx, it, end, pat)) return;
+         if (!bson_detail::read_cstring(ctx, it, end, opt)) return;
+         value.pattern.assign(pat);
+         value.options.assign(opt);
+      }
+   };
+
+   template <>
+   struct from<BSON, bson::javascript>
+   {
+      template <auto Opts, class It, class End>
+      static void op(bson::javascript& value, uint8_t tag, is_context auto& ctx, It& it, const End& end) noexcept
+      {
+         if (tag != bson::type::javascript) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         std::string_view sv{};
+         if (!bson_detail::read_bson_string(ctx, it, end, sv)) return;
+         value.code.assign(sv);
+      }
+   };
+
+   template <>
+   struct from<BSON, bson::decimal128>
+   {
+      template <auto Opts, class It, class End>
+      GLZ_ALWAYS_INLINE static void op(bson::decimal128& value, uint8_t tag, is_context auto& ctx, It& it,
+                                       const End& end) noexcept
+      {
+         if (tag != bson::type::decimal128) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         if (static_cast<size_t>(end - it) < 16) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return;
+         }
+         std::memcpy(value.bytes.data(), it, 16);
+         it += 16;
+      }
+   };
+
+   template <>
+   struct from<BSON, bson::min_key>
+   {
+      template <auto Opts, class It, class End>
+      GLZ_ALWAYS_INLINE static void op(bson::min_key&, uint8_t tag, is_context auto& ctx, It&, const End&) noexcept
+      {
+         if (tag != bson::type::min_key) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+         }
+      }
+   };
+
+   template <>
+   struct from<BSON, bson::max_key>
+   {
+      template <auto Opts, class It, class End>
+      GLZ_ALWAYS_INLINE static void op(bson::max_key&, uint8_t tag, is_context auto& ctx, It&, const End&) noexcept
+      {
+         if (tag != bson::type::max_key) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+         }
+      }
+   };
+
+   template <class Bytes>
+   struct from<BSON, bson::binary<Bytes>>
+   {
+      template <auto Opts, class It, class End>
+      static void op(bson::binary<Bytes>& value, uint8_t tag, is_context auto& ctx, It& it, const End& end) noexcept
+      {
+         if (tag != bson::type::binary) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         int32_t outer_len{};
+         if (!bson_detail::read_le<int32_t>(ctx, it, end, outer_len)) return;
+         if (outer_len < 0) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         if (it >= end) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return;
+         }
+         value.subtype = static_cast<uint8_t>(*it++);
+         int32_t payload_len = outer_len;
+         if (value.subtype == bson::binary_subtype::binary_old) [[unlikely]] {
+            // Spec: 0x02 wraps the payload in a redundant inner int32 length.
+            // Outer length must equal 4 + inner.
+            if (outer_len < 4) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            int32_t inner_len{};
+            if (!bson_detail::read_le<int32_t>(ctx, it, end, inner_len)) return;
+            if (inner_len < 0 || inner_len != outer_len - 4) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            payload_len = inner_len;
+         }
+         if (static_cast<size_t>(end - it) < static_cast<size_t>(payload_len)) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return;
+         }
+         value.data.resize(static_cast<size_t>(payload_len));
+         if (payload_len) {
+            std::memcpy(value.data.data(), it, static_cast<size_t>(payload_len));
+            it += payload_len;
+         }
+      }
+   };
+
+   // --- glz::uuid ← binary subtype 0x04 -------------------------------------
+   template <>
+   struct from<BSON, uuid>
+   {
+      template <auto Opts, class It, class End>
+      static void op(uuid& value, uint8_t tag, is_context auto& ctx, It& it, const End& end) noexcept
+      {
+         if (tag != bson::type::binary) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         int32_t len{};
+         if (!bson_detail::read_le<int32_t>(ctx, it, end, len)) return;
+         if (len != 16) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         if (it >= end) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return;
+         }
+         const uint8_t subtype = static_cast<uint8_t>(*it++);
+         // Only accept canonical subtype 0x04 (RFC 9562 byte order). Legacy
+         // 0x03 (uuid_old) is rejected because its bytes are ambiguous: Java,
+         // C#, and Python drivers each laid them out differently, so decoding
+         // without the origin flavor silently yields scrambled bytes.
+         if (subtype != bson::binary_subtype::uuid) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         if (static_cast<size_t>(end - it) < 16) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return;
+         }
+         std::memcpy(value.bytes.data(), it, 16);
+         it += 16;
+      }
+   };
+
+   // --- std::chrono::system_clock::time_point ← datetime --------------------
+   template <>
+   struct from<BSON, std::chrono::system_clock::time_point>
+   {
+      template <auto Opts, class It, class End>
+      GLZ_ALWAYS_INLINE static void op(std::chrono::system_clock::time_point& value, uint8_t tag, is_context auto& ctx,
+                                       It& it, const End& end) noexcept
+      {
+         if (tag != bson::type::datetime) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         int64_t ms{};
+         if (!bson_detail::read_le<int64_t>(ctx, it, end, ms)) return;
+         value = std::chrono::system_clock::time_point{std::chrono::milliseconds{ms}};
+      }
+   };
+
+   // ==========================================================================
+   // Variant — BSON-style auto-deduction from the element tag byte.
+   //
+   // Mirrors the JSONB pattern: each BSON wire type maps to a category trait,
+   // and for each category the writer picks the first variant alternative
+   // matching that trait. This requires at most one alternative per category,
+   // enforced by a static_assert. Users needing multiple alternatives sharing
+   // a BSON type (e.g., two distinct document shapes) must drop one or switch
+   // to an explicit tag-based variant convention (not yet supported here).
+   //
+   // The writer serializes the active alternative directly (its type byte and
+   // key are already on the wire from the enclosing document), so round-trip
+   // works as long as the alternative category is unique.
+   // ==========================================================================
+
+   namespace bson_detail
+   {
+      // --- Category traits ---------------------------------------------------
+
+      template <class T>
+      struct is_bson_variant_null : std::bool_constant<null_t<T>>
+      {};
+
+      template <class T>
+      struct is_bson_variant_bool : std::bool_constant<bool_t<T>>
+      {};
+
+      template <class T>
+      struct is_bson_variant_int : std::bool_constant<std::integral<std::remove_cvref_t<T>> && !bool_t<T>>
+      {};
+
+      template <class T>
+      struct is_bson_variant_float : std::bool_constant<std::floating_point<std::remove_cvref_t<T>>>
+      {};
+
+      template <class T>
+      struct is_bson_variant_string : std::bool_constant<str_t<T>>
+      {};
+
+      // BSON helper types: these are reflectable aggregates but have dedicated
+      // wire tags, so they must NOT be classified as generic documents. Listed
+      // ahead of the document/array traits so those can exclude them.
+      template <class T>
+      struct is_bson_variant_binary : std::false_type
+      {};
+      template <class Bytes>
+      struct is_bson_variant_binary<bson::binary<Bytes>> : std::true_type
+      {};
+
+      template <class T>
+      struct is_bson_variant_uuid : std::bool_constant<std::same_as<std::remove_cvref_t<T>, uuid>>
+      {};
+
+      template <class T>
+      struct is_bson_variant_object_id : std::bool_constant<std::same_as<std::remove_cvref_t<T>, bson::object_id>>
+      {};
+
+      template <class T>
+      struct is_bson_variant_datetime
+         : std::bool_constant<std::same_as<std::remove_cvref_t<T>, bson::datetime> ||
+                              std::same_as<std::remove_cvref_t<T>, std::chrono::system_clock::time_point>>
+      {};
+
+      template <class T>
+      struct is_bson_variant_timestamp : std::bool_constant<std::same_as<std::remove_cvref_t<T>, bson::timestamp>>
+      {};
+
+      template <class T>
+      struct is_bson_variant_regex : std::bool_constant<std::same_as<std::remove_cvref_t<T>, bson::regex>>
+      {};
+
+      template <class T>
+      struct is_bson_variant_javascript : std::bool_constant<std::same_as<std::remove_cvref_t<T>, bson::javascript>>
+      {};
+
+      template <class T>
+      struct is_bson_variant_decimal128 : std::bool_constant<std::same_as<std::remove_cvref_t<T>, bson::decimal128>>
+      {};
+
+      template <class T>
+      struct is_bson_variant_min_key : std::bool_constant<std::same_as<std::remove_cvref_t<T>, bson::min_key>>
+      {};
+
+      template <class T>
+      struct is_bson_variant_max_key : std::bool_constant<std::same_as<std::remove_cvref_t<T>, bson::max_key>>
+      {};
+
+      // True if T is one of the BSON helper types above. Used to exclude them
+      // from the generic document / array categories.
+      template <class T>
+      struct is_bson_helper_type
+         : std::bool_constant<is_bson_variant_binary<T>::value || is_bson_variant_uuid<T>::value ||
+                              is_bson_variant_object_id<T>::value || is_bson_variant_datetime<T>::value ||
+                              is_bson_variant_timestamp<T>::value || is_bson_variant_regex<T>::value ||
+                              is_bson_variant_javascript<T>::value || is_bson_variant_decimal128<T>::value ||
+                              is_bson_variant_min_key<T>::value || is_bson_variant_max_key<T>::value>
+      {};
+
+      // Matches reflected structs, reflectable aggregates, and string-keyed maps.
+      // Excludes arrays (which land in their own category), strings, and the BSON
+      // helper types (which are reflectable aggregates but have dedicated tags).
+      template <class T>
+      struct is_bson_variant_document
+         : std::bool_constant<(glaze_object_t<T> || reflectable<T> || writable_map_t<T>) && !writable_array_t<T> &&
+                              !str_t<T> && !is_bson_helper_type<T>::value>
+      {};
+
+      template <class T>
+      struct is_bson_variant_array : std::bool_constant<(writable_array_t<T> || glaze_array_t<T>) && !str_t<T> &&
+                                                        !writable_map_t<T> && !is_bson_helper_type<T>::value>
+      {};
+
+      // --- first_matching_index<V, Trait> : finds the first alternative index
+      // whose alternative type satisfies Trait, or std::variant_npos.
+      template <class Variant, template <class> class Trait>
+      struct first_matching_index_impl;
+
+      template <template <class> class Trait, class... Ts>
+      struct first_matching_index_impl<std::variant<Ts...>, Trait>
+      {
+         static constexpr size_t find()
+         {
+            size_t result = std::variant_npos;
+            size_t idx = 0;
+            ((Trait<std::remove_cvref_t<Ts>>::value && result == std::variant_npos ? (result = idx, ++idx) : ++idx),
+             ...);
+            return result;
+         }
+         static constexpr size_t value = find();
+      };
+
+      template <class Variant, template <class> class Trait>
+      constexpr size_t first_matching_index_v = first_matching_index_impl<Variant, Trait>::value;
+
+      // --- auto-deducibility check: at most one alternative per category ----
+      template <is_variant T>
+      consteval bool variant_bson_auto_deducible()
+      {
+         constexpr auto N = std::variant_size_v<T>;
+         size_t nulls = 0, bools = 0, ints = 0, floats = 0, strings = 0, documents = 0, arrays = 0, binaries = 0,
+                uuids = 0, object_ids = 0, datetimes = 0, timestamps = 0, regexes = 0, javascripts = 0,
+                decimal128s = 0, min_keys = 0, max_keys = 0;
+         [&]<size_t... I>(std::index_sequence<I...>) {
+            (([&]<size_t Idx>() {
+                using V = std::remove_cvref_t<std::variant_alternative_t<Idx, T>>;
+                nulls += is_bson_variant_null<V>::value;
+                bools += is_bson_variant_bool<V>::value;
+                ints += is_bson_variant_int<V>::value;
+                floats += is_bson_variant_float<V>::value;
+                strings += is_bson_variant_string<V>::value;
+                documents += is_bson_variant_document<V>::value;
+                arrays += is_bson_variant_array<V>::value;
+                binaries += is_bson_variant_binary<V>::value;
+                uuids += is_bson_variant_uuid<V>::value;
+                object_ids += is_bson_variant_object_id<V>::value;
+                datetimes += is_bson_variant_datetime<V>::value;
+                timestamps += is_bson_variant_timestamp<V>::value;
+                regexes += is_bson_variant_regex<V>::value;
+                javascripts += is_bson_variant_javascript<V>::value;
+                decimal128s += is_bson_variant_decimal128<V>::value;
+                min_keys += is_bson_variant_min_key<V>::value;
+                max_keys += is_bson_variant_max_key<V>::value;
+             }.template operator()<I>()),
+             ...);
+         }(std::make_index_sequence<N>{});
+         // Binary wire tag 0x05 is shared between `binary<...>` and `uuid`;
+         // allow both in the same variant — the reader prefers `binary` when
+         // both are present because its reader accepts any subtype.
+         return nulls <= 1 && bools <= 1 && ints <= 1 && floats <= 1 && strings <= 1 && documents <= 1 &&
+                arrays <= 1 && binaries <= 1 && uuids <= 1 && object_ids <= 1 && datetimes <= 1 && timestamps <= 1 &&
+                regexes <= 1 && javascripts <= 1 && decimal128s <= 1 && min_keys <= 1 && max_keys <= 1;
+      }
+   } // namespace bson_detail
+
+   template <is_variant T>
+   struct from<BSON, T>
+   {
+      static_assert(bson_detail::variant_bson_auto_deducible<T>(),
+                    "BSON variant alternatives must be unique per BSON element category "
+                    "(at most one each of: null, bool, int, float, string, document, array, binary, "
+                    "uuid, object_id, datetime, timestamp, regex, javascript, decimal128, min_key, max_key).");
+
+      template <auto Opts, class It, class End>
+      static void op(T& value, uint8_t tag, is_context auto& ctx, It& it, const End& end) noexcept
+      {
+         using V = std::remove_cvref_t<T>;
+         constexpr size_t null_idx = bson_detail::first_matching_index_v<V, bson_detail::is_bson_variant_null>;
+         constexpr size_t bool_idx = bson_detail::first_matching_index_v<V, bson_detail::is_bson_variant_bool>;
+         constexpr size_t int_idx = bson_detail::first_matching_index_v<V, bson_detail::is_bson_variant_int>;
+         constexpr size_t float_idx = bson_detail::first_matching_index_v<V, bson_detail::is_bson_variant_float>;
+         constexpr size_t string_idx = bson_detail::first_matching_index_v<V, bson_detail::is_bson_variant_string>;
+         constexpr size_t document_idx = bson_detail::first_matching_index_v<V, bson_detail::is_bson_variant_document>;
+         constexpr size_t array_idx = bson_detail::first_matching_index_v<V, bson_detail::is_bson_variant_array>;
+         constexpr size_t binary_idx = bson_detail::first_matching_index_v<V, bson_detail::is_bson_variant_binary>;
+         constexpr size_t uuid_idx = bson_detail::first_matching_index_v<V, bson_detail::is_bson_variant_uuid>;
+         constexpr size_t object_id_idx =
+            bson_detail::first_matching_index_v<V, bson_detail::is_bson_variant_object_id>;
+         constexpr size_t datetime_idx = bson_detail::first_matching_index_v<V, bson_detail::is_bson_variant_datetime>;
+         constexpr size_t timestamp_idx =
+            bson_detail::first_matching_index_v<V, bson_detail::is_bson_variant_timestamp>;
+         constexpr size_t regex_idx = bson_detail::first_matching_index_v<V, bson_detail::is_bson_variant_regex>;
+         constexpr size_t javascript_idx =
+            bson_detail::first_matching_index_v<V, bson_detail::is_bson_variant_javascript>;
+         constexpr size_t decimal128_idx =
+            bson_detail::first_matching_index_v<V, bson_detail::is_bson_variant_decimal128>;
+         constexpr size_t min_key_idx = bson_detail::first_matching_index_v<V, bson_detail::is_bson_variant_min_key>;
+         constexpr size_t max_key_idx = bson_detail::first_matching_index_v<V, bson_detail::is_bson_variant_max_key>;
+
+         auto dispatch = [&]<size_t Idx>() {
+            if constexpr (Idx == std::variant_npos) {
+               ctx.error = error_code::no_matching_variant_type;
+            }
+            else {
+               using Alt = std::remove_cvref_t<std::variant_alternative_t<Idx, V>>;
+               if (value.index() != Idx) {
+                  emplace_runtime_variant(value, Idx);
+               }
+               from<BSON, Alt>::template op<Opts>(std::get<Idx>(value), tag, ctx, it, end);
+            }
+         };
+
+         switch (tag) {
+         case bson::type::null:
+            dispatch.template operator()<null_idx>();
+            return;
+         case bson::type::boolean:
+            dispatch.template operator()<bool_idx>();
+            return;
+         case bson::type::int32:
+         case bson::type::int64:
+            // Prefer int alternative; widen to float if the variant has only
+            // float, since the float reader accepts int tags.
+            if constexpr (int_idx != std::variant_npos) {
+               dispatch.template operator()<int_idx>();
+            }
+            else {
+               dispatch.template operator()<float_idx>();
+            }
+            return;
+         case bson::type::double_:
+            // No narrowing fallback: the int reader rejects double tags, so
+            // falling back would just yield syntax_error. A clean
+            // no_matching_variant_type is more informative.
+            dispatch.template operator()<float_idx>();
+            return;
+         case bson::type::string:
+            dispatch.template operator()<string_idx>();
+            return;
+         case bson::type::document:
+            dispatch.template operator()<document_idx>();
+            return;
+         case bson::type::array:
+            dispatch.template operator()<array_idx>();
+            return;
+         case bson::type::binary:
+            // `binary<...>` accepts any subtype and so takes priority when both
+            // are present. A lone `uuid` alternative still works because
+            // binary_idx is npos and we fall through.
+            if constexpr (binary_idx != std::variant_npos) {
+               dispatch.template operator()<binary_idx>();
+            }
+            else {
+               dispatch.template operator()<uuid_idx>();
+            }
+            return;
+         case bson::type::object_id:
+            dispatch.template operator()<object_id_idx>();
+            return;
+         case bson::type::datetime:
+            dispatch.template operator()<datetime_idx>();
+            return;
+         case bson::type::regex:
+            dispatch.template operator()<regex_idx>();
+            return;
+         case bson::type::javascript:
+            dispatch.template operator()<javascript_idx>();
+            return;
+         case bson::type::timestamp:
+            dispatch.template operator()<timestamp_idx>();
+            return;
+         case bson::type::decimal128:
+            dispatch.template operator()<decimal128_idx>();
+            return;
+         case bson::type::min_key:
+            dispatch.template operator()<min_key_idx>();
+            return;
+         case bson::type::max_key:
+            dispatch.template operator()<max_key_idx>();
+            return;
+         default:
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+      }
+   };
+
+   // ==========================================================================
+   // Document-family readers: struct, map, array, glaze_array_t.
+   //
+   // All four share the same wire framing — [int32 length][elements][0x00] —
+   // and differ only in how they route each element's value by key/index.
+   // ==========================================================================
+
+   namespace bson_detail
+   {
+      // Read the body of a BSON document whose outer [int32 length] has
+      // already been consumed. Calls `on_element(tag, key)` for each
+      // (tag, key) pair; the callback must consume the value bytes itself.
+      //
+      // A correctly-framed document ends with exactly one 0x00 byte at
+      // `stop - 1`. Two ways that can fail:
+      //   - terminator appears early (length field is larger than the body) →
+      //     we exit the loop via `tag == 0` with `it < stop`.
+      //   - terminator missing (declared length undercounts, or body is
+      //     corrupted so the terminator is consumed as part of an element) →
+      //     the loop exits via `it >= stop` without ever seeing a zero tag.
+      // Both surface as `syntax_error` with a specific custom message.
+      template <class It, class F>
+      bool read_document_elements(is_context auto& ctx, It& it, const It& stop, F&& on_element) noexcept
+      {
+         while (it < stop) {
+            const uint8_t tag = static_cast<uint8_t>(*it++);
+            if (tag == 0) {
+               if (it != stop) [[unlikely]] {
+                  ctx.error = error_code::syntax_error;
+                  ctx.custom_error_message = "document terminator before end of declared length";
+                  return false;
+               }
+               return true;
+            }
+            std::string_view key{};
+            if (!read_cstring(ctx, it, stop, key)) {
+               // Most plausible cause: no 0x00 terminator in the expected slot,
+               // so what we read as a tag was garbage and read_cstring ran off
+               // the end of the document looking for the key's null byte.
+               if (ctx.error == error_code::unexpected_end) {
+                  ctx.custom_error_message = "missing document terminator";
+               }
+               return false;
+            }
+            on_element(tag, key);
+            if (bool(ctx.error)) return false;
+         }
+         ctx.error = error_code::syntax_error;
+         ctx.custom_error_message = "missing document terminator";
+         return false;
+      }
+
+      template <auto Opts, class T, class It>
+      void read_struct_body(T& value, is_context auto& ctx, It& it, const It& stop)
+      {
+         using DT = std::remove_cvref_t<T>;
+         static constexpr auto N = reflect<DT>::size;
+
+         auto fields = [&]() -> decltype(auto) {
+            if constexpr (Opts.error_on_missing_keys) {
+               return bit_array<N>{};
+            }
+            else {
+               return nullptr;
+            }
+         }();
+
+         read_document_elements(ctx, it, stop, [&](uint8_t tag, std::string_view key) {
+            bool matched = false;
+            if constexpr (N > 0) {
+               static constexpr auto HashInfo = hash_info<DT>;
+               const auto index =
+                  decode_hash_with_size<BSON, DT, HashInfo, HashInfo.type>::op(key.data(), key.data() + key.size(),
+                                                                                key.size());
+               if (index < N) {
+                  visit<N>(
+                     [&]<size_t I>() {
+                        static constexpr auto TargetKey = get<I>(reflect<DT>::keys);
+                        static constexpr auto Length = TargetKey.size();
+                        if ((Length == key.size()) && compare<Length>(TargetKey.data(), key.data())) [[likely]] {
+                           matched = true;
+                           using MemberT = std::remove_cvref_t<field_t<DT, I>>;
+                           if constexpr (reflectable<DT>) {
+                              from<BSON, MemberT>::template op<Opts>(get_member(value, get<I>(to_tie(value))), tag, ctx,
+                                                                     it, stop);
+                           }
+                           else {
+                              from<BSON, MemberT>::template op<Opts>(
+                                 get_member(value, get<I>(reflect<DT>::values)), tag, ctx, it, stop);
+                           }
+                           if constexpr (Opts.error_on_missing_keys) {
+                              fields[I] = true;
+                           }
+                        }
+                     },
+                     index);
+               }
+            }
+            if (!matched) {
+               if constexpr (Opts.error_on_unknown_keys) {
+                  ctx.error = error_code::unknown_key;
+                  ctx.custom_error_message = key;
+                  return;
+               }
+               skip_value<BSON>::template op<Opts>(tag, ctx, it, stop);
+            }
+         });
+
+         if (bool(ctx.error)) return;
+
+         if constexpr (Opts.error_on_missing_keys) {
+            static constexpr auto req_fields = required_fields<DT, Opts>();
+            if ((req_fields & fields) != req_fields) {
+               for (size_t i = 0; i < N; ++i) {
+                  if (!fields[i] && req_fields[i]) {
+                     ctx.custom_error_message = reflect<DT>::keys[i];
+                     break;
+                  }
+               }
+               ctx.error = error_code::missing_key;
+            }
+         }
+      }
+   } // namespace bson_detail
+
+   // --- Reflected struct / glaze_object_t -----------------------------------
+   template <class T>
+      requires((glaze_object_t<T> || reflectable<T>) && !custom_read<T>)
+   struct from<BSON, T>
+   {
+      template <auto Opts, class It, class End>
+      static void op(auto& value, uint8_t tag, is_context auto& ctx, It& it, const End& end) noexcept
+      {
+         if (tag != bson::type::document) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         bson_detail::depth_guard guard{ctx};
+         if (!guard) return;
+         It stop{};
+         if (!bson_detail::read_document_stop(ctx, it, end, stop)) return;
+         bson_detail::read_struct_body<Opts, T>(value, ctx, it, stop);
+      }
+   };
+
+   // --- Map with string keys ------------------------------------------------
+   //
+   // BSON keys are cstrings; non-string map keys are unreachable on the wire,
+   // so reading into such a map is rejected at compile time to match the
+   // writer's static assertion.
+   template <writable_map_t T>
+   struct from<BSON, T>
+   {
+      template <auto Opts, class It, class End>
+      static void op(T& value, uint8_t tag, is_context auto& ctx, It& it, const End& end) noexcept
+      {
+         if (tag != bson::type::document) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         using key_t = typename T::key_type;
+         static_assert(str_t<key_t> || std::is_constructible_v<key_t, std::string_view>,
+                       "BSON map keys must be string-like");
+
+         bson_detail::depth_guard guard{ctx};
+         if (!guard) return;
+         It stop{};
+         if (!bson_detail::read_document_stop(ctx, it, end, stop)) return;
+
+         value.clear();
+
+         bson_detail::read_document_elements(ctx, it, stop, [&](uint8_t element_tag, std::string_view key) {
+            using V = typename T::mapped_type;
+            auto [iter, inserted] = value.try_emplace(key_t{key});
+            (void)inserted;
+            from<BSON, V>::template op<Opts>(iter->second, element_tag, ctx, it, stop);
+         });
+      }
+   };
+
+   // --- Arrays / vectors / ranges -------------------------------------------
+   //
+   // Encoded on the wire as a document with integer-string keys; the keys are
+   // not validated against the sequence order — matching MongoDB's tolerance
+   // for out-of-order arrays on the wire. Elements are appended in the order
+   // they appear in the document.
+   template <writable_array_t T>
+      requires(emplace_backable<T> || resizable<T> || has_size<T>)
+   struct from<BSON, T>
+   {
+      template <auto Opts, class It, class End>
+      static void op(T& value, uint8_t tag, is_context auto& ctx, It& it, const End& end) noexcept
+      {
+         if (tag != bson::type::array) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         bson_detail::depth_guard guard{ctx};
+         if (!guard) return;
+         It stop{};
+         if (!bson_detail::read_document_stop(ctx, it, end, stop)) return;
+
+         using V = range_value_t<T>;
+         if constexpr (emplace_backable<T>) {
+            value.clear();
+            bson_detail::read_document_elements(ctx, it, stop, [&](uint8_t element_tag, std::string_view /*key*/) {
+               value.emplace_back();
+               from<BSON, V>::template op<Opts>(value.back(), element_tag, ctx, it, stop);
+            });
+         }
+         else {
+            // Fixed-capacity container (e.g., std::array): fill by index.
+            size_t i = 0;
+            const size_t cap = value.size();
+            bson_detail::read_document_elements(ctx, it, stop, [&](uint8_t element_tag, std::string_view /*key*/) {
+               if (i >= cap) [[unlikely]] {
+                  ctx.error = error_code::exceeded_static_array_size;
+                  return;
+               }
+               from<BSON, V>::template op<Opts>(value[i], element_tag, ctx, it, stop);
+               ++i;
+            });
+         }
+      }
+   };
+
+   // --- glaze_array_t (tuple-like) ------------------------------------------
+   template <class T>
+      requires glaze_array_t<T>
+   struct from<BSON, T>
+   {
+      template <auto Opts, class It, class End>
+      static void op(auto& value, uint8_t tag, is_context auto& ctx, It& it, const End& end) noexcept
+      {
+         if (tag != bson::type::array) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         bson_detail::depth_guard guard{ctx};
+         if (!guard) return;
+         It stop{};
+         if (!bson_detail::read_document_stop(ctx, it, end, stop)) return;
+
+         static constexpr auto N = reflect<T>::size;
+         size_t i = 0;
+         bson_detail::read_document_elements(ctx, it, stop, [&](uint8_t element_tag, std::string_view /*key*/) {
+            if (i >= N) [[unlikely]] {
+               ctx.error = error_code::exceeded_static_array_size;
+               return;
+            }
+            visit<N>(
+               [&]<size_t I>() {
+                  using MemberT = std::remove_cvref_t<field_t<T, I>>;
+                  from<BSON, MemberT>::template op<Opts>(get_member(value, get<I>(reflect<T>::values)), element_tag, ctx,
+                                                        it, stop);
+               },
+               i);
+            ++i;
+         });
+      }
+   };
+
+   // ==========================================================================
+   // Public entry points
+   // ==========================================================================
+
+   template <class T>
+   concept bson_top_level_read_t = glaze_object_t<std::remove_cvref_t<T>> || reflectable<std::remove_cvref_t<T>> ||
+                                   writable_map_t<std::remove_cvref_t<T>> ||
+                                   writable_array_t<std::remove_cvref_t<T>> ||
+                                   glaze_array_t<std::remove_cvref_t<T>>;
+
+   // BSON documents are length-prefixed (int32 header = total bytes). The core
+   // reader consumes exactly that many bytes, but would otherwise silently
+   // ignore anything trailing the top-level document. Enforce exact-fill at the
+   // public boundary so truncation/concatenation bugs surface instead of being
+   // masked.
+   namespace bson_detail
+   {
+      template <class Buffer>
+      GLZ_ALWAYS_INLINE error_ctx enforce_exact_fill(const Buffer& buffer, error_ctx ec) noexcept
+      {
+         if (!ec && ec.count != buffer.size()) [[unlikely]] {
+            return {ec.count, error_code::syntax_error};
+         }
+         return ec;
+      }
+   }
+
+   template <auto Opts = opts{}, bson_top_level_read_t T, class Buffer>
+   [[nodiscard]] inline error_ctx read_bson(T&& value, Buffer&& buffer)
+   {
+      auto ec = read<set_bson<Opts>()>(std::forward<T>(value), buffer);
+      return bson_detail::enforce_exact_fill(buffer, ec);
+   }
+
+   template <class T, auto Opts = opts{}, class Buffer>
+      requires bson_top_level_read_t<T>
+   [[nodiscard]] inline expected<T, error_ctx> read_bson(Buffer&& buffer)
+   {
+      T value{};
+      auto ec = read<set_bson<Opts>()>(value, buffer);
+      ec = bson_detail::enforce_exact_fill(buffer, ec);
+      if (ec) [[unlikely]] {
+         return unexpected(ec);
+      }
+      return value;
+   }
+
+   template <auto Opts = opts{}, bson_top_level_read_t T>
+   [[nodiscard]] inline error_ctx read_file_bson(T& value, const sv file_name, auto&& buffer)
+   {
+      context ctx{};
+      ctx.current_file = file_name;
+      const auto file_error = file_to_buffer(buffer, ctx.current_file);
+      if (bool(file_error)) [[unlikely]] {
+         return error_ctx{0, file_error};
+      }
+      auto ec = read<set_bson<Opts>()>(value, buffer, ctx);
+      return bson_detail::enforce_exact_fill(buffer, ec);
+   }
+}

--- a/include/glaze/bson/read.hpp
+++ b/include/glaze/bson/read.hpp
@@ -1243,7 +1243,7 @@ namespace glz
       GLZ_ALWAYS_INLINE error_ctx enforce_exact_fill(const Buffer& buffer, error_ctx ec) noexcept
       {
          if (!ec && ec.count != buffer.size()) [[unlikely]] {
-            return {ec.count, error_code::syntax_error};
+            return {ec.count, error_code::syntax_error, "trailing bytes after document terminator"};
          }
          return ec;
       }

--- a/include/glaze/bson/read.hpp
+++ b/include/glaze/bson/read.hpp
@@ -371,6 +371,9 @@ namespace glz
             value.assign(sv.data(), sv.size());
          }
          else {
+            // Non-assignable targets (notably std::string_view) alias into
+            // the input buffer — the caller must keep the buffer alive as
+            // long as the view is used. See docs/bson.md "Strings".
             value = sv;
          }
       }

--- a/include/glaze/bson/skip.hpp
+++ b/include/glaze/bson/skip.hpp
@@ -1,0 +1,197 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include <bit>
+#include <cstdint>
+#include <cstring>
+
+#include "glaze/bson/header.hpp"
+#include "glaze/core/context.hpp"
+#include "glaze/core/opts.hpp"
+#include "glaze/util/inline.hpp"
+
+// Skip a single BSON value given its element type byte. Used by the struct
+// and map readers to drop over unknown keys, and by the deprecated-type
+// fallbacks (undefined / dbpointer / symbol / code_w_scope) that we can read
+// but choose not to materialise.
+
+namespace glz::bson_detail
+{
+   template <class It, class End>
+   GLZ_ALWAYS_INLINE bool skip_bytes(is_context auto& ctx, It& it, const End& end, size_t n) noexcept
+   {
+      if (static_cast<size_t>(end - it) < n) [[unlikely]] {
+         ctx.error = error_code::unexpected_end;
+         return false;
+      }
+      it += n;
+      return true;
+   }
+
+   // Read a little-endian int32 without advancing (used for length prefixes
+   // when the consumer needs the length before deciding what to do with the
+   // body).
+   template <class It, class End>
+   GLZ_ALWAYS_INLINE bool peek_le_int32(is_context auto& ctx, It it, const End& end, int32_t& out) noexcept
+   {
+      if ((end - it) < 4) [[unlikely]] {
+         ctx.error = error_code::unexpected_end;
+         return false;
+      }
+      int32_t v{};
+      std::memcpy(&v, it, 4);
+      if constexpr (std::endian::native == std::endian::big) {
+         v = static_cast<int32_t>(std::byteswap(static_cast<uint32_t>(v)));
+      }
+      out = v;
+      return true;
+   }
+
+   template <class It, class End>
+   GLZ_ALWAYS_INLINE bool read_le_int32(is_context auto& ctx, It& it, const End& end, int32_t& out) noexcept
+   {
+      if (!peek_le_int32(ctx, it, end, out)) [[unlikely]] {
+         return false;
+      }
+      it += 4;
+      return true;
+   }
+
+   // Advance `it` past a null-terminated cstring. On success, it points just
+   // past the 0x00 terminator.
+   template <class It, class End>
+   GLZ_ALWAYS_INLINE bool skip_cstring(is_context auto& ctx, It& it, const End& end) noexcept
+   {
+      while (it < end) {
+         if (*it == 0) {
+            ++it;
+            return true;
+         }
+         ++it;
+      }
+      ctx.error = error_code::unexpected_end;
+      return false;
+   }
+}
+
+namespace glz
+{
+   // BSON skip: the type byte is supplied by the caller (the document/array
+   // reader) because BSON values do not carry a self-describing header — the
+   // element tag lives outside the value.
+   template <>
+   struct skip_value<BSON>
+   {
+      template <auto Opts, class It, class End>
+      static void op(uint8_t type_byte, is_context auto& ctx, It& it, const End& end) noexcept
+      {
+         using namespace bson;
+         switch (type_byte) {
+         case type::null:
+         case type::undefined:
+         case type::min_key:
+         case type::max_key:
+            return;
+
+         case type::boolean:
+            (void)bson_detail::skip_bytes(ctx, it, end, 1);
+            return;
+
+         case type::int32:
+            (void)bson_detail::skip_bytes(ctx, it, end, 4);
+            return;
+
+         case type::double_:
+         case type::datetime:
+         case type::timestamp:
+         case type::int64:
+            (void)bson_detail::skip_bytes(ctx, it, end, 8);
+            return;
+
+         case type::object_id:
+            (void)bson_detail::skip_bytes(ctx, it, end, 12);
+            return;
+
+         case type::decimal128:
+            (void)bson_detail::skip_bytes(ctx, it, end, 16);
+            return;
+
+         case type::string:
+         case type::javascript:
+         case type::symbol: {
+            int32_t len{};
+            if (!bson_detail::read_le_int32(ctx, it, end, len)) return;
+            if (len < 1) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            (void)bson_detail::skip_bytes(ctx, it, end, static_cast<size_t>(len));
+            return;
+         }
+
+         case type::document:
+         case type::array: {
+            // The length prefix *includes* itself. Skip the rest, plus
+            // the trailing null byte that the prefix already accounts for.
+            int32_t len{};
+            if (!bson_detail::peek_le_int32(ctx, it, end, len)) return;
+            if (len < 5) [[unlikely]] {
+               // Minimum: 4-byte length + 0x00 terminator.
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            (void)bson_detail::skip_bytes(ctx, it, end, static_cast<size_t>(len));
+            return;
+         }
+
+         case type::binary: {
+            int32_t len{};
+            if (!bson_detail::read_le_int32(ctx, it, end, len)) return;
+            if (len < 0) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            // One-byte subtype follows, then `len` payload bytes.
+            (void)bson_detail::skip_bytes(ctx, it, end, 1 + static_cast<size_t>(len));
+            return;
+         }
+
+         case type::regex:
+            if (!bson_detail::skip_cstring(ctx, it, end)) return;
+            if (!bson_detail::skip_cstring(ctx, it, end)) return;
+            return;
+
+         case type::db_pointer: {
+            // String (length-prefixed UTF-8 + null) + 12-byte ObjectId.
+            int32_t len{};
+            if (!bson_detail::read_le_int32(ctx, it, end, len)) return;
+            if (len < 1) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            if (!bson_detail::skip_bytes(ctx, it, end, static_cast<size_t>(len) + 12)) return;
+            return;
+         }
+
+         case type::code_w_scope: {
+            // Total int32 length includes itself, the string, and the scope
+            // document. Skip the whole thing in one go.
+            int32_t len{};
+            if (!bson_detail::peek_le_int32(ctx, it, end, len)) return;
+            if (len < 4) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            (void)bson_detail::skip_bytes(ctx, it, end, static_cast<size_t>(len));
+            return;
+         }
+
+         default:
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+      }
+   };
+}

--- a/include/glaze/bson/write.hpp
+++ b/include/glaze/bson/write.hpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <array>
 #include <bit>
-#include <cassert>
 #include <charconv>
 #include <chrono>
 #include <cstdint>
@@ -44,10 +43,10 @@
 //   - std::map<std::string, T> keys
 //   - bson::regex::pattern and bson::regex::options
 // Strings passed in these fields must not contain an embedded NUL; otherwise
-// the resulting wire bytes are malformed (the reader will terminate the
-// cstring at the first NUL and misinterpret subsequent bytes). Struct field
-// names are compile-time safe. Debug builds assert on this; release builds
-// trust the caller for zero write-path overhead.
+// the resulting wire bytes are malformed and a downstream read will terminate
+// the cstring at the first NUL and fail with a syntax_error when the trailing
+// bytes no longer parse as a valid element stream. Struct field names are
+// safe by construction — they come from reflected identifiers.
 //
 // Caveat on nested optionals: std::optional<std::optional<T>> loses the
 // outer/inner distinction on the wire. Both `nullopt` and `optional{nullopt}`
@@ -147,8 +146,6 @@ namespace glz
       GLZ_ALWAYS_INLINE bool write_element_prefix(is_context auto& ctx, uint8_t type_byte, std::string_view key, B& b,
                                                   size_t& ix) noexcept
       {
-         assert(std::memchr(key.data(), 0, key.size()) == nullptr &&
-                "BSON cstring key must not contain embedded NUL");
          if (!ensure_space(ctx, b, ix + 2 + key.size() + write_padding_bytes)) [[unlikely]] {
             return false;
          }
@@ -355,9 +352,14 @@ namespace glz
 
    // --- Enums ----------------------------------------------------------------
    //
-   // Serialized as their underlying integer. Glaze-reflected enum names are
-   // only emitted when `reflect_enums` is on — not applicable for BSON v1,
-   // which has no string enum convention on the wire.
+   // Always emitted as the underlying integer. `Opts.reflect_enums` is
+   // intentionally not honored — JSON (which does honor it and emits the
+   // reflected name as a string) and BSON will therefore produce different
+   // wire shapes from the same shared `opts`. This is a deliberate interop
+   // choice, not a spec constraint: BSON strings (type 0x02) can carry any
+   // UTF-8 name, but MongoDB and other driver ecosystems expect integer-
+   // backed enums on the wire, and emitting names here would silently
+   // break cross-driver round-trips.
    template <class T>
       requires(std::is_enum_v<T>)
    struct to<BSON, T>
@@ -452,10 +454,6 @@ namespace glz
       template <auto Opts>
       static void op(const bson::regex& value, is_context auto&& ctx, auto&& b, auto& ix) noexcept
       {
-         assert(std::memchr(value.pattern.data(), 0, value.pattern.size()) == nullptr &&
-                "BSON regex pattern is a cstring and must not contain embedded NUL");
-         assert(std::memchr(value.options.data(), 0, value.options.size()) == nullptr &&
-                "BSON regex options is a cstring and must not contain embedded NUL");
          if (!ensure_space(ctx, b, ix + value.pattern.size() + value.options.size() + 2 + write_padding_bytes))
             [[unlikely]] {
             return;

--- a/include/glaze/bson/write.hpp
+++ b/include/glaze/bson/write.hpp
@@ -1,0 +1,867 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cassert>
+#include <charconv>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <string_view>
+
+#include "glaze/bson/header.hpp"
+#include "glaze/core/buffer_traits.hpp"
+#include "glaze/core/opts.hpp"
+#include "glaze/core/reflect.hpp"
+#include "glaze/core/to.hpp"
+#include "glaze/core/write.hpp"
+#include "glaze/file/file_ops.hpp"
+#include "glaze/util/dump.hpp"
+#include "glaze/util/for_each.hpp"
+#include "glaze/util/uuid.hpp"
+
+// BSON writer — https://bsonspec.org/spec.html
+//
+// BSON's top-level container is always a document:
+//     int32 total_length | element* | 0x00
+// where `total_length` counts itself and the terminating null byte, and each
+// element is:
+//     type_byte | key cstring | value bytes
+//
+// Because the document length precedes its body, the writer reserves 4 bytes
+// up front, emits the body, emits the null terminator, then patches the
+// reserved slot with the computed length. Arrays are encoded as documents
+// whose keys are the decimal strings "0", "1", "2", ...
+//
+// All multi-byte integers and floats on the wire are little-endian.
+//
+// Caveat on cstring fields (BSON spec prohibits embedded 0x00):
+//   - std::map<std::string, T> keys
+//   - bson::regex::pattern and bson::regex::options
+// Strings passed in these fields must not contain an embedded NUL; otherwise
+// the resulting wire bytes are malformed (the reader will terminate the
+// cstring at the first NUL and misinterpret subsequent bytes). Struct field
+// names are compile-time safe. Debug builds assert on this; release builds
+// trust the caller for zero write-path overhead.
+//
+// Caveat on nested optionals: std::optional<std::optional<T>> loses the
+// outer/inner distinction on the wire. Both `nullopt` and `optional{nullopt}`
+// encode as a single null element, so reads cannot tell them apart. This is
+// inherent to the tagged-null encoding (same limitation in JSON, CBOR, etc.).
+
+namespace glz
+{
+   namespace bson_detail
+   {
+      // --- Little-endian byte writers -----------------------------------------
+      //
+      // On little-endian hosts (x86, ARM64) a std::memcpy of the native integer
+      // is already in wire order. On big-endian hosts we byteswap first.
+
+      template <std::integral T, class B>
+      GLZ_ALWAYS_INLINE void dump_le(T value, B& b, size_t& ix) noexcept
+      {
+         if constexpr (std::endian::native == std::endian::big) {
+            value = static_cast<T>(std::byteswap(static_cast<std::make_unsigned_t<T>>(value)));
+         }
+         std::memcpy(&b[ix], &value, sizeof(T));
+         ix += sizeof(T);
+      }
+
+      // Patch a little-endian integer into a previously reserved slot without
+      // advancing `pos`. Used to backfill document lengths.
+      template <std::integral T, class B>
+      GLZ_ALWAYS_INLINE void patch_le(T value, B& b, size_t pos) noexcept
+      {
+         if constexpr (std::endian::native == std::endian::big) {
+            value = static_cast<T>(std::byteswap(static_cast<std::make_unsigned_t<T>>(value)));
+         }
+         std::memcpy(&b[pos], &value, sizeof(T));
+      }
+
+      template <class B>
+      GLZ_ALWAYS_INLINE void dump_le_double(double value, B& b, size_t& ix) noexcept
+      {
+         const uint64_t bits = std::bit_cast<uint64_t>(value);
+         dump_le<uint64_t>(bits, b, ix);
+      }
+
+      // --- Raw byte writers ----------------------------------------------------
+
+      template <class B>
+      GLZ_ALWAYS_INLINE void put_byte(uint8_t byte, B& b, size_t& ix) noexcept
+      {
+         using V = typename std::decay_t<B>::value_type;
+         b[ix] = static_cast<V>(byte);
+         ++ix;
+      }
+
+      template <class B>
+      GLZ_ALWAYS_INLINE void put_bytes(const void* src, size_t n, B& b, size_t& ix) noexcept
+      {
+         if (n) {
+            std::memcpy(&b[ix], src, n);
+            ix += n;
+         }
+      }
+
+      // --- Document lifecycle --------------------------------------------------
+
+      // Reserve 4 bytes for the int32 length field and record the starting ix.
+      template <class B>
+      GLZ_ALWAYS_INLINE bool reserve_document_length(is_context auto& ctx, B& b, size_t& ix, size_t& start) noexcept
+      {
+         if (!ensure_space(ctx, b, ix + 4 + write_padding_bytes)) [[unlikely]] {
+            return false;
+         }
+         start = ix;
+         ix += 4;
+         return true;
+      }
+
+      // Emit the terminating null byte and backfill the int32 length.
+      template <class B>
+      GLZ_ALWAYS_INLINE bool finalize_document(is_context auto& ctx, B& b, size_t& ix, size_t start) noexcept
+      {
+         if (!ensure_space(ctx, b, ix + 1 + write_padding_bytes)) [[unlikely]] {
+            return false;
+         }
+         put_byte(0, b, ix);
+         const size_t total = ix - start;
+         if (total > static_cast<size_t>(std::numeric_limits<int32_t>::max())) [[unlikely]] {
+            ctx.error = error_code::invalid_length;
+            return false;
+         }
+         patch_le<int32_t>(static_cast<int32_t>(total), b, start);
+         return true;
+      }
+
+      // --- Element prefix: type_byte | key cstring | 0x00 ---------------------
+
+      template <class B>
+      GLZ_ALWAYS_INLINE bool write_element_prefix(is_context auto& ctx, uint8_t type_byte, std::string_view key, B& b,
+                                                  size_t& ix) noexcept
+      {
+         assert(std::memchr(key.data(), 0, key.size()) == nullptr &&
+                "BSON cstring key must not contain embedded NUL");
+         if (!ensure_space(ctx, b, ix + 2 + key.size() + write_padding_bytes)) [[unlikely]] {
+            return false;
+         }
+         put_byte(type_byte, b, ix);
+         put_bytes(key.data(), key.size(), b, ix);
+         put_byte(0, b, ix);
+         return true;
+      }
+
+      // --- BSON string value: int32(len+1) | UTF-8 | 0x00 ---------------------
+
+      template <class B>
+      GLZ_ALWAYS_INLINE bool dump_string_value(is_context auto& ctx, std::string_view str, B& b, size_t& ix) noexcept
+      {
+         // The length field stores byte count of the UTF-8 payload PLUS the
+         // trailing null byte, per spec.
+         if (str.size() > static_cast<size_t>(std::numeric_limits<int32_t>::max()) - 1) [[unlikely]] {
+            ctx.error = error_code::invalid_length;
+            return false;
+         }
+         if (!ensure_space(ctx, b, ix + 4 + str.size() + 1 + write_padding_bytes)) [[unlikely]] {
+            return false;
+         }
+         const int32_t len = static_cast<int32_t>(str.size() + 1);
+         dump_le<int32_t>(len, b, ix);
+         put_bytes(str.data(), str.size(), b, ix);
+         put_byte(0, b, ix);
+         return true;
+      }
+
+      // --- Array key emission: decimal string of index, null-terminated -------
+
+      // For small indices a static string table is used; larger indices fall
+      // back to std::to_chars. Each element is a null-terminated C string
+      // suitable for a BSON e_name. 1024 covers nearly all real-world array
+      // sizes at ~5KB of .rodata, keeping the hot path branch-free.
+      inline constexpr auto make_small_array_keys()
+      {
+         std::array<std::array<char, 5>, 1024> t{};
+         for (int i = 0; i < 1024; ++i) {
+            if (i < 10) {
+               t[i][0] = static_cast<char>('0' + i);
+               t[i][1] = '\0';
+            }
+            else if (i < 100) {
+               t[i][0] = static_cast<char>('0' + i / 10);
+               t[i][1] = static_cast<char>('0' + i % 10);
+               t[i][2] = '\0';
+            }
+            else if (i < 1000) {
+               t[i][0] = static_cast<char>('0' + i / 100);
+               t[i][1] = static_cast<char>('0' + (i / 10) % 10);
+               t[i][2] = static_cast<char>('0' + i % 10);
+               t[i][3] = '\0';
+            }
+            else {
+               t[i][0] = static_cast<char>('0' + i / 1000);
+               t[i][1] = static_cast<char>('0' + (i / 100) % 10);
+               t[i][2] = static_cast<char>('0' + (i / 10) % 10);
+               t[i][3] = static_cast<char>('0' + i % 10);
+               t[i][4] = '\0';
+            }
+         }
+         return t;
+      }
+
+      inline constexpr auto small_array_keys = make_small_array_keys();
+
+      // Returns the key bytes for the given index as a string_view over a
+      // caller-owned scratch buffer or the precomputed table. The returned
+      // string_view does not include the null terminator.
+      GLZ_ALWAYS_INLINE std::string_view array_key(size_t index, std::array<char, 24>& scratch) noexcept
+      {
+         if (index < small_array_keys.size()) {
+            const auto& entry = small_array_keys[index];
+            size_t n = 0;
+            while (entry[n] != '\0') ++n;
+            return std::string_view{entry.data(), n};
+         }
+         auto [end, ec] = std::to_chars(scratch.data(), scratch.data() + scratch.size(), index);
+         return std::string_view{scratch.data(), static_cast<size_t>(end - scratch.data())};
+      }
+
+      // --- Skip logic (ported from JSONB) ------------------------------------
+
+      template <class T, auto Opts, size_t I>
+      consteval bool should_skip_reflected_field()
+      {
+         using V = field_t<T, I>;
+         if constexpr (std::same_as<V, hidden> || std::same_as<V, skip>) {
+            return true;
+         }
+         else if constexpr (is_any_function_ptr<V>) {
+            return !check_write_function_pointers(Opts);
+         }
+         else {
+            return false;
+         }
+      }
+   } // namespace bson_detail
+
+   // Dispatcher — routes top-level writes through to<BSON, T>::op.
+   template <>
+   struct serialize<BSON>
+   {
+      template <auto Opts, class T, is_context Ctx, class B, class IX>
+      GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, B&& b, IX&& ix)
+      {
+         to<BSON, std::remove_cvref_t<T>>::template op<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx),
+                                                             std::forward<B>(b), std::forward<IX>(ix));
+      }
+   };
+
+   // ==========================================================================
+   // Value-only writers: to<BSON, T>::op writes just the value bytes (no type
+   // byte, no key). Each specialization also exposes a static constexpr
+   // `type_code` member giving the BSON element type byte for that T, which
+   // the enclosing document/array writer emits before the key and value.
+   //
+   // For types with runtime-varying type codes (std::optional, std::variant),
+   // `type_code` is not defined; the member-element helper dispatches those
+   // cases explicitly.
+   // ==========================================================================
+
+   // --- Boolean --------------------------------------------------------------
+   template <>
+   struct to<BSON, bool>
+   {
+      static constexpr uint8_t type_code = bson::type::boolean;
+
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(bool value, is_context auto&& ctx, auto&& b, auto& ix) noexcept
+      {
+         if (!ensure_space(ctx, b, ix + 1 + write_padding_bytes)) [[unlikely]] {
+            return;
+         }
+         bson_detail::put_byte(value ? 1 : 0, b, ix);
+      }
+   };
+
+   // --- Integers -------------------------------------------------------------
+   //
+   // BSON has two integer element types: int32 (0x10) and int64 (0x12). We pick
+   // based on the C++ type's range, not the runtime value, so the encoding is
+   // deterministic from the schema alone.
+   //
+   //   int8/int16/int32, uint8/uint16           → int32
+   //   uint32, int64, uint64                    → int64 (uint64 overflow → error)
+   //
+   // uint32 goes to int64 because UINT32_MAX exceeds INT32_MAX; emitting int32
+   // would silently truncate values in 2^31..2^32-1. This differs from the
+   // MongoDB shell default (NumberInt for anything 32-bit wide), so drivers or
+   // tools inspecting the wire output will see int64 where they may expect
+   // int32. The round-trip is lossless and the encoding stays type-driven.
+   template <class T>
+      requires(std::integral<T> && !std::same_as<T, bool>)
+   struct to<BSON, T>
+   {
+      static constexpr bool fits_int32 =
+         (sizeof(T) <= 2) || (sizeof(T) == 4 && std::is_signed_v<T>);
+      static constexpr uint8_t type_code = fits_int32 ? bson::type::int32 : bson::type::int64;
+
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(T value, is_context auto&& ctx, auto&& b, auto& ix) noexcept
+      {
+         if constexpr (fits_int32) {
+            if (!ensure_space(ctx, b, ix + 4 + write_padding_bytes)) [[unlikely]] {
+               return;
+            }
+            bson_detail::dump_le<int32_t>(static_cast<int32_t>(value), b, ix);
+         }
+         else {
+            if (!ensure_space(ctx, b, ix + 8 + write_padding_bytes)) [[unlikely]] {
+               return;
+            }
+            if constexpr (std::same_as<T, uint64_t>) {
+               if (value > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) [[unlikely]] {
+                  ctx.error = error_code::invalid_length;
+                  return;
+               }
+            }
+            bson_detail::dump_le<int64_t>(static_cast<int64_t>(value), b, ix);
+         }
+      }
+   };
+
+   // --- Floating point -------------------------------------------------------
+   //
+   // BSON has only `double` (type 0x01). `float` promotes without loss.
+   template <std::floating_point T>
+   struct to<BSON, T>
+   {
+      static constexpr uint8_t type_code = bson::type::double_;
+
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(T value, is_context auto&& ctx, auto&& b, auto& ix) noexcept
+      {
+         if (!ensure_space(ctx, b, ix + 8 + write_padding_bytes)) [[unlikely]] {
+            return;
+         }
+         bson_detail::dump_le_double(static_cast<double>(value), b, ix);
+      }
+   };
+
+   // --- Enums ----------------------------------------------------------------
+   //
+   // Serialized as their underlying integer. Glaze-reflected enum names are
+   // only emitted when `reflect_enums` is on — not applicable for BSON v1,
+   // which has no string enum convention on the wire.
+   template <class T>
+      requires(std::is_enum_v<T>)
+   struct to<BSON, T>
+   {
+      using U = std::underlying_type_t<T>;
+      static constexpr uint8_t type_code = to<BSON, U>::type_code;
+
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(T value, is_context auto&& ctx, auto&& b, auto& ix) noexcept
+      {
+         to<BSON, U>::template op<Opts>(static_cast<U>(value), ctx, b, ix);
+      }
+   };
+
+   // --- Strings --------------------------------------------------------------
+   //
+   // BSON string value layout: int32(byte_count + 1) | UTF-8 bytes | 0x00
+   template <str_t T>
+   struct to<BSON, T>
+   {
+      static constexpr uint8_t type_code = bson::type::string;
+
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& b, auto& ix) noexcept
+      {
+         const std::string_view str = [&]() -> std::string_view {
+            if constexpr (!char_array_t<T> && std::is_pointer_v<std::decay_t<decltype(value)>>) {
+               return value ? std::string_view{value} : std::string_view{};
+            }
+            else {
+               return std::string_view{value};
+            }
+         }();
+         (void)bson_detail::dump_string_value(ctx, str, b, ix);
+      }
+   };
+
+   // --- BSON-native helper types --------------------------------------------
+
+   template <>
+   struct to<BSON, bson::object_id>
+   {
+      static constexpr uint8_t type_code = bson::type::object_id;
+
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(const bson::object_id& value, is_context auto&& ctx, auto&& b, auto& ix) noexcept
+      {
+         if (!ensure_space(ctx, b, ix + 12 + write_padding_bytes)) [[unlikely]] {
+            return;
+         }
+         bson_detail::put_bytes(value.bytes.data(), 12, b, ix);
+      }
+   };
+
+   template <>
+   struct to<BSON, bson::datetime>
+   {
+      static constexpr uint8_t type_code = bson::type::datetime;
+
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(const bson::datetime& value, is_context auto&& ctx, auto&& b, auto& ix) noexcept
+      {
+         if (!ensure_space(ctx, b, ix + 8 + write_padding_bytes)) [[unlikely]] {
+            return;
+         }
+         bson_detail::dump_le<int64_t>(value.ms_since_epoch, b, ix);
+      }
+   };
+
+   template <>
+   struct to<BSON, bson::timestamp>
+   {
+      static constexpr uint8_t type_code = bson::type::timestamp;
+
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(const bson::timestamp& value, is_context auto&& ctx, auto&& b, auto& ix) noexcept
+      {
+         if (!ensure_space(ctx, b, ix + 8 + write_padding_bytes)) [[unlikely]] {
+            return;
+         }
+         // BSON timestamp wire format: low 32 bits = increment, high 32 bits = seconds.
+         bson_detail::dump_le<uint32_t>(value.increment, b, ix);
+         bson_detail::dump_le<uint32_t>(value.seconds, b, ix);
+      }
+   };
+
+   template <>
+   struct to<BSON, bson::regex>
+   {
+      static constexpr uint8_t type_code = bson::type::regex;
+
+      template <auto Opts>
+      static void op(const bson::regex& value, is_context auto&& ctx, auto&& b, auto& ix) noexcept
+      {
+         assert(std::memchr(value.pattern.data(), 0, value.pattern.size()) == nullptr &&
+                "BSON regex pattern is a cstring and must not contain embedded NUL");
+         assert(std::memchr(value.options.data(), 0, value.options.size()) == nullptr &&
+                "BSON regex options is a cstring and must not contain embedded NUL");
+         if (!ensure_space(ctx, b, ix + value.pattern.size() + value.options.size() + 2 + write_padding_bytes))
+            [[unlikely]] {
+            return;
+         }
+         bson_detail::put_bytes(value.pattern.data(), value.pattern.size(), b, ix);
+         bson_detail::put_byte(0, b, ix);
+         // BSON spec requires regex options be stored in alphabetical order.
+         // std::sort works on the raw buffer regardless of element type: char,
+         // uint8_t, and std::byte all expose ordering (std::byte via its scoped
+         // enum underlying_type, per C++20), which matches ASCII lex order.
+         const auto opts_start = ix;
+         bson_detail::put_bytes(value.options.data(), value.options.size(), b, ix);
+         std::sort(&b[opts_start], &b[ix]);
+         bson_detail::put_byte(0, b, ix);
+      }
+   };
+
+   template <>
+   struct to<BSON, bson::javascript>
+   {
+      static constexpr uint8_t type_code = bson::type::javascript;
+
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(const bson::javascript& value, is_context auto&& ctx, auto&& b,
+                                       auto& ix) noexcept
+      {
+         (void)bson_detail::dump_string_value(ctx, value.code, b, ix);
+      }
+   };
+
+   template <>
+   struct to<BSON, bson::decimal128>
+   {
+      static constexpr uint8_t type_code = bson::type::decimal128;
+
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(const bson::decimal128& value, is_context auto&& ctx, auto&& b,
+                                       auto& ix) noexcept
+      {
+         if (!ensure_space(ctx, b, ix + 16 + write_padding_bytes)) [[unlikely]] {
+            return;
+         }
+         bson_detail::put_bytes(value.bytes.data(), 16, b, ix);
+      }
+   };
+
+   template <>
+   struct to<BSON, bson::min_key>
+   {
+      static constexpr uint8_t type_code = bson::type::min_key;
+
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(const bson::min_key&, is_context auto&&, auto&&, auto&) noexcept
+      {
+         // min_key carries no value bytes.
+      }
+   };
+
+   template <>
+   struct to<BSON, bson::max_key>
+   {
+      static constexpr uint8_t type_code = bson::type::max_key;
+
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(const bson::max_key&, is_context auto&&, auto&&, auto&) noexcept
+      {
+         // max_key carries no value bytes.
+      }
+   };
+
+   // Binary payload: int32(size) | subtype_byte | bytes. The `Bytes` container
+   // is whatever the user chose (std::vector<std::byte>, std::string, etc.).
+   template <class Bytes>
+   struct to<BSON, bson::binary<Bytes>>
+   {
+      static constexpr uint8_t type_code = bson::type::binary;
+
+      template <auto Opts>
+      static void op(const bson::binary<Bytes>& value, is_context auto&& ctx, auto&& b, auto& ix) noexcept
+      {
+         const size_t n = value.data.size();
+         // Subtype 0x02 (binary_old) is spec-required to wrap the payload in
+         // a redundant inner int32 length, so its outer length is 4 + N.
+         const bool is_binary_old = value.subtype == bson::binary_subtype::binary_old;
+         const size_t cap = static_cast<size_t>(std::numeric_limits<int32_t>::max()) - (is_binary_old ? 4 : 0);
+         if (n > cap) [[unlikely]] {
+            ctx.error = error_code::invalid_length;
+            return;
+         }
+         const size_t extra = is_binary_old ? 4 : 0;
+         if (!ensure_space(ctx, b, ix + 5 + extra + n + write_padding_bytes)) [[unlikely]] {
+            return;
+         }
+         bson_detail::dump_le<int32_t>(static_cast<int32_t>(n + extra), b, ix);
+         bson_detail::put_byte(value.subtype, b, ix);
+         if (is_binary_old) {
+            bson_detail::dump_le<int32_t>(static_cast<int32_t>(n), b, ix);
+         }
+         if (n) {
+            bson_detail::put_bytes(value.data.data(), n, b, ix);
+         }
+      }
+   };
+
+   // --- glz::uuid → binary subtype 0x04 -------------------------------------
+   template <>
+   struct to<BSON, uuid>
+   {
+      static constexpr uint8_t type_code = bson::type::binary;
+
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(const uuid& value, is_context auto&& ctx, auto&& b, auto& ix) noexcept
+      {
+         if (!ensure_space(ctx, b, ix + 5 + 16 + write_padding_bytes)) [[unlikely]] {
+            return;
+         }
+         bson_detail::dump_le<int32_t>(16, b, ix);
+         bson_detail::put_byte(bson::binary_subtype::uuid, b, ix);
+         bson_detail::put_bytes(value.bytes.data(), 16, b, ix);
+      }
+   };
+
+   // --- std::chrono::system_clock::time_point → datetime --------------------
+   template <>
+   struct to<BSON, std::chrono::system_clock::time_point>
+   {
+      static constexpr uint8_t type_code = bson::type::datetime;
+
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(const std::chrono::system_clock::time_point& value, is_context auto&& ctx,
+                                       auto&& b, auto& ix) noexcept
+      {
+         if (!ensure_space(ctx, b, ix + 8 + write_padding_bytes)) [[unlikely]] {
+            return;
+         }
+         const auto ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(value.time_since_epoch()).count();
+         bson_detail::dump_le<int64_t>(static_cast<int64_t>(ms), b, ix);
+      }
+   };
+
+   // ==========================================================================
+   // Member-element writer: emits a complete (type_byte | key cstring | value)
+   // element for a named member of a document. Handles the runtime-dispatched
+   // cases (nullable/optional, variant) that `to<BSON, T>::type_code` cannot.
+   //
+   // Both the nullable and variant branches recurse back into this helper so
+   // alternatives that are themselves nullable, always_null_t, or nested
+   // variants resolve to a concrete (type_byte | value) pair. Only the final
+   // else-branch reads `to<BSON, DT>::type_code` directly.
+   // ==========================================================================
+   namespace bson_detail
+   {
+      template <auto Opts, class T, class B>
+      void write_member_element(std::string_view key, T&& value, is_context auto& ctx, B&& b, size_t& ix)
+      {
+         using DT = std::remove_cvref_t<T>;
+
+         if constexpr (always_null_t<DT>) {
+            (void)write_element_prefix(ctx, bson::type::null, key, b, ix);
+         }
+         else if constexpr (nullable_like<DT>) {
+            if (value) {
+               write_member_element<Opts>(key, *value, ctx, b, ix);
+            }
+            else {
+               (void)write_element_prefix(ctx, bson::type::null, key, b, ix);
+            }
+         }
+         else if constexpr (is_variant<DT>) {
+            std::visit([&](auto&& alt) { write_member_element<Opts>(key, alt, ctx, b, ix); },
+                       std::forward<T>(value));
+         }
+         else {
+            if (!write_element_prefix(ctx, to<BSON, DT>::type_code, key, b, ix)) [[unlikely]] {
+               return;
+            }
+            to<BSON, DT>::template op<Opts>(std::forward<T>(value), ctx, b, ix);
+         }
+      }
+
+      // Returns true iff the struct field at index I should be omitted from
+      // output under the given options (skip_null_members on an empty optional,
+      // skip_default_members on a default-valued field, etc.).
+      template <class T, auto Opts, size_t I, class Value, class Tie>
+      GLZ_ALWAYS_INLINE bool should_skip_field_runtime(const Value& value, [[maybe_unused]] const Tie& t) noexcept
+      {
+         using val_t = field_t<T, I>;
+
+         decltype(auto) member = [&]() -> decltype(auto) {
+            if constexpr (reflectable<T>) {
+               return get<I>(t);
+            }
+            else {
+               return get<I>(reflect<T>::values);
+            }
+         }();
+
+         if constexpr (Opts.skip_null_members && null_t<val_t>) {
+            if constexpr (always_null_t<val_t>) {
+               return true;
+            }
+            else if constexpr (nullable_value_t<val_t>) {
+               if (!get_member(value, member).has_value()) return true;
+            }
+            else {
+               if (!bool(get_member(value, member))) return true;
+            }
+         }
+         if constexpr (check_skip_default_members(Opts) && has_skippable_default<val_t>) {
+            if (is_default_value(get_member(value, member))) return true;
+         }
+         return false;
+      }
+   } // namespace bson_detail
+
+   // ==========================================================================
+   // Document writers — top-level or embedded. These write a full BSON
+   // document: [int32 length][elements...][0x00]. The enclosing element byte
+   // (0x03 for a struct/map, 0x04 for an array) is emitted by the caller in
+   // `write_member_element`.
+   // ==========================================================================
+
+   // --- Reflected struct / glaze_object_t -----------------------------------
+   template <class T>
+      requires((glaze_object_t<T> || reflectable<T>) && !custom_write<T>)
+   struct to<BSON, T>
+   {
+      static constexpr uint8_t type_code = bson::type::document;
+      static constexpr auto N = reflect<T>::size;
+
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& b, auto& ix) noexcept
+      {
+         size_t start{};
+         if (!bson_detail::reserve_document_length(ctx, b, ix, start)) [[unlikely]] {
+            return;
+         }
+
+         [[maybe_unused]] decltype(auto) t = [&]() -> decltype(auto) {
+            if constexpr (reflectable<T>) {
+               return to_tie(value);
+            }
+            else {
+               return nullptr;
+            }
+         }();
+
+         for_each<N>([&]<size_t I>() {
+            if (bool(ctx.error)) [[unlikely]] return;
+            if constexpr (bson_detail::should_skip_reflected_field<T, Opts, I>()) {
+               return;
+            }
+            else {
+               if (bson_detail::should_skip_field_runtime<T, Opts, I>(value, t)) return;
+
+               decltype(auto) member = [&]() -> decltype(auto) {
+                  if constexpr (reflectable<T>) {
+                     return get<I>(t);
+                  }
+                  else {
+                     return get<I>(reflect<T>::values);
+                  }
+               }();
+
+               static constexpr sv key = reflect<T>::keys[I];
+               bson_detail::write_member_element<Opts>(key, get_member(value, member), ctx, b, ix);
+            }
+         });
+
+         if (bool(ctx.error)) [[unlikely]] return;
+         (void)bson_detail::finalize_document(ctx, b, ix, start);
+      }
+   };
+
+   // --- Map with string keys ------------------------------------------------
+   //
+   // BSON keys are cstrings; non-string map keys are rejected at compile time
+   // to avoid silent loss of fidelity.
+   template <writable_map_t T>
+   struct to<BSON, T>
+   {
+      static constexpr uint8_t type_code = bson::type::document;
+
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& b, auto& ix) noexcept
+      {
+         using map_t = std::remove_cvref_t<decltype(value)>;
+         using key_t = typename map_t::key_type;
+         static_assert(str_t<key_t> || std::is_convertible_v<key_t, std::string_view>,
+                       "BSON map keys must be string-like (cstring on the wire)");
+
+         size_t start{};
+         if (!bson_detail::reserve_document_length(ctx, b, ix, start)) [[unlikely]] {
+            return;
+         }
+
+         using val_t = std::remove_cvref_t<detail::iterator_second_type<map_t>>;
+         constexpr bool may_skip = null_t<val_t> && Opts.skip_null_members;
+
+         for (auto&& [k, v] : value) {
+            if (bool(ctx.error)) [[unlikely]] return;
+            if constexpr (may_skip) {
+               if (skip_member<Opts>(v)) continue;
+            }
+            const std::string_view key_sv{k};
+            bson_detail::write_member_element<Opts>(key_sv, v, ctx, b, ix);
+         }
+
+         if (bool(ctx.error)) [[unlikely]] return;
+         (void)bson_detail::finalize_document(ctx, b, ix, start);
+      }
+   };
+
+   // --- Arrays / vectors / ranges -------------------------------------------
+   //
+   // Encoded as a BSON document whose keys are "0", "1", "2", ..., matching
+   // the MongoDB convention. The document framing is identical to a struct.
+   template <writable_array_t T>
+   struct to<BSON, T>
+   {
+      static constexpr uint8_t type_code = bson::type::array;
+
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& b, auto& ix) noexcept
+      {
+         size_t start{};
+         if (!bson_detail::reserve_document_length(ctx, b, ix, start)) [[unlikely]] {
+            return;
+         }
+
+         std::array<char, 24> scratch{};
+         size_t i = 0;
+         for (auto&& item : value) {
+            if (bool(ctx.error)) [[unlikely]] return;
+            const std::string_view key = bson_detail::array_key(i, scratch);
+            bson_detail::write_member_element<Opts>(key, item, ctx, b, ix);
+            ++i;
+         }
+
+         if (bool(ctx.error)) [[unlikely]] return;
+         (void)bson_detail::finalize_document(ctx, b, ix, start);
+      }
+   };
+
+   // --- glaze_array_t (tuple-like fixed array) ------------------------------
+   template <class T>
+      requires glaze_array_t<T>
+   struct to<BSON, T>
+   {
+      static constexpr uint8_t type_code = bson::type::array;
+      static constexpr auto N = reflect<T>::size;
+
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& b, auto& ix) noexcept
+      {
+         size_t start{};
+         if (!bson_detail::reserve_document_length(ctx, b, ix, start)) [[unlikely]] {
+            return;
+         }
+
+         std::array<char, 24> scratch{};
+         for_each<N>([&]<size_t I>() {
+            if (bool(ctx.error)) [[unlikely]] return;
+            const std::string_view key = bson_detail::array_key(I, scratch);
+            bson_detail::write_member_element<Opts>(key, get_member(value, get<I>(reflect<T>::values)), ctx, b, ix);
+         });
+
+         if (bool(ctx.error)) [[unlikely]] return;
+         (void)bson_detail::finalize_document(ctx, b, ix, start);
+      }
+   };
+
+   // ==========================================================================
+   // Public entry points
+   // ==========================================================================
+
+   // BSON's wire format requires the top-level value to be a document. Allow
+   // reflected structs, maps with string keys, sequence containers (encoded
+   // as integer-keyed documents), and glaze_array_t. Primitives are rejected
+   // at the call site — they have no valid BSON document encoding on their
+   // own.
+   template <class T>
+   concept bson_top_level_t = glaze_object_t<std::remove_cvref_t<T>> || reflectable<std::remove_cvref_t<T>> ||
+                              writable_map_t<std::remove_cvref_t<T>> || writable_array_t<std::remove_cvref_t<T>> ||
+                              glaze_array_t<std::remove_cvref_t<T>>;
+
+   template <auto Opts = opts{}, bson_top_level_t T, class Buffer>
+   [[nodiscard]] error_ctx write_bson(T&& value, Buffer&& buffer)
+   {
+      return write<set_bson<Opts>()>(std::forward<T>(value), std::forward<Buffer>(buffer));
+   }
+
+   template <auto Opts = opts{}, bson_top_level_t T>
+   [[nodiscard]] glz::expected<std::string, error_ctx> write_bson(T&& value)
+   {
+      return write<set_bson<Opts>()>(std::forward<T>(value));
+   }
+
+   template <auto Opts = opts{}, bson_top_level_t T>
+   [[nodiscard]] inline error_code write_file_bson(T&& value, const sv file_name, auto&& buffer)
+   {
+      const auto ec = write<set_bson<Opts>()>(std::forward<T>(value), buffer);
+      if (bool(ec)) [[unlikely]] {
+         return ec.ec;
+      }
+      return buffer_to_file(buffer, file_name);
+   }
+}

--- a/include/glaze/cbor/write.hpp
+++ b/include/glaze/cbor/write.hpp
@@ -561,11 +561,27 @@ namespace glz
       template <auto Opts>
       static void op(auto&& value, is_context auto&& ctx, auto&& b, auto& ix)
       {
-         if (!cbor_detail::encode_arg(ctx, cbor::major::map, value.size(), b, ix)) [[unlikely]] {
+         using map_t = std::remove_cvref_t<decltype(value)>;
+         using val_t = std::remove_cvref_t<detail::iterator_second_type<map_t>>;
+         constexpr bool may_skip = null_t<val_t> && Opts.skip_null_members;
+
+         size_t count = value.size();
+         if constexpr (may_skip) {
+            count = 0;
+            for (auto&& [k, v] : value) {
+               (void)k;
+               if (!skip_member<Opts>(v)) ++count;
+            }
+         }
+
+         if (!cbor_detail::encode_arg(ctx, cbor::major::map, count, b, ix)) [[unlikely]] {
             return;
          }
 
          for (auto&& [k, v] : value) {
+            if constexpr (may_skip) {
+               if (skip_member<Opts>(v)) continue;
+            }
             serialize<CBOR>::op<Opts>(k, ctx, b, ix);
             if (bool(ctx.error)) [[unlikely]]
                return;
@@ -1301,10 +1317,10 @@ namespace glz
 
    // ===== High-level write APIs =====
 
-   template <write_supported<CBOR> T, class Buffer>
+   template <auto Opts = opts{}, write_supported<CBOR> T, class Buffer>
    [[nodiscard]] error_ctx write_cbor(T&& value, Buffer&& buffer)
    {
-      return write<opts{.format = CBOR}>(std::forward<T>(value), std::forward<Buffer>(buffer));
+      return write<set_cbor<Opts>()>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
    template <auto Opts = opts{}, write_supported<CBOR> T>

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -21,6 +21,7 @@ namespace glz
    inline constexpr uint32_t BEVE = 1;
    inline constexpr uint32_t CBOR = 2; // RFC 8949 - Concise Binary Object Representation
    inline constexpr uint32_t JSONB = 3; // SQLite JSONB binary JSON format - https://sqlite.org/jsonb.html
+   inline constexpr uint32_t BSON = 4; // MongoDB BSON 1.1 - https://bsonspec.org/spec.html
    inline constexpr uint32_t JSON = 10;
    inline constexpr uint32_t JSON_PTR = 20;
    inline constexpr uint32_t MSGPACK = 30;
@@ -1432,6 +1433,14 @@ namespace glz
    {
       auto ret = Opts;
       ret.format = JSONB;
+      return ret;
+   }
+
+   template <auto Opts>
+   constexpr auto set_bson()
+   {
+      auto ret = Opts;
+      ret.format = BSON;
       return ret;
    }
 

--- a/include/glaze/jsonb/write.hpp
+++ b/include/glaze/jsonb/write.hpp
@@ -288,7 +288,14 @@ namespace glz
          }
          const size_t payload_start = ix;
 
+         using map_t = std::remove_cvref_t<decltype(value)>;
+         using val_t = std::remove_cvref_t<detail::iterator_second_type<map_t>>;
+         constexpr bool may_skip = null_t<val_t> && Opts.skip_null_members;
+
          for (auto&& [k, v] : value) {
+            if constexpr (may_skip) {
+               if (skip_member<Opts>(v)) continue;
+            }
             serialize<JSONB>::op<Opts>(k, ctx, b, ix);
             if (bool(ctx.error)) [[unlikely]]
                return;
@@ -711,10 +718,10 @@ namespace glz
 
    // ===== High-level write APIs =====
 
-   template <write_supported<JSONB> T, class Buffer>
+   template <auto Opts = opts{}, write_supported<JSONB> T, class Buffer>
    [[nodiscard]] error_ctx write_jsonb(T&& value, Buffer&& buffer)
    {
-      return write<opts{.format = JSONB}>(std::forward<T>(value), std::forward<Buffer>(buffer));
+      return write<set_jsonb<Opts>()>(std::forward<T>(value), std::forward<Buffer>(buffer));
    }
 
    template <auto Opts = opts{}, write_supported<JSONB> T>

--- a/include/glaze/msgpack/write.hpp
+++ b/include/glaze/msgpack/write.hpp
@@ -692,12 +692,27 @@ namespace glz
       template <auto Opts, class Value, is_context Ctx, class B, class IX>
       GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, B&& b, IX&& ix)
       {
-         if (!msgpack::detail::write_map_header(ctx, value.size(), b, ix)) [[unlikely]] {
+         using map_t = std::remove_cvref_t<Value>;
+         using val_t = std::remove_cvref_t<detail::iterator_second_type<map_t>>;
+         constexpr bool may_skip = null_t<val_t> && Opts.skip_null_members;
+
+         size_t count = value.size();
+         if constexpr (may_skip) {
+            count = 0;
+            for (auto&& item : value) {
+               if (!skip_member<Opts>(item.second)) ++count;
+            }
+         }
+
+         if (!msgpack::detail::write_map_header(ctx, count, b, ix)) [[unlikely]] {
             return;
          }
          for (auto&& item : value) {
             if (bool(ctx.error)) [[unlikely]] {
                return;
+            }
+            if constexpr (may_skip) {
+               if (skip_member<Opts>(item.second)) continue;
             }
             serialize<MSGPACK>::op<Opts>(item.first, ctx, b, ix);
             serialize<MSGPACK>::op<Opts>(item.second, ctx, b, ix);

--- a/include/glaze/util/uuid.hpp
+++ b/include/glaze/util/uuid.hpp
@@ -1,0 +1,118 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include <array>
+#include <compare>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <string_view>
+
+#include "glaze/util/inline.hpp"
+
+namespace glz
+{
+   // A 16-byte universally unique identifier (RFC 9562 / RFC 4122).
+   //
+   // Byte order is the canonical RFC 9562 big-endian layout used by the
+   // 36-character textual form (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) and
+   // by BSON binary subtype 0x04. bytes[0] is the most significant byte of
+   // the first hex group; bytes[15] is the last byte of the final group.
+   struct uuid
+   {
+      std::array<uint8_t, 16> bytes{};
+
+      [[nodiscard]] constexpr bool operator==(const uuid&) const noexcept = default;
+      [[nodiscard]] constexpr auto operator<=>(const uuid&) const noexcept = default;
+
+      [[nodiscard]] constexpr bool is_nil() const noexcept
+      {
+         for (auto b : bytes) {
+            if (b != 0) return false;
+         }
+         return true;
+      }
+   };
+
+   namespace detail
+   {
+      [[nodiscard]] constexpr int uuid_hex_nibble(char c) noexcept
+      {
+         if (c >= '0' && c <= '9') return c - '0';
+         if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+         if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+         return -1;
+      }
+
+      // Offsets into a 36-character canonical UUID string for each of the 16
+      // bytes. The 4-2-2-2-6 byte groups are separated by hyphens at positions
+      // 8, 13, 18, 23.
+      inline constexpr std::array<uint8_t, 16> uuid_byte_offsets{
+         0, 2, 4, 6, 9, 11, 14, 16, 19, 21, 24, 26, 28, 30, 32, 34};
+   }
+
+   // Write the 36-character canonical form of `u` into `out`. The caller must
+   // provide at least 36 writable bytes. No null terminator is appended.
+   GLZ_ALWAYS_INLINE constexpr void format_uuid(const uuid& u, char* out) noexcept
+   {
+      constexpr char hex[] = "0123456789abcdef";
+      size_t byte_idx = 0;
+      size_t out_idx = 0;
+      constexpr int group_sizes[5] = {4, 2, 2, 2, 6};
+      for (int g = 0; g < 5; ++g) {
+         if (g > 0) {
+            out[out_idx++] = '-';
+         }
+         for (int i = 0; i < group_sizes[g]; ++i) {
+            const uint8_t b = u.bytes[byte_idx++];
+            out[out_idx++] = hex[(b >> 4) & 0xF];
+            out[out_idx++] = hex[b & 0xF];
+         }
+      }
+   }
+
+   [[nodiscard]] inline std::string to_string(const uuid& u)
+   {
+      std::string s(36, '\0');
+      format_uuid(u, s.data());
+      return s;
+   }
+
+   // Parse a 36-character canonical hyphenated UUID string. Accepts upper- or
+   // lower-case hex digits. Returns true on success and writes the result to
+   // `out`; returns false on malformed input, leaving `out` unmodified.
+   [[nodiscard]] constexpr bool parse_uuid(std::string_view s, uuid& out) noexcept
+   {
+      if (s.size() != 36) return false;
+      if (s[8] != '-' || s[13] != '-' || s[18] != '-' || s[23] != '-') return false;
+
+      std::array<uint8_t, 16> result{};
+      for (size_t i = 0; i < 16; ++i) {
+         const size_t pos = detail::uuid_byte_offsets[i];
+         const int hi = detail::uuid_hex_nibble(s[pos]);
+         const int lo = detail::uuid_hex_nibble(s[pos + 1]);
+         if (hi < 0 || lo < 0) return false;
+         result[i] = static_cast<uint8_t>((hi << 4) | lo);
+      }
+      out.bytes = result;
+      return true;
+   }
+}
+
+template <>
+struct std::hash<glz::uuid>
+{
+   [[nodiscard]] size_t operator()(const glz::uuid& u) const noexcept
+   {
+      // FNV-1a over the 16 bytes. Deterministic and allocation-free.
+      size_t h = 14695981039346656037ULL;
+      for (auto b : u.bytes) {
+         h ^= b;
+         h *= 1099511628211ULL;
+      }
+      return h;
+   }
+};

--- a/include/glaze/util/uuid.hpp
+++ b/include/glaze/util/uuid.hpp
@@ -107,12 +107,24 @@ struct std::hash<glz::uuid>
 {
    [[nodiscard]] size_t operator()(const glz::uuid& u) const noexcept
    {
-      // FNV-1a over the 16 bytes. Deterministic and allocation-free.
-      size_t h = 14695981039346656037ULL;
-      for (auto b : u.bytes) {
-         h ^= b;
-         h *= 1099511628211ULL;
+      // FNV-1a over the 16 bytes. Deterministic and allocation-free. The
+      // offset basis and prime are width-specific so this compiles cleanly on
+      // 32-bit platforms where size_t is 32 bits.
+      if constexpr (sizeof(size_t) >= 8) {
+         uint64_t h = 14695981039346656037ULL;
+         for (auto b : u.bytes) {
+            h ^= b;
+            h *= 1099511628211ULL;
+         }
+         return static_cast<size_t>(h);
       }
-      return h;
+      else {
+         uint32_t h = 2166136261u;
+         for (auto b : u.bytes) {
+            h ^= b;
+            h *= 16777619u;
+         }
+         return static_cast<size_t>(h);
+      }
    }
 };

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
  - Formats:
    - JSON: json.md
    - BEVE (binary): binary.md
+   - BSON: bson.md
    - CBOR: cbor.md
    - JSONB: jsonb.md
    - CSV: csv.md

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -117,6 +117,7 @@ endif()
 
 add_subdirectory(api_test)
 add_subdirectory(beve_test)
+add_subdirectory(bson_test)
 add_subdirectory(cbor_test)
 add_subdirectory(jsonb_test)
 add_subdirectory(jsonb_sqlite_test)

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -784,6 +784,30 @@ void write_tests()
       }
    };
 
+   "map_skips_empty_optional_by_default"_test = [] {
+      std::map<std::string, std::optional<int>> in{{"a", 1}, {"b", std::nullopt}, {"c", 3}};
+      std::string buf;
+      expect(not glz::write_beve(in, buf));
+      std::map<std::string, std::optional<int>> out{};
+      expect(not glz::read_beve(out, buf));
+      expect(out.size() == 2);
+      expect(out.count("b") == 0);
+      expect(out.at("a").value() == 1);
+      expect(out.at("c").value() == 3);
+   };
+
+   "map_preserves_nulls_when_skip_disabled"_test = [] {
+      constexpr auto preserve = glz::opts{.format = glz::BEVE, .skip_null_members = false};
+      std::map<std::string, std::optional<int>> in{{"a", 1}, {"b", std::nullopt}};
+      std::string buf;
+      expect(not glz::write<preserve>(in, buf));
+      std::map<std::string, std::optional<int>> out{};
+      expect(not glz::read<preserve>(out, buf));
+      expect(out.size() == 2);
+      expect(out.at("a").value() == 1);
+      expect(!out.at("b").has_value());
+   };
+
    "enum"_test = [] {
       Color color = Color::Green;
       std::string buffer{};

--- a/tests/bson_test/CMakeLists.txt
+++ b/tests/bson_test/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(bson_test)
+
+add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE glz_test_common)
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
+
+target_code_coverage(${PROJECT_NAME} AUTO ALL)

--- a/tests/bson_test/bson_test.cpp
+++ b/tests/bson_test/bson_test.cpp
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
+#include <limits>
 #include <map>
 #include <optional>
 #include <string>
@@ -336,7 +337,37 @@ namespace bson_test
       bool operator==(const deep_s&) const = default;
    };
 
+   // --- Types exercising glz::meta-annotated (non-aggregate) reflection ------
+
+   struct meta_renamed_s
+   {
+      int32_t id{};
+      std::string label{};
+      bool operator==(const meta_renamed_s&) const = default;
+   };
+
+   struct meta_nested_s
+   {
+      meta_renamed_s child{};
+      double value{};
+      bool operator==(const meta_nested_s&) const = default;
+   };
+
 } // namespace bson_test
+
+template <>
+struct glz::meta<bson_test::meta_renamed_s>
+{
+   using T = bson_test::meta_renamed_s;
+   static constexpr auto value = glz::object("identifier", &T::id, "display_name", &T::label);
+};
+
+template <>
+struct glz::meta<bson_test::meta_nested_s>
+{
+   using T = bson_test::meta_nested_s;
+   static constexpr auto value = glz::object("child", &T::child, "v", &T::value);
+};
 
 using namespace bson_test;
 
@@ -902,6 +933,27 @@ namespace
          auto ec = glz::read_bson(dst, std::string_view{w.value()});
          expect(ec.ec == glz::error_code::parse_number_failure);
       };
+
+      "uint64-write-above-int64-max-rejected"_test = [] {
+         // BSON's int64 wire type is signed; uint64_t values above INT64_MAX
+         // cannot be represented and must fail the write path with
+         // invalid_length (see write.hpp uint64_t range check).
+         u64_s src{static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1};
+         auto w = glz::write_bson(src);
+         expect(not w.has_value());
+         expect(w.error().ec == glz::error_code::invalid_length);
+      };
+
+      "uint64-write-at-int64-max-ok"_test = [] {
+         // Boundary: INT64_MAX itself must write successfully.
+         u64_s src{static_cast<uint64_t>(std::numeric_limits<int64_t>::max())};
+         auto w = glz::write_bson(src);
+         expect(w.has_value());
+         u64_s dst{};
+         auto ec = glz::read_bson(dst, std::string_view{w.value()});
+         expect(not ec);
+         expect(dst.x == src.x);
+      };
    };
 
    suite bson_unknown_key_tests = [] {
@@ -1283,6 +1335,33 @@ namespace
          monostate_field_s out{};
          expect(not glz::read_bson(out, buf));
          expect(out.x == 99);
+      };
+   };
+
+   // ===========================================================================
+   // glz::meta-annotated (non-aggregate) struct reflection.
+   // Exercises the reflect<T>::keys path where keys come from the meta
+   // specialization rather than aggregate member-name extraction.
+   // ===========================================================================
+   suite bson_meta_annotated_tests = [] {
+      "meta-renamed-keys-roundtrip"_test = [] {
+         expect_roundtrip_equal(meta_renamed_s{7, "alpha"});
+      };
+
+      "meta-renamed-keys-emit-mapped-names"_test = [] {
+         // Wire keys must come from the glz::meta declaration, not the
+         // C++ member names.
+         meta_renamed_s src{1, "x"};
+         auto w = glz::write_bson(src);
+         expect(w.has_value());
+         const auto& buf = w.value();
+         expect(buf.find("identifier") != std::string::npos);
+         expect(buf.find("display_name") != std::string::npos);
+      };
+
+      "meta-nested-struct-roundtrip"_test = [] {
+         // Nested glz::meta struct — inner and outer both use mapped keys.
+         expect_roundtrip_equal(meta_nested_s{meta_renamed_s{42, "beta"}, 3.14});
       };
    };
 

--- a/tests/bson_test/bson_test.cpp
+++ b/tests/bson_test/bson_test.cpp
@@ -1,0 +1,1531 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#include "glaze/bson.hpp"
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <map>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <variant>
+#include <vector>
+
+#include "ut/ut.hpp"
+
+using namespace ut;
+
+namespace bson_test
+{
+   // --- helpers -------------------------------------------------------------
+
+   // Compare a written BSON buffer against an expected byte sequence.
+   inline bool bytes_equal(const std::string& got, std::initializer_list<uint8_t> want)
+   {
+      if (got.size() != want.size()) return false;
+      size_t i = 0;
+      for (auto w : want) {
+         if (static_cast<uint8_t>(got[i++]) != w) return false;
+      }
+      return true;
+   }
+
+   template <class T>
+   inline void expect_roundtrip_equal(const T& original)
+   {
+      auto encoded = glz::write_bson(original);
+      if (!encoded) {
+         expect(false) << "write_bson failed: " << glz::format_error(encoded.error());
+         return;
+      }
+      T decoded{};
+      auto ec = glz::read_bson(decoded, std::string_view{encoded.value()});
+      if (ec) {
+         expect(false) << "read_bson failed: " << glz::format_error(ec, encoded.value());
+         return;
+      }
+      expect(decoded == original);
+   }
+
+   // --- test types (file-scope so reflection can see them) -----------------
+
+   struct hello_t
+   {
+      std::string hello{};
+      bool operator==(const hello_t&) const = default;
+   };
+
+   struct i32_s
+   {
+      int32_t x{};
+      bool operator==(const i32_s&) const = default;
+   };
+
+   struct i64_s
+   {
+      int64_t x{};
+      bool operator==(const i64_s&) const = default;
+   };
+
+   struct u32_s
+   {
+      uint32_t x{};
+      bool operator==(const u32_s&) const = default;
+   };
+
+   struct u64_s
+   {
+      uint64_t x{};
+      bool operator==(const u64_s&) const = default;
+   };
+
+   struct u8_s
+   {
+      uint8_t x{};
+      bool operator==(const u8_s&) const = default;
+   };
+
+   struct u16_s
+   {
+      uint16_t x{};
+      bool operator==(const u16_s&) const = default;
+   };
+
+   struct i8_s
+   {
+      int8_t x{};
+      bool operator==(const i8_s&) const = default;
+   };
+
+   struct bool_s
+   {
+      bool b{};
+      bool operator==(const bool_s&) const = default;
+   };
+
+   struct double_s
+   {
+      double d{};
+      bool operator==(const double_s&) const = default;
+   };
+
+   struct array_s
+   {
+      std::vector<int32_t> a{};
+      bool operator==(const array_s&) const = default;
+   };
+
+   struct fixed_array_s
+   {
+      std::array<int32_t, 3> a{};
+      bool operator==(const fixed_array_s&) const = default;
+   };
+
+   struct optional_s
+   {
+      std::optional<int32_t> o{};
+      bool operator==(const optional_s&) const = default;
+   };
+
+   struct inner_s
+   {
+      int32_t x{};
+      bool operator==(const inner_s&) const = default;
+   };
+
+   struct outer_s
+   {
+      inner_s inner{};
+      bool operator==(const outer_s&) const = default;
+   };
+
+   struct uuid_s
+   {
+      glz::uuid u{};
+      bool operator==(const uuid_s&) const = default;
+   };
+
+   struct time_s
+   {
+      std::chrono::system_clock::time_point t{};
+      bool operator==(const time_s&) const = default;
+   };
+
+   struct oid_s
+   {
+      glz::bson::object_id id{};
+      bool operator==(const oid_s&) const = default;
+   };
+
+   struct person_s
+   {
+      std::string name{};
+      int32_t age{};
+      bool operator==(const person_s&) const = default;
+   };
+
+   struct team_s
+   {
+      std::vector<person_s> members{};
+      bool operator==(const team_s&) const = default;
+   };
+
+   struct big_s
+   {
+      int32_t a{};
+      int32_t b{};
+      int32_t c{};
+   };
+
+   struct small_s
+   {
+      int32_t b{};
+   };
+
+   struct helpers_s
+   {
+      glz::bson::datetime when{};
+      glz::bson::timestamp ts{};
+      glz::bson::regex re{};
+      glz::bson::javascript js{};
+      glz::bson::decimal128 d128{};
+      glz::bson::min_key mn{};
+      glz::bson::max_key mx{};
+      glz::bson::binary<std::vector<std::byte>> blob{};
+
+      bool operator==(const helpers_s& other) const
+      {
+         return when == other.when && ts == other.ts && re == other.re && js == other.js && d128 == other.d128 &&
+                mn == other.mn && mx == other.mx && blob == other.blob;
+      }
+   };
+
+   // Variant types -----------------------------------------------------------
+
+   struct int_or_string_s
+   {
+      std::variant<int32_t, std::string> v{};
+      bool operator==(const int_or_string_s&) const = default;
+   };
+
+   struct maybe_int_s
+   {
+      std::variant<std::monostate, int32_t> v{};
+      bool operator==(const maybe_int_s&) const = default;
+   };
+
+   struct num_s
+   {
+      std::variant<int32_t, double> v{};
+      bool operator==(const num_s&) const = default;
+   };
+
+   struct scalar_or_array_s
+   {
+      std::variant<int32_t, std::vector<int32_t>> v{};
+      bool operator==(const scalar_or_array_s&) const = default;
+   };
+
+   struct id_or_time_s
+   {
+      std::variant<glz::bson::object_id, glz::bson::datetime> v{};
+      bool operator==(const id_or_time_s& other) const { return v == other.v; }
+   };
+
+   // --- Single-helper wrapper structs for byte-exact assertions -------------
+
+   struct oid_only_s
+   {
+      glz::bson::object_id id{};
+      bool operator==(const oid_only_s&) const = default;
+   };
+
+   struct regex_only_s
+   {
+      glz::bson::regex r{};
+      bool operator==(const regex_only_s&) const = default;
+   };
+
+   struct js_only_s
+   {
+      glz::bson::javascript j{};
+      bool operator==(const js_only_s&) const = default;
+   };
+
+   struct dec128_only_s
+   {
+      glz::bson::decimal128 d{};
+      bool operator==(const dec128_only_s&) const = default;
+   };
+
+   struct min_only_s
+   {
+      glz::bson::min_key mn{};
+      bool operator==(const min_only_s&) const = default;
+   };
+
+   struct max_only_s
+   {
+      glz::bson::max_key mx{};
+      bool operator==(const max_only_s&) const = default;
+   };
+
+   struct bin_only_s
+   {
+      glz::bson::binary<std::vector<std::byte>> b{};
+      bool operator==(const bin_only_s&) const = default;
+   };
+
+   // --- Types exercising monostate, nesting, required keys ------------------
+
+   struct monostate_field_s
+   {
+      std::monostate m{};
+      int32_t x{};
+
+      bool operator==(const monostate_field_s& other) const { return x == other.x; }
+   };
+
+   struct nested_vec_s
+   {
+      std::vector<std::vector<int32_t>> rows{};
+      bool operator==(const nested_vec_s&) const = default;
+   };
+
+   struct nested_opt_s
+   {
+      std::optional<std::optional<int32_t>> oo{};
+      bool operator==(const nested_opt_s&) const = default;
+   };
+
+   struct required_s
+   {
+      int32_t id{};
+      std::optional<int32_t> opt{};
+      bool operator==(const required_s&) const = default;
+   };
+
+   // --- Helpers for bson_to_json tests (namespace-scope so reflection works) -
+
+   struct prim_doc_s
+   {
+      int32_t a{};
+      int64_t b{};
+      double c{};
+      bool d{};
+      std::string e{};
+   };
+
+   struct dt_field_s
+   {
+      glz::bson::datetime when{};
+   };
+
+   struct ts_field_s
+   {
+      glz::bson::timestamp ts{};
+   };
+
+   struct deep_s
+   {
+      std::optional<std::string> a{};
+      bool operator==(const deep_s&) const = default;
+   };
+
+} // namespace bson_test
+
+using namespace bson_test;
+
+namespace
+{
+   suite bson_interop_tests = [] {
+      "spec-canonical-hello-world"_test = [] {
+         // {"hello": "world"} — the canonical example from bsonspec.org.
+         static constexpr std::initializer_list<uint8_t> expected = {
+            0x16, 0x00, 0x00, 0x00,                 //
+            0x02, 'h', 'e', 'l', 'l', 'o', 0x00,    //
+            0x06, 0x00, 0x00, 0x00,                 //
+            'w', 'o', 'r', 'l', 'd', 0x00,          //
+            0x00                                    //
+         };
+         hello_t h{"world"};
+         auto w = glz::write_bson(h);
+         expect(w.has_value());
+         expect(bytes_equal(w.value(), expected));
+      };
+
+      "int32-bytes"_test = [] {
+         i32_s v{42};
+         auto w = glz::write_bson(v);
+         expect(w.has_value());
+         expect(bytes_equal(w.value(),
+                            {0x0C, 0x00, 0x00, 0x00, 0x10, 'x', 0x00, 0x2A, 0x00, 0x00, 0x00, 0x00}));
+      };
+
+      "int64-bytes"_test = [] {
+         i64_s v{1000000000000LL};
+         auto w = glz::write_bson(v);
+         expect(w.has_value());
+         expect(bytes_equal(w.value(), {0x10, 0x00, 0x00, 0x00, 0x12, 'x', 0x00, 0x00, 0x10, 0xA5, 0xD4, 0xE8,
+                                        0x00, 0x00, 0x00, 0x00}));
+      };
+
+      "double-bytes"_test = [] {
+         double_s v{1.5};
+         auto w = glz::write_bson(v);
+         expect(w.has_value());
+         // 1.5 as IEEE 754 double → 0x3FF8000000000000, little-endian.
+         expect(bytes_equal(w.value(), {0x10, 0x00, 0x00, 0x00, 0x01, 'd', 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                        0x00, 0xF8, 0x3F, 0x00}));
+      };
+
+      "bool-bytes"_test = [] {
+         bool_s v{true};
+         auto w = glz::write_bson(v);
+         expect(w.has_value());
+         expect(bytes_equal(w.value(), {0x09, 0x00, 0x00, 0x00, 0x08, 'b', 0x00, 0x01, 0x00}));
+      };
+
+      "array-bytes"_test = [] {
+         array_s v{{1, 2}};
+         auto w = glz::write_bson(v);
+         expect(w.has_value());
+         expect(bytes_equal(w.value(), {0x1B, 0x00, 0x00, 0x00,                                   //
+                                        0x04, 'a', 0x00,                                          //
+                                        0x13, 0x00, 0x00, 0x00,                                   //
+                                        0x10, '0', 0x00, 0x01, 0x00, 0x00, 0x00,                  //
+                                        0x10, '1', 0x00, 0x02, 0x00, 0x00, 0x00,                  //
+                                        0x00,                                                     //
+                                        0x00}));
+      };
+
+      "optional-full-bytes"_test = [] {
+         optional_s v{42};
+         auto w = glz::write_bson(v);
+         expect(w.has_value());
+         expect(bytes_equal(w.value(),
+                            {0x0C, 0x00, 0x00, 0x00, 0x10, 'o', 0x00, 0x2A, 0x00, 0x00, 0x00, 0x00}));
+      };
+
+      "optional-empty-skips-key"_test = [] {
+         // Default skip_null_members=true, so absent optional leaves only the
+         // empty 5-byte document.
+         optional_s v{};
+         auto w = glz::write_bson(v);
+         expect(w.has_value());
+         expect(bytes_equal(w.value(), {0x05, 0x00, 0x00, 0x00, 0x00}));
+      };
+
+      "uuid-binary-subtype-04"_test = [] {
+         uuid_s v{};
+         expect(glz::parse_uuid("00112233-4455-6677-8899-aabbccddeeff", v.u));
+         auto w = glz::write_bson(v);
+         expect(w.has_value());
+         expect(bytes_equal(w.value(), {0x1D, 0x00, 0x00, 0x00,                                      //
+                                        0x05, 'u', 0x00,                                             //
+                                        0x10, 0x00, 0x00, 0x00, 0x04,                                //
+                                        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,  //
+                                        0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,                          //
+                                        0x00}));
+      };
+
+      "uuid-legacy-subtype-03-rejected"_test = [] {
+         // Subtype 0x03 is ambiguous — Java, C#, and Python drivers all laid
+         // the bytes out differently. Reading without the flavor would silently
+         // scramble the UUID, so Glaze rejects it outright.
+         static constexpr uint8_t buf[] = {0x1D, 0x00, 0x00, 0x00, //
+                                           0x05, 'u', 0x00,        //
+                                           0x10, 0x00, 0x00, 0x00, 0x03, //
+                                           0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
+                                           0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,  //
+                                           0x00};
+         uuid_s r{};
+         auto ec = glz::read_bson(r, std::string_view{reinterpret_cast<const char*>(buf), sizeof(buf)});
+         expect(bool(ec));
+         expect(ec.ec == glz::error_code::syntax_error);
+      };
+
+      "object-id-bytes"_test = [] {
+         oid_only_s v{};
+         for (uint8_t i = 0; i < 12; ++i) v.id.bytes[i] = i;
+         auto w = glz::write_bson(v);
+         expect(w.has_value());
+         expect(bytes_equal(w.value(), {0x15, 0x00, 0x00, 0x00,                                             //
+                                        0x07, 'i', 'd', 0x00,                                              //
+                                        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A,  //
+                                        0x0B,                                                              //
+                                        0x00}));
+      };
+
+      "regex-bytes"_test = [] {
+         regex_only_s v{};
+         v.r.pattern = "abc";
+         v.r.options = "i";
+         auto w = glz::write_bson(v);
+         expect(w.has_value());
+         // pattern cstring then options cstring.
+         expect(bytes_equal(w.value(), {0x0E, 0x00, 0x00, 0x00,        //
+                                        0x0B, 'r', 0x00,               //
+                                        'a', 'b', 'c', 0x00, 'i', 0x00, //
+                                        0x00}));
+      };
+
+      "regex-options-sorted"_test = [] {
+         // BSON spec requires regex options stored in alphabetical order.
+         // Input "mi" must be emitted as "im" on the wire.
+         regex_only_s v{};
+         v.r.pattern = "a";
+         v.r.options = "mi";
+         auto w = glz::write_bson(v);
+         expect(w.has_value());
+         expect(bytes_equal(w.value(), {0x0D, 0x00, 0x00, 0x00,              //
+                                        0x0B, 'r', 0x00,                     //
+                                        'a', 0x00, 'i', 'm', 0x00,           //
+                                        0x00}));
+      };
+
+      "javascript-bytes"_test = [] {
+         js_only_s v{};
+         v.j.code = "x";
+         auto w = glz::write_bson(v);
+         expect(w.has_value());
+         // int32 length (bytes+1 for null) then code then null.
+         expect(bytes_equal(w.value(), {0x0E, 0x00, 0x00, 0x00,              //
+                                        0x0D, 'j', 0x00,                     //
+                                        0x02, 0x00, 0x00, 0x00, 'x', 0x00,   //
+                                        0x00}));
+      };
+
+      "decimal128-bytes"_test = [] {
+         dec128_only_s v{};
+         // Opaque 16-byte payload: 0x01 ascending, to prove byte order is preserved.
+         for (uint8_t i = 0; i < 16; ++i) v.d.bytes[i] = uint8_t(0x01 + i);
+         auto w = glz::write_bson(v);
+         expect(w.has_value());
+         // Doc length = 4 (len) + 3 (tag+"d"+NUL) + 16 (value) + 1 (term) = 24 = 0x18.
+         expect(bytes_equal(w.value(), {0x18, 0x00, 0x00, 0x00,                                           //
+                                        0x13, 'd', 0x00,                                                  //
+                                        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, //
+                                        0x0C, 0x0D, 0x0E, 0x0F, 0x10,                                     //
+                                        0x00}));
+      };
+
+      "min-key-bytes"_test = [] {
+         min_only_s v{};
+         auto w = glz::write_bson(v);
+         expect(w.has_value());
+         // Doc length = 4 + 1 (tag) + 2 ("mn") + 1 (NUL) + 0 (no value) + 1 (term) = 9.
+         expect(bytes_equal(w.value(), {0x09, 0x00, 0x00, 0x00, 0xFF, 'm', 'n', 0x00, 0x00}));
+      };
+
+      "max-key-bytes"_test = [] {
+         max_only_s v{};
+         auto w = glz::write_bson(v);
+         expect(w.has_value());
+         // Same framing as min_key with tag 0x7F.
+         expect(bytes_equal(w.value(), {0x09, 0x00, 0x00, 0x00, 0x7F, 'm', 'x', 0x00, 0x00}));
+      };
+
+      "binary-generic-subtype-bytes"_test = [] {
+         bin_only_s v{};
+         v.b.subtype = glz::bson::binary_subtype::generic;
+         v.b.data = {std::byte{'a'}, std::byte{'b'}, std::byte{'c'}};
+         auto w = glz::write_bson(v);
+         expect(w.has_value());
+         // length 3, subtype 0x00, payload "abc".
+         expect(bytes_equal(w.value(), {0x10, 0x00, 0x00, 0x00,                         //
+                                        0x05, 'b', 0x00,                                //
+                                        0x03, 0x00, 0x00, 0x00, 0x00, 'a', 'b', 'c',    //
+                                        0x00}));
+      };
+
+      "binary-old-subtype-02-bytes"_test = [] {
+         // Subtype 0x02 is spec-required to wrap the payload in a redundant
+         // inner int32 length: outer = 4 + N, then subtype, then int32(N),
+         // then N payload bytes.
+         bin_only_s v{};
+         v.b.subtype = glz::bson::binary_subtype::binary_old;
+         v.b.data = {std::byte{'a'}, std::byte{'b'}, std::byte{'c'}};
+         auto w = glz::write_bson(v);
+         expect(w.has_value());
+         // Doc length = 4 (outer len field) + 3 (tag+"b"+NUL) + 4 (outer len)
+         // + 1 (subtype) + 4 (inner len) + 3 (payload) + 1 (term) = 20 = 0x14.
+         expect(bytes_equal(w.value(), {0x14, 0x00, 0x00, 0x00,              //
+                                        0x05, 'b', 0x00,                     //
+                                        0x07, 0x00, 0x00, 0x00,              //
+                                        0x02,                                //
+                                        0x03, 0x00, 0x00, 0x00,              //
+                                        'a', 'b', 'c',                       //
+                                        0x00}));
+      };
+   };
+
+   suite bson_roundtrip_tests = [] {
+      "roundtrip-primitives"_test = [] {
+         expect_roundtrip_equal(hello_t{"world"});
+         expect_roundtrip_equal(i32_s{42});
+         expect_roundtrip_equal(i32_s{-2000000000});
+         expect_roundtrip_equal(i64_s{1000000000000LL});
+         expect_roundtrip_equal(i64_s{-9000000000000LL});
+         expect_roundtrip_equal(bool_s{true});
+         expect_roundtrip_equal(bool_s{false});
+         expect_roundtrip_equal(double_s{3.14159});
+         expect_roundtrip_equal(double_s{-2.5e10});
+      };
+
+      "roundtrip-containers"_test = [] {
+         expect_roundtrip_equal(array_s{{}});
+         expect_roundtrip_equal(array_s{{1, 2, 3, 4, 5}});
+         expect_roundtrip_equal(outer_s{{7}});
+         expect_roundtrip_equal(team_s{{{"alice", 30}, {"bob", 25}}});
+      };
+
+      "roundtrip-optional"_test = [] {
+         expect_roundtrip_equal(optional_s{42});
+         expect_roundtrip_equal(optional_s{-1});
+         // optional-empty: read leaves default, which matches original.
+         expect_roundtrip_equal(optional_s{});
+      };
+
+      "roundtrip-uuid"_test = [] {
+         uuid_s v{};
+         expect(glz::parse_uuid("550e8400-e29b-41d4-a716-446655440000", v.u));
+         expect_roundtrip_equal(v);
+      };
+
+      "roundtrip-chrono"_test = [] {
+         using namespace std::chrono;
+         time_s v{system_clock::time_point{milliseconds{1700000000000LL}}};
+         expect_roundtrip_equal(v);
+      };
+
+      "roundtrip-object_id"_test = [] {
+         oid_s v{};
+         for (int i = 0; i < 12; ++i) v.id.bytes[i] = static_cast<uint8_t>(i * 17);
+         expect_roundtrip_equal(v);
+      };
+
+      "roundtrip-map"_test = [] {
+         std::map<std::string, int32_t> m{{"alpha", 1}, {"beta", 2}, {"gamma", 3}};
+         auto w = glz::write_bson(m);
+         expect(w.has_value());
+         std::map<std::string, int32_t> r{};
+         auto ec = glz::read_bson(r, std::string_view{w.value()});
+         expect(not ec);
+         expect(r == m);
+      };
+
+      "map-duplicate-keys-last-writer-wins"_test = [] {
+         // BSON does not forbid duplicate keys on the wire. Glaze's policy is
+         // last-writer-wins (subsequent occurrences overwrite the prior value).
+         // Hand-authored doc: {"k": 1, "k": 2}. Reader must yield {k: 2}.
+         static constexpr uint8_t dup[] = {
+            0x13, 0x00, 0x00, 0x00,                  // doc length = 4+7+7+1 = 19
+            0x10, 'k', 0x00, 0x01, 0x00, 0x00, 0x00, //
+            0x10, 'k', 0x00, 0x02, 0x00, 0x00, 0x00, //
+            0x00};
+         std::map<std::string, int32_t> r{};
+         auto ec = glz::read_bson(r, std::string_view{reinterpret_cast<const char*>(dup), sizeof(dup)});
+         expect(not ec);
+         expect(r.size() == 1);
+         expect(r.at("k") == 2);
+      };
+
+      "roundtrip-helpers"_test = [] {
+         helpers_s v{};
+         v.when.ms_since_epoch = 1700000000000LL;
+         v.ts.increment = 7;
+         v.ts.seconds = 1700000000;
+         v.re.pattern = "^hello";
+         v.re.options = "i";
+         v.js.code = "function(x){ return x+1; }";
+         for (int i = 0; i < 16; ++i) v.d128.bytes[i] = static_cast<uint8_t>(i);
+         v.blob.data = {std::byte{0x01}, std::byte{0x02}, std::byte{0x03}, std::byte{0x04}};
+         v.blob.subtype = glz::bson::binary_subtype::generic;
+         expect_roundtrip_equal(v);
+      };
+
+      "roundtrip-binary-old-subtype-02"_test = [] {
+         bin_only_s v{};
+         v.b.subtype = glz::bson::binary_subtype::binary_old;
+         v.b.data = {std::byte{0xDE}, std::byte{0xAD}, std::byte{0xBE}, std::byte{0xEF}};
+         expect_roundtrip_equal(v);
+      };
+
+      "roundtrip-binary-function-subtype-01"_test = [] {
+         // Subtype 0x01 (function) is framed identically to generic bytes on
+         // the wire; the distinction is semantic only.
+         bin_only_s v{};
+         v.b.subtype = glz::bson::binary_subtype::function;
+         v.b.data = {std::byte{'f'}, std::byte{'n'}, std::byte{0x00}, std::byte{0x42}};
+         expect_roundtrip_equal(v);
+      };
+
+      "roundtrip-fixed-array"_test = [] {
+         // std::array is fixed-capacity: not emplace_backable, not resizable.
+         // The reader must dispatch to the indexed-fill else-branch.
+         expect_roundtrip_equal(fixed_array_s{{10, 20, 30}});
+      };
+
+      "roundtrip-empty-string"_test = [] {
+         // Edge case: BSON string with length prefix 1 (just the terminator).
+         expect_roundtrip_equal(hello_t{""});
+      };
+
+      "roundtrip-top-level-fixed-array"_test = [] {
+         // Top-level std::array must dispatch to the array reader even though
+         // BSON's top-level container is always a "document" on the wire.
+         std::array<int32_t, 3> src{11, 22, 33};
+         auto w = glz::write_bson(src);
+         expect(w.has_value());
+         std::array<int32_t, 3> dst{};
+         auto ec = glz::read_bson(dst, std::string_view{w.value()});
+         expect(not ec);
+         expect(dst == src);
+      };
+
+      "roundtrip-top-level-vector"_test = [] {
+         std::vector<int32_t> src{7, 8, 9, 10};
+         auto w = glz::write_bson(src);
+         expect(w.has_value());
+         std::vector<int32_t> dst{};
+         auto ec = glz::read_bson(dst, std::string_view{w.value()});
+         expect(not ec);
+         expect(dst == src);
+      };
+
+      "fixed-array-wire-overflow-rejected"_test = [] {
+         // Wire has 4 elements, target array has capacity 3 — must fail with
+         // exceeded_static_array_size.
+         array_s src{{1, 2, 3, 4}};
+         auto w = glz::write_bson(src);
+         expect(w.has_value());
+         fixed_array_s dst{};
+         auto ec = glz::read_bson(dst, std::string_view{w.value()});
+         expect(ec.ec == glz::error_code::exceeded_static_array_size);
+      };
+
+      "read-binary-old-from-external-producer"_test = [] {
+         // Spec-compliant 0x02 wire bytes hand-authored (what a MongoDB driver
+         // would emit): outer_len = 4 + N, subtype 0x02, inner int32(N),
+         // then N payload bytes.
+         static constexpr uint8_t compliant[] = {
+            0x14, 0x00, 0x00, 0x00,  // doc length
+            0x05, 'b', 0x00,         // tag + key
+            0x07, 0x00, 0x00, 0x00,  // outer_len = 4 + 3 = 7
+            0x02,                    // subtype 0x02
+            0x03, 0x00, 0x00, 0x00,  // inner_len = 3
+            'x', 'y', 'z',           // payload
+            0x00};
+         bin_only_s dst{};
+         auto ec = glz::read_bson(dst, std::string_view{reinterpret_cast<const char*>(compliant), sizeof(compliant)});
+         expect(not ec);
+         expect(dst.b.subtype == glz::bson::binary_subtype::binary_old);
+         expect(dst.b.data.size() == 3);
+         expect(dst.b.data[0] == std::byte{'x'});
+         expect(dst.b.data[1] == std::byte{'y'});
+         expect(dst.b.data[2] == std::byte{'z'});
+      };
+
+      "read-binary-old-inner-outer-mismatch-rejected"_test = [] {
+         // Malformed 0x02: outer_len says 7 but inner_len says 5, so they
+         // disagree. Reader must reject with syntax_error.
+         static constexpr uint8_t bad[] = {
+            0x14, 0x00, 0x00, 0x00,  //
+            0x05, 'b', 0x00,         //
+            0x07, 0x00, 0x00, 0x00,  // outer_len = 7 (implies inner = 3)
+            0x02,                    //
+            0x05, 0x00, 0x00, 0x00,  // inner_len = 5 (mismatch)
+            'x', 'y', 'z',           //
+            0x00};
+         bin_only_s dst{};
+         auto ec = glz::read_bson(dst, std::string_view{reinterpret_cast<const char*>(bad), sizeof(bad)});
+         expect(ec.ec == glz::error_code::syntax_error);
+      };
+   };
+
+   suite bson_coercion_tests = [] {
+      "int64-wire-to-int32-target-in-range"_test = [] {
+         i64_s src{42};
+         auto w = glz::write_bson(src);
+         expect(w.has_value());
+         i32_s dst{};
+         auto ec = glz::read_bson(dst, std::string_view{w.value()});
+         expect(not ec);
+         expect(dst.x == 42);
+      };
+
+      "int64-wire-to-int32-target-out-of-range"_test = [] {
+         i64_s src{int64_t{1} << 40};
+         auto w = glz::write_bson(src);
+         expect(w.has_value());
+         i32_s dst{};
+         auto ec = glz::read_bson(dst, std::string_view{w.value()});
+         expect(ec.ec == glz::error_code::parse_number_failure);
+      };
+
+      "int32-wire-to-int64-target"_test = [] {
+         i32_s src{-5};
+         auto w = glz::write_bson(src);
+         expect(w.has_value());
+         i64_s dst{};
+         auto ec = glz::read_bson(dst, std::string_view{w.value()});
+         expect(not ec);
+         expect(dst.x == -5);
+      };
+
+      "int32-wire-to-uint32-target-non-negative"_test = [] {
+         // External producer emits int32; target is uint32_t. Any non-negative
+         // int32 fits and must not trip the range check.
+         i32_s src{42};
+         auto w = glz::write_bson(src);
+         expect(w.has_value());
+         u32_s dst{};
+         auto ec = glz::read_bson(dst, std::string_view{w.value()});
+         expect(not ec);
+         expect(dst.x == 42u);
+      };
+
+      "int32-wire-to-uint32-target-negative-rejected"_test = [] {
+         i32_s src{-1};
+         auto w = glz::write_bson(src);
+         expect(w.has_value());
+         u32_s dst{};
+         auto ec = glz::read_bson(dst, std::string_view{w.value()});
+         expect(ec.ec == glz::error_code::parse_number_failure);
+      };
+
+      "int32-wire-to-uint64-target-non-negative"_test = [] {
+         i32_s src{42};
+         auto w = glz::write_bson(src);
+         expect(w.has_value());
+         u64_s dst{};
+         auto ec = glz::read_bson(dst, std::string_view{w.value()});
+         expect(not ec);
+         expect(dst.x == 42u);
+      };
+
+      "int32-wire-to-uint64-target-negative-rejected"_test = [] {
+         // Was silently producing UINT64_MAX before the fix.
+         i32_s src{-1};
+         auto w = glz::write_bson(src);
+         expect(w.has_value());
+         u64_s dst{};
+         auto ec = glz::read_bson(dst, std::string_view{w.value()});
+         expect(ec.ec == glz::error_code::parse_number_failure);
+      };
+
+      "int32-wire-to-uint16-target-in-range"_test = [] {
+         i32_s src{1000};
+         auto w = glz::write_bson(src);
+         expect(w.has_value());
+         u16_s dst{};
+         auto ec = glz::read_bson(dst, std::string_view{w.value()});
+         expect(not ec);
+         expect(dst.x == 1000u);
+      };
+
+      "int32-wire-to-uint16-target-out-of-range"_test = [] {
+         i32_s src{100000};
+         auto w = glz::write_bson(src);
+         expect(w.has_value());
+         u16_s dst{};
+         auto ec = glz::read_bson(dst, std::string_view{w.value()});
+         expect(ec.ec == glz::error_code::parse_number_failure);
+      };
+
+      "int32-wire-to-uint16-target-negative-rejected"_test = [] {
+         i32_s src{-1};
+         auto w = glz::write_bson(src);
+         expect(w.has_value());
+         u16_s dst{};
+         auto ec = glz::read_bson(dst, std::string_view{w.value()});
+         expect(ec.ec == glz::error_code::parse_number_failure);
+      };
+
+      "int32-wire-to-uint8-target-in-range"_test = [] {
+         i32_s src{200};
+         auto w = glz::write_bson(src);
+         expect(w.has_value());
+         u8_s dst{};
+         auto ec = glz::read_bson(dst, std::string_view{w.value()});
+         expect(not ec);
+         expect(dst.x == 200u);
+      };
+
+      "int32-wire-to-uint8-target-out-of-range"_test = [] {
+         i32_s src{300};
+         auto w = glz::write_bson(src);
+         expect(w.has_value());
+         u8_s dst{};
+         auto ec = glz::read_bson(dst, std::string_view{w.value()});
+         expect(ec.ec == glz::error_code::parse_number_failure);
+      };
+
+      "int32-wire-to-uint8-target-negative-rejected"_test = [] {
+         i32_s src{-1};
+         auto w = glz::write_bson(src);
+         expect(w.has_value());
+         u8_s dst{};
+         auto ec = glz::read_bson(dst, std::string_view{w.value()});
+         expect(ec.ec == glz::error_code::parse_number_failure);
+      };
+
+      "int64-wire-to-int8-target-out-of-range"_test = [] {
+         i64_s src{1000};
+         auto w = glz::write_bson(src);
+         expect(w.has_value());
+         i8_s dst{};
+         auto ec = glz::read_bson(dst, std::string_view{w.value()});
+         expect(ec.ec == glz::error_code::parse_number_failure);
+      };
+
+      "int64-wire-to-uint32-target-out-of-range"_test = [] {
+         // Value above UINT32_MAX.
+         i64_s src{int64_t{1} << 40};
+         auto w = glz::write_bson(src);
+         expect(w.has_value());
+         u32_s dst{};
+         auto ec = glz::read_bson(dst, std::string_view{w.value()});
+         expect(ec.ec == glz::error_code::parse_number_failure);
+      };
+
+      "int64-wire-to-uint32-target-negative-rejected"_test = [] {
+         i64_s src{-1};
+         auto w = glz::write_bson(src);
+         expect(w.has_value());
+         u32_s dst{};
+         auto ec = glz::read_bson(dst, std::string_view{w.value()});
+         expect(ec.ec == glz::error_code::parse_number_failure);
+      };
+   };
+
+   suite bson_unknown_key_tests = [] {
+      "strict-default-rejects-unknown-keys"_test = [] {
+         big_s big{1, 2, 3};
+         auto w = glz::write_bson(big);
+         expect(w.has_value());
+         small_s dst{};
+         auto ec = glz::read_bson(dst, std::string_view{w.value()});
+         expect(ec.ec == glz::error_code::unknown_key);
+      };
+
+      "permissive-skips-unknown-keys"_test = [] {
+         big_s big{1, 2, 3};
+         auto w = glz::write_bson(big);
+         expect(w.has_value());
+         small_s dst{};
+         constexpr auto permissive = glz::opts{.error_on_unknown_keys = false};
+         auto ec = glz::read_bson<permissive>(dst, std::string_view{w.value()});
+         expect(not ec);
+         expect(dst.b == 2);
+      };
+   };
+
+   suite bson_spec_parse_tests = [] {
+      "parse-canonical-hello-world"_test = [] {
+         static constexpr uint8_t hw[] = {
+            0x16, 0x00, 0x00, 0x00,              //
+            0x02, 'h', 'e', 'l', 'l', 'o', 0x00, //
+            0x06, 0x00, 0x00, 0x00,              //
+            'w', 'o', 'r', 'l', 'd', 0x00,       //
+            0x00                                 //
+         };
+         std::string_view buf(reinterpret_cast<const char*>(hw), sizeof(hw));
+         hello_t h{};
+         auto ec = glz::read_bson(h, buf);
+         expect(not ec);
+         expect(h.hello == "world");
+      };
+
+      "empty-document"_test = [] {
+         // {} — smallest legal document: just 4-byte length + terminator.
+         static constexpr uint8_t empty_doc[] = {0x05, 0x00, 0x00, 0x00, 0x00};
+         std::string_view buf(reinterpret_cast<const char*>(empty_doc), sizeof(empty_doc));
+         hello_t h{"prefilled"};
+         constexpr auto permissive = glz::opts{.error_on_unknown_keys = false};
+         auto ec = glz::read_bson<permissive>(h, buf);
+         expect(not ec);
+         // no "hello" key present → field stays as it was
+         expect(h.hello == "prefilled");
+      };
+
+      "negative-length-prefix-rejected"_test = [] {
+         // Length field is 0xFFFFFFFF (−1 when read as int32). Must be rejected.
+         static constexpr uint8_t bad[] = {0xFF, 0xFF, 0xFF, 0xFF, 0x00};
+         std::string_view buf(reinterpret_cast<const char*>(bad), sizeof(bad));
+         hello_t h{};
+         auto ec = glz::read_bson(h, buf);
+         expect(bool(ec));
+      };
+
+      "truncated-document"_test = [] {
+         // Length says 22 but buffer only has 10 bytes.
+         static constexpr uint8_t bad[] = {0x16, 0x00, 0x00, 0x00, 0x02, 'h', 'i', 0x00, 0x01, 0x00};
+         std::string_view buf(reinterpret_cast<const char*>(bad), sizeof(bad));
+         hello_t h{};
+         auto ec = glz::read_bson(h, buf);
+         expect(ec.ec == glz::error_code::unexpected_end);
+      };
+
+      "trailing-bytes-rejected"_test = [] {
+         // Valid {"hello":"world"} document followed by a stray byte. The header
+         // length covers only the first 22 bytes; anything past that is garbage.
+         static constexpr uint8_t doc_plus_garbage[] = {
+            0x16, 0x00, 0x00, 0x00,              //
+            0x02, 'h', 'e', 'l', 'l', 'o', 0x00, //
+            0x06, 0x00, 0x00, 0x00,              //
+            'w', 'o', 'r', 'l', 'd', 0x00,       //
+            0x00,                                //
+            0xFF                                 // trailing garbage
+         };
+         std::string_view buf(reinterpret_cast<const char*>(doc_plus_garbage), sizeof(doc_plus_garbage));
+         hello_t h{};
+         auto ec = glz::read_bson(h, buf);
+         expect(ec.ec == glz::error_code::syntax_error);
+      };
+
+      "exact-fill-accepted"_test = [] {
+         // Same document without trailing bytes must still succeed.
+         static constexpr uint8_t doc[] = {
+            0x16, 0x00, 0x00, 0x00,              //
+            0x02, 'h', 'e', 'l', 'l', 'o', 0x00, //
+            0x06, 0x00, 0x00, 0x00,              //
+            'w', 'o', 'r', 'l', 'd', 0x00,       //
+            0x00                                 //
+         };
+         std::string_view buf(reinterpret_cast<const char*>(doc), sizeof(doc));
+         hello_t h{};
+         auto ec = glz::read_bson(h, buf);
+         expect(not ec);
+         expect(h.hello == "world");
+      };
+   };
+
+   suite bson_write_api_tests = [] {
+      "fixed-buffer-write"_test = [] {
+         // Bounded buffers require at least 512 bytes to account for the write
+         // padding reservation (see glaze/core/buffer_traits.hpp).
+         std::array<char, 512> buf{};
+         hello_t h{"world"};
+         auto ec = glz::write_bson(h, buf);
+         expect(not ec);
+         expect(ec.count == 22);
+      };
+
+      "vector-byte-buffer-write"_test = [] {
+         std::vector<std::byte> buf{};
+         hello_t h{"world"};
+         auto ec = glz::write_bson(h, buf);
+         expect(not ec);
+         expect(buf.size() == 22);
+      };
+   };
+
+   suite bson_variant_tests = [] {
+      "variant-int-or-string-roundtrip-int"_test = [] {
+         expect_roundtrip_equal(int_or_string_s{42});
+      };
+
+      "variant-int-or-string-roundtrip-string"_test = [] {
+         expect_roundtrip_equal(int_or_string_s{std::string{"hello"}});
+      };
+
+      "variant-monostate-roundtrip-absent"_test = [] {
+         // Active alternative is std::monostate → null on the wire.
+         expect_roundtrip_equal(maybe_int_s{});
+      };
+
+      "variant-monostate-roundtrip-int"_test = [] {
+         maybe_int_s v{};
+         v.v = int32_t{7};
+         expect_roundtrip_equal(v);
+      };
+
+      "variant-monostate-writes-null-byte"_test = [] {
+         // {v: null} — doc length 8 | 0x0A 'v' 0x00 | 0x00 (no value bytes for null).
+         maybe_int_s v{};
+         auto w = glz::write_bson(v);
+         expect(w.has_value());
+         expect(bytes_equal(w.value(),
+                            {0x08, 0x00, 0x00, 0x00,  //
+                             0x0A, 'v', 0x00,         //
+                             0x00}));
+      };
+
+      "variant-num-int-and-double"_test = [] {
+         // Variant with distinct int and float categories: both round-trip.
+         num_s a{int32_t{11}};
+         expect_roundtrip_equal(a);
+         num_s b{3.14};
+         expect_roundtrip_equal(b);
+      };
+
+      "variant-scalar-or-array"_test = [] {
+         scalar_or_array_s a{int32_t{5}};
+         expect_roundtrip_equal(a);
+         scalar_or_array_s b{std::vector<int32_t>{1, 2, 3}};
+         expect_roundtrip_equal(b);
+      };
+
+      "variant-helper-types"_test = [] {
+         id_or_time_s a{};
+         glz::bson::object_id oid{};
+         for (int i = 0; i < 12; ++i) oid.bytes[i] = static_cast<uint8_t>(i);
+         a.v = oid;
+         expect_roundtrip_equal(a);
+
+         id_or_time_s b{};
+         b.v = glz::bson::datetime{1700000000000LL};
+         expect_roundtrip_equal(b);
+      };
+
+      "variant-read-unknown-tag-errors"_test = [] {
+         // Forge a document with a variant field holding a double (0x01),
+         // but the variant has no float alternative → no_matching_variant_type.
+         // int_or_string_s has int32 + string only. Manual bytes: length | 01 v 00 | double | 00.
+         static constexpr uint8_t bad[] = {
+            0x10, 0x00, 0x00, 0x00,                                              //
+            0x01, 'v', 0x00,                                                     //
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF8, 0x3F,                      //
+            0x00                                                                 //
+         };
+         std::string_view buf(reinterpret_cast<const char*>(bad), sizeof(bad));
+         int_or_string_s v{};
+         auto ec = glz::read_bson(v, buf);
+         expect(ec.ec == glz::error_code::no_matching_variant_type);
+      };
+   };
+
+   suite bson_map_skip_null_tests = [] {
+      "map-skips-empty-optional-by-default"_test = [] {
+         std::map<std::string, std::optional<int32_t>> in{{"a", 1}, {"b", std::nullopt}, {"c", 3}};
+         std::vector<std::byte> buf{};
+         auto wec = glz::write_bson(in, buf);
+         expect(not wec);
+
+         std::map<std::string, std::optional<int32_t>> out{};
+         auto rec = glz::read_bson(out, buf);
+         expect(not rec);
+         expect(out.size() == 2);
+         expect(out.count("b") == 0);
+         expect(out.at("a") == 1);
+         expect(out.at("c") == 3);
+      };
+
+      "map-preserves-nulls-when-skip-disabled"_test = [] {
+         constexpr auto preserve = glz::opts{.skip_null_members = false};
+         std::map<std::string, std::optional<int32_t>> in{{"a", 1}, {"b", std::nullopt}};
+         std::vector<std::byte> buf{};
+         auto wec = glz::write_bson<preserve>(in, buf);
+         expect(not wec);
+
+         std::map<std::string, std::optional<int32_t>> out{};
+         auto rec = glz::read_bson<preserve>(out, buf);
+         expect(not rec);
+         expect(out.size() == 2);
+         expect(out.at("a") == 1);
+         expect(!out.at("b").has_value());
+      };
+   };
+
+   // ===========================================================================
+   // Deprecated element types: present on the wire, the reader must skip them
+   // cleanly when the receiving type has no such key.
+   // ===========================================================================
+   suite bson_deprecated_type_skip_tests = [] {
+      "skip-undefined"_test = [] {
+         constexpr auto permissive = glz::opts{.error_on_unknown_keys = false};
+         // {"u": undefined} — type tag 0x06 carries no value bytes.
+         static constexpr uint8_t bytes[] = {0x08, 0x00, 0x00, 0x00, 0x06, 'u', 0x00, 0x00};
+         std::string_view buf(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+         hello_t h{"pre"};
+         auto ec = glz::read_bson<permissive>(h, buf);
+         expect(not ec);
+         expect(h.hello == "pre");
+      };
+
+      "skip-symbol"_test = [] {
+         constexpr auto permissive = glz::opts{.error_on_unknown_keys = false};
+         // {"s": symbol("x")} — symbol is length-prefixed UTF-8 like a string.
+         static constexpr uint8_t bytes[] = {
+            0x0E, 0x00, 0x00, 0x00,               //
+            0x0E, 's', 0x00,                      //
+            0x02, 0x00, 0x00, 0x00, 'x', 0x00,    //
+            0x00                                  //
+         };
+         std::string_view buf(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+         hello_t h{"pre"};
+         auto ec = glz::read_bson<permissive>(h, buf);
+         expect(not ec);
+         expect(h.hello == "pre");
+      };
+
+      "skip-db-pointer"_test = [] {
+         constexpr auto permissive = glz::opts{.error_on_unknown_keys = false};
+         // {"p": DBPointer("x", <12 zero bytes>)} — ns string + 12-byte object id.
+         static constexpr uint8_t bytes[] = {
+            0x1A, 0x00, 0x00, 0x00,                                                   //
+            0x0C, 'p', 0x00,                                                          //
+            0x02, 0x00, 0x00, 0x00, 'x', 0x00,                                        //
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,   //
+            0x00                                                                      //
+         };
+         std::string_view buf(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+         hello_t h{"pre"};
+         auto ec = glz::read_bson<permissive>(h, buf);
+         expect(not ec);
+         expect(h.hello == "pre");
+      };
+
+      "skip-code-with-scope"_test = [] {
+         constexpr auto permissive = glz::opts{.error_on_unknown_keys = false};
+         // {"c": CodeWithScope("x", {})} — int32 total-len | string | document.
+         static constexpr uint8_t bytes[] = {
+            0x17, 0x00, 0x00, 0x00,                //
+            0x0F, 'c', 0x00,                       //
+            0x0F, 0x00, 0x00, 0x00,                // inner total length = 15
+            0x02, 0x00, 0x00, 0x00, 'x', 0x00,     // string "x"
+            0x05, 0x00, 0x00, 0x00, 0x00,          // empty scope document
+            0x00                                   //
+         };
+         std::string_view buf(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+         hello_t h{"pre"};
+         auto ec = glz::read_bson<permissive>(h, buf);
+         expect(not ec);
+         expect(h.hello == "pre");
+      };
+   };
+
+   // ===========================================================================
+   // File I/O round-trip
+   // ===========================================================================
+   suite bson_file_io_tests = [] {
+      "file-roundtrip"_test = [] {
+         namespace fs = std::filesystem;
+         const auto path = (fs::temp_directory_path() / "glaze_bson_file_roundtrip.bson").string();
+
+         person_s out_person{"Ada", 36};
+         std::string write_buf;
+         const auto wec = glz::write_file_bson(out_person, path, write_buf);
+         expect(wec == glz::error_code::none);
+
+         person_s in_person{};
+         std::string read_buf;
+         const auto rec = glz::read_file_bson(in_person, path, read_buf);
+         expect(not rec);
+         expect(in_person == out_person);
+
+         std::error_code ignore{};
+         fs::remove(path, ignore);
+      };
+   };
+
+   // ===========================================================================
+   // error_on_missing_keys — required (non-nullable) fields must be present.
+   // ===========================================================================
+   suite bson_missing_keys_tests = [] {
+      "missing-required-field-errors"_test = [] {
+         constexpr auto strict = glz::opts{.error_on_missing_keys = true};
+         // {"opt": 7} — the required "id" field is absent.
+         static constexpr uint8_t bytes[] = {
+            0x0E, 0x00, 0x00, 0x00,                                   //
+            0x10, 'o', 'p', 't', 0x00, 0x07, 0x00, 0x00, 0x00,        //
+            0x00                                                      //
+         };
+         std::string_view buf(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+         required_s v{};
+         auto ec = glz::read_bson<strict>(v, buf);
+         expect(ec.ec == glz::error_code::missing_key);
+      };
+
+      "missing-optional-field-ok"_test = [] {
+         constexpr auto strict = glz::opts{.error_on_missing_keys = true};
+         // {"id": 42} — "opt" is optional and absent, strict mode tolerates it.
+         static constexpr uint8_t bytes[] = {
+            0x0D, 0x00, 0x00, 0x00,                                   //
+            0x10, 'i', 'd', 0x00, 0x2A, 0x00, 0x00, 0x00,             //
+            0x00                                                      //
+         };
+         std::string_view buf(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+         required_s v{};
+         auto ec = glz::read_bson<strict>(v, buf);
+         expect(not ec);
+         expect(v.id == 42);
+         expect(not v.opt.has_value());
+      };
+   };
+
+   // ===========================================================================
+   // Nested containers / optionals + struct-field monostate
+   // ===========================================================================
+   suite bson_nested_and_monostate_tests = [] {
+      "nested-vectors-roundtrip"_test = [] {
+         expect_roundtrip_equal(nested_vec_s{{{1, 2, 3}, {}, {4, 5}}});
+      };
+
+      "nested-optional-present-roundtrip"_test = [] {
+         // Outer present, inner present.
+         expect_roundtrip_equal(nested_opt_s{std::optional<int32_t>{123}});
+      };
+
+      "monostate-struct-field-roundtrip"_test = [] {
+         // The monostate writes as a null element and round-trips — the
+         // reader dispatches to from<BSON, always_null_t T>.
+         monostate_field_s in{};
+         in.x = 99;
+         std::vector<std::byte> buf{};
+         expect(not glz::write_bson(in, buf));
+         monostate_field_s out{};
+         expect(not glz::read_bson(out, buf));
+         expect(out.x == 99);
+      };
+   };
+
+   // ===========================================================================
+   // Large-array key fast path (small_array_keys table covers 0..1023).
+   // ===========================================================================
+   suite bson_large_array_tests = [] {
+      "array-1024-elements-roundtrips"_test = [] {
+         // Uses array_s (defined at namespace scope) so reflection works; 1500
+         // entries exercise both the precomputed key table (0..1023) and the
+         // std::to_chars fallback (1024+).
+         array_s v{};
+         v.a.resize(1500);
+         for (size_t i = 0; i < v.a.size(); ++i) v.a[i] = static_cast<int32_t>(i);
+         expect_roundtrip_equal(v);
+      };
+   };
+
+   // ===========================================================================
+   // Missing-terminator error carries a specific custom_error_message.
+   // ===========================================================================
+   suite bson_terminator_error_tests = [] {
+      "missing-terminator-has-clear-message"_test = [] {
+         // Doc claims length 12, but byte 11 (where the 0x00 terminator should
+         // sit) is 0xFF — so after reading the int32 element the reader
+         // encounters 0xFF as a tag and fails trying to read a key. The
+         // resulting unexpected_end is decorated with a specific message so
+         // users don't have to guess whether it's a truncation or a framing
+         // bug.
+         static constexpr uint8_t bad[] = {
+            0x0C, 0x00, 0x00, 0x00,                              //
+            0x10, 'x', 0x00, 0x2A, 0x00, 0x00, 0x00,             //
+            0xFF                                                 //
+         };
+         std::string_view buf(reinterpret_cast<const char*>(bad), sizeof(bad));
+         i32_s v{};
+         auto ec = glz::read_bson(v, buf);
+         expect(ec.ec == glz::error_code::unexpected_end);
+         expect(ec.custom_error_message == "missing document terminator");
+      };
+
+      "early-terminator-has-clear-message"_test = [] {
+         // Doc claims length 13 but the 0x00 terminator appears at byte 11 (one
+         // byte early); byte 12 is an unexpected 0x7F.
+         static constexpr uint8_t bad[] = {
+            0x0D, 0x00, 0x00, 0x00,                              //
+            0x10, 'x', 0x00, 0x2A, 0x00, 0x00, 0x00,             //
+            0x00,                                                //
+            0x7F                                                 //
+         };
+         std::string_view buf(reinterpret_cast<const char*>(bad), sizeof(bad));
+         i32_s v{};
+         auto ec = glz::read_bson(v, buf);
+         expect(ec.ec == glz::error_code::syntax_error);
+         expect(ec.custom_error_message == "document terminator before end of declared length");
+      };
+   };
+
+   // ===========================================================================
+   // bson_to_json converter.
+   // ===========================================================================
+   suite bson_to_json_tests = [] {
+      "convert-primitives"_test = [] {
+         prim_doc_s v{.a = 1, .b = 9000000000LL, .c = 1.5, .d = true, .e = "hi"};
+         auto bson = glz::write_bson(v);
+         expect(bson.has_value());
+         auto json = glz::bson_to_json(bson.value());
+         expect(json.has_value());
+         expect(json.value() == R"({"a":1,"b":9000000000,"c":1.5,"d":true,"e":"hi"})");
+      };
+
+      "convert-nested-document"_test = [] {
+         outer_s v{inner_s{42}};
+         auto bson = glz::write_bson(v);
+         auto json = glz::bson_to_json(bson.value());
+         expect(json.has_value());
+         expect(json.value() == R"({"inner":{"x":42}})");
+      };
+
+      "convert-array"_test = [] {
+         array_s v{{10, 20, 30}};
+         auto bson = glz::write_bson(v);
+         auto json = glz::bson_to_json(bson.value());
+         expect(json.has_value());
+         expect(json.value() == R"({"a":[10,20,30]})");
+      };
+
+      "convert-null-and-optional"_test = [] {
+         // skip_null_members=false so the optional's null survives to JSON.
+         constexpr auto preserve = glz::opts{.skip_null_members = false};
+         optional_s v{};
+         std::vector<std::byte> buf;
+         expect(not glz::write_bson<preserve>(v, buf));
+         auto json = glz::bson_to_json(buf);
+         expect(json.has_value());
+         expect(json.value() == R"({"o":null})");
+      };
+
+      "convert-object-id-extended-json"_test = [] {
+         oid_only_s v{};
+         for (uint8_t i = 0; i < 12; ++i) v.id.bytes[i] = i;
+         auto bson = glz::write_bson(v);
+         auto json = glz::bson_to_json(bson.value());
+         expect(json.has_value());
+         expect(json.value() == R"({"id":{"$oid":"000102030405060708090a0b"}})");
+      };
+
+      "convert-datetime-extended-json"_test = [] {
+         dt_field_s v{};
+         v.when.ms_since_epoch = 1700000000000LL;
+         auto bson = glz::write_bson(v);
+         auto json = glz::bson_to_json(bson.value());
+         expect(json.has_value());
+         expect(json.value() == R"({"when":{"$date":{"$numberLong":"1700000000000"}}})");
+      };
+
+      "convert-binary-base64"_test = [] {
+         bin_only_s v{};
+         v.b.subtype = glz::bson::binary_subtype::generic;
+         v.b.data = {std::byte{'f'}, std::byte{'o'}, std::byte{'o'}};
+         auto bson = glz::write_bson(v);
+         auto json = glz::bson_to_json(bson.value());
+         expect(json.has_value());
+         // "foo" base64 = "Zm9v", subtype 0x00 → "00".
+         expect(json.value() == R"({"b":{"$binary":{"base64":"Zm9v","subType":"00"}}})");
+      };
+
+      "convert-binary-old-subtype-02-strips-inner-length"_test = [] {
+         // 0x02 payloads include a redundant inner int32 length before the
+         // real bytes. The converter must strip it so the base64 field reflects
+         // only the data.
+         bin_only_s v{};
+         v.b.subtype = glz::bson::binary_subtype::binary_old;
+         v.b.data = {std::byte{'f'}, std::byte{'o'}, std::byte{'o'}};
+         auto bson = glz::write_bson(v);
+         auto json = glz::bson_to_json(bson.value());
+         expect(json.has_value());
+         expect(json.value() == R"({"b":{"$binary":{"base64":"Zm9v","subType":"02"}}})");
+      };
+
+      "convert-regex-extended-json"_test = [] {
+         regex_only_s v{};
+         v.r.pattern = "abc";
+         v.r.options = "i";
+         auto bson = glz::write_bson(v);
+         auto json = glz::bson_to_json(bson.value());
+         expect(json.has_value());
+         expect(json.value() == R"({"r":{"$regularExpression":{"pattern":"abc","options":"i"}}})");
+      };
+
+      "convert-javascript-extended-json"_test = [] {
+         js_only_s v{};
+         v.j.code = "f()";
+         auto bson = glz::write_bson(v);
+         auto json = glz::bson_to_json(bson.value());
+         expect(json.has_value());
+         expect(json.value() == R"X({"j":{"$code":"f()"}})X");
+      };
+
+      "convert-timestamp-extended-json"_test = [] {
+         ts_field_s v{};
+         v.ts.seconds = 100;
+         v.ts.increment = 3;
+         auto bson = glz::write_bson(v);
+         auto json = glz::bson_to_json(bson.value());
+         expect(json.has_value());
+         expect(json.value() == R"({"ts":{"$timestamp":{"t":100,"i":3}}})");
+      };
+
+      "convert-min-and-max-key"_test = [] {
+         min_only_s v{};
+         auto json = glz::bson_to_json(glz::write_bson(v).value());
+         expect(json.has_value());
+         expect(json.value() == R"({"mn":{"$minKey":1}})");
+
+         max_only_s w{};
+         auto json2 = glz::bson_to_json(glz::write_bson(w).value());
+         expect(json2.has_value());
+         expect(json2.value() == R"({"mx":{"$maxKey":1}})");
+      };
+
+      "convert-decimal128-hex-fallback"_test = [] {
+         dec128_only_s v{};
+         for (uint8_t i = 0; i < 16; ++i) v.d.bytes[i] = i;
+         auto bson = glz::write_bson(v);
+         auto json = glz::bson_to_json(bson.value());
+         expect(json.has_value());
+         expect(json.value() == R"({"d":{"decimal128Hex":"000102030405060708090a0b0c0d0e0f"}})");
+      };
+
+      "convert-rejects-truncated-input"_test = [] {
+         // Declared length 22 but buffer only 10 bytes.
+         static constexpr uint8_t bad[] = {0x16, 0x00, 0x00, 0x00, 0x02, 'h', 'i', 0x00, 0x01, 0x00};
+         std::string_view buf(reinterpret_cast<const char*>(bad), sizeof(bad));
+         auto json = glz::bson_to_json(buf);
+         expect(not json.has_value());
+      };
+
+      "convert-rejects-trailing-bytes"_test = [] {
+         // Well-formed {"hello":"world"} document (22 bytes) + 1 trailing
+         // garbage byte. Must be rejected symmetrically with read_bson.
+         static constexpr uint8_t with_trailer[] = {
+            0x16, 0x00, 0x00, 0x00,              //
+            0x02, 'h', 'e', 'l', 'l', 'o', 0x00, //
+            0x06, 0x00, 0x00, 0x00,              //
+            'w', 'o', 'r', 'l', 'd', 0x00,       //
+            0x00,                                //
+            0xFF};
+         std::string_view buf(reinterpret_cast<const char*>(with_trailer), sizeof(with_trailer));
+         auto json = glz::bson_to_json(buf);
+         expect(not json.has_value());
+         expect(json.error().ec == glz::error_code::syntax_error);
+      };
+
+      "convert-enforces-depth-limit"_test = [] {
+         // Same deeply-nested build as in bson_depth_limit_tests — converter
+         // walks the same document tree so the guard must trip here too.
+         // Reference the real limit so the test self-adjusts if it changes.
+         constexpr size_t depth = glz::max_recursive_depth_limit + 1;
+         auto append_le_i32 = [&](std::string& dst, int32_t v) {
+            char b[4];
+            for (int i = 0; i < 4; ++i) b[i] = char((v >> (8 * i)) & 0xFF);
+            dst.append(b, 4);
+         };
+         std::string inner;
+         append_le_i32(inner, 5);
+         inner.push_back('\0');
+         for (size_t i = 0; i < depth; ++i) {
+            std::string next;
+            const auto inner_size = static_cast<int32_t>(inner.size());
+            append_le_i32(next, 4 + 1 + 2 + inner_size + 1);
+            next.push_back('\x03');
+            next.push_back('a');
+            next.push_back('\0');
+            next.append(inner);
+            next.push_back('\0');
+            inner = std::move(next);
+         }
+         auto json = glz::bson_to_json(inner);
+         expect(not json.has_value());
+         expect(json.error().ec == glz::error_code::exceeded_max_recursive_depth);
+      };
+   };
+}
+
+int main() { return 0; }

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -748,6 +748,30 @@ void map_tests()
          expect(result[item.first] == item.second);
       }
    };
+
+   "map_skips_empty_optional_by_default"_test = [] {
+      std::map<std::string, std::optional<int>> in{{"a", 1}, {"b", std::nullopt}, {"c", 3}};
+      std::string buf;
+      expect(not glz::write_cbor(in, buf));
+      std::map<std::string, std::optional<int>> out{};
+      expect(not glz::read_cbor(out, buf));
+      expect(out.size() == 2);
+      expect(out.count("b") == 0);
+      expect(out.at("a").value() == 1);
+      expect(out.at("c").value() == 3);
+   };
+
+   "map_preserves_nulls_when_skip_disabled"_test = [] {
+      constexpr auto preserve = glz::opts{.format = glz::CBOR, .skip_null_members = false};
+      std::map<std::string, std::optional<int>> in{{"a", 1}, {"b", std::nullopt}};
+      std::string buf;
+      expect(not glz::write<preserve>(in, buf));
+      std::map<std::string, std::optional<int>> out{};
+      expect(not glz::read<preserve>(out, buf));
+      expect(out.size() == 2);
+      expect(out.at("a").value() == 1);
+      expect(!out.at("b").has_value());
+   };
 }
 
 void object_tests()

--- a/tests/jsonb_test/jsonb_test.cpp
+++ b/tests/jsonb_test/jsonb_test.cpp
@@ -1762,6 +1762,27 @@ suite skip_null_members_tests = [] {
       expect(j.has_value());
       expect(j.value() == R"({"id":5,"nickname":"Al"})");
    };
+
+   "skip_null_members drops empty optionals from map values"_test = [] {
+      std::map<std::string, std::optional<int>> in{{"a", 1}, {"b", std::nullopt}, {"c", 3}};
+      std::string buf;
+      constexpr glz::opts O{.format = glz::JSONB};
+      expect(not glz::write<O>(in, buf));
+      auto j = glz::jsonb_to_json(buf);
+      expect(j.has_value());
+      // Ordered map → predictable key order.
+      expect(j.value() == R"({"a":1,"c":3})");
+   };
+
+   "skip_null_members=false preserves map nulls"_test = [] {
+      std::map<std::string, std::optional<int>> in{{"a", 1}, {"b", std::nullopt}};
+      std::string buf;
+      constexpr glz::opts O{.format = glz::JSONB, .skip_null_members = false};
+      expect(not glz::write<O>(in, buf));
+      auto j = glz::jsonb_to_json(buf);
+      expect(j.has_value());
+      expect(j.value() == R"({"a":1,"b":null})");
+   };
 };
 
 suite skip_default_members_tests = [] {

--- a/tests/msgpack_test/msgpack_test.cpp
+++ b/tests/msgpack_test/msgpack_test.cpp
@@ -384,12 +384,45 @@ int main()
                   .tags = {{"zones", {0, 1}}},
                },
             },
-         .metrics = {{"errors", {{1, 2, 3}}}, {"warnings", std::nullopt}},
+         // "warnings" would be std::nullopt, but skip_null_members (default) drops empty
+         // optionals in maps just like struct fields. A dedicated test below covers that path.
+         .metrics = {{"errors", {{1, 2, 3}}}},
          .header = std::make_tuple(2024, std::string{"glaze-msgpack"}, true),
          .status = 200,
       };
 
       expect_roundtrip_equal(batch);
+   };
+
+   "msgpack map skips empty optional values by default"_test = [] {
+      // skip_null_members defaults to true. Empty optional values in a map should
+      // be dropped on write (matching the struct-field behavior); non-empty ones
+      // and non-null value types are unaffected.
+      std::map<std::string, std::optional<int>> in{{"a", 1}, {"b", std::nullopt}, {"c", 3}};
+      auto encoded = glz::write_msgpack(in);
+      expect(bool(encoded));
+
+      std::map<std::string, std::optional<int>> decoded{};
+      auto ec = glz::read_msgpack(decoded, std::string_view{encoded.value()});
+      expect(not ec);
+      expect(decoded.size() == 2);
+      expect(decoded.count("b") == 0);
+      expect(decoded.at("a").value() == 1);
+      expect(decoded.at("c").value() == 3);
+   };
+
+   "msgpack map preserves nulls when skip_null_members=false"_test = [] {
+      constexpr auto preserve = glz::opts{.format = glz::MSGPACK, .skip_null_members = false};
+      std::map<std::string, std::optional<int>> in{{"a", 1}, {"b", std::nullopt}};
+      auto encoded = glz::write<preserve>(in);
+      expect(bool(encoded));
+
+      std::map<std::string, std::optional<int>> decoded{};
+      auto ec = glz::read<preserve>(decoded, std::string_view{encoded.value()});
+      expect(not ec);
+      expect(decoded.size() == 2);
+      expect(decoded.at("a").value() == 1);
+      expect(!decoded.at("b").has_value());
    };
 
    "msgpack structs_as_arrays roundtrip"_test = [] {


### PR DESCRIPTION
## Summary
- Adds full BSON read/write with automatic reflection — any type that already serializes to JSON serializes to BSON without additional metadata
- Provides helper types (`glz::bson::object_id`, `datetime`, `regex`, `javascript`, `decimal128`, `timestamp`, `binary`, `min_key`, `max_key`) for BSON wire types that have no native JSON equivalent
- Adds `glz::bson_to_json` converter producing MongoDB Canonical Extended JSON v2, plus a skip path that advances past deprecated BSON types (undefined, DBPointer, symbol, code-with-scope) without erroring
- Cross-format fix: JSONB, CBOR, MsgPack, and BEVE map writers now honor `skip_null_members`, matching the struct-writer behavior

## Test plan
- [x] 103 BSON tests (225 asserts) covering: primitive coercion with range checks, helper-type round-trips, strict/permissive unknown-key modes, variant auto-deduction from element tag, nested documents/arrays, top-level documents AND top-level arrays, deep-nesting depth guard, exact-fill enforcement, malformed-input rejection (truncated, trailing bytes, negative length prefix, inner/outer-length mismatch for binary subtype 0x02, legacy UUID subtype 0x03)
- [x] Byte-exact wire-conformance tests (length-prefix computation, regex option alphabetical ordering, subtype 0x02 redundant inner length)
- [x] `bson_to_json` converter coverage for all supported types, depth-limit enforcement, and trailing-byte rejection
- [x] Full suite green: 91/91 tests passing — no regressions in JSON, BEVE, JSONB, CBOR, MsgPack, networking, or RPC