### PR TITLE
Fix WebSocket client handling data received with handshake response

### DIFF
--- a/include/glaze/net/websocket_client.hpp
+++ b/include/glaze/net/websocket_client.hpp
@@ -452,18 +452,9 @@ namespace glz
                                       ws_conn->set_client_mode(true);
                                       ws_conn->set_max_message_size(self->max_message_size);
 
-                                      if (response_buf->size() > 0) {
-                                         std::string_view initial_data{
-                                            static_cast<const char*>(response_buf->data().data()),
-                                            response_buf->size()};
-                                         ws_conn->set_initial_data(initial_data);
-                                      }
-
                                       if (self->on_message && *self->on_message) ws_conn->on_message(*self->on_message);
                                       if (self->on_close && *self->on_close) ws_conn->on_close(*self->on_close);
                                       if (self->on_error && *self->on_error) ws_conn->on_error(*self->on_error);
-
-                                      ws_conn->start_read();
 
                                       {
                                          std::lock_guard<std::mutex> lock(self->connection_mutex);
@@ -471,6 +462,14 @@ namespace glz
                                       }
 
                                       if (self->on_open && *self->on_open) (*self->on_open)();
+
+                                      if (response_buf->size() > 0) {
+                                         std::vector<uint8_t> initial_data(response_buf->size());
+                                         asio::buffer_copy(asio::buffer(initial_data), response_buf->data());
+                                         ws_conn->set_initial_data(std::move(initial_data));
+                                      }
+
+                                      ws_conn->start_read();
                                    });
          }
 

--- a/include/glaze/net/websocket_connection.hpp
+++ b/include/glaze/net/websocket_connection.hpp
@@ -558,9 +558,18 @@ namespace glz
       std::string_view get_close_reason() const override { return close_reason_; }
 
       // Inject initial data read during handshake
-      inline void set_initial_data(std::string_view data)
+      inline void set_initial_data(std::vector<uint8_t> data)
       {
-         frame_buffer_.insert(frame_buffer_.end(), data.begin(), data.end());
+         if (frame_buffer_.empty()) {
+            // Avoid allocations and steal the original buffer if frame_buffer_ is empty
+            frame_buffer_ = std::move(data);
+         }
+         else {
+            // Otherwise, if for some reason the frame_buffer_ is not empty,
+            // append a copy of the initial data to it
+            frame_buffer_.insert(frame_buffer_.end(), data.begin(), data.end());
+         }
+
          size_t consumed = process_frames(frame_buffer_.data(), frame_buffer_.size());
          if (consumed > 0) {
             frame_buffer_.erase(frame_buffer_.begin(), frame_buffer_.begin() + consumed);

--- a/tests/networking_tests/websocket_test/websocket_client_test.cpp
+++ b/tests/networking_tests/websocket_test/websocket_client_test.cpp
@@ -280,6 +280,79 @@ void run_lb_header_handshake_server(std::atomic<bool>& server_ready, std::atomic
    }
 }
 
+// Helper to run a server that sends WebSocket frames in the same TCP segment
+// as the handshake response
+void run_initial_data_handshake_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_stop,
+                                       std::atomic<uint16_t>& selected_port)
+{
+   try {
+      asio::io_context io_ctx;
+      asio::ip::tcp::acceptor acceptor(io_ctx, asio::ip::tcp::endpoint(asio::ip::tcp::v4(), 0));
+      selected_port = acceptor.local_endpoint().port();
+      server_ready = true;
+
+      asio::ip::tcp::socket socket(io_ctx);
+      acceptor.accept(socket);
+
+      asio::streambuf request_buf;
+      asio::error_code ec;
+      asio::read_until(socket, request_buf, "\r\n\r\n", ec);
+      if (ec) return;
+
+      std::istream request_stream(&request_buf);
+      std::string request_line;
+      std::getline(request_stream, request_line);
+
+      std::string websocket_key;
+      std::string header;
+      while (std::getline(request_stream, header) && header != "\r") {
+         if (!header.empty() && header.back() == '\r') header.pop_back();
+
+         auto colon = header.find(':');
+         if (colon == std::string::npos) continue;
+
+         std::string name = header.substr(0, colon);
+         std::string value = header.substr(colon + 1);
+         while (!value.empty() && (value.front() == ' ' || value.front() == '\t')) value.erase(0, 1);
+         while (!value.empty() && (value.back() == ' ' || value.back() == '\t')) value.pop_back();
+
+         if (case_insensitive_equal(name, "Sec-WebSocket-Key")) {
+            websocket_key = std::move(value);
+         }
+      }
+
+      if (websocket_key.empty()) return;
+
+      const std::string accept_key = ws_util::generate_accept_key(websocket_key);
+      const std::string payload = "hello from handshake buffer";
+
+      std::string response =
+         "HTTP/1.1 101 Switching Protocols\r\n"
+         "Upgrade: websocket\r\n"
+         "Connection: Upgrade\r\n"
+         "Sec-WebSocket-Accept: " +
+         accept_key + "\r\n\r\n";
+
+      response.push_back(static_cast<char>(0x81));
+      response.push_back(static_cast<char>(payload.size()));
+      response += payload;
+      response.push_back(static_cast<char>(0x88));
+      response.push_back(static_cast<char>(0x00));
+
+      asio::write(socket, asio::buffer(response), ec);
+      if (ec) return;
+
+      auto stop_at = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+      while (!should_stop && std::chrono::steady_clock::now() < stop_at) {
+         std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      }
+   }
+   catch (const std::exception& e) {
+      std::cerr << "[initial_data_handshake_server] Exception: " << e.what() << "\n";
+      server_ready = true;
+   }
+}
+
 // Helper to run a server that requires an Authorization header in the WebSocket handshake
 void run_auth_websocket_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_stop,
                                std::atomic<uint16_t>& selected_port, const std::string& expected_auth)
