### PR TITLE
toml: fix inline tables parsing, support for nullables

### DIFF
--- a/include/glaze/toml/read.hpp
+++ b/include/glaze/toml/read.hpp
@@ -2859,7 +2859,7 @@ namespace glz
       }
    };
 
-   // Nullable types (std::optional, pointers)
+   // Nullable types: std::optional, std::unique_ptr, std::shared_ptr, raw pointers
    template <nullable_like T>
    struct from<TOML, T>
    {
@@ -2877,8 +2877,25 @@ namespace glz
          }
 
          if (!value) {
-            if constexpr (requires { value.emplace(); }) {
+            if constexpr (optional_like<T>) {
                value.emplace();
+            }
+            else if constexpr (is_specialization_v<T, std::unique_ptr>) {
+               value = std::make_unique<typename T::element_type>();
+            }
+            else if constexpr (is_specialization_v<T, std::shared_ptr>) {
+               value = std::make_shared<typename T::element_type>();
+            }
+            else if constexpr (requires { value.emplace(); }) {
+               value.emplace();
+            }
+            else if constexpr (constructible<T>) {
+               value = meta_construct_v<T>();
+            }
+            else if constexpr (std::is_pointer_v<T> && can_allocate_raw_pointer<Opts, std::decay_t<decltype(ctx)>>) {
+               if (!try_allocate_raw_pointer<Opts>(value, ctx)) {
+                  return;
+               }
             }
             else {
                ctx.error = error_code::invalid_nullable_read;

--- a/include/glaze/toml/read.hpp
+++ b/include/glaze/toml/read.hpp
@@ -2323,6 +2323,7 @@ namespace glz
                // TODO: Rewrite logic here, for now it works just fine so we leave it.
                detail::parse_toml_object_members<Opts>(value, it, end, ctx, true); // true for is_inline_table
                // The parse_toml_object_members should consume the final '}' if successful
+               return;
             }
             else if (*it == '[') { // Normal table or array of tables
                std::vector<std::string> path;
@@ -2855,6 +2856,38 @@ namespace glz
                ctx.error = error_code::syntax_error;
             }
          }
+      }
+   };
+
+   // Nullable types (std::optional, pointers)
+   template <nullable_like T>
+   struct from<TOML, T>
+   {
+      template <auto Opts, class It>
+      static void op(auto&& value, is_context auto&& ctx, It&& it, auto end) noexcept
+      {
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+
+         skip_ws_and_comments(it, end);
+
+         if (it == end) {
+            value = {};
+            return;
+         }
+
+         if (!value) {
+            if constexpr (requires { value.emplace(); }) {
+               value.emplace();
+            }
+            else {
+               ctx.error = error_code::invalid_nullable_read;
+               return;
+            }
+         }
+
+         using V = std::remove_cvref_t<decltype(*value)>;
+         from<TOML, V>::template op<Opts>(*value, ctx, it, end);
       }
    };
 

--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -2044,7 +2044,7 @@ namespace glz
       }
    };
 
