### PR TITLE
flatten_map_wrapper: support top-level wrapping via CTAD

### DIFF
--- a/docs/wrappers.md
+++ b/docs/wrappers.md
@@ -332,6 +332,22 @@ The wrapper flattens each entry as `[key elements..., mapped value]`, so multipl
 
 This is intended for pair-ranges and map-like containers whose keys can be flattened without additional metadata, including `std::pair`, tuples, Glaze arrays, and fixed-size containers like `std::array`.
 
+To serialize a top-level map directly (without defining a `glz::meta`), construct `glz::flatten_map_wrapper` around the map:
+
+```c++
+std::unordered_map<std::pair<int, int>, std::string, pair_hash> map{};
+map[{1, 2}] = "example";
+
+std::string json{};
+expect(!glz::write_json(glz::flatten_map_wrapper{map}, json));
+expect(json == R"([1,2,"example"])");
+
+std::unordered_map<std::pair<int, int>, std::string, pair_hash> parsed{};
+auto wrapped = glz::flatten_map_wrapper{parsed};
+expect(!glz::read_json(wrapped, json));
+expect(parsed.at({1, 2}) == "example");
+```
+
 ## string_as_number
 
 Read JSON numbers into strings and write strings as JSON numbers.

--- a/include/glaze/json/flatten_map.hpp
+++ b/include/glaze/json/flatten_map.hpp
@@ -19,6 +19,10 @@ namespace glz
       T& value;
    };
 
+   template <class T>
+      requires(range<T> && pair_t<range_value_t<T>>)
+   flatten_map_wrapper(T&) -> flatten_map_wrapper<T>;
+
    template <auto MemPtr>
    constexpr auto flatten_map_impl() noexcept
    {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -1168,6 +1168,31 @@ suite container_types = [] {
       expect(not glz::write_json(glz::flatten_map<&flatten_map_box<decltype(entries)>::map>(vec_box), buffer));
       expect(buffer == R"([1,2,"a",3,4,"b"])") << buffer;
    };
+   "flatten_map_wrapper top-level map"_test = [] {
+      using map_t = std::unordered_map<std::pair<int, int>, std::string, pair_hash>;
+
+      map_t map{};
+      map[{1, 2}] = "example";
+
+      std::string buffer{};
+      expect(not glz::write_json(glz::flatten_map_wrapper{map}, buffer));
+      expect(buffer == R"([1,2,"example"])") << buffer;
+
+      map_t parsed{};
+      auto wrapped = glz::flatten_map_wrapper{parsed};
+      expect(not glz::read_json(wrapped, buffer));
+      expect(parsed == map);
+   };
+   "flatten_map_wrapper top-level multi entry"_test = [] {
+      using map_t = std::unordered_map<std::pair<int, int>, std::string, pair_hash>;
+
+      map_t parsed{};
+      auto wrapped = glz::flatten_map_wrapper{parsed};
+      expect(not glz::read_json(wrapped, R"([1,2,"a",3,4,"b"])"));
+      expect(parsed.size() == size_t{2});
+      expect(parsed.at({1, 2}) == "a");
+      expect(parsed.at({3, 4}) == "b");
+   };
    "deque roundtrip"_test = [] {
       std::vector<int> deq(100);
       for (auto& item : deq) item = rand();


### PR DESCRIPTION
## Summary
- Adds a concept-constrained CTAD deduction guide on `flatten_map_wrapper` so users can wrap a top-level map directly with `glz::flatten_map_wrapper{map}` and pass it straight to `glz::read_json` / `glz::write_json`, without defining a `glz::meta` containing `glz::flatten_map<&T::m>`.
- The `requires(range<T> && pair_t<range_value_t<T>>)` constraint gives an early, targeted diagnostic at CTAD time instead of deferring to the `static_assert` inside `from<JSON>` / `to<JSON>`.
- Existing `glz::flatten_map<&T::m>` variable-template usage is unchanged, so meta-tuple usage continues to work unaffected.

Closes #2183.

## Documentation
See the `flatten_map` wrapper docs — [published](https://stephenberry.github.io/glaze/wrappers/#flatten_map) and [source](https://github.com/stephenberry/glaze/blob/main/docs/wrappers.md#flatten_map). This PR extends the section with a top-level usage example.

## Example

```cpp
std::unordered_map<std::pair<int, int>, std::string, pair_hash> map;
map[{1, 2}] = "example";

std::string out;
glz::write_json(glz::flatten_map_wrapper{map}, out);
// out == R"([1,2,"example"])"

std::unordered_map<std::pair<int, int>, std::string, pair_hash> parsed;
auto wrapped = glz::flatten_map_wrapper{parsed};
glz::read_json(wrapped, out);
// parsed.at({1, 2}) == "example"
```

## Test plan
- [x] `tests/json_test` — new cases `flatten_map_wrapper top-level map` and `flatten_map_wrapper top-level multi entry` pass (676/676 tests, 57202/57202 asserts).
- [x] Existing `flatten_map` member-pointer tests still pass.