### PR TITLE
Support custom_read/custom_write types as tagged variant alternatives (#2589)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ pr_description.md
 /tmp_benchmark
 /exterior
 pr.md
+/tmp/

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2933,10 +2933,15 @@ namespace glz
    template <class T, string_literal Tag>
    inline consteval bool contains_tag()
    {
-      auto& keys = reflect<T>::keys;
-      for (size_t i = 0; i < keys.size(); ++i) {
-         if (Tag.sv() == keys[i]) {
-            return true;
+      // Only object-like types expose reflect<T>::keys. Custom-read types (and other
+      // non-reflectable variant alternatives) have no fields, so the tag can never be
+      // one of their members and we must not touch reflect<T> (it may be incomplete).
+      if constexpr (requires { reflect<T>::keys; }) {
+         auto& keys = reflect<T>::keys;
+         for (size_t i = 0; i < keys.size(); ++i) {
+            if (Tag.sv() == keys[i]) {
+               return true;
+            }
          }
       }
       return false;
@@ -3706,6 +3711,7 @@ namespace glz
    };
 
    template <is_variant T>
+      requires(not custom_read<T>)
    struct from<JSON, T>
    {
       // Note that items in the variant are required to be default constructable for us to switch types
@@ -3873,7 +3879,8 @@ namespace glz
                                  std::visit(
                                     [&](auto&& v) {
                                        using V = std::decay_t<decltype(v)>;
-                                       constexpr bool is_object = glaze_object_t<V> || reflectable<V>;
+                                       constexpr bool is_object =
+                                          (glaze_object_t<V> || reflectable<V>) && not custom_read<V>;
                                        if constexpr (is_object) {
                                           if constexpr (contains_tag<V, tag_literal>()) {
                                              it = start; // tag is a struct field, must re-parse
@@ -3918,6 +3925,20 @@ namespace glz
                                           from<JSON, memory_type<V>>::template op<opening_handled<Opts>(), tag_literal>(
                                              *v, ctx, it, end);
                                        }
+                                       else if constexpr (custom_read<V>) {
+                                          // Custom handlers parse the remaining body themselves and do not
+                                          // accept the tag template parameter; the tag was already consumed.
+                                          // This only works when the tag was the first key. If it came later,
+                                          // we were reset to the object start and the custom handler would
+                                          // absorb the tag, so error rather than corrupt the value.
+                                          if (it == start) {
+                                             ctx.error = error_code::feature_not_supported;
+                                             ctx.custom_error_message =
+                                                "the tag must be the first key for a custom variant alternative";
+                                             return;
+                                          }
+                                          from<JSON, V>::template op<opening_handled<Opts>()>(v, ctx, it, end);
+                                       }
                                     },
                                     value);
 
@@ -3943,7 +3964,8 @@ namespace glz
                                     std::visit(
                                        [&](auto&& v) {
                                           using V = std::decay_t<decltype(v)>;
-                                          constexpr bool is_object = glaze_object_t<V> || reflectable<V>;
+                                          constexpr bool is_object =
+                                             (glaze_object_t<V> || reflectable<V>) && not custom_read<V>;
                                           if constexpr (is_object) {
                                              if constexpr (contains_tag<V, tag_literal>()) {
                                                 it = start; // tag is a struct field, must re-parse
@@ -3984,6 +4006,19 @@ namespace glz
                                              }
                                              from<JSON, memory_type<V>>::template op<opening_handled<Opts>()>(*v, ctx,
                                                                                                               it, end);
+                                          }
+                                          else if constexpr (custom_read<V>) {
+                                             // Custom handlers parse the remaining body themselves; this only
+                                             // works when the tag was the first key (see above). If it came
+                                             // later we were reset to the object start, so error rather than
+                                             // let the custom handler absorb the tag.
+                                             if (it == start) {
+                                                ctx.error = error_code::feature_not_supported;
+                                                ctx.custom_error_message =
+                                                   "the tag must be the first key for a custom variant alternative";
+                                                return;
+                                             }
+                                             from<JSON, V>::template op<opening_handled<Opts>()>(v, ctx, it, end);
                                           }
                                        },
                                        value);
@@ -4060,10 +4095,27 @@ namespace glz
                            std::visit(
                               [&](auto&& v) {
                                  using V = std::decay_t<decltype(v)>;
-                                 if constexpr (contains_tag<V, tag_literal>()) {
-                                    it = start; // tag is a struct field, must re-parse
+                                 if constexpr (custom_read<V>) {
+                                    // Custom handlers parse the remaining object body themselves and do not
+                                    // accept the tag template parameter that reflected objects use to skip an
+                                    // interior tag key. That only works when the tag is the first key (it was
+                                    // just consumed). If the tag came after other keys, position_after_tag()
+                                    // reset us to the object start and the custom handler would absorb the tag
+                                    // into its value, so error here rather than corrupt the result.
+                                    if (it == start) {
+                                       ctx.error = error_code::feature_not_supported;
+                                       ctx.custom_error_message =
+                                          "the tag must be the first key for a custom variant alternative";
+                                       return;
+                                    }
+                                    from<JSON, V>::template op<opening_handled<Opts>()>(v, ctx, it, end);
                                  }
-                                 from<JSON, V>::template op<opening_handled<Opts>(), tag_literal>(v, ctx, it, end);
+                                 else {
+                                    if constexpr (contains_tag<V, tag_literal>()) {
+                                       it = start; // tag is a struct field, must re-parse
+                                    }
+                                    from<JSON, V>::template op<opening_handled<Opts>(), tag_literal>(v, ctx, it, end);
+                                 }
                               },
                               value);
                            if constexpr (Opts.null_terminated) {
@@ -4110,7 +4162,7 @@ namespace glz
                            std::visit(
                               [&](auto&& v) {
                                  using V = std::decay_t<decltype(v)>;
-                                 constexpr bool is_object = glaze_object_t<V> || reflectable<V>;
+                                 constexpr bool is_object = (glaze_object_t<V> || reflectable<V>) && not custom_read<V>;
                                  if constexpr (is_object) {
                                     from<JSON, V>::template op<opening_handled<Opts>(), tag_literal>(v, ctx, it, end);
                                  }
@@ -4146,6 +4198,10 @@ namespace glz
                                     }
                                     from<JSON, memory_type<V>>::template op<opening_handled<Opts>(), tag_literal>(
                                        *v, ctx, it, end);
+                                 }
+                                 else if constexpr (custom_read<V>) {
+                                    // Custom handlers parse the remaining body themselves.
+                                    from<JSON, V>::template op<opening_handled<Opts>()>(v, ctx, it, end);
                                  }
                               },
                               value);
@@ -4195,7 +4251,7 @@ namespace glz
                         std::visit(
                            [&](auto&& v) {
                               using V = std::decay_t<decltype(v)>;
-                              constexpr bool is_object = glaze_object_t<V> || reflectable<V>;
+                              constexpr bool is_object = (glaze_object_t<V> || reflectable<V>) && not custom_read<V>;
                               if constexpr (is_object) {
                                  from<JSON, V>::template op<opening_handled<Opts>(), tag_literal>(v, ctx, it, end);
                               }
@@ -4229,6 +4285,10 @@ namespace glz
                                  }
                                  from<JSON, memory_type<V>>::template op<opening_handled<Opts>(), tag_literal>(*v, ctx,
                                                                                                                it, end);
+                              }
+                              else if constexpr (custom_read<V>) {
+                                 // Custom handlers parse the remaining body themselves.
+                                 from<JSON, V>::template op<opening_handled<Opts>()>(v, ctx, it, end);
                               }
                            },
                            value);
@@ -4287,7 +4347,7 @@ namespace glz
                            std::visit(
                               [&](auto&& v) {
                                  using V = std::decay_t<decltype(v)>;
-                                 constexpr bool is_object = glaze_object_t<V> || reflectable<V>;
+                                 constexpr bool is_object = (glaze_object_t<V> || reflectable<V>) && not custom_read<V>;
                                  if constexpr (is_object) {
                                     from<JSON, V>::template op<opening_handled<Opts>(), tag_literal>(v, ctx, it, end);
                                  }
@@ -4321,6 +4381,10 @@ namespace glz
                                     }
                                     from<JSON, memory_type<V>>::template op<opening_handled<Opts>(), tag_literal>(
                                        *v, ctx, it, end);
+                                 }
+                                 else if constexpr (custom_read<V>) {
+                                    // Custom handlers parse the remaining body themselves.
+                                    from<JSON, V>::template op<opening_handled<Opts>()>(v, ctx, it, end);
                                  }
                               },
                               value);

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1671,6 +1671,7 @@ namespace glz
    };
 
    template <is_variant T>
