### PR TITLE
fix(toml): render writable_map_t struct fields as inline tables

### DIFF
--- a/include/glaze/toml/write.hpp
+++ b/include/glaze/toml/write.hpp
@@ -1087,8 +1087,109 @@ namespace glz
       // Check if inline_arrays mode is enabled
       constexpr bool inline_mode = use_inline_arrays<Options>();
 
+      // Helper lambda to write a map-typed struct field as a TOML table.
+      //
+      // Before this helper existed, ``writable_map_t`` fields fell through PASS 1
+      // as scalars: the struct writer emitted ``key = `` and then handed off to the
+      // map writer which produced bare ``inner_key = value\n`` lines, composing
+      // into invalid TOML such as ``items = bar = false\nfoo = true`` (issue
+      // #2540).  Render maps as inline TOML tables on the right-hand side of
+      // the field assignment so the document round-trips through
+      // ``glz::read_toml``.
+      auto write_map_field = [&]<size_t I>() {
+         using val_t = field_t<T, I>;
+         using map_value_t = typename std::remove_cvref_t<val_t>::mapped_type;
+         constexpr bool value_is_object = glaze_object_t<map_value_t> || reflectable<map_value_t>;
+
+         decltype(auto) m = [&]() -> decltype(auto) {
+            if constexpr (reflectable<T>) {
+               return get_member(value, get<I>(t));
+            }
+            else {
+               return get_member(value, get<I>(reflect<T>::values));
+            }
+         }();
+
+         static constexpr auto key = glz::get<I>(reflect<T>::keys);
+
+         if (!ensure_space(ctx, b, ix + padding)) [[unlikely]] {
+            return;
+         }
+         if (!first) {
+            std::memcpy(&b[ix], "\n", 1);
+            ++ix;
+         }
+         else {
+            first = false;
+         }
+
+         std::memcpy(&b[ix], key.data(), key.size());
+         ix += key.size();
+         std::memcpy(&b[ix], " = ", 3);
+         ix += 3;
+
+         if (empty_range(m)) {
+            if (!ensure_space(ctx, b, ix + 2)) [[unlikely]] {
+               return;
+            }
+            std::memcpy(&b[ix], "{}", 2);
+            ix += 2;
+            return;
+         }
+
+         if (!ensure_space(ctx, b, ix + 2)) [[unlikely]] {
+            return;
+         }
+         std::memcpy(&b[ix], "{ ", 2);
+         ix += 2;
+
+         bool inner_first = true;
+         for (auto&& [mk, mv] : m) {
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            const auto mk_view = std::string_view{mk};
+            if (!ensure_space(ctx, b, ix + mk_view.size() + 6)) [[unlikely]] {
+               return;
+            }
+            if (!inner_first) {
+               std::memcpy(&b[ix], ", ", 2);
+               ix += 2;
+            }
+            else {
+               inner_first = false;
+            }
+            std::memcpy(&b[ix], mk_view.data(), mk_view.size());
+            ix += mk_view.size();
+            std::memcpy(&b[ix], " = ", 3);
+            ix += 3;
+
+            if constexpr (value_is_object) {
+               // Render nested struct values as inline tables so the entire
+               // map field remains inline-valid.
+               write_inline_object<Options, map_value_t>(mv, ctx, b, ix);
+            }
+            else {
+               to<TOML, map_value_t>::template op<Options>(mv, ctx, b, ix);
+            }
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+         }
+         if (!ensure_space(ctx, b, ix + 2)) [[unlikely]] {
+            return;
+         }
+         std::memcpy(&b[ix], " }", 2);
+         ix += 2;
+      };
+
       // PASS 1: Write all scalar fields first (TOML spec conformance)
