### PR TITLE
feat(schema): distinguish input vs output JSON schemas (closes #2508)

### DIFF
--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -143,6 +143,28 @@ namespace glz
       }
    };
 
+   // Distinguish JSON Schemas generated for serialization output vs parsing input.
+   //
+   // output: schema describes what glaze will produce. All non-skipped object members
+   //         are guaranteed to be written, and tuples always serialize at their full
+   //         length, so the schema emits `required` and `minItems = maxItems`.
+   //
+   // input:  schema describes what glaze will accept. Partial parsing is supported,
+   //         so `required` is omitted on objects (except for variant discriminator
+   //         tags, which must be present to select an alternative) and `minItems`
+   //         is omitted on tuples.
+   enum struct schema_purpose : uint8_t { input, output };
+
+   consteval schema_purpose check_schema_purpose(auto&& Opts)
+   {
+      if constexpr (requires { Opts.schema_purpose_v; }) {
+         return Opts.schema_purpose_v;
+      }
+      else {
+         return schema_purpose::output;
+      }
+   }
+
    namespace detail
    {
       enum struct defined_formats : uint32_t;
@@ -907,6 +929,11 @@ namespace glz
             });
             s.items = false;
             s.maxItems = N;
+            if constexpr (check_schema_purpose(Opts) == schema_purpose::output) {
+               // Output schemas describe serialized data: tuples always emit every element,
+               // so the array length is fixed (minItems == maxItems == N).
+               s.minItems = N;
+            }
          }
       };
 
@@ -973,6 +1000,8 @@ namespace glz
 
             using V = std::decay_t<T>;
 
