### PR TITLE
cast to uint8_t before cctype calls in parsers

### DIFF
--- a/include/glaze/net/http_client.hpp
+++ b/include/glaze/net/http_client.hpp
@@ -461,7 +461,8 @@ namespace glz
             path = std::string(url.substr(port_end));
          }
 
-         if (!port_str.empty() && !std::all_of(port_str.begin(), port_str.end(), ::isdigit)) {
+         if (!port_str.empty() &&
+             !std::all_of(port_str.begin(), port_str.end(), [](unsigned char c) { return std::isdigit(c); })) {
             return std::unexpected(std::make_error_code(std::errc::invalid_argument));
          }
       }

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -1699,8 +1699,9 @@ namespace glz
          }
          std::string_view major_v = version_number.substr(0, dot_pos);
          std::string_view minor_v = version_number.substr(dot_pos + 1);
-         if (major_v.empty() || !std::all_of(major_v.begin(), major_v.end(), ::isdigit) || minor_v.empty() ||
-             !std::all_of(minor_v.begin(), minor_v.end(), ::isdigit)) {
+         const auto is_digit = [](unsigned char c) { return std::isdigit(c); };
+         if (major_v.empty() || !std::all_of(major_v.begin(), major_v.end(), is_digit) || minor_v.empty() ||
+             !std::all_of(minor_v.begin(), minor_v.end(), is_digit)) {
             result.status = parse_status::error;
             send_error_response_with_close(conn, 400, "Bad Request");
             return result;

--- a/include/glaze/net/websocket_connection.hpp
+++ b/include/glaze/net/websocket_connection.hpp
@@ -268,7 +268,10 @@ namespace glz
             // Case-insensitive comparison
             if (token.size() == value.size() &&
                 std::equal(token.begin(), token.end(), value.begin(), value.end(),
-                           [](char a, char b) { return std::tolower(a) == std::tolower(b); })) {
+                           [](char a, char b) {
+                              return std::tolower(static_cast<unsigned char>(a)) ==
+                                     std::tolower(static_cast<unsigned char>(b));
+                           })) {
                return true;
             }
 
@@ -610,7 +613,10 @@ namespace glz
          constexpr std::string_view websocket_str = "websocket";
          if (it == req.headers.end() ||
              !std::equal(it->second.begin(), it->second.end(), websocket_str.begin(), websocket_str.end(),
-                         [](char a, char b) { return std::tolower(a) == std::tolower(b); })) {
+                         [](char a, char b) {
+                            return std::tolower(static_cast<unsigned char>(a)) ==
+                                   std::tolower(static_cast<unsigned char>(b));
+                         })) {
             do_close();
             return;
          }

--- a/include/glaze/toml/read.hpp
+++ b/include/glaze/toml/read.hpp
@@ -211,7 +211,7 @@ namespace glz
       }
       else {
          // Bare key
-         while (it != end && (std::isalnum(*it) || *it == '_' || *it == '-')) {
+         while (it != end && (std::isalnum(static_cast<unsigned char>(*it)) || *it == '_' || *it == '-')) {
             key.push_back(*it);
             ++it;
          }
@@ -288,7 +288,7 @@ namespace glz
             ++it; // skip closing quote
          }
          else {
-            while (it != end && (std::isalnum(*it) || *it == '_' || *it == '-')) {
+            while (it != end && (std::isalnum(static_cast<unsigned char>(*it)) || *it == '_' || *it == '-')) {
                key.push_back(*it);
                ++it;
             }

--- a/include/glaze/yaml/common.hpp
+++ b/include/glaze/yaml/common.hpp
@@ -1150,7 +1150,7 @@ namespace glz::yaml
       }
 
       // Check if it looks like a number
-      if (std::isdigit(first) || first == '-' || first == '+' || first == '.') {
+      if (std::isdigit(static_cast<unsigned char>(first)) || first == '-' || first == '+' || first == '.') {
          return true;
       }
 


### PR DESCRIPTION
    isalnum called with arg = -61

A bare-key byte above 0x7F (here the first byte of UTF-8 'é', 0xC3) reaches `std::isalnum` as a negative int. C requires the argument be representable as `unsigned char` or EOF, so on signed-char targets this is undefined: glibc indexes its classification table out of bounds and MSVC's debug CRT aborts.

The same guard is already applied everywhere else (`http.hpp`, `websocket_client.hpp`, `rpc/registry.hpp`). These eight sites were missed across the TOML, YAML and net parsers, all reachable from untrusted input (TOML bare keys, YAML scalar quoting, HTTP version and URL port validation, WebSocket header tokens).

Before: a plain `char` is handed to the ctype function, so any byte >= 0x80 arrives as a negative value.
After: the argument is cast to `unsigned char` at each site, matching the surrounding code.

No behavioral change for ASCII input. The tradeoff is one cast per call with no measurable cost.