-   // Nullable types (std::optional, pointers)
+   // Nullable types: std::optional, std::unique_ptr, std::shared_ptr, raw pointers
    template <nullable_like T>
    struct from<YAML, T>
    {
@@ -2113,8 +2113,25 @@ namespace glz
          }
 
          if (!value) {
-            if constexpr (requires { value.emplace(); }) {
+            if constexpr (optional_like<T>) {
                value.emplace();
+            }
+            else if constexpr (is_specialization_v<T, std::unique_ptr>) {
+               value = std::make_unique<typename T::element_type>();
+            }
+            else if constexpr (is_specialization_v<T, std::shared_ptr>) {
+               value = std::make_shared<typename T::element_type>();
+            }
+            else if constexpr (requires { value.emplace(); }) {
+               value.emplace();
+            }
+            else if constexpr (constructible<T>) {
+               value = meta_construct_v<T>();
+            }
+            else if constexpr (std::is_pointer_v<T> && can_allocate_raw_pointer<Opts, std::decay_t<decltype(ctx)>>) {
+               if (!try_allocate_raw_pointer<Opts>(value, ctx)) {
+                  return;
+               }
             }
             else {
                ctx.error = error_code::invalid_nullable_read;

--- a/tests/toml_test/toml_test.cpp
+++ b/tests/toml_test/toml_test.cpp
@@ -94,6 +94,13 @@ struct int_array_struct
    std::vector<int> values{};
 };
 
+struct int_array_struct_pad
+{
+   int a;
+   std::vector<int> values{};
+   int b;
+};
+
 template <>
 struct glz::meta<dotted_unknown_inner>
 {
@@ -120,6 +127,13 @@ struct optional_struct
    std::optional<int> maybe = 99;
 };
 
+struct complex_optional_struct
+{
+   std::string name{};
+   std::optional<int> age{};
+   std::optional<std::string> email{};
+};
+
 struct inline_table_member
 {
    std::string key1{};
@@ -139,15 +153,23 @@ struct struct_with_inline_table
 {
    std::string name{};
    inline_table_member inline_data{};
+   std::string sname{};
 
    bool operator==(const struct_with_inline_table&) const = default;
+};
+
+struct struct_with_optional_inline_table
+{
+   int a;
+   std::optional<inline_table_member> inline_data{};
+   int b;
 };
 
 template <>
 struct glz::meta<struct_with_inline_table>
 {
    using T = struct_with_inline_table;
-   static constexpr auto value = object("name", &T::name, "inline_data", &T::inline_data);
+   static constexpr auto value = object("name", &T::name, "inline_data", &T::inline_data, "sname", &T::sname);
 };
 
 struct complex_strings_struct
@@ -1246,13 +1268,15 @@ value = "string")";
 
    "read_inline_table"_test = [] {
       std::string toml_input = R"(name = "Test Person"
-inline_data = { key1 = "value1", key2 = 100 })";
+inline_data = { key1 = "value1", key2 = 100 }
+sname = "Second String")";
       struct_with_inline_table s{};
       auto error = glz::read_toml(s, toml_input);
       expect(!error) << glz::format_error(error, toml_input);
       expect(s.name == "Test Person");
       expect(s.inline_data.key1 == "value1");
       expect(s.inline_data.key2 == 100);
+      expect(s.sname == "Second String");
    };
 
    "read_complex_strings"_test = [] {
@@ -2286,6 +2310,69 @@ arr = [7, 8, 9])";
       expect(parsed.time_ms.minutes() == original.time_ms.minutes());
       expect(parsed.time_ms.seconds() == original.time_ms.seconds());
       expect(parsed.time_ms.subseconds() == original.time_ms.subseconds());
+   };
+
+   "read_optional_with_value"_test = [] {
+      std::string input = R"(name = "Test"
+age = 25
+email = "test@example.com")";
+      complex_optional_struct obj{};
+      auto ec = glz::read_toml(obj, input);
+      expect(!ec) << glz::format_error(ec, input);
+      expect(obj.name == "Test");
+      expect(obj.age.value() == 25);
+      expect(obj.email.value() == "test@example.com");
+   };
+   "read_optional_without_int_value"_test = [] {
+      std::string input = R"(name = "Test"
+age = 25)";
+      complex_optional_struct obj{};
+      auto ec = glz::read_toml(obj, input);
+      expect(!ec) << glz::format_error(ec, input);
+      expect(obj.name == "Test");
+      expect(obj.age.value() == 25);
+      expect(!obj.email.has_value());
+   };
+   "read_optional_without_string_value"_test = [] {
+      std::string input = R"(name = "Test"
+email = "test@example.com")";
+      complex_optional_struct obj{};
+      auto ec = glz::read_toml(obj, input);
+      expect(!ec) << glz::format_error(ec, input);
+      expect(obj.name == "Test");
+      expect(!obj.age.has_value());
+      expect(obj.email.value() == "test@example.com");
+   };
+   "read_optional_without_values_defval"_test = [] {
+      std::string input = R"( )";
+      optional_struct obj{};
+      auto ec = glz::read_toml(obj, input);
+      expect(!ec) << glz::format_error(ec, input);
+      expect(obj.maybe.has_value());
+      expect(obj.maybe.value() == 99);
+   };
+   "read_optional_with_inline_table"_test = [] {
+      std::string input = R"(a = 1
+inline_data = { key1 = "value1", key2 = 100 }
+b = 2)";
+      struct_with_optional_inline_table s{};
+      auto error = glz::read_toml(s, input);
+      expect(!error) << glz::format_error(error, input);
+      expect(s.a == 1);
+      expect(s.b == 2);
+      expect(s.inline_data.has_value());
+      expect(s.inline_data->key1 == "value1");
+      expect(s.inline_data->key2 == 100);
+   };
+   "read_optional_with_inline_table_missing"_test = [] {
+      std::string input = R"(a = 1
+b = 2)";
+      struct_with_optional_inline_table s{};
+      auto error = glz::read_toml(s, input);
+      expect(!error) << glz::format_error(error, input);
+      expect(s.a == 1);
+      expect(s.b == 2);
+      expect(!s.inline_data.has_value());
    };
 };
 
