### PR TITLE
RFC 6455: fix WebSocket close frame validation

### DIFF
--- a/include/glaze/net/websocket_connection.hpp
+++ b/include/glaze/net/websocket_connection.hpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
-#include <chrono>
 #include <cstring>
 #include <deque>
 #include <functional>
@@ -16,6 +15,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 // Optional OpenSSL support - detected at compile time
@@ -49,7 +49,10 @@ namespace glz
       policy_violation = 1008,
       message_too_big = 1009,
       mandatory_extension = 1010,
-      internal_error = 1011
+      internal_error = 1011,
+      service_restart = 1012,
+      try_again_later = 1013,
+      bad_gateway = 1014,
    };
 
    // WebSocket frame header helper
@@ -188,6 +191,27 @@ namespace glz
          }
       }
 #endif
+
+      inline bool is_valid_close_code(uint16_t code)
+      {
+         switch (static_cast<ws_close_code>(code)) {
+         case ws_close_code::normal:
+         case ws_close_code::going_away:
+         case ws_close_code::protocol_error:
+         case ws_close_code::unsupported_data:
+         case ws_close_code::invalid_payload:
+         case ws_close_code::policy_violation:
+         case ws_close_code::message_too_big:
+         case ws_close_code::mandatory_extension:
+         case ws_close_code::internal_error:
+         case ws_close_code::service_restart:
+         case ws_close_code::try_again_later:
+         case ws_close_code::bad_gateway:
+            return true;
+         }
+
+         return code >= 3000 && code <= 4999;
+      }
 
       // Generate WebSocket accept key from client key
       inline std::string generate_accept_key(std::string_view client_key)
@@ -851,17 +875,47 @@ namespace glz
          // send a Close frame, the endpoint MUST send a Close frame in response."
          // https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.1
          case ws_opcode::close: {
-            ws_close_code code = ws_close_code::normal;
+            uint16_t code_value = static_cast<uint16_t>(ws_close_code::normal);
             std::string reason;
 
+            // Based on the RFC sections 5.5 and 5.5.1, the payload length of a
+            // close frame can be either 0 (no close code) or >= 2 && <= 125.
+            // RFC 6455 Section 5.5: "All control frames MUST have a payload length of 125
+            // bytes or less and MUST NOT be fragmented."
+            //
+            // RFC 6455 Section 5.5.1: "If there is a body, the first two bytes of
+            // the body MUST be a 2-byte unsigned integer ..."
+            if (length > 125 || length == 1) {
+               fail_connection(ws_close_code::protocol_error, "Invalid close payload length");
+               return;
+            }
+
             if (length >= 2) {
-               code = static_cast<ws_close_code>((payload[0] << 8) | payload[1]);
+               code_value = static_cast<uint16_t>((payload[0] << 8) | payload[1]);
                if (length > 2) {
                   reason = std::string(reinterpret_cast<const char*>(payload + 2), length - 2);
                }
             }
 
+            // The RFC 6455 does not explicitly mention the validation of close codes, but it is expected
+            // that this will be evident from a combination of several requirements:
+            // 1. Section 5.5.1: "the first two bytes of the body MUST be a 2-byte unsigned integer".
+            // 2. Section 7.4 clearly specifies which status codes exist and which ranges are allowed.
+            // 2. Section 10.7: "Incoming data MUST always be validated by both clients and servers".
+            if (!ws_util::is_valid_close_code(code_value)) {
+               fail_connection(ws_close_code::protocol_error, "Invalid close code");
+               return;
+            }
+
+            // RFC 6455 Section 5.5.1: "Following the 2-byte integer, the body MAY contain
+            // UTF-8-encoded data with value /reason/"
+            if (!reason.empty() && !glz::validate_utf8(reason.c_str(), reason.size())) {
+               fail_connection(ws_close_code::invalid_payload, "Invalid close reason");
+               return;
+            }
+
             // Store close code and reason for callback
+            auto code = static_cast<ws_close_code>(code_value);
             close_code_ = code;
             close_reason_ = std::move(reason);
 
@@ -1195,6 +1249,19 @@ namespace glz
                socket_->lowest_layer().close(ec);
                socket_.reset(); // Reset pointer so subsequent checks know socket is closed
             }
+         }
+      }
+
+      inline void fail_connection(ws_close_code close_code, std::string_view close_reason = {})
+      {
+         close_code_ = close_code;
+         close_reason_ = close_reason;
+         bool expected = false;
+         if (is_closing_.compare_exchange_strong(expected, true)) {
+            send_close_frame(close_code, close_reason, true);
+         }
+         else {
+            do_close();
          }
       }
 

