### PR TITLE
Support custom_read/custom_write types as tagged variant alternatives in YAML

### DIFF
--- a/include/glaze/yaml/common.hpp
+++ b/include/glaze/yaml/common.hpp
@@ -77,6 +77,12 @@ namespace glz::yaml
       // Used to distinguish indentless-sequence continuation from next sibling items.
       bool sequence_item_value_context = false;
 
+      // One-shot known indent for the next block mapping. Set by the tagged-variant reader
+      // when handing a custom alternative's body (which sits at the variant's own column,
+      // not nested deeper) to a discover-mode reader such as the map reader. -1 == unset.
+      // Consumed (and reset) by the first parse_block_mapping_loop that observes it.
+      int32_t forced_block_mapping_indent = -1;
+
       // Column of the enclosing block-sequence '-' indicator (-1 when not inside
       // a block sequence item).  Used by plain-scalar multiline folding to decide
       // whether a continuation-line '- ' is a sibling entry (terminate) or plain

--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -77,9 +77,12 @@ namespace glz
 
          // A directive line (%YAML/%TAG/...) is only valid in the document prefix.
          // If parsing stopped before the end and we encounter a directive in the
-         // remaining tail, treat it as malformed stream structure.
+         // remaining tail, treat it as malformed stream structure. This is a document-level
+         // concern, so only enforce it at the document root: a nested call (e.g. a tagged
+         // variant handing a custom alternative its body) is mid-document and its tail
+         // belongs to an enclosing node, not this value.
          if constexpr (!check_partial_read(Opts)) {
-            if (!bool(ctx.error)) {
+            if (!bool(ctx.error) && ctx.current_indent() < 0) {
                auto is_document_start = [&](auto pos) {
                   if (end - pos >= 3 && pos[0] == '-' && pos[1] == '-' && pos[2] == '-') {
                      auto after = pos + 3;
@@ -3256,6 +3259,15 @@ namespace glz
       template <auto Opts, class Ctx, class It, class End, class ProcessEntry>
       void parse_block_mapping_loop(Ctx& ctx, It& it, End end, int32_t mapping_indent, ProcessEntry&& process_entry)
       {
+         // A tagged-variant custom alternative hands its body (at the variant's own column) to a
+         // discover-mode reader. Honor the known indent it published so continuation/dedent are
+         // judged against the outer parent, not the body itself. One-shot: reset on observation.
+         if (ctx.forced_block_mapping_indent >= 0) {
+            if (mapping_indent < 0) {
+               mapping_indent = ctx.forced_block_mapping_indent;
+            }
+            ctx.forced_block_mapping_indent = -1;
+         }
          const int32_t parent_indent = ctx.current_indent();
          const bool discover_indent = (mapping_indent < 0);
          bool first_key = !discover_indent;
@@ -5237,9 +5249,59 @@ namespace glz
                   std::visit(
                      [&](auto&& alt) {
                         using Alt = std::remove_cvref_t<decltype(alt)>;
-                        if constexpr (glaze_object_t<Alt> || reflectable<Alt>) {
+                        if constexpr ((glaze_object_t<Alt> || reflectable<Alt>) && not custom_read<Alt>) {
                            // Parse the mapping into the resolved struct; the tag key is skipped.
                            from<YAML, Alt>::template op<Opts, tag_literal>(alt, ctx, it, end);
+                        }
+                        else if constexpr (custom_read<Alt>) {
+                           // Custom alternatives read the mapping body themselves and cannot skip an
+                           // interior tag key the way reflected objects do, so the tag must be the
+                           // first key (glaze always writes it first). Consume that leading "tag: id"
+                           // entry, then hand the remaining mapping to the custom handler.
+                           if constexpr (yaml::check_flow_context(Opts)) {
+                              ctx.error = error_code::feature_not_supported;
+                              ctx.custom_error_message =
+                                 "custom variant alternatives are not supported in YAML flow style";
+                           }
+                           else {
+                              ctx.scratch.clear();
+                              if (yaml::parse_yaml_key(ctx.scratch, ctx, it, end, false)) {
+                                 if (std::string_view{ctx.scratch} != tag_v<V>) {
+                                    ctx.error = error_code::feature_not_supported;
+                                    ctx.custom_error_message =
+                                       "the tag must be the first key for a custom variant alternative";
+                                 }
+                                 else {
+                                    yaml::skip_inline_ws(it, end);
+                                    if (it == end || *it != ':') {
+                                       ctx.error = error_code::syntax_error;
+                                    }
+                                    else {
+                                       ++it;
+                                       yaml::skip_inline_ws(it, end);
+                                       yaml::skip_unknown_block_value<Opts>(ctx, it, end, mapping_column);
+                                       if (!bool(ctx.error)) {
+                                          // If nothing but trailing whitespace/comments remains, the tag
+                                          // was the whole mapping: leave the alternative default.
+                                          auto probe = it;
+                                          yaml::skip_ws_newlines_comments(probe, end);
+                                          if (probe == end) {
+                                             it = probe;
+                                          }
+                                          else {
+                                             // Publish the mapping's column so the custom handler's block
+                                             // mapping (which would otherwise discover its own indent) reads
+                                             // the remaining entries at the variant's indent and dedents
+                                             // correctly in every context (root, sequence, nested).
+                                             ctx.forced_block_mapping_indent = mapping_column;
+                                             from<YAML, Alt>::template op<Opts>(alt, ctx, it, end);
+                                             ctx.forced_block_mapping_indent = -1;
+                                          }
+                                       }
+                                    }
+                                 }
+                              }
+                           }
                         }
                         else {
                            // Non-object alternative (e.g. std::monostate): the emplaced default is

--- a/include/glaze/yaml/write.hpp
+++ b/include/glaze/yaml/write.hpp
@@ -625,7 +625,10 @@ namespace glz
                      std::visit(
                         [&](auto&& inner) {
                            using inner_t = std::remove_cvref_t<decltype(inner)>;
-                           if constexpr (glaze_object_t<inner_t> || reflectable<inner_t>) {
+                           // not custom_write: a custom alternative that is also reflectable (e.g. a
+                           // non-aggregate class under P2996) must take the custom branch below.
+                           if constexpr ((glaze_object_t<inner_t> || reflectable<inner_t>) &&
+                                         not custom_write<inner_t>) {
                               // Compact form: first key (or the discriminator tag) inline after dash
                               dump(' ', b, ix);
                               if constexpr (check_write_type_info(Opts) && not tag_v<element_t>.empty()) {
@@ -1149,8 +1152,10 @@ namespace glz
             std::visit(
                [&](auto&& inner) {
                   using inner_t = std::remove_cvref_t<decltype(inner)>;
-                  if constexpr ((glaze_object_t<inner_t> || reflectable<inner_t>) && check_write_type_info(Opts) &&
-                                not tag_v<V>.empty()) {
+                  // not custom_write: a custom alternative that is also reflectable (e.g. a
+                  // non-aggregate class under P2996) must take the custom branch below.
+                  if constexpr ((glaze_object_t<inner_t> || reflectable<inner_t>) && not custom_write<inner_t> &&
+                                check_write_type_info(Opts) && not tag_v<V>.empty()) {
                      write_tagged_block_object<Opts, V>(inner, index, ctx, b, ix, indent_level, false);
                   }
                   else if constexpr (custom_write<inner_t> && check_write_type_info(Opts) && not tag_v<V>.empty()) {
@@ -1546,7 +1551,9 @@ namespace glz
             std::visit(
                [&](auto&& v) {
                   using Vt = std::remove_cvref_t<decltype(v)>;
-                  if constexpr (glaze_object_t<Vt> || reflectable<Vt>) {
+                  // not custom_write: a custom alternative that also happens to be reflectable (e.g.
+                  // a non-aggregate class under P2996 reflection) must take the custom branch below.
+                  if constexpr ((glaze_object_t<Vt> || reflectable<Vt>) && not custom_write<Vt>) {
                      if constexpr (yaml::check_flow_style(Opts) || yaml::check_flow_context(Opts)) {
                         yaml::write_tagged_flow_object<Opts, V>(v, index, ctx, b, ix);
                      }

--- a/include/glaze/yaml/write.hpp
+++ b/include/glaze/yaml/write.hpp
@@ -421,6 +421,11 @@ namespace glz
       inline void write_tagged_block_object(T&& inner, size_t index, is_context auto&& ctx, B&& b, auto& ix,
                                             int32_t indent_level, bool skip_first_indent);
 
+      // Forward declaration for custom-alternative tagged-variant block output (needs serialize<YAML>).
+      template <auto Opts, class Variant, class T, class B>
+      inline void write_tagged_block_custom(T&& inner, size_t index, is_context auto&& ctx, B&& b, auto& ix,
+                                            int32_t indent_level, bool skip_first_indent);
+
       // Helper to check if a type is "simple" (writes on same line)
       template <class T>
       consteval bool is_simple_type()
@@ -630,6 +635,13 @@ namespace glz
                               else {
                                  write_block_mapping<Opts>(inner, ctx, b, ix, indent_level + 1, true);
                               }
+                           }
+                           else if constexpr (custom_write<inner_t> && check_write_type_info(Opts) &&
+                                              not tag_v<element_t>.empty()) {
+                              // Custom alternative: discriminator tag inline after the dash, body merged.
+                              dump(' ', b, ix);
+                              write_tagged_block_custom<Opts, element_t>(inner, index, ctx, b, ix, indent_level + 1,
+                                                                         true);
                            }
                            else {
                               if constexpr (writable_map_t<inner_t>) {
@@ -1141,6 +1153,9 @@ namespace glz
                                 not tag_v<V>.empty()) {
                      write_tagged_block_object<Opts, V>(inner, index, ctx, b, ix, indent_level, false);
                   }
+                  else if constexpr (custom_write<inner_t> && check_write_type_info(Opts) && not tag_v<V>.empty()) {
+                     write_tagged_block_custom<Opts, V>(inner, index, ctx, b, ix, indent_level, false);
+                  }
                   else {
                      write_block_mapping_nested<Opts>(inner, ctx, b, ix, indent_level);
                   }
@@ -1385,6 +1400,66 @@ namespace glz
          write_flow_mapping_members<Opts>(inner, ctx, b, ix, first);
          dump('}', b, ix);
       }
+
+      // Write a tagged variant alternative whose body comes from a custom serializer (custom_write).
+      // Like write_tagged_block_object, but the body is produced by serialize<YAML> rather than by
+      // field reflection. The custom serializer is expected to emit an object body (e.g. a map);
+      // it is driven at the variant's own indent so the tag and the body share one mapping.
+      template <auto Opts, class Variant, class T, class B>
+      inline void write_tagged_block_custom(T&& inner, size_t index, is_context auto&& ctx, B&& b, auto& ix,
+                                            int32_t indent_level, bool skip_first_indent)
+      {
+         constexpr uint8_t indent_width = check_indent_width(yaml_opts{});
+         static constexpr sv tag = tag_v<Variant>;
+
+         if (!skip_first_indent) {
+            const int32_t spaces = indent_level * indent_width;
+            if (!ensure_space(ctx, b, ix + spaces + tag.size() + 8)) [[unlikely]] {
+               return;
+            }
+            for (int32_t i = 0; i < spaces; ++i) {
+               b[ix++] = ' ';
+            }
+         }
+         dump(tag, b, ix);
+         dump(": ", b, ix);
+         write_variant_tag_id<Opts, Variant>(index, ctx, b, ix, indent_level);
+         dump('\n', b, ix);
+
+         // The YAML writer threads indentation through explicit parameters, not the context, so a
+         // custom serializer (which can only call serialize<YAML>) always emits its body relative to
+         // column 0. Render the body, then re-indent every line to the mapping's column so the tag
+         // and the body share one block mapping. Relative indentation within the body is preserved.
+         std::string body;
+         size_t body_ix = 0;
+         serialize<YAML>::op<Opts>(inner, ctx, body, body_ix);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+
+         const int32_t spaces = indent_level * indent_width;
+         const std::string_view body_sv{body.data(), body_ix};
+         size_t line_start = 0;
+         while (line_start < body_sv.size()) {
+            const size_t nl = body_sv.find('\n', line_start);
+            const size_t line_end = (nl == std::string_view::npos) ? body_sv.size() : nl;
+            const std::string_view line = body_sv.substr(line_start, line_end - line_start);
+            if (!line.empty()) {
+               if (!ensure_space(ctx, b, ix + size_t(spaces) + line.size() + 2)) [[unlikely]] {
+                  return;
+               }
+               for (int32_t i = 0; i < spaces; ++i) {
+                  b[ix++] = ' ';
+               }
+               dump(line, b, ix);
+            }
+            if (nl == std::string_view::npos) {
+               break;
+            }
+            dump('\n', b, ix);
+            line_start = nl + 1;
+         }
+      }
    } // namespace yaml
 
    // glaze_object_t and reflectable (structs)
@@ -1481,6 +1556,20 @@ namespace glz
                            indent_level = ctx.indent_level;
                         }
                         yaml::write_tagged_block_object<Opts, V>(v, index, ctx, b, ix, indent_level, false);
+                     }
+                  }
+                  else if constexpr (custom_write<Vt>) {
+                     // Custom alternative: merge the tag into the body the custom serializer emits.
+                     if constexpr (yaml::check_flow_style(Opts) || yaml::check_flow_context(Opts)) {
+                        ctx.error = error_code::feature_not_supported;
+                        ctx.custom_error_message = "custom variant alternatives are not supported in YAML flow style";
+                     }
+                     else {
+                        int32_t indent_level = 0;
+                        if constexpr (requires { ctx.indent_level; }) {
+                           indent_level = ctx.indent_level;
+                        }
+                        yaml::write_tagged_block_custom<Opts, V>(v, index, ctx, b, ix, indent_level, false);
                      }
                   }
                   else {

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -9653,4 +9653,152 @@ suite yaml_tagged_variant_stress_suite = [] {
    };
 };
 
+// A tagged-variant alternative that uses custom_read/custom_write and serializes an object body
+// should merge the variant tag into that body and round-trip in block YAML, across root, sequence,
+// struct-field and map-value contexts. Flow style is reported as unsupported.
+namespace yaml_custom_alt_tests
+{
+   struct put_action
+   {
+      std::map<std::string, int>& data() { return m_data; }
+      const std::map<std::string, int>& data() const { return m_data; }
+      bool operator==(const put_action&) const = default;
+
+     private:
+      std::map<std::string, int> m_data{};
+   };
+
+   struct delete_action
+   {
+      std::string note{};
+      bool operator==(const delete_action&) const = default;
+   };
+
+   using action_variant = std::variant<put_action, delete_action>;
+
+   struct action_holder
+   {
+      int id{};
+      action_variant act{};
+      bool operator==(const action_holder&) const = default;
+   };
+}
+
+template <>
+struct glz::meta<yaml_custom_alt_tests::put_action>
+{
+   static constexpr auto custom_read = true;
+   static constexpr auto custom_write = true;
+};
+
+template <uint32_t Format>
+struct glz::from<Format, yaml_custom_alt_tests::put_action>
+{
+   template <auto Opts>
+   static void op(yaml_custom_alt_tests::put_action& value, is_context auto&& ctx, auto&&... args)
+   {
+      glz::parse<Format>::template op<Opts>(value.data(), ctx, args...);
+   }
+};
+
+template <uint32_t Format>
+struct glz::to<Format, yaml_custom_alt_tests::put_action>
+{
+   template <auto Opts>
+   static void op(auto&& value, is_context auto&& ctx, auto&&... args)
+   {
+      glz::serialize<Format>::template op<Opts>(value.data(), ctx, args...);
+   }
+};
+
+template <>
+struct glz::meta<yaml_custom_alt_tests::delete_action>
+{
+   using T = yaml_custom_alt_tests::delete_action;
+   static constexpr auto value = object("note", &T::note);
+};
+
+template <>
+struct glz::meta<yaml_custom_alt_tests::action_variant>
+{
+   static constexpr std::string_view tag = "action";
+   static constexpr auto ids = std::array{"PUT", "DELETE"};
+};
+
+template <>
+struct glz::meta<yaml_custom_alt_tests::action_holder>
+{
+   using T = yaml_custom_alt_tests::action_holder;
+   static constexpr auto value = object("id", &T::id, "act", &T::act);
+};
+
+suite yaml_custom_alternative_variant_tests = [] {
+   using namespace yaml_custom_alt_tests;
+   auto put = [](std::map<std::string, int> m) {
+      put_action p{};
+      p.data() = std::move(m);
+      return p;
+   };
+
+   "custom alternative block round-trips"_test = [&] {
+      action_variant v = put({{"a", 1}, {"b", 2}});
+      std::string s{};
+      expect(not glz::write_yaml(v, s));
+      expect(s == "action: PUT\na: 1\nb: 2\n") << s;
+      action_variant r{};
+      expect(not glz::read_yaml(r, s));
+      expect(r == v);
+   };
+
+   "custom alternative empty body"_test = [&] {
+      action_variant v = put({});
+      std::string s{};
+      expect(not glz::write_yaml(v, s));
+      expect(s == "action: PUT\n") << s;
+      action_variant r{};
+      expect(not glz::read_yaml(r, s));
+      expect(r == v);
+   };
+
+   "custom alternative in a sequence"_test = [&] {
+      std::vector<action_variant> v{put({{"x", 9}}), delete_action{"bye"}, put({})};
+      std::string s{};
+      expect(not glz::write_yaml(v, s));
+      std::vector<action_variant> r{};
+      expect(not glz::read_yaml(r, s));
+      expect(r == v);
+   };
+
+   "custom alternative as a struct field"_test = [&] {
+      action_holder v{5, put({{"k", 7}})};
+      std::string s{};
+      expect(not glz::write_yaml(v, s));
+      action_holder r{};
+      expect(not glz::read_yaml(r, s));
+      expect(r == v);
+   };
+
+   "custom alternative as a map value"_test = [&] {
+      std::map<std::string, action_variant> v{{"first", put({{"a", 1}})}, {"second", delete_action{"hi"}}};
+      std::string s{};
+      expect(not glz::write_yaml(v, s));
+      std::map<std::string, action_variant> r{};
+      expect(not glz::read_yaml(r, s));
+      expect(r == v);
+   };
+
+   "custom alternative requires the tag first"_test = [&] {
+      action_variant r{};
+      const auto ec = glz::read_yaml(r, std::string("a: 1\naction: PUT\n"));
+      expect(ec == glz::error_code::feature_not_supported);
+   };
+
+   "custom alternative errors in flow style"_test = [&] {
+      action_variant v = put({{"a", 1}});
+      std::string s{};
+      const auto ec = glz::write_yaml<glz::yaml::yaml_opts{.flow_style = true}>(v, s);
+      expect(ec == glz::error_code::feature_not_supported);
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
Brings YAML to parity with the JSON tagged-variant support from #2589 / #2591.

## Problem

A `std::variant` alternative that uses `custom_read`/`custom_write` (e.g. one that serializes a `std::map` body) worked in JSON tagged variants after #2591, but YAML had the analogous gaps:

- **Read:** YAML passed the `tag_literal` template parameter to a reflectable+custom alternative (hard compile error at `yaml/read.hpp`), and silently dropped non-reflectable custom alternative bodies.
- **Write:** custom alternatives were written without the discriminator tag, so they did not round-trip.

## Fix

Full round-trip parity for **block** YAML, across root, sequence, struct-field, and map-value contexts.

### Read (`yaml/read.hpp`, `yaml/common.hpp`)
- Exclude `custom_read` alternatives from the object dispatch and add a custom branch: consume the leading `tag: id` entry, then hand the remaining mapping to the custom handler. The tag must be the first key (glaze always writes it first); otherwise emit `feature_not_supported` rather than absorbing the tag into the custom value.
- A custom map body sits at the variant's own column, but the map reader *discovers* its indent and would reject sibling keys as belonging to the parent. A one-shot `yaml_context::forced_block_mapping_indent` publishes the known column; `parse_block_mapping_loop` honors it so continuation/dedent are judged against the outer parent.
- Gate `parse<YAML>`'s document-tail validation on the document root — it's a document-level concern and was firing for nested custom-body parses mid-stream.

### Write (`yaml/write.hpp`)
- Merge the tag for `custom_write` alternatives at all three block dispatch sites (variant `to<>`, `write_block_sequence`, `write_block_mapping_nested`). YAML threads indentation through explicit parameters (not the context), so a custom serializer always emits at column 0; `write_tagged_block_custom` renders the body and re-indents each line to the mapping's column, preserving relative structure.

## Scope: flow style

Flow style (`{action: PUT, ...}`) for a custom alternative is reported as `feature_not_supported`. YAML's map writer can't suppress its own braces to merge a custom body into a flow mapping; block style (the default) has full support. This was an explicit scope decision.

## Example

```yaml
# round-trips both ways now
- action: PUT
  a: 1
  b: 2
- action: DELETE
  note: bye
```

## Tests

Adds a `yaml_custom_alternative_variant_tests` suite: round-trip across root / sequence / struct-field / map-value, empty bodies, the tag-first requirement (`feature_not_supported`), and the flow-style error.

Full suite: **95/95 passing** (yaml_test 657 tests / 2395 asserts), no conformance regressions.

## Notes

- Independent of the cross-format ambiguity fix in #2592 (different code paths); both can land in either order.
- BEVE/CBOR encode variants by index (no in-object tag), so custom alternatives already round-trip there. MessagePack has a separate, pre-existing custom-type limitation (positional type-tag byte), unrelated to variants.