### PR TITLE
jsonb_to_json: match SQLite json() for infinities

### DIFF
--- a/docs/jsonb.md
+++ b/docs/jsonb.md
@@ -78,9 +78,16 @@ The reader handles all four text types for interop with SQLite or hand-crafted b
 
 Per the SQLite JSONB spec, legacy readers **must** interpret element types 0 (NULL), 1 (TRUE), and 2 (FALSE) as their nominal value even when the payload size is non-zero, so that future spec extensions that store information in those payload bytes don't break older readers. Glaze skips any payload bytes and keeps the nominal value — it does not reject such elements as malformed.
 
-### Integer narrowing on read
+### Numeric range on read
 
-JSONB INT and INT5 payloads are spec'd to fit in 64 bits. When reading into a narrower target type (e.g. `int8_t`, `uint16_t`), Glaze bounds-checks the parsed value against `numeric_limits<T>::min()` / `max()` and returns `error_code::parse_number_failure` if the value won't fit, rather than silently truncating. The two's-complement edge case `|min()| == max()+1` is allowed for negative INT5 hex (so `-0x80000000` fits cleanly into `int32_t`).
+The SQLite JSONB spec does **not** cap INT/INT5 at 64 bits or FLOAT/FLOAT5 at IEEE-754 binary64 — the payload is ASCII text and the spec leaves magnitude open-ended. Producers in languages with arbitrary-precision numerics (e.g. Python `int`, `float`) can legitimately emit payloads that overflow these widths.
+
+Glaze's reader parses INT/INT5 through `int64_t` / `uint64_t` and FLOAT/FLOAT5 through `double` as intermediates, then bounds-checks into the destination type. A payload that exceeds those intermediates returns `error_code::parse_number_failure` rather than silently truncating or saturating. In practice:
+
+* **Integers:** values outside `[INT64_MIN, UINT64_MAX]` fail. Within that range, values are bounds-checked against the target type (`int8_t`, `uint16_t`, etc). The two's-complement edge case `|min()| == max()+1` is allowed for negative INT5 hex (so `-0x80000000` fits cleanly into `int32_t`).
+* **Floats:** values whose ASCII form fast-float cannot convert to `double` fail. Finite values beyond `double`'s range round to `±infinity` per IEEE-754, which is then cast to the target float type.
+
+If you need to consume blobs produced by arbitrary-precision writers, pre-validate or route those fields through a string alternative before reading.
 
 ### DoS protection
 
@@ -96,7 +103,15 @@ The spec permits non-minimal headers, so blobs Glaze writes are spec-compliant b
 
 ## Floating-Point Special Values
 
-Standard JSON has no representation for `NaN`, `Infinity`, or `-Infinity`. JSONB inherits JSON5's ability to represent them via the FLOAT5 element type, and Glaze writes them as FLOAT5 automatically. `jsonb_to_json` renders them as JSON `null` when emitting strict JSON.
+Standard JSON has no representation for `NaN`, `Infinity`, or `-Infinity`. JSONB inherits JSON5's ability to represent them via the FLOAT5 element type, and Glaze writes them as FLOAT5 automatically. `jsonb_to_json` matches SQLite's `json()` convention on output:
+
+| FLOAT5 payload | `jsonb_to_json` output |
+|---|---|
+| `NaN` | `null` |
+| `Infinity`, `+Infinity` | `9e999` |
+| `-Infinity` | `-9e999` |
+
+`9e999` is outside the representable range of IEEE-754 binary64, so a strict-JSON parser reading the output into `double` yields `±infinity`, round-tripping the value. Parsers targeting a wider float type (`long double`, or 128-bit formats on some platforms) may accept `9e999` as a finite number since `10^999` fits in those ranges, so the infinity semantic is lost. If you need exact fidelity across float widths, keep the value in JSONB rather than routing it through the JSON text form.
 
 ## Variants
 

