### PR TITLE
Enhance JSON reading logic to validate buffer length before assignment

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1275,7 +1275,11 @@ namespace glz
                   while (it < end) [[likely]] {
                      *p = *it;
                      if (*it == '"') {
-                        value.assign(buffer.data(), size_t(p - buffer.data()));
+                        const size_t n = size_t(p - buffer.data());
+#if __has_cpp_attribute(assume) >= 202207L
+                        [[assume(n <= sizeof(buffer))]];
+#endif
+                        value.assign(buffer.data(), n);
                         ++it;
                         if constexpr (not Opts.null_terminated) {
                            if (it == end) {


### PR DESCRIPTION
Some projects compile Glaze as a header-only library with GCC 16 and strict warnings, especially -Warray-bounds and -Werror. In one place we copy a short JSON string into a tiny 8-byte stack buffer, then build a std::string from that buffer.

The compiler couldn’t always see that the length we pass to assign is safe, so it warned that we might read past the buffer even when the code is actually fine. With -Werror, that warning stops the build.