### PR TITLE
Support YAML tagged variants (meta::tag/ids discriminator)

### DIFF
--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -2124,12 +2124,12 @@ namespace glz
       }
    };
 
-   // std::nullptr_t - null literal type
-   template <>
-   struct from<YAML, std::nullptr_t>
+   // Always-null literal types (std::nullptr_t, std::monostate, std::nullopt_t)
+   template <always_null_t T>
+   struct from<YAML, T>
    {
       template <auto Opts, class It>
-      static void op(std::nullptr_t&, is_context auto&& ctx, It&& it, auto end) noexcept
+      static void op(auto&&, is_context auto&& ctx, It&& it, auto end) noexcept
       {
          if (bool(ctx.error)) [[unlikely]]
             return;
@@ -2524,12 +2524,13 @@ namespace glz
       }
 
       // Parse flow mapping {key: value, ...}
-      template <auto Opts, class T, class Ctx, class It, class End>
+      template <auto Opts, string_literal Tag = "", class T, class Ctx, class It, class End>
       inline void parse_flow_mapping(T&& value, Ctx& ctx, It& it, End end)
       {
          using U = std::remove_cvref_t<T>;
          static constexpr auto N = reflect<U>::size;
          static constexpr auto HashInfo = hash_info<U>;
+         static constexpr sv variant_tag = Tag.sv();
 
          decltype(auto) fields = [&]() -> decltype(auto) {
             if constexpr (Opts.error_on_missing_keys) {
@@ -2617,14 +2618,24 @@ namespace glz
                      },
                      index);
                }
-               else {
+               else if constexpr (not variant_tag.empty()) {
+                  // A tagged variant's discriminator key is "unknown" to the resolved struct (unless
+                  // the struct declares it as a field). The variant resolver already consumed it to
+                  // choose this alternative, so it is skipped rather than rejected.
                   if constexpr (Opts.error_on_unknown_keys) {
-                     ctx.error = error_code::unknown_key;
-                     return;
+                     if (std::string_view{ctx.scratch} != variant_tag) {
+                        ctx.error = error_code::unknown_key;
+                        return;
+                     }
                   }
-                  else { // else used to fix MSVC unreachable code warning
-                     skip_yaml_value<Opts>(ctx, it, end, 0, true);
-                  }
+                  skip_yaml_value<Opts>(ctx, it, end, 0, true);
+               }
+               else if constexpr (Opts.error_on_unknown_keys) {
+                  ctx.error = error_code::unknown_key;
+                  return;
+               }
+               else { // else used to fix MSVC unreachable code warning
+                  skip_yaml_value<Opts>(ctx, it, end, 0, true);
                }
 
                if (bool(ctx.error)) [[unlikely]]
@@ -3217,6 +3228,24 @@ namespace glz
          }
       }
 
+      // Skip the value of an unknown block-mapping entry, whether it is inline (on the key's line)
+      // or begins on a following, more-indented line (a nested block sequence or mapping).
+      // `key_indent` is the column of the entry's key; deeper lines belong to the value.
+      template <auto Opts, class Ctx, class It, class End>
+      inline void skip_unknown_block_value(Ctx& ctx, It& it, End end, int32_t key_indent) noexcept
+      {
+         if (it != end && !yaml::line_end_or_comment_table[static_cast<uint8_t>(*it)]) {
+            skip_yaml_value<Opts>(ctx, it, end, key_indent, false);
+         }
+         else {
+            const int32_t nested_indent = detect_nested_value_indent(ctx, it, end, key_indent);
+            if (nested_indent >= 0) {
+               skip_to_content(it, end);
+               skip_yaml_value<Opts>(ctx, it, end, key_indent, false);
+            }
+         }
+      }
+
       // Shared loop for block mapping parsing.
       // Handles blank/comment skipping, indent detection, dedent, and trailing whitespace.
       // process_entry(ctx, it, end, line_indent) should parse key+colon+value and return
@@ -3477,7 +3506,7 @@ namespace glz
       // Parse block mapping for struct/object types
       // key1: value1
       // key2: value2
-      template <auto Opts, class T, class Ctx, class It, class End>
+      template <auto Opts, string_literal Tag = "", class T, class Ctx, class It, class End>
       inline void parse_block_mapping(T&& value, Ctx& ctx, It& it, End end, int32_t mapping_indent)
       {
          using U = std::remove_cvref_t<T>;
@@ -3584,25 +3613,27 @@ namespace glz
                      },
                      index);
                }