@@ -4237,7 +4324,8 @@ suite toml_1_1_delta_tests = [] {
 inline_data = {
   key1 = "value1",
   key2 = 100,
-})";
+}
+sname = "Second String")";
 
       struct_with_inline_table s{};
       const auto error = glz::read_toml(s, input);
@@ -4245,6 +4333,7 @@ inline_data = {
       expect(s.name == "Test Person");
       expect(s.inline_data.key1 == "value1");
       expect(s.inline_data.key2 == 100);
+      expect(s.sname == "Second String");
    };
 
    "toml_1_1_inline_table_allows_newlines_and_trailing_comma_map"_test = [] {
@@ -4370,6 +4459,20 @@ inline_data = {
       int_array_struct value{};
       const auto error = glz::read_toml(value, input);
       expect(error);
+   };
+   
+   "toml_struct_array_padded"_test = [] {
+      const std::string input = R"(a = 111
+values = [1, 2,]
+b = 222)";
+      int_array_struct_pad value{};
+      const auto error = glz::read_toml(value, input);
+      expect(not error) << glz::format_error(error, input);
+      expect(value.a == 111);
+      expect(value.values.size() == 2);
+      expect(value.values[0] == 1);
+      expect(value.values[1] == 2);
+      expect(value.b == 222);
    };
 
    "toml_1_1_basic_string_hex_escape_xHH_invalid_short"_test = [] {

--- a/tests/toml_test/toml_test.cpp
+++ b/tests/toml_test/toml_test.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <limits>
 #include <map>
+#include <memory>
 #include <set>
 #include <span>
 #include <string_view>
@@ -163,6 +164,48 @@ struct struct_with_optional_inline_table
    int a;
    std::optional<inline_table_member> inline_data{};
    int b;
+};
+
+struct struct_with_unique_ptr
+{
+   int a{};
+   std::unique_ptr<int> p{};
+   int b{};
+};
+
+struct struct_with_shared_ptr
+{
+   int a{};
+   std::shared_ptr<int> p{};
+   int b{};
+};
+
+struct struct_with_unique_ptr_inline_table
+{
+   int a{};
+   std::unique_ptr<inline_table_member> data{};
+   int b{};
+};
+
+struct struct_with_shared_ptr_inline_table
+{
+   int a{};
+   std::shared_ptr<inline_table_member> data{};
+   int b{};
+};
+
+struct struct_with_nested_optional
+{
+   int a{};
+   std::optional<std::optional<int>> v{};
+   int b{};
+};
+
+struct struct_with_optional_vector
+{
+   int a{};
+   std::optional<std::vector<int>> arr{};
+   int b{};
 };
 
 template <>
@@ -2373,6 +2416,139 @@ b = 2)";
       expect(s.a == 1);
       expect(s.b == 2);
       expect(!s.inline_data.has_value());
