### PR TITLE
Make jmespath opt in for faster compilation

### DIFF
--- a/docs/JMESPath.md
+++ b/docs/JMESPath.md
@@ -6,6 +6,12 @@ Glaze currently has limited support for partial reading with JMESPath. Broader s
 
 - Compile time evaluated JMESPath expressions offer excellent performance.
 
+JMESPath is opt-in. Include it explicitly in addition to your JSON include:
+
+```c++
+#include "glaze/json/jmespath.hpp"
+```
+
 Example:
 
 ```c++

--- a/fuzzing/json_jmespath.cpp
+++ b/fuzzing/json_jmespath.cpp
@@ -2,6 +2,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <glaze/glaze.hpp>
+#include <glaze/json/jmespath.hpp>
 #include <string>
 #include <string_view>
 

--- a/include/glaze/json.hpp
+++ b/include/glaze/json.hpp
@@ -11,7 +11,6 @@
 #include "glaze/json/float_format.hpp"
 #include "glaze/json/generic.hpp"
 #include "glaze/json/invoke.hpp"
-#include "glaze/json/jmespath.hpp"
 #include "glaze/json/json_concepts.hpp"
 #include "glaze/json/json_ptr.hpp"
 #include "glaze/json/json_stream.hpp"

--- a/tests/jmespath/jmespath.cpp
+++ b/tests/jmespath/jmespath.cpp
@@ -2,6 +2,7 @@
 // For the license information refer to glaze.hpp
 
 #include "glaze/glaze.hpp"
+#include "glaze/json/jmespath.hpp"
 #include "ut/ut.hpp"
 
 using namespace ut;


### PR DESCRIPTION
#include "glaze/json/jmespath.hpp" is now required explicitly rather than bundled in json.hpp or glaze.hpp