--- a/include/glaze/jsonb/jsonb_to_json.hpp
+++ b/include/glaze/jsonb/jsonb_to_json.hpp
@@ -165,11 +165,24 @@ namespace glz
          }
          case jsonb::type::float5: {
             sv s{reinterpret_cast<const char*>(payload), static_cast<size_t>(sz)};
-            if (s == "NaN" || s == "Infinity" || s == "+Infinity" || s == "-Infinity") {
-               // Strict JSON has no representation; emit null.
+            if (s == "NaN") {
+               // Strict JSON has no NaN representation; emit null (matches SQLite json()).
                if (!ensure_space(ctx, out, ix + 4 + write_padding_bytes)) return;
                std::memcpy(&out[ix], "null", 4);
                ix += 4;
+               return;
+            }
+            if (s == "Infinity" || s == "+Infinity") {
+               // Match SQLite json(): emit 9e999, which parses as +infinity in IEEE-754 binary64.
+               if (!ensure_space(ctx, out, ix + 5 + write_padding_bytes)) return;
+               std::memcpy(&out[ix], "9e999", 5);
+               ix += 5;
+               return;
+            }
+            if (s == "-Infinity") {
+               if (!ensure_space(ctx, out, ix + 6 + write_padding_bytes)) return;
+               std::memcpy(&out[ix], "-9e999", 6);
+               ix += 6;
                return;
             }
             // Otherwise, best effort: strip leading '+'.

--- a/tests/jsonb_test/jsonb_test.cpp
+++ b/tests/jsonb_test/jsonb_test.cpp
@@ -1045,7 +1045,7 @@ suite converter_tests = [] {
       expect(j.value() == "255");
    };
 
-   "jsonb_to_json maps NaN/Inf to null"_test = [] {
+   "jsonb_to_json maps NaN to null and infinities to 9e999"_test = [] {
       std::string buf;
       expect(not glz::write_jsonb(std::numeric_limits<double>::quiet_NaN(), buf));
       auto j = glz::jsonb_to_json(buf);
@@ -1055,7 +1055,12 @@ suite converter_tests = [] {
       buf.clear();
       expect(not glz::write_jsonb(std::numeric_limits<double>::infinity(), buf));
       j = glz::jsonb_to_json(buf);
-      expect(j.value() == "null");
+      expect(j.value() == "9e999");
+
+      buf.clear();
+      expect(not glz::write_jsonb(-std::numeric_limits<double>::infinity(), buf));
+      j = glz::jsonb_to_json(buf);
+      expect(j.value() == "-9e999");
    };
 
    "jsonb_to_json TEXTJ passthrough"_test = [] {


### PR DESCRIPTION
## Summary
- `jsonb_to_json` now emits `9e999` / `-9e999` for `±Infinity` instead of `null`, matching the convention SQLite's own `json()` function uses. `NaN` still maps to `null` (also matching SQLite). `9e999` parses back to `±infinity` under IEEE-754 binary64, so the value round-trips through any strict-JSON consumer that targets `double`.
- Docs correction: the SQLite JSONB spec does **not** cap INT/INT5 at 64 bits or FLOAT/FLOAT5 at binary64 — Glaze's 64-bit intermediates are an implementation constraint. Producers with arbitrary-precision numerics (e.g. Python) can legitimately emit payloads outside these ranges, and Glaze returns `parse_number_failure` rather than silently truncating. The "Integer narrowing on read" section is now "Numeric range on read" and reflects this.
- Docs addition: fidelity note that `9e999` is accepted as a finite value by parsers targeting float types wider than `double` (e.g. `long double` on platforms where it's 80- or 128-bit), so the infinity semantic is lost in those pipelines. Keep the value in JSONB if you need exact fidelity across float widths.

## Test plan
- [x] `tests/jsonb_test` — updated `jsonb_to_json maps NaN to null and infinities to 9e999` asserts the new outputs (`9e999`, `-9e999`, `null`). 141/141 pass locally.
- [x] Round-trip tests in `float special values as FLOAT5` still pass — the FLOAT5 binary encoding is unchanged; only the JSON text conversion path changed.