-               else {
+               else if constexpr (not Tag.sv().empty()) {
+                  // A tagged variant's discriminator key is "unknown" to the resolved struct (unless
+                  // the struct declares it as a field). The variant resolver already consumed it to
+                  // choose this alternative, so it is skipped rather than rejected - even under
+                  // error_on_unknown_keys. The mapping's true column is on the indent stack
+                  // (established by the variant op), so this generic skip does not fold a following
+                  // sibling entry into the discriminator's inline value.
                   if constexpr (Opts.error_on_unknown_keys) {
-                     ctx.error = error_code::unknown_key;
-                     return false;
-                  }
-                  else { // else used to fix MSVC unreachable code warning
-                     // Skip unknown value
-                     if (it != end && !yaml::line_end_or_comment_table[static_cast<uint8_t>(*it)]) {
-                        skip_yaml_value<Opts>(ctx, it, end, line_indent, false);
-                     }
-                     else {
-                        // Value may be on the next line (block sequence, mapping, etc.)
-                        int32_t nested_indent = detect_nested_value_indent(ctx, it, end, line_indent);
-                        if (nested_indent >= 0) {
-                           skip_to_content(it, end);
-                           skip_yaml_value<Opts>(ctx, it, end, line_indent, false);
-                        }
+                     if (std::string_view{ctx.scratch} != Tag.sv()) {
+                        ctx.error = error_code::unknown_key;
+                        return false;
                      }
                   }
+                  skip_unknown_block_value<Opts>(ctx, it, end, line_indent);
+               }
+               else if constexpr (Opts.error_on_unknown_keys) {
+                  ctx.error = error_code::unknown_key;
+                  return false;
+               }
+               else {
+                  skip_unknown_block_value<Opts>(ctx, it, end, line_indent);
                }
 
                return !bool(ctx.error);
@@ -4030,7 +4061,10 @@ namespace glz
       requires((glaze_object_t<T> || reflectable<T>) && !custom_read<T>)
    struct from<YAML, T>
    {
-      template <auto Opts, class It>
+      // Tag is the discriminator key of an enclosing tagged variant (empty when not tagged).
+      // When set, the mapping parsers skip an entry whose key equals the tag, since the
+      // variant resolver has already consumed it to select this alternative.
+      template <auto Opts, string_literal Tag = "", class It>
       static void op(auto&& value, is_context auto&& ctx, It&& it, auto end)
       {
          if (bool(ctx.error)) [[unlikely]]
@@ -4043,11 +4077,11 @@ namespace glz
 
          if (*it == '{') {
             // Flow mapping
-            yaml::parse_flow_mapping<Opts>(value, ctx, it, end);
+            yaml::parse_flow_mapping<Opts, Tag>(value, ctx, it, end);
          }
          else {
             // Block mapping - use indent from context (set by parent parser)
-            yaml::parse_block_mapping<Opts>(value, ctx, it, end, ctx.current_indent());
+            yaml::parse_block_mapping<Opts, Tag>(value, ctx, it, end, ctx.current_indent());
          }
 
          yaml::finalize_node_anchor(preamble.node_props, ctx, it);
@@ -5013,6 +5047,143 @@ namespace glz
       }
       process_yaml_variant_alternatives<Variant, is_yaml_variant_str>::template op<Opts>(value, ctx, it, end);
    }
+
+   // Column (visual indent) of `it` within its current line, for contiguous buffers. The variant
+   // op is entered after the parent has consumed the leading indentation, so the indent stack no
+   // longer reflects the mapping's true column; recovering it from the buffer gives a single
+   // context-independent value (root, struct member, sequence item all differ) that drives both the
+   // tag scan and the indent under which the chosen alternative is parsed.
+   template <class It>
+   inline int32_t tagged_mapping_visual_indent(It it, const char* stream_begin, int32_t fallback) noexcept
+   {
+      if constexpr (std::is_pointer_v<std::decay_t<It>>) {
+         if (stream_begin && it >= stream_begin) {
+            auto line_begin = it;
+            while (line_begin > stream_begin && *(line_begin - 1) != '\n' && *(line_begin - 1) != '\r') {
+               --line_begin;
+            }
+            return static_cast<int32_t>(it - line_begin);
+         }
+      }
+      return fallback;
+   }
+
+   // Walk a tagged variant's mapping (block or flow), invoking on_tag(ctx, it, end, line_indent,
+   // in_flow) for the entry whose key equals `tag` and skipping every other entry's value. The
+   // whole mapping is consumed, so on completion the iterator sits just past it. on_tag is
+   // responsible for consuming the tag entry's value. Used both to resolve the alternative
+   // (running on copies of the iterator/context) and to consume the mapping when the resolved
+   // alternative is not an object (running on the caller's iterator/context).
+   template <auto Opts, class Ctx, class It, class End, class OnTag>
+   inline void walk_tagged_mapping(Ctx& ctx, It& it, End end, sv tag, int32_t mapping_indent, OnTag&& on_tag)
+   {
+      auto skip_entry_value = [&](Ctx& ctx, It& it, End end, int32_t line_indent, bool in_flow) {
+         if (in_flow) {
+            yaml::skip_yaml_value<Opts>(ctx, it, end, 0, true);
+         }
+         else {
+            yaml::skip_unknown_block_value<Opts>(ctx, it, end, line_indent);
+         }
+      };
+
+      if constexpr (yaml::check_flow_context(Opts)) {
+         // Flow mapping {tag: id, ...}
+         if (it == end || *it != '{') return;
+         ++it;
+         yaml::skip_flow_ws_and_newlines(ctx, it, end);
+         while (it != end && *it != '}') {
+            ctx.scratch.clear();
+            if (!yaml::parse_yaml_key(ctx.scratch, ctx, it, end, true)) return;
+            yaml::skip_flow_ws_and_newlines(ctx, it, end);
+            if (it == end || *it != ':') {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            ++it;
+            yaml::skip_flow_ws_and_newlines(ctx, it, end);
+            if (std::string_view{ctx.scratch} == tag) {
+               on_tag(ctx, it, end, 0, true);
+            }
+            else {
+               skip_entry_value(ctx, it, end, 0, true);
+            }
+            if (bool(ctx.error)) return;
+            yaml::skip_flow_ws_and_newlines(ctx, it, end);
+            if (it != end && *it == ',') {
+               ++it;
+               yaml::skip_flow_ws_and_newlines(ctx, it, end);
+            }
+         }
+         if (it != end && *it == '}') ++it;
+      }
+      else {
+         // A '{' in block context still introduces a flow mapping value.
+         if (it != end && *it == '{') {
+            walk_tagged_mapping<yaml::flow_context_on<Opts>()>(ctx, it, end, tag, mapping_indent, on_tag);
+            return;
+         }
+         if (mapping_indent < 0) mapping_indent = 0;
+         yaml::parse_block_mapping_loop<Opts>(
+            ctx, it, end, mapping_indent, [&](Ctx& ctx, It& it, End end, int32_t line_indent) -> bool {
+               ctx.scratch.clear();
+               if (!yaml::parse_yaml_key(ctx.scratch, ctx, it, end, false)) return false;
+               yaml::skip_inline_ws(it, end);
+               if (it == end || *it != ':') {
+                  ctx.error = error_code::syntax_error;
+                  return false;
+               }
+               ++it;
+               yaml::skip_inline_ws(it, end);
+               if (std::string_view{ctx.scratch} == tag) {
+                  on_tag(ctx, it, end, line_indent, false);
+               }
+               else {
+                  skip_entry_value(ctx, it, end, line_indent, false);
+               }
+               return !bool(ctx.error);
+            });
+      }
+   }
+
+   // Resolve a tagged variant's alternative index by scanning the mapping for the discriminator
+   // key (tag_v<V>). Operates on copies of the context and iterator so the caller's parse
+   // position is left untouched. Returns ids_v<V>.size() (the not-found sentinel) when the tag
+   // key is absent or its value matches no known id.
+   template <class V, auto Opts, class Ctx, class It, class End>
+   inline size_t scan_variant_tag_index(Ctx ctx, It it, End end, int32_t mapping_indent)
+   {
+      using id_type = std::decay_t<decltype(ids_v<V>[0])>;
+      size_t resolved = ids_v<V>.size();
+      // The id is read with the flow-ness of the entry it appears in: a plain scalar in a flow
+      // mapping ends at ',' or '}', whereas in a block mapping it runs to end of line.
+      auto read_id = [&]<auto O>(Ctx& ctx, It& it, End end) {
+         if constexpr (std::integral<id_type>) {
+            id_type id{};
+            from<YAML, id_type>::template op<O>(id, ctx, it, end);
+            if (!bool(ctx.error)) {
+               resolved = variant_id_to_index<V>::op(id);
+            }
+         }
+         else {
+            std::string id{};
+            from<YAML, std::string>::template op<O>(id, ctx, it, end);
+            if (!bool(ctx.error)) {
+               resolved = variant_id_to_index<V>::op(id.data(), id.data() + id.size(), id.size());
+            }
+         }
+      };
+      walk_tagged_mapping<Opts>(ctx, it, end, tag_v<V>, mapping_indent,
+                                [&](Ctx& ctx, It& it, End end, int32_t, bool in_flow) {
+                                   if (in_flow) {
+                                      read_id.template operator()<yaml::flow_context_on<Opts>()>(ctx, it, end);
+                                   }
+                                   else {
+                                      read_id.template operator()<Opts>(ctx, it, end);
+                                   }
+                                });
+      return resolved;
+   }
+
    // Variant support
    template <is_variant T>
    struct from<YAML, T>
@@ -5035,6 +5206,60 @@ namespace glz
          if (it == end) [[unlikely]] {
             ctx.error = error_code::unexpected_end;
             return;
+         }
+
+         // Tagged variants: a discriminator key (meta::tag) selects the alternative, with the
+         // matching meta::ids entry naming each type. This mirrors the JSON behavior so the
+         // same variant definitions round-trip across both formats.
+         if constexpr (not tag_v<std::remove_cvref_t<T>>.empty()) {
+            using V = std::remove_cvref_t<T>;
+            const bool value_is_mapping =
+               (*it == '{') ||
+               (!yaml::check_flow_context(Opts) && yaml::line_could_be_block_mapping(it, end));
+            if (value_is_mapping) {
+               // The mapping's keys sit at the column of `it`. Recover that column from the buffer:
+               // the indent stack carries the parent context's indent (a struct member, a sequence
+               // item, etc. each push a different offset), not this mapping's true column (see helper).
+               const int32_t mapping_column =
+                  tagged_mapping_visual_indent(it, ctx.stream_begin, ctx.current_indent() + 1);
+               const size_t index =
+                  scan_variant_tag_index<V, Opts>(ctx.make_speculative(), it, end, mapping_column);
+               if (index < ids_v<V>.size()) {
+                  static constexpr auto tag_literal = string_literal_from_view<tag_v<V>.size()>(tag_v<V>);
+                  emplace_runtime_variant(value, index);
+                  // Establish the mapping's true column on the indent stack for the alternative parse.
+                  // The chosen object is then parsed - and the discriminator's inline value skipped -
+                  // at a consistent indent in every context, so a tag on the first key does not fold
+                  // the following sibling entries into its value (no special-casing needed downstream).
+                  if (!ctx.push_indent(mapping_column)) [[unlikely]] {
+                     ctx.error = error_code::exceeded_max_recursive_depth;
+                     return;
+                  }
+                  std::visit(
+                     [&](auto&& alt) {
+                        using Alt = std::remove_cvref_t<decltype(alt)>;
+                        if constexpr (glaze_object_t<Alt> || reflectable<Alt>) {
+                           // Parse the mapping into the resolved struct; the tag key is skipped.
+                           from<YAML, Alt>::template op<Opts, tag_literal>(alt, ctx, it, end);
+                        }
+                        else {
+                           // Non-object alternative (e.g. std::monostate): the emplaced default is
+                           // the value, but the mapping must still be consumed.
+                           walk_tagged_mapping<Opts>(
+                              ctx, it, end, tag_v<V>, mapping_column,
+                              [&](auto&& c, auto&& i, auto&& e, int32_t line_indent, bool in_flow) {
+                                 yaml::skip_yaml_value<Opts>(c, i, e, in_flow ? 0 : line_indent, in_flow);
+                              });
+                        }
+                     },
+                     value);
+                  ctx.pop_indent();
+                  return;
+               }
+               // No resolvable tag key was found. Fall through to structural deduction:
+               // if the alternatives are distinguishable by their fields this still succeeds,
+               // otherwise the deduction path reports no_matching_variant_type.
+            }
          }
 
          if constexpr (yaml_variant_is_auto_deducible<std::remove_cvref_t<T>>()) {

--- a/include/glaze/yaml/write.hpp
+++ b/include/glaze/yaml/write.hpp
@@ -64,12 +64,12 @@ namespace glz
       }
    };
 
-   // std::nullptr_t
-   template <>
-   struct to<YAML, std::nullptr_t>
+   // Always-null literal types (std::nullptr_t, std::monostate, std::nullopt_t)
+   template <always_null_t T>
+   struct to<YAML, T>
    {
       template <auto Opts, class B>
-      static void op(std::nullptr_t, is_context auto&& ctx, B&& b, auto& ix)
+      static void op(auto&&, is_context auto&& ctx, B&& b, auto& ix)
       {
          if (!ensure_space(ctx, b, ix + 8)) [[unlikely]] {
             return;
@@ -416,6 +416,11 @@ namespace glz
       inline void write_block_mapping(T&& value, is_context auto&& ctx, B&& b, auto& ix, int32_t indent_level,
                                       bool skip_first_indent = false);
 
+      // Forward declaration for tagged-variant block output (definition needs write_block_mapping).
+      template <auto Opts, class Variant, class T, class B>
+      inline void write_tagged_block_object(T&& inner, size_t index, is_context auto&& ctx, B&& b, auto& ix,
+                                            int32_t indent_level, bool skip_first_indent);
+
       // Helper to check if a type is "simple" (writes on same line)
       template <class T>
       consteval bool is_simple_type()
@@ -611,13 +616,20 @@ namespace glz
                else {
                   // Complex variant content (maps/arrays/objects) - write in block style
                   if constexpr (is_variant<element_t>) {
+                     const size_t index = element.index();
                      std::visit(
                         [&](auto&& inner) {
                            using inner_t = std::remove_cvref_t<decltype(inner)>;
                            if constexpr (glaze_object_t<inner_t> || reflectable<inner_t>) {
-                              // Compact form: first key inline after dash
+                              // Compact form: first key (or the discriminator tag) inline after dash
                               dump(' ', b, ix);
-                              write_block_mapping<Opts>(inner, ctx, b, ix, indent_level + 1, true);
+                              if constexpr (check_write_type_info(Opts) && not tag_v<element_t>.empty()) {
+                                 write_tagged_block_object<Opts, element_t>(inner, index, ctx, b, ix, indent_level + 1,
+                                                                            true);
+                              }
+                              else {
+                                 write_block_mapping<Opts>(inner, ctx, b, ix, indent_level + 1, true);
+                              }
                            }
                            else {
                               if constexpr (writable_map_t<inner_t>) {
@@ -1119,8 +1131,21 @@ namespace glz
             write_block_mapping_nested<Opts>(get_member(value, meta_wrapper_v<V>), ctx, b, ix, indent_level);
          }
          else if constexpr (is_variant<V>) {
-            // Handle variants by visiting and recursing with the same indent level
-            std::visit([&](auto&& inner) { write_block_mapping_nested<Opts>(inner, ctx, b, ix, indent_level); }, value);
+            // Handle variants by visiting and recursing with the same indent level. A tagged
+            // variant holding an object also emits its discriminator (meta::tag) entry.
+            const size_t index = value.index();
+            std::visit(
+               [&](auto&& inner) {
+                  using inner_t = std::remove_cvref_t<decltype(inner)>;
+                  if constexpr ((glaze_object_t<inner_t> || reflectable<inner_t>) &&
+                                check_write_type_info(Opts) && not tag_v<V>.empty()) {
+                     write_tagged_block_object<Opts, V>(inner, index, ctx, b, ix, indent_level, false);
+                  }
+                  else {
+                     write_block_mapping_nested<Opts>(inner, ctx, b, ix, indent_level);
+                  }
+               },
+               value);
          }
          else if constexpr (writable_array_t<V>) {
             write_block_sequence<Opts>(value, ctx, b, ix, indent_level);
@@ -1233,19 +1258,15 @@ namespace glz
          }
       }
 
-      // Write flow-style mapping
+      // Write the comma-separated "key: value" entries of a flow mapping (no surrounding braces).
+      // `first` tracks whether a leading ", " separator is needed, letting callers prepend
+      // entries (e.g. a tagged variant's discriminator) before the object's own members.
       template <auto Opts, class T, class B>
-      inline void write_flow_mapping(T&& value, is_context auto&& ctx, B&& b, auto& ix)
+      inline void write_flow_mapping_members(T&& value, is_context auto&& ctx, B&& b, auto& ix, bool& first)
       {
          using V = std::remove_cvref_t<T>;
          constexpr auto N = reflect<V>::size;
 
-         if (!ensure_space(ctx, b, ix + 8)) [[unlikely]] {
-            return;
-         }
-         dump('{', b, ix);
-
-         bool first = true;
          for_each<N>([&]<size_t I>() {
             if (bool(ctx.error)) [[unlikely]]
                return;
@@ -1292,7 +1313,76 @@ namespace glz
                serialize<YAML>::op<flow_context_on<Opts>()>(member, ctx, b, ix);
             }
          });
+      }
 
+      // Write flow-style mapping
+      template <auto Opts, class T, class B>
+      inline void write_flow_mapping(T&& value, is_context auto&& ctx, B&& b, auto& ix)
+      {
+         if (!ensure_space(ctx, b, ix + 8)) [[unlikely]] {
+            return;
+         }
+         dump('{', b, ix);
+         bool first = true;
+         write_flow_mapping_members<Opts>(value, ctx, b, ix, first);
+         dump('}', b, ix);
+      }
+
+      // Write a tagged variant's discriminator value (the meta::ids entry for `index`).
+      template <auto Opts, class Variant, class B>
+      inline void write_variant_tag_id(size_t index, is_context auto&& ctx, B&& b, auto& ix, int32_t indent_level)
+      {
+         using id_type = std::decay_t<decltype(ids_v<Variant>[0])>;
+         if constexpr (std::integral<id_type>) {
+            serialize<YAML>::op<Opts>(ids_v<Variant>[index], ctx, b, ix);
+         }
+         else {
+            write_yaml_string<Opts>(sv{ids_v<Variant>[index]}, ctx, b, ix, indent_level);
+         }
+      }
+
+      // Write a tagged variant alternative that holds an object as a block mapping, emitting the
+      // discriminator entry (meta::tag: id) ahead of the object's own members so it round-trips.
+      template <auto Opts, class Variant, class T, class B>
+      inline void write_tagged_block_object(T&& inner, size_t index, is_context auto&& ctx, B&& b, auto& ix,
+                                            int32_t indent_level, bool skip_first_indent)
+      {
+         constexpr uint8_t indent_width = check_indent_width(yaml_opts{});
+         static constexpr sv tag = tag_v<Variant>;
+
+         if (!skip_first_indent) {
+            const int32_t spaces = indent_level * indent_width;
+            if (!ensure_space(ctx, b, ix + spaces + tag.size() + 8)) [[unlikely]] {
+               return;
+            }
+            for (int32_t i = 0; i < spaces; ++i) {
+               b[ix++] = ' ';
+            }
+         }
+         dump(tag, b, ix);
+         dump(": ", b, ix);
+         write_variant_tag_id<Opts, Variant>(index, ctx, b, ix, indent_level);
+         dump('\n', b, ix);
+
+         // Remaining members are emitted at the mapping's indent (the tag occupied the first line).
+         write_block_mapping<Opts>(inner, ctx, b, ix, indent_level, false);
+      }
+
+      // Write a tagged variant alternative that holds an object as a flow mapping
+      // ({tag: id, key: value, ...}).
+      template <auto Opts, class Variant, class T, class B>
+      inline void write_tagged_flow_object(T&& inner, size_t index, is_context auto&& ctx, B&& b, auto& ix)
+      {
+         static constexpr sv tag = tag_v<Variant>;
+         if (!ensure_space(ctx, b, ix + tag.size() + 8)) [[unlikely]] {
+            return;
+         }
+         dump('{', b, ix);
+         dump(tag, b, ix);
+         dump(": ", b, ix);
+         write_variant_tag_id<Opts, Variant>(index, ctx, b, ix, 0);
+         bool first = false; // tag already written, so members need a leading ", "
+         write_flow_mapping_members<Opts>(inner, ctx, b, ix, first);
          dump('}', b, ix);
       }
    } // namespace yaml
@@ -1373,7 +1463,36 @@ namespace glz
       template <auto Opts, class B>
       static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
       {
-         std::visit([&](auto&& v) { serialize<YAML>::op<Opts>(v, ctx, b, ix); }, value);
+         using V = std::remove_cvref_t<T>;
+         // Tagged variants emit a discriminator entry (meta::tag) when holding an object, so the
+         // output names which alternative it is and round-trips through the reader.
+         if constexpr (check_write_type_info(Opts) && not tag_v<V>.empty()) {
+            const size_t index = value.index();
+            std::visit(
+               [&](auto&& v) {
+                  using Vt = std::remove_cvref_t<decltype(v)>;
+                  if constexpr (glaze_object_t<Vt> || reflectable<Vt>) {
+                     if constexpr (yaml::check_flow_style(Opts) || yaml::check_flow_context(Opts)) {
+                        yaml::write_tagged_flow_object<Opts, V>(v, index, ctx, b, ix);
+                     }
+                     else {
+                        int32_t indent_level = 0;
+                        if constexpr (requires { ctx.indent_level; }) {
+                           indent_level = ctx.indent_level;
+                        }
+                        yaml::write_tagged_block_object<Opts, V>(v, index, ctx, b, ix, indent_level, false);
+                     }
+                  }
+                  else {
+                     // Non-object alternatives (scalars, null) carry no tag, matching JSON.
+                     serialize<YAML>::op<Opts>(v, ctx, b, ix);
+                  }
+               },
+               value);
+         }
+         else {
+            std::visit([&](auto&& v) { serialize<YAML>::op<Opts>(v, ctx, b, ix); }, value);
+         }
       }
    };
 

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -9034,4 +9034,312 @@ suite yaml_skip_marker_suite = [] {
    };
 };
 
+// Tagged variants: a meta::tag discriminator key selects the alternative (meta::ids names each
+// type). Mirrors the JSON behavior so the same definitions round-trip across both formats.
+namespace yaml_tagged_variant_tests
+{
+   struct put_action
+   {
+      std::map<std::string, int> data{};
+      bool operator==(const put_action&) const = default;
+   };
+   struct delete_action
+   {
+      std::string data{};
+      bool operator==(const delete_action&) const = default;
+   };
+
+   using tagged_variant = std::variant<put_action, delete_action>;
+
+   // Automatic ids (default to glz::name_v) plus a monostate "none" alternative.
+   using tagged_variant_auto = std::variant<put_action, delete_action, std::monostate>;
+
+   // The discriminator name is also a member of each alternative.
+   struct option_a
+   {
+      std::string tag{};
+      int a{};
+      bool operator==(const option_a&) const = default;
+   };
+   struct option_b
+   {
+      std::string tag{};
+      int a{};
+      bool operator==(const option_b&) const = default;
+   };
+   using tagged_object = std::variant<option_a, option_b>;
+
+   // Integral discriminator ids.
+   struct event_open
+   {
+      int fd{};
+      bool operator==(const event_open&) const = default;
+   };
+   struct event_close
+   {
+      std::string reason{};
+      bool operator==(const event_close&) const = default;
+   };
+   using int_tagged = std::variant<event_open, event_close>;
+
+   struct holder
+   {
+      tagged_variant v{};
+      bool operator==(const holder&) const = default;
+   };
+}
+
+template <>
+struct glz::meta<yaml_tagged_variant_tests::put_action>
+{
+   using T = yaml_tagged_variant_tests::put_action;
+   static constexpr auto value = object("data", &T::data);
+};
+template <>
+struct glz::meta<yaml_tagged_variant_tests::delete_action>
+{
+   using T = yaml_tagged_variant_tests::delete_action;
+   static constexpr auto value = object("data", &T::data);
+};
+template <>
+struct glz::meta<yaml_tagged_variant_tests::tagged_variant>
+{
+   static constexpr std::string_view tag = "action";
+   static constexpr auto ids = std::array{"PUT", "DELETE"};
+};
+template <>
+struct glz::meta<yaml_tagged_variant_tests::tagged_variant_auto>
+{
+   static constexpr std::string_view tag = "type";
+   static constexpr auto ids = std::array{"PUT", "DELETE", "NONE"};
+};
+template <>
+struct glz::meta<yaml_tagged_variant_tests::option_a>
+{
+   using T = yaml_tagged_variant_tests::option_a;
+   static constexpr auto value = object("tag", &T::tag, "a", &T::a);
+};
+template <>
+struct glz::meta<yaml_tagged_variant_tests::option_b>
+{
+   using T = yaml_tagged_variant_tests::option_b;
+   static constexpr auto value = object("tag", &T::tag, "a", &T::a);
+};
+template <>
+struct glz::meta<yaml_tagged_variant_tests::tagged_object>
+{
+   static constexpr std::string_view tag = "tag";
+   static constexpr auto ids = std::array{"A", "B"};
+};
+template <>
+struct glz::meta<yaml_tagged_variant_tests::event_open>
+{
+   using T = yaml_tagged_variant_tests::event_open;
+   static constexpr auto value = object("fd", &T::fd);
+};
+template <>
+struct glz::meta<yaml_tagged_variant_tests::event_close>
+{
+   using T = yaml_tagged_variant_tests::event_close;
+   static constexpr auto value = object("reason", &T::reason);
+};
+template <>
+struct glz::meta<yaml_tagged_variant_tests::int_tagged>
+{
+   static constexpr std::string_view tag = "code";
+   static constexpr auto ids = std::array{10, 20};
+};
+template <>
+struct glz::meta<yaml_tagged_variant_tests::holder>
+{
+   using T = yaml_tagged_variant_tests::holder;
+   static constexpr auto value = object("v", &T::v);
+};
+
+suite yaml_tagged_variant_suite = [] {
+   using namespace yaml_tagged_variant_tests;
+
+   "tagged read: tag first"_test = [] {
+      tagged_variant v{};
+      const std::string yaml = "action: DELETE\ndata: the_internet\n";
+      expect(!glz::read_yaml(v, yaml));
+      expect(std::holds_alternative<delete_action>(v));
+      expect(std::get<delete_action>(v).data == "the_internet");
+   };
+
+   "tagged read: tag at end"_test = [] {
+      tagged_variant v{};
+      const std::string yaml = "data: the_internet\naction: DELETE\n";
+      expect(!glz::read_yaml(v, yaml));
+      expect(std::holds_alternative<delete_action>(v));
+      expect(std::get<delete_action>(v).data == "the_internet");
+   };
+
+   "tagged read: nested mapping value"_test = [] {
+      tagged_variant v{};
+      const std::string yaml = "action: PUT\ndata:\n  x: 100\n  y: 200\n";
+      expect(!glz::read_yaml(v, yaml));
+      expect(std::holds_alternative<put_action>(v));
+      expect(std::get<put_action>(v).data.at("x") == 100);
+      expect(std::get<put_action>(v).data.at("y") == 200);
+   };
+
+   "tagged read: flow style"_test = [] {
+      tagged_variant v{};
+      expect(!glz::read_yaml(v, std::string("{action: DELETE, data: the_internet}")));
+      expect(std::holds_alternative<delete_action>(v));
+      expect(std::get<delete_action>(v).data == "the_internet");
+
+      tagged_variant v2{};
+      expect(!glz::read_yaml(v2, std::string("{data: the_internet, action: DELETE}")));
+      expect(std::holds_alternative<delete_action>(v2));
+   };
+
+   "tagged read: automatic ids with monostate"_test = [] {
+      tagged_variant_auto v = put_action{};
+      expect(!glz::read_yaml(v, std::string("type: NONE\n")));
+      expect(std::holds_alternative<std::monostate>(v));
+
+      tagged_variant_auto v2{};
+      expect(!glz::read_yaml(v2, std::string("type: PUT\ndata:\n  x: 1\n")));
+      expect(std::holds_alternative<put_action>(v2));
+      expect(std::get<put_action>(v2).data.at("x") == 1);
+   };
+
+   "tagged read: tag is also a member"_test = [] {
+      tagged_object v{};
+      expect(!glz::read_yaml(v, std::string("tag: A\na: 2\n")));
+      expect(std::holds_alternative<option_a>(v));
+      expect(std::get<option_a>(v).a == 2);
+      // The discriminator value is also stored in the matching member.
+      expect(std::get<option_a>(v).tag == "A");
+   };
+
+   "tagged read: integral ids"_test = [] {
+      int_tagged v{};
+      expect(!glz::read_yaml(v, std::string("code: 20\nreason: bye\n")));
+      expect(std::holds_alternative<event_close>(v));
+      expect(std::get<event_close>(v).reason == "bye");
+
+      int_tagged v2{};
+      expect(!glz::read_yaml(v2, std::string("code: 10\nfd: 7\n")));
+      expect(std::holds_alternative<event_open>(v2));
+      expect(std::get<event_open>(v2).fd == 7);
+   };
+
+   "tagged read: unknown id errors"_test = [] {
+      tagged_variant v{};
+      const auto ec = glz::read_yaml(v, std::string("action: NOPE\ndata: x\n"));
+      expect(ec == glz::error_code::no_matching_variant_type);
+   };
+
+   "tagged write: block emits discriminator"_test = [] {
+      tagged_variant v = delete_action{{"the_internet"}};
+      std::string yaml;
+      expect(!glz::write_yaml(v, yaml));
+      expect(yaml == "action: DELETE\ndata: the_internet\n") << yaml;
+   };
+
+   "tagged write: flow emits discriminator"_test = [] {
+      tagged_variant v = delete_action{{"the_internet"}};
+      std::string yaml;
+      expect(!glz::write<glz::yaml::yaml_opts{.flow_style = true}>(v, yaml));
+      expect(yaml == "{action: DELETE, data: the_internet}") << yaml;
+   };
+
+   "tagged write: integral id"_test = [] {
+      int_tagged v = event_close{{"bye"}};
+      std::string yaml;
+      expect(!glz::write_yaml(v, yaml));
+      expect(yaml == "code: 20\nreason: bye\n") << yaml;
+   };
+
+   "tagged roundtrip: block and flow"_test = [] {
+      const std::vector<tagged_variant> values{put_action{{{"x", 1}, {"y", 2}}}, delete_action{{"net"}}};
+      for (const auto& original : values) {
+         std::string block;
+         expect(!glz::write_yaml(original, block));
+         tagged_variant from_block{};
+         expect(!glz::read_yaml(from_block, block)) << block;
+         expect(from_block == original);
+
+         std::string flow;
+         expect(!glz::write<glz::yaml::yaml_opts{.flow_style = true}>(original, flow));
+         tagged_variant from_flow{};
+         expect(!glz::read_yaml(from_flow, flow)) << flow;
+         expect(from_flow == original);
+      }
+   };
+
+   "tagged roundtrip: nested as struct member"_test = [] {
+      const holder original{delete_action{{"member"}}};
+      std::string yaml;
+      expect(!glz::write_yaml(original, yaml));
+      holder decoded{};
+      expect(!glz::read_yaml(decoded, yaml)) << yaml;
+      expect(decoded == original);
+   };
+
+   "tagged roundtrip: sequence of variants"_test = [] {
+      const std::vector<tagged_variant> original{put_action{{{"a", 1}}}, delete_action{{"x"}}};
+      std::string yaml;
+      expect(!glz::write_yaml(original, yaml));
+      std::vector<tagged_variant> decoded;
+      expect(!glz::read_yaml(decoded, yaml)) << yaml;
+      expect(decoded == original);
+   };
+
+   "tagged read: discriminator after other members"_test = [] {
+      // The discriminator may appear after other members, including within sequence items.
+      const std::string yaml = "- data: alpha\n  action: DELETE\n- data: beta\n  action: DELETE\n";
+      std::vector<tagged_variant> decoded;
+      const auto ec = glz::read_yaml(decoded, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(decoded.size() == 2);
+      expect(std::holds_alternative<delete_action>(decoded.at(0)));
+      expect(std::holds_alternative<delete_action>(decoded.at(1)));
+      expect(std::get<delete_action>(decoded.at(0)).data == "alpha");
+      expect(std::get<delete_action>(decoded.at(1)).data == "beta");
+   };
+
+   "tagged read: tag first with extra dash spacing"_test = [] {
+      // Extra spaces after the dash put the first key (the discriminator) at a column that is not
+      // dash_indent + 1. The variant op recovers that column from the buffer and parses the
+      // alternative at it, so the tag's inline value does not fold the following sibling entry, and
+      // the next sequence item is still recognized as a dedent.
+      const std::string yaml =
+         "-   action: PUT\n"
+         "    data:\n"
+         "      x: 7\n"
+         "-   action: DELETE\n"
+         "    data: gone\n";
+      std::vector<tagged_variant> decoded;
+      const auto ec = glz::read_yaml(decoded, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(decoded.size() == 2);
+      expect(std::holds_alternative<put_action>(decoded.at(0)));
+      // A regression here over-folds `data` into the tag's value, leaving the map empty; check the
+      // key is present first so the failure reports cleanly instead of throwing from at().
+      const auto& put_data = std::get<put_action>(decoded.at(0)).data;
+      expect(put_data.contains("x")) << "data folded into the discriminator value";
+      if (put_data.contains("x")) {
+         expect(put_data.at("x") == 7);
+      }
+      expect(std::holds_alternative<delete_action>(decoded.at(1)));
+      expect(std::get<delete_action>(decoded.at(1)).data == "gone");
+   };
+
+   "tagged read: tag skipped but other unknown keys still error"_test = [] {
+      // error_on_unknown_keys is true by default. The discriminator key is skipped (not a field of
+      // delete_action), but a genuinely unknown key must still be rejected.
+      tagged_variant ok{};
+      expect(!glz::read_yaml(ok, std::string("action: DELETE\ndata: kept\n")));
+      expect(std::holds_alternative<delete_action>(ok));
+
+      tagged_variant bad{};
+      const auto ec = glz::read_yaml(bad, std::string("action: DELETE\ndata: kept\nbogus: 1\n"));
+      expect(ec == glz::error_code::unknown_key);
+   };
+};
+
 int main() { return 0; }

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -9342,4 +9342,316 @@ suite yaml_tagged_variant_suite = [] {
    };
 };
 
+// Stress tests for tagged variants: nesting, containers, irregular indentation, comments, quoting,
+// block scalars, sparse/auto ids, and round-trips through less common parent contexts.
+namespace yaml_tagged_variant_stress_tests
+{
+   using namespace yaml_tagged_variant_tests;
+
+   // Structurally identical multi-field alternatives: only the discriminator can distinguish them
+   // (not field-based deduction), and the multiple fields let the tag sit before/between/after them.
+   struct rec_a
+   {
+      int x{};
+      int y{};
+      bool operator==(const rec_a&) const = default;
+   };
+   struct rec_b
+   {
+      int x{};
+      int y{};
+      bool operator==(const rec_b&) const = default;
+   };
+   using multi_tagged = std::variant<rec_a, rec_b>;
+
+   // An alternative that itself holds a tagged variant - exercises the indent-column recovery and
+   // push recursively (outer variant -> envelope object -> inner variant).
+   struct envelope
+   {
+      tagged_variant payload{};
+      int seq{};
+      bool operator==(const envelope&) const = default;
+   };
+   using nested_tagged = std::variant<envelope, delete_action>;
+
+   // Sparse, negative integral discriminator ids.
+   struct sa
+   {
+      int v{};
+      bool operator==(const sa&) const = default;
+   };
+   struct sb
+   {
+      int w{};
+      bool operator==(const sb&) const = default;
+   };
+   using sparse_tagged = std::variant<sa, sb>;
+
+   // A tag with no explicit ids: ids default to glz::name_v of each alternative. The alternatives are
+   // structurally identical, so only the name-derived discriminator can select the right one.
+   struct auto_x
+   {
+      int a{};
+      bool operator==(const auto_x&) const = default;
+   };
+   struct auto_y
+   {
+      int a{};
+      bool operator==(const auto_y&) const = default;
+   };
+   using auto_tagged = std::variant<auto_x, auto_y>;
+}
+
+template <>
+struct glz::meta<yaml_tagged_variant_stress_tests::rec_a>
+{
+   using T = yaml_tagged_variant_stress_tests::rec_a;
+   static constexpr auto value = object("x", &T::x, "y", &T::y);
+};
+template <>
+struct glz::meta<yaml_tagged_variant_stress_tests::rec_b>
+{
+   using T = yaml_tagged_variant_stress_tests::rec_b;
+   static constexpr auto value = object("x", &T::x, "y", &T::y);
+};
+template <>
+struct glz::meta<yaml_tagged_variant_stress_tests::multi_tagged>
+{
+   static constexpr std::string_view tag = "kind";
+   static constexpr auto ids = std::array{"A", "B"};
+};
+template <>
+struct glz::meta<yaml_tagged_variant_stress_tests::envelope>
+{
+   using T = yaml_tagged_variant_stress_tests::envelope;
+   static constexpr auto value = object("payload", &T::payload, "seq", &T::seq);
+};
+template <>
+struct glz::meta<yaml_tagged_variant_stress_tests::nested_tagged>
+{
+   static constexpr std::string_view tag = "otype";
+   static constexpr auto ids = std::array{"ENV", "DEL"};
+};
+template <>
+struct glz::meta<yaml_tagged_variant_stress_tests::sa>
+{
+   using T = yaml_tagged_variant_stress_tests::sa;
+   static constexpr auto value = object("v", &T::v);
+};
+template <>
+struct glz::meta<yaml_tagged_variant_stress_tests::sb>
+{
+   using T = yaml_tagged_variant_stress_tests::sb;
+   static constexpr auto value = object("w", &T::w);
+};
+template <>
+struct glz::meta<yaml_tagged_variant_stress_tests::sparse_tagged>
+{
+   static constexpr std::string_view tag = "id";
+   static constexpr auto ids = std::array{-5, 1000};
+};
+template <>
+struct glz::meta<yaml_tagged_variant_stress_tests::auto_x>
+{
+   using T = yaml_tagged_variant_stress_tests::auto_x;
+   static constexpr auto value = object("a", &T::a);
+};
+template <>
+struct glz::meta<yaml_tagged_variant_stress_tests::auto_y>
+{
+   using T = yaml_tagged_variant_stress_tests::auto_y;
+   static constexpr auto value = object("a", &T::a);
+};
+template <>
+struct glz::meta<yaml_tagged_variant_stress_tests::auto_tagged>
+{
+   static constexpr std::string_view tag = "t";
+};
+
+suite yaml_tagged_variant_stress_suite = [] {
+   using namespace yaml_tagged_variant_stress_tests;
+
+   "stress: variant as map value"_test = [] {
+      const std::string yaml =
+         "first:\n"
+         "  action: PUT\n"
+         "  data:\n"
+         "    x: 1\n"
+         "second:\n"
+         "  action: DELETE\n"
+         "  data: bye\n";
+      std::map<std::string, tagged_variant> m;
+      const auto ec = glz::read_yaml(m, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      const std::map<std::string, tagged_variant> expected{{"first", put_action{{{"x", 1}}}},
+                                                            {"second", delete_action{{"bye"}}}};
+      expect(m == expected);
+   };
+
+   "stress: optional<variant> read and round-trip"_test = [] {
+      std::optional<tagged_variant> o;
+      const auto ec = glz::read_yaml(o, std::string("action: DELETE\ndata: x\n"));
+      expect(!ec);
+      expect(o == std::optional<tagged_variant>{delete_action{{"x"}}});
+
+      std::string s;
+      expect(!glz::write_yaml(o, s));
+      std::optional<tagged_variant> back;
+      expect(!glz::read_yaml(back, s)) << s;
+      expect(back == o);
+   };
+
+   "stress: variant alternative holding a tagged variant"_test = [] {
+      const std::string yaml =
+         "otype: ENV\n"
+         "seq: 5\n"
+         "payload:\n"
+         "  action: DELETE\n"
+         "  data: inner\n";
+      nested_tagged v;
+      const auto ec = glz::read_yaml(v, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(v == nested_tagged{envelope{tagged_variant{delete_action{{"inner"}}}, 5}});
+
+      std::string s;
+      expect(!glz::write_yaml(v, s));
+      nested_tagged back;
+      expect(!glz::read_yaml(back, s)) << s;
+      expect(back == v);
+   };
+
+   "stress: discriminator before, between, and after members"_test = [] {
+      // rec_a and rec_b are identical, so resolution is purely by the tag, at any position.
+      const multi_tagged expected{rec_a{1, 2}};
+      for (const std::string yaml :
+           {"kind: A\nx: 1\ny: 2\n", "x: 1\nkind: A\ny: 2\n", "x: 1\ny: 2\nkind: A\n"}) {
+         multi_tagged v;
+         const auto ec = glz::read_yaml(v, yaml);
+         expect(!ec) << glz::format_error(ec, yaml);
+         expect(v == expected) << yaml;
+      }
+      // The other id selects the other (identical-shaped) alternative.
+      multi_tagged b;
+      expect(!glz::read_yaml(b, std::string("x: 3\nkind: B\ny: 4\n")));
+      expect(b == multi_tagged{rec_b{3, 4}});
+   };
+
+   "stress: sparse and negative integral ids"_test = [] {
+      sparse_tagged v;
+      expect(!glz::read_yaml(v, std::string("id: -5\nv: 7\n")));
+      expect(v == sparse_tagged{sa{7}});
+
+      sparse_tagged v2;
+      expect(!glz::read_yaml(v2, std::string("id: 1000\nw: 9\n")));
+      expect(v2 == sparse_tagged{sb{9}});
+
+      // Round-trip both.
+      for (const sparse_tagged original : {sparse_tagged{sa{3}}, sparse_tagged{sb{4}}}) {
+         std::string s;
+         expect(!glz::write_yaml(original, s));
+         sparse_tagged back;
+         expect(!glz::read_yaml(back, s)) << s;
+         expect(back == original);
+      }
+   };
+
+   "stress: auto ids (no explicit ids array) round-trip"_test = [] {
+      // Identical shapes and identical field values: the type survives the round-trip only because
+      // the name-derived discriminator is written and read back.
+      for (const auto_tagged original : {auto_tagged{auto_x{42}}, auto_tagged{auto_y{42}}}) {
+         std::string s;
+         expect(!glz::write_yaml(original, s));
+         auto_tagged back;
+         expect(!glz::read_yaml(back, s)) << s;
+         expect(back.index() == original.index()) << s;
+         expect(back == original);
+      }
+   };
+
+   "stress: comments and blank lines within the mapping"_test = [] {
+      const std::string yaml =
+         "action: DELETE  # the discriminator\n"
+         "\n"
+         "data: kept  # value\n";
+      tagged_variant v;
+      const auto ec = glz::read_yaml(v, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(v == tagged_variant{delete_action{{"kept"}}});
+   };
+
+   "stress: quoted discriminator value"_test = [] {
+      tagged_variant v;
+      expect(!glz::read_yaml(v, std::string("action: \"DELETE\"\ndata: x\n")));
+      expect(v == tagged_variant{delete_action{{"x"}}});
+
+      tagged_variant v2;
+      expect(!glz::read_yaml(v2, std::string("action: 'DELETE'\ndata: y\n")));
+      expect(v2 == tagged_variant{delete_action{{"y"}}});
+   };
+
+   "stress: flow with nested flow value"_test = [] {
+      tagged_variant v;
+      const auto ec = glz::read_yaml(v, std::string("{action: PUT, data: {x: 1, y: 2}}"));
+      expect(!ec);
+      expect(v == tagged_variant{put_action{{{"x", 1}, {"y", 2}}}});
+   };
+
+   "stress: block scalar member value"_test = [] {
+      const std::string yaml =
+         "action: DELETE\n"
+         "data: |\n"
+         "  line one\n"
+         "  line two\n";
+      tagged_variant v;
+      const auto ec = glz::read_yaml(v, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(v == tagged_variant{delete_action{{"line one\nline two\n"}}});
+   };
+
+   "stress: sequence of structs each holding a variant"_test = [] {
+      const std::string yaml =
+         "- v:\n"
+         "    action: DELETE\n"
+         "    data: a\n"
+         "- v:\n"
+         "    action: PUT\n"
+         "    data:\n"
+         "      x: 1\n";
+      std::vector<holder> vec;
+      const auto ec = glz::read_yaml(vec, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      const std::vector<holder> expected{holder{delete_action{{"a"}}}, holder{put_action{{{"x", 1}}}}};
+      expect(vec == expected);
+   };
+
+   "stress: monostate round-trips through null"_test = [] {
+      tagged_variant_auto original = std::monostate{};
+      std::string s;
+      expect(!glz::write_yaml(original, s));
+      tagged_variant_auto back = put_action{};
+      const auto ec = glz::read_yaml(back, s);
+      expect(!ec) << s;
+      expect(std::holds_alternative<std::monostate>(back)) << "wrote: " << s;
+   };
+
+   "stress: monostate via tag in flow"_test = [] {
+      tagged_variant_auto v = put_action{};
+      const auto ec = glz::read_yaml(v, std::string("{type: NONE}"));
+      expect(!ec);
+      expect(std::holds_alternative<std::monostate>(v));
+   };
+
+   "stress: unknown integral id is rejected"_test = [] {
+      sparse_tagged v;
+      const auto ec = glz::read_yaml(v, std::string("id: 7\n"));
+      expect(ec == glz::error_code::no_matching_variant_type) << glz::format_error(ec, std::string("id: 7\n"));
+   };
+
+   "stress: unterminated flow mapping errors"_test = [] {
+      tagged_variant v;
+      const auto ec = glz::read_yaml(v, std::string("{action: PUT, data: {x: 1"));
+      expect(bool(ec));
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
Closes #2583.

Adds tagged-variant support to the YAML reader and writer, matching the existing JSON behavior so the same `meta::tag` / `meta::ids` variant definitions round-trip across both formats.

## Read
- `from<YAML, variant>` checks for a non-empty `tag_v<V>` before auto-deduction. For a mapping value it resolves the alternative by scanning for the discriminator key on a speculative copy of the iterator (`scan_variant_tag_index` / `walk_tagged_mapping`), then emplaces and parses the chosen alternative.
- The tag is threaded through `from<YAML, object>`, `parse_block_mapping`, and `parse_flow_mapping` (new `string_literal Tag` param) so the discriminator entry is skipped — or stored, when the struct declares the tag name as a field.
- String and integral ids are supported. `std::monostate` (now covered by `always_null_t`, alongside `nullptr_t` / `nullopt_t`) writes as `null` with no tag and is selectable by its id on read.

## Indentation
When the variant op runs, the parent has already consumed the mapping's leading indentation, and the indent-stack offset relative to the mapping's true column differs by context (sequence item pushes `dash_indent + 1`, a variant member pushes `nested_indent − 1`, a plain object member pushes `nested_indent`). The op recovers the column from the buffer and pushes it onto the indent stack, so the chosen alternative is parsed — and the discriminator's inline value skipped — at a consistent indent everywhere. The unknown-key value skip is shared between the struct parser and the tag walker via `skip_unknown_block_value`.

## Write
Emits `tag: id` ahead of the object's members in both block and flow styles, wired into the top-level variant, struct-member, and sequence-element paths. Non-object alternatives carry no tag, matching JSON.

## Testing
- `yaml_test`: 635 tests / 2319 assertions pass — adds a tagged-variant suite covering tag-first/last, nested mapping values, flow style, integral ids, monostate, the tag-as-member case, irregular dash spacing, and unknown-key rejection under `error_on_unknown_keys`.
- `yaml_conformance` (402/694) and `yaml_conformance_struct` (105/213) unchanged.
