### PR TITLE
inplace_vector: match C++26 P3981 try_emplace_back/try_push_back API

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -87,3 +87,47 @@ jobs:
 
     - name: Test
       run: ctest --output-on-failure --test-dir "$GITHUB_WORKSPACE/build"
+
+  build-gcc16:
+    runs-on: ubuntu-24.04
+    container:
+      image: gcc:16.1
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug]
+        std: [23, 26]
+
+    env:
+      CC: gcc
+      CXX: g++
+
+    steps:
+    - name: Install build dependencies
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        apt-get update
+        apt-get install -y --no-install-recommends \
+          ca-certificates \
+          cmake \
+          git \
+          libssl-dev \
+          python3
+        update-ca-certificates
+
+    - uses: actions/checkout@v6
+
+    - name: Prepare build directory
+      run: cmake -E make_directory "$GITHUB_WORKSPACE/build"
+
+    - name: Configure CMake
+      run: |
+        CXXFLAGS="-g3" cmake -S "$GITHUB_WORKSPACE" -B "$GITHUB_WORKSPACE/build" -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DCMAKE_CXX_STANDARD=${{matrix.std}}
+
+    - name: Build
+      run: cmake --build "$GITHUB_WORKSPACE/build" -j $(nproc)
+
+    - name: Test
+      run: ctest --output-on-failure --test-dir "$GITHUB_WORKSPACE/build"

--- a/include/glaze/concepts/container_concepts.hpp
+++ b/include/glaze/concepts/container_concepts.hpp
@@ -169,9 +169,11 @@ namespace glz
       { container.emplace_back() } -> std::same_as<typename T::reference>;
    };
 
+   // Accepts both the C++23 return type (T*) and the C++26 P3981 return type
+   // (std::optional<T&>); both are contextually convertible to bool.
    template <class T>
    concept has_try_emplace_back = requires(T container) {
-      { container.try_emplace_back() } -> std::same_as<typename T::pointer>;
+      { static_cast<bool>(container.try_emplace_back()) };
    };
 
    template <class T>

--- a/include/glaze/containers/inplace_vector.hpp
+++ b/include/glaze/containers/inplace_vector.hpp
@@ -11,10 +11,13 @@
 #include <iterator>
 #include <memory>
 #include <new>
+#include <optional>
 #include <ranges>
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
+
+#include "glaze/core/feature_test.hpp"
 
 #ifndef GLZ_THROW_OR_ABORT
 #if __cpp_exceptions
@@ -230,20 +233,49 @@ namespace glz
          }
 
          // Fallible APIs
+         //
+         // C++26 P3981 changed the return type of try_emplace_back / try_push_back
+         // from T* (C++23) to std::optional<T&>. We emit the matching shape when the
+         // stdlib provides std::optional<T&> (gated by GLZ_HAS_OPTIONAL_REF), and fall
+         // back to T* otherwise. Both spellings are contextually convertible to bool
+         // and support operator* / operator->, so the unchecked_* wrappers below work
+         // unchanged.
+#if GLZ_HAS_OPTIONAL_REF
+         using try_emplace_back_result = std::optional<T&>;
+#else
+         using try_emplace_back_result = T*;
+#endif
+
          template <class... Args>
-         constexpr T* try_emplace_back(Args&&... args)
+         constexpr try_emplace_back_result try_emplace_back(Args&&... args)
             requires(std::constructible_from<T, Args...>)
          {
-            if (storage_size() >= N) return nullptr;
+            if (storage_size() >= N) {
+#if GLZ_HAS_OPTIONAL_REF
+               return std::nullopt;
+#else
+               return nullptr;
+#endif
+            }
 
             std::construct_at(this->data_ptr() + storage_size(), std::forward<Args>(args)...);
             set_storage_size(storage_size() + 1);
+#if GLZ_HAS_OPTIONAL_REF
+            return std::optional<T&>{back()};
+#else
             return &back();
+#endif
          }
 
