### PR TITLE
CI workflow for MSVC O2

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -16,10 +16,6 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
-env:
-  CTEST_OUTPUT_ON_FAILURE: 1
-  BUILD_TYPE: Debug
-
 jobs:
   build:
     runs-on: windows-2025-vs2026
@@ -28,16 +24,17 @@ jobs:
     strategy:
       matrix:
         cpp_version: [23]
+        build_type: [Debug, Release]
 
     steps:
     - uses: actions/checkout@v6
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_STANDARD=${{matrix.cpp_version}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DCMAKE_CXX_STANDARD=${{matrix.cpp_version}}
 
     - name: Build
-      run: cmake --build build --config ${{env.BUILD_TYPE}} --parallel
+      run: cmake --build build --config ${{matrix.build_type}} --parallel
 
     - name: Test
       working-directory: build
-      run: ctest --build-config ${{env.BUILD_TYPE}} --timeout 300
+      run: ctest --output-on-failure --build-config ${{matrix.build_type}} --timeout 300

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   build:
     runs-on: windows-2025-vs2026
-    timeout-minutes: 25
+    timeout-minutes: 60
 
     strategy:
       matrix:


### PR DESCRIPTION
I noticed that glaze uses `asio::awaitable` in its code, and immediately recalled a time debugging a crash on O2 caused by `asio::co_composed`, and even though I didn’t see any use of `asio::co_composed_future` in glaze - I thought it wouldn’t hurt to add an extra check for the O2 build for MSVC, because it's probably one of the most finicky compilers out there.

Motivation is my recent very negative experience with the MSVC optimizer: https://github.com/chriskohlhoff/asio/pull/1724.
In short, MSVC emitted an aligned 128-bit `movaps`, even though the operand address was aligned to 8 bytes, not 16, so this resulted in `STATUS_ACCESS_VIOLATION`