### PR TITLE
Support type-level skip via meta::value = glz::skip{} (#2539)

### DIFF
--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -1891,17 +1891,23 @@ namespace glz
             ++it;
             using V = std::decay_t<T>;
             constexpr auto N = reflect<V>::size;
+            constexpr auto N_written = []<size_t... I>(std::index_sequence<I...>) consteval {
+               return (size_t{} + ... + (always_skipped<field_t<V, I>> ? size_t{} : size_t{1}));
+            }(std::make_index_sequence<N>{});
             const auto n = int_from_compressed(ctx, it, end);
             if (bool(ctx.error)) [[unlikely]] {
                return;
             }
-            if (n != N) {
+            if (n != N_written) {
                ctx.error = error_code::syntax_error;
                return;
             }
 
-            for_each<N>(
-               [&]<size_t I>() { parse<BEVE>::op<Opts>(get_member(value, get<I>(reflect<V>::values)), ctx, it, end); });
+            for_each<N>([&]<size_t I>() {
+               if constexpr (!always_skipped<field_t<V, I>>) {
+                  parse<BEVE>::op<Opts>(get_member(value, get<I>(reflect<V>::values)), ctx, it, end);
+               }
+            });
          }
       }
 

--- a/include/glaze/beve/size.hpp
+++ b/include/glaze/beve/size.hpp
@@ -457,7 +457,7 @@ namespace glz
       {
          using V = field_t<Value, I>;
 
-         if constexpr (std::same_as<V, hidden> || std::same_as<V, skip>) {
+         if constexpr (always_skipped<V>) {
             return true;
          }
          else if constexpr (is_any_function_ptr<V>) {
@@ -524,7 +524,7 @@ namespace glz
       {
          using V = field_t<T, I>;
 
-         if constexpr (std::same_as<V, hidden> || std::same_as<V, skip>) {
+         if constexpr (always_skipped<V>) {
             return true;
          }
          else if constexpr (is_any_function_ptr<V>) {

--- a/include/glaze/beve/write.hpp
+++ b/include/glaze/beve/write.hpp
@@ -1176,7 +1176,7 @@ namespace glz
       {
          using V = field_t<Value, I>;
 
-         if constexpr (std::same_as<V, hidden> || std::same_as<V, skip>) {
+         if constexpr (always_skipped<V>) {
             return true;
          }
          else if constexpr (is_any_function_ptr<V>) {
@@ -1249,7 +1249,7 @@ namespace glz
       {
          using V = field_t<T, I>;
 
-         if constexpr (std::same_as<V, hidden> || std::same_as<V, skip>) {
+         if constexpr (always_skipped<V>) {
             return true;
          }
          else if constexpr (is_any_function_ptr<V>) {

--- a/include/glaze/bson/read.hpp
+++ b/include/glaze/bson/read.hpp
@@ -1039,12 +1039,18 @@ namespace glz
                if (index < N) {
                   visit<N>(
                      [&]<size_t I>() {
+                        using MemberT = std::remove_cvref_t<field_t<DT, I>>;
                         static constexpr auto TargetKey = get<I>(reflect<DT>::keys);
                         static constexpr auto Length = TargetKey.size();
                         if ((Length == key.size()) && compare<Length>(TargetKey.data(), key.data())) [[likely]] {
                            matched = true;
-                           using MemberT = std::remove_cvref_t<field_t<DT, I>>;
-                           if constexpr (reflectable<DT>) {
+                           if constexpr (always_skipped<MemberT>) {
+                              // Marker / hidden / skip / includer fields are never
+                              // written, so any matching key here came from
+                              // foreign input. Silently consume the value.
+                              skip_value<BSON>::template op<Opts>(tag, ctx, it, stop);
+                           }
+                           else if constexpr (reflectable<DT>) {
                               from<BSON, MemberT>::template op<Opts>(get_member(value, get<I>(to_tie(value))), tag, ctx,
                                                                      it, stop);
                            }

--- a/include/glaze/bson/write.hpp
+++ b/include/glaze/bson/write.hpp
@@ -235,7 +235,7 @@ namespace glz
       consteval bool should_skip_reflected_field()
       {
          using V = field_t<T, I>;
-         if constexpr (std::same_as<V, hidden> || std::same_as<V, skip>) {
+         if constexpr (always_skipped<V>) {
             return true;
          }
          else if constexpr (is_any_function_ptr<V>) {

--- a/include/glaze/cbor/write.hpp
+++ b/include/glaze/cbor/write.hpp
@@ -625,7 +625,7 @@ namespace glz
       {
          using V = field_t<T, I>;
 
-         if constexpr (std::same_as<V, hidden> || std::same_as<V, skip>) {
+         if constexpr (always_skipped<V>) {
             return true;
          }
          else if constexpr (is_any_function_ptr<V>) {

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -393,8 +393,20 @@ namespace glz
    concept always_null_t =
       std::same_as<T, std::nullptr_t> || std::convertible_to<T, std::monostate> || std::same_as<T, std::nullopt_t>;
 
+   // Allows any type to opt out of serialization entirely by setting its meta
+   // value to glz::skip{}. Fields of such a type are never written, and any
+   // matching key in an input stream is silently consumed on read. Two opt-in
+   // forms are supported, matching the local/external metadata convention used
+   // elsewhere in Glaze:
+   //   1. Local metadata inside the type (preferred when you control the type):
+   //        struct glaze { static constexpr auto value = glz::skip{}; };
+   //   2. External metadata via glz::meta specialization (for third-party types):
+   //        template <> struct glz::meta<T> { static constexpr auto value = glz::skip{}; };
+   // Useful for marker classes used purely for compile-time metadata that
+   // should never appear in serialized output.
    template <class T>
-   concept always_skipped = is_includer<T> || std::same_as<T, hidden> || std::same_as<T, skip>;
+   concept always_skipped = is_includer<T> || std::same_as<T, hidden> || std::same_as<T, skip> ||
+                            std::same_as<meta_wrapper_t<std::decay_t<T>>, skip>;
 
    // Detect function pointers and function references (which should not be treated as nullable)
    template <class T>
@@ -480,6 +492,17 @@ namespace glz
       glaze_t<T> && !(glaze_array_t<T> || glaze_object_t<T> || glaze_enum_t<T> || meta_keys<T> || glaze_flags_t<T>);
 
    // With C++26 P2996 reflection, we can reflect non-aggregate types (classes with custom constructors)
+   // skip / hidden are empty marker structs with dedicated to<>/from<>
+   // specializations, so they must not be treated as reflectable aggregates.
+   // Registered in both P2996 and pre-P2996 modes.
+   template <>
+   struct specified<skip> : std::true_type
+   {};
+
+   template <>
+   struct specified<hidden> : std::true_type
+   {};
+
    // Without P2996, we require aggregate types for reflection
 #if GLZ_REFLECTION26
    // Register std library types as having specified Glaze serialization

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -409,7 +409,7 @@ namespace glz
    // glz::skip itself has no meta, so meta_wrapper_t<skip> is empty, not skip.
    template <class T>
    concept always_skipped = is_includer<T> || std::same_as<T, hidden> || std::same_as<T, skip> ||
-                            std::same_as<meta_wrapper_t<std::decay_t<T>>, skip>;
+                            std::same_as<meta_wrapper_t<T>, skip>;
 
    // Detect function pointers and function references (which should not be treated as nullable)
    template <class T>

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -404,6 +404,9 @@ namespace glz
    //        template <> struct glz::meta<T> { static constexpr auto value = glz::skip{}; };
    // Useful for marker classes used purely for compile-time metadata that
    // should never appear in serialized output.
+   //
+   // The same_as<T, skip> clause is not redundant with the meta_wrapper check:
+   // glz::skip itself has no meta, so meta_wrapper_t<skip> is empty, not skip.
    template <class T>
    concept always_skipped = is_includer<T> || std::same_as<T, hidden> || std::same_as<T, skip> ||
                             std::same_as<meta_wrapper_t<std::decay_t<T>>, skip>;

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -774,6 +774,14 @@ namespace glz
          for_each<N>([&]<auto I>() constexpr {
             using V = std::decay_t<refl_t<T, I>>;
 
+            // Fields whose type is always_skipped (hidden, skip, includer, or a
+            // type that opted out via meta::value = skip{}) are never written,
+            // so they must not be marked required.
+            if constexpr (always_skipped<V>) {
+               fields[I] = false;
+               return;
+            }
+
             // Check if field is skipped during parse - if so, don't require it
             if constexpr (meta_has_skip<T>) {
                constexpr auto key = reflect<T>::keys[I];

--- a/include/glaze/jsonb/write.hpp
+++ b/include/glaze/jsonb/write.hpp
@@ -341,7 +341,7 @@ namespace glz
       consteval bool should_skip_reflected_field()
       {
          using V = field_t<T, I>;
-         if constexpr (std::same_as<V, hidden> || std::same_as<V, skip>) {
+         if constexpr (always_skipped<V>) {
             return true;
          }
          else if constexpr (is_any_function_ptr<V>) {

--- a/include/glaze/msgpack/read.hpp
+++ b/include/glaze/msgpack/read.hpp
@@ -158,12 +158,10 @@ namespace glz::msgpack::detail
    template <class T>
    GLZ_ALWAYS_INLINE constexpr bool should_skip_field()
    {
-      if constexpr (std::same_as<T, hidden> || std::same_as<T, skip>) {
-         return true;
-      }
-      else {
-         return false;
-      }
+      // Mirrors the writer's count_members predicate so structs_as_arrays reads
+      // stay aligned with the wire layout, including is_includer and types
+      // opted out via meta::value = skip{}.
+      return always_skipped<T>;
    }
 
 }

--- a/include/glaze/msgpack/read.hpp
+++ b/include/glaze/msgpack/read.hpp
@@ -231,6 +231,18 @@ namespace glz
       }
    };
 
+   // Silently consume any value bound to a glz::skip sentinel. Reached when a
+   // type opts out of serialization via meta::value = glz::skip{}.
+   template <>
+   struct from<MSGPACK, skip>
+   {
+      template <auto Opts, class Value, is_context Ctx, class It, class End>
+      GLZ_ALWAYS_INLINE static void op(Value&&, uint8_t tag, Ctx&& ctx, It& it, const End& end) noexcept
+      {
+         skip_value<MSGPACK>::template op<Opts>(tag, ctx, it, end);
+      }
+   };
+
    template <always_null_t T>
    struct from<MSGPACK, T>
    {

--- a/include/glaze/msgpack/skip.hpp
+++ b/include/glaze/msgpack/skip.hpp
@@ -23,6 +23,14 @@ namespace glz
          skip_with_tag<Opts>(ctx, tag, it, end);
       }
 
+      // Overload for callers that have already consumed the tag byte (e.g.
+      // dispatchers in parse<MSGPACK>::op that route by tag).
+      template <auto Opts, class It, class End>
+      static void op(uint8_t tag, is_context auto& ctx, It& it, const End& end) noexcept
+      {
+         skip_with_tag<Opts>(ctx, tag, it, end);
+      }
+
      private:
       template <auto Opts, class It, class End>
       static void skip_with_tag(is_context auto& ctx, const uint8_t tag, It& it, const End& end) noexcept

--- a/include/glaze/msgpack/write.hpp
+++ b/include/glaze/msgpack/write.hpp
@@ -625,8 +625,7 @@ namespace glz
       static consteval size_t count_members()
       {
          return []<size_t... I>(std::index_sequence<I...>) consteval {
-            return (size_t{} + ... +
-                    (std::same_as<field_t<T, I>, hidden> || std::same_as<field_t<T, I>, skip> ? size_t{} : size_t{1}));
+            return (size_t{} + ... + (always_skipped<field_t<T, I>> ? size_t{} : size_t{1}));
          }(std::make_index_sequence<N>{});
       }
 
@@ -641,7 +640,7 @@ namespace glz
                if (bool(ctx.error)) [[unlikely]] {
                   return;
                }
-               if constexpr (!std::same_as<field_t<T, I>, hidden> && !std::same_as<field_t<T, I>, skip>) {
+               if constexpr (!always_skipped<field_t<T, I>>) {
                   serialize<MSGPACK>::op<Opts>(get_member(value, get<I>(reflect<T>::values)), ctx, b, ix);
                   if constexpr (is_output_streaming<decltype(b)>) {
                      flush_buffer(b, ix);
@@ -657,7 +656,7 @@ namespace glz
                if (bool(ctx.error)) [[unlikely]] {
                   return;
                }
-               if constexpr (!std::same_as<field_t<T, I>, hidden> && !std::same_as<field_t<T, I>, skip>) {
+               if constexpr (!always_skipped<field_t<T, I>>) {
                   static constexpr sv key = reflect<T>::keys[I];
                   if (!msgpack::detail::write_str_header(ctx, key.size(), b, ix)) [[unlikely]] {
                      return;

--- a/include/glaze/toml/read.hpp
+++ b/include/glaze/toml/read.hpp
@@ -324,7 +324,7 @@ namespace glz
       template <auto Opts, is_context Ctx, class It0, class It1>
       static void op(auto&& value, Ctx&& ctx, It0&& it, It1 end)
       {
-         using V = std::remove_cvref_t<decltype(get_member(std::declval<T>(), meta_wrapper_v<T>))>;
+         using V = std::decay_t<decltype(get_member(std::declval<T>(), meta_wrapper_v<T>))>;
          from<TOML, V>::template op<Opts>(get_member(value, meta_wrapper_v<T>), std::forward<Ctx>(ctx),
                                           std::forward<It0>(it), std::forward<It1>(end));
       }

--- a/include/glaze/toml/read.hpp
+++ b/include/glaze/toml/read.hpp
@@ -324,9 +324,21 @@ namespace glz
       template <auto Opts, is_context Ctx, class It0, class It1>
       static void op(auto&& value, Ctx&& ctx, It0&& it, It1 end)
       {
-         using V = decltype(get_member(std::declval<T>(), meta_wrapper_v<T>));
+         using V = std::remove_cvref_t<decltype(get_member(std::declval<T>(), meta_wrapper_v<T>))>;
          from<TOML, V>::template op<Opts>(get_member(value, meta_wrapper_v<T>), std::forward<Ctx>(ctx),
                                           std::forward<It0>(it), std::forward<It1>(end));
+      }
+   };
+
+   // Silently consume any value bound to a glz::skip sentinel. Reached when a
+   // type opts out of serialization via meta::value = glz::skip{}.
+   template <>
+   struct from<TOML, skip>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, auto&&... args) noexcept
+      {
+         skip_value<TOML>::template op<Opts>(ctx, args...);
       }
    };
 

--- a/include/glaze/toml/write.hpp
+++ b/include/glaze/toml/write.hpp
@@ -755,62 +755,60 @@ namespace glz
 
          using val_t = field_t<Type, I>;
 
-         if constexpr (skip_toml_field<val_t, Options>) {
-            return;
-         }
-
-         // Check if nullable and null
-         if constexpr (null_t<val_t>) {
-            if constexpr (always_null_t<val_t>) {
-               return;
-            }
-            else {
-               decltype(auto) element = [&]() -> decltype(auto) {
-                  if constexpr (reflectable<Type>) {
-                     return get<I>(t);
-                  }
-                  else {
-                     return get<I>(reflect<Type>::values);
-                  }
-               };
-
-               bool is_null = false;
-               if constexpr (nullable_wrapper<val_t>)
-                  is_null = !bool(element()(value).val);
-               else if constexpr (nullable_value_t<val_t>)
-                  is_null = !get_member(value, element()).has_value();
-               else
-                  is_null = !bool(get_member(value, element()));
-
-               if (is_null) {
+         if constexpr (!skip_toml_field<val_t, Options>) {
+            // Check if nullable and null
+            if constexpr (null_t<val_t>) {
+               if constexpr (always_null_t<val_t>) {
                   return;
                }
+               else {
+                  decltype(auto) element = [&]() -> decltype(auto) {
+                     if constexpr (reflectable<Type>) {
+                        return get<I>(t);
+                     }
+                     else {
+                        return get<I>(reflect<Type>::values);
+                     }
+                  };
+
+                  bool is_null = false;
+                  if constexpr (nullable_wrapper<val_t>)
+                     is_null = !bool(element()(value).val);
+                  else if constexpr (nullable_value_t<val_t>)
+                     is_null = !get_member(value, element()).has_value();
+                  else
+                     is_null = !bool(get_member(value, element()));
+
+                  if (is_null) {
+                     return;
+                  }
+               }
             }
-         }
 
-         static constexpr auto key = glz::get<I>(reflect<Type>::keys);
-         static constexpr auto padding = key.size() + 16;
-         if (!ensure_space(ctx, b, ix + padding)) [[unlikely]] {
-            return;
-         }
+            static constexpr auto key = glz::get<I>(reflect<Type>::keys);
+            static constexpr auto padding = key.size() + 16;
+            if (!ensure_space(ctx, b, ix + padding)) [[unlikely]] {
+               return;
+            }
 
-         if (!first) {
-            dump(", ", b, ix);
-         }
-         else {
-            first = false;
-         }
+            if (!first) {
+               dump(", ", b, ix);
+            }
+            else {
+               first = false;
+            }
 
-         std::memcpy(&b[ix], key.data(), key.size());
-         ix += key.size();
-         dump(" = ", b, ix);
+            std::memcpy(&b[ix], key.data(), key.size());
+            ix += key.size();
+            dump(" = ", b, ix);
 
-         // Write the value
-         if constexpr (reflectable<Type>) {
-            to<TOML, val_t>::template op<Options>(get_member(value, get<I>(t)), ctx, b, ix);
-         }
-         else {
-            to<TOML, val_t>::template op<Options>(get_member(value, get<I>(reflect<Type>::values)), ctx, b, ix);
+            // Write the value
+            if constexpr (reflectable<Type>) {
+               to<TOML, val_t>::template op<Options>(get_member(value, get<I>(t)), ctx, b, ix);
+            }
+            else {
+               to<TOML, val_t>::template op<Options>(get_member(value, get<I>(reflect<Type>::values)), ctx, b, ix);
+            }
          }
       });
 
@@ -1097,21 +1095,19 @@ namespace glz
          }
          using val_t = field_t<T, I>;
 
-         if constexpr (skip_toml_field<val_t, Options>) {
-            return;
-         }
+         if constexpr (!skip_toml_field<val_t, Options>) {
+            // Skip null fields
+            if (is_null_field.template operator()<I>()) {
+               return;
+            }
 
-         // Skip null fields
-         if (is_null_field.template operator()<I>()) {
-            return;
-         }
-
-         // Only process scalar fields in this pass (not objects or arrays of objects)
-         // Exception: in inline_mode, arrays of objects are written as inline arrays
-         constexpr bool is_scalar =
-            !(glaze_object_t<val_t> || reflectable<val_t>) && (!is_array_of_objects_v<val_t> || inline_mode);
-         if constexpr (is_scalar) {
-            write_scalar_field.template operator()<I>();
+            // Only process scalar fields in this pass (not objects or arrays of objects)
+            // Exception: in inline_mode, arrays of objects are written as inline arrays
+            constexpr bool is_scalar =
+               !(glaze_object_t<val_t> || reflectable<val_t>) && (!is_array_of_objects_v<val_t> || inline_mode);
+            if constexpr (is_scalar) {
+               write_scalar_field.template operator()<I>();
+            }
          }
       });
 
@@ -1123,21 +1119,19 @@ namespace glz
          }
          using val_t = field_t<T, I>;
 
-         if constexpr (skip_toml_field<val_t, Options>) {
-            return;
-         }
+         if constexpr (!skip_toml_field<val_t, Options>) {
+            // Skip null fields
+            if (is_null_field.template operator()<I>()) {
+               return;
+            }
 
-         // Skip null fields
-         if (is_null_field.template operator()<I>()) {
-            return;
-         }
-
-         // Process nested objects and arrays of objects
-         if constexpr (glaze_object_t<val_t> || reflectable<val_t>) {
-            write_table_field.template operator()<I>();
-         }
-         else if constexpr (is_array_of_objects_v<val_t> && !inline_mode) {
-            write_array_of_tables_field.template operator()<I>();
+            // Process nested objects and arrays of objects
+            if constexpr (glaze_object_t<val_t> || reflectable<val_t>) {
+               write_table_field.template operator()<I>();
+            }
+            else if constexpr (is_array_of_objects_v<val_t> && !inline_mode) {
+               write_array_of_tables_field.template operator()<I>();
+            }
          }
       });
    }

--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -197,6 +197,18 @@ namespace glz
       }
    };
 
+   // Silently consume any value bound to a glz::skip sentinel. Reached when a
+   // type opts out of serialization via meta::value = glz::skip{}.
+   template <>
+   struct from<YAML, skip>
+   {
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&&, is_context auto&& ctx, auto&&... args) noexcept
+      {
+         skip_value<YAML>::template op<Opts>(ctx, args...);
+      }
+   };
+
    namespace yaml
    {
       // Handle YAML alias (*name) by replaying the stored anchor span.

--- a/include/glaze/yaml/write.hpp
+++ b/include/glaze/yaml/write.hpp
@@ -928,150 +928,163 @@ namespace glz
 
             using val_t = field_t<V, I>;
 
-            if constexpr (always_skipped<val_t>) {
-               return;
-            }
-            else {
-            static constexpr sv key = get<I>(reflect<V>::keys);
+            if constexpr (!always_skipped<val_t>) {
+               static constexpr sv key = get<I>(reflect<V>::keys);
 
-            // Get member value (supports both glaze_object_t and reflectable)
-            auto&& member = [&]() -> decltype(auto) {
-               if constexpr (glaze_object_t<V>) {
-                  return get_member(value, get<I>(reflect<V>::values));
+               // Get member value (supports both glaze_object_t and reflectable)
+               auto&& member = [&]() -> decltype(auto) {
+                  if constexpr (glaze_object_t<V>) {
+                     return get_member(value, get<I>(reflect<V>::values));
+                  }
+                  else {
+                     return get<I>(to_tie(value));
+                  }
+               }();
+
+               // Skip fields based on meta::skip (compile-time) and meta::skip_if (runtime)
+               if constexpr (meta_has_skip<V>) {
+                  static constexpr meta_context mctx{.op = operation::serialize};
+                  if constexpr (meta<V>::skip(reflect<V>::keys[I], mctx)) return;
                }
-               else {
-                  return get<I>(to_tie(value));
+               if constexpr (meta_has_skip_if<V>) {
+                  static constexpr auto k = glz::get<I>(reflect<V>::keys);
+                  static constexpr meta_context mctx{.op = operation::serialize};
+                  if (meta<V>::skip_if(member, k, mctx)) return;
                }
-            }();
 
-            // Skip fields based on meta::skip (compile-time) and meta::skip_if (runtime)
-            if constexpr (meta_has_skip<V>) {
-               static constexpr meta_context mctx{.op = operation::serialize};
-               if constexpr (meta<V>::skip(reflect<V>::keys[I], mctx)) return;
-            }
-            if constexpr (meta_has_skip_if<V>) {
-               static constexpr auto k = glz::get<I>(reflect<V>::keys);
-               static constexpr meta_context mctx{.op = operation::serialize};
-               if (meta<V>::skip_if(member, k, mctx)) return;
-            }
+               // Skip null members if configured
+               if constexpr (nullable_like<val_t>) {
+                  if constexpr (Opts.skip_null_members) {
+                     if (!member) {
+                        return;
+                     }
+                  }
+               }
 
-            // Skip null members if configured
-            if constexpr (nullable_like<val_t>) {
-               if constexpr (Opts.skip_null_members) {
-                  if (!member) {
+               if constexpr (check_skip_default_members(Opts) && has_skippable_default<val_t>) {
+                  if (is_default_value(member)) return;
+               }
+
+               // Write indentation (skip for first field when in compact sequence context)
+               if (skip_first_indent) {
+                  skip_first_indent = false;
+                  if (!ensure_space(ctx, b, ix + key.size() + 8)) [[unlikely]] {
                      return;
                   }
                }
-            }
-
-            if constexpr (check_skip_default_members(Opts) && has_skippable_default<val_t>) {
-               if (is_default_value(member)) return;
-            }
-
-            // Write indentation (skip for first field when in compact sequence context)
-            if (skip_first_indent) {
-               skip_first_indent = false;
-               if (!ensure_space(ctx, b, ix + key.size() + 8)) [[unlikely]] {
-                  return;
-               }
-            }
-            else {
-               const int32_t spaces = indent_level * indent_width;
-               if (!ensure_space(ctx, b, ix + spaces + key.size() + 8)) [[unlikely]] {
-                  return;
-               }
-               for (int32_t i = 0; i < spaces; ++i) {
-                  b[ix++] = ' ';
-               }
-            }
-
-            // Write key
-            dump(key, b, ix);
-            dump(':', b, ix);
-
-            // Handle empty containers inline (before type dispatch)
-            if constexpr (range<val_t> && !str_t<val_t> && !is_simple_type<val_t>() && has_empty<val_t>) {
-               if (member.empty()) {
-                  if constexpr (writable_map_t<val_t>) {
-                     dump(" {}\n", b, ix);
-                  }
-                  else {
-                     dump(" []\n", b, ix);
-                  }
-                  return;
-               }
-            }
-
-            if constexpr (is_simple_type<val_t>()) {
-               // Simple types go on same line
-               dump(' ', b, ix);
-               if constexpr (str_t<val_t>) {
-                  yaml::write_yaml_string<Opts>(sv{member}, ctx, b, ix, indent_level);
-               }
                else {
-                  serialize<YAML>::op<Opts>(member, ctx, b, ix);
-               }
-               dump('\n', b, ix);
-            }
-            else if constexpr (nullable_like<val_t>) {
-               using inner_t = std::remove_cvref_t<decltype(*std::declval<val_t&>())>;
-               if (!member) {
-                  // Null - always same line
-                  dump(' ', b, ix);
-                  serialize<YAML>::op<Opts>(member, ctx, b, ix);
-                  dump('\n', b, ix);
-               }
-               else if constexpr (is_simple_type<inner_t>() || str_t<inner_t>) {
-                  // Simple inner type - same line
-                  dump(' ', b, ix);
-                  if constexpr (str_t<inner_t>) {
-                     yaml::write_yaml_string<Opts>(sv{*member}, ctx, b, ix, indent_level);
+                  const int32_t spaces = indent_level * indent_width;
+                  if (!ensure_space(ctx, b, ix + spaces + key.size() + 8)) [[unlikely]] {
+                     return;
                   }
-                  else {
-                     serialize<YAML>::op<Opts>(*member, ctx, b, ix);
+                  for (int32_t i = 0; i < spaces; ++i) {
+                     b[ix++] = ' ';
                   }
-                  dump('\n', b, ix);
                }
-               else {
-                  // Complex inner type - check for empty containers first
-                  bool wrote_empty = false;
-                  if constexpr (writable_map_t<inner_t>) {
-                     if (member->empty()) {
+
+               // Write key
+               dump(key, b, ix);
+               dump(':', b, ix);
+
+               // Handle empty containers inline (before type dispatch)
+               if constexpr (range<val_t> && !str_t<val_t> && !is_simple_type<val_t>() && has_empty<val_t>) {
+                  if (member.empty()) {
+                     if constexpr (writable_map_t<val_t>) {
                         dump(" {}\n", b, ix);
-                        wrote_empty = true;
                      }
+                     else {
+                        dump(" []\n", b, ix);
+                     }
+                     return;
                   }
-                  else if constexpr (writable_array_t<inner_t>) {
-                     if constexpr (requires { member->empty(); }) {
+               }
+
+               if constexpr (is_simple_type<val_t>()) {
+                  // Simple types go on same line
+                  dump(' ', b, ix);
+                  if constexpr (str_t<val_t>) {
+                     yaml::write_yaml_string<Opts>(sv{member}, ctx, b, ix, indent_level);
+                  }
+                  else {
+                     serialize<YAML>::op<Opts>(member, ctx, b, ix);
+                  }
+                  dump('\n', b, ix);
+               }
+               else if constexpr (nullable_like<val_t>) {
+                  using inner_t = std::remove_cvref_t<decltype(*std::declval<val_t&>())>;
+                  if (!member) {
+                     // Null - always same line
+                     dump(' ', b, ix);
+                     serialize<YAML>::op<Opts>(member, ctx, b, ix);
+                     dump('\n', b, ix);
+                  }
+                  else if constexpr (is_simple_type<inner_t>() || str_t<inner_t>) {
+                     // Simple inner type - same line
+                     dump(' ', b, ix);
+                     if constexpr (str_t<inner_t>) {
+                        yaml::write_yaml_string<Opts>(sv{*member}, ctx, b, ix, indent_level);
+                     }
+                     else {
+                        serialize<YAML>::op<Opts>(*member, ctx, b, ix);
+                     }
+                     dump('\n', b, ix);
+                  }
+                  else {
+                     // Complex inner type - check for empty containers first
+                     bool wrote_empty = false;
+                     if constexpr (writable_map_t<inner_t>) {
                         if (member->empty()) {
-                           dump(" []\n", b, ix);
+                           dump(" {}\n", b, ix);
                            wrote_empty = true;
                         }
                      }
+                     else if constexpr (writable_array_t<inner_t>) {
+                        if constexpr (requires { member->empty(); }) {
+                           if (member->empty()) {
+                              dump(" []\n", b, ix);
+                              wrote_empty = true;
+                           }
+                        }
+                     }
+                     if (!wrote_empty) {
+                        // Non-empty complex inner type - next line with increased indent
+                        dump('\n', b, ix);
+                        if constexpr (requires { ctx.indent_level; }) {
+                           auto nested_ctx = ctx;
+                           nested_ctx.indent_level = indent_level + 1;
+                           serialize<YAML>::op<Opts>(*member, nested_ctx, b, ix);
+                        }
+                        else {
+                           write_block_mapping_nested<Opts>(*member, ctx, b, ix, indent_level + 1);
+                        }
+                     }
                   }
-                  if (!wrote_empty) {
-                     // Non-empty complex inner type - next line with increased indent
+               }
+               else if constexpr (is_or_wraps_variant<val_t>()) {
+                  // Variants and variant-wrappers (e.g., glz::generic) may hold simple values
+                  if (variant_holds_simple_type(member)) {
+                     dump(' ', b, ix);
+                     write_variant_value<Opts>(member, ctx, b, ix, indent_level);
+                     dump('\n', b, ix);
+                  }
+                  else {
                      dump('\n', b, ix);
                      if constexpr (requires { ctx.indent_level; }) {
                         auto nested_ctx = ctx;
                         nested_ctx.indent_level = indent_level + 1;
-                        serialize<YAML>::op<Opts>(*member, nested_ctx, b, ix);
+                        serialize<YAML>::op<Opts>(member, nested_ctx, b, ix);
                      }
                      else {
-                        write_block_mapping_nested<Opts>(*member, ctx, b, ix, indent_level + 1);
+                        write_block_mapping_nested<Opts>(member, ctx, b, ix, indent_level + 1);
                      }
                   }
                }
-            }
-            else if constexpr (is_or_wraps_variant<val_t>()) {
-               // Variants and variant-wrappers (e.g., glz::generic) may hold simple values
-               if (variant_holds_simple_type(member)) {
-                  dump(' ', b, ix);
-                  write_variant_value<Opts>(member, ctx, b, ix, indent_level);
+               else if constexpr (writable_map_t<val_t> || writable_array_t<val_t> || glaze_object_t<val_t> ||
+                                  reflectable<val_t>) {
+                  // Complex types go on next line with increased indent
                   dump('\n', b, ix);
-               }
-               else {
-                  dump('\n', b, ix);
+
+                  // Create a modified context with incremented indent level
                   if constexpr (requires { ctx.indent_level; }) {
                      auto nested_ctx = ctx;
                      nested_ctx.indent_level = indent_level + 1;
@@ -1081,29 +1094,13 @@ namespace glz
                      write_block_mapping_nested<Opts>(member, ctx, b, ix, indent_level + 1);
                   }
                }
-            }
-            else if constexpr (writable_map_t<val_t> || writable_array_t<val_t> || glaze_object_t<val_t> ||
-                               reflectable<val_t>) {
-               // Complex types go on next line with increased indent
-               dump('\n', b, ix);
-
-               // Create a modified context with incremented indent level
-               if constexpr (requires { ctx.indent_level; }) {
-                  auto nested_ctx = ctx;
-                  nested_ctx.indent_level = indent_level + 1;
-                  serialize<YAML>::op<Opts>(member, nested_ctx, b, ix);
-               }
                else {
-                  write_block_mapping_nested<Opts>(member, ctx, b, ix, indent_level + 1);
+                  // All other types (custom_t, types with custom to/from<YAML>, etc.)
+                  // are assumed to produce scalar values - write on same line
+                  dump(' ', b, ix);
+                  serialize<YAML>::op<Opts>(member, ctx, b, ix);
+                  dump('\n', b, ix);
                }
-            }
-            else {
-               // All other types (custom_t, types with custom to/from<YAML>, etc.)
-               // are assumed to produce scalar values — write on same line
-               dump(' ', b, ix);
-               serialize<YAML>::op<Opts>(member, ctx, b, ix);
-               dump('\n', b, ix);
-            }
             }
          });
       }

--- a/include/glaze/yaml/write.hpp
+++ b/include/glaze/yaml/write.hpp
@@ -927,6 +927,11 @@ namespace glz
                return;
 
             using val_t = field_t<V, I>;
+
+            if constexpr (always_skipped<val_t>) {
+               return;
+            }
+            else {
             static constexpr sv key = get<I>(reflect<V>::keys);
 
             // Get member value (supports both glaze_object_t and reflectable)
@@ -1099,6 +1104,7 @@ namespace glz
                serialize<YAML>::op<Opts>(member, ctx, b, ix);
                dump('\n', b, ix);
             }
+            }
          });
       }
 
@@ -1248,43 +1254,46 @@ namespace glz
                return;
 
             using val_t = field_t<V, I>;
-            static constexpr sv key = get<I>(reflect<V>::keys);
 
-            // Get member value (supports both glaze_object_t and reflectable)
-            auto&& member = [&]() -> decltype(auto) {
-               if constexpr (glaze_object_t<V>) {
-                  return get_member(value, get<I>(reflect<V>::values));
-               }
-               else {
-                  return get<I>(to_tie(value));
-               }
-            }();
+            if constexpr (!always_skipped<val_t>) {
+               static constexpr sv key = get<I>(reflect<V>::keys);
 
-            // Skip null members if configured
-            if constexpr (nullable_like<val_t>) {
-               if constexpr (Opts.skip_null_members) {
-                  if (!member) {
-                     return;
+               // Get member value (supports both glaze_object_t and reflectable)
+               auto&& member = [&]() -> decltype(auto) {
+                  if constexpr (glaze_object_t<V>) {
+                     return get_member(value, get<I>(reflect<V>::values));
+                  }
+                  else {
+                     return get<I>(to_tie(value));
+                  }
+               }();
+
+               // Skip null members if configured
+               if constexpr (nullable_like<val_t>) {
+                  if constexpr (Opts.skip_null_members) {
+                     if (!member) {
+                        return;
+                     }
                   }
                }
-            }
 
-            if constexpr (check_skip_default_members(Opts) && has_skippable_default<val_t>) {
-               if (is_default_value(member)) return;
-            }
+               if constexpr (check_skip_default_members(Opts) && has_skippable_default<val_t>) {
+                  if (is_default_value(member)) return;
+               }
 
-            if (!first) {
-               dump(", ", b, ix);
-            }
-            first = false;
+               if (!first) {
+                  dump(", ", b, ix);
+               }
+               first = false;
 
-            if (!ensure_space(ctx, b, ix + key.size() + 8)) [[unlikely]] {
-               return;
-            }
-            dump(key, b, ix);
-            dump(": ", b, ix);
+               if (!ensure_space(ctx, b, ix + key.size() + 8)) [[unlikely]] {
+                  return;
+               }
+               dump(key, b, ix);
+               dump(": ", b, ix);
 
-            serialize<YAML>::op<flow_context_on<Opts>()>(member, ctx, b, ix);
+               serialize<YAML>::op<flow_context_on<Opts>()>(member, ctx, b, ix);
+            }
          });
 
          dump('}', b, ix);

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -6704,6 +6704,66 @@ suite beve_skip_complex_suite = [] {
    };
 };
 
+// Issue #2539: types opted out of serialization via meta::value = glz::skip{}
+// must round-trip correctly in BEVE, both keyed and structs_as_arrays.
+namespace beve_skip_marker_tests
+{
+   struct marker
+   {
+      struct glaze
+      {
+         static constexpr auto value = glz::skip{};
+      };
+   };
+
+   struct settings
+   {
+      marker m1{};
+      bool active{true};
+      int count{42};
+      marker m2{};
+      std::string name{"hello"};
+   };
+}
+
+template <>
+struct glz::meta<beve_skip_marker_tests::settings>
+{
+   using T = beve_skip_marker_tests::settings;
+   static constexpr auto value =
+      object("m1", &T::m1, "active", &T::active, "count", &T::count, "m2", &T::m2, "name", &T::name);
+};
+
+suite beve_skip_marker_suite = [] {
+   using namespace beve_skip_marker_tests;
+
+   "beve skip-marker keyed roundtrip"_test = [] {
+      settings original{.active = false, .count = 7, .name = "world"};
+      auto encoded = glz::write_beve(original);
+      expect(encoded.has_value());
+
+      settings decoded{};
+      auto ec = glz::read_beve(decoded, *encoded);
+      expect(!ec);
+      expect(decoded.active == false);
+      expect(decoded.count == 7);
+      expect(decoded.name == "world");
+   };
+
+   "beve skip-marker untagged (structs_as_arrays) roundtrip"_test = [] {
+      settings original{.active = false, .count = 7, .name = "world"};
+      auto encoded = glz::write_beve_untagged(original);
+      expect(encoded.has_value());
+
+      settings decoded{};
+      auto ec = glz::read_beve_untagged(decoded, *encoded);
+      expect(!ec);
+      expect(decoded.active == false);
+      expect(decoded.count == 7);
+      expect(decoded.name == "world");
+   };
+};
+
 int main()
 {
    trace.begin("binary_test");

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -2855,7 +2855,7 @@ suite merge_tests = [] {
 
       std::string json{};
       expect(!glz::beve_to_json(bin, json));
-      expect(json == R"({"a":{"i":287,"d":3.14,"hello":"Hello World","arr":[1,2,3],"include":""},"c":"d"})") << json;
+      expect(json == R"({"a":{"i":287,"d":3.14,"hello":"Hello World","arr":[1,2,3]},"c":"d"})") << json;
    };
 };
 
@@ -5932,8 +5932,9 @@ suite beve_peek_header_tests = [] {
       auto result = glz::beve_peek_header(buffer);
       expect(result.has_value());
       expect(result->type == glz::tag::object);
-      // my_struct has 5 members in its glz::meta: i, d, hello, arr, include
-      expect(result->count == 5u);
+      // my_struct has 5 members in its glz::meta (i, d, hello, arr, include); the
+      // include field is filtered by always_skipped, so the wire count is 4.
+      expect(result->count == 4u);
    };
 
    "beve_peek_header map"_test = [] {

--- a/tests/bson_test/bson_test.cpp
+++ b/tests/bson_test/bson_test.cpp
@@ -1594,4 +1594,41 @@ namespace
    };
 }
 
+namespace bson_skip_marker_tests
+{
+   struct marker
+   {
+      struct glaze
+      {
+         static constexpr auto value = glz::skip{};
+      };
+   };
+
+   struct settings
+   {
+      marker m{};
+      bool active{true};
+      int count{42};
+      std::string name{"hello"};
+   };
+}
+
+// Issue #2539: types opted out of serialization via meta::value = glz::skip{}
+// must round-trip correctly in BSON.
+suite bson_skip_marker_suite = [] {
+   using namespace bson_skip_marker_tests;
+   "bson skip-marker roundtrip"_test = [] {
+      settings original{.active = false, .count = 7, .name = "world"};
+      auto encoded = glz::write_bson(original);
+      expect(encoded.has_value());
+
+      settings decoded{};
+      auto ec = glz::read_bson(decoded, *encoded);
+      expect(!ec);
+      expect(decoded.active == false);
+      expect(decoded.count == 7);
+      expect(decoded.name == "world");
+   };
+};
+
 int main() { return 0; }

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -3286,6 +3286,44 @@ void merge_meta_tests()
    };
 }
 
+// Issue #2539: types opted out of serialization via meta::value = glz::skip{}
+// must round-trip correctly in CBOR.
+namespace cbor_skip_marker_tests
+{
+   struct marker
+   {
+      struct glaze
+      {
+         static constexpr auto value = glz::skip{};
+      };
+   };
+
+   struct settings
+   {
+      marker m{};
+      bool active{true};
+      int count{42};
+      std::string name{"hello"};
+   };
+}
+
+void cbor_skip_marker_tests_run()
+{
+   using namespace cbor_skip_marker_tests;
+   "cbor skip-marker roundtrip"_test = [] {
+      settings original{.active = false, .count = 7, .name = "world"};
+      auto encoded = glz::write_cbor(original);
+      expect(encoded.has_value());
+
+      settings decoded{};
+      auto ec = glz::read_cbor(decoded, *encoded);
+      expect(!ec);
+      expect(decoded.active == false);
+      expect(decoded.count == 7);
+      expect(decoded.name == "world");
+   };
+}
+
 int main()
 {
    basic_types_tests();
@@ -3325,6 +3363,7 @@ int main()
    chrono_tests();
    chrono_struct_tests();
    merge_meta_tests();
+   cbor_skip_marker_tests_run();
 #if __cpp_exceptions
    exceptions_tests();
 #endif

--- a/tests/msgpack_test/msgpack_test.cpp
+++ b/tests/msgpack_test/msgpack_test.cpp
@@ -296,6 +296,72 @@ struct glz::meta<msgpack_error_on_missing_keys_tests::MigrationV2>
    static constexpr auto value = object("id", &T::id, "name", &T::name, "version", &T::version);
 };
 
+// Issue #2539: types opted out of serialization via meta::value = glz::skip{}
+// must round-trip correctly in MsgPack, including the structs_as_arrays mode
+// where writer and reader must agree on the wire count of non-skipped fields.
+namespace msgpack_skip_marker_tests
+{
+   struct marker
+   {
+      struct glaze
+      {
+         static constexpr auto value = glz::skip{};
+      };
+   };
+
+   struct settings
+   {
+      marker m{};
+      bool active{true};
+      int count{42};
+      std::string name{"hello"};
+   };
+}
+
+template <>
+struct glz::meta<msgpack_skip_marker_tests::settings>
+{
+   using T = msgpack_skip_marker_tests::settings;
+   static constexpr auto value = object("m", &T::m, "active", &T::active, "count", &T::count, "name", &T::name);
+};
+
+namespace msgpack_skip_marker_tests
+{
+   inline void run()
+   {
+      using namespace ut;
+      "msgpack skip-marker keyed roundtrip"_test = [] {
+         settings original{.active = false, .count = 7, .name = "world"};
+         auto encoded = glz::write_msgpack(original);
+         expect(encoded.has_value());
+
+         settings decoded{};
+         auto ec = glz::read_msgpack(decoded, *encoded);
+         expect(!ec) << glz::format_error(ec, *encoded);
+         expect(decoded.active == false);
+         expect(decoded.count == 7);
+         expect(decoded.name == "world");
+      };
+
+      "msgpack skip-marker structs_as_arrays roundtrip"_test = [] {
+         constexpr auto opts =
+            glz::opt_true<glz::opts{.format = glz::MSGPACK}, glz::structs_as_arrays_opt_tag{}>;
+         settings original{.active = false, .count = 7, .name = "world"};
+         std::string buffer;
+         auto write_ec = glz::write<opts>(original, buffer);
+         expect(!write_ec);
+
+         settings decoded{};
+         glz::context ctx{};
+         auto ec = glz::read<opts>(decoded, std::string_view{buffer}, ctx);
+         expect(!ec) << glz::format_error(ec, buffer);
+         expect(decoded.active == false);
+         expect(decoded.count == 7);
+         expect(decoded.name == "world");
+      };
+   }
+}
+
 int main()
 {
    "msgpack primitive roundtrip"_test = [] {
@@ -1032,6 +1098,8 @@ int main()
          expect(decoded.active == batch.active) << "active should match";
       };
    }
+
+   msgpack_skip_marker_tests::run();
 
    return 0;
 }

--- a/tests/toml_test/toml_test.cpp
+++ b/tests/toml_test/toml_test.cpp
@@ -4607,4 +4607,126 @@ apple.taste.sweet = true
    };
 };
 
+// Issue #2539: marking an entire class as always-skipped from serialization
+// by setting its meta value to glz::skip{}. Two opt-in styles are supported,
+// matching Glaze's local/external metadata convention:
+//   1. Local:    struct glaze { static constexpr auto value = glz::skip{}; };
+//   2. External: glz::meta<T> { static constexpr auto value = glz::skip{}; };
+template <int N>
+struct skip_marker_local
+{
+   static constexpr int secret = N;
+   struct glaze
+   {
+      static constexpr auto value = glz::skip{};
+   };
+};
+
+template <int N>
+struct skip_marker_via_meta
+{
+   static constexpr int secret = N;
+};
+
+template <int N>
+struct glz::meta<skip_marker_via_meta<N>>
+{
+   static constexpr auto value = glz::skip{};
+};
+
+struct settings_with_local_markers
+{
+   skip_marker_local<99> things_marker{};
+   bool enable_things{true};
+   int number_of_things{42};
+
+   skip_marker_local<200> stuff_marker{};
+   float stuff_multiplier{13.37f};
+};
+
+struct settings_with_meta_markers
+{
+   skip_marker_via_meta<1> alpha{};
+   bool enable{true};
+   skip_marker_via_meta<2> beta{};
+   int count{42};
+};
+
+suite skip_meta_value_tests = [] {
+   "skip_local_meta_toml_write"_test = [] {
+      settings_with_local_markers s{};
+      const auto result = glz::write_toml(s);
+      expect(result.has_value());
+      expect(*result == "enable_things = true\nnumber_of_things = 42\nstuff_multiplier = 13.37");
+   };
+
+   "skip_external_meta_toml_write"_test = [] {
+      settings_with_meta_markers s{};
+      const auto result = glz::write_toml(s);
+      expect(result.has_value());
+      expect(*result == "enable = true\ncount = 42");
+   };
+
+   "skip_local_meta_json_write"_test = [] {
+      settings_with_local_markers s{};
+      std::string buffer{};
+      expect(not glz::write_json(s, buffer));
+      expect(buffer == R"({"enable_things":true,"number_of_things":42,"stuff_multiplier":13.37})");
+   };
+
+   "skip_external_meta_json_write"_test = [] {
+      settings_with_meta_markers s{};
+      std::string buffer{};
+      expect(not glz::write_json(s, buffer));
+      expect(buffer == R"({"enable":true,"count":42})");
+   };
+
+   // Read-side: input containing the skipped key must be silently consumed.
+   "skip_local_meta_json_read_silently_skips"_test = [] {
+      settings_with_local_markers s{};
+      std::string input =
+         R"({"things_marker":{"junk":1,"more":[1,2,3]},"enable_things":false,"number_of_things":7,"stuff_marker":"anything goes","stuff_multiplier":2.5})";
+      auto err = glz::read_json(s, input);
+      expect(not err) << glz::format_error(err, input);
+      expect(s.enable_things == false);
+      expect(s.number_of_things == 7);
+      expect(std::abs(s.stuff_multiplier - 2.5f) < 1e-6f);
+   };
+
+   "skip_external_meta_json_read_silently_skips"_test = [] {
+      settings_with_meta_markers s{};
+      std::string input = R"({"alpha":{"x":1},"enable":false,"beta":[1,2,3],"count":11})";
+      auto err = glz::read_json(s, input);
+      expect(not err) << glz::format_error(err, input);
+      expect(s.enable == false);
+      expect(s.count == 11);
+   };
+
+   "skip_local_meta_toml_read_silently_skips"_test = [] {
+      settings_with_local_markers s{};
+      std::string input = R"(things_marker = "garbage"
+enable_things = false
+number_of_things = 7
+stuff_marker = 12345
+stuff_multiplier = 2.5)";
+      auto err = glz::read_toml(s, input);
+      expect(not err) << glz::format_error(err, input);
+      expect(s.enable_things == false);
+      expect(s.number_of_things == 7);
+      expect(std::abs(s.stuff_multiplier - 2.5f) < 1e-6f);
+   };
+
+   "skip_external_meta_toml_read_silently_skips"_test = [] {
+      settings_with_meta_markers s{};
+      std::string input = R"(alpha = [1, 2, 3]
+enable = false
+beta = "throwaway"
+count = 11)";
+      auto err = glz::read_toml(s, input);
+      expect(not err) << glz::format_error(err, input);
+      expect(s.enable == false);
+      expect(s.count == 11);
+   };
+};
+
 int main() { return 0; }

--- a/tests/toml_test/toml_test.cpp
+++ b/tests/toml_test/toml_test.cpp
@@ -4727,6 +4727,28 @@ count = 11)";
       expect(s.enable == false);
       expect(s.count == 11);
    };
+
+   // Regression: marker fields must not be flagged as missing when
+   // error_on_missing_keys is set. They are never written, so requiring them
+   // would make every read of error_on_missing_keys fail.
+   "skip_marker_with_error_on_missing_keys"_test = [] {
+      settings_with_local_markers s{};
+      std::string input = R"({"enable_things":false,"number_of_things":7,"stuff_multiplier":2.5})";
+      auto err = glz::read<glz::opts{.error_on_missing_keys = true}>(s, input);
+      expect(not err) << glz::format_error(err, input);
+      expect(s.enable_things == false);
+      expect(s.number_of_things == 7);
+      expect(std::abs(s.stuff_multiplier - 2.5f) < 1e-6f);
+   };
+
+   "skip_marker_via_meta_with_error_on_missing_keys"_test = [] {
+      settings_with_meta_markers s{};
+      std::string input = R"({"enable":false,"count":11})";
+      auto err = glz::read<glz::opts{.error_on_missing_keys = true}>(s, input);
+      expect(not err) << glz::format_error(err, input);
+      expect(s.enable == false);
+      expect(s.count == 11);
+   };
 };
 
 int main() { return 0; }

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -8923,4 +8923,42 @@ suite merge_meta_yaml_tests = [] {
    };
 };
 
+namespace yaml_skip_marker_tests
+{
+   struct marker
+   {
+      struct glaze
+      {
+         static constexpr auto value = glz::skip{};
+      };
+   };
+
+   struct settings
+   {
+      marker m{};
+      bool active{true};
+      int count{42};
+      std::string name{"hello"};
+   };
+}
+
+// Issue #2539: types opted out of serialization via meta::value = glz::skip{}
+// must round-trip correctly in YAML.
+suite yaml_skip_marker_suite = [] {
+   using namespace yaml_skip_marker_tests;
+   "yaml skip-marker roundtrip"_test = [] {
+      settings original{.active = false, .count = 7, .name = "world"};
+      std::string yaml{};
+      expect(not glz::write_yaml(original, yaml));
+      // Marker key must not appear in the output.
+      expect(yaml.find("m:") == std::string::npos) << yaml;
+
+      settings decoded{};
+      expect(not glz::read_yaml(decoded, yaml));
+      expect(decoded.active == false);
+      expect(decoded.count == 7);
+      expect(decoded.name == "world");
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
## Summary

Lets a type opt out of serialization entirely by setting its meta value to `glz::skip{}`. Closes #2539.

```cpp
// local
struct Marker { struct glaze { static constexpr auto value = glz::skip{}; }; };
// external
template <> struct glz::meta<Marker> { static constexpr auto value = glz::skip{}; };
```

Routes through the existing `glaze_value_t` dispatch chain. All format writers now key off a unified `always_skipped` concept.

## ⚠️ Wire-format change for `glz::file_include`

BEVE / MsgPack / CBOR / BSON / JSONB previously emitted `file_include` fields as a placeholder. They are now filtered, matching JSON's longstanding behavior. **Older blobs containing such fields will not deserialize with the new reader.** JSON / TOML / YAML are unaffected.

## Test plan

- [x] Roundtrip tests added per format with a marker field (keyed + `structs_as_arrays` where applicable)
- [x] `error_on_missing_keys` regression covered
- [x] All format suites pass