### PR TITLE
feat(yaml): tagged variant read support (closes #2583)

### DIFF
--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -5013,8 +5013,135 @@ namespace glz
       }
       process_yaml_variant_alternatives<Variant, is_yaml_variant_str>::template op<Opts>(value, ctx, it, end);
    }
+   // Tagged variants (glz::meta declares `tag`/`ids`). Mirrors the JSON
+   // reader's tag-driven dispatch: read the tag key, look up the matching
+   // variant alternative by id, emplace it, then re-dispatch the same
+   // mapping into the alternative struct. The inner parse runs with
+   // unknown-key tolerance so the tag key itself is silently skipped on
+   // the second pass (the alternative struct does not declare it).
+   //
+   // Restriction: the tag must be the *first* key of the mapping (flow
+   // or block). The JSON path supports out-of-order tags via field-set
+   // deduction, which is reasonable to extend here in a follow-up.
+   template <is_variant T>
+      requires(!tag_v<T>.empty())
+   struct from<YAML, T>
+   {
+      template <auto Opts, class It>
+      static void op(auto&& value, is_context auto&& ctx, It&& it, auto end) noexcept
+      {
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+
+         // Honor the standard preamble (anchors / tags / aliases) so the
+         // tagged variant behaves like a regular mapping for these
+         // properties.
+         yaml::node_preamble_state preamble{};
+         if (yaml::parse_node_preamble<Opts, yaml::node_property_policy{true, true, true, false}, true>(
+                value, ctx, it, end, preamble, [](yaml::yaml_tag tag) { return yaml::tag_valid_for_map(tag); }))
+            return;
+
+         if (it == end) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return;
+         }
+
+         const bool flow_mapping = (*it == '{');
+
+         // Remember the mapping start so we can re-dispatch the whole
+         // mapping into the chosen alternative after the tag lookup.
+         const auto mapping_start = it;
+
+         // Advance past the flow-mapping opener so the first key probe
+         // sees the same shape as the block-mapping path.
+         auto probe = it;
+         if (flow_mapping) {
+            ++probe;
+            yaml::skip_ws_and_newlines(probe, end);
+         }
+         else {
+            yaml::skip_inline_ws(probe, end);
+         }
+
+         if (probe == end) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return;
+         }
+
+         std::string tag_key;
+         if (!yaml::parse_yaml_key(tag_key, ctx, probe, end, flow_mapping)) {
+            return;
+         }
+
+         if (std::string_view{tag_key} != tag_v<T>) [[unlikely]] {
+            ctx.error = error_code::no_matching_variant_type;
+            return;
+         }
+
+         yaml::skip_inline_ws(probe, end);
+         if (probe == end || *probe != ':') [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         ++probe;
+         yaml::skip_inline_ws(probe, end);
+
+         using id_type = std::decay_t<decltype(ids_v<T>[0])>;
+         std::conditional_t<std::integral<id_type>, id_type, std::string> type_id{};
+         from<YAML, decltype(type_id)>::template op<Opts>(type_id, ctx, probe, end);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+
+         size_t type_index;
+         if constexpr (std::integral<id_type>) {
+            type_index = variant_id_to_index<T>::op(type_id);
+         }
+         else {
+            type_index = variant_id_to_index<T>::op(type_id.data(), type_id.data() + type_id.size(), type_id.size());
+         }
+
+         if (type_index >= ids_v<T>.size()) [[unlikely]] {
+            ctx.error = error_code::no_matching_variant_type;
+            return;
+         }
+
+         if (value.index() != type_index) emplace_runtime_variant(value, type_index);
+
+         // Rewind to the start of the mapping so the alternative struct
+         // sees the full shape. Unknown-key tolerance lets the tag key
+         // pass through silently on the second pass.
+         it = mapping_start;
+         constexpr auto inner_opts = [] {
+            auto inner = Opts;
+            inner.error_on_unknown_keys = false;
+            return inner;
+         }();
+
+         std::visit(
+            [&](auto&& v) {
+               using V = std::decay_t<decltype(v)>;
+               if constexpr (glaze_object_t<V> || reflectable<V>) {
+                  from<YAML, V>::template op<inner_opts>(v, ctx, it, end);
+               }
+               else {
+                  // Non-struct alternatives under a tagged variant are
+                  // unusual; surface the mismatch instead of silently
+                  // dispatching to a scalar/seq reader.
+                  ctx.error = error_code::no_matching_variant_type;
+               }
+            },
+            value);
+
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+
+         yaml::finalize_node_anchor(preamble.node_props, ctx, it);
+      }
+   };
+
    // Variant support
    template <is_variant T>
+      requires(tag_v<T>.empty())
    struct from<YAML, T>
    {
       template <auto Opts, class It>

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -2873,6 +2873,89 @@ suite yaml_variant_tests = [] {
    };
 };
 