+   };
+   "read_unique_ptr_with_value"_test = [] {
+      std::string input = R"(a = 1
+p = 42
+b = 2)";
+      struct_with_unique_ptr s{};
+      auto error = glz::read_toml(s, input);
+      expect(!error) << glz::format_error(error, input);
+      expect(s.a == 1);
+      expect(s.b == 2);
+      expect(s.p != nullptr);
+      expect(*s.p == 42);
+   };
+   "read_unique_ptr_missing"_test = [] {
+      std::string input = R"(a = 1
+b = 2)";
+      struct_with_unique_ptr s{};
+      auto error = glz::read_toml(s, input);
+      expect(!error) << glz::format_error(error, input);
+      expect(s.a == 1);
+      expect(s.b == 2);
+      expect(s.p == nullptr);
+   };
+   "read_unique_ptr_overwrites_existing"_test = [] {
+      std::string input = R"(a = 1
+p = 7
+b = 2)";
+      struct_with_unique_ptr s{};
+      s.p = std::make_unique<int>(99);
+      auto error = glz::read_toml(s, input);
+      expect(!error) << glz::format_error(error, input);
+      expect(s.p != nullptr);
+      expect(*s.p == 7);
+   };
+   "read_shared_ptr_with_value"_test = [] {
+      std::string input = R"(a = 1
+p = 5
+b = 2)";
+      struct_with_shared_ptr s{};
+      auto error = glz::read_toml(s, input);
+      expect(!error) << glz::format_error(error, input);
+      expect(s.a == 1);
+      expect(s.b == 2);
+      expect(s.p != nullptr);
+      expect(*s.p == 5);
+   };
+   "read_shared_ptr_missing"_test = [] {
+      std::string input = R"(a = 1
+b = 2)";
+      struct_with_shared_ptr s{};
+      auto error = glz::read_toml(s, input);
+      expect(!error) << glz::format_error(error, input);
+      expect(s.a == 1);
+      expect(s.b == 2);
+      expect(s.p == nullptr);
+   };
+   "read_unique_ptr_inline_table"_test = [] {
+      std::string input = R"(a = 1
+data = { key1 = "hello", key2 = 11 }
+b = 2)";
+      struct_with_unique_ptr_inline_table s{};
+      auto error = glz::read_toml(s, input);
+      expect(!error) << glz::format_error(error, input);
+      expect(s.a == 1);
+      expect(s.b == 2);
+      expect(s.data != nullptr);
+      expect(s.data->key1 == "hello");
+      expect(s.data->key2 == 11);
+   };
+   "read_shared_ptr_inline_table"_test = [] {
+      std::string input = R"(a = 1
+data = { key1 = "world", key2 = 22 }
+b = 2)";
+      struct_with_shared_ptr_inline_table s{};
+      auto error = glz::read_toml(s, input);
+      expect(!error) << glz::format_error(error, input);
+      expect(s.a == 1);
+      expect(s.b == 2);
+      expect(s.data != nullptr);
+      expect(s.data->key1 == "world");
+      expect(s.data->key2 == 22);
+   };
+   "read_nested_optional"_test = [] {
+      std::string input = R"(a = 1
+v = 33
+b = 2)";
+      struct_with_nested_optional s{};
+      auto error = glz::read_toml(s, input);
+      expect(!error) << glz::format_error(error, input);
+      expect(s.a == 1);
+      expect(s.b == 2);
+      expect(s.v.has_value());
+      expect(s.v->has_value());
+      expect(s.v->value() == 33);
+   };
+   "read_optional_vector"_test = [] {
+      std::string input = R"(a = 1
+arr = [10, 20, 30]
+b = 2)";
+      struct_with_optional_vector s{};
+      auto error = glz::read_toml(s, input);
+      expect(!error) << glz::format_error(error, input);
+      expect(s.a == 1);
+      expect(s.b == 2);
+      expect(s.arr.has_value());
+      expect(s.arr->size() == 3);
+      expect((*s.arr)[0] == 10);
+      expect((*s.arr)[1] == 20);
+      expect((*s.arr)[2] == 30);
+   };
+   "read_optional_vector_missing"_test = [] {
+      std::string input = R"(a = 1
+b = 2)";
+      struct_with_optional_vector s{};
+      auto error = glz::read_toml(s, input);
+      expect(!error) << glz::format_error(error, input);
+      expect(s.a == 1);
+      expect(s.b == 2);
+      expect(!s.arr.has_value());
+   };
+   "read_top_level_optional_int"_test = [] {
+      std::optional<int> value{};
+      auto ec = glz::read_toml(value, std::string{"42"});
+      expect(!ec) << glz::format_error(ec, std::string{"42"});
+      expect(value.has_value());
+      expect(value.value() == 42);
+   };
+   "read_top_level_unique_ptr"_test = [] {
+      std::unique_ptr<int> value{};
+      auto ec = glz::read_toml(value, std::string{"99"});
+      expect(!ec) << glz::format_error(ec, std::string{"99"});
+      expect(value != nullptr);
+      expect(*value == 99);
    };
 };
 

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -2083,6 +2083,79 @@ suite yaml_nullable_tests = [] {
       expect(yaml.find("x:") != std::string::npos);
       expect(yaml.find("5") != std::string::npos);
    };