-         constexpr T* try_push_back(const T& x)
+         constexpr try_emplace_back_result try_push_back(const T& x)
          {
-            if (storage_size() >= N) return nullptr;
+            if (storage_size() >= N) {
+#if GLZ_HAS_OPTIONAL_REF
+               return std::nullopt;
+#else
+               return nullptr;
+#endif
+            }
 
             if constexpr (std::is_trivially_copyable_v<T>) {
                std::memcpy(this->data_ptr() + storage_size(), &x, sizeof(T));
@@ -252,16 +284,30 @@ namespace glz
                std::construct_at(this->data_ptr() + storage_size(), x);
             }
             set_storage_size(storage_size() + 1);
+#if GLZ_HAS_OPTIONAL_REF
+            return std::optional<T&>{back()};
+#else
             return &back();
+#endif
          }
 
-         constexpr T* try_push_back(T&& x)
+         constexpr try_emplace_back_result try_push_back(T&& x)
          {
-            if (storage_size() >= N) return nullptr;
+            if (storage_size() >= N) {
+#if GLZ_HAS_OPTIONAL_REF
+               return std::nullopt;
+#else
+               return nullptr;
+#endif
+            }
 
             std::construct_at(this->data_ptr() + storage_size(), std::move(x));
             set_storage_size(storage_size() + 1);
+#if GLZ_HAS_OPTIONAL_REF
+            return std::optional<T&>{back()};
+#else
             return &back();
+#endif
          }
 
          template <std::ranges::input_range R>

--- a/include/glaze/core/feature_test.hpp
+++ b/include/glaze/core/feature_test.hpp
@@ -25,6 +25,18 @@
 #endif
 #endif
 
+// C++26 P2988 std::optional<T&> support.
+// Pre-P2988 stdlibs report __cpp_lib_optional == 202110L (the C++23 monadic-ops value);
+// any post-C++23 bump indicates optional<T&> is available. Used by glz::inplace_vector to
+// match the C++26 P3981 try_emplace_back / try_push_back return type.
+#ifndef GLZ_HAS_OPTIONAL_REF
+#if defined(__cpp_lib_optional) && __cpp_lib_optional > 202110L
+#define GLZ_HAS_OPTIONAL_REF 1
+#else
+#define GLZ_HAS_OPTIONAL_REF 0
+#endif
+#endif
+
 namespace glz
 {
    // Constexpr bool for use in if constexpr or other compile-time contexts
@@ -34,6 +46,10 @@ namespace glz
    // C++26 P2996 reflection support
    // Use GLZ_REFLECTION26 macro for #if preprocessor guards
    inline constexpr bool has_reflection26 = GLZ_REFLECTION26;
+
+   // C++26 P2988 std::optional<T&> support
+   // Use GLZ_HAS_OPTIONAL_REF macro for #if preprocessor guards
+   inline constexpr bool has_optional_ref = GLZ_HAS_OPTIONAL_REF;
 }
 
 // Glaze Feature Test Macros for breaking changes