@@ -1061,6 +1134,84 @@ suite websocket_client_tests = [] {
       stop_server = true;
       server_thread.join();
    };
+
+   "handshake_buffered_frame_delivery_test"_test = [] {
+      std::atomic<bool> server_ready{false};
+      std::atomic<bool> stop_server{false};
+      std::atomic<uint16_t> port{0};
+
+      std::thread server_thread(run_initial_data_handshake_server, std::ref(server_ready), std::ref(stop_server),
+                                std::ref(port));
+
+      expect(wait_for_condition([&] { return server_ready.load() && port.load() != 0; })) << "Server failed to start";
+
+      websocket_client client;
+      std::atomic<bool> open_called{false};
+      std::atomic<bool> message_received{false};
+      std::atomic<bool> message_before_open{false};
+      std::atomic<bool> close_called{false};
+      std::atomic<bool> error_called{false};
+      std::string received_message;
+      std::mutex received_mu;
+
+      client.on_open([&]() { open_called = true; });
+
+      client.on_message([&](std::string_view message, ws_opcode opcode) {
+         if (!open_called) {
+            message_before_open = true;
+         }
+         if (opcode == ws_opcode::text) {
+            {
+               std::lock_guard lock(received_mu);
+               received_message = std::string(message);
+            }
+            message_received = true;
+         }
+      });
+
+      client.on_close([&](ws_close_code, std::string_view) {
+         close_called = true;
+         client.context()->stop();
+      });
+
+      client.on_error([&](std::error_code ec) {
+         std::cerr << "[handshake_buffered_frame_test] Client Error: " << ec.message() << "\n";
+         error_called = true;
+         client.context()->stop();
+      });
+
+      const std::string client_url = "ws://127.0.0.1:" + std::to_string(port.load()) + "/ws";
+      client.connect(client_url);
+
+      std::thread client_thread([&client]() { client.context()->run(); });
+
+      bool buffered_frames_processed =
+         wait_for_condition([&] { return error_called.load() || (message_received.load() && close_called.load()); });
+
+      expect(buffered_frames_processed) << "Client did not finish processing buffered WebSocket frames";
+      expect(message_received.load()) << "Text frame buffered after the handshake response was not delivered";
+      expect(close_called.load()) << "Close frame buffered after the handshake response was not delivered";
+      expect(open_called.load()) << "on_open should fire before processing buffered WebSocket frames";
+      expect(!message_before_open.load()) << "Buffered message was delivered before on_open";
+      expect(!error_called.load()) << "Handshake and buffered frames should not produce an error";
+
+      {
+         std::lock_guard lock(received_mu);
+         expect(received_message == "hello from handshake buffer")
+            << "Unexpected buffered message payload: " << received_message;
+      }
+
+      if (!client.context()->stopped()) {
+         client.context()->stop();
+      }
+      if (client_thread.joinable()) {
+         client_thread.join();
+      }
+
+      stop_server = true;
+      server_thread.join();
+   };
+
    "custom_handshake_header_auth_test"_test = [] {
       std::atomic<bool> server_ready{false};
       std::atomic<bool> stop_server{false};


### PR DESCRIPTION
## Main Issue
The main issue is that Glaze currently invoking `ws_conn->set_initial_data` **before** the user callbacks are set up, and it leads to:
```
1. set_initial_data
2. process_frames
3. handle_frame
4. dispatch_message {
     if (client_message_handler_) {
       client_message_handler_(...)
     }
   }
```
which expects message callback to already be installed.
This caused the message received as a result of reading data from the socket after the double-CRLF delimiter to be completely lost.

I also fixed an issue with reading the remaining data from `asio::streambuf`, which, in the current Asio implementation wasn't actually a bug, but according to the contract, Asio states that this approach should be avoided. The current `asio::basic_streambuf` implementation uses a single contiguous char array, but the class's API contract is designed for multiple buffer segments (which is why `.data` returns a `ConstBufferSequence` rather than for example a `std::span`), and if tomorrow Asio decides to implement `basic_streambuf` differently, the current code for reading the remaining data from `response_buf` may encounter some problems, since it relies on there being a single buffer segment left in `response_buf`, but this is not guaranteed by the asio API.

I also changed the signature of `set_initial_data` to accept a `std::vector<uint8_t>` to avoid copying the received data twice (via `asio::buffer_copy` and `frame_buffer_.insert()`). I replaced `std::string_view` with `std::vector<uint8_t>` specifically because using `std::string` makes moving impossible due to the different `value_type` inside the `frame_buffer_` and `data` iterators.

## Part that requires a review
I also fixed one issue that seemed wrong to me, but I can't be sure that it isn't part of the API design. It seemed strange to me that the read loop (`start_read`) is started before `on_open` was called. Couldn't this create a problem where the user's message callback might be called before the `on_open` callback, leading to an unobvious API?