+            constexpr auto purpose = check_schema_purpose(Opts);
+
             if constexpr (requires { meta<V>::required; }) {
                if (!s.required) {
                   s.required = std::vector<sv>{};
@@ -1000,8 +1029,12 @@ namespace glz
                using val_t = std::decay_t<refl_t<T, I>>;
 
                static constexpr sv key = reflect<T>::keys[I];
-               if constexpr (requires_key<T, val_t, Opts>(key)) {
-                  req.emplace_back(key);
+               // Output schemas describe guaranteed-present keys after serialization.
+               // Input schemas omit `required` so partial parsing is permitted.
+               if constexpr (purpose == schema_purpose::output) {
+                  if constexpr (requires_key<T, val_t, Opts>(key)) {
+                     req.emplace_back(key);
+                  }
                }
 
                schema prop{};
@@ -1290,12 +1323,22 @@ namespace glz
       bool write_type_info = false;
    };
 
-   template <class T, auto Opts = opts{}, class Buffer>
+   // Carries the schema_purpose tag through to_json_schema specializations via the existing
+   // `auto Opts` template parameter. Kept at namespace scope to avoid MSVC issues with
+   // function-local non-type template arguments.
+   template <class Opts>
+   struct opts_with_schema_purpose : std::decay_t<Opts>
+   {
+      schema_purpose schema_purpose_v = schema_purpose::output;
+   };
+
+   template <class T, auto Opts = opts{}, schema_purpose Purpose = schema_purpose::output, class Buffer>
    [[nodiscard]] error_ctx write_json_schema(Buffer&& buffer)
    {
+      static constexpr auto schema_opts = opts_with_schema_purpose<decltype(Opts)>{{Opts}, Purpose};
       schema s{};
       s.defs.emplace();
-      detail::to_json_schema<std::decay_t<T>>::template op<Opts>(s, *s.defs);
+      detail::to_json_schema<std::decay_t<T>>::template op<schema_opts>(s, *s.defs);
       s.title = name_v<T>;
 
       // Inline single-use $defs entries at their reference sites
@@ -1314,15 +1357,42 @@ namespace glz
       return write<options>(std::move(s), std::forward<Buffer>(buffer));
    }
 
-   template <class T, auto Opts = opts{}>
+   template <class T, auto Opts = opts{}, schema_purpose Purpose = schema_purpose::output>
    [[nodiscard]] glz::expected<std::string, error_ctx> write_json_schema()
    {
       std::string buffer{};
-      const error_ctx ec = write_json_schema<T, Opts>(buffer);
+      const error_ctx ec = write_json_schema<T, Opts, Purpose>(buffer);
       if (bool(ec)) [[unlikely]] {
          return glz::unexpected(ec);
       }
       return {buffer};
+   }
+
+   // Convenience entry points for the two schema purposes. Output schemas describe what
+   // glaze guarantees on serialization (required keys, fixed tuple lengths). Input schemas
+   // describe what glaze accepts on parsing (partial objects allowed, partial tuples allowed).
+   template <class T, auto Opts = opts{}, class Buffer>
+   [[nodiscard]] error_ctx write_json_input_schema(Buffer&& buffer)
+   {
+      return write_json_schema<T, Opts, schema_purpose::input>(std::forward<Buffer>(buffer));
+   }
+
+   template <class T, auto Opts = opts{}>
+   [[nodiscard]] glz::expected<std::string, error_ctx> write_json_input_schema()
+   {
+      return write_json_schema<T, Opts, schema_purpose::input>();
+   }
+
+   template <class T, auto Opts = opts{}, class Buffer>
+   [[nodiscard]] error_ctx write_json_output_schema(Buffer&& buffer)
+   {
+      return write_json_schema<T, Opts, schema_purpose::output>(std::forward<Buffer>(buffer));
+   }
+
+   template <class T, auto Opts = opts{}>
+   [[nodiscard]] glz::expected<std::string, error_ctx> write_json_output_schema()
+   {
+      return write_json_schema<T, Opts, schema_purpose::output>();
    }
 
    // Custom reader for sv_opt: delegates to string_view reader, then assigns to sv_opt.

--- a/tests/json_test/jsonschema_test.cpp
+++ b/tests/json_test/jsonschema_test.cpp
@@ -573,7 +573,7 @@ suite value_type_variant_schema = [] {
       auto schema = glz::write_json_schema<tuple_t>().value();
       expect(
          schema ==
-         R"({"type":"array","prefixItems":[{"type":"integer","minimum":-2147483648,"maximum":2147483647},{"type":"string"},{"type":"boolean"}],"items":false,"title":"std::tuple<int32_t,std::string,bool>","maxItems":3})")
+         R"({"type":"array","prefixItems":[{"type":"integer","minimum":-2147483648,"maximum":2147483647},{"type":"string"},{"type":"boolean"}],"items":false,"title":"std::tuple<int32_t,std::string,bool>","minItems":3,"maxItems":3})")
          << schema;
    };
 
@@ -1173,6 +1173,76 @@ suite schema_round_trip_test = [] {
       expect(!ec);
       expect(re_serialized == schema_str)
          << "round-trip mismatch:\n  original: " << schema_str << "\n  re-serialized: " << re_serialized;
+   };
+};
+
+namespace schema_purpose_fixtures
+{
+   struct partial_person
+   {
+      std::string name{};
+      int age{};
+      std::optional<std::string> nickname{};
+   };
+}
+
+suite schema_purpose_test = [] {
+   using namespace schema_purpose_fixtures;
+
+   "input schema for tuple omits minItems"_test = [] {
+      using tuple_t = std::tuple<int, std::string, bool>;
+      auto s = glz::write_json_input_schema<tuple_t>().value();
+      glz::schema obj{};
+      auto err = glz::read<glz::opts{.error_on_unknown_keys = false}>(obj, s);
+      expect(!err) << glz::format_error(err, s);
+      expect(obj.maxItems.has_value());
+      expect(*obj.maxItems == 3UL);
+      expect(!obj.minItems.has_value()) << "input schema should not set minItems on a tuple: " << s;
+   };
+
+   "output schema for tuple sets minItems == maxItems"_test = [] {
+      using tuple_t = std::tuple<int, std::string, bool>;
+      auto s = glz::write_json_output_schema<tuple_t>().value();
+      glz::schema obj{};
+      auto err = glz::read<glz::opts{.error_on_unknown_keys = false}>(obj, s);
+      expect(!err) << glz::format_error(err, s);
+      expect(obj.maxItems.has_value());
+      expect(obj.minItems.has_value()) << "output schema should set minItems on a tuple: " << s;
+      expect(*obj.minItems == *obj.maxItems);
+      expect(*obj.minItems == 3UL);
+   };
+
+   "input schema for object omits required from non-optional members"_test = [] {
+      auto s = glz::write_json_input_schema<partial_person,
+                                            glz::opts{.error_on_missing_keys = true}>()
+                  .value();
+      glz::schema obj{};
+      auto err = glz::read<glz::opts{.error_on_unknown_keys = false}>(obj, s);
+      expect(!err) << glz::format_error(err, s);
+      expect(!obj.required.has_value())
+         << "input schema must allow partial parsing - required must be absent: " << s;
+   };
+
+   "output schema for object emits required for non-optional members"_test = [] {
+      auto s = glz::write_json_output_schema<partial_person,
+                                             glz::opts{.error_on_missing_keys = true}>()
+                  .value();
+      glz::schema obj{};
+      auto err = glz::read<glz::opts{.error_on_unknown_keys = false}>(obj, s);
+      expect(!err) << glz::format_error(err, s);
+      expect(obj.required.has_value()) << "output schema must list required keys: " << s;
+      auto& req = *obj.required;
+      expect(std::find(req.begin(), req.end(), "name") != req.end());
+      expect(std::find(req.begin(), req.end(), "age") != req.end());
+      expect(std::find(req.begin(), req.end(), "nickname") == req.end())
+         << "nullable members must not appear in required";
+   };
+
+   "default write_json_schema matches output purpose"_test = [] {
+      using tuple_t = std::tuple<int, double>;
+      auto def = glz::write_json_schema<tuple_t>().value();
+      auto out = glz::write_json_output_schema<tuple_t>().value();
+      expect(def == out) << "default purpose should be output: \n  default: " << def << "\n  output:  " << out;
    };
 };
 