--- a/include/glaze/json/flatten_map.hpp
+++ b/include/glaze/json/flatten_map.hpp
@@ -275,7 +275,7 @@ namespace glz
 
          if constexpr (readable_array_t<T>) {
             if constexpr (has_try_emplace_back<T>) {
-               if (value.try_emplace_back() == nullptr) [[unlikely]] {
+               if (not value.try_emplace_back()) [[unlikely]] {
                   ctx.error = error_code::exceeded_static_array_size;
                   return;
                }

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2350,7 +2350,7 @@ namespace glz
                   }
 
                   if constexpr (has_try_emplace_back<T>) {
-                     if (value.try_emplace_back() != nullptr)
+                     if (value.try_emplace_back())
                         parse<JSON>::op<ws_handled<Opts>()>(value.back(), ctx, it, end);
                      else
                         ctx.error = error_code::exceeded_static_array_size;
@@ -2466,7 +2466,7 @@ namespace glz
             }
 
             if constexpr (has_try_emplace_back<T>) {
-               if (value.try_emplace_back() == nullptr) [[unlikely]] {
+               if (not value.try_emplace_back()) [[unlikely]] {
                   ctx.error = error_code::exceeded_static_array_size;
                   return;
                }

--- a/tests/inplace_vector/inplace_vector_test.cpp
+++ b/tests/inplace_vector/inplace_vector_test.cpp
@@ -399,10 +399,10 @@ suite capacity_tests = [] {
       expect(throws([&v] { v.insert(v.begin(), 0); })) << "insert should throw if capacity would be exceeded\n";
 #endif
 
-      expect(v.try_emplace_back(4) == nullptr);
+      expect(not v.try_emplace_back(4));
       expect(v.size() == 3) << "try_emplace_back should not modify size if capacity exceeded\n";
 
-      expect(v.try_push_back(4) == nullptr);
+      expect(not v.try_push_back(4));
       expect(v.size() == 3) << "try_push_back should not modify size if capacity exceeded\n";
    };
 };
@@ -700,49 +700,49 @@ suite fallible_apis_tests = [] {
    "try_push_back"_test = [] {
       inplace_vector<int, 3> v;
 
-      auto ptr1 = v.try_push_back(1);
-      expect(ptr1 != nullptr) << "try_push_back should return non-null if successful\n";
-      expect(*ptr1 == 1) << "try_push_back should return pointer to the inserted element\n";
+      auto r1 = v.try_push_back(1);
+      expect(bool(r1)) << "try_push_back should return engaged result if successful\n";
+      expect(*r1 == 1) << "try_push_back result should refer to the inserted element\n";
       expect(v.size() == 1) << "try_push_back should increment size if successful\n";
 
-      auto ptr2 = v.try_push_back(2);
-      expect(ptr2 != nullptr) << "try_push_back should return non-null if successful\n";
-      expect(*ptr2 == 2) << "try_push_back should return pointer to the inserted element\n";
+      auto r2 = v.try_push_back(2);
+      expect(bool(r2)) << "try_push_back should return engaged result if successful\n";
+      expect(*r2 == 2) << "try_push_back result should refer to the inserted element\n";
       expect(v.size() == 2) << "try_push_back should increment size if successful\n";
 
-      auto ptr3 = v.try_push_back(3);
-      expect(ptr3 != nullptr) << "try_push_back should return non-null if successful\n";
-      expect(*ptr3 == 3) << "try_push_back should return pointer to the inserted element\n";
+      auto r3 = v.try_push_back(3);
+      expect(bool(r3)) << "try_push_back should return engaged result if successful\n";
+      expect(*r3 == 3) << "try_push_back result should refer to the inserted element\n";
       expect(v.size() == 3) << "try_push_back should increment size if successful\n";
 
-      auto ptr4 = v.try_push_back(4);
-      expect(ptr4 == nullptr) << "try_push_back should return null if capacity would be exceeded\n";
+      auto r4 = v.try_push_back(4);
+      expect(not r4) << "try_push_back should return disengaged result if capacity would be exceeded\n";
       expect(v.size() == 3) << "try_push_back should not change size if unsuccessful\n";
    };
 
    "try_emplace_back"_test = [] {
       inplace_vector<std::pair<int, int>, 3> v;
 
-      auto ptr1 = v.try_emplace_back(1, 10);
-      expect(ptr1 != nullptr) << "try_emplace_back should return non-null if successful\n";
-      expect(ptr1->first == 1) << "try_emplace_back should return pointer to the inserted element\n";
-      expect(ptr1->second == 10) << "try_emplace_back should return pointer to the inserted element\n";
+      auto r1 = v.try_emplace_back(1, 10);
+      expect(bool(r1)) << "try_emplace_back should return engaged result if successful\n";
+      expect(r1->first == 1) << "try_emplace_back result should refer to the inserted element\n";
+      expect(r1->second == 10) << "try_emplace_back result should refer to the inserted element\n";
       expect(v.size() == 1) << "try_emplace_back should increment size if successful\n";
 
-      auto ptr2 = v.try_emplace_back(2, 20);
-      expect(ptr2 != nullptr) << "try_emplace_back should return non-null if successful\n";
-      expect(ptr2->first == 2) << "try_emplace_back should return pointer to the inserted element\n";
-      expect(ptr2->second == 20) << "try_emplace_back should return pointer to the inserted element\n";
+      auto r2 = v.try_emplace_back(2, 20);
+      expect(bool(r2)) << "try_emplace_back should return engaged result if successful\n";
+      expect(r2->first == 2) << "try_emplace_back result should refer to the inserted element\n";
+      expect(r2->second == 20) << "try_emplace_back result should refer to the inserted element\n";
       expect(v.size() == 2) << "try_emplace_back should increment size if successful\n";
 
-      auto ptr3 = v.try_emplace_back(3, 30);
-      expect(ptr3 != nullptr) << "try_emplace_back should return non-null if successful\n";
-      expect(ptr3->first == 3) << "try_emplace_back should return pointer to the inserted element\n";
-      expect(ptr3->second == 30) << "try_emplace_back should return pointer to the inserted element\n";
+      auto r3 = v.try_emplace_back(3, 30);
+      expect(bool(r3)) << "try_emplace_back should return engaged result if successful\n";
+      expect(r3->first == 3) << "try_emplace_back result should refer to the inserted element\n";
+      expect(r3->second == 30) << "try_emplace_back result should refer to the inserted element\n";
       expect(v.size() == 3) << "try_emplace_back should increment size if successful\n";
 
-      auto ptr4 = v.try_emplace_back(4, 40);
-      expect(ptr4 == nullptr) << "try_emplace_back should return null if capacity would be exceeded\n";
+      auto r4 = v.try_emplace_back(4, 40);
+      expect(not r4) << "try_emplace_back should return disengaged result if capacity would be exceeded\n";
       expect(v.size() == 3) << "try_emplace_back should not change size if unsuccessful\n";
    };
 
@@ -931,8 +931,8 @@ suite edge_cases_tests = [] {
       expect(throws([&v] { v.push_back(1); })) << "push_back on vector with zero capacity should throw\n";
 #endif
 
-      auto ptr = v.try_push_back(1);
-      expect(ptr == nullptr) << "try_push_back on vector with zero capacity should return nullptr\n";
+      auto r = v.try_push_back(1);
+      expect(not r) << "try_push_back on vector with zero capacity should return disengaged result\n";
 
       // Test that the is_empty type trait works
       expect(std::is_empty_v<inplace_vector<int, 0>>) << "inplace_vector<T, 0> should be an empty type\n";


### PR DESCRIPTION
Closes #2543.

## Summary
- `has_try_emplace_back` no longer hard-requires `T*`; it accepts any result that's contextually-convertible to `bool`, so a real C++26 `std::inplace_vector` (whose `try_emplace_back` returns `std::optional<T&>` per P3981) is detected. JSON parser call sites use truthy / `not` checks instead of `!= nullptr` / `== nullptr`.
- `glz::inplace_vector` now emits the matching API shape under `GLZ_HAS_OPTIONAL_REF` (auto-detected via `__cpp_lib_optional > 202110L`, mirroring the `GLZ_REFLECTION26` pattern in `feature_test.hpp`). On stdlibs that ship `std::optional<T&>` the polyfill returns `optional<T&>`; otherwise it keeps the C++23 `T*` shape. `unchecked_emplace_back` / `unchecked_push_back` are unchanged because `*result` yields `T&` either way.
- Tests switched to `bool(r)` / `not r` so they compile against either return type.

## Test plan
- [x] `inplace_vector_test`: 67/67 tests, 468/468 asserts (libc++, T* path)
- [x] `inplace_vector_test_noexceptions`: 66/66, 461/461
- [x] `json_test`: 676/676, 57202/57202
- [x] Full project build clean, no new warnings
- [x] CI verification on GCC 16 / libstdc++ that ships `optional<T&>` (exercises the `GLZ_HAS_OPTIONAL_REF == 1` path)

## Notes
The threshold `__cpp_lib_optional > 202110L` is "anything newer than the C++23 monadic-ops bump." If a stdlib enables `optional<T&>` without bumping the macro, users can force the path with `-DGLZ_HAS_OPTIONAL_REF=1`.