### PR TITLE
Improvements after integration

### DIFF
--- a/include/glaze/eetf/eetf_to_json.hpp
+++ b/include/glaze/eetf/eetf_to_json.hpp
@@ -15,16 +15,16 @@ namespace glz
    namespace detail
    {
       template <class It0, class It1>
-      GLZ_ALWAYS_INLINE size_t get8s(auto&& ctx, It0&& it, It1&& end)
+      GLZ_ALWAYS_INLINE size_t get8s(auto&& ctx, It0&& it, It1&& end) noexcept
       {
-         if (check_offset(ctx, it, end, 1)) return 0;
+         if (check_invalid_offset(ctx, it, end, 1)) return 0;
          return std::size_t(*it++);
       }
 
       template <class It0, class It1>
-      GLZ_ALWAYS_INLINE size_t get16be(auto&& ctx, It0&& it, It1&& end)
+      GLZ_ALWAYS_INLINE size_t get16be(auto&& ctx, It0&& it, It1&& end) noexcept
       {
-         if (check_offset(ctx, it, end, 2)) return 0;
+         if (check_invalid_offset(ctx, it, end, 2)) return 0;
          const std::size_t b1 = (*it++) << 8;
          return b1 | *it++;
       }
@@ -121,7 +121,7 @@ namespace glz
             ++it; // skip type
             const size_t len = get16be(ctx, it, end);
             if (bool(ctx.error)) return;
-            if (check_offset(ctx, it, end, len)) return;
+            if (check_invalid_offset(ctx, it, end, len)) return;
             const sv value{reinterpret_cast<const char*>(it), len};
             to<JSON, sv>::template op<Opts>(value, ctx, out, ix);
             std::advance(it, len);
@@ -133,7 +133,7 @@ namespace glz
             ++it; // skip type
             const size_t len = get8s(ctx, it, end);
             if (bool(ctx.error)) return;
-            if (check_offset(ctx, it, end, len)) return;
+            if (check_invalid_offset(ctx, it, end, len)) return;
             const sv value{reinterpret_cast<const char*>(it), len};
             if (len == 4 && std::memcmp(it, "true", 4) == 0) {
                dump("true", out, ix);
@@ -239,7 +239,8 @@ namespace glz
       }
    } // namespace detail
 