+      requires(not custom_write<T>)
    struct to<JSON, T>
    {
       template <auto Opts, class B>
@@ -1680,9 +1681,76 @@ namespace glz
             [&](auto&& val) {
                using V = std::decay_t<decltype(val)>;
 
-               if constexpr (check_write_type_info(Opts) && not tag_v<T>.empty() &&
-                             (glaze_object_t<V> || (reflectable<V> && !has_member_with_name<V>(tag_v<T>)) ||
-                              is_memory_object<V>)) {
+               if constexpr (check_write_type_info(Opts) && not tag_v<T>.empty() && custom_write<V>) {
+                  // Custom alternative: the user's serializer emits the object body, into which we
+                  // merge the variant tag. For this to produce valid JSON the custom to<> must (1)
+                  // write an object body and (2) honor opening_and_closing_handled (suppress its own
+                  // braces) so the tag shares the alternative's object. A custom writer that emits a
+                  // scalar/array, or that ignores those flags, would yield malformed output.
+                  //
+                  // The tag-emission below mirrors the reflected-object branch that follows; keep the
+                  // two in sync. The body size is not known at compile time, so we always write the
+                  // tag separator and then drop it at runtime if the body turned out empty.
+                  using id_type = std::decay_t<decltype(ids_v<T>[value.index()])>;
+                  if constexpr (Opts.prettify) {
+                     dump("{\n", b, ix);
+                     ctx.depth += check_indentation_width(Opts);
+                     dumpn(check_indentation_char(Opts), ctx.depth, b, ix);
+                     dump('"', b, ix);
+                     dump_maybe_empty(tag_v<T>, b, ix);
+                     if constexpr (std::integral<id_type>) {
+                        dump("\": ", b, ix);
+                        serialize<JSON>::op<Opts>(ids_v<T>[value.index()], ctx, b, ix);
+                     }
+                     else {
+                        dump("\": \"", b, ix);
+                        dump_maybe_empty(ids_v<T>[value.index()], b, ix);
+                        dump('"', b, ix);
+                     }
+                     const auto pos_after_tag = ix;
+                     dump(",\n", b, ix);
+                     dumpn(check_indentation_char(Opts), ctx.depth, b, ix);
+                     const auto pos_body_start = ix;
+                     to<JSON, V>::template op<opening_and_closing_handled<Opts>()>(val, ctx, b, ix);
+                     if (ix == pos_body_start) {
+                        ix = pos_after_tag; // custom body was empty: undo the tag separator
+                     }
+                     ctx.depth -= check_indentation_width(Opts);
+                     if (!ensure_space(ctx, b, ix + ctx.depth + write_padding_bytes)) [[unlikely]] {
+                        return;
+                     }
+                     std::memcpy(&b[ix], "\n", 1);
+                     ++ix;
+                     std::memset(&b[ix], check_indentation_char(Opts), ctx.depth);
+                     ix += ctx.depth;
+                     std::memcpy(&b[ix], "}", 1);
+                     ++ix;
+                  }
+                  else {
+                     dump("{\"", b, ix);
+                     dump_maybe_empty(tag_v<T>, b, ix);
+                     if constexpr (std::integral<id_type>) {
+                        dump("\":", b, ix);
+                        serialize<JSON>::op<Opts>(ids_v<T>[value.index()], ctx, b, ix);
+                     }
+                     else {
+                        dump("\":\"", b, ix);
+                        dump_maybe_empty(ids_v<T>[value.index()], b, ix);
+                        dump('"', b, ix);
+                     }
+                     const auto pos_after_tag = ix;
+                     dump(',', b, ix);
+                     const auto pos_body_start = ix;
+                     to<JSON, V>::template op<opening_and_closing_handled<Opts>()>(val, ctx, b, ix);
+                     if (ix == pos_body_start) {
+                        ix = pos_after_tag; // custom body was empty: undo the tag separator
+                     }
+                     dump('}', b, ix);
+                  }
+               }
+               else if constexpr (check_write_type_info(Opts) && not tag_v<T>.empty() &&
+                                  (glaze_object_t<V> || (reflectable<V> && !has_member_with_name<V>(tag_v<T>)) ||
+                                   is_memory_object<V>)) {
                   constexpr auto N = []() {
                      if constexpr (is_memory_object<V>) {
                         return reflect<memory_type<V>>::size;

--- a/tests/json_test/json_variant_support_test.cpp
+++ b/tests/json_test/json_variant_support_test.cpp
@@ -2081,4 +2081,173 @@ suite vector_pair_object_variant_tests = [] {
    };
 };
 
+// Regression coverage for https://github.com/stephenberry/glaze/issues/2589
+//
+// A tagged-variant alternative that uses custom_read/custom_write (for example to access
+// the parse context) and serializes an object body should merge the variant tag into that
+// body and round-trip, even alongside an empty (fieldless) alternative.
+
+struct custom_map_action
+{
+   std::map<std::string, int>& data() { return m_data; }
+   const std::map<std::string, int>& data() const { return m_data; }
+   bool operator==(const custom_map_action&) const = default;
+
+  private:
+   std::map<std::string, int> m_data{};
+};
+
+template <>
+struct glz::meta<custom_map_action>
+{
+   static constexpr auto custom_read = true;
+   static constexpr auto custom_write = true;
+};
+
+template <uint32_t Format>
+struct glz::from<Format, custom_map_action>
+{
+   template <auto Opts>
+   static void op(custom_map_action& value, is_context auto&& ctx, auto&& it, auto&& end)
+   {
+      glz::parse<Format>::template op<Opts>(value.data(), ctx, it, end);
+   }
+};
+
+template <uint32_t Format>
+struct glz::to<Format, custom_map_action>
+{
+   template <auto Opts>
+   static void op(auto&& value, is_context auto&& ctx, auto&&... args)
+   {
+      glz::serialize<Format>::template op<Opts>(value.data(), ctx, args...);
+   }
+};
+
+struct empty_action
+{
+   bool operator==(const empty_action&) const = default;
+};
+
+template <>
+struct glz::meta<empty_action>
+{};
+
+using custom_tagged_variant = std::variant<custom_map_action, empty_action>;
+
+template <>
+struct glz::meta<custom_tagged_variant>
+{
+   static constexpr std::string_view tag = "action";
+   static constexpr auto ids = std::array{"PUT", "DELETE"};
+};
+
+suite custom_alternative_variant_tests = [] {
+   "custom alternative tagged variant write+read"_test = [] {
+      custom_map_action put{};
+      put.data() = {{"a", 1}, {"b", 2}};
+      std::vector<custom_tagged_variant> v{empty_action{}, custom_map_action{}, put};
+
+      std::string s{};
+      expect(not glz::write_json(v, s));
+      expect(s == R"([{"action":"DELETE"},{"action":"PUT"},{"action":"PUT","a":1,"b":2}])") << s;
+
+      std::vector<custom_tagged_variant> parsed{};
+      expect(not glz::read_json(parsed, s));
+      expect(parsed.size() == 3);
+      expect(std::holds_alternative<empty_action>(parsed[0]));
+      expect(std::holds_alternative<custom_map_action>(parsed[1]));
+      expect(std::get<custom_map_action>(parsed[1]).data().empty());
+      expect(std::holds_alternative<custom_map_action>(parsed[2]));
+      expect(std::get<custom_map_action>(parsed[2]).data().at("a") == 1);
+      expect(std::get<custom_map_action>(parsed[2]).data().at("b") == 2);
+   };
+
+   "custom alternative prettify round-trips"_test = [] {
+      custom_map_action put{};
+      put.data() = {{"x", 10}};
+      custom_tagged_variant v{put};
+
+      std::string s{};
+      expect(not glz::write<glz::opts{.prettify = true}>(v, s));
+      custom_tagged_variant parsed{};
+      expect(not glz::read_json(parsed, s));
+      std::string s2{};
+      expect(not glz::write<glz::opts{.prettify = true}>(parsed, s2));
+      expect(s == s2) << s;
+   };
+
+   "empty custom alternative prettify has no trailing comma"_test = [] {
+      custom_tagged_variant v{custom_map_action{}};
+      std::string s{};
+      expect(not glz::write<glz::opts{.prettify = true}>(v, s));
+      expect(s == "{\n   \"action\": \"PUT\"\n}") << s;
+   };
+
+   // A custom alternative receives the object body directly and cannot skip an interior
+   // tag the way reflected objects do, so the tag must be the first key. glaze always
+   // writes it first; reordered (e.g. hand-written) input must error rather than corrupt.
+   "custom alternative requires the tag first"_test = [] {
+      // tag first: parses the body
+      custom_tagged_variant ok{};
+      expect(not glz::read_json(ok, R"({"action":"PUT","a":1})"));
+      expect(std::holds_alternative<custom_map_action>(ok));
+      expect(std::get<custom_map_action>(ok).data().at("a") == 1);
+
+      // tag after another key, error_on_unknown_keys = false: must not silently absorb
+      // the tag into the custom value
+      custom_tagged_variant corrupt{};
+      auto ec = glz::read<glz::opts{.error_on_unknown_keys = false}>(corrupt, R"({"a":1,"action":"PUT"})");
+      expect(bool(ec));
+      expect(ec == glz::error_code::feature_not_supported);
+
+      // tag after another key, default keys handling: unknown key is reported
+      custom_tagged_variant unknown{};
+      expect(bool(glz::read_json(unknown, R"({"a":1,"action":"PUT"})")));
+   };
+};
+
+// A std::variant whose own meta opts into custom_read/custom_write (with full from/to
+// specializations) must not be ambiguous with the built-in variant handlers.
+
+struct fully_custom_a
+{};
+struct fully_custom_b
+{};
+using fully_custom_variant = std::variant<fully_custom_a, fully_custom_b>;
+
+template <>
+struct glz::meta<fully_custom_variant>
+{
+   static constexpr auto custom_read = true;
+   static constexpr auto custom_write = true;
+};
+
+template <uint32_t Format>
+struct glz::from<Format, fully_custom_variant>
+{
+   template <auto Opts>
+   static void op(fully_custom_variant&, is_context auto&&, auto&&, auto&&)
+   {}
+};
+
+template <uint32_t Format>
+struct glz::to<Format, fully_custom_variant>
+{
+   template <auto Opts>
+   static void op(auto&&, is_context auto&& ctx, auto&&... args)
+   {
+      glz::serialize<Format>::template op<Opts>("custom", ctx, args...);
+   }
+};
+
+suite fully_custom_variant_tests = [] {
+   "fully custom variant specialization is unambiguous"_test = [] {
+      fully_custom_variant v{};
+      std::string s{};
+      expect(not glz::write_json(v, s));
+      expect(s == R"("custom")") << s;
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
Fixes #2589.

## Problem

The issue reported two distinct failures with `custom_read`/`custom_write` and tagged `std::variant`:

1. **Compile error** — a variant alternative using `custom_read`/`custom_write` (e.g. one that serializes a `std::map` body) fails to compile inside a tagged variant, especially alongside an empty/fieldless alternative.
2. **Ambiguous specialization** (from the issue comment) — giving a `std::variant`'s own `glz::meta` both `custom_read` and `custom_write` makes a user's `glz::to<Format, MyVariant>` / `from<Format, MyVariant>` ambiguous with the built-in variant handler, so it can't be used as a workaround.

Investigating these surfaced two further problems: the write side never merged the tag into a non-aggregate custom alternative (so it wasn't round-trippable), and a custom alternative that happened to be an aggregate was treated as `reflectable` and handed a tag template parameter its `op()` doesn't accept.

## Fixes

**Read (`json/read.hpp`)**
- Guard `contains_tag()` with `requires { reflect<T>::keys; }` so it no longer instantiates the incomplete `reflect<T>` for custom alternatives.
- Exclude `custom_read` types from the `is_object` dispatch and add a `custom_read` branch at each `std::visit` site that calls `op<Opts>()` **without** the tag template parameter.
- A custom handler receives the object body directly and cannot skip an interior tag the way reflected objects do. When the tag is **not** the first key (so we were reset to the object start), emit `error_code::feature_not_supported` rather than silently absorbing the tag into the custom value.

**Write (`json/write.hpp`)**
- Merge the variant tag into a custom alternative's object body, dropping the tag separator at runtime when the body turns out empty (correct for both compact and prettify). Comment documents the custom serializer contract: write an object body and honor `opening_and_closing_handled`.

**Ambiguity (both)**
- Constrain the built-in variant `to<JSON,T>` / `from<JSON,T>` with `not custom_write<T>` / `not custom_read<T>`, matching every other built-in handler, so a fully custom variant specialization is unambiguous.

## Behavior

The issue's reproducer now round-trips:

```
[{"action":"DELETE"},{"action":"PUT"}]      // writes and reads back, error_code 0
```

Tag ordering for custom alternatives (glaze always writes the tag first; reordered/hand-written input):

| input | mode | result |
|---|---|---|
| `{"action":"PUT","k":"v"}` | default | parses the body |
| `{"k":"v","action":"PUT"}` | default | `unknown_key` |
| `{"k":"v","action":"PUT"}` | `error_on_unknown_keys=false` | `feature_not_supported` (previously silently corrupted) |

## Tests

Adds regression coverage in `json_variant_support_test.cpp`: write+read of a mixed custom/empty tagged variant, prettify round-trip, the empty custom body (no trailing comma), the tag-first requirement (including the `feature_not_supported` path), and the fully-custom variant specialization.

Full suite: **95/95 passing**.

## Scope

JSON only, as reported. BEVE/CBOR/etc. encode variants by type index rather than an in-object tag, so the tag-merge logic doesn't transfer; the only plausibly-shared gap is the `not custom_read`/`not custom_write` exclusion, left untouched here.