### PR TITLE
Guard std::min & std::max calls from minwindef.h defines

### DIFF
--- a/benchmarks/http_benchmark/http_benchmark.cpp
+++ b/benchmarks/http_benchmark/http_benchmark.cpp
@@ -529,7 +529,7 @@ int main()
    static constexpr uint16_t beast_port = 18766;
    static constexpr int batch = 1000;
 
-   const unsigned hw_threads = std::max(1u, std::thread::hardware_concurrency());
+   const unsigned hw_threads = (std::max)(1u, std::thread::hardware_concurrency());
    const int client_threads = static_cast<int>(hw_threads);
 
    const auto plaintext_req = make_get_req("/plaintext");

--- a/benchmarks/skip_ws_benchmark.cpp
+++ b/benchmarks/skip_ws_benchmark.cpp
@@ -576,7 +576,7 @@ int main()
 
          // For matching: record first 8 bytes (or fewer) as the pattern
          // In reality the pattern would be the first line's indent
-         std::string pattern(std::min(sz, size_t(8)), ' ');
+         std::string pattern((std::min)(sz, size_t(8)), ' ');
 
          char label[64];
          std::snprintf(label, sizeof(label), "Contiguous spaces (%zu B)", sz);

--- a/benchmarks/string_write_benchmark.cpp
+++ b/benchmarks/string_write_benchmark.cpp
@@ -162,7 +162,7 @@ static void verify(const char* name, const std::string& input)
                    simd_result.size() > 200 ? "..." : "");
 
       // Find first difference
