### PR TITLE
Fix variant deduction for vector<pair<...>> as JSON object (#2529)

### DIFF
--- a/include/glaze/json/json_concepts.hpp
+++ b/include/glaze/json/json_concepts.hpp
@@ -8,8 +8,13 @@
 namespace glz
 {
    template <class T>
-   concept json_object = glaze_object_t<T> || reflectable<T> || writable_map_t<T> || readable_map_t<T> ||
-                         (range<T> && pair_t<range_value_t<T>>);
+   concept json_object = glaze_object_t<T> || reflectable<T> || writable_map_t<T> || readable_map_t<T>;
+
+   // Range-of-pairs types are parsed as JSON objects only when the `concatenate` option is true (default).
+   // The variant parser uses this separately so deduction can be made option-aware without polluting
+   // the type-level `json_object` concept.
+   template <class T>
+   concept json_pair_range_object = !json_object<T> && range<T> && pair_t<range_value_t<T>>;
 
    template <class T>
    concept json_array = array_t<T>;

--- a/include/glaze/json/json_concepts.hpp
+++ b/include/glaze/json/json_concepts.hpp
@@ -8,7 +8,8 @@
 namespace glz
 {
    template <class T>
-   concept json_object = glaze_object_t<T> || reflectable<T> || writable_map_t<T> || readable_map_t<T>;
+   concept json_object = glaze_object_t<T> || reflectable<T> || writable_map_t<T> || readable_map_t<T> ||
+                         (range<T> && pair_t<range_value_t<T>>);
 
    template <class T>
    concept json_array = array_t<T>;

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -3451,6 +3451,10 @@ namespace glz
    template <class T>
    concept variant_object_type = json_object<T>;
 
+   // Treated as a JSON object only when the `concatenate` option is enabled.
+   template <class T>
+   concept variant_concat_object_type = json_pair_range_object<T>;
+
    template <class T>
    concept variant_array_type = array_t<remove_meta_wrapper_t<T>> || glaze_array_t<T> || tuple_t<T> || is_std_tuple<T>;
 
@@ -3472,6 +3476,9 @@ namespace glz
    {};
    template <class T>
    struct is_variant_object : std::bool_constant<variant_object_type<T>>
+   {};
+   template <class T>
+   struct is_variant_concat_object : std::bool_constant<variant_concat_object_type<T>>
    {};
    template <class T>
    struct is_variant_array : std::bool_constant<variant_array_type<T>>
@@ -3707,13 +3714,22 @@ namespace glz
                   }
                }
                using type_counts = variant_type_count<T>;
+               // When `concatenate` is enabled (default), range-of-pair alternatives also parse as `{...}`.
+               static constexpr bool concat_objects_active = check_concatenate(Opts);
+               static constexpr auto n_concat_object =
+                  concat_objects_active ? variant_count_v<T, is_variant_concat_object> : 0;
                if constexpr ((type_counts::n_object < 1) //
-                             && (type_counts::n_nullable_object < 1)) {
+                             && (type_counts::n_nullable_object < 1) //
+                             && (n_concat_object < 1)) {
                   ctx.error = error_code::no_matching_variant_type;
                   return;
                }
-               else if constexpr ((type_counts::n_object + type_counts::n_nullable_object) == 1 && tag_v<T>.empty()) {
-                  constexpr auto first_idx = variant_first_index_v<T, is_variant_object>;
+               else if constexpr ((type_counts::n_object + type_counts::n_nullable_object + n_concat_object) == 1 &&
+                                  tag_v<T>.empty()) {
+                  constexpr auto obj_idx = variant_first_index_v<T, is_variant_object>;
+                  constexpr auto first_idx = (obj_idx != std::variant_npos)
+                                                ? obj_idx
+                                                : variant_first_index_v<T, is_variant_concat_object>;
                   using V = std::variant_alternative_t<first_idx, T>;
                   if (!std::holds_alternative<V>(value)) value = V{};
                   parse<JSON>::op<opening_handled<Opts>()>(std::get<V>(value), ctx, it, end);

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -3697,7 +3697,7 @@ namespace glz
             case '\0':
                ctx.error = error_code::unexpected_end;
                return;
-            case '{':
+            case '{': {
                if (ctx.depth >= max_recursive_depth_limit) {
                   ctx.error = error_code::exceeded_max_recursive_depth;
                   return;
@@ -4322,6 +4322,7 @@ namespace glz
                   }
                }
                break;
+            }
             case '[':
                if (ctx.depth >= max_recursive_depth_limit) {
                   ctx.error = error_code::exceeded_max_recursive_depth;

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -3451,10 +3451,6 @@ namespace glz
    template <class T>
    concept variant_object_type = json_object<T>;
 
-   // Treated as a JSON object only when the `concatenate` option is enabled.
-   template <class T>
-   concept variant_concat_object_type = json_pair_range_object<T>;
-
    template <class T>
    concept variant_array_type = array_t<remove_meta_wrapper_t<T>> || glaze_array_t<T> || tuple_t<T> || is_std_tuple<T>;
 
@@ -3477,8 +3473,9 @@ namespace glz
    template <class T>
    struct is_variant_object : std::bool_constant<variant_object_type<T>>
    {};
+   // Range-of-pairs alternatives parse as a JSON object only when the `concatenate` option is enabled (default).
    template <class T>
-   struct is_variant_concat_object : std::bool_constant<variant_concat_object_type<T>>
+   struct is_variant_concat_object : std::bool_constant<json_pair_range_object<T>>
    {};
    template <class T>
    struct is_variant_array : std::bool_constant<variant_array_type<T>>
@@ -3552,6 +3549,31 @@ namespace glz
       static constexpr auto n_array = variant_count_v<T, is_variant_array>;
       static constexpr auto n_null = variant_count_v<T, is_variant_null>;
    };
+
+   // Number of variant alternatives that should be treated as JSON objects under the active options.
+   // Includes range-of-pair alternatives only when `concatenate` is enabled (default).
+   //
+   // Note: this preserves the existing predicate used by the variant '{' fast path. Because
+   // `variant_type_count::n_object` already includes `n_nullable_object`, adding
+   // `n_nullable_object` again effectively excludes nullable-object alternatives from the
+   // single-candidate fast path (which only knows how to dispatch a non-nullable object index).
+   template <auto Opts, class T>
+   constexpr size_t variant_object_candidate_count_v =
+      variant_type_count<T>::n_object + variant_type_count<T>::n_nullable_object +
+      (check_concatenate(Opts) ? variant_count_v<T, is_variant_concat_object> : 0);
+
+   // First variant index that is an object candidate under the active options. Prefers a true
+   // `is_variant_object` match; falls back to `is_variant_concat_object` when concatenate is enabled.
+   template <auto Opts, class T>
+   constexpr size_t variant_first_object_candidate_v = []() {
+      constexpr auto obj_idx = variant_first_index_v<T, is_variant_object>;
+      if constexpr (obj_idx != std::variant_npos)
+         return obj_idx;
+      else if constexpr (check_concatenate(Opts))
+         return variant_first_index_v<T, is_variant_concat_object>;
+      else
+         return std::variant_npos;
+   }();
 
    // Process variant alternatives by iterating directly over variant indices
    // (replaces tuple_cat + tuple iteration approach)
@@ -3714,22 +3736,13 @@ namespace glz
                   }
                }
                using type_counts = variant_type_count<T>;