### PR DESCRIPTION
## Summary

Closes #2508.

Glaze previously emitted a single JSON Schema for every type even though serialization and parsing contracts differ. The mixed behavior — `required` on objects but no `minItems` on tuples after #2461 — described neither contract fully.

This PR introduces `schema_purpose { input, output }` and threads it through `to_json_schema` via an `opts_with_schema_purpose` wrapper that carries the tag in the existing constexpr `Opts`.

New entry points:

- `glz::write_json_input_schema<T>()` — partial-parse friendly: no `required` on objects, no `minItems` on tuples.
- `glz::write_json_output_schema<T>()` — serialization contract: `required` listed for guaranteed-present keys, `minItems == maxItems` on tuples.

`glz::write_json_schema<T>()` keeps its existing signature and now defaults to `output` purpose. For objects this preserves the existing `required` emission; for tuples this newly emits `minItems == maxItems`, completing the output-schema contract.

User-provided `meta<V>::required` is always honored regardless of purpose, since it expresses a developer-asserted parsing requirement. Variant discriminator tags also stay in `required` for input schemas because the tag must be present to select an alternative.

## Test plan

- [x] `jsonschema_test` builds cleanly.
- [x] Updated `tuple schema uses prefixItems` expected string to include `minItems`.
- [x] New `schema_purpose_test` suite covers:
  - input schema for tuples omits `minItems`,
  - output schema for tuples sets `minItems == maxItems`,
  - input schema for objects omits `required` (with `error_on_missing_keys`),
  - output schema for objects lists non-nullable members in `required`,
  - default `write_json_schema` matches output purpose.