--- a/include/glaze/net/websocket_connection.hpp
+++ b/include/glaze/net/websocket_connection.hpp
@@ -798,6 +798,14 @@ namespace glz
 
       inline void handle_frame(ws_opcode opcode, const uint8_t* payload, std::size_t length, bool fin)
       {
+         // RFC 6455 Section 5.5: "All control frames ... MUST NOT be fragmented."
+         // A fragmented control frame (FIN == 0) is a protocol error and the connection must fail.
+         // https://datatracker.ietf.org/doc/html/rfc6455#section-5.5
+         if (!fin && (opcode == ws_opcode::close || opcode == ws_opcode::ping || opcode == ws_opcode::pong)) {
+            fail_connection(ws_close_code::protocol_error, "Fragmented control frame");
+            return;
+         }
+
          switch (opcode) {
          case ws_opcode::text:
          case ws_opcode::binary:
@@ -901,7 +909,7 @@ namespace glz
             // that this will be evident from a combination of several requirements:
             // 1. Section 5.5.1: "the first two bytes of the body MUST be a 2-byte unsigned integer".
             // 2. Section 7.4 clearly specifies which status codes exist and which ranges are allowed.
-            // 2. Section 10.7: "Incoming data MUST always be validated by both clients and servers".
+            // 3. Section 10.7: "Incoming data MUST always be validated by both clients and servers".
             if (!ws_util::is_valid_close_code(code_value)) {
                fail_connection(ws_close_code::protocol_error, "Invalid close code");
                return;

--- a/tests/networking_tests/websocket_test/websocket_client_test.cpp
+++ b/tests/networking_tests/websocket_test/websocket_client_test.cpp
@@ -1,6 +1,7 @@
 #include "glaze/net/websocket_client.hpp"
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <cctype>
 #include <chrono>
@@ -276,6 +277,120 @@ void run_lb_header_handshake_server(std::atomic<bool>& server_ready, std::atomic
    }
    catch (const std::exception& e) {
       std::cerr << "[lb_header_server] Exception: " << e.what() << "\n";
+      server_ready = true;
+   }
+}
+
+// Helper to run a raw server that sends a specific close frame after the
+// WebSocket handshake and records the close frame sent back by the client.
+void run_raw_close_frame_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_stop,
+                                std::atomic<uint16_t>& selected_port, std::vector<uint8_t> close_payload,
+                                std::atomic<bool>& client_close_received, std::atomic<uint16_t>& client_close_code)
+{
+   try {
+      asio::io_context io_ctx;
+      asio::ip::tcp::acceptor acceptor(io_ctx, asio::ip::tcp::endpoint(asio::ip::tcp::v4(), 0));
+      selected_port = acceptor.local_endpoint().port();
+      server_ready = true;
+
+      asio::ip::tcp::socket socket(io_ctx);
+      acceptor.accept(socket);
+
+      asio::streambuf request_buf;
+      asio::error_code ec;
+      asio::read_until(socket, request_buf, "\r\n\r\n", ec);
+      if (ec) return;
+
+      std::istream request_stream(&request_buf);
+      std::string request_line;
+      std::getline(request_stream, request_line);
+
+      std::string websocket_key;
+      std::string header;
+      while (std::getline(request_stream, header) && header != "\r") {
+         if (!header.empty() && header.back() == '\r') header.pop_back();
+
+         auto colon = header.find(':');
+         if (colon == std::string::npos) continue;
+
+         std::string name = header.substr(0, colon);
+         std::string value = header.substr(colon + 1);
+         while (!value.empty() && (value.front() == ' ' || value.front() == '\t')) value.erase(0, 1);
+         while (!value.empty() && (value.back() == ' ' || value.back() == '\t')) value.pop_back();
+
+         if (case_insensitive_equal(name, "Sec-WebSocket-Key")) {
+            websocket_key = std::move(value);
+         }
+      }
+
+      if (websocket_key.empty()) return;
+
+      const std::string accept_key = ws_util::generate_accept_key(websocket_key);
+      std::string response =
+         "HTTP/1.1 101 Switching Protocols\r\n"
+         "Upgrade: websocket\r\n"
+         "Connection: Upgrade\r\n"
+         "Sec-WebSocket-Accept: " +
+         accept_key + "\r\n\r\n";
+
+      asio::write(socket, asio::buffer(response), ec);
+      if (ec) return;
+
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+      std::vector<uint8_t> close_frame;
+      close_frame.reserve(4 + close_payload.size());
+      close_frame.push_back(0x88);
+      if (close_payload.size() < 126) {
+         close_frame.push_back(static_cast<uint8_t>(close_payload.size()));
+      }
+      else {
+         close_frame.push_back(126);
+         close_frame.push_back(static_cast<uint8_t>(close_payload.size() >> 8));
+         close_frame.push_back(static_cast<uint8_t>(close_payload.size() & 0xFF));
+      }
+      close_frame.insert(close_frame.end(), close_payload.begin(), close_payload.end());
+
+      asio::write(socket, asio::buffer(close_frame), ec);
+      if (ec) return;
+
+      auto wait_for_bytes = [&](size_t count) {
+         auto stop_at = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+         while (!should_stop && std::chrono::steady_clock::now() < stop_at) {
+            const auto available = socket.available(ec);
+            if (ec) return false;
+            if (available >= count) return true;
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+         }
+         return false;
+      };
+
+      std::array<uint8_t, 2> frame_header{};
+      if (!wait_for_bytes(frame_header.size())) return;
+      asio::read(socket, asio::buffer(frame_header), ec);
+      if (ec) return;
+
+      const bool is_close_frame = (frame_header[0] & 0x0F) == static_cast<uint8_t>(ws_opcode::close);
+      const bool is_masked = (frame_header[1] & 0x80) != 0;
+      const auto payload_length = static_cast<size_t>(frame_header[1] & 0x7F);
+      if (!is_close_frame || !is_masked || payload_length < 2 || payload_length >= 126) return;
+
+      std::array<uint8_t, 4> mask{};
+      std::vector<uint8_t> payload(payload_length);
+      if (!wait_for_bytes(mask.size() + payload.size())) return;
+
+      asio::read(socket, asio::buffer(mask), ec);
+      if (ec) return;
+      asio::read(socket, asio::buffer(payload), ec);
+      if (ec) return;
+
+      payload[0] ^= mask[0];
+      payload[1] ^= mask[1];
+      client_close_code = static_cast<uint16_t>((payload[0] << 8) | payload[1]);
+      client_close_received = true;
+   }
+   catch (const std::exception& e) {
+      std::cerr << "[raw_close_frame_server] Exception: " << e.what() << "\n";
       server_ready = true;
    }
 }
@@ -667,6 +782,101 @@ suite websocket_client_tests = [] {
 
       stop_server = true;
       server_thread.join();
+   };
+
+   "invalid_server_close_frame_test"_test = [] {
+      auto run_case = [](std::string_view name, std::vector<uint8_t> close_payload, ws_close_code expected_code,
+                         std::string_view expected_reason) {
+         std::atomic<bool> server_ready{false};
+         std::atomic<bool> stop_server{false};
+         std::atomic<uint16_t> port{0};
+         std::atomic<bool> client_close_received{false};
+         std::atomic<uint16_t> client_close_code{0};
+
+         std::thread server_thread(run_raw_close_frame_server, std::ref(server_ready), std::ref(stop_server),
+                                   std::ref(port), std::move(close_payload), std::ref(client_close_received),
+                                   std::ref(client_close_code));
+
+         if (!wait_for_condition([&] { return server_ready.load() && port.load() != 0; })) {
+            expect(false) << name << ": server failed to start";
+            stop_server = true;
+            if (server_thread.joinable()) {
+               server_thread.join();
+            }
+            return;
+         }
+
+         websocket_client client;
+         std::atomic<bool> open_called{false};
+         std::atomic<bool> close_called{false};
+         std::atomic<bool> error_called{false};
+         std::atomic<uint16_t> observed_close_code{0};
+         std::string observed_close_reason;
+         std::mutex close_mu;
+
+         client.on_open([&] { open_called = true; });
+         client.on_message([](std::string_view, ws_opcode) {});
+         client.on_close([&](ws_close_code code, std::string_view reason) {
+            observed_close_code = static_cast<uint16_t>(code);
+            {
+               std::lock_guard lock(close_mu);
+               observed_close_reason = std::string(reason);
+            }
+            close_called = true;
+            client.context()->stop();
+         });
+         client.on_error([&](std::error_code ec) {
+            std::cerr << "[invalid_close_frame_test] Client Error: " << ec.message() << "\n";
+            error_called = true;
+            client.context()->stop();
+         });
+
+         const std::string client_url = "ws://127.0.0.1:" + std::to_string(port.load()) + "/ws";
+         client.connect(client_url);
+
+         std::thread client_thread([&client]() { client.context()->run(); });
+
+         const bool completed = wait_for_condition(
+            [&] { return error_called.load() || (close_called.load() && client_close_received.load()); });
+
+         expect(completed) << name << ": client did not complete invalid close handling";
+         expect(open_called.load()) << name << ": client did not open before receiving close frame";
+         expect(!error_called.load()) << name << ": invalid close frame should complete through on_close";
+         expect(close_called.load()) << name << ": on_close was not called";
+         expect(observed_close_code.load() == static_cast<uint16_t>(expected_code))
+            << name << ": unexpected local close code";
+         expect(client_close_received.load()) << name << ": client did not send close frame response";
+         expect(client_close_code.load() == static_cast<uint16_t>(expected_code))
+            << name << ": unexpected close response code";
+
+         {
+            std::lock_guard lock(close_mu);
+            expect(observed_close_reason == expected_reason)
+               << name << ": unexpected local close reason: " << observed_close_reason;
+         }
+
+         if (!client.context()->stopped()) {
+            client.context()->stop();
+         }
+         if (client_thread.joinable()) {
+            client_thread.join();
+         }
+
+         stop_server = true;
+         if (server_thread.joinable()) {
+            server_thread.join();
+         }
+      };
+
+      run_case("invalid close payload length", {0x03}, ws_close_code::protocol_error, "Invalid close payload length");
+      std::vector<uint8_t> oversized_close_payload(126, 'x');
+      oversized_close_payload[0] = 0x03;
+      oversized_close_payload[1] = 0xE8;
+      run_case("oversized close payload", std::move(oversized_close_payload), ws_close_code::protocol_error,
+               "Invalid close payload length");
+      run_case("invalid close code", {0x03, 0xED}, ws_close_code::protocol_error, "Invalid close code");
+      run_case("invalid close reason", {0x03, 0xE8, 0xC3, 0x28}, ws_close_code::invalid_payload,
+               "Invalid close reason");
    };
 
    "multiple_clients_shared_context_test"_test = [] {

--- a/tests/networking_tests/websocket_test/websocket_client_test.cpp
+++ b/tests/networking_tests/websocket_test/websocket_client_test.cpp
@@ -285,7 +285,8 @@ void run_lb_header_handshake_server(std::atomic<bool>& server_ready, std::atomic
 // WebSocket handshake and records the close frame sent back by the client.
 void run_raw_close_frame_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_stop,
                                 std::atomic<uint16_t>& selected_port, std::vector<uint8_t> close_payload,
-                                std::atomic<bool>& client_close_received, std::atomic<uint16_t>& client_close_code)
+                                std::atomic<bool>& client_close_received, std::atomic<uint16_t>& client_close_code,
+                                uint8_t frame_first_byte)
 {
    try {
       asio::io_context io_ctx;
@@ -340,7 +341,7 @@ void run_raw_close_frame_server(std::atomic<bool>& server_ready, std::atomic<boo
 
       std::vector<uint8_t> close_frame;
       close_frame.reserve(4 + close_payload.size());
-      close_frame.push_back(0x88);
+      close_frame.push_back(frame_first_byte);
       if (close_payload.size() < 126) {
          close_frame.push_back(static_cast<uint8_t>(close_payload.size()));
       }
@@ -786,7 +787,7 @@ suite websocket_client_tests = [] {
 
    "invalid_server_close_frame_test"_test = [] {
       auto run_case = [](std::string_view name, std::vector<uint8_t> close_payload, ws_close_code expected_code,
-                         std::string_view expected_reason) {
+                         std::string_view expected_reason, uint8_t frame_first_byte = 0x88) {
          std::atomic<bool> server_ready{false};
          std::atomic<bool> stop_server{false};
          std::atomic<uint16_t> port{0};
@@ -795,7 +796,7 @@ suite websocket_client_tests = [] {
 
          std::thread server_thread(run_raw_close_frame_server, std::ref(server_ready), std::ref(stop_server),
                                    std::ref(port), std::move(close_payload), std::ref(client_close_received),
-                                   std::ref(client_close_code));
+                                   std::ref(client_close_code), frame_first_byte);
 
          if (!wait_for_condition([&] { return server_ready.load() && port.load() != 0; })) {
             expect(false) << name << ": server failed to start";
@@ -877,6 +878,10 @@ suite websocket_client_tests = [] {
       run_case("invalid close code", {0x03, 0xED}, ws_close_code::protocol_error, "Invalid close code");
       run_case("invalid close reason", {0x03, 0xE8, 0xC3, 0x28}, ws_close_code::invalid_payload,
                "Invalid close reason");
+      // RFC 6455 Section 5.5: control frames MUST NOT be fragmented. First byte 0x08 is a close
+      // opcode with FIN cleared, which must fail the connection with a protocol error.
+      run_case("fragmented control frame", {0x03, 0xE8}, ws_close_code::protocol_error, "Fragmented control frame",
+               0x08);
    };
 
    "multiple_clients_shared_context_test"_test = [] {


### PR DESCRIPTION
Currently, Glaze does not validate incoming WebSocket close frames, which does not fully comply with RFC 6455 (according to Section 10.7, all data validation is a MUST requirement).

This PR fixes the following issues:
- Validation of payload length (based on Sections 5.5 and 5.5.1)
- Validation of the incoming close-code, which is a MUST requirement that is not explicitly stated in the RFC, so I can't reference a section for it. I've added a comment with explanation in the code for this.
- Validation of the UTF-8 correctness of the incoming close-reason based on 5.5.1.

I've added `fail_connection` because, from what I could tell, the existing `close` function is not entirely suitable for a connection failure, since it waits for a close-frame in response and is intended for a graceful-close, which is probably not the best usecase for a connection failure.