-   template <auto Opts = opts{}, class EETFBuffer, class JSONBuffer>
+   template <auto Opts = eetf::eetf_opts{}, contiguous EETFBuffer, class JSONBuffer>
+   requires has_value_type<EETFBuffer> && (sizeof(typename EETFBuffer::value_type) == sizeof(char))
    [[nodiscard]] inline error_ctx eetf_to_json(const EETFBuffer& term, JSONBuffer& out)
    {
       size_t ix{}; // write index
@@ -250,9 +251,11 @@ namespace glz
       context ctx{};
 
       // Check format version
-      const auto version = decode_version(ctx, it);
-      if (eetf_magic_version != version) {
-         return {1, error_code::version_mismatch};
+      if constexpr (not check_no_header(Opts)) {
+         const auto version = decode_version(ctx, it);
+         if (eetf_magic_version != version) {
+            return {0, error_code::version_mismatch};
+         }
       }
 
       while (it < end) {

--- a/include/glaze/eetf/ei.hpp
+++ b/include/glaze/eetf/ei.hpp
@@ -13,7 +13,7 @@ namespace glz
 {
 
    template <class Ctx, class It0, class It1>
-   [[nodiscard]] GLZ_ALWAYS_INLINE bool check_offset(Ctx&& ctx, It0&& it, It1&& end, size_t off)
+   [[nodiscard]] GLZ_ALWAYS_INLINE bool check_invalid_offset(Ctx&& ctx, It0&& it, It1&& end, size_t off) noexcept
    {
       if ((it + off) > end) [[unlikely]] {
          ctx.error = error_code::unexpected_end;
@@ -27,15 +27,15 @@ namespace glz
    namespace detail
    {
       template <class F, is_context Ctx, class It0, class It1>
-      GLZ_ALWAYS_INLINE void decode_impl(F&& func, Ctx&& ctx, It0&& it, It1 end)
+      GLZ_ALWAYS_INLINE void decode_impl(F&& func, Ctx&& ctx, It0&& it, It1&& end) noexcept
       {
          int index{};
-         if (func(it, &index) < 0) [[unlikely]] {
+         if (func(reinterpret_cast<const char*>(it), &index) < 0) [[unlikely]] {
             ctx.error = error_code::parse_number_failure;
             return;
          }
 
-         if (check_offset(ctx, it, end, index)) return;
+         if (check_invalid_offset(ctx, it, end, index)) return;
          std::advance(it, index);
       }
 
@@ -70,11 +70,11 @@ namespace glz
    } // namespace detail
 
    template <class It>
-   [[nodiscard]] GLZ_ALWAYS_INLINE int decode_version(is_context auto&& ctx, It&& it)
+   [[nodiscard]] GLZ_ALWAYS_INLINE int decode_version(is_context auto&& ctx, It&& it) noexcept
    {
       int index{};
       int version{};
-      if (ei_decode_version(it, &index, &version) < 0) [[unlikely]] {
+      if (ei_decode_version(reinterpret_cast<const char*>(it), &index, &version) < 0) [[unlikely]] {
          ctx.error = error_code::syntax_error;
          return -1;
       }
@@ -84,12 +84,12 @@ namespace glz
    }
 
    template <class It>
-   GLZ_ALWAYS_INLINE int get_type(is_context auto&& ctx, It&& it)
+   GLZ_ALWAYS_INLINE int get_type(is_context auto&& ctx, It&& it) noexcept
    {
       int type{};
       int size{};
       int index{};
-      if (ei_get_type(it, &index, &type, &size) < 0) {
+      if (ei_get_type(reinterpret_cast<const char*>(it), &index, &type, &size) < 0) {
          ctx.error = error_code::syntax_error;
          return -1;
       }
@@ -98,20 +98,20 @@ namespace glz
    }
 
    template <class It0, class It1>
-   auto skip_term(is_context auto&& ctx, It0&& it, It1 end)
+   auto skip_term(is_context auto&& ctx, It0&& it, It1&& end) noexcept
    {
       int index{};
-      if (ei_skip_term(it, &index) < 0) {
+      if (ei_skip_term(reinterpret_cast<const char*>(it), &index) < 0) {
          ctx.error = error_code::syntax_error;
          index = 0;
       }
 
-      if (check_offset(ctx, it, end, index)) return;
+      if (check_invalid_offset(ctx, it, end, index)) return;
       std::advance(it, index);
    }
 
    template <num_t T, class... Args>
-   GLZ_ALWAYS_INLINE void decode_number(T&& value, Args&&... args)
+   GLZ_ALWAYS_INLINE void decode_number(T&& value, Args&&... args) noexcept
    {
       using namespace std::placeholders;
       using V = std::remove_cvref_t<T>;
@@ -149,19 +149,19 @@ namespace glz
    }
 
    template <class It0, class It1>
-   GLZ_ALWAYS_INLINE void decode_token(auto&& value, is_context auto&& ctx, It0&& it, It1 end)
+   GLZ_ALWAYS_INLINE void decode_token(auto&& value, is_context auto&& ctx, It0&& it, It1&& end)
    {
       using namespace std::placeholders;
 
       int index{};
       int type{};
       int sz{};
-      if (ei_get_type(it, &index, &type, &sz) < 0) [[unlikely]] {
+      if (ei_get_type(reinterpret_cast<const char*>(it), &index, &type, &sz) < 0) [[unlikely]] {
          ctx.error = error_code::syntax_error;
          return;
       }
 
-      if (check_offset(ctx, it, end, sz)) return;
+      if (check_invalid_offset(ctx, it, end, sz)) return;
 
       value.resize(sz);
       if (eetf::is_atom(type)) {
@@ -173,7 +173,7 @@ namespace glz
    }
 
    template <class... Args>
-   GLZ_ALWAYS_INLINE void decode_boolean(auto&& value, Args&&... args)
+   GLZ_ALWAYS_INLINE void decode_boolean(auto&& value, Args&&... args) noexcept
    {
       using namespace std::placeholders;
 
@@ -183,11 +183,11 @@ namespace glz
    }
 
    template <auto Opts, class T, class It0>
-   void decode_binary(T&& value, std::size_t sz, is_context auto&& ctx, It0&& it, auto end)
+   void decode_binary(T&& value, std::size_t sz, is_context auto&& ctx, It0&& it, auto&& end)
    {
       using namespace std::placeholders;
 
-      if (check_offset(ctx, it, end, sz * sizeof(std::uint8_t))) return;
+      if (check_invalid_offset(ctx, it, end, sz * sizeof(std::uint8_t))) return;
 
       using V = range_value_t<std::decay_t<T>>;
 
@@ -216,11 +216,11 @@ namespace glz
    }
 
    template <is_context Ctx, class It>
-   GLZ_ALWAYS_INLINE auto decode_list_header(Ctx&& ctx, It&& it)
+   GLZ_ALWAYS_INLINE auto decode_list_header(Ctx&& ctx, It&& it) noexcept
    {
       int arity{};
       int index{};
-      if (ei_decode_list_header(it, &index, &arity) < 0) [[unlikely]] {
+      if (ei_decode_list_header(reinterpret_cast<const char*>(it), &index, &arity) < 0) [[unlikely]] {
          ctx.error = error_code::syntax_error;
          return header_pair(-1ull, -1ull);
       }
@@ -229,7 +229,7 @@ namespace glz
    }
 
    template <auto Opts, class T>
-   GLZ_ALWAYS_INLINE void decode_list(T&& value, is_context auto&& ctx, auto&& it, auto end)
+   GLZ_ALWAYS_INLINE void decode_list(T&& value, is_context auto&& ctx, auto&& it, auto&& end)
    {
       using V = range_value_t<std::decay_t<T>>;
 
@@ -251,7 +251,7 @@ namespace glz
          }
       }
 
-      if (check_offset(ctx, it, end, index)) return;
+      if (check_invalid_offset(ctx, it, end, index)) return;
       std::advance(it, index);
 
       for (std::size_t idx = 0; idx < arity; idx++) {
@@ -268,12 +268,12 @@ namespace glz
    }
 
    template <auto Opts, class T, is_context Ctx, class It0, class It1>
-   GLZ_ALWAYS_INLINE void decode_sequence(T&& value, Ctx&& ctx, It0&& it, It1 end)
+   GLZ_ALWAYS_INLINE void decode_sequence(T&& value, Ctx&& ctx, It0&& it, It1&& end)
    {
       int index{};
       int type{};
       int sz{};
-      if (ei_get_type(it, &index, &type, &sz) < 0) [[unlikely]] {
+      if (ei_get_type(reinterpret_cast<const char*>(it), &index, &type, &sz) < 0) [[unlikely]] {
          ctx.error = error_code::syntax_error;
          return;
       }
@@ -311,11 +311,11 @@ namespace glz
    }
 
    template <is_context Ctx, class It>
-   GLZ_ALWAYS_INLINE auto decode_map_header(Ctx&& ctx, It&& it)
+   GLZ_ALWAYS_INLINE auto decode_map_header(Ctx&& ctx, It&& it) noexcept
    {
       int arity{};
       int index{};
-      if (ei_decode_map_header(it, &index, &arity) < 0) [[unlikely]] {
+      if (ei_decode_map_header(reinterpret_cast<const char*>(it), &index, &arity) < 0) [[unlikely]] {
          ctx.error = error_code::syntax_error;
          return header_pair(-1ull, -1ull);
       }
@@ -324,11 +324,11 @@ namespace glz
    }
 
    template <is_context Ctx, class It>
-   GLZ_ALWAYS_INLINE auto decode_tuple_header(Ctx&& ctx, It&& it)
+   GLZ_ALWAYS_INLINE auto decode_tuple_header(Ctx&& ctx, It&& it) noexcept
    {
       int arity{};
       int index{};
-      if (ei_decode_tuple_header(it, &index, &arity) < 0) [[unlikely]] {
+      if (ei_decode_tuple_header(reinterpret_cast<const char*>(it), &index, &arity) < 0) [[unlikely]] {
          ctx.error = error_code::syntax_error;
          return header_pair(-1ull, -1ull);
       }
@@ -337,7 +337,7 @@ namespace glz
    }
 
    template <class B, class IX>
-   GLZ_ALWAYS_INLINE void encode_version(is_context auto&& ctx, B&& b, IX&& ix)
+   GLZ_ALWAYS_INLINE void encode_version(is_context auto&& ctx, B&& b, IX&& ix) noexcept
    {
       int index{static_cast<int>(ix)};
       if (ei_encode_version(reinterpret_cast<char*>(b.data()), &index) < 0) [[unlikely]] {

--- a/include/glaze/eetf/opts.hpp
+++ b/include/glaze/eetf/opts.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <glaze/core/opts.hpp>
+#include "glaze/core/opts.hpp"
 
 namespace glz::eetf
 {
@@ -11,12 +11,16 @@ namespace glz::eetf
 
    struct eetf_opts
    {
-      uint32_t format;
-      uint8_t layout{map_layout};
-      bool error_on_unknown_keys{true};
-      bool shrink_to_fit{false};
+      uint32_t format = EETF;
       uint32_t internal{};
-      bool prettify{false};
+      uint8_t layout = map_layout;
+      bool error_on_unknown_keys = true;
+      bool shrink_to_fit = false;
+      bool prettify = false;
+      bool quoted_num = false; // treat numbers as quoted or array-like types as having quoted numbers
+      bool string_as_number = false; // treats all types like std::string as numbers: read/write these quoted numbers
+      bool unquoted = false; // write out string like values without quotes
+      bool raw_string = false; // do not decode/encode escaped characters for strings (improves read/write performance)
    };
 
 } // namespace glz::eetf

--- a/include/glaze/eetf/read.hpp
+++ b/include/glaze/eetf/read.hpp
@@ -16,21 +16,21 @@ namespace glz
       {
         public:
          template <typename F>
-         field_iterator(F&& header_parser, Ctx&& ctx, It0&& it, It1 end)
+         field_iterator(F&& header_parser, Ctx&& ctx, It0&& it, It1&& end)
          {
             term_header = header_parser(ctx, it);
             if (bool(ctx.error)) [[unlikely]] {
                return;
             }
 
-            if (check_offset(ctx, it, end, term_header.second)) return;
+            if (check_invalid_offset(ctx, it, end, term_header.second)) return;
             std::advance(it, term_header.second);
          }
 
          field_iterator(error_code ec, Ctx&& ctx) : term_header{-1ull, -1ull} { ctx.error = ec; }
 
          template <auto Opts>
-         bool next(Ctx&& ctx, It0&& it, It1 end)
+         bool next(Ctx&& ctx, It0&& it, It1&& end)
          {
             if (term_header.first == 0) {
                return false;
@@ -66,7 +66,7 @@ namespace glz
       };
 
       template <auto Opts, is_context Ctx, class It0, class It1>
-      static auto make_term_iterator(Ctx&& ctx, It0&& it, It1 end)
+      static auto make_term_iterator(Ctx&& ctx, It0&& it, It1&& end)
       {
          using fi = field_iterator<Ctx, It0, It1>;
          const auto tag = get_type(ctx, it);
@@ -89,7 +89,7 @@ namespace glz
    struct skip_value<EETF>
    {
       template <auto Opts>
-      GLZ_ALWAYS_INLINE static void op(is_context auto&& ctx, auto&& it, auto end) noexcept
+      GLZ_ALWAYS_INLINE static void op(is_context auto&& ctx, auto&& it, auto&& end) noexcept
       {
          skip_term(ctx, it, end);
       }
@@ -100,7 +100,7 @@ namespace glz
    {
       template <auto Opts, class T, is_context Ctx, class It0, class It1>
          requires(not check_no_header(Opts))
-      GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, It0&& it, It1 end) noexcept
+      GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
       {
          const auto version = decode_version(ctx, it);
          // This version number is not in public headers - use as magic number
@@ -120,7 +120,7 @@ namespace glz
 
       template <auto Opts, class T, is_context Ctx, class It0, class It1>
          requires(check_no_header(Opts))
-      GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, It0&& it, It1 end) noexcept
+      GLZ_ALWAYS_INLINE static void op(T&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
       {
          if (bool(ctx.error)) {
             return;
@@ -146,7 +146,7 @@ namespace glz
    struct from<EETF, T> final
    {
       template <auto Opts, is_context Ctx, class It0, class It1>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1 end) noexcept
+      GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
       {
          decode_sequence<Opts>(std::forward<T>(value), std::forward<Ctx>(ctx), std::forward<It0>(it),
                                std::forward<It1>(end));
@@ -157,7 +157,7 @@ namespace glz
    struct from<EETF, T>
    {
       template <auto Opts, is_context Ctx, class It0, class It1>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1 end) noexcept
+      GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
       {
          if (bool(ctx.error)) [[unlikely]] {
             return;
@@ -175,7 +175,7 @@ namespace glz
    struct from<EETF, T> final
    {
       template <auto Opts, is_context Ctx, class It0, class It1>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1 end) noexcept
+      GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
       {
          if (bool(ctx.error)) [[unlikely]] {
             return;
@@ -193,7 +193,7 @@ namespace glz
    struct from<EETF, T> final
    {
       template <auto Opts, is_context Ctx, class It0, class It1>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1 end) noexcept
+      GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
       {
          if (bool(ctx.error)) [[unlikely]] {
             return;
@@ -213,7 +213,7 @@ namespace glz
    struct from<EETF, T> final
    {
       template <auto Opts, is_context Ctx, class It0, class It1>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1 end) noexcept
+      GLZ_ALWAYS_INLINE static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
       {
          if (bool(ctx.error)) [[unlikely]] {
             return;
@@ -234,7 +234,7 @@ namespace glz
    struct from<EETF, T> final
    {
       template <auto Opts>
-      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto end) noexcept
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end) noexcept
       {
          if (bool(ctx.error)) [[unlikely]] {
             return;
@@ -278,7 +278,7 @@ namespace glz
    struct from<EETF, T> final
    {
       template <auto Opts, is_context Ctx, class It0, class It1>
-      static void op(auto&& value, Ctx&& ctx, It0&& it, It1 end) noexcept
+      static void op(auto&& value, Ctx&& ctx, It0&& it, It1&& end) noexcept
       {
          if (bool(ctx.error)) [[unlikely]] {
             return;
@@ -375,7 +375,7 @@ namespace glz
    struct from<EETF, T> final
    {
       template <auto Opts>
-      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto end)
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto&& end)
       {
          using Key = typename T::key_type;
 

--- a/include/glaze/eetf/wrappers.hpp
+++ b/include/glaze/eetf/wrappers.hpp
@@ -33,7 +33,7 @@ namespace glz
    struct to<EETF, atom_as_string_t<T>>
    {
       template <auto Opts>
-      static void op(auto&& value, is_context auto&& ctx, auto&& b, auto& ix)
+      static void op(auto&& value, is_context auto&& ctx, auto&& b, auto&& ix)
       {
          eetf::atom s(value.val);
          using S = core_t<decltype(s)>;

--- a/tests/eetf_test/eetf_test.cpp
+++ b/tests/eetf_test/eetf_test.cpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstdint>
+#include <format>
 #include <map>
 #include <string>
 #include <variant>
@@ -41,6 +42,11 @@ std::array<std::uint8_t, 92> term_proplist_001{
    108, 111, 32,  69,  114, 108, 97,  110, 103, 32,  84, 101, 114, 109, 104, 2,   100, 0,   1,   105, 97,  1,   106};
 
 std::array<std::uint8_t, 16> term_atom{131, 116, 0, 0, 0, 1, 100, 0, 1, 97, 100, 0, 3, 113, 119, 101};
+
+struct simple
+{
+   int a;
+};
 
 struct my_struct
 {
@@ -419,6 +425,40 @@ suite eetf_to_json_tests = [] {
       std::string json{};
       expect(!glz::eetf_to_json(buffer, json));
       expect(json == R"([99,"spiders"])") << json;
+   };
+
+   "eetf_to_json no header"_test = [] {
+      constexpr int items = 3;
+      std::vector<simple> v;
+      for (int idx = 0; idx < items; idx++) {
+         v.push_back({idx});
+      }
+
+      std::string buffer{};
+      expect(not glz::write_term(v, buffer));
+
+      // parse list header manually and iterate through items
+      int index{0};
+      int version;
+      int res = ei_decode_version(buffer.data(), &index, &version);
+      expect(res == 0);
+      expect(version == glz::eetf_magic_version);
+
+      int arity;
+      res = ei_decode_list_header(buffer.data(), &index, &arity);
+      expect(res == 0);
+      expect(arity == items);
+
+      for (int idx = 0; idx < arity; idx++) {
+         std::string json;
+         int curr = index;
+         res = ei_skip_term(buffer.data(), &index);
+         expect(res == 0);
+
+         expect(!glz::eetf_to_json<glz::no_header_on<glz::eetf::eetf_opts{}>()>(
+            std::string_view{buffer.data() + curr, static_cast<size_t>(index - curr)}, json));
+         expect(json == std::format(R"({{"a":{}}})", idx));
+      }
    };
 };
 


### PR DESCRIPTION
After using in real project there is some additional fixes:
* Add noexcept to eetf functions
* Use eetf_opts for eetf_to_json
* Add requires for input buffer (has to contains only single-byte elements to use in ei functions)
* Fix universal refs
* Add test for eetf_to_json conversion without eetf header