### PR TITLE
Resolve custom variant specialization ambiguity for YAML/BEVE/CBOR/MessagePack/TOML

### DIFF
--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -532,6 +532,7 @@ namespace glz
    };
 
    template <is_variant T>
+      requires(not custom_read<T>)
    struct from<BEVE, T>
    {
       template <auto Opts>

--- a/include/glaze/beve/write.hpp
+++ b/include/glaze/beve/write.hpp
@@ -500,6 +500,7 @@ namespace glz
    }(std::make_index_sequence<std::variant_size_v<V>>{});
 
    template <is_variant T>
+      requires(not custom_write<T>)
    struct to<BEVE, T> final
    {
       template <auto Opts, class B>

--- a/include/glaze/cbor/read.hpp
+++ b/include/glaze/cbor/read.hpp
@@ -1743,6 +1743,7 @@ namespace glz
 
    // Variants
    template <is_variant T>
+      requires(not custom_read<T>)
    struct from<CBOR, T>
    {
       template <auto Opts>

--- a/include/glaze/cbor/write.hpp
+++ b/include/glaze/cbor/write.hpp
@@ -973,6 +973,7 @@ namespace glz
 
    // Variants
    template <is_variant T>
+      requires(not custom_write<T>)
    struct to<CBOR, T> final
    {
       template <auto Opts>

--- a/include/glaze/msgpack/read.hpp
+++ b/include/glaze/msgpack/read.hpp
@@ -1015,6 +1015,7 @@ namespace glz
    };
 
    template <is_variant T>
+      requires(not custom_read<T>)
    struct from<MSGPACK, T>
    {
       template <auto Opts, class Value, is_context Ctx, class It, class End>

--- a/include/glaze/msgpack/write.hpp
+++ b/include/glaze/msgpack/write.hpp
@@ -1030,6 +1030,7 @@ namespace glz
    };
 
    template <is_variant T>
+      requires(not custom_write<T>)
    struct to<MSGPACK, T>
    {
       template <auto Opts, class Value, is_context Ctx, class B, class IX>

--- a/include/glaze/toml/write.hpp
+++ b/include/glaze/toml/write.hpp
@@ -1474,6 +1474,7 @@ namespace glz
    // Variant support for TOML
    // Serializes the active variant alternative using the appropriate TOML type
    template <is_variant T>
+      requires(not custom_write<T>)
    struct to<TOML, T>
    {
       template <auto Opts, class B>

--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -5187,6 +5187,7 @@ namespace glz
 
    // Variant support
    template <is_variant T>
+      requires(not custom_read<T>)
    struct from<YAML, T>
    {
       template <auto Opts, class It>

--- a/include/glaze/yaml/write.hpp
+++ b/include/glaze/yaml/write.hpp
@@ -1458,6 +1458,7 @@ namespace glz
 
    // Variant support
    template <is_variant T>
+      requires(not custom_write<T>)
    struct to<YAML, T>
    {
       template <auto Opts, class B>

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -6764,6 +6764,50 @@ suite beve_skip_marker_suite = [] {
    };
 };
 
+// A std::variant whose own meta opts into custom_read/custom_write (with full from/to
+// specializations) must not be ambiguous with the built-in BEVE variant handlers.
+// Parity with the JSON fix in #2591.
+struct beve_fc_a
+{};
+struct beve_fc_b
+{};
+using beve_fc_variant = std::variant<beve_fc_a, beve_fc_b>;
+
+template <>
+struct glz::meta<beve_fc_variant>
+{
+   static constexpr auto custom_read = true;
+   static constexpr auto custom_write = true;
+};
+
+template <uint32_t Format>
+struct glz::from<Format, beve_fc_variant>
+{
+   template <auto Opts>
+   static void op(beve_fc_variant&, glz::is_context auto&&, auto&&, auto&&)
+   {}
+};
+
+template <uint32_t Format>
+struct glz::to<Format, beve_fc_variant>
+{
+   template <auto Opts>
+   static void op(auto&&, glz::is_context auto&& ctx, auto&&... args)
+   {
+      glz::serialize<Format>::template op<Opts>(42, ctx, args...);
+   }
+};
+
+suite beve_fully_custom_variant_tests = [] {
+   "fully custom variant specialization is unambiguous"_test = [] {
+      beve_fc_variant v{};
+      std::string s{};
+      expect(not glz::write_beve(v, s));
+      beve_fc_variant r{};
+      expect(not glz::read_beve(r, s));
+   };
+};
+
 int main()
 {
    trace.begin("binary_test");

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -3324,8 +3324,54 @@ void cbor_skip_marker_tests_run()
    };
 }
 
+// A std::variant whose own meta opts into custom_read/custom_write (with full from/to
+// specializations) must not be ambiguous with the built-in CBOR variant handlers.
+// Parity with the JSON fix in #2591.
+struct cbor_fc_a
+{};
+struct cbor_fc_b
+{};
+using cbor_fc_variant = std::variant<cbor_fc_a, cbor_fc_b>;
+
+template <>
+struct glz::meta<cbor_fc_variant>
+{
+   static constexpr auto custom_read = true;
+   static constexpr auto custom_write = true;
+};
+
+template <uint32_t Format>
+struct glz::from<Format, cbor_fc_variant>
+{
+   template <auto Opts>
+   static void op(cbor_fc_variant&, glz::is_context auto&&, auto&&, auto&&)
+   {}
+};
+
+template <uint32_t Format>
+struct glz::to<Format, cbor_fc_variant>
+{
+   template <auto Opts>
+   static void op(auto&&, glz::is_context auto&& ctx, auto&&... args)
+   {
+      glz::serialize<Format>::template op<Opts>(42, ctx, args...);
+   }
+};
+
+void custom_variant_ambiguity_tests()
+{
+   "fully custom variant specialization is unambiguous"_test = [] {
+      cbor_fc_variant v{};
+      std::string s{};
+      expect(not glz::write_cbor(v, s));
+      cbor_fc_variant r{};
+      expect(not glz::read_cbor(r, s));
+   };
+}
+
 int main()
 {
+   custom_variant_ambiguity_tests();
    basic_types_tests();
    integer_tests();
    float_tests();

--- a/tests/msgpack_test/msgpack_test.cpp
+++ b/tests/msgpack_test/msgpack_test.cpp
@@ -361,8 +361,44 @@ namespace msgpack_skip_marker_tests
    }
 }
 
+// A std::variant whose own meta opts into custom_read/custom_write (with full from/to
+// specializations) must not be ambiguous with the built-in MessagePack variant handlers.
+// Parity with the JSON fix in #2591.
+struct mp_fc_a
+{};
+struct mp_fc_b
+{};
+using mp_fc_variant = std::variant<mp_fc_a, mp_fc_b>;
+
+template <>
+struct glz::meta<mp_fc_variant>
+{
+   static constexpr auto custom_read = true;
+   static constexpr auto custom_write = true;
+};
+
+template <uint32_t Format>
+struct glz::to<Format, mp_fc_variant>
+{
+   template <auto Opts>
+   static void op(auto&&, glz::is_context auto&& ctx, auto&&... args)
+   {
+      glz::serialize<Format>::template op<Opts>(42, ctx, args...);
+   }
+};
+
 int main()
 {
+   // Only the write side is exercised here: MessagePack passes its type-tag byte
+   // positionally to from::op, so a generic JSON-style custom from signature cannot be
+   // read-tested (a separate MessagePack custom-type limitation). The from exclusion is
+   // the same one-line change and is read-tested in the BEVE/CBOR/YAML suites.
+   "fully custom variant specialization is unambiguous"_test = [] {
+      mp_fc_variant v{};
+      std::string s{};
+      expect(not glz::write_msgpack(v, s));
+   };
+
    "msgpack primitive roundtrip"_test = [] {
       expect_roundtrip_equal(int8_t{-8});
       expect_roundtrip_equal(int32_t{123456});

--- a/tests/toml_test/toml_test.cpp
+++ b/tests/toml_test/toml_test.cpp
@@ -5578,4 +5578,39 @@ count = 11)";
    };
 };
 
+// A std::variant whose own meta opts into custom_read/custom_write (with full from/to
+// specializations) must not be ambiguous with the built-in TOML variant handler.
+// Parity with the JSON fix in #2591.
+struct toml_fc_a
+{};
+struct toml_fc_b
+{};
+using toml_fc_variant = std::variant<toml_fc_a, toml_fc_b>;
+
+template <>
+struct glz::meta<toml_fc_variant>
+{
+   static constexpr auto custom_read = true;
+   static constexpr auto custom_write = true;
+};
+
+template <uint32_t Format>
+struct glz::to<Format, toml_fc_variant>
+{
+   template <auto Opts>
+   static void op(auto&&, glz::is_context auto&& ctx, auto&&... args)
+   {
+      glz::serialize<Format>::template op<Opts>(42, ctx, args...);
+   }
+};
+
+suite toml_fully_custom_variant_tests = [] {
+   "fully custom variant specialization is unambiguous"_test = [] {
+      toml_fc_variant v{};
+      std::string s{};
+      expect(not glz::write_toml(v, s));
+      expect(s == "42") << s;
+   };
+};
+
 int main() { return 0; }

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -9653,4 +9653,47 @@ suite yaml_tagged_variant_stress_suite = [] {
    };
 };
 
+// A std::variant whose own meta opts into custom_read/custom_write (with full from/to
+// specializations) must not be ambiguous with the built-in YAML variant handler.
+// Parity with the JSON fix in #2591.
+struct yaml_fc_a
+{};
+struct yaml_fc_b
+{};
+using yaml_fc_variant = std::variant<yaml_fc_a, yaml_fc_b>;
+
+template <>
+struct glz::meta<yaml_fc_variant>
+{
+   static constexpr auto custom_read = true;
+   static constexpr auto custom_write = true;
+};
+
+template <uint32_t Format>
+struct glz::from<Format, yaml_fc_variant>
+{
+   template <auto Opts>
+   static void op(yaml_fc_variant&, is_context auto&&, auto&&, auto&&)
+   {}
+};
+
+template <uint32_t Format>
+struct glz::to<Format, yaml_fc_variant>
+{
+   template <auto Opts>
+   static void op(auto&&, is_context auto&& ctx, auto&&... args)
+   {
+      glz::serialize<Format>::template op<Opts>(42, ctx, args...);
+   }
+};
+
+suite yaml_fully_custom_variant_tests = [] {
+   "fully custom variant specialization is unambiguous"_test = [] {
+      yaml_fc_variant v{};
+      std::string s{};
+      expect(not glz::write_yaml(v, s));
+      expect(s == "42") << s;
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
Follow-up to #2591, extending part of that fix to the remaining formats.

## Problem

The built-in `is_variant` `to`/`from` handlers for YAML, BEVE, CBOR, MessagePack, and TOML did **not** exclude `custom_read`/`custom_write`, unlike every other built-in handler (and unlike the JSON variant handlers fixed in #2591).

So a `std::variant` whose own `glz::meta` opts into `custom_read`/`custom_write` — the documented way to fully take over a type's (de)serialization — collided with the built-in handler:

```
ambiguous partial specializations of 'to<450, std::variant<...>>'   // YAML (450 = YAML format)
```

This blocked users from providing a custom `to<Format, MyVariant>` / `from<Format, MyVariant>` in any non-JSON format.

## Fix

Constrain the built-in variant handlers with `requires(not custom_write<T>)` / `requires(not custom_read<T>)`, matching the pattern used by all other built-in handlers. One line per handler:

- YAML: `to<YAML,T>`, `from<YAML,T>`
- BEVE: `to<BEVE,T>`, `from<BEVE,T>`
- CBOR: `to<CBOR,T>`, `from<CBOR,T>`
- MessagePack: `to<MSGPACK,T>`, `from<MSGPACK,T>`
- TOML: `to<TOML,T>` (variants are write-only in TOML)

A normal variant (no custom meta) still uses the built-in handler unchanged.

## Tests

Adds a `fully custom variant specialization is unambiguous` regression test to each format's test suite. The MessagePack test is write-only: msgpack passes its type-tag byte positionally to `from::op`, so a generic JSON-style custom `from` signature cannot satisfy it (a separate, pre-existing msgpack custom-type limitation — see below). The `from` exclusion is the same one-line change and is read-tested in the BEVE/CBOR/YAML suites.

Full suite: **95/95 passing**.

## Scope / follow-ups (not in this PR)

- **JSON tag-merge for custom variant *alternatives*** (the larger half of #2591) is **not** ported here. YAML has the analogous gaps — it passes `tag_literal` to a reflectable+custom alternative (compile error at `yaml/read.hpp`) and writes non-reflectable custom alternatives tag-less. That's a substantial, whitespace-sensitive change to YAML's block/flow writer and indent-aware reader, tracked separately.
- **MessagePack does not support custom types in general** (not variant-specific): `from::op` receives the msgpack type-tag byte positionally (`msgpack/read.hpp:215`), which a JSON-style custom `from(value, ctx, …)` can't match. Separate issue.
- BEVE/CBOR encode variants by index (no in-object tag), so custom alternatives already round-trip there — only this ambiguity fix was needed.