### PR TITLE
chore: remove unused is_schema_class concept

### DIFF
--- a/include/glaze/util/tuple.hpp
+++ b/include/glaze/util/tuple.hpp
@@ -14,11 +14,4 @@ namespace glz
 {
    template <class T>
    concept is_std_tuple = is_specialization_v<T, std::tuple>;
-
-   // TODO: This doesn't appear to be used. Should it be removed?
-   template <class Type>
-   concept is_schema_class = requires {
-      requires std::is_class_v<Type>;
-      requires Type::schema_attributes;
-   };
 }


### PR DESCRIPTION
### Summary

`is_schema_class` in `include/glaze/util/tuple.hpp` is defined but never used anywhere in the library or its tests. The TODO right above the definition has been asking the same question for a while:

```cpp
// TODO: This doesn't appear to be used. Should it be removed?
template <class Type>
concept is_schema_class = requires {
   requires std::is_class_v<Type>;
   requires Type::schema_attributes;
};
```

### Verification

```
$ grep -rn 'is_schema_class' --include='*.hpp' --include='*.cpp' .
include/glaze/util/tuple.hpp:20:   concept is_schema_class = requires {
```

The only mention is the definition itself. The related `schema_attributes` sentinel (used in `include/glaze/json/schema.hpp:215`) is read directly by the schema writer and doesn't go through this concept.

Removes the concept and its TODO; `is_std_tuple` above it is unaffected.