### PR TITLE
cmake: allow to skip install for glaze

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,8 @@ target_include_directories(
     INTERFACE "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
 )
 
-if(NOT CMAKE_SKIP_INSTALL_RULES)
+option(glaze_SKIP_INSTALL_RULES "Skip generating installation rules for glaze" OFF)
+if(NOT CMAKE_SKIP_INSTALL_RULES AND NOT glaze_SKIP_INSTALL_RULES)
   include(cmake/install-rules.cmake)
 endif()
 


### PR DESCRIPTION
Hello o/

Currently, when using the recommended cmake setup:
```
include(FetchContent)
FetchContent_Declare(
        glaze
        GIT_REPOSITORY https://github.com/stephenberry/glaze.git
        GIT_TAG v7.5.0
        GIT_SHALLOW TRUE
)
FetchContent_MakeAvailable(glaze)
```
glaze adds itself to the installation rules by default, even when it's not a top level project, which results in glaze being  picked up by CPack installers:
<img width="747" height="285" alt="image" src="https://github.com/user-attachments/assets/aafc0882-d2a8-4309-9e74-f1f2cc4ef96d" />

This can be disabled by manipulating global `CMAKE_SKIP_INSTALL_RULES` variable somewhat:
```
include(FetchContent)
FetchContent_Declare(
        glaze
        GIT_REPOSITORY https://github.com/stephenberry/glaze.git
        GIT_TAG v7.5.0
        GIT_SHALLOW TRUE
)
set(CMAKE_SKIP_INSTALL_RULES TRUE)
FetchContent_MakeAvailable(glaze)
set(CMAKE_SKIP_INSTALL_RULES FALSE FORCE)
```
its awkward and works locally, but in CI it results in different issue:
<img width="885" height="258" alt="image" src="https://github.com/user-attachments/assets/32636c97-df03-4f32-b070-a5408189efeb" />

For that reason I propose to introduce a new cmake `glaze_SKIP_INSTALL_RULES` variable to makes this less of a hassle:
```
include(FetchContent)
FetchContent_Declare(
        glaze
        GIT_REPOSITORY https://github.com/stephenberry/glaze.git
        GIT_TAG v7.5.0
        GIT_SHALLOW TRUE
)
set(glaze_SKIP_INSTALL_RULES ON)
FetchContent_MakeAvailable(glaze)
```
