### PR TITLE
RFC 9112: fix Host authority in HTTP and WebSocket clients

### DIFF
--- a/include/glaze/net/http_client.hpp
+++ b/include/glaze/net/http_client.hpp
@@ -273,7 +273,7 @@ namespace glz
          request_str.append("Host: ");
          request_str.append(url.host);
          if (!is_default_port) {
-            char port_buf[5];
+            char port_buf[8]; // a uint16_t port is at most 5 digits; pad so the sizing does not depend on itoa internals
             auto* end = glz::to_chars(port_buf, url.port);
             request_str.push_back(':');
             request_str.append(port_buf, static_cast<size_t>(end - port_buf));

--- a/include/glaze/net/http_client.hpp
+++ b/include/glaze/net/http_client.hpp
@@ -24,6 +24,7 @@
 #include "glaze/ext/glaze_asio.hpp"
 #include "glaze/net/http_router.hpp"
 #include "glaze/util/env.hpp"
+#include "glaze/util/itoa.hpp"
 #include "glaze/util/key_transformers.hpp"
 
 #ifdef GLZ_ENABLE_SSL
@@ -257,34 +258,42 @@ namespace glz
       // buffer once, so the async chain (and retry) can share it without re-copying the
       // body or re-iterating the headers map. For large idempotent PUT bodies this is
       // the difference between O(1) and O(N) body copies per request through the chain.
-      inline std::string build_http_request_bytes(const std::string& method, const url_parts& url,
+      inline std::string build_http_request_bytes(const std::string& method, const url_parts& url, bool use_https,
                                                   const std::string& body,
                                                   const std::unordered_map<std::string, std::string>& headers)
       {
-         std::string s;
-         s.reserve(512 + body.size());
-         s.append(method);
-         s.append(" ");
-         s.append(url.path);
-         s.append(" HTTP/1.1\r\n");
-         s.append("Host: ");
-         s.append(url.host);
-         s.append("\r\n");
-         s.append("Connection: keep-alive\r\n");
+         const bool is_default_port = (!use_https && url.port == 80) || (use_https && url.port == 443);
+
+         std::string request_str;
+         request_str.reserve(512 + body.size());
+         request_str.append(method);
+         request_str.append(" ");
+         request_str.append(url.path);
+         request_str.append(" HTTP/1.1\r\n");
+         request_str.append("Host: ");
+         request_str.append(url.host);
+         if (!is_default_port) {
+            char port_buf[5];
+            auto* end = glz::to_chars(port_buf, url.port);
+            request_str.push_back(':');
+            request_str.append(port_buf, static_cast<size_t>(end - port_buf));
+         }
+         request_str.append("\r\n");
+         request_str.append("Connection: keep-alive\r\n");
          if (!body.empty()) {
-            s.append("Content-Length: ");
-            s.append(std::to_string(body.size()));
-            s.append("\r\n");
+            request_str.append("Content-Length: ");
+            request_str.append(std::to_string(body.size()));
+            request_str.append("\r\n");
          }
          for (const auto& [name, value] : headers) {
-            s.append(name);
-            s.append(": ");
-            s.append(value);
-            s.append("\r\n");
+            request_str.append(name);
+            request_str.append(": ");
+            request_str.append(value);
+            request_str.append("\r\n");
          }
-         s.append("\r\n");
-         s.append(body);
-         return s;
+         request_str.append("\r\n");
+         request_str.append(body);
+         return request_str;
       }
 
 #ifdef GLZ_ENABLE_SSL
@@ -1499,35 +1508,10 @@ namespace glz
                                http_error_handler on_error, http_connect_handler on_connect,
                                http_disconnect_handler on_disconnect)
       {
-         std::string request_str;
-         request_str.reserve(512 + body.size());
+         const bool use_https = url.protocol == "https";
 
-         request_str.append(method);
-         request_str.append(" ");
-         request_str.append(url.path);
-         request_str.append(" HTTP/1.1\r\n");
-         request_str.append("Host: ");
-         request_str.append(url.host);
-         request_str.append("\r\n");
-         // Use keep-alive to allow the connection to be pooled
-         request_str.append("Connection: keep-alive\r\n");
-
-         if (!body.empty()) {
-            request_str.append("Content-Length: ");
-            request_str.append(std::to_string(body.size()));
-            request_str.append("\r\n");
-         }
-
-         for (const auto& [name, value] : headers) {
-            request_str.append(name);
-            request_str.append(": ");
-            request_str.append(value);
-            request_str.append("\r\n");
-         }
-         request_str.append("\r\n");
-         request_str.append(body);
-
-         auto request_buffer = std::make_shared<std::string>(std::move(request_str));
+         auto request_buffer =
+            std::make_shared<std::string>(detail::build_http_request_bytes(method, url, use_https, body, headers));
 
          std::visit(
             [&, this](auto& sock) {
@@ -1883,7 +1867,7 @@ namespace glz
 
          // Build the wire bytes once. If retry fires, the same bytes are written on
          // the fresh socket: no rebuild, no extra body copy.
-         const std::string request_str = detail::build_http_request_bytes(method, url, body, headers);
+         const std::string request_str = detail::build_http_request_bytes(method, url, use_https, body, headers);
 
          auto attempt = perform_sync_request_attempt(url, request_str, use_https, std::move(acquired.socket));
 
@@ -2226,7 +2210,7 @@ namespace glz
          // retry, and by every async lambda capture in the chain - those just bump the
          // shared_ptr refcount instead of copying the request body and header map.
          auto request_bytes =
-            std::make_shared<std::string>(detail::build_http_request_bytes(method, url, body, headers));
+            std::make_shared<std::string>(detail::build_http_request_bytes(method, url, use_https, body, headers));
 
          // Non-idempotent methods (POST, PATCH) are never retried because the client
          // cannot tell whether a write+read failure means the server already processed

--- a/include/glaze/net/websocket_client.hpp
+++ b/include/glaze/net/websocket_client.hpp
@@ -354,7 +354,7 @@ namespace glz
 
             std::string host_str = url.host;
             if ((url.protocol == "ws" && url.port != 80) || (url.protocol == "wss" && url.port != 443)) {
-               char port_buf[5];
+               char port_buf[8]; // a uint16_t port is at most 5 digits; pad so the sizing does not depend on itoa internals
                auto* end = glz::to_chars(port_buf, url.port);
                host_str.push_back(':');
                host_str.append(port_buf, static_cast<size_t>(end - port_buf));

--- a/include/glaze/net/websocket_client.hpp
+++ b/include/glaze/net/websocket_client.hpp
@@ -7,11 +7,13 @@
 #include <memory>
 #include <mutex>
 #include <random>
+#include <string>
 #include <variant>
 #include <vector>
 
 #include "glaze/net/http_client.hpp"
 #include "glaze/net/websocket_connection.hpp"
+#include "glaze/util/itoa.hpp"
 
 namespace glz
 {
@@ -350,7 +352,15 @@ namespace glz
             for (auto& b : key_bytes) b = static_cast<char>(dist(rng));
             std::string key = glz::write_base64(key_bytes);
 
-            std::string handshake = "GET " + url.path + " HTTP/1.1\r\n" + "Host: " + url.host + "\r\n" +
+            std::string host_str = url.host;
+            if ((url.protocol == "ws" && url.port != 80) || (url.protocol == "wss" && url.port != 443)) {
+               char port_buf[5];
+               auto* end = glz::to_chars(port_buf, url.port);
+               host_str.push_back(':');
+               host_str.append(port_buf, static_cast<size_t>(end - port_buf));
+            }
+
+            std::string handshake = "GET " + url.path + " HTTP/1.1\r\n" + "Host: " + host_str + "\r\n" +
                                     "Upgrade: websocket\r\n" + "Connection: Upgrade\r\n" + "Sec-WebSocket-Key: " + key +
                                     "\r\n" + "Sec-WebSocket-Version: 13\r\n";
 

--- a/tests/networking_tests/http_client_test/http_client_test.cpp
+++ b/tests/networking_tests/http_client_test/http_client_test.cpp
@@ -1377,6 +1377,78 @@ class eof_delimited_server
    uint16_t port_{0};
 };
 
+class host_header_server
+{
+  public:
+   host_header_server() = default;
+   ~host_header_server() { stop(); }
+
+   bool start()
+   {
+      try {
+         acceptor_ = std::make_unique<asio::ip::tcp::acceptor>(
+            io_, asio::ip::tcp::endpoint(asio::ip::make_address("127.0.0.1"), 0));
+         port_ = acceptor_->local_endpoint().port();
+
+         server_thread_ = std::thread([this]() {
+            try {
+               asio::ip::tcp::socket socket(io_);
+               acceptor_->accept(socket);
+
+               asio::streambuf request_buf;
+               asio::read_until(socket, request_buf, "\r\n\r\n");
+
+               std::istream request_stream(&request_buf);
+               std::string line;
+               std::getline(request_stream, line);
+
+               while (std::getline(request_stream, line) && line != "\r") {
+                  if (!line.empty() && line.back() == '\r') line.pop_back();
+                  if (line.rfind("Host: ", 0) == 0) {
+                     host_header_ = line.substr(6);
+                     break;
+                  }
+               }
+
+               const std::string http_response =
+                  "HTTP/1.1 200 OK\r\n"
+                  "Content-Length: 0\r\n"
+                  "Connection: close\r\n"
+                  "\r\n";
+
+               asio::write(socket, asio::buffer(http_response));
+               socket.shutdown(asio::ip::tcp::socket::shutdown_both);
+               socket.close();
+            }
+            catch (...) {
+            }
+         });
+
+         return true;
+      }
+      catch (...) {
+         return false;
+      }
+   }
+
+   void stop()
+   {
+      if (acceptor_) acceptor_->close();
+      if (server_thread_.joinable()) server_thread_.join();
+   }
+
+   uint16_t port() const { return port_; }
+   std::string base_url() const { return "http://127.0.0.1:" + std::to_string(port_); }
+   const std::string& host_header() const { return host_header_; }
+
+  private:
+   asio::io_context io_;
+   std::unique_ptr<asio::ip::tcp::acceptor> acceptor_;
+   std::thread server_thread_;
+   uint16_t port_{0};
+   std::string host_header_;
+};
+
 suite eof_delimited_tests = [] {
    "sync_eof_delimited_body"_test = [] {
       const std::string expected_body = R"({"name":"Hue Bridge","modelid":"BSB002"})";
@@ -1481,6 +1553,26 @@ suite eof_delimited_tests = [] {
       }
 
       server.stop();
+   };
+};
+
+suite host_header_tests = [] {
+   "http_request_host_header_includes_port"_test = [] {
+      host_header_server server;
+      expect(server.start()) << "Host header server should start";
+
+      glz::http_client client;
+      auto result = client.get(server.base_url() + "/host-header");
+
+      server.stop();
+
+      expect(result.has_value()) << "GET should succeed";
+      if (result.has_value()) {
+         expect(result->status_code == 200) << "Status should be 200";
+      }
+
+      const std::string expected_host = "127.0.0.1:" + std::to_string(server.port());
+      expect(server.host_header() == expected_host) << "Host header should include authority port";
    };
 };
 

--- a/tests/networking_tests/websocket_test/websocket_client_test.cpp
+++ b/tests/networking_tests/websocket_test/websocket_client_test.cpp
@@ -219,7 +219,7 @@ void run_counting_server(std::atomic<bool>& server_ready, std::atomic<bool>& sho
 
 // Helper to run a server that returns a load-balancer-style connection header
 void run_lb_header_handshake_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_stop,
-                                    std::atomic<uint16_t>& selected_port)
+                                    std::atomic<uint16_t>& selected_port, std::string* host_header = nullptr)
 {
    try {
       asio::io_context io_ctx;
@@ -252,7 +252,10 @@ void run_lb_header_handshake_server(std::atomic<bool>& server_ready, std::atomic
          while (!value.empty() && (value.front() == ' ' || value.front() == '\t')) value.erase(0, 1);
          while (!value.empty() && (value.back() == ' ' || value.back() == '\t')) value.pop_back();
 
-         if (case_insensitive_equal(name, "Sec-WebSocket-Key")) {
+         if (host_header && case_insensitive_equal(name, "Host")) {
+            *host_header = value;
+         }
+         else if (case_insensitive_equal(name, "Sec-WebSocket-Key")) {
             websocket_key = std::move(value);
          }
       }
@@ -1305,7 +1308,7 @@ suite websocket_client_tests = [] {
       std::atomic<uint16_t> port{0};
 
       std::thread server_thread(run_lb_header_handshake_server, std::ref(server_ready), std::ref(stop_server),
-                                std::ref(port));
+                                std::ref(port), nullptr);
 
       expect(wait_for_condition([&] { return server_ready.load() && port.load() != 0; })) << "Server failed to start";
 
@@ -1348,6 +1351,59 @@ suite websocket_client_tests = [] {
 
       stop_server = true;
       server_thread.join();
+   };
+
+   "websocket_handshake_host_header_includes_port"_test = [] {
+      std::atomic<bool> server_ready{false};
+      std::atomic<bool> stop_server{false};
+      std::atomic<uint16_t> port{0};
+      std::string host_header;
+
+      std::thread server_thread(run_lb_header_handshake_server, std::ref(server_ready), std::ref(stop_server),
+                                std::ref(port), &host_header);
+
+      expect(wait_for_condition([&] { return server_ready.load() && port.load() != 0; })) << "Server failed to start";
+
+      websocket_client client;
+      std::atomic<bool> open_called{false};
+      std::atomic<bool> error_called{false};
+
+      client.on_open([&]() {
+         open_called = true;
+         client.context()->stop();
+      });
+
+      client.on_message([](std::string_view, ws_opcode) {});
+      client.on_close([](ws_close_code, std::string_view) {});
+
+      client.on_error([&](std::error_code) {
+         error_called = true;
+         client.context()->stop();
+      });
+
+      std::string client_url = "ws://127.0.0.1:" + std::to_string(port.load()) + "/ws";
+      client.connect(client_url);
+
+      std::thread client_thread([&client]() { client.context()->run(); });
+
+      expect(wait_for_condition([&] { return open_called.load() || error_called.load(); }))
+         << "Handshake did not complete";
+      expect(open_called.load()) << "Handshake should succeed";
+      expect(!error_called.load()) << "Handshake should not fail";
+
+      if (!client.context()->stopped()) {
+         client.context()->stop();
+      }
+
+      if (client_thread.joinable()) {
+         client_thread.join();
+      }
+
+      stop_server = true;
+      server_thread.join();
+
+      const std::string expected_host = "127.0.0.1:" + std::to_string(port.load());
+      expect(host_header == expected_host) << "Host header should include authority port";
    };
 
    "handshake_buffered_frame_delivery_test"_test = [] {


### PR DESCRIPTION
[RFC 9112 Section 3.2](https://datatracker.ietf.org/doc/html/rfc9112#section-3.2-5) states: "If the target URI includes an authority component, then a client MUST send a field value for Host that is identical to that authority component...".

In the case of a URI such as "ws://127.0.0.1:3829/ws", the authority will be "127.0.0.1:3829", so this is what should be set in the Host header.

Currently, Glaze HTTP and WebSocket clients can only connect correctly to hosts running on default ports, as [RFC 9110 Section 4.2.3](https://datatracker.ietf.org/doc/html/rfc9110#section-4.2.3-4.1) specifies that omitting the port in the authority when connecting to a default port (80/443) is a normal form.

I also removed a small section of duplicate code in `http_client.hpp http_client::send_stream_request` by reusing the existing `detail::build_http_request_bytes`