### PR TITLE
Named enum fix

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -3344,7 +3344,7 @@ namespace glz
                   }
                   else {
                      Key key_value{};
-                     if constexpr (glaze_enum_t<Key> || mimics_str_t<Key>) {
+                     if constexpr (is_named_enum<Key> || mimics_str_t<Key>) {
                         parse<JSON>::op<Opts>(key_value, ctx, it, end);
                      }
                      else if constexpr (std::is_arithmetic_v<Key>) {

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1197,7 +1197,7 @@ namespace glz
    template <auto Opts, class Key, class Value, is_context Ctx, class B>
    GLZ_ALWAYS_INLINE void write_pair_content(const Key& key, Value&& value, Ctx& ctx, B&& b, auto& ix)
    {
-      if constexpr (str_t<Key> || char_t<Key> || glaze_enum_t<Key> || mimics_str_t<Key> || custom_str_t<Key> ||
+      if constexpr (str_t<Key> || char_t<Key> || is_named_enum<Key> || mimics_str_t<Key> || custom_str_t<Key> ||
                     check_quoted_num(Opts)) {
          to<JSON, core_t<Key>>::template op<Opts>(key, ctx, b, ix);
       }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -8109,6 +8109,34 @@ suite enum_map = [] {
    };
 };
 
+enum class NamedEnumKeys { A, B, C };
+
+template <>
+struct glz::meta<NamedEnumKeys>
+{
+   static constexpr auto keys = std::array<std::string_view, 3>{{"A", "B", "C"}};
+   static constexpr auto value = std::array<NamedEnumKeys, 3>{{NamedEnumKeys::A, NamedEnumKeys::B, NamedEnumKeys::C}};
+};
+
+suite named_enum_map_keys = [] {
+   "map with keys/value array named enum"_test = [] {
+      constexpr std::string_view input = R"({"A":0.5,"C":12})";
+      using Data = std::map<NamedEnumKeys, double>;
+      auto result = glz::read_json<Data>(input);
+      expect(result.has_value());
+      if (result.has_value()) {
+         auto& data = result.value();
+         expect(data.at(NamedEnumKeys::A) == 0.5);
+         expect(data.at(NamedEnumKeys::C) == 12);
+      }
+
+      std::string out;
+      Data roundtrip{{NamedEnumKeys::A, 0.5}, {NamedEnumKeys::C, 12}};
+      expect(not glz::write_json(roundtrip, out));
+      expect(out == R"({"A":0.5,"C":12})") << out;
+   };
+};
+
 suite obj_handling = [] {
    "obj handling"_test = [] {
       size_t cnt = 0;


### PR DESCRIPTION
## Summary
- Fixes #2522: reading a `std::map` keyed by a named enum failed with `expected_quote` when the enum was declared with the `keys` + `value` array form of `glz::meta`.
- The map key dispatch in `read.hpp` / `write.hpp` was checking `glaze_enum_t<Key>` (only matches `glz::enumerate(...)` form) and falling through to the `quoted_t` path for `keys`/`value`-array enums, which stripped the quotes before the named-enum parser expected them.
- Switched both call sites to `is_named_enum<Key>`, which covers both `glz::enumerate` and `keys`/`value`-array forms.