-      // In inline_mode, arrays of objects are treated as scalars (written inline)
+      // In inline_mode, arrays of objects are treated as scalars (written inline).
+      // Map-typed fields are rendered as inline tables on the right-hand side
+      // of the assignment, which is syntactically a scalar in TOML and so MUST
+      // be emitted before any nested ``[table]`` header opens a sub-scope
+      // (otherwise the inline-table assignment would be parsed as a key of
+      // that nested table instead of the enclosing struct).
       for_each<N>([&]<size_t I>() {
          if (bool(ctx.error)) [[unlikely]] {
             return;
@@ -1101,12 +1202,18 @@ namespace glz
                return;
             }
 
-            // Only process scalar fields in this pass (not objects or arrays of objects)
-            // Exception: in inline_mode, arrays of objects are written as inline arrays
-            constexpr bool is_scalar =
-               !(glaze_object_t<val_t> || reflectable<val_t>) && (!is_array_of_objects_v<val_t> || inline_mode);
-            if constexpr (is_scalar) {
-               write_scalar_field.template operator()<I>();
+            if constexpr (writable_map_t<val_t>) {
+               write_map_field.template operator()<I>();
+            }
+            else {
+               // Only process scalar fields in this pass (not objects or
+               // arrays of objects).  In inline_mode, arrays of objects are
+               // written as inline arrays here.
+               constexpr bool is_scalar =
+                  !(glaze_object_t<val_t> || reflectable<val_t>) && (!is_array_of_objects_v<val_t> || inline_mode);
+               if constexpr (is_scalar) {
+                  write_scalar_field.template operator()<I>();
+               }
             }
          }
       });
@@ -1125,7 +1232,8 @@ namespace glz
                return;
             }
 
-            // Process nested objects and arrays of objects
+            // Process nested objects and arrays of objects (maps already
+            // emitted inline in PASS 1).
             if constexpr (glaze_object_t<val_t> || reflectable<val_t>) {
                write_table_field.template operator()<I>();
             }

--- a/tests/toml_test/CMakeLists.txt
+++ b/tests/toml_test/CMakeLists.txt
@@ -8,10 +8,23 @@ if (MINGW)
     target_compile_options(${PROJECT_NAME} PRIVATE "-Wa,-mbig-obj")
 endif ()
 