-      for (size_t i = 0; i < std::min(swar_result.size(), simd_result.size()); ++i) {
+      for (size_t i = 0; i < (std::min)(swar_result.size(), simd_result.size()); ++i) {
          if (swar_result[i] != simd_result[i]) {
             std::fprintf(stderr, "  First diff at byte %zu: SWAR=0x%02X SIMD=0x%02X\n", i,
                          (unsigned char)swar_result[i], (unsigned char)simd_result[i]);

--- a/include/glaze/containers/inplace_vector.hpp
+++ b/include/glaze/containers/inplace_vector.hpp
@@ -415,7 +415,7 @@ namespace glz
                x.set_storage_size(temp_size);
             }
             else {
-               const auto min_size = std::min(storage_size(), x.storage_size());
+               const auto min_size = (std::min)(storage_size(), x.storage_size());
 
                // Swap common elements
                for (size_type i = 0; i < min_size; ++i) std::swap(this->data_ptr()[i], x.data_ptr()[i]);
@@ -849,19 +849,19 @@ namespace glz
          else {
             // General case for non-trivial types
             // First, move elements at the end to their new positions
-            for (size_type i = 0; i < std::min(n, this->storage_size() - pos_idx); ++i) {
+            for (size_type i = 0; i < (std::min)(n, this->storage_size() - pos_idx); ++i) {
                std::construct_at(this->data_ptr() + this->storage_size() + n - 1 - i,
                                  std::move(this->data_ptr()[this->storage_size() - 1 - i]));
             }
 
             // Move the remaining elements that need to be shifted but not constructed
-            for (size_type i = this->storage_size() - std::min(n, this->storage_size() - pos_idx) - 1;
+            for (size_type i = this->storage_size() - (std::min)(n, this->storage_size() - pos_idx) - 1;
                  i >= pos_idx && i < this->storage_size(); --i) {
                this->data_ptr()[i + n] = std::move(this->data_ptr()[i]);
             }
 
             // Destroy elements that will be overwritten
-            for (size_type i = pos_idx; i < std::min(pos_idx + n, this->storage_size()); ++i) {
+            for (size_type i = pos_idx; i < (std::min)(pos_idx + n, this->storage_size()); ++i) {
                std::destroy_at(this->data_ptr() + i);
             }
 
@@ -907,19 +907,19 @@ namespace glz
                // Make space first
                if (pos_idx < this->storage_size()) {
                   // Move elements after position count positions to the right
-                  for (size_type i = 0; i < std::min(count, this->storage_size() - pos_idx); ++i) {
+                  for (size_type i = 0; i < (std::min)(count, this->storage_size() - pos_idx); ++i) {
                      std::construct_at(this->data_ptr() + this->storage_size() + count - 1 - i,
                                        std::move(this->data_ptr()[this->storage_size() - 1 - i]));
                   }
 
                   // Move the remaining elements
-                  for (size_type i = this->storage_size() - std::min(count, this->storage_size() - pos_idx) - 1;
+                  for (size_type i = this->storage_size() - (std::min)(count, this->storage_size() - pos_idx) - 1;
                        i >= pos_idx && i < this->storage_size(); --i) {
                      this->data_ptr()[i + count] = std::move(this->data_ptr()[i]);
                   }
 
                   // Destroy elements that will be overwritten
-                  for (size_type i = pos_idx; i < std::min(pos_idx + count, this->storage_size()); ++i) {
+                  for (size_type i = pos_idx; i < (std::min)(pos_idx + count, this->storage_size()); ++i) {
                      std::destroy_at(this->data_ptr() + i);
                   }
                }
@@ -975,19 +975,19 @@ namespace glz
                // Make space first
                if (pos_idx < this->storage_size()) {
                   // Move elements after position count positions to the right
-                  for (size_type i = 0; i < std::min(count, this->storage_size() - pos_idx); ++i) {
+                  for (size_type i = 0; i < (std::min)(count, this->storage_size() - pos_idx); ++i) {
                      std::construct_at(this->data_ptr() + this->storage_size() + count - 1 - i,
                                        std::move(this->data_ptr()[this->storage_size() - 1 - i]));
                   }
 
                   // Move the remaining elements
-                  for (size_type i = this->storage_size() - std::min(count, this->storage_size() - pos_idx) - 1;
+                  for (size_type i = this->storage_size() - (std::min)(count, this->storage_size() - pos_idx) - 1;
                        i >= pos_idx && i < this->storage_size(); --i) {
                      this->data_ptr()[i + count] = std::move(this->data_ptr()[i]);
                   }
 
                   // Destroy elements that will be overwritten
-                  for (size_type i = pos_idx; i < std::min(pos_idx + count, this->storage_size()); ++i) {
+                  for (size_type i = pos_idx; i < (std::min)(pos_idx + count, this->storage_size()); ++i) {
                      std::destroy_at(this->data_ptr() + i);
                   }
                }

--- a/include/glaze/containers/ordered_map.hpp
+++ b/include/glaze/containers/ordered_map.hpp
@@ -310,7 +310,7 @@ namespace glz
          : values_(alloc), max_load_factor_(default_max_load_factor), hash_(hash), equal_(equal)
       {
          if (bucket_count > 0) {
-            auto bc = round_up_pow2(static_cast<uint32_t>(std::max(bucket_count, size_type(min_bucket_count))));
+            auto bc = round_up_pow2(static_cast<uint32_t>((std::max)(bucket_count, size_type(min_bucket_count))));
             bucket_count_ = bc;
             bucket_mask_ = bc - 1;
             load_threshold_ = static_cast<uint32_t>(static_cast<float>(bc) * max_load_factor_);
@@ -337,8 +337,8 @@ namespace glz
       {
          if (!values_.empty()) {
             auto bc = round_up_pow2(static_cast<uint32_t>(
-               std::max(size_type(min_bucket_count),
-                        static_cast<size_type>(static_cast<float>(values_.size()) / max_load_factor_) + 1)));
+               (std::max)(size_type(min_bucket_count),
+                          static_cast<size_type>(static_cast<float>(values_.size()) / max_load_factor_) + 1)));
             bucket_count_ = bc;
             bucket_mask_ = bc - 1;
             load_threshold_ = static_cast<uint32_t>(static_cast<float>(bc) * max_load_factor_);
@@ -434,8 +434,8 @@ namespace glz
          // Optionally rehash to minimal bucket count
          if (bucket_count_ > 0) {
             auto needed = round_up_pow2(static_cast<uint32_t>(
-               std::max(size_type(min_bucket_count),
-                        static_cast<size_type>(static_cast<float>(values_.size()) / max_load_factor_) + 1)));
+               (std::max)(size_type(min_bucket_count),
+                          static_cast<size_type>(static_cast<float>(values_.size()) / max_load_factor_) + 1)));
             if (needed < bucket_count_) {
                rehash_impl(needed);
             }
@@ -878,8 +878,8 @@ namespace glz
       void rehash(size_type count)
       {
          auto needed = static_cast<size_type>(static_cast<float>(values_.size()) / max_load_factor_) + 1;
-         count = std::max(count, needed);
-         auto bc = round_up_pow2(static_cast<uint32_t>(std::max(count, size_type(min_bucket_count))));
+         count = (std::max)(count, needed);
+         auto bc = round_up_pow2(static_cast<uint32_t>((std::max)(count, size_type(min_bucket_count))));
          if (bc != bucket_count_) {
             rehash_impl(bc);
          }
@@ -889,7 +889,7 @@ namespace glz
       {
          values_.reserve(count);
          auto needed = static_cast<size_type>(static_cast<float>(count) / max_load_factor_) + 1;
-         auto bc = round_up_pow2(static_cast<uint32_t>(std::max(needed, size_type(min_bucket_count))));
+         auto bc = round_up_pow2(static_cast<uint32_t>((std::max)(needed, size_type(min_bucket_count))));
          if (bc > bucket_count_) {
             rehash_impl(bc);
          }

--- a/include/glaze/csv/write.hpp
+++ b/include/glaze/csv/write.hpp
@@ -208,7 +208,7 @@ namespace glz
             // Find maximum column count
             size_t max_cols = 0;
             for (const auto& row : value) {
-               max_cols = std::max(max_cols, row.size());
+               max_cols = (std::max)(max_cols, row.size());
             }
 
             // Write transposed data

--- a/include/glaze/json/patch.hpp
+++ b/include/glaze/json/patch.hpp
@@ -662,7 +662,7 @@ namespace glz
                   const auto& src_arr = src_val;
                   const auto& tgt_arr = std::get<typename GenericType::array_t>(target.data);
 
-                  size_t min_len = std::min(src_arr.size(), tgt_arr.size());
+                  size_t min_len = (std::min)(src_arr.size(), tgt_arr.size());
 
                   // Compare common elements
                   for (size_t i = 0; i < min_len; ++i) {

--- a/include/glaze/net/http_client.hpp
+++ b/include/glaze/net/http_client.hpp
@@ -1304,7 +1304,7 @@ namespace glz
          // don't start worker threads when an io_executor was provided
          if (!async_io_context) return;
 
-         size_t num_threads = std::max(2u, std::thread::hardware_concurrency());
+         size_t num_threads = (std::max)(2u, std::thread::hardware_concurrency());
          worker_threads.reserve(num_threads);
 
          for (size_t i = 0; i < num_threads; ++i) {
@@ -2175,7 +2175,7 @@ namespace glz
                }
 
                response_body.assign(static_cast<const char*>(response_buffer.data().data()),
-                                    std::min(content_length, response_buffer.size()));
+                                    (std::min)(content_length, response_buffer.size()));
             }
 
             response resp;

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -1743,7 +1743,7 @@ namespace glz
             if (colon_pos != std::string_view::npos) {
                std::string_view name_sv = line.substr(0, colon_pos);
                std::string_view value_sv = line.substr(colon_pos + 1);
-               value_sv.remove_prefix(std::min(value_sv.find_first_not_of(" \t"), value_sv.size()));
+               value_sv.remove_prefix((std::min)(value_sv.find_first_not_of(" \t"), value_sv.size()));
                std::string key(name_sv);
                for (auto& c : key) c = ascii_tolower(c);
                headers[std::move(key)] = std::string(value_sv);
@@ -1790,7 +1790,7 @@ namespace glz
 
          if (content_length > 0) {
             conn->request_.body.resize(content_length);
-            const size_t initial_body_size = std::min(content_length, available_body);
+            const size_t initial_body_size = (std::min)(content_length, available_body);
             if (initial_body_size > 0) {
                std::memcpy(conn->request_.body.data(), &conn->read_buf[body_offset], initial_body_size);
             }

--- a/include/glaze/util/buffer_pool.hpp
+++ b/include/glaze/util/buffer_pool.hpp
@@ -98,7 +98,7 @@ namespace glz
       explicit buffer_pool(size_t max_buffers = 1024, size_t max_buffer_size = 1024 * 1024) noexcept
          : max_buffers_(max_buffers), max_buffer_size_(max_buffer_size)
       {
-         buffers_.reserve(std::min(max_buffers, size_t{64})); // Pre-allocate some capacity
+         buffers_.reserve((std::min)(max_buffers, size_t{64})); // Pre-allocate some capacity
       }
 
       // Non-copyable, non-movable (due to mutex and pointers in scoped_buffers)

--- a/include/glaze/util/fast_float.hpp
+++ b/include/glaze/util/fast_float.hpp
@@ -3709,7 +3709,7 @@ fastfloat_really_inline GLZ_FASTFLOAT_CONSTEXPR14 void round(adjusted_mantissa &
   if (-am.power2 >= mantissa_shift) {
     // have a denormal float
     int32_t shift = -am.power2 + 1;
-    cb(am, std::min<int32_t>(shift, 64));
+    cb(am, (std::min<int32_t>)(shift, 64));
     // check for round-up: if rounding-nearest carried us to the hidden bit.
     am.power2 = (am.mantissa <
                  (uint64_t(1) << binary_format<T>::mantissa_explicit_bits()))

--- a/tests/istream_buffer_test/istream_buffer_test.cpp
+++ b/tests/istream_buffer_test/istream_buffer_test.cpp
@@ -34,7 +34,7 @@ class slow_stringbuf : public std::stringbuf
    std::streamsize xsgetn(char* s, std::streamsize n) override
    {
       // Only return up to max_bytes_per_read_ bytes, simulating chunked arrival
-      return std::stringbuf::xsgetn(s, std::min(n, static_cast<std::streamsize>(max_bytes_per_read_)));
+      return std::stringbuf::xsgetn(s, (std::min)(n, static_cast<std::streamsize>(max_bytes_per_read_)));
    }
 };
 
@@ -113,7 +113,7 @@ class pipe_buffer : public std::streambuf
          return 0;
       }
 
-      size_t to_read = std::min(static_cast<size_t>(n), available);
+      size_t to_read = (std::min)(static_cast<size_t>(n), available);
       std::memcpy(s, buffer_.data() + read_pos_, to_read);
       read_pos_ += to_read;
 
@@ -148,7 +148,7 @@ class slow_ostringbuf : public std::stringbuf
       std::streamsize total_written = 0;
       while (total_written < n) {
          ++total_write_calls_;
-         std::streamsize to_write = std::min(n - total_written, static_cast<std::streamsize>(max_bytes_per_write_));
+         std::streamsize to_write = (std::min)(n - total_written, static_cast<std::streamsize>(max_bytes_per_write_));
          auto written = std::stringbuf::xsputn(s + total_written, to_write);
          if (written <= 0) break; // Error case
          total_written += written;
@@ -1249,7 +1249,7 @@ suite async_streaming_tests = [] {
          size_t pos = 0;
          size_t chunk_size = 5;
          while (pos < json.size()) {
-            size_t len = std::min(chunk_size, json.size() - pos);
+            size_t len = (std::min)(chunk_size, json.size() - pos);
             pbuf.write(json.data() + pos, len);
             pos += len;
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
@@ -1287,7 +1287,7 @@ suite async_streaming_tests = [] {
          // Send in variable-sized chunks
          size_t pos = 0;
          while (pos < json.size()) {
-            size_t len = std::min(size_t(7 + (pos % 5)), json.size() - pos); // Varying chunk sizes
+            size_t len = (std::min)(size_t(7 + (pos % 5)), json.size() - pos); // Varying chunk sizes
             pbuf.write(json.data() + pos, len);
             pos += len;
             std::this_thread::sleep_for(std::chrono::milliseconds(5));
@@ -1320,7 +1320,7 @@ suite async_streaming_tests = [] {
          // Send with longer delays between chunks
          size_t pos = 0;
          while (pos < json.size()) {
-            size_t len = std::min(size_t(10), json.size() - pos);
+            size_t len = (std::min)(size_t(10), json.size() - pos);
             pbuf.write(json.data() + pos, len);
             pos += len;
             std::this_thread::sleep_for(std::chrono::milliseconds(15));

--- a/tests/networking_tests/websocket_test/websocket_client_test.cpp
+++ b/tests/networking_tests/websocket_test/websocket_client_test.cpp
@@ -1980,7 +1980,7 @@ void run_integrity_check_server(std::atomic<bool>& server_ready, std::atomic<boo
             std::cerr << "[integrity_server] Invalid message detected! Size=" << message.size() << std::endl;
             // Print hex dump of first 64 bytes for debugging
             std::cerr << "[integrity_server] Hex dump: ";
-            for (size_t i = 0; i < std::min(message.size(), size_t(64)); ++i) {
+            for (size_t i = 0; i < (std::min)(message.size(), size_t(64)); ++i) {
                std::cerr << std::hex << std::setw(2) << std::setfill('0') << (int)(unsigned char)message[i] << " ";
             }
             std::cerr << std::dec << std::endl;

--- a/tests/simple_float_test/simple_float_test.cpp
+++ b/tests/simple_float_test/simple_float_test.cpp
@@ -262,7 +262,7 @@ suite exhaustive_float_tests = [] {
    "exhaustive_float_roundtrip"_test = [] {
       std::cout << "\n=== Exhaustive float roundtrip test (all 2^32 values) ===" << std::endl;
 
-      const unsigned num_threads = std::max(1u, std::thread::hardware_concurrency());
+      const unsigned num_threads = (std::max)(1u, std::thread::hardware_concurrency());
       std::cout << "Using " << num_threads << " threads" << std::endl;
 
       constexpr uint64_t total_values = 0x100000000ULL; // 2^32

--- a/tests/threading_test/threading_test.cpp
+++ b/tests/threading_test/threading_test.cpp
@@ -4,12 +4,14 @@
 #include <algorithm>
 #include <atomic>
 #include <cstdint>
-#include <latch>
+#include <deque>
 #include <limits>
 #include <random>
 #include <thread>
 
-#include "glaze/glaze_exceptions.hpp"
+#include "glaze/beve/read.hpp"
+#include "glaze/beve/write.hpp"
+#include "glaze/json/write.hpp"
 #include "glaze/thread/async_string.hpp"
 #include "glaze/thread/async_vector.hpp"
 #include "glaze/thread/guard.hpp"

--- a/tests/threading_test/threading_test.cpp
+++ b/tests/threading_test/threading_test.cpp
@@ -2,7 +2,9 @@
 // For the license information refer to glaze.hpp
 
 #include <algorithm>
+#include <atomic>
 #include <cstdint>
+#include <latch>
 #include <limits>
 #include <random>
 #include <thread>
@@ -1418,18 +1420,20 @@ suite async_vector_tests = [] {
 
    "thread_safety_mixed"_test = [] {
       glz::async_vector<int> vec;
-      for (int i = 0; i < 100; ++i) {
+      constexpr int initial_size = 100, readers = 5, writers = 5, writes_per_writer = 100;
+
+      for (int i = 0; i < initial_size; ++i) {
          vec.push_back(i);
       }
 
-      std::atomic<bool> stop{false};
+      std::atomic<int> active_writers{writers};
       std::deque<std::thread> threads;
 
       // Reader threads
       std::atomic<size_t> sum = 0;
-      for (int i = 0; i < 5; ++i) {
-         threads.emplace_back([&vec, &stop, &sum]() {
-            while (!stop) {
+      for (int i = 0; i < readers; ++i) {
+         threads.emplace_back([&vec, &active_writers, &sum]() {
+            while (active_writers > 0) {
                for (size_t j = 0; j < vec.size(); ++j) {
                   sum += vec.read()[j];
                }
@@ -1438,25 +1442,23 @@ suite async_vector_tests = [] {
       }
 
       // Writer threads
-      for (int i = 0; i < 5; ++i) {
-         threads.emplace_back([&vec, &stop, i]() {
-            for (int j = 0; j < 100 && !stop; ++j) {
+      for (int i = 0; i < writers; ++i) {
+         threads.emplace_back([&vec, &active_writers, i]() {
+            for (int j = 0; j < writes_per_writer; ++j) {
                vec.push_back(i * 100 + j);
                std::this_thread::sleep_for(std::chrono::milliseconds(1));
             }
+            active_writers--;
          });
       }
-
-      // Let the threads run for a short time
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
-      stop = true;
 
       for (auto& t : threads) {
          t.join();
       }
 
-      // We can't check exact values due to the concurrent nature, but we should have more than we started with
-      expect(vec.size() > 100) << "Vector should have grown during concurrent operations";
+      expect(vec.size() == static_cast<size_t>(initial_size + writers * writes_per_writer))
+         << "Vector should contain all values written by writer threads";
+      expect(sum > 0) << "Reader threads should observe vector contents";
    };
 };
 


### PR DESCRIPTION
This one is trivial, but also a fatal user-facing issue when building on Windows & including `Windows.h` before **some** glaze headers (some headers already use `()` guards). any glaze function compiled into the final target whose headers were included after `Windows.h` and that uses `std::min` or `std::max` without guards will cause the compilation to fail.
fix assumes that not all users are aware of this historical issue and `#define NOMINMAX`, but in any case, there's no point in forcing them to use it

```
[build] C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\shared\minwindef.h(197,29): note: expanded from macro 'min'
[build]   197 | #define min(a,b)            (((a) < (b)) ? (a) : (b))
[build]       |                             ^
[build] In file included from C:\artem\!cpp\proj\src\main.cpp:10:
[build] C:\artem\!cpp\proj\build\_deps\glaze-src\include\glaze/containers/inplace_vector.hpp(852,44): error: expected unqualified-id
[build]   852 |             for (size_type i = 0; i < std::min(n, this->storage_size() - pos_idx); ++i) {
[build]       |                                            ^
...
```