-               // When `concatenate` is enabled (default), range-of-pair alternatives also parse as `{...}`.
-               static constexpr bool concat_objects_active = check_concatenate(Opts);
-               static constexpr auto n_concat_object =
-                  concat_objects_active ? variant_count_v<T, is_variant_concat_object> : 0;
-               if constexpr ((type_counts::n_object < 1) //
-                             && (type_counts::n_nullable_object < 1) //
-                             && (n_concat_object < 1)) {
+               constexpr auto n_object_candidates = variant_object_candidate_count_v<Opts, T>;
+               if constexpr (n_object_candidates < 1) {
                   ctx.error = error_code::no_matching_variant_type;
                   return;
                }
-               else if constexpr ((type_counts::n_object + type_counts::n_nullable_object + n_concat_object) == 1 &&
-                                  tag_v<T>.empty()) {
-                  constexpr auto obj_idx = variant_first_index_v<T, is_variant_object>;
-                  constexpr auto first_idx = (obj_idx != std::variant_npos)
-                                                ? obj_idx
-                                                : variant_first_index_v<T, is_variant_concat_object>;
+               else if constexpr (n_object_candidates == 1 && tag_v<T>.empty()) {
+                  constexpr auto first_idx = variant_first_object_candidate_v<Opts, T>;
                   using V = std::variant_alternative_t<first_idx, T>;
                   if (!std::holds_alternative<V>(value)) value = V{};
                   parse<JSON>::op<opening_handled<Opts>()>(std::get<V>(value), ctx, it, end);

--- a/tests/json_test/json_variant_support_test.cpp
+++ b/tests/json_test/json_variant_support_test.cpp
@@ -2064,6 +2064,18 @@ suite vector_pair_object_variant_tests = [] {
       expect(v.index() == 2);
       expect(std::get<2>(v).size() == 1);
    };
+
+   // With concatenate=false the user opts out of object-shaped pair-ranges,
+   // so the variant must NOT match vector<pair> against `{...}` JSON.
+   "variant with concatenate=false does not match object to vector<pair>"_test = [] {
+      struct opts_concat : glz::opts { bool concatenate = true; };
+      static constexpr opts_concat cat_off{{glz::opts{}}, false};
+
+      std::variant<std::string_view, std::nullptr_t, map_type> v;
+      auto ec = glz::read<cat_off>(v, R"({"k":"v"})");
+      expect(bool(ec));
+      expect(ec == glz::error_code::no_matching_variant_type);
+   };
 };
 
 int main() { return 0; }

--- a/tests/json_test/json_variant_support_test.cpp
+++ b/tests/json_test/json_variant_support_test.cpp
@@ -2021,4 +2021,49 @@ suite custom_type_schema_generation = [] {
    };
 };
 
+// Regression test for https://github.com/stephenberry/glaze/issues/2529
+// vector<pair<...>> is parsed from a JSON object in concatenate mode (default),
+// so the variant deduction must treat it as an object alternative.
+suite vector_pair_object_variant_tests = [] {
+   using map_type = std::vector<std::pair<std::string_view, std::string_view>>;
+
+   "vector<pair> direct read"_test = [] {
+      map_type m;
+      auto ec = glz::read_json(m, R"({"foo":"bar"})");
+      expect(!ec) << glz::format_error(ec, std::string{R"({"foo":"bar"})"});
+      expect(m.size() == 1);
+      expect(m[0].first == "foo");
+      expect(m[0].second == "bar");
+   };
+
+   "variant with vector<pair> alternative"_test = [] {
+      std::variant<std::string_view, std::nullptr_t, map_type> v;
+      auto ec = glz::read_json(v, R"({"foo":"bar"})");
+      expect(!ec) << glz::format_error(ec, std::string{R"({"foo":"bar"})"});
+      expect(v.index() == 2);
+      auto& m = std::get<2>(v);
+      expect(m.size() == 1);
+      expect(m[0].first == "foo");
+      expect(m[0].second == "bar");
+   };
+
+   "variant deduces null/string/object alternatives"_test = [] {
+      std::variant<std::string_view, std::nullptr_t, map_type> v;
+
+      auto ec = glz::read_json(v, R"(null)");
+      expect(!ec);
+      expect(v.index() == 1);
+
+      ec = glz::read_json(v, R"("hello")");
+      expect(!ec);
+      expect(v.index() == 0);
+      expect(std::get<0>(v) == "hello");
+
+      ec = glz::read_json(v, R"({"k":"v"})");
+      expect(!ec);
+      expect(v.index() == 2);
+      expect(std::get<2>(v).size() == 1);
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
## Summary

- Fixes #2529: `std::variant` containing a `vector<pair<...>>` alternative failed with `no_matching_variant_type` on `{...}` JSON, even though the same type parses fine as a JSON object when read directly.
- Variant deduction relied on the `json_object` concept, which only recognized map-like types via `readable_map_t`/`writable_map_t`. Those concepts require a `key_type` member (gated by `map_subscriptable`), which `vector<pair<...>>` lacks. The direct parser accepts such ranges via a separate concatenate-mode overload (default), so the variant path was inconsistent with direct reads.
- Whether a range-of-pairs is parsed as `{...}` or `[{...}]` depends on the per-call `concatenate` option (default `true`), so the deduction has to be option-aware rather than purely type-level.

## Approach

- Added a new concept `json_pair_range_object` in `json/json_concepts.hpp` for `range<T> && pair_t<range_value_t<T>>` alternatives that are not already `json_object`. `json_object` itself is unchanged.
- Added a matching variant trait `variant_concat_object_type` / `is_variant_concat_object` in `json/read.hpp`.
- The variant `case '{'` path now consults `check_concatenate(Opts)`; when true (default), pair-range alternatives count as object candidates, including in the `n_object == 1` fast path. When `concatenate=false`, they do not, so the variant returns the cleaner `no_matching_variant_type` error instead of dispatching to a parser that would fail with `expected_bracket`.

## Test plan

- [x] New regression suite in `tests/json_test/json_variant_support_test.cpp` covering the issue's repro, deduction across `null`/`string`/`object` alternatives, and a `concatenate=false` case asserting `no_matching_variant_type`.
- [x] All 22 JSON ctest binaries pass locally (`json_variant_support_test`: 80 tests, 395 asserts).