-target_compile_definitions(${PROJECT_NAME} PRIVATE 
+target_compile_definitions(${PROJECT_NAME} PRIVATE
     GLZ_TEST_DIRECTORY="${CMAKE_CURRENT_SOURCE_DIR}"
 )
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
 
 target_code_coverage(${PROJECT_NAME} AUTO ALL)
+
+# Standalone regression test for issue #2540 (map-typed struct fields must be
+# rendered as TOML tables, not scalars).  Kept separate so it can run quickly
+# in isolation -- intentionally does NOT link the heavier ``glz_test_common``
+# fixture so it stays fast on every supported platform.
+add_executable(toml_map_field_test toml_map_field_test.cpp)
+target_link_libraries(toml_map_field_test PRIVATE glaze::glaze)
+target_compile_features(toml_map_field_test PRIVATE cxx_std_23)
+if (MINGW)
+    target_compile_options(toml_map_field_test PRIVATE "-Wa,-mbig-obj")
+endif ()
+add_test(NAME toml_map_field_test COMMAND toml_map_field_test)
+target_code_coverage(toml_map_field_test AUTO ALL)

--- a/tests/toml_test/toml_map_field_test.cpp
+++ b/tests/toml_test/toml_map_field_test.cpp
@@ -1,0 +1,195 @@
+// Standalone regression test for issue #2540.
+//
+// Before this fix, glaze's TOML struct writer treated a ``writable_map_t``
+// struct field as a scalar (PASS 1), emitting ``items = `` and then handing
+// off to the map writer which produced bare ``key = value\n`` lines without
+// table-header wrapping.  The two writers composed into invalid TOML that
+// did not round-trip:
+//
+//     items = bar = false
+//     foo = true
+//
+// The fix routes map-typed struct fields through PASS 2 as TOML tables.
+//
+// This test is intentionally kept small and standalone so it can run quickly
+// in isolation -- the full ``toml_test`` suite has unrelated long-running
+// cases that mask iteration on this issue.
+
+#include <iostream>
+#include <map>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include "glaze/glaze.hpp"
+#include "glaze/toml.hpp"
+
+namespace
+{
+   struct Item
+   {
+      bool enabled;
+   };
+
+   struct Cfg1
+   {
+      std::map<std::string, Item> items;
+   };
+
+   struct Cfg2
+   {
+      std::map<std::string, bool> items;
+   };
+
+   struct Cfg3
+   {
+      std::map<std::string, std::vector<int>> items;
+   };
+
+   struct Cfg4
+   {
+      std::map<std::string, Item> items;
+   };
+
+   int failures = 0;
+
+   void check(bool cond, std::string_view label, std::string_view detail = "")
+   {
+      if (cond) {
+         std::cout << "PASS  " << label << "\n";
+      }
+      else {
+         std::cout << "FAIL  " << label;
+         if (!detail.empty()) {
+            std::cout << "\n      " << detail;
+         }
+         std::cout << "\n";
+         ++failures;
+      }
+   }
+
+   bool contains(std::string_view haystack, std::string_view needle) { return haystack.find(needle) != std::string_view::npos; }
+}
+
+template <>
+struct glz::meta<Item>
+{
+   using T = Item;
+   static constexpr auto value = object("enabled", &T::enabled);
+};
+
+template <>
+struct glz::meta<Cfg1>
+{
+   using T = Cfg1;
+   static constexpr auto value = object("items", &T::items);
+};
+
+template <>
+struct glz::meta<Cfg2>
+{
+   using T = Cfg2;
+   static constexpr auto value = object("items", &T::items);
+};
+
+template <>
+struct glz::meta<Cfg3>
+{
+   using T = Cfg3;
+   static constexpr auto value = object("items", &T::items);
+};
+
+template <>
+struct glz::meta<Cfg4>
+{
+   using T = Cfg4;
+   static constexpr auto value = object("items", &T::items);
+};
+
+int main()
+{
+   // --- Case 1: map<string, struct> as a struct field -----------------
+   {
+      Cfg1 c{.items = {{"foo", {true}}, {"bar", {false}}}};
+      std::string buf;
+      const auto ec = glz::write_toml(c, buf);
+      check(!ec, "Case 1 write returns no error");
+      // Expected: ``items = { foo = { ... }, bar = { ... } }`` (inline table).
+      check(contains(buf, "items = { "), "Case 1 opens inline table on `items = { `", buf);
+      check(contains(buf, "foo = {"), "Case 1 nests struct value inline", buf);
+      check(contains(buf, "enabled = true"), "Case 1 emits enabled = true", buf);
+      check(contains(buf, "enabled = false"), "Case 1 emits enabled = false", buf);
+      check(contains(buf, " }"), "Case 1 closes inline table", buf);
+      // Must NOT emit the broken pre-fix scalar form.
+      check(!contains(buf, "items = bar = "), "Case 1 does not emit invalid `items = bar = ...`", buf);
+
+      // Roundtrip
+      Cfg1 r{};
+      const auto rec = glz::read_toml(r, buf);
+      check(!rec, "Case 1 read parses the emitted output");
+      check(r.items.size() == 2, "Case 1 read recovers two entries");
+      check(r.items["foo"].enabled == true, "Case 1 foo.enabled == true");
+      check(r.items["bar"].enabled == false, "Case 1 bar.enabled == false");
+   }
+
+   // --- Case 2: map<string, bool> as a struct field -------------------
+   {
+      Cfg2 c{.items = {{"foo", true}, {"bar", false}}};
+      std::string buf;
+      const auto ec = glz::write_toml(c, buf);
+      check(!ec, "Case 2 write returns no error");
+      check(contains(buf, "items = { "), "Case 2 opens inline table on `items = { `", buf);
+      check(contains(buf, "foo = true"), "Case 2 emits foo = true", buf);
+      check(contains(buf, "bar = false"), "Case 2 emits bar = false", buf);
+      check(contains(buf, " }"), "Case 2 closes inline table", buf);
+      check(!contains(buf, "items = bar = "), "Case 2 does not emit invalid `items = bar = ...`", buf);
+
+      Cfg2 r{};
+      const auto rec = glz::read_toml(r, buf);
+      check(!rec, "Case 2 read parses the emitted output");
+      check(r.items.size() == 2, "Case 2 read recovers two entries");
+      check(r.items["foo"] == true, "Case 2 foo == true");
+      check(r.items["bar"] == false, "Case 2 bar == false");
+   }
+
+   // --- Case 3: map<string, vector<int>> as a struct field ------------
+   {
+      Cfg3 c{.items = {{"foo", {1, 2}}, {"bar", {3}}}};
+      std::string buf;
+      const auto ec = glz::write_toml(c, buf);
+      check(!ec, "Case 3 write returns no error");
+      check(contains(buf, "items = { "), "Case 3 opens inline table on `items = { `", buf);
+      check(contains(buf, "foo = ["), "Case 3 emits foo entry as inline array", buf);
+      check(contains(buf, "bar = ["), "Case 3 emits bar entry as inline array", buf);
+
+      Cfg3 r{};
+      const auto rec = glz::read_toml(r, buf);
+      check(!rec, "Case 3 read parses the emitted output");
+      check(r.items.size() == 2, "Case 3 read recovers two entries");
+      check(r.items["foo"] == std::vector<int>({1, 2}), "Case 3 foo == {1,2}");
+      check(r.items["bar"] == std::vector<int>({3}), "Case 3 bar == {3}");
+   }
+
+   // --- Case 4: empty map<string, struct> field -----------------------
+   {
+      Cfg4 c{};
+      std::string buf;
+      const auto ec = glz::write_toml(c, buf);
+      check(!ec, "Case 4 (empty map) write returns no error");
+      // Empty form should be ``items = {}`` to keep TOML valid.
+      check(contains(buf, "items = {}"), "Case 4 emits `items = {}`", buf);
+
+      Cfg4 r{};
+      const auto rec = glz::read_toml(r, buf);
+      check(!rec, "Case 4 read parses `items = {}`");
+      check(r.items.empty(), "Case 4 read recovers empty map");
+   }
+
+   if (failures == 0) {
+      std::cout << "\nALL OK\n";
+      return 0;
+   }
+   std::cout << "\n" << failures << " FAILURES\n";
+   return 1;
+}


### PR DESCRIPTION
## Summary
- Fixes #2540. glaze's TOML struct writer treated a ``writable_map_t`` field as a scalar in PASS 1: it emitted ``key = `` and then handed off to the top-level map writer, which produced bare ``inner_key = value\n`` lines without any wrapping. The two writers composed into invalid TOML such as

  ```
  items = bar = false
  foo = true
  ```

  and the document could not round-trip through ``glz::read_toml``.

- Add a dedicated ``write_map_field`` helper that renders a map-typed struct field as an inline TOML table on the right-hand side of the field assignment:

  - `map<K, scalar>` -> `items = { foo = true, bar = false }`
  - `map<K, struct>` -> `items = { foo = { enabled = true }, bar = { enabled = false } }` (nested struct via ``write_inline_object`` so the whole field stays inline-valid)
  - `map<K, vector<T>>` -> `items = { foo = [1, 2], bar = [3] }`
  - empty map -> `items = {}`

- Inline tables are syntactically scalars in TOML, so the dispatch sits in PASS 1 -- it must run before any nested ``[table]`` header opens a sub-scope, otherwise the inline-table assignment would be parsed as a key of the nested table instead of the enclosing struct. PASS 2 continues to handle nested objects and array-of-tables sections.

## Validation
- New test executable ``toml_map_field_test`` (see ``tests/toml_test/toml_map_field_test.cpp``) -- 32 assertions across 4 cases, all pass:
  - Case 1: `map<string, struct>` as a struct field
  - Case 2: `map<string, bool>` as a struct field
  - Case 3: `map<string, vector<int>>` as a struct field
  - Case 4: empty `map<string, struct>` field renders as `items = {}` and round-trips back to an empty map
- Each case writes the value, asserts the new inline form is emitted and the broken pre-fix ``items = bar = ...`` shape is NOT present, then reads the emitted output back and asserts the populated map matches the original.
- The test is standalone (no ``glz_test_common`` link) so it can run quickly in CI without depending on the rest of the heavier TOML test suite.

## Notes
- The fix matches the first form the reporter listed as acceptable: ``items = { foo = { enabled = true }, bar = { enabled = false } }``. The alternative table-header form ``[items.foo]\nenabled = true`` was considered but does not currently round-trip through ``glz::read_toml`` for ``map<K, struct>`` fields, so the inline form was chosen as the lower-risk shape that immediately closes the read/write asymmetry the reporter described.

Fixes #2540