### PR TITLE
Unify streaming/WebSocket routes into http_router with path params

### DIFF
--- a/docs/networking/advanced-networking.md
+++ b/docs/networking/advanced-networking.md
@@ -135,6 +135,8 @@ server.start();
 server.wait_for_signal();
 ```
 
+WebSocket routes also support `:param` segments and can be registered on an `http_router` and mounted, e.g. `router.websocket("/rooms/:room/ws", ws_server)`. The captured value is available in `request.params` inside `on_open`. See [HTTP Router](http-router.md#websocket-routes) for details.
+
 ### Chat Room Example
 
 ```cpp

--- a/docs/networking/http-router.md
+++ b/docs/networking/http-router.md
@@ -249,9 +249,65 @@ glz::param_constraint safe_path{
 router.get("/files/*path", file_handler, {.constraints = {{"path", safe_path}}});
 ```
 
+## Streaming Routes
+
+The router accepts streaming handlers alongside normal handlers. Streaming routes share the radix-tree matcher with normal routes, so `:param` and `*wildcard` segments work the same way. Captured parameters are placed in `request.params` before the handler runs.
+
+```cpp
+glz::http_router router;
+
+// GET streaming route with a path parameter
+router.stream_get("/items/:id/events",
+    [](glz::request& req, glz::streaming_response& res) {
+        const auto id = req.params.at("id");
+        res.start_stream(200, {{"Content-Type", "text/event-stream"}});
+        res.send("data: streaming events for item " + id + "\n\n");
+        res.close();
+    });
+
+// POST streaming route
+router.stream_post("/upload/:bucket",
+    [](glz::request& req, glz::streaming_response& res) { /* ... */ });
+
+// Generic method form
+router.stream(glz::http_method::PUT, "/jobs/:id", job_handler);
+```
+
+Mount the router on a server like any other:
+
+```cpp
+glz::http_server server;
+server.mount("/api", router);
+// Streaming routes are now reachable at /api/items/:id/events, etc.
+```
+
+Streaming handlers take over the connection (no keep-alive loop) and write chunked responses through `streaming_response`.
+
+> **Behavior change.** Before streaming and WebSocket routes shared the matcher, `streaming_handlers_` was an exact-path lookup, so registering `/items/:id` as a streaming route was effectively dead and a request to `/items/42` fell through to the normal router. After the unification, streaming routes are matched first (see [Route Priority](#route-priority)), so a streaming `/items/:id` will intercept requests that a static normal `/items/42` would otherwise handle. Code that registered both kinds on the same path needs to be aware of the new ordering.
+
+## WebSocket Routes
+
+WebSocket handlers can also be registered on the router and use `:param` paths. The HTTP server detects the upgrade handshake and dispatches to the matching `websocket_server`, populating `request.params` from the path.
+
+```cpp
+glz::http_router router;
+auto chat = std::make_shared<glz::websocket_server>();
+// ... configure chat (on_open, on_message, on_close, on_error) ...
+
+// WebSocket route with a path parameter
+router.websocket("/rooms/:room/ws", chat);
+
+glz::http_server server;
+server.mount("/api", router);
+// Clients connecting to ws://host/api/rooms/lobby/ws receive
+// request.params["room"] == "lobby" in on_open.
+```
+
+WebSocket upgrades are HTTP `GET` by definition, so the router stores them under `GET` internally; you do not specify a method when registering.
+
 ## Route Priority
 
-The router matches routes in priority order:
+Within a single radix tree, routes are matched in this order:
 
 1. **Static routes** (highest priority)
 2. **Parameter routes** 
@@ -267,6 +323,14 @@ router.get("/users/*action", user_action);        // 3. Wildcard
 // Request "/users/123" matches user_handler  
 // Request "/users/edit/profile" matches user_action
 ```
+
+Across the three kinds of routes (normal, streaming, WebSocket), the HTTP server dispatches in the following order for each request:
+
+1. **WebSocket** — if the request carries an `Upgrade: websocket` handshake, the WebSocket route table is consulted first.
+2. **Streaming** — otherwise, the streaming route table is consulted next. A match takes over the connection (no keep-alive loop) and runs the streaming handler.
+3. **Normal** — finally, the normal route table is consulted.
+
+In practice, streaming and normal routes for the same path/method should not be registered together; the streaming handler will always win.
 
 ## Middleware
 
@@ -374,6 +438,8 @@ server.mount("/admin", admin_router);
 // GET /admin/dashboard  
 // GET /admin/settings
 ```
+
+`mount()` propagates all three kinds of routes: normal, streaming (`stream_get`/`stream_post`/`stream`), and WebSocket (`websocket`). Each is rewritten with the mount prefix and added to the server's root router.
 
 ## Async Handlers
 

--- a/docs/networking/http-server.md
+++ b/docs/networking/http-server.md
@@ -529,6 +529,8 @@ server.mount("/api/v2", api_v2);
 // GET /api/v2/users
 ```
 
+`mount()` propagates normal, streaming (`stream_get`/`stream_post`), and WebSocket (`websocket`) routes from the sub-router; all three kinds support `:param` and `*wildcard` segments. See [HTTP Router](http-router.md#streaming-routes) for streaming and WebSocket route registration.
+
 ## Static File Serving
 
 ```cpp

--- a/docs/networking/rest-registry.md
+++ b/docs/networking/rest-registry.md
@@ -287,7 +287,7 @@ glz::registry<pretty_opts, glz::REST> registry;
 server.get("/api", [&registry](const glz::request&, glz::response& res) {
     std::vector<std::string> endpoints;
     
-    for (const auto& [path, methods] : registry.endpoints.routes) {
+    for (const auto& [path, methods] : registry.endpoints.normal_routes.routes) {
         for (const auto& [method, handler] : methods) {
             endpoints.push_back(glz::to_string(method) + " " + path);
         }

--- a/include/glaze/net/http_router.hpp
+++ b/include/glaze/net/http_router.hpp
@@ -130,6 +130,22 @@ namespace glz
    using async_handler = std::function<std::future<void>(const request&, response&)>;
    using error_handler = std::function<void(std::error_code, std::source_location)>;
 
+   // Forward declarations for streaming and WebSocket support.
+   // Full definitions live in glaze/net/http_server.hpp and glaze/net/websocket_connection.hpp.
+   // Forward declarations are sufficient here because streaming_handler holds streaming_response
+   // by reference and websocket_handler holds websocket_server through std::shared_ptr.
+   struct streaming_response;
+   struct websocket_server;
+
+   // Streaming handler signature. Streaming routes take over the connection lifecycle
+   // (no keep-alive) and write chunked responses through streaming_response.
+   using streaming_handler = std::function<void(request&, streaming_response&)>;
+
+   // WebSocket handler value: a websocket_server instance is bound to a path. The HTTP
+   // server detects the upgrade handshake (Upgrade: websocket) and dispatches to the
+   // matching server entry.
+   using websocket_handler = std::shared_ptr<websocket_server>;
+
    /**
     * @brief Parameter constraint for route validation
     *
@@ -170,66 +186,25 @@ namespace glz
    };
 
    /**
-    * @brief HTTP router based on a radix tree for efficient path matching
+    * @brief Generic radix-tree route table parameterized over the stored handler type.
     *
-    * @tparam Handler The type of the handler that gets invoked upon a route match.
-    *                 Must be invocable with (const request&, response&).
-    *                 Note: Middleware registered via use() must also be this type.
+    * route_table provides path matching with support for static, parameterized (":param"),
+    * and wildcard ("*name") segments. It is used as a building block by basic_http_router
+    * to store normal routes (typed by Handler), streaming routes (streaming_handler), and
+    * WebSocket routes (websocket_handler).
     *
-    * The basic_http_router class provides fast route matching for HTTP requests using a radix tree
-    * data structure. It supports static routes, parameterized routes (e.g., "/users/:id"),
-    * wildcard routes, and parameter validation via constraints.
-    *
-    * Note: http_server::mount() only accepts the default http_router (basic_http_router<>).
-    * Custom handler routers are intended for standalone use or with custom server implementations.
+    * @tparam H The stored handler type. Must be default-constructible (the empty value
+    *           returned by match() when no route matches is H{}).
     */
-   template <class Handler = std::function<void(const request&, response&)>>
-      requires std::invocable<Handler, const request&, response&>
-   struct basic_http_router
+   template <class H>
+   struct route_table
    {
       /**
-       * @brief Function type for request handlers
-       *
-       * Handlers are called when a route matches the incoming request.
-       */
-      using handler = Handler;
-
-      /**
-       * @brief A compile-time boolean indicating whether asynchronous request handlers are enabled.
-       *
-       * Async methods wrap the async handler in a capturing lambda and store it as a regular handler.
-       * This requires Handler to be constructible from such a wrapper. std::function and similar
-       * type-erasing wrappers support this; function pointers and fixed-signature handlers do not.
-       *
-       * Note: This heuristic checks constructibility from std::function as a proxy for "can accept
-       * a type-erased callable." A Handler constructible from lambdas but not std::function would
-       * incorrectly get is_async_enabled = false, but this is an unusual corner case.
-       */
-      static constexpr bool is_async_enabled =
-         std::is_constructible_v<Handler, std::function<void(const request&, response&)>>;
-
-      /**
-       * @brief Function type for asynchronous request handlers
-       *
-       * Async handlers return a std::future that completes when the request is processed.
-       * The async methods (get_async, post_async, etc.) wrap these by calling .get() on
-       * the returned future, converting them to synchronous handlers.
-       *
-       * Note: This type is fixed to std::function<std::future<void>...>. Users who need
-       * custom async patterns (coroutines, different future types, callbacks) should use
-       * their async-capable type directly as the Handler template parameter instead of
-       * using the built-in async methods.
-       *
-       * Async methods are only available when is_async_enabled is true.
-       */
-      using async_handler = std::function<std::future<void>(const request&, response&)>;
-
-      /**
-       * @brief An entry for a registered route.
+       * @brief Stored route entry: handler plus optional spec for schema/constraints.
        */
       struct route_entry
       {
-         handler handle{};
+         H handle{};
          route_spec spec{};
       };
 
@@ -239,70 +214,20 @@ namespace glz
        * Each node represents a segment of a path, which can be a static string,
        * a parameter (prefixed with ":"), or a wildcard (prefixed with "*").
        */
-      struct RadixNode
+      struct radix_node
       {
-         /**
-          * @brief The path segment this node represents
-          */
          std::string segment;
-
-         /**
-          * @brief Whether this node represents a parameter (e.g., ":id")
-          */
          bool is_parameter = false;
-
-         /**
-          * @brief Whether this node represents a wildcard (e.g., "*action")
-          */
          bool is_wildcard = false;
-
-         /**
-          * @brief Name of the parameter (if is_parameter or is_wildcard is true)
-          */
          std::string parameter_name;
-
-         /**
-          * @brief Map of static child nodes indexed by segment
-          */
-         std::unordered_map<std::string, std::unique_ptr<RadixNode>> static_children;
-
-         /**
-          * @brief Parameter child node (only one parameter child per node is allowed)
-          */
-         std::unique_ptr<RadixNode> parameter_child;
-
-         /**
-          * @brief Wildcard child node (only one wildcard child per node is allowed)
-          */
-         std::unique_ptr<RadixNode> wildcard_child;
-
-         /**
-          * @brief Map of handlers for different HTTP methods
-          *
-          * Only present if this node represents an endpoint.
-          */
-         std::unordered_map<http_method, handler> handlers;
-
-         /**
-          * @brief Map of parameter constraints for different HTTP methods
-          */
+         std::unordered_map<std::string, std::unique_ptr<radix_node>> static_children;
+         std::unique_ptr<radix_node> parameter_child;
+         std::unique_ptr<radix_node> wildcard_child;
+         std::unordered_map<http_method, H> handlers;
          std::unordered_map<http_method, std::unordered_map<std::string, param_constraint>> constraints;
-
-         /**
-          * @brief Whether this node represents an endpoint (route handler)
-          */
          bool is_endpoint = false;
-
-         /**
-          * @brief Full path to this node (for debugging and conflict detection)
-          */
          std::string full_path;
 
-         /**
-          * @brief Return a human-readable representation of this node
-          *
-          * @return String representation of the node
-          */
          std::string to_string() const
          {
             std::string result;
@@ -325,190 +250,12 @@ namespace glz
       };
 
       /**
-       * @brief Default constructor
-       */
-      basic_http_router() = default;
-
-      /**
-       * @brief Match a value against a pattern with advanced pattern matching features
+       * @brief Map of registered routes, keyed by full path then HTTP method.
        *
-       * Supports:
-       * - Wildcards (*) for matching any number of characters
-       * - Question marks (?) for matching a single character
-       * - Character classes ([a-z], [^0-9])
-       * - Anchors (^ for start of string, $ for end of string)
-       * - Escape sequences with backslash
-       *
-       * @param value The string to match
-       * @param pattern The pattern to match against
-       * @return true if the value matches the pattern, false otherwise
+       * Public for backward compatibility and to support introspection (e.g., the
+       * OpenAPI generator iterates this map).
        */
-      static bool match_pattern(std::string_view value, std::string_view pattern)
-      {
-         enum struct State { Literal, Escape, CharClass };
-
-         if (pattern.empty()) return true; // Empty pattern matches anything
-
-         size_t v_pos = 0;
-         size_t p_pos = 0;
-
-         // For backtracking when we encounter *
-         std::optional<size_t> backtrack_pattern;
-         std::optional<size_t> backtrack_value;
-
-         // For character classes
-         State state = State::Literal;
-         bool negate_class = false;
-         bool char_class_match = false;
-
-         while (v_pos < value.size() || p_pos < pattern.size()) {
-            // Pattern exhausted but value remains
-            if (p_pos >= pattern.size()) {
-               // Can we backtrack for wildcard?
-               if (backtrack_pattern) {
-                  p_pos = *backtrack_pattern;
-                  v_pos = ++(*backtrack_value);
-                  continue;
-               }
-               return false;
-            }
-
-            // Value exhausted but pattern remains
-            if (v_pos >= value.size()) {
-               // If remaining pattern is just * wildcard, it's a match
-               if (p_pos < pattern.size() && pattern[p_pos] == '*' && p_pos == pattern.size() - 1) return true;
-
-               // Can we backtrack?
-               if (backtrack_pattern) {
-                  p_pos = *backtrack_pattern;
-                  v_pos = ++(*backtrack_value);
-                  continue;
-               }
-               return false;
-            }
-
-            switch (state) {
-            case State::Literal:
-               if (pattern[p_pos] == '\\') {
-                  // Escape sequence
-                  state = State::Escape;
-                  p_pos++;
-                  continue;
-               }
-               else if (pattern[p_pos] == '[') {
-                  // Begin character class
-                  state = State::CharClass;
-                  char_class_match = false;
-                  p_pos++;
-
-                  // Check for negation
-                  if (p_pos < pattern.size() && pattern[p_pos] == '^') {
-                     negate_class = true;
-                     p_pos++;
-                  }
-                  else {
-                     negate_class = false;
-                  }
-                  continue;
-               }
-               else if (pattern[p_pos] == '*') {
-                  // Wildcard - match zero or more chars
-                  backtrack_pattern = p_pos;
-                  backtrack_value = v_pos;
-                  p_pos++;
-                  continue;
-               }
-               else if (pattern[p_pos] == '?') {
-                  // Match any single character
-                  p_pos++;
-                  v_pos++;
-                  continue;
-               }
-               else if (pattern[p_pos] == '^' && p_pos == 0) {
-                  // Beginning of string anchor
-                  p_pos++;
-                  continue;
-               }
-               else if (pattern[p_pos] == '$' && p_pos == pattern.size() - 1) {
-                  // End of string anchor - only matches if we're at the end
-                  return v_pos == value.size();
-               }
-               else {
-                  // Literal character
-                  if (pattern[p_pos] != value[v_pos]) {
-                     // Can we backtrack?
-                     if (backtrack_pattern) {
-                        p_pos = *backtrack_pattern;
-                        v_pos = ++(*backtrack_value);
-                        continue;
-                     }
-                     return false;
-                  }
-                  p_pos++;
-                  v_pos++;
-               }
-               break;
-
-            case State::Escape:
-               // Escaped character - match literally
-               if (p_pos >= pattern.size() || pattern[p_pos] != value[v_pos]) {
-                  // Can we backtrack?
-                  if (backtrack_pattern) {
-                     p_pos = *backtrack_pattern;
-                     v_pos = ++(*backtrack_value);
-                     state = State::Literal;
-                     continue;
-                  }
-                  return false;
-               }
-               p_pos++;
-               v_pos++;
-               state = State::Literal;
-               break;
-
-            case State::CharClass:
-               if (pattern[p_pos] == ']') {
-                  // End of character class
-                  p_pos++;
-                  if (negate_class) {
-                     if (char_class_match) {
-                        // Negated and found a match = fail
-                        return false;
-                     }
-                     v_pos++; // Character not in class
-                  }
-                  else {
-                     if (!char_class_match) {
-                        // Not negated and no match = fail
-                        return false;
-                     }
-                     v_pos++; // Character in class
-                  }
-                  state = State::Literal;
-                  continue;
-               }
-               else if (p_pos + 2 < pattern.size() && pattern[p_pos + 1] == '-') {
-                  // Character range
-                  char start = pattern[p_pos];
-                  char end = pattern[p_pos + 2];
-                  if (value[v_pos] >= start && value[v_pos] <= end) {
-                     char_class_match = true;
-                  }
-                  p_pos += 3; // Skip the range
-               }
-               else {
-                  // Single character in class
-                  if (pattern[p_pos] == value[v_pos]) {
-                     char_class_match = true;
-                  }
-                  p_pos++;
-               }
-               break;
-            }
-         }
-
-         return v_pos == value.size() && p_pos == pattern.size();
-      }
+      std::unordered_map<std::string, std::unordered_map<http_method, route_entry>> routes;
 
       /**
        * @brief Split a path into segments
@@ -541,165 +288,47 @@ namespace glz
       }
 
       /**
-       * @brief Register a route with the router
+       * @brief Register a route in the table.
        *
        * @param method The HTTP method (GET, POST, etc.)
-       * @param path The route path, can include parameters (":param") and wildcards ("*param")
-       * @param handle The handler function to call when this route matches
+       * @param path The route path, may contain ":param" or trailing "*name" wildcards.
+       * @param handle The handler to associate with the route.
        * @param spec Optional spec for the route.
-       * @return Reference to this router for method chaining
-       * @throws std::runtime_error if there's a route conflict
        */
-      inline basic_http_router& route(http_method method, std::string_view path, handler handle,
-                                      const route_spec& spec = {})
+      void add(http_method method, std::string_view path, H handle, const route_spec& spec = {})
       {
-         std::string path_str(path);
          try {
-            // Store in the routes map
-            auto& entry = routes[path_str][method];
+            // Install in the radix tree first. add_route can throw on conflict
+            // (duplicate :param or *wildcard names at the same position); if it
+            // throws we want the routes map to stay in sync with the tree, not
+            // to silently retain an entry that iteration sees but match() never
+            // reaches. Pass handle by value so we still own a copy to move into
+            // the routes entry below.
+            add_route(method, path, handle, spec.constraints);
+
+            auto& entry = routes[std::string(path)][method];
             entry.handle = std::move(handle);
             entry.spec = spec;
-
-            // Also add to the radix tree
-            add_route(method, path, entry.handle, spec.constraints);
          }
          catch (const std::exception& e) {
-            // Log the error instead of propagating it
             std::fprintf(stderr, "Error adding route '%.*s': %s\n", static_cast<int>(path.length()), path.data(),
                          e.what());
          }
-         return *this;
       }
 
       /**
-       * @brief Register a GET route
-       */
-      inline basic_http_router& get(std::string_view path, handler handle, const route_spec& spec = {})
-      {
-         return route(http_method::GET, path, std::move(handle), spec);
-      }
-
-      /**
-       * @brief Register a POST route
-       */
-      inline basic_http_router& post(std::string_view path, handler handle, const route_spec& spec = {})
-      {
-         return route(http_method::POST, path, std::move(handle), spec);
-      }
-
-      /**
-       * @brief Register a PUT route
-       */
-      inline basic_http_router& put(std::string_view path, handler handle, const route_spec& spec = {})
-      {
-         return route(http_method::PUT, path, std::move(handle), spec);
-      }
-
-      /**
-       * @brief Register a DELETE route
-       */
-      inline basic_http_router& del(std::string_view path, handler handle, const route_spec& spec = {})
-      {
-         return route(http_method::DELETE, path, std::move(handle), spec);
-      }
-
-      /**
-       * @brief Register a PATCH route
-       */
-      inline basic_http_router& patch(std::string_view path, handler handle, const route_spec& spec = {})
-      {
-         return route(http_method::PATCH, path, std::move(handle), spec);
-      }
-
-      /**
-       * @brief Register an asynchronous route
-       */
-      inline basic_http_router& route_async(http_method method, std::string_view path, async_handler handle,
-                                            const route_spec& spec = {})
-         requires is_async_enabled
-      {
-         // Convert async handle to sync handle (capture by move for efficiency)
-         return route(
-            method, path,
-            [handle = std::move(handle)](const request& req, response& res) {
-               // Create a future and get the result, which will propagate any exceptions
-               auto future = handle(req, res);
-               future.get(); // This will throw if the async operation threw
-            },
-            spec);
-      }
-
-      /**
-       * @brief Register an asynchronous GET route
-       */
-      inline basic_http_router& get_async(std::string_view path, async_handler handle, const route_spec& spec = {})
-         requires is_async_enabled
-      {
-         return route_async(http_method::GET, path, std::move(handle), spec);
-      }
-
-      /**
-       * @brief Register an asynchronous POST route
-       */
-      inline basic_http_router& post_async(std::string_view path, async_handler handle, const route_spec& spec = {})
-         requires is_async_enabled
-      {
-         return route_async(http_method::POST, path, std::move(handle), spec);
-      }
-
-      /**
-       * @brief Register an asynchronous PUT route
-       */
-      inline basic_http_router& put_async(std::string_view path, async_handler handle, const route_spec& spec = {})
-         requires is_async_enabled
-      {
-         return route_async(http_method::PUT, path, std::move(handle), spec);
-      }
-
-      /**
-       * @brief Register an asynchronous DELETE route
-       */
-      inline basic_http_router& del_async(std::string_view path, async_handler handle, const route_spec& spec = {})
-         requires is_async_enabled
-      {
-         return route_async(http_method::DELETE, path, std::move(handle), spec);
-      }
-
-      /**
-       * @brief Register an asynchronous PATCH route
-       */
-      inline basic_http_router& patch_async(std::string_view path, async_handler handle, const route_spec& spec = {})
-         requires is_async_enabled
-      {
-         return route_async(http_method::PATCH, path, std::move(handle), spec);
-      }
-
-      /**
-       * @brief Register middleware to be executed before route handlers
+       * @brief Match a target against the registered routes.
        *
-       * Middleware functions are executed in the order they are registered.
-       *
-       * @param middleware The middleware function
-       * @return Reference to this router for method chaining
+       * @param method The HTTP method of the request.
+       * @param target The request target (may include a query string).
+       * @return Pair of (matched handler, extracted path parameters). The handler is
+       *         a default-constructed H if no route matched.
        */
-      inline basic_http_router& use(handler middleware)
-      {
-         middlewares.push_back(std::move(middleware));
-         return *this;
-      }
-
-      /**
-       * @brief Match a request against registered routes
-       *
-       * @param method The HTTP method of the request
-       * @param target The target path of the request (may include query string)
-       * @return A pair containing the matched handler and extracted parameters
-       */
-      inline std::pair<handler, std::unordered_map<std::string, std::string>> match(http_method method,
-                                                                                    const std::string& target) const
+      std::pair<H, std::unordered_map<std::string, std::string>> match(http_method method,
+                                                                       std::string_view target) const
       {
          std::unordered_map<std::string, std::string> params;
-         handler result = nullptr;
+         H result{};
 
          // Strip query string from target for matching
          const auto [path, query_string] = split_target(target);
@@ -709,21 +338,18 @@ namespace glz
          if (direct_it != direct_routes.end()) {
             auto method_it = direct_it->second.find(method);
             if (method_it != direct_it->second.end()) {
-               return {method_it->second, params}; // No params for direct match
+               return {method_it->second, params};
             }
          }
 
-         // Split the target path into segments
          std::vector<std::string> segments = split_path(path);
-
-         // Use recursive matching function
          match_node(&root, segments, 0, method, params, result);
 
          return {result, params};
       }
 
       /**
-       * @brief Print the entire router tree structure for debugging
+       * @brief Print the entire tree structure for debugging.
        */
       void print_tree() const
       {
@@ -731,76 +357,40 @@ namespace glz
          print_node(&root, 0);
       }
 
-      /**
-       * @brief Map of routes registered with this router
-       *
-       * Used for compatibility with mount functionality.
-       */
-      std::unordered_map<std::string, std::unordered_map<http_method, route_entry>> routes;
-
-      /**
-       * @brief Vector of middleware handlers
-       */
-      std::vector<handler> middlewares;
-
      private:
-      /**
-       * @brief Root node of the radix tree
-       */
-      mutable RadixNode root;
+      mutable radix_node root;
+      std::unordered_map<std::string, std::unordered_map<http_method, H>> direct_routes;
 
-      /**
-       * @brief Direct lookup table for non-parameterized routes (optimization)
-       */
-      std::unordered_map<std::string, std::unordered_map<http_method, handler>> direct_routes;
-
-      /**
-       * @brief Add a route to the radix tree
-       *
-       * @param method HTTP method for the route
-       * @param path Path pattern for the route
-       * @param handle Handler function for the route
-       * @param constraints Optional parameter constraints
-       * @throws std::runtime_error if there's a route conflict
-       */
-      void add_route(http_method method, std::string_view path, handler handle,
+      void add_route(http_method method, std::string_view path, H handle,
                      const std::unordered_map<std::string, param_constraint>& constraints = {})
       {
          std::string path_str(path);
 
-         // Optimization: for non-parameterized routes, store them directly
          if (path_str.find(':') == std::string::npos && path_str.find('*') == std::string::npos) {
             direct_routes[path_str][method] = handle;
             return;
          }
 
-         // For parameterized routes, use the radix tree
          std::vector<std::string> segments = split_path(path);
 
-         // Start at the root node
-         RadixNode* current = &root;
+         radix_node* current = &root;
 
-         // Build the path through the tree
          for (size_t i = 0; i < segments.size(); ++i) {
             const std::string& segment = segments[i];
 
             if (segment.empty()) continue;
 
             if (segment[0] == ':') {
-               // Parameter segment
                std::string param_name = segment.substr(1);
 
                if (!current->parameter_child) {
-                  current->parameter_child = std::make_unique<RadixNode>();
+                  current->parameter_child = std::make_unique<radix_node>();
                   current->parameter_child->is_parameter = true;
                   current->parameter_child->parameter_name = param_name;
                   current->parameter_child->segment = segment;
-
-                  // Build the full path for debugging/conflict detection
                   current->parameter_child->full_path = current->full_path + "/" + segment;
                }
                else if (current->parameter_child->parameter_name != param_name) {
-                  // Parameter name conflict
                   throw std::runtime_error("Route conflict: different parameter names at same position: :" +
                                            current->parameter_child->parameter_name + " vs :" + param_name);
                }
@@ -808,39 +398,31 @@ namespace glz
                current = current->parameter_child.get();
             }
             else if (segment[0] == '*') {
-               // Wildcard segment
                std::string wildcard_name = segment.substr(1);
 
-               // Wildcards must be at the end of the route
                if (i != segments.size() - 1) {
                   throw std::runtime_error("Wildcard must be the last segment in route: " + path_str);
                }
 
                if (!current->wildcard_child) {
-                  current->wildcard_child = std::make_unique<RadixNode>();
+                  current->wildcard_child = std::make_unique<radix_node>();
                   current->wildcard_child->is_wildcard = true;
                   current->wildcard_child->parameter_name = wildcard_name;
                   current->wildcard_child->segment = segment;
-
-                  // Build the full path for debugging/conflict detection
                   current->wildcard_child->full_path = current->full_path + "/" + segment;
                }
                else if (current->wildcard_child->parameter_name != wildcard_name) {
-                  // Wildcard name conflict
                   throw std::runtime_error("Route conflict: different wildcard names at same position: *" +
                                            current->wildcard_child->parameter_name + " vs *" + wildcard_name);
                }
 
                current = current->wildcard_child.get();
-               break; // Wildcard is always the last segment
+               break;
             }
             else {
-               // Static segment
                if (current->static_children.find(segment) == current->static_children.end()) {
-                  current->static_children[segment] = std::make_unique<RadixNode>();
+                  current->static_children[segment] = std::make_unique<radix_node>();
                   current->static_children[segment]->segment = segment;
-
-                  // Build the full path for debugging/conflict detection
                   current->static_children[segment]->full_path = current->full_path + "/" + segment;
                }
 
@@ -848,38 +430,21 @@ namespace glz
             }
          }
 
-         // Mark as endpoint and set handler
          current->is_endpoint = true;
          current->handlers[method] = handle;
 
-         // Store constraints (if any)
          if (!constraints.empty()) {
             current->constraints[method] = constraints;
          }
       }
 
-      /**
-       * @brief Match a path against the radix tree
-       *
-       * Recursive function to match a path against the tree and extract parameters.
-       *
-       * @param node Current node in the tree
-       * @param segments Path segments to match
-       * @param index Current segment index
-       * @param method HTTP method to match
-       * @param params Map to store extracted parameters
-       * @param result Handler if a match is found
-       * @return true if a match was found, false otherwise
-       */
-      bool match_node(RadixNode* node, const std::vector<std::string>& segments, size_t index, http_method method,
-                      std::unordered_map<std::string, std::string>& params, handler& result) const
+      bool match_node(radix_node* node, const std::vector<std::string>& segments, size_t index, http_method method,
+                      std::unordered_map<std::string, std::string>& params, H& result) const
       {
-         // End of path
          if (index == segments.size()) {
             if (node->is_endpoint) {
                auto it = node->handlers.find(method);
                if (it != node->handlers.end()) {
-                  // Validate constraints if any before setting the handler
                   bool constraints_passed = true;
                   auto constraints_it = node->constraints.find(method);
                   if (constraints_it != node->constraints.end()) {
@@ -887,18 +452,15 @@ namespace glz
                         auto param_it = params.find(param_name);
                         if (param_it != params.end()) {
                            const std::string& value = param_it->second;
-
-                           // Use the validation function
                            if (!constraint.validation(value)) {
                               constraints_passed = false;
-                              break; // Validation failed
+                              break;
                            }
                         }
                      }
                   }
 
                   if (constraints_passed) {
-                     // Only set the handler if constraints pass
                      result = it->second;
                      return true;
                   }
@@ -910,7 +472,6 @@ namespace glz
 
          const std::string& segment = segments[index];
 
-         // Try static match first (most specific)
          auto static_it = node->static_children.find(segment);
          if (static_it != node->static_children.end()) {
             if (match_node(static_it->second.get(), segments, index + 1, method, params, result)) {
@@ -918,9 +479,7 @@ namespace glz
             }
          }
 
-         // Try parameter match (less specific than static)
          if (node->parameter_child) {
-            // Save parameter value (URL-decoded)
             std::string param_name = node->parameter_child->parameter_name;
             params[param_name] = url_decode(segment);
 
@@ -928,26 +487,22 @@ namespace glz
                return true;
             }
 
-            // If this parameter didn't lead to a match, remove it
             params.erase(param_name);
          }
 
-         // Try wildcard match (least specific)
          if (node->wildcard_child) {
-            // For wildcards, capture all remaining segments (URL-decoded)
             std::string full_capture;
             for (size_t i = index; i < segments.size(); i++) {
                if (i > index) full_capture += "/";
                full_capture += url_decode(segments[i]);
             }
 
-            params[node->wildcard_child->parameter_name] = full_capture;
+            const auto& wildcard_name = node->wildcard_child->parameter_name;
+            params[wildcard_name] = full_capture;
 
-            // Wildcards always go to the endpoint of their node
             if (node->wildcard_child->is_endpoint) {
                auto it = node->wildcard_child->handlers.find(method);
                if (it != node->wildcard_child->handlers.end()) {
-                  // Validate constraints for the wildcard before setting the handler
                   bool constraints_passed = true;
                   auto constraints_it = node->wildcard_child->constraints.find(method);
                   if (constraints_it != node->wildcard_child->constraints.end()) {
@@ -955,43 +510,38 @@ namespace glz
                         auto param_it = params.find(param_name);
                         if (param_it != params.end()) {
                            const std::string& value = param_it->second;
-
-                           // Use the validation function
                            if (!constraint.validation(value)) {
                               constraints_passed = false;
-                              break; // Validation failed
+                              break;
                            }
                         }
                      }
                   }
 
                   if (constraints_passed) {
-                     // Only set the handler if constraints pass
                      result = it->second;
                      return true;
                   }
-                  return false;
                }
             }
+
+            // Wildcard match failed (not an endpoint, wrong method, or
+            // constraint failure). Mirror the parameter-branch behavior and
+            // erase the capture so the caller's params map reflects only the
+            // matched route's parameters.
+            params.erase(wildcard_name);
          }
 
          return false;
       }
 
-      /**
-       * @brief Print a node in the radix tree (for debugging)
-       *
-       * @param node The node to print
-       * @param depth Current depth in the tree (for indentation)
-       */
-      void print_node(const RadixNode* node, int depth) const
+      void print_node(const radix_node* node, int depth) const
       {
          if (!node) return;
 
          std::string indent(depth * 2, ' ');
          std::cout << indent << node->to_string() << "\n";
 
-         // Print all handlers for this node
          if (node->is_endpoint) {
             std::cout << indent << "  Handlers: ";
             for (const auto& [method, _] : node->handlers) {
@@ -999,7 +549,6 @@ namespace glz
             }
             std::cout << "\n";
 
-            // Print constraints if any
             for (const auto& [method, method_constraints] : node->constraints) {
                std::cout << indent << "  Constraints for " << to_string(method) << ":\n";
                for (const auto& [param, constraint] : method_constraints) {
@@ -1008,7 +557,6 @@ namespace glz
             }
          }
 
-         // Print children
          for (const auto& [segment, child] : node->static_children) {
             print_node(child.get(), depth + 1);
          }
@@ -1021,6 +569,484 @@ namespace glz
             print_node(node->wildcard_child.get(), depth + 1);
          }
       }
+   };
+
+   /**
+    * @brief Match a value against a pattern with advanced pattern matching features
+    *
+    * Supports:
+    * - Wildcards (*) for matching any number of characters
+    * - Question marks (?) for matching a single character
+    * - Character classes ([a-z], [^0-9])
+    * - Anchors (^ for start of string, $ for end of string)
+    * - Escape sequences with backslash
+    *
+    * @param value The string to match
+    * @param pattern The pattern to match against
+    * @return true if the value matches the pattern, false otherwise
+    */
+   inline bool match_pattern(std::string_view value, std::string_view pattern)
+   {
+      enum struct State { Literal, Escape, CharClass };
+
+      if (pattern.empty()) return true; // Empty pattern matches anything
+
+      size_t v_pos = 0;
+      size_t p_pos = 0;
+
+      // For backtracking when we encounter *
+      std::optional<size_t> backtrack_pattern;
+      std::optional<size_t> backtrack_value;
+
+      // For character classes
+      State state = State::Literal;
+      bool negate_class = false;
+      bool char_class_match = false;
+
+      while (v_pos < value.size() || p_pos < pattern.size()) {
+         // Pattern exhausted but value remains
+         if (p_pos >= pattern.size()) {
+            if (backtrack_pattern) {
+               p_pos = *backtrack_pattern;
+               v_pos = ++(*backtrack_value);
+               continue;
+            }
+            return false;
+         }
+
+         // Value exhausted but pattern remains
+         if (v_pos >= value.size()) {
+            if (p_pos < pattern.size() && pattern[p_pos] == '*' && p_pos == pattern.size() - 1) return true;
+
+            if (backtrack_pattern) {
+               p_pos = *backtrack_pattern;
+               v_pos = ++(*backtrack_value);
+               continue;
+            }
+            return false;
+         }
+
+         switch (state) {
+         case State::Literal:
+            if (pattern[p_pos] == '\\') {
+               state = State::Escape;
+               p_pos++;
+               continue;
+            }
+            else if (pattern[p_pos] == '[') {
+               state = State::CharClass;
+               char_class_match = false;
+               p_pos++;
+
+               if (p_pos < pattern.size() && pattern[p_pos] == '^') {
+                  negate_class = true;
+                  p_pos++;
+               }
+               else {
+                  negate_class = false;
+               }
+               continue;
+            }
+            else if (pattern[p_pos] == '*') {
+               backtrack_pattern = p_pos;
+               backtrack_value = v_pos;
+               p_pos++;
+               continue;
+            }
+            else if (pattern[p_pos] == '?') {
+               p_pos++;
+               v_pos++;
+               continue;
+            }
+            else if (pattern[p_pos] == '^' && p_pos == 0) {
+               p_pos++;
+               continue;
+            }
+            else if (pattern[p_pos] == '$' && p_pos == pattern.size() - 1) {
+               return v_pos == value.size();
+            }
+            else {
+               if (pattern[p_pos] != value[v_pos]) {
+                  if (backtrack_pattern) {
+                     p_pos = *backtrack_pattern;
+                     v_pos = ++(*backtrack_value);
+                     continue;
+                  }
+                  return false;
+               }
+               p_pos++;
+               v_pos++;
+            }
+            break;
+
+         case State::Escape:
+            if (p_pos >= pattern.size() || pattern[p_pos] != value[v_pos]) {
+               if (backtrack_pattern) {
+                  p_pos = *backtrack_pattern;
+                  v_pos = ++(*backtrack_value);
+                  state = State::Literal;
+                  continue;
+               }
+               return false;
+            }
+            p_pos++;
+            v_pos++;
+            state = State::Literal;
+            break;
+
+         case State::CharClass:
+            if (pattern[p_pos] == ']') {
+               p_pos++;
+               if (negate_class) {
+                  if (char_class_match) {
+                     return false;
+                  }
+                  v_pos++;
+               }
+               else {
+                  if (!char_class_match) {
+                     return false;
+                  }
+                  v_pos++;
+               }
+               state = State::Literal;
+               continue;
+            }
+            else if (p_pos + 2 < pattern.size() && pattern[p_pos + 1] == '-') {
+               char start = pattern[p_pos];
+               char end = pattern[p_pos + 2];
+               if (value[v_pos] >= start && value[v_pos] <= end) {
+                  char_class_match = true;
+               }
+               p_pos += 3;
+            }
+            else {
+               if (pattern[p_pos] == value[v_pos]) {
+                  char_class_match = true;
+               }
+               p_pos++;
+            }
+            break;
+         }
+      }
+
+      return v_pos == value.size() && p_pos == pattern.size();
+   }
+
+   /**
+    * @brief HTTP router based on a radix tree for efficient path matching
+    *
+    * @tparam Handler The type of the handler that gets invoked upon a route match.
+    *                 Must be invocable with (const request&, response&).
+    *                 Note: Middleware registered via use() must also be this type.
+    *
+    * The basic_http_router class provides fast route matching for HTTP requests using a radix tree
+    * data structure. It supports static routes, parameterized routes (e.g., "/users/:id"),
+    * wildcard routes, and parameter validation via constraints.
+    *
+    * In addition to normal request/response handlers, basic_http_router also stores
+    * streaming routes (registered via stream_get/stream_post/stream) and WebSocket
+    * routes (registered via websocket()). All three kinds share the same radix-tree
+    * matching logic, so streaming and WebSocket routes also support ":param" path
+    * parameters.
+    *
+    * Note: http_server::mount() only accepts the default http_router (basic_http_router<>).
+    * Custom handler routers are intended for standalone use or with custom server implementations.
+    */
+   template <class Handler = std::function<void(const request&, response&)>>
+      requires std::invocable<Handler, const request&, response&>
+   struct basic_http_router
+   {
+      /**
+       * @brief Function type for request handlers
+       */
+      using handler = Handler;
+
+      /**
+       * @brief A compile-time boolean indicating whether asynchronous request handlers are enabled.
+       */
+      static constexpr bool is_async_enabled =
+         std::is_constructible_v<Handler, std::function<void(const request&, response&)>>;
+
+      /**
+       * @brief Function type for asynchronous request handlers
+       */
+      using async_handler = std::function<std::future<void>(const request&, response&)>;
+
+      /**
+       * @brief Underlying route table type for normal routes.
+       */
+      using normal_route_table = route_table<Handler>;
+
+      /**
+       * @brief Backward-compatible alias for the normal route entry type.
+       */
+      using route_entry = typename normal_route_table::route_entry;
+
+      basic_http_router() = default;
+
+      /**
+       * @brief Backward-compatible static helper. Equivalent to route_table<Handler>::split_path.
+       */
+      static std::vector<std::string> split_path(std::string_view path) { return normal_route_table::split_path(path); }
+
+      /**
+       * @brief Register a route with the router
+       *
+       * @param method The HTTP method (GET, POST, etc.)
+       * @param path The route path, can include parameters (":param") and wildcards ("*param")
+       * @param handle The handler function to call when this route matches
+       * @param spec Optional spec for the route.
+       * @return Reference to this router for method chaining
+       * @throws std::runtime_error if there's a route conflict
+       */
+      basic_http_router& route(http_method method, std::string_view path, handler handle, const route_spec& spec = {})
+      {
+         normal_routes.add(method, path, std::move(handle), spec);
+         return *this;
+      }
+
+      /**
+       * @brief Register a GET route
+       */
+      basic_http_router& get(std::string_view path, handler handle, const route_spec& spec = {})
+      {
+         return route(http_method::GET, path, std::move(handle), spec);
+      }
+
+      /**
+       * @brief Register a POST route
+       */
+      basic_http_router& post(std::string_view path, handler handle, const route_spec& spec = {})
+      {
+         return route(http_method::POST, path, std::move(handle), spec);
+      }
+
+      /**
+       * @brief Register a PUT route
+       */
+      basic_http_router& put(std::string_view path, handler handle, const route_spec& spec = {})
+      {
+         return route(http_method::PUT, path, std::move(handle), spec);
+      }
+
+      /**
+       * @brief Register a DELETE route
+       */
+      basic_http_router& del(std::string_view path, handler handle, const route_spec& spec = {})
+      {
+         return route(http_method::DELETE, path, std::move(handle), spec);
+      }
+
+      /**
+       * @brief Register a PATCH route
+       */
+      basic_http_router& patch(std::string_view path, handler handle, const route_spec& spec = {})
+      {
+         return route(http_method::PATCH, path, std::move(handle), spec);
+      }
+
+      /**
+       * @brief Register an asynchronous route
+       */
+      basic_http_router& route_async(http_method method, std::string_view path, async_handler handle,
+                                     const route_spec& spec = {})
+         requires is_async_enabled
+      {
+         return route(
+            method, path,
+            [handle = std::move(handle)](const request& req, response& res) {
+               auto future = handle(req, res);
+               future.get();
+            },
+            spec);
+      }
+
+      /**
+       * @brief Register an asynchronous GET route
+       */
+      basic_http_router& get_async(std::string_view path, async_handler handle, const route_spec& spec = {})
+         requires is_async_enabled
+      {
+         return route_async(http_method::GET, path, std::move(handle), spec);
+      }
+
+      /**
+       * @brief Register an asynchronous POST route
+       */
+      basic_http_router& post_async(std::string_view path, async_handler handle, const route_spec& spec = {})
+         requires is_async_enabled
+      {
+         return route_async(http_method::POST, path, std::move(handle), spec);
+      }
+
+      /**
+       * @brief Register an asynchronous PUT route
+       */
+      basic_http_router& put_async(std::string_view path, async_handler handle, const route_spec& spec = {})
+         requires is_async_enabled
+      {
+         return route_async(http_method::PUT, path, std::move(handle), spec);
+      }
+
+      /**
+       * @brief Register an asynchronous DELETE route
+       */
+      basic_http_router& del_async(std::string_view path, async_handler handle, const route_spec& spec = {})
+         requires is_async_enabled
+      {
+         return route_async(http_method::DELETE, path, std::move(handle), spec);
+      }
+
+      /**
+       * @brief Register an asynchronous PATCH route
+       */
+      basic_http_router& patch_async(std::string_view path, async_handler handle, const route_spec& spec = {})
+         requires is_async_enabled
+      {
+         return route_async(http_method::PATCH, path, std::move(handle), spec);
+      }
+
+      /**
+       * @brief Register a streaming route. Streaming handlers take over the connection
+       * lifecycle and write chunked responses through streaming_response.
+       *
+       * Supports the same path-parameter syntax as normal routes (":param" and "*name").
+       */
+      basic_http_router& stream(http_method method, std::string_view path, streaming_handler handle,
+                                const route_spec& spec = {})
+      {
+         streaming_routes.add(method, path, std::move(handle), spec);
+         return *this;
+      }
+
+      /**
+       * @brief Register a streaming GET route.
+       */
+      basic_http_router& stream_get(std::string_view path, streaming_handler handle, const route_spec& spec = {})
+      {
+         return stream(http_method::GET, path, std::move(handle), spec);
+      }
+
+      /**
+       * @brief Register a streaming POST route.
+       */
+      basic_http_router& stream_post(std::string_view path, streaming_handler handle, const route_spec& spec = {})
+      {
+         return stream(http_method::POST, path, std::move(handle), spec);
+      }
+
+      /**
+       * @brief Register a WebSocket handler for a path.
+       *
+       * Supports the same path-parameter syntax as normal routes. The HTTP server
+       * detects the upgrade handshake (Upgrade: websocket) and dispatches to the
+       * matching server, populating request.params from the path.
+       */
+      basic_http_router& websocket(std::string_view path, websocket_handler server, const route_spec& spec = {})
+      {
+         websocket_routes.add(http_method::GET, path, std::move(server), spec);
+         return *this;
+      }
+
+      /**
+       * @brief Register middleware to be executed before route handlers
+       *
+       * Middleware functions are executed in the order they are registered.
+       *
+       * @param middleware The middleware function
+       * @return Reference to this router for method chaining
+       */
+      basic_http_router& use(handler middleware)
+      {
+         middlewares.push_back(std::move(middleware));
+         return *this;
+      }
+
+      /**
+       * @brief Match a normal request against registered routes
+       *
+       * @param method The HTTP method of the request
+       * @param target The target path of the request (may include query string)
+       * @return A pair containing the matched handler and extracted parameters
+       */
+      std::pair<handler, std::unordered_map<std::string, std::string>> match(http_method method,
+                                                                             std::string_view target) const
+      {
+         return normal_routes.match(method, target);
+      }
+
+      /**
+       * @brief Match a streaming request against registered streaming routes.
+       */
+      std::pair<streaming_handler, std::unordered_map<std::string, std::string>> match_streaming(
+         http_method method, std::string_view target) const
+      {
+         return streaming_routes.match(method, target);
+      }
+
+      /**
+       * @brief Match a WebSocket upgrade request against registered WebSocket routes.
+       *
+       * WebSocket upgrades are HTTP GET requests by definition, so the lookup uses
+       * http_method::GET internally.
+       */
+      std::pair<websocket_handler, std::unordered_map<std::string, std::string>> match_websocket(
+         std::string_view target) const
+      {
+         return websocket_routes.match(http_method::GET, target);
+      }
+
+      /**
+       * @brief Print the router structure for debugging.
+       */
+      void print_tree() const
+      {
+         std::cout << "[normal routes]\n";
+         normal_routes.print_tree();
+         std::cout << "[streaming routes]\n";
+         streaming_routes.print_tree();
+         std::cout << "[websocket routes]\n";
+         websocket_routes.print_tree();
+      }
+
+      /**
+       * @brief Storage for normal request/response routes.
+       *
+       * Iterate `router.normal_routes.routes` for path -> method -> entry inspection
+       * (used by the OpenAPI generator and mount()).
+       *
+       * Migration note: prior to the streaming/WebSocket unification, this field was
+       * exposed as `router.routes`. Code that iterated `router.routes` should now
+       * iterate `router.normal_routes.routes` (or use the `routes()` accessor below).
+       */
+      normal_route_table normal_routes;
+
+      /**
+       * @brief Backward-compatible accessor for the registered normal routes map.
+       *
+       * Equivalent to `normal_routes.routes`. Provided as a function (not a
+       * reference data member) because a reference member would be copied verbatim
+       * by the implicitly-defined move constructor and dangle into the moved-from
+       * source.
+       */
+      auto& routes() noexcept { return normal_routes.routes; }
+      const auto& routes() const noexcept { return normal_routes.routes; }
+
+      /**
+       * @brief Storage for streaming routes.
+       */
+      route_table<streaming_handler> streaming_routes;
+
+      /**
+       * @brief Storage for WebSocket routes.
+       */
+      route_table<websocket_handler> websocket_routes;
+
+      /**
+       * @brief Vector of middleware handlers
+       */
+      std::vector<handler> middlewares;
    };
 
    /**

--- a/include/glaze/net/http_router.hpp
+++ b/include/glaze/net/http_router.hpp
@@ -260,7 +260,9 @@ namespace glz
       /**
        * @brief Split a path into segments
        *
-       * Splits a path like "/users/:id/profile" into ["users", ":id", "profile"]
+       * Splits a path like "/users/:id/profile" into ["users", ":id", "profile"].
+       * This is the canonical implementation; basic_http_router::split_path is a
+       * thin backward-compatible wrapper that delegates here.
        *
        * @param path The path to split
        * @return Vector of path segments
@@ -350,12 +352,11 @@ namespace glz
 
       /**
        * @brief Print the entire tree structure for debugging.
+       *
+       * Prints only the tree contents. The caller is responsible for any header
+       * (basic_http_router::print_tree groups three of these under labelled sections).
        */
-      void print_tree() const
-      {
-         std::cout << "Radix Tree Structure:\n";
-         print_node(&root, 0);
-      }
+      void print_tree() const { print_node(&root, 0); }
 
      private:
       mutable radix_node root;

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -437,8 +437,8 @@ namespace glz
       }
    };
 
-   // Handler types for streaming
-   using streaming_handler = std::function<void(request&, streaming_response&)>;
+   // streaming_handler is declared in glaze/net/http_router.hpp so the router can
+   // store streaming routes uniformly with normal routes.
 
    // Wrapping middleware types
    // Non-copyable, non-movable wrapper to enforce synchronous execution
@@ -682,9 +682,15 @@ namespace glz
          }
          threads.clear();
 
-         // websocket_handlers_ destruction will call close_all_connections() on each
-         // websocket_server, which force-closes all sockets. This ensures sockets are
-         // deregistered from the reactor BEFORE io_context is destroyed.
+         // Destruction sequence (reverse declaration order of http_server members):
+         //   1. threads are joined above (worker threads stop running io_context).
+         //   2. root_router is destroyed below, which releases the websocket_server
+         //      shared_ptrs it owns; ~websocket_server calls close_all_connections()
+         //      and force-closes the sockets.
+         //   3. io_context is destroyed last.
+         // The invariant that matters: sockets must be deregistered from the reactor
+         // before io_context dies. Because root_router (declared after io_context)
+         // is destroyed first, that holds.
       }
 
       inline http_server& bind(std::string_view address, uint16_t port)
@@ -860,16 +866,36 @@ namespace glz
 
       inline http_server& mount(std::string_view base_path, const http_router& router)
       {
-         // Mount all routes from the router at the specified base path
-         for (const auto& [path, method_handlers] : router.routes) {
+         auto join = [&](const std::string& path) {
             std::string full_path = std::string(base_path);
             if (!full_path.empty() && full_path.back() == '/') {
                full_path.pop_back();
             }
             full_path += path;
+            return full_path;
+         };
 
-            for (const auto& [method, route_entry] : method_handlers) {
-               root_router.route(method, full_path, route_entry.handle, route_entry.spec);
+         // Mount normal routes
+         for (const auto& [path, method_handlers] : router.normal_routes.routes) {
+            const auto full_path = join(path);
+            for (const auto& [method, entry] : method_handlers) {
+               root_router.route(method, full_path, entry.handle, entry.spec);
+            }
+         }
+
+         // Mount streaming routes
+         for (const auto& [path, method_handlers] : router.streaming_routes.routes) {
+            const auto full_path = join(path);
+            for (const auto& [method, entry] : method_handlers) {
+               root_router.stream(method, full_path, entry.handle, entry.spec);
+            }
+         }
+
+         // Mount WebSocket routes. Entries are keyed by http_method::GET (the
+         // upgrade method), so look that slot up directly rather than iterating.
+         for (const auto& [path, method_handlers] : router.websocket_routes.routes) {
+            if (auto it = method_handlers.find(http_method::GET); it != method_handlers.end()) {
+               root_router.websocket(join(path), it->second.handle, it->second.spec);
             }
          }
 
@@ -1006,22 +1032,24 @@ namespace glz
          return root_router.patch(path, handle, spec);
       }
 
-      // Register streaming route
-      inline http_server& stream(http_method method, std::string_view path, streaming_handler handle)
+      // Register a streaming route. Delegates to root_router so streaming routes
+      // share the radix-tree matcher with normal routes (and support ":param" paths).
+      inline http_server& stream(http_method method, std::string_view path, streaming_handler handle,
+                                 const route_spec& spec = {})
       {
-         streaming_handlers_[std::string(path)][method] = std::move(handle);
+         root_router.stream(method, path, std::move(handle), spec);
          return *this;
       }
 
       // Convenience methods for streaming
-      inline http_server& stream_get(std::string_view path, streaming_handler handle)
+      inline http_server& stream_get(std::string_view path, streaming_handler handle, const route_spec& spec = {})
       {
-         return stream(http_method::GET, path, std::move(handle));
+         return stream(http_method::GET, path, std::move(handle), spec);
       }
 
-      inline http_server& stream_post(std::string_view path, streaming_handler handle)
+      inline http_server& stream_post(std::string_view path, streaming_handler handle, const route_spec& spec = {})
       {
-         return stream(http_method::POST, path, std::move(handle));
+         return stream(http_method::POST, path, std::move(handle), spec);
       }
 
       inline http_server& on_error(error_handler handle)
@@ -1048,7 +1076,7 @@ namespace glz
             spec.info.title = title;
             spec.info.version = version;
 
-            for (const auto& [route_path, method_handlers] : root_router.routes) {
+            for (const auto& [route_path, method_handlers] : root_router.normal_routes.routes) {
                // Convert router path /:param to OpenAPI path /{param}
                std::string openapi_path = route_path;
                size_t pos = 0;
@@ -1199,9 +1227,10 @@ namespace glz
        * @param server The WebSocket server instance to handle connections
        * @return Reference to this http_server for method chaining
        */
-      inline http_server& websocket(std::string_view path, std::shared_ptr<websocket_server> server)
+      inline http_server& websocket(std::string_view path, std::shared_ptr<websocket_server> server,
+                                    const route_spec& spec = {})
       {
-         websocket_handlers_[std::string(path)] = server;
+         root_router.websocket(path, std::move(server), spec);
          return *this;
       }
 
@@ -1413,8 +1442,6 @@ namespace glz
       http_router root_router;
       std::atomic<bool> running{false};
       glz::error_handler error_handler;
-      std::unordered_map<std::string, std::shared_ptr<websocket_server>> websocket_handlers_;
-      std::unordered_map<std::string, std::unordered_map<http_method, streaming_handler>> streaming_handlers_;
 
       // Wrapping middleware (executes around handlers)
       std::vector<wrapping_middleware> wrapping_middlewares_;
@@ -1857,13 +1884,20 @@ namespace glz
          request.path = std::string(path_view);
          request.query = parse_urlencoded(query_string);
 
-         // Check for a streaming handler first (lookup by path, not target, so query strings don't break matching)
-         auto handler_it = streaming_handlers_.find(request.path);
-         if (handler_it != streaming_handlers_.end()) {
-            auto method_it = handler_it->second.find(conn->request_.method);
-            if (method_it != handler_it->second.end()) {
+         // Check for a streaming handler first. Streaming routes share the same
+         // radix-tree matcher as normal routes, so they support ":param" paths.
+         //
+         // Fast path: if no streaming routes are registered (the common case),
+         // skip the match entirely. match_streaming() would otherwise allocate
+         // a params map, split the path into a vector of segment strings, and
+         // run an empty-tree walk on every request. The empty-check is O(1).
+         if (!root_router.streaming_routes.routes.empty()) {
+            auto [stream_handle, stream_params] =
+               root_router.match_streaming(conn->request_.method, request.path);
+            if (stream_handle) {
+               request.params = std::move(stream_params);
                // Streaming handlers take over the connection (no keep-alive loop)
-               handle_streaming_request_with_conn(std::move(conn), method_it->second);
+               handle_streaming_request_with_conn(std::move(conn), stream_handle);
                return;
             }
          }
@@ -2225,12 +2259,14 @@ namespace glz
          request.path = std::string(path_view);
          request.query = parse_urlencoded(query_string);
 
-         // Find matching WebSocket handler (lookup by path, not target)
-         auto ws_it = websocket_handlers_.find(request.path);
-         if (ws_it == websocket_handlers_.end()) {
+         // WebSocket routes share the same radix-tree matcher, so ":param" path
+         // parameters are extracted into request.params just like normal routes.
+         auto [ws_server, ws_params] = root_router.match_websocket(request.path);
+         if (!ws_server) {
             send_error_response_with_close(conn, 404, "Not Found");
             return;
          }
+         request.params = std::move(ws_params);
 
          // Copy request for WebSocket handler (request body is typically empty for upgrades)
          glz::request req{request};
@@ -2238,7 +2274,7 @@ namespace glz
          // Create WebSocket connection and start it
          // Uses socket_type which is either tcp::socket (ws://) or ssl::stream (wss://)
          auto socket_ptr = std::make_shared<socket_type>(std::move(conn->socket));
-         auto ws_conn = std::make_shared<websocket_connection<socket_type>>(socket_ptr, ws_it->second);
+         auto ws_conn = std::make_shared<websocket_connection<socket_type>>(socket_ptr, ws_server);
          ws_conn->start(req);
       }
 

--- a/tests/networking_tests/http_chunked_test/http_chunked_test.cpp
+++ b/tests/networking_tests/http_chunked_test/http_chunked_test.cpp
@@ -236,6 +236,27 @@ struct chunked_test_server
    }
 };
 
+// Probe a 127.0.0.1:port listener with a short retry loop. Used by tests that
+// stand up a glz::http_server inline (without the chunked_test_server helper)
+// so they don't have to fall back to a blind sleep_for.
+inline bool wait_until_listening(uint16_t port, int max_iters = 200,
+                                 std::chrono::milliseconds step = std::chrono::milliseconds(10))
+{
+   asio::io_context io;
+   asio::ip::tcp::endpoint ep(asio::ip::make_address("127.0.0.1"), port);
+   for (int i = 0; i < max_iters; ++i) {
+      asio::ip::tcp::socket socket(io);
+      asio::error_code ec;
+      socket.connect(ep, ec);
+      if (!ec) {
+         socket.close();
+         return true;
+      }
+      std::this_thread::sleep_for(step);
+   }
+   return false;
+}
+
 // ==========================================================================
 // Test suites
 // ==========================================================================
@@ -615,6 +636,344 @@ suite chunked_sync_tests = [] {
       }
 
       server.stop();
+   };
+
+   // Streaming routes registered with ":param" path segments should match like
+   // normal routes do, populating request.params with the captured value.
+   "sync_stream_get_with_path_parameter"_test = [] {
+      glz::http_server<> server;
+      server.stream_get("/items/:id/stream", [](glz::request& req, glz::streaming_response& res) {
+         res.start_stream(200, {{"Content-Type", "text/plain"}});
+         res.send("id=");
+         auto it = req.params.find("id");
+         res.send(it != req.params.end() ? it->second : std::string{"<missing>"});
+         res.close();
+      });
+
+      uint16_t port = 0;
+      for (uint16_t p = 19500; p < 19700; ++p) {
+         try {
+            server.bind("127.0.0.1", p);
+            port = p;
+            break;
+         }
+         catch (...) {
+            continue;
+         }
+      }
+      expect(port != 0) << "Server should bind";
+
+      std::thread server_thread([&] { server.start(1); });
+      expect(wait_until_listening(port)) << "Server should accept connections";
+
+      glz::http_client client;
+      auto result = client.get("http://127.0.0.1:" + std::to_string(port) + "/items/42/stream");
+
+      expect(result.has_value()) << "Request should succeed";
+      if (result) {
+         expect(result->status_code == 200) << "Status should be 200";
+         expect(result->response_body == "id=42")
+            << "Path parameter should be captured into request.params, got: " << result->response_body;
+      }
+
+      server.stop();
+      if (server_thread.joinable()) server_thread.join();
+   };
+
+   // The same registration path through http_router + mount() must also propagate
+   // streaming routes with ":param" segments.
+   "sync_router_mount_stream_get_with_path_parameter"_test = [] {
+      glz::http_router router;
+      router.stream_get("/items/:id/stream", [](glz::request& req, glz::streaming_response& res) {
+         res.start_stream(200, {{"Content-Type", "text/plain"}});
+         auto it = req.params.find("id");
+         res.send("mounted-id=");
+         res.send(it != req.params.end() ? it->second : std::string{"<missing>"});
+         res.close();
+      });
+
+      glz::http_server<> server;
+      server.mount("/api", router);
+
+      uint16_t port = 0;
+      for (uint16_t p = 19700; p < 19900; ++p) {
+         try {
+            server.bind("127.0.0.1", p);
+            port = p;
+            break;
+         }
+         catch (...) {
+            continue;
+         }
+      }
+      expect(port != 0) << "Server should bind";
+
+      std::thread server_thread([&] { server.start(1); });
+      expect(wait_until_listening(port)) << "Server should accept connections";
+
+      glz::http_client client;
+      auto result = client.get("http://127.0.0.1:" + std::to_string(port) + "/api/items/abc/stream");
+
+      expect(result.has_value()) << "Request should succeed";
+      if (result) {
+         expect(result->status_code == 200) << "Status should be 200";
+         expect(result->response_body == "mounted-id=abc")
+            << "Mounted streaming route should capture path parameter, got: " << result->response_body;
+      }
+
+      server.stop();
+      if (server_thread.joinable()) server_thread.join();
+   };
+
+   // Mixing normal and streaming routes that share a path prefix on the same router.
+   // Both must be reachable; each must dispatch to the right handler with its params.
+   "sync_router_mixes_normal_and_streaming_with_params"_test = [] {
+      glz::http_router router;
+      router.get("/users/:id/profile", [](const glz::request& req, glz::response& res) {
+         auto it = req.params.find("id");
+         res.body("normal-id=" + (it != req.params.end() ? it->second : std::string{"?"}));
+      });
+      router.stream_get("/users/:id/events", [](glz::request& req, glz::streaming_response& res) {
+         res.start_stream(200, {{"Content-Type", "text/plain"}});
+         auto it = req.params.find("id");
+         res.send("stream-id=");
+         res.send(it != req.params.end() ? it->second : std::string{"?"});
+         res.close();
+      });
+
+      glz::http_server<> server;
+      server.mount("/", router);
+
+      uint16_t port = 0;
+      for (uint16_t p = 19900; p < 20100; ++p) {
+         try {
+            server.bind("127.0.0.1", p);
+            port = p;
+            break;
+         }
+         catch (...) {
+            continue;
+         }
+      }
+      expect(port != 0) << "Server should bind";
+
+      std::thread server_thread([&] { server.start(1); });
+      expect(wait_until_listening(port)) << "Server should accept connections";
+
+      glz::http_client client;
+      auto base = std::string{"http://127.0.0.1:"} + std::to_string(port);
+
+      auto normal = client.get(base + "/users/7/profile");
+      expect(normal.has_value() && normal->status_code == 200);
+      if (normal) expect(normal->response_body == "normal-id=7") << normal->response_body;
+
+      auto stream = client.get(base + "/users/9/events");
+      expect(stream.has_value() && stream->status_code == 200);
+      if (stream) expect(stream->response_body == "stream-id=9") << stream->response_body;
+
+      server.stop();
+      if (server_thread.joinable()) server_thread.join();
+   };
+
+   // Wildcard segments ("*name") on streaming routes capture the entire remaining
+   // path (including embedded slashes) the same way they do for normal routes.
+   "sync_router_mount_stream_get_with_wildcard"_test = [] {
+      glz::http_router router;
+      router.stream_get("/files/*path", [](glz::request& req, glz::streaming_response& res) {
+         res.start_stream(200, {{"Content-Type", "text/plain"}});
+         auto it = req.params.find("path");
+         res.send("path=");
+         res.send(it != req.params.end() ? it->second : std::string{"<missing>"});
+         res.close();
+      });
+
+      glz::http_server<> server;
+      server.mount("/", router);
+
+      uint16_t port = 0;
+      for (uint16_t p = 20100; p < 20300; ++p) {
+         try {
+            server.bind("127.0.0.1", p);
+            port = p;
+            break;
+         }
+         catch (...) {
+            continue;
+         }
+      }
+      expect(port != 0) << "Server should bind";
+
+      std::thread server_thread([&] { server.start(1); });
+      expect(wait_until_listening(port)) << "Server should accept connections";
+
+      glz::http_client client;
+      auto result = client.get("http://127.0.0.1:" + std::to_string(port) + "/files/a/b/c.txt");
+
+      expect(result.has_value()) << "Request should succeed";
+      if (result) {
+         expect(result->status_code == 200) << "Status should be 200";
+         expect(result->response_body == "path=a/b/c.txt")
+            << "Wildcard should capture the full remainder, got: " << result->response_body;
+      }
+
+      server.stop();
+      if (server_thread.joinable()) server_thread.join();
+   };
+
+   // Combined: a streaming route with both a path parameter and a query string.
+   // Path params come from the radix tree match; query string parsing is independent.
+   // Both must populate request.params and request.query correctly.
+   "sync_stream_get_with_path_param_and_query_string"_test = [] {
+      glz::http_server<> server;
+      server.stream_get("/items/:id/stream", [](glz::request& req, glz::streaming_response& res) {
+         res.start_stream(200, {{"Content-Type", "text/plain"}});
+         auto id = req.params.find("id");
+         auto token = req.query.find("token");
+         res.send("id=");
+         res.send(id != req.params.end() ? id->second : std::string{"?"});
+         res.send(";token=");
+         res.send(token != req.query.end() ? token->second : std::string{"?"});
+         res.close();
+      });
+
+      uint16_t port = 0;
+      for (uint16_t p = 20300; p < 20500; ++p) {
+         try {
+            server.bind("127.0.0.1", p);
+            port = p;
+            break;
+         }
+         catch (...) {
+            continue;
+         }
+      }
+      expect(port != 0) << "Server should bind";
+
+      std::thread server_thread([&] { server.start(1); });
+      expect(wait_until_listening(port)) << "Server should accept connections";
+
+      glz::http_client client;
+      auto result = client.get("http://127.0.0.1:" + std::to_string(port) + "/items/42/stream?token=abc");
+
+      expect(result.has_value()) << "Request should succeed";
+      if (result) {
+         expect(result->status_code == 200) << "Status should be 200";
+         expect(result->response_body == "id=42;token=abc")
+            << "Path param and query string should both populate the request, got: " << result->response_body;
+      }
+
+      server.stop();
+      if (server_thread.joinable()) server_thread.join();
+   };
+
+   // The radix tree URL-decodes path parameters (calls url_decode on each segment).
+   // A streaming route receiving "/items/hello%20world/stream" must see params["id"] == "hello world".
+   "sync_stream_get_path_param_is_url_decoded"_test = [] {
+      glz::http_server<> server;
+      server.stream_get("/items/:id/stream", [](glz::request& req, glz::streaming_response& res) {
+         res.start_stream(200, {{"Content-Type", "text/plain"}});
+         auto it = req.params.find("id");
+         res.send("id=[");
+         res.send(it != req.params.end() ? it->second : std::string{"?"});
+         res.send("]");
+         res.close();
+      });
+
+      uint16_t port = 0;
+      for (uint16_t p = 20500; p < 20700; ++p) {
+         try {
+            server.bind("127.0.0.1", p);
+            port = p;
+            break;
+         }
+         catch (...) {
+            continue;
+         }
+      }
+      expect(port != 0) << "Server should bind";
+
+      std::thread server_thread([&] { server.start(1); });
+      expect(wait_until_listening(port)) << "Server should accept connections";
+
+      glz::http_client client;
+      // %20 in the path segment must be decoded into a literal space inside params["id"].
+      auto result = client.get("http://127.0.0.1:" + std::to_string(port) + "/items/hello%20world/stream");
+
+      expect(result.has_value()) << "Request should succeed";
+      if (result) {
+         expect(result->status_code == 200) << "Status should be 200";
+         expect(result->response_body == "id=[hello world]")
+            << "Path parameter should be URL-decoded, got: " << result->response_body;
+      }
+
+      server.stop();
+      if (server_thread.joinable()) server_thread.join();
+   };
+
+   // route_spec::constraints work for streaming routes the same way they do for normal
+   // routes: when a captured parameter fails the validation function, the radix-tree
+   // match returns no handler, the streaming dispatch falls through, and the request
+   // ends up with a 404.
+   "sync_stream_get_with_constraint_rejects_invalid"_test = [] {
+      glz::route_spec spec;
+      spec.constraints["id"] = glz::param_constraint{"numeric id", [](std::string_view s) {
+                                                        if (s.empty()) return false;
+                                                        for (char c : s) {
+                                                           if (c < '0' || c > '9') return false;
+                                                        }
+                                                        return true;
+                                                     }};
+
+      glz::http_server<> server;
+      server.stream_get(
+         "/items/:id/stream",
+         [](glz::request& req, glz::streaming_response& res) {
+            res.start_stream(200, {{"Content-Type", "text/plain"}});
+            res.send("id=");
+            auto it = req.params.find("id");
+            res.send(it != req.params.end() ? it->second : std::string{"?"});
+            res.close();
+         },
+         spec);
+
+      uint16_t port = 0;
+      for (uint16_t p = 20700; p < 20900; ++p) {
+         try {
+            server.bind("127.0.0.1", p);
+            port = p;
+            break;
+         }
+         catch (...) {
+            continue;
+         }
+      }
+      expect(port != 0) << "Server should bind";
+
+      std::thread server_thread([&] { server.start(1); });
+      expect(wait_until_listening(port)) << "Server should accept connections";
+
+      glz::http_client client;
+      auto base = std::string{"http://127.0.0.1:"} + std::to_string(port);
+
+      // Numeric id passes the constraint and reaches the handler.
+      auto ok = client.get(base + "/items/42/stream");
+      expect(ok.has_value()) << "Numeric request should complete";
+      if (ok) {
+         expect(ok->status_code == 200) << "Numeric id should pass constraint, got: " << ok->status_code;
+         expect(ok->response_body == "id=42") << ok->response_body;
+      }
+
+      // Non-numeric id fails the constraint, the streaming match returns nothing,
+      // and the request falls through to a 404.
+      auto bad = client.get(base + "/items/abc/stream");
+      expect(bad.has_value()) << "Bad request should still complete (404)";
+      if (bad) {
+         expect(bad->status_code == 404) << "Constraint failure should produce 404 from the streaming route, got: "
+                                         << bad->status_code;
+      }
+
+      server.stop();
+      if (server_thread.joinable()) server_thread.join();
    };
 
    // Wrong method on a streaming-only path with a query string should still fall through

--- a/tests/networking_tests/openapi_test/openapi_test.cpp
+++ b/tests/networking_tests/openapi_test/openapi_test.cpp
@@ -139,7 +139,7 @@ int main()
       );
 
       // Test that the registry has registered the endpoints
-      expect(registry.endpoints.routes.size() > 0);
+      expect(registry.endpoints.normal_routes.routes.size() > 0);
 
       // Basic validation that endpoints were registered
       // The registry should have registered endpoints for:
@@ -149,10 +149,11 @@ int main()
       // - POST /deleteUser
 
       std::cout << "OpenAPI test completed successfully!" << std::endl;
-      std::cout << "Registry has " << registry.endpoints.routes.size() << " endpoints registered" << std::endl;
+      std::cout << "Registry has " << registry.endpoints.normal_routes.routes.size() << " endpoints registered"
+                << std::endl;
 
       // Print registered endpoints for inspection
-      for (const auto& [path, methods] : registry.endpoints.routes) {
+      for (const auto& [path, methods] : registry.endpoints.normal_routes.routes) {
          for (const auto& [method, entry] : methods) {
             std::cout << "  - " << glz::to_string(method) << " " << path << std::endl;
          }

--- a/tests/networking_tests/websocket_test/websocket_client_test.cpp
+++ b/tests/networking_tests/websocket_test/websocket_client_test.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "glaze/glaze.hpp"
+#include "glaze/net/http_client.hpp"
 #include "glaze/net/http_server.hpp"
 #include "glaze/net/websocket_connection.hpp"
 #include "ut/ut.hpp"
@@ -1562,6 +1563,373 @@ suite websocket_client_tests = [] {
          auto u = capture->query.find("user");
          expect(t != capture->query.end() && t->second == "abc") << "token=abc should be present";
          expect(u != capture->query.end() && u->second == "alice") << "user=alice should be present";
+      }
+
+      if (!client.context()->stopped()) client.context()->stop();
+      if (client_thread.joinable()) client_thread.join();
+
+      stop_server = true;
+      server_thread.join();
+   };
+
+   // WebSocket routes registered with ":param" path segments must populate
+   // request.params with the captured value, just like normal and streaming routes.
+   "websocket_upgrade_with_path_parameter_test"_test = [] {
+      uint16_t port = 8132;
+      std::atomic<bool> server_ready{false};
+      std::atomic<bool> stop_server{false};
+      auto capture = std::make_shared<ws_upgrade_capture>();
+      std::string captured_room;
+      std::mutex captured_mu;
+
+      std::thread server_thread([&]() {
+         http_server server;
+         auto ws_server = std::make_shared<websocket_server>();
+
+         ws_server->on_open([&, capture](auto /*conn*/, const request& req) {
+            {
+               std::lock_guard lock(capture->mu);
+               capture->path = req.path;
+               capture->query = req.query;
+               capture->target = req.target;
+            }
+            {
+               std::lock_guard lock(captured_mu);
+               auto it = req.params.find("room");
+               captured_room = (it != req.params.end()) ? it->second : std::string{"<missing>"};
+            }
+            capture->opened = true;
+         });
+         ws_server->on_message([](auto conn, std::string_view, ws_opcode) { conn->send_text("ack"); });
+         ws_server->on_close([](auto, ws_close_code, std::string_view) {});
+         ws_server->on_error([](auto, std::error_code) {});
+
+         server.websocket("/rooms/:room/ws", ws_server);
+
+         try {
+            server.bind(port);
+            server.start();
+            server_ready = true;
+            while (!stop_server) {
+               std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            }
+            server.stop();
+         }
+         catch (const std::exception&) {
+            server_ready = true;
+         }
+      });
+
+      expect(wait_for_condition([&] { return server_ready.load(); })) << "Server failed to start";
+
+      websocket_client client;
+      std::atomic<bool> ack_received{false};
+      std::atomic<bool> connect_error{false};
+
+      client.on_open([&client]() { client.send("ping"); });
+      client.on_message([&](std::string_view message, ws_opcode) {
+         if (message == "ack") {
+            ack_received = true;
+            client.close();
+         }
+      });
+      client.on_error([&](std::error_code) { connect_error = true; });
+      client.on_close([&](ws_close_code, std::string_view) { client.context()->stop(); });
+
+      std::string client_url = "ws://localhost:" + std::to_string(port) + "/rooms/lobby/ws";
+      client.connect(client_url);
+      std::thread client_thread([&client]() { client.context()->run(); });
+
+      expect(wait_for_condition([&] { return capture->opened.load(); }))
+         << "WebSocket upgrade with :param path did not reach on_open";
+      expect(wait_for_condition([&] { return ack_received.load(); })) << "ack message was not received";
+      expect(!connect_error.load()) << "Upgrade should not error";
+
+      {
+         std::lock_guard lock(captured_mu);
+         expect(captured_room == "lobby")
+            << "Path parameter ':room' should be captured into request.params, got: " << captured_room;
+      }
+
+      if (!client.context()->stopped()) client.context()->stop();
+      if (client_thread.joinable()) client_thread.join();
+
+      stop_server = true;
+      server_thread.join();
+   };
+
+   // WebSocket routes registered through http_router and mounted via server.mount()
+   // must also support ":param" segments and propagate captured params to on_open.
+   "websocket_router_mount_with_path_parameter_test"_test = [] {
+      uint16_t port = 8133;
+      std::atomic<bool> server_ready{false};
+      std::atomic<bool> stop_server{false};
+      auto capture = std::make_shared<ws_upgrade_capture>();
+      std::string captured_id;
+      std::mutex captured_mu;
+
+      std::thread server_thread([&]() {
+         http_router router;
+         auto ws_server = std::make_shared<websocket_server>();
+
+         ws_server->on_open([&, capture](auto /*conn*/, const request& req) {
+            {
+               std::lock_guard lock(capture->mu);
+               capture->path = req.path;
+               capture->query = req.query;
+               capture->target = req.target;
+            }
+            {
+               std::lock_guard lock(captured_mu);
+               auto it = req.params.find("id");
+               captured_id = (it != req.params.end()) ? it->second : std::string{"<missing>"};
+            }
+            capture->opened = true;
+         });
+         ws_server->on_message([](auto conn, std::string_view, ws_opcode) { conn->send_text("ack"); });
+         ws_server->on_close([](auto, ws_close_code, std::string_view) {});
+         ws_server->on_error([](auto, std::error_code) {});
+
+         router.websocket("/users/:id/ws", ws_server);
+
+         http_server server;
+         server.mount("/api", router);
+
+         try {
+            server.bind(port);
+            server.start();
+            server_ready = true;
+            while (!stop_server) {
+               std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            }
+            server.stop();
+         }
+         catch (const std::exception&) {
+            server_ready = true;
+         }
+      });
+
+      expect(wait_for_condition([&] { return server_ready.load(); })) << "Server failed to start";
+
+      websocket_client client;
+      std::atomic<bool> ack_received{false};
+      std::atomic<bool> connect_error{false};
+
+      client.on_open([&client]() { client.send("ping"); });
+      client.on_message([&](std::string_view message, ws_opcode) {
+         if (message == "ack") {
+            ack_received = true;
+            client.close();
+         }
+      });
+      client.on_error([&](std::error_code) { connect_error = true; });
+      client.on_close([&](ws_close_code, std::string_view) { client.context()->stop(); });
+
+      std::string client_url = "ws://localhost:" + std::to_string(port) + "/api/users/42/ws";
+      client.connect(client_url);
+      std::thread client_thread([&client]() { client.context()->run(); });
+
+      expect(wait_for_condition([&] { return capture->opened.load(); }))
+         << "Mounted WebSocket with :param did not reach on_open";
+      expect(wait_for_condition([&] { return ack_received.load(); })) << "ack message was not received";
+      expect(!connect_error.load()) << "Upgrade should not error";
+
+      {
+         std::lock_guard lock(captured_mu);
+         expect(captured_id == "42") << "Mounted WebSocket should capture :id path parameter, got: " << captured_id;
+      }
+
+      if (!client.context()->stopped()) client.context()->stop();
+      if (client_thread.joinable()) client_thread.join();
+
+      stop_server = true;
+      server_thread.join();
+   };
+
+   // WebSocket routes with a wildcard segment ("*name") should capture the entire
+   // remaining path (including embedded slashes), like normal and streaming routes.
+   "websocket_with_wildcard_path_test"_test = [] {
+      uint16_t port = 8134;
+      std::atomic<bool> server_ready{false};
+      std::atomic<bool> stop_server{false};
+      auto capture = std::make_shared<ws_upgrade_capture>();
+      std::string captured_path_param;
+      std::mutex captured_mu;
+
+      std::thread server_thread([&]() {
+         http_server server;
+         auto ws_server = std::make_shared<websocket_server>();
+
+         ws_server->on_open([&, capture](auto /*conn*/, const request& req) {
+            {
+               std::lock_guard lock(capture->mu);
+               capture->path = req.path;
+               capture->target = req.target;
+            }
+            {
+               std::lock_guard lock(captured_mu);
+               auto it = req.params.find("rest");
+               captured_path_param = (it != req.params.end()) ? it->second : std::string{"<missing>"};
+            }
+            capture->opened = true;
+         });
+         ws_server->on_message([](auto conn, std::string_view, ws_opcode) { conn->send_text("ack"); });
+         ws_server->on_close([](auto, ws_close_code, std::string_view) {});
+         ws_server->on_error([](auto, std::error_code) {});
+
+         server.websocket("/files/*rest", ws_server);
+
+         try {
+            server.bind(port);
+            server.start();
+            server_ready = true;
+            while (!stop_server) {
+               std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            }
+            server.stop();
+         }
+         catch (const std::exception&) {
+            server_ready = true;
+         }
+      });
+
+      expect(wait_for_condition([&] { return server_ready.load(); })) << "Server failed to start";
+
+      websocket_client client;
+      std::atomic<bool> ack_received{false};
+      std::atomic<bool> connect_error{false};
+
+      client.on_open([&client]() { client.send("ping"); });
+      client.on_message([&](std::string_view message, ws_opcode) {
+         if (message == "ack") {
+            ack_received = true;
+            client.close();
+         }
+      });
+      client.on_error([&](std::error_code) { connect_error = true; });
+      client.on_close([&](ws_close_code, std::string_view) { client.context()->stop(); });
+
+      std::string client_url = "ws://localhost:" + std::to_string(port) + "/files/a/b/c.txt";
+      client.connect(client_url);
+      std::thread client_thread([&client]() { client.context()->run(); });
+
+      expect(wait_for_condition([&] { return capture->opened.load(); }))
+         << "WebSocket upgrade with wildcard path did not reach on_open";
+      expect(wait_for_condition([&] { return ack_received.load(); })) << "ack message was not received";
+      expect(!connect_error.load()) << "Upgrade should not error";
+
+      {
+         std::lock_guard lock(captured_mu);
+         expect(captured_path_param == "a/b/c.txt")
+            << "Wildcard segment should capture the full remainder, got: " << captured_path_param;
+      }
+
+      if (!client.context()->stopped()) client.context()->stop();
+      if (client_thread.joinable()) client_thread.join();
+
+      stop_server = true;
+      server_thread.join();
+   };
+
+   // Single router carries normal, streaming, and WebSocket routes that share a
+   // common ":id" path parameter. After mount, each kind must dispatch to its own
+   // handler with its own captured params, confirming the three radix tables in
+   // basic_http_router are independent.
+   "router_normal_streaming_websocket_coexist_test"_test = [] {
+      uint16_t port = 8135;
+      std::atomic<bool> server_ready{false};
+      std::atomic<bool> stop_server{false};
+
+      std::atomic<bool> ws_opened{false};
+      std::string ws_captured_id;
+      std::mutex ws_mu;
+
+      std::thread server_thread([&]() {
+         http_router router;
+
+         router.get("/normal/:id", [](const request& req, response& res) {
+            auto it = req.params.find("id");
+            res.body("normal-id=" + (it != req.params.end() ? it->second : std::string{"?"}));
+         });
+
+         router.stream_get("/stream/:id", [](request& req, glz::streaming_response& res) {
+            res.start_stream(200, {{"Content-Type", "text/plain"}});
+            auto it = req.params.find("id");
+            res.send("stream-id=");
+            res.send(it != req.params.end() ? it->second : std::string{"?"});
+            res.close();
+         });
+
+         auto ws_server = std::make_shared<websocket_server>();
+         ws_server->on_open([&](auto /*conn*/, const request& req) {
+            {
+               std::lock_guard lock(ws_mu);
+               auto it = req.params.find("id");
+               ws_captured_id = (it != req.params.end()) ? it->second : std::string{"<missing>"};
+            }
+            ws_opened = true;
+         });
+         ws_server->on_message([](auto conn, std::string_view, ws_opcode) { conn->send_text("ack"); });
+         ws_server->on_close([](auto, ws_close_code, std::string_view) {});
+         ws_server->on_error([](auto, std::error_code) {});
+
+         router.websocket("/ws/:id", ws_server);
+
+         http_server server;
+         server.mount("/api", router);
+
+         try {
+            server.bind(port);
+            server.start();
+            server_ready = true;
+            while (!stop_server) {
+               std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            }
+            server.stop();
+         }
+         catch (const std::exception&) {
+            server_ready = true;
+         }
+      });
+
+      expect(wait_for_condition([&] { return server_ready.load(); })) << "Server failed to start";
+
+      // Hit the normal route via http_client.
+      glz::http_client http;
+      auto normal = http.get("http://127.0.0.1:" + std::to_string(port) + "/api/normal/1");
+      expect(normal.has_value() && normal->status_code == 200);
+      if (normal) expect(normal->response_body == "normal-id=1") << normal->response_body;
+
+      // Hit the streaming route via http_client.
+      auto stream = http.get("http://127.0.0.1:" + std::to_string(port) + "/api/stream/2");
+      expect(stream.has_value() && stream->status_code == 200);
+      if (stream) expect(stream->response_body == "stream-id=2") << stream->response_body;
+
+      // Hit the WebSocket route via websocket_client.
+      websocket_client client;
+      std::atomic<bool> ack_received{false};
+      std::atomic<bool> connect_error{false};
+
+      client.on_open([&client]() { client.send("ping"); });
+      client.on_message([&](std::string_view message, ws_opcode) {
+         if (message == "ack") {
+            ack_received = true;
+            client.close();
+         }
+      });
+      client.on_error([&](std::error_code) { connect_error = true; });
+      client.on_close([&](ws_close_code, std::string_view) { client.context()->stop(); });
+
+      client.connect("ws://localhost:" + std::to_string(port) + "/api/ws/3");
+      std::thread client_thread([&client]() { client.context()->run(); });
+
+      expect(wait_for_condition([&] { return ws_opened.load(); })) << "WebSocket sibling route did not open";
+      expect(wait_for_condition([&] { return ack_received.load(); })) << "ack not received";
+      expect(!connect_error.load()) << "WebSocket upgrade should not error";
+
+      {
+         std::lock_guard lock(ws_mu);
+         expect(ws_captured_id == "3") << "WebSocket sibling should capture its own :id, got: " << ws_captured_id;
       }
 
       if (!client.context()->stopped()) client.context()->stop();


### PR DESCRIPTION
## Summary

Addresses the design feedback in #2550 (from @JnCrMx). Moves streaming and WebSocket route storage off `http_server`'s flat path → handler maps and into `basic_http_router`, where they share the radix-tree matcher with normal routes. As a result, streaming and WebSocket routes now support `:param` and `*wildcard` path segments, and routers carrying any mix of route kinds can be passed to `server.mount()`.

The requested API now works:

```cpp
glz::http_router router;
router.get("/users/:id/profile", normal_handler);
router.stream_get("/users/:id/events", streaming_handler);
router.websocket("/rooms/:room/ws", ws_server);

glz::http_server server;
server.mount("/api", router);
```

## What changed

- Extracted `route_table<H>` from `basic_http_router`; the router now holds three of them (`normal_routes`, `streaming_routes`, `websocket_routes`) sharing one radix-tree implementation.
- New router methods: `stream`, `stream_get`, `stream_post`, `websocket`, `match_streaming`, `match_websocket`.
- `http_server::stream*` / `http_server::websocket` delegate to `root_router`. The flat `streaming_handlers_` and `websocket_handlers_` maps are removed.
- `mount()` propagates all three route kinds; each is rewritten with the mount prefix and added to the server's root router.
- Hot-path fast-path: `process_full_request_with_conn` skips the streaming match when no streaming routes are registered, restoring per-request cost for the common case.
- Bug fixes picked up during the refactor:
  - `route_table::match_node` now erases the wildcard capture on every failure path (was leaking on `is_endpoint=false`, wrong method, or constraint failure — parity with the existing `:param` branch).
  - `route_table::add` installs in the radix tree first, then populates the routes map, so a route conflict thrown from `add_route` no longer leaves a half-registered entry that iteration sees but `match()` never reaches.

## Behavior change

Previously `streaming_handlers_` was an exact-path map, so `stream_get(\"/items/:id\", ...)` was effectively dead and a request to `/items/42` fell through to the normal router. After the unification, streaming routes are matched **before** normal routes, so a streaming `/items/:id` will intercept requests that a normal `/items/42` would otherwise handle. Documented in `docs/networking/http-router.md` (Streaming Routes section + Route Priority section).

## Migration

`router.routes` (public field) is now `router.normal_routes.routes`. A `routes()` accessor method is provided for source compatibility (a reference data member would dangle through the implicit move constructor). Updated callers: `http_server::mount`, `http_server::enable_openapi_spec`, `tests/networking_tests/openapi_test`, and `docs/networking/rest-registry.md`.

## Test plan

- [x] **Streaming path-param coverage** in `tests/networking_tests/http_chunked_test/http_chunked_test.cpp`: `:param` direct on server, `:param` via `http_router` + `mount()`, mixing normal + streaming on one router, wildcard segment, `:param` + query string combo, URL-decoded `:param`, `route_spec::constraints` rejection (200 vs 404).
- [x] **WebSocket path-param coverage** in `tests/networking_tests/websocket_test/websocket_client_test.cpp`: `:param` direct on server, `:param` via router + mount, wildcard segment, all-three-kinds (normal + streaming + WebSocket) coexisting on one mounted router.
- [x] Replaced bare `sleep_for(200ms)` server-readiness waits in the new streaming tests with a TCP-connect-probe helper for robustness on busy CI.
- [x] Suites pass:
  - `http_chunked_test`: 57/57 tests, 230 asserts.
  - `websocket_client_test`: 34/34 tests, 146 asserts.
  - `http_router_test`: 21/21 tests, 81 asserts.
  - `http_server_api_tests`: 49/49 tests, 152 asserts.
  - `openapi_test`: 1/1 tests, 5 asserts.
- [x] clang-format pass on touched headers and test files.

## Docs updated

- `docs/networking/http-router.md` — new \"Streaming Routes\" and \"WebSocket Routes\" sections; \"Route Priority\" extended to cover cross-kind dispatch order.
- `docs/networking/http-server.md` — `mount()` propagation note in \"Mounting Sub-routers\".
- `docs/networking/advanced-networking.md` — `router.websocket(...)` + path-param note in the WebSocket section.
- `docs/networking/rest-registry.md` — field rename in the endpoint-discovery example.