### PR TITLE
RFC 6455: reject oversized WebSocket control frames

### DIFF
--- a/include/glaze/net/websocket_connection.hpp
+++ b/include/glaze/net/websocket_connection.hpp
@@ -192,6 +192,11 @@ namespace glz
       }
 #endif
 
+      inline bool is_control_frame(ws_opcode opcode)
+      {
+         return opcode == ws_opcode::close || opcode == ws_opcode::ping || opcode == ws_opcode::pong;
+      }
+
       inline bool is_valid_close_code(uint16_t code)
       {
          switch (static_cast<ws_close_code>(code)) {
@@ -813,8 +818,14 @@ namespace glz
          // RFC 6455 Section 5.5: "All control frames ... MUST NOT be fragmented."
          // A fragmented control frame (FIN == 0) is a protocol error and the connection must fail.
          // https://datatracker.ietf.org/doc/html/rfc6455#section-5.5
-         if (!fin && (opcode == ws_opcode::close || opcode == ws_opcode::ping || opcode == ws_opcode::pong)) {
+         if (!fin && ws_util::is_control_frame(opcode)) [[unlikely]] {
             fail_connection(ws_close_code::protocol_error, "Fragmented control frame");
+            return;
+         }
+
+         // RFC 6455 Section 5.5: "All control frames MUST have a payload length of 125 bytes or less."
+         if (length > 125 && ws_util::is_control_frame(opcode)) [[unlikely]] {
+            fail_connection(ws_close_code::protocol_error, "Invalid control frame payload length");
             return;
          }
 
@@ -900,12 +911,9 @@ namespace glz
 
             // Based on the RFC sections 5.5 and 5.5.1, the payload length of a
             // close frame can be either 0 (no close code) or >= 2 && <= 125.
-            // RFC 6455 Section 5.5: "All control frames MUST have a payload length of 125
-            // bytes or less and MUST NOT be fragmented."
-            //
             // RFC 6455 Section 5.5.1: "If there is a body, the first two bytes of
             // the body MUST be a 2-byte unsigned integer ..."
-            if (length > 125 || length == 1) {
+            if (length == 1) {
                fail_connection(ws_close_code::protocol_error, "Invalid close payload length");
                return;
             }

--- a/tests/networking_tests/websocket_test/websocket_client_test.cpp
+++ b/tests/networking_tests/websocket_test/websocket_client_test.cpp
@@ -354,12 +354,12 @@ void run_initial_data_handshake_server(std::atomic<bool>& server_ready, std::ato
    }
 }
 
-// Helper to run a raw server that sends a specific close frame after the
+// Helper to run a raw server that sends a specific control frame after the
 // WebSocket handshake and records the close frame sent back by the client.
-void run_raw_close_frame_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_stop,
-                                std::atomic<uint16_t>& selected_port, std::vector<uint8_t> close_payload,
-                                std::atomic<bool>& client_close_received, std::atomic<uint16_t>& client_close_code,
-                                uint8_t frame_first_byte)
+void run_raw_control_frame_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_stop,
+                                  std::atomic<uint16_t>& selected_port, std::vector<uint8_t> frame_payload,
+                                  std::atomic<bool>& client_close_received, std::atomic<uint16_t>& client_close_code,
+                                  uint8_t frame_first_byte)
 {
    try {
       asio::io_context io_ctx;
@@ -412,20 +412,20 @@ void run_raw_close_frame_server(std::atomic<bool>& server_ready, std::atomic<boo
 
       std::this_thread::sleep_for(std::chrono::milliseconds(20));
 
-      std::vector<uint8_t> close_frame;
-      close_frame.reserve(4 + close_payload.size());
-      close_frame.push_back(frame_first_byte);
-      if (close_payload.size() < 126) {
-         close_frame.push_back(static_cast<uint8_t>(close_payload.size()));
+      std::vector<uint8_t> control_frame;
+      control_frame.reserve(4 + frame_payload.size());
+      control_frame.push_back(frame_first_byte);
+      if (frame_payload.size() < 126) {
+         control_frame.push_back(static_cast<uint8_t>(frame_payload.size()));
       }
       else {
-         close_frame.push_back(126);
-         close_frame.push_back(static_cast<uint8_t>(close_payload.size() >> 8));
-         close_frame.push_back(static_cast<uint8_t>(close_payload.size() & 0xFF));
+         control_frame.push_back(126);
+         control_frame.push_back(static_cast<uint8_t>(frame_payload.size() >> 8));
+         control_frame.push_back(static_cast<uint8_t>(frame_payload.size() & 0xFF));
       }
-      close_frame.insert(close_frame.end(), close_payload.begin(), close_payload.end());
+      control_frame.insert(control_frame.end(), frame_payload.begin(), frame_payload.end());
 
-      asio::write(socket, asio::buffer(close_frame), ec);
+      asio::write(socket, asio::buffer(control_frame), ec);
       if (ec) return;
 
       auto wait_for_bytes = [&](size_t count) {
@@ -464,7 +464,7 @@ void run_raw_close_frame_server(std::atomic<bool>& server_ready, std::atomic<boo
       client_close_received = true;
    }
    catch (const std::exception& e) {
-      std::cerr << "[raw_close_frame_server] Exception: " << e.what() << "\n";
+      std::cerr << "[raw_control_frame_server] Exception: " << e.what() << "\n";
       server_ready = true;
    }
 }
@@ -858,8 +858,8 @@ suite websocket_client_tests = [] {
       server_thread.join();
    };
 
-   "invalid_server_close_frame_test"_test = [] {
-      auto run_case = [](std::string_view name, std::vector<uint8_t> close_payload, ws_close_code expected_code,
+   "invalid_server_control_frame_test"_test = [] {
+      auto run_case = [](std::string_view name, std::vector<uint8_t> frame_payload, ws_close_code expected_code,
                          std::string_view expected_reason, uint8_t frame_first_byte = 0x88) {
          std::atomic<bool> server_ready{false};
          std::atomic<bool> stop_server{false};
@@ -867,8 +867,8 @@ suite websocket_client_tests = [] {
          std::atomic<bool> client_close_received{false};
          std::atomic<uint16_t> client_close_code{0};
 
-         std::thread server_thread(run_raw_close_frame_server, std::ref(server_ready), std::ref(stop_server),
-                                   std::ref(port), std::move(close_payload), std::ref(client_close_received),
+         std::thread server_thread(run_raw_control_frame_server, std::ref(server_ready), std::ref(stop_server),
+                                   std::ref(port), std::move(frame_payload), std::ref(client_close_received),
                                    std::ref(client_close_code), frame_first_byte);
 
          if (!wait_for_condition([&] { return server_ready.load() && port.load() != 0; })) {
@@ -900,7 +900,7 @@ suite websocket_client_tests = [] {
             client.context()->stop();
          });
          client.on_error([&](std::error_code ec) {
-            std::cerr << "[invalid_close_frame_test] Client Error: " << ec.message() << "\n";
+            std::cerr << "[invalid_control_frame_test] Client Error: " << ec.message() << "\n";
             error_called = true;
             client.context()->stop();
          });
@@ -913,9 +913,9 @@ suite websocket_client_tests = [] {
          const bool completed = wait_for_condition(
             [&] { return error_called.load() || (close_called.load() && client_close_received.load()); });
 
-         expect(completed) << name << ": client did not complete invalid close handling";
-         expect(open_called.load()) << name << ": client did not open before receiving close frame";
-         expect(!error_called.load()) << name << ": invalid close frame should complete through on_close";
+         expect(completed) << name << ": client did not complete invalid control frame handling";
+         expect(open_called.load()) << name << ": client did not open before receiving control frame";
+         expect(!error_called.load()) << name << ": invalid control frame should complete through on_close";
          expect(close_called.load()) << name << ": on_close was not called";
          expect(observed_close_code.load() == static_cast<uint16_t>(expected_code))
             << name << ": unexpected local close code";
@@ -942,15 +942,22 @@ suite websocket_client_tests = [] {
          }
       };
 
-      run_case("invalid close payload length", {0x03}, ws_close_code::protocol_error, "Invalid close payload length");
-      std::vector<uint8_t> oversized_close_payload(126, 'x');
-      oversized_close_payload[0] = 0x03;
-      oversized_close_payload[1] = 0xE8;
-      run_case("oversized close payload", std::move(oversized_close_payload), ws_close_code::protocol_error,
+      run_case("invalid close payload length", {0x03}, ws_close_code::protocol_error,
                "Invalid close payload length");
       run_case("invalid close code", {0x03, 0xED}, ws_close_code::protocol_error, "Invalid close code");
       run_case("invalid close reason", {0x03, 0xE8, 0xC3, 0x28}, ws_close_code::invalid_payload,
                "Invalid close reason");
+
+      std::vector<uint8_t> oversized_close_payload(126, 'x');
+      oversized_close_payload[0] = 0x03;
+      oversized_close_payload[1] = 0xE8;
+      run_case("oversized close payload", std::move(oversized_close_payload), ws_close_code::protocol_error,
+               "Invalid control frame payload length");
+      run_case("oversized ping payload", std::vector<uint8_t>(126, 'x'), ws_close_code::protocol_error,
+               "Invalid control frame payload length", 0x89);
+      run_case("oversized pong payload", std::vector<uint8_t>(126, 'x'), ws_close_code::protocol_error,
+               "Invalid control frame payload length", 0x8A);
+
       // RFC 6455 Section 5.5: control frames MUST NOT be fragmented. First byte 0x08 is a close
       // opcode with FIN cleared, which must fail the connection with a protocol error.
       run_case("fragmented control frame", {0x03, 0xE8}, ws_close_code::protocol_error, "Fragmented control frame",


### PR DESCRIPTION
As described in [RFC 6455 Section 5.5](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5): "All control frames MUST have a payload length of 125 bytes or less and MUST NOT be fragmented.", currently only close frame payload length is validated, but ping frame with length >125 is still considered valid.