### PR TITLE
Fix float serialization on 32-bit MSVC (zmij SIMD path)

### DIFF
--- a/include/glaze/util/zmij.hpp
+++ b/include/glaze/util/zmij.hpp
@@ -33,7 +33,13 @@
 #include <type_traits>
 
 #ifndef ZMIJ_USE_SIMD
+// SIMD (SSE/NEON) is enabled by default; defining GLZ_DISABLE_SIMD selects the
+// scalar code paths, matching the rest of Glaze.
+#if defined(GLZ_DISABLE_SIMD)
+#define ZMIJ_USE_SIMD 0
+#else
 #define ZMIJ_USE_SIMD 1
+#endif
 #endif
 
 // Non-finite output format for zmij::detail::write. 0 (default) emits "null"
@@ -685,6 +691,22 @@ namespace glz::zmij
 
       using m128ptr = const __m128i*;
 
+      // Extract the low 64 bits of an SSE register. _mm_cvtsi128_si64 targets a
+      // 64-bit GPR and is x86-64 only (MSVC does not define it for 32-bit x86),
+      // so on 32-bit targets fall back to a MOVQ store, which is plain SSE2 and
+      // produces the same value. The cvt path is kept on x64 to avoid the extra
+      // store/load round-trip there.
+      ZMIJ_INLINE auto lo_u64(__m128i x) noexcept -> uint64_t
+      {
+#if defined(__x86_64__) || defined(_M_X64)
+         return uint64_t(_mm_cvtsi128_si64(x));
+#else
+         uint64_t result;
+         _mm_storel_epi64(reinterpret_cast<__m128i*>(&result), x);
+         return result;
+#endif
+      }
+
       template <bool OptSize>
       ZMIJ_INLINE auto to_bcd_4x4(__m128i y, const constants<OptSize>& c) noexcept -> __m128i
       {
@@ -750,13 +772,13 @@ namespace glz::zmij
          return {bcd, count_trailing_nonzeros(bcd)};
 #elif ZMIJ_USE_SSE4_1
          uint64_t abcd_efgh = abcdefgh + neg10k_v * ((abcdefgh * div10k_sig) >> div10k_exp);
-         uint64_t unshuffled_bcd = _mm_cvtsi128_si64(to_bcd_4x4(_mm_set_epi64x(0, abcd_efgh), *c));
+         uint64_t unshuffled_bcd = lo_u64(to_bcd_4x4(_mm_set_epi64x(0, abcd_efgh), *c));
          int len = unshuffled_bcd ? 8 - ctz(unshuffled_bcd) / 8 : 0;
          return {bswap64(unshuffled_bcd), len};
 #elif ZMIJ_USE_SSE
          uint64_t abcd_efgh =
             (abcdefgh << 32) - uint64_t((10000ull << 32) - 1) * ((abcdefgh * div10k_sig) >> div10k_exp);
-         uint64_t bcd = _mm_cvtsi128_si64(to_bcd_4x4(_mm_set_epi64x(0, abcd_efgh), *c));
+         uint64_t bcd = lo_u64(to_bcd_4x4(_mm_set_epi64x(0, abcd_efgh), *c));
          return {bcd, count_trailing_nonzeros(bcd)};
 #endif
       }

--- a/tests/jsonrpc_test/jsonrpc_test.cpp
+++ b/tests/jsonrpc_test/jsonrpc_test.cpp
@@ -7,7 +7,7 @@
 #include "ut/ut.hpp"
 
 namespace rpc = glz::rpc;
-using ut::operator""_test;
+using namespace ut;
 
 ut::suite valid_vector_test_cases_server = [] {
    using vec_t = std::vector<int>;


### PR DESCRIPTION
## Problem

Fixes #2581. On 32-bit MSVC, serializing a struct with floats fails to compile, while parsing compiles fine. Two distinct issues in `glaze/util/zmij.hpp`:

### 1. `_mm_cvtsi128_si64` is x86-64 only (the actual compile error)

On 32-bit MSVC the default `/arch:SSE2` sets `_M_IX86_FP == 2`, so `ZMIJ_USE_SSE` turns on. But `to_bcd8` extracted the low 64 bits of an SSE register via `_mm_cvtsi128_si64` (zmij.hpp L759 and the SSE4.1 path), which maps to a `MOVQ` into a 64-bit general-purpose register that doesn't exist in 32-bit mode. MSVC doesn't define that intrinsic there, so the **write** path failed; the read path doesn't use it, which is why reading compiled.

The file already handles 32-bit MSVC elsewhere (`clz`/`ctz` fall back to the 32-bit `_BitScanReverse`/`_BitScanForward` under `_M_IX86`; `_umul128` is gated behind `_M_AMD64`). This SSE extract was the one spot that was missed.

### 2. `GLZ_DISABLE_SIMD` was ignored by zmij

`ZMIJ_USE_SIMD` defaulted to `1` unconditionally and never consulted Glaze's project-wide `GLZ_DISABLE_SIMD` switch (which `glaze/simd/simd.hpp` honors), so the documented SIMD-disable escape hatch didn't turn off zmij's SSE/NEON paths.

## Changes

- Add a `lo_u64` helper that keeps `_mm_cvtsi128_si64` on x64 (no codegen change there) and falls back to `_mm_storel_epi64` (plain SSE2, available on 32-bit x86) elsewhere. Used by both the SSE and SSE4.1 paths in `to_bcd8`.
- Default `ZMIJ_USE_SIMD` to `0` when `GLZ_DISABLE_SIMD` is defined.

With #1 fixed, 32-bit MSVC no longer needs the `GLZ_DISABLE_SIMD` workaround at all; with #2 fixed, that workaround now actually works for anyone who wants it.

## Verification

- Compiles and round-trips correctly on ARM64/NEON, x86_64 SSE2, x86_64 SSE4.1, and the scalar `GLZ_DISABLE_SIMD` path.
- The `_mm_storel_epi64` fallback was verified bit-identical to `_mm_cvtsi128_si64` across all-zeros / all-ones / sign-bit / mixed inputs.

---

## Also included: MSVC 19.51 CI fix (`jsonrpc_test.cpp`)

While validating this PR, the `msvc` job (`build (23)`) began failing for a reason **unrelated to the float change**: the `windows-2025-vs2026` runner image bumped MSVC `19.50 -> 19.51`, and 19.51 regressed using-declarations of literal-operator-templates. `jsonrpc_test.cpp` was the only test file using `using ut::operator""_test;`; under 19.51 the brought-in name stops resolving as a string UDL, so every `"name"_test` case errors with C2672. The other ~95 test files use `using namespace ut;` and compile fine (e.g. `yaml_test.cpp` with 600+ `_test` cases).

The second commit switches `jsonrpc_test.cpp` to `using namespace ut;` to match the rest of the suite and unblock MSVC CI. This is bundled here only because it was the sole failing target blocking this PR's checks; it is otherwise independent of the zmij change. (Likely also a Microsoft compiler bug worth reporting upstream.)