### PR TITLE
cmake: add glaze_INSTALL option to gate install rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,8 @@ target_include_directories(
     INTERFACE "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
 )
 
-if(NOT CMAKE_SKIP_INSTALL_RULES)
+option(glaze_INSTALL "Generate installation rules for glaze" "${PROJECT_IS_TOP_LEVEL}")
+if(glaze_INSTALL AND NOT CMAKE_SKIP_INSTALL_RULES)
   include(cmake/install-rules.cmake)
 endif()
 


### PR DESCRIPTION
## Summary
- Adds a `glaze_INSTALL` option defaulted to `${PROJECT_IS_TOP_LEVEL}`.
- Top-level builds keep current behavior (install rules generated).
- Subproject / FetchContent builds no longer leak glaze's `install()` and CPack rules into the parent project by default.
- `CMAKE_SKIP_INSTALL_RULES` is still honored as the CMake-wide opt-out.
- Consumers who deliberately want the install cascade can set `glaze_INSTALL=ON` before `FetchContent_MakeAvailable(glaze)`.

Alternative to #2577. The skip-style option in that PR requires every affected consumer to learn about a new flag; defaulting `glaze_INSTALL` from `PROJECT_IS_TOP_LEVEL` fixes the bug automatically for all subproject consumers and matches the convention used by fmt, spdlog, abseil, nlohmann/json, and GoogleTest.

## Test plan
- [x] Top-level configure: install rules still registered (`glazeConfig.cmake`, `glazeConfigVersion.cmake`, `glazeTargets.cmake`, headers).
- [x] Synthetic parent project `add_subdirectory(glaze)`: zero glaze install rules registered in parent's `cmake_install.cmake`.
- [ ] CI green.