+
+   "shared_ptr_read_scalar"_test = [] {
+      std::shared_ptr<int> value;
+      const std::string yaml = "42";
+      auto rec = glz::read_yaml(value, yaml);
+      expect(!rec) << glz::format_error(rec, yaml);
+      expect(value != nullptr);
+      expect(*value == 42);
+   };
+
+   "shared_ptr_read_null"_test = [] {
+      std::shared_ptr<int> value = std::make_shared<int>(7);
+      const std::string yaml = "null";
+      auto rec = glz::read_yaml(value, yaml);
+      expect(!rec) << glz::format_error(rec, yaml);
+      expect(value == nullptr);
+   };
+
+   "unique_ptr_read_scalar"_test = [] {
+      std::unique_ptr<double> value;
+      const std::string yaml = "3.14";
+      auto rec = glz::read_yaml(value, yaml);
+      expect(!rec) << glz::format_error(rec, yaml);
+      expect(value != nullptr);
+      expect(std::abs(*value - 3.14) < 0.0001);
+   };
+
+   "unique_ptr_read_null"_test = [] {
+      std::unique_ptr<std::string> value = std::make_unique<std::string>("seed");
+      const std::string yaml = "null";
+      auto rec = glz::read_yaml(value, yaml);
+      expect(!rec) << glz::format_error(rec, yaml);
+      expect(value == nullptr);
+   };
+
+   "shared_ptr_struct_roundtrip"_test = [] {
+      auto original = std::make_shared<simple_struct>(simple_struct{5, 1.5, "ptr"});
+      std::string yaml;
+      auto wec = glz::write_yaml(original, yaml);
+      expect(!wec);
+
+      std::shared_ptr<simple_struct> parsed;
+      auto rec = glz::read_yaml(parsed, yaml);
+      expect(!rec) << glz::format_error(rec, yaml);
+      expect(parsed != nullptr);
+      expect(parsed->x == 5);
+      expect(std::abs(parsed->y - 1.5) < 0.001);
+      expect(parsed->name == "ptr");
+   };
+
+   "unique_ptr_struct_roundtrip"_test = [] {
+      auto original = std::make_unique<simple_struct>(simple_struct{9, 4.5, "uniq"});
+      std::string yaml;
+      auto wec = glz::write_yaml(original, yaml);
+      expect(!wec);
+
+      std::unique_ptr<simple_struct> parsed;
+      auto rec = glz::read_yaml(parsed, yaml);
+      expect(!rec) << glz::format_error(rec, yaml);
+      expect(parsed != nullptr);
+      expect(parsed->x == 9);
+      expect(std::abs(parsed->y - 4.5) < 0.001);
+      expect(parsed->name == "uniq");
+   };
+
+   "unique_ptr_read_overwrites_existing"_test = [] {
+      std::unique_ptr<int> value = std::make_unique<int>(99);
+      const std::string yaml = "7";
+      auto rec = glz::read_yaml(value, yaml);
+      expect(!rec) << glz::format_error(rec, yaml);
+      expect(value != nullptr);
+      expect(*value == 7);
+   };
 };
 
 // ============================================================


### PR DESCRIPTION
Seems like it was forgotten to exit from the inline table parsing context, resulting in "unknown key" errors afterwards

Relevant example (parser errored on `b`):
```toml
a = 1
inline_data = { key1 = "value1", key2 = 100 }
b = 2
```