### PR TITLE
chore(progress_bar): build status string with std::format

### DIFF
--- a/include/glaze/util/progress_bar.hpp
+++ b/include/glaze/util/progress_bar.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cmath>
+#include <format>
 #include <ostream>
 #include <string>
 
@@ -47,17 +48,8 @@ namespace glz
             std::round(((one_or_total - one_or_completed) * time_taken) / (std::max)(one_or_completed, one)));
          const auto minutes = eta_s / 60;
          const auto seconds = eta_s - minutes * 60;
-         s += " " + std::to_string(std::lround(percentage)) + "%";
-         s += " | ETA: " + std::to_string(minutes) + "m " + std::to_string(seconds) + "s";
-         s += " | " + std::to_string(one_or_completed) + "/" + std::to_string(one_or_total);
-
-         // TODO: use std::format when available
-         /*fmt::format_to(std::back_inserter(s), FMT_COMPILE(" {}% | ETA: {}m {}s | {}/{}"), //
-                        std::round(percentage), //
-                        minutes, //
-                        seconds, //
-                        one_or_completed,                                                   //
-                        one_or_total);*/
+         std::format_to(std::back_inserter(s), " {}% | ETA: {}m {}s | {}/{}", percentage, minutes, seconds,
+                        one_or_completed, one_or_total);
          return s;
       }
    };


### PR DESCRIPTION
### Summary

`progress_bar::string()` composes its percent / ETA / progress trailer with hand-rolled `std::to_string` concatenation, with a stale comment block right after it sketching a `fmt::format_to` / `std::format` replacement marked `TODO: use std::format when available`.

Glaze now requires C++23 (`cxx_std_23` in `CMakeLists.txt`) and already uses `std::format` in `include/glaze/core/write_chars.hpp`, so the placeholder can finally land:

```cpp
std::format_to(std::back_inserter(s),
               " {}% | ETA: {}m {}s | {}/{}",
               percentage, minutes, seconds,
               one_or_completed, one_or_total);
```

### Output

Byte-identical to the previous concatenation for all in-range values — `percentage` is already `size_t`, and the old `std::lround(percentage)` was a no-op cast to `long` before going through `std::to_string`. Smoke-checked locally (Apple clang 17, `-std=c++23`):

```
[=====-------------] 25% | ETA: 0m 30s | 25/100
 0% | ETA: 0m 0s | 0/1
 100% | ETA: 0m 0s | 100/100
```

### Change

`include/glaze/util/progress_bar.hpp`:

- Add `#include <format>`.
- Replace the three `s += "..." + std::to_string(...)` lines and the stale `fmt::format_to` comment block with a single `std::format_to` call.