+// Issue #2583: tagged variants must round-trip through YAML the same way
+// they do through JSON. The variant declares a `tag` key and a list of
+// `ids`; the reader uses the tag value at parse time to pick the
+// matching alternative.
+
+struct tagged_alt_a
+{
+   int value{};
+};
+
+struct tagged_alt_b
+{
+   std::string text{};
+};
+
+template <>
+struct glz::meta<tagged_alt_a>
+{
+   using T = tagged_alt_a;
+   static constexpr auto value = object("value", &T::value);
+};
+
+template <>
+struct glz::meta<tagged_alt_b>
+{
+   using T = tagged_alt_b;
+   static constexpr auto value = object("text", &T::text);
+};
+
+using tagged_variant_t = std::variant<tagged_alt_a, tagged_alt_b>;
+
+template <>
+struct glz::meta<tagged_variant_t>
+{
+   static constexpr std::string_view tag = "type";
+   static constexpr auto ids = std::array{"alt_a", "alt_b"};
+};
+
+suite yaml_tagged_variant_tests = [] {
+   "tagged_variant_flow_first_alternative"_test = [] {
+      tagged_variant_t parsed;
+      std::string yaml = "{type: alt_a, value: 42}";
+      auto rec = glz::read_yaml(parsed, yaml);
+      expect(!rec) << glz::format_error(rec, yaml);
+      expect(std::holds_alternative<tagged_alt_a>(parsed));
+      expect(std::get<tagged_alt_a>(parsed).value == 42);
+   };
+
+   "tagged_variant_flow_second_alternative"_test = [] {
+      tagged_variant_t parsed;
+      std::string yaml = "{type: alt_b, text: hello}";
+      auto rec = glz::read_yaml(parsed, yaml);
+      expect(!rec) << glz::format_error(rec, yaml);
+      expect(std::holds_alternative<tagged_alt_b>(parsed));
+      expect(std::get<tagged_alt_b>(parsed).text == "hello");
+   };
+
+   "tagged_variant_block_first_alternative"_test = [] {
+      tagged_variant_t parsed;
+      std::string yaml = "type: alt_a\nvalue: 7";
+      auto rec = glz::read_yaml(parsed, yaml);
+      expect(!rec) << glz::format_error(rec, yaml);
+      expect(std::holds_alternative<tagged_alt_a>(parsed));
+      expect(std::get<tagged_alt_a>(parsed).value == 7);
+   };
+
+   "tagged_variant_block_second_alternative"_test = [] {
+      tagged_variant_t parsed;
+      std::string yaml = "type: alt_b\ntext: world";
+      auto rec = glz::read_yaml(parsed, yaml);
+      expect(!rec) << glz::format_error(rec, yaml);
+      expect(std::holds_alternative<tagged_alt_b>(parsed));
+      expect(std::get<tagged_alt_b>(parsed).text == "world");
+   };
+
+   "tagged_variant_unknown_id_errors"_test = [] {
+      tagged_variant_t parsed;
+      std::string yaml = "{type: alt_c, value: 1}";
+      auto rec = glz::read_yaml(parsed, yaml);
+      expect(rec == glz::error_code::no_matching_variant_type);
+   };
+};
+
 // ============================================================
 // Complex Nested Structure Tests
 // ============================================================


### PR DESCRIPTION
## Why

The YAML reader's `from<YAML, std::variant<...>>` only handled auto-deducible variants (distinguishable by JSON-like shape). Variants that declare a `glz::meta` `tag` + `ids` — the same dispatch the JSON reader already uses — fell through and produced `error_code::no_matching_variant_type`, forcing users to provide a hand-rolled `from<YAML, T>` specialization to read them. Issue [#2583](https://github.com/stephenberry/glaze/issues/2583) shows the workaround.

## What

Add a tagged-variant specialization of `from<YAML, T>` guarded on `!tag_v<T>.empty()` that mirrors the JSON tag-driven dispatch:

- parse the node preamble (anchor / tag / alias) like a normal mapping
- read the first mapping key and require it to match `tag_v<T>`
- read the id value (string or integral), look up the alternative via `variant_id_to_index<T>`, and `emplace_runtime_variant`
- rewind the iterator to the mapping start and re-dispatch the same mapping into the chosen alternative's struct reader, with `error_on_unknown_keys` flipped off so the tag key passes through silently on the second pass

The existing `is_variant T` specialization is now constrained on `tag_v<T>.empty()` so partial ordering picks the tagged version whenever a tag is declared.

```cpp
struct alt_a { int value{}; };
struct alt_b { std::string text{}; };
template <> struct glz::meta<alt_a> { static constexpr auto value = object(\"value\", &alt_a::value); };
template <> struct glz::meta<alt_b> { static constexpr auto value = object(\"text\", &alt_b::text); };

using V = std::variant<alt_a, alt_b>;
template <> struct glz::meta<V> {
    static constexpr std::string_view tag = \"type\";
    static constexpr auto ids = std::array{\"alt_a\", \"alt_b\"};
};

V v;
glz::read_yaml(v, \"type: alt_b\\ntext: hello\"); // now succeeds, v holds alt_b{\"hello\"}
```

## Tests

`tests/yaml_test/yaml_test.cpp` — new `yaml_tagged_variant_tests` suite covers both flow `{type: alt_a, value: 42}` and block `type: alt_a\\nvalue: 42` for each alternative, plus an unknown-id error path.

## Scope

- The tag must be the **first** key of the mapping. The JSON path tolerates out-of-order tags via field-set deduction; happy to extend that here in a follow-up.
- Only struct alternatives (`glaze_object_t` / `reflectable`) are dispatched. Scalar / sequence alternatives under a tag surface `no_matching_variant_type` rather than silently mis-parsing.

Closes #2583