### PR TITLE
Fix streaming buffer refill when skipping unknown keys

### DIFF
--- a/include/glaze/json/skip.hpp
+++ b/include/glaze/json/skip.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "glaze/core/streaming_state.hpp"
 #include "glaze/util/parse.hpp"
 
 namespace glz
@@ -180,6 +181,128 @@ namespace glz
       }
    }
 
+   // Streaming-aware value skip. The fixed-position skip routines error with
+   // unexpected_end when a value extends past the current buffer, so when a
+   // streaming context is active we instead scan character by character,
+   // refilling the input buffer whenever it runs dry. String, escape, and
+   // nesting state is tracked across refills, so skipped values may be
+   // arbitrarily larger than the buffer (e.g. unknown keys holding large arrays).
+   // Skipped bytes are consumed and not validated, matching the non-validating
+   // skip path. After this returns, the caller's `end` may be stale; callers
+   // resynchronize iterators at their streaming refill checkpoints.
+   template <auto Opts>
+      requires(not Opts.comments)
+   void skip_value_streaming(is_context auto&& ctx, auto&& it, auto end) noexcept
+   {
+      const auto refill = [&]() -> bool {
+         const size_t consumed = static_cast<size_t>(it - ctx.stream.data());
+         const char* new_it;
+         const char* new_end;
+         ctx.stream.consume_and_refill(consumed, new_it, new_end);
+         it = new_it;
+         end = new_end;
+         return it < end;
+      };
+
+      // Skip leading whitespace, refilling as needed
+      while (true) {
+         while (it < end && whitespace_table[uint8_t(*it)]) {
+            ++it;
+         }
+         if (it < end) break;
+         if (!refill()) {
+            ctx.error = error_code::unexpected_end;
+            return;
+         }
+      }
+
+      const char open = *it;
+      if (open == '{' || open == '[') {
+         ++it;
+         size_t depth = 1;
+         bool in_string = false;
+         bool escaped = false;
+         while (depth) {
+            if (it == end) {
+               if (!refill()) {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
+               continue;
+            }
+            const char c = *it;
+            ++it;
+            if (in_string) {
+               if (escaped) {
+                  escaped = false;
+               }
+               else if (c == '\\') {
+                  escaped = true;
+               }
+               else if (c == '"') {
+                  in_string = false;
+               }
+            }
+            else {
+               switch (c) {
+               case '"':
+                  in_string = true;
+                  break;
+               case '{':
+               case '[':
+                  ++depth;
+                  break;
+               case '}':
+               case ']':
+                  --depth;
+                  break;
+               }
+            }
+         }
+      }
+      else if (open == '"') {
+         ++it;
+         bool escaped = false;
+         while (true) {
+            if (it == end) {
+               if (!refill()) {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
+               continue;
+            }
+            const char c = *it;
+            ++it;
+            if (escaped) {
+               escaped = false;
+            }
+            else if (c == '\\') {
+               escaped = true;
+            }
+            else if (c == '"') {
+               break;
+            }
+         }
+      }
+      else {
+         // Numbers and literals (true/false/null): scan until a delimiter.
+         // End of stream also terminates the value.
+         while (true) {
+            if (it == end) {
+               if (!refill()) {
+                  break;
+               }
+               continue;
+            }
+            const char c = *it;
+            if (whitespace_table[uint8_t(c)] || c == ',' || c == '}' || c == ']') {
+               break;
+            }
+            ++it;
+         }
+      }
+   }
+
    // parse_value is used for JSON pointer reading
    // we want the JSON pointer access to not care about trailing whitespace
    // so we use validate_skipped for precise validation and value skipping
@@ -201,6 +324,15 @@ namespace glz
    GLZ_ALWAYS_INLINE void skip_value<JSON>::op(is_context auto&& ctx, auto&& it, auto end) noexcept
    {
       using namespace glz::detail;
+
+      // Validating skips (parse_value/JSON pointer) require the full value in a
+      // contiguous buffer, so streaming refill is not applied there.
+      if constexpr (has_streaming_state<decltype(ctx)> && not check_validate_skipped(Opts)) {
+         if (ctx.stream.enabled()) {
+            skip_value_streaming<Opts>(ctx, it, end);
+            return;
+         }
+      }
 
       if constexpr (not check_validate_skipped(Opts)) {
          if constexpr (not check_ws_handled(Opts)) {

--- a/tests/istream_buffer_test/istream_buffer_test.cpp
+++ b/tests/istream_buffer_test/istream_buffer_test.cpp
@@ -477,6 +477,121 @@ suite json_read_streaming_tests = [] {
    };
 };
 
+// Regression tests for https://github.com/stephenberry/glaze/issues/2609
+// Skipping unknown keys (error_on_unknown_keys = false) must refill the
+// streaming buffer when the skipped value is larger than the buffer.
+suite json_streaming_skip_unknown_tests = [] {
+   "skip unknown array larger than buffer"_test = [] {
+      std::string json = R"({"fill":[)";
+      for (int i = 0; i < 4096; ++i) {
+         json += "0,";
+      }
+      json.back() = ']'; // replace trailing comma
+      json += R"(,"id":7,"name":"after"})";
+      expect(json.size() > 1024u);
+
+      std::istringstream iss(json);
+      glz::istream_buffer<1024> buffer(iss);
+
+      Record r{};
+      auto ec = glz::read_streaming<glz::opts{.error_on_unknown_keys = false}>(r, buffer);
+      expect(!ec) << glz::format_error(ec, json);
+      expect(r.id == 7);
+      expect(r.name == "after");
+   };
+
+   "skip unknown nested object larger than buffer"_test = [] {
+      std::string json = R"({"fill":{)";
+      for (int i = 0; i < 512; ++i) {
+         json += "\"k" + std::to_string(i) + R"(":{"a":[1,2,3],"b":"text"},)";
+      }
+      json.pop_back(); // remove trailing comma
+      json += R"(},"id":3,"name":"nested"})";
+      expect(json.size() > 1024u);
+
+      std::istringstream iss(json);
+      glz::istream_buffer<1024> buffer(iss);
+
+      Record r{};
+      auto ec = glz::read_streaming<glz::opts{.error_on_unknown_keys = false}>(r, buffer);
+      expect(!ec) << glz::format_error(ec, json);
+      expect(r.id == 3);
+      expect(r.name == "nested");
+   };
+
+   "skip unknown string larger than buffer with escapes"_test = [] {
+      std::string json = R"({"fill":")";
+      for (int i = 0; i < 1024; ++i) {
+         json += R"(abc\"\\)";
+      }
+      json += R"(","id":9,"name":"escaped"})";
+      expect(json.size() > 1024u);
+
+      std::istringstream iss(json);
+      glz::istream_buffer<1024> buffer(iss);
+
+      Record r{};
+      auto ec = glz::read_streaming<glz::opts{.error_on_unknown_keys = false}>(r, buffer);
+      expect(!ec) << glz::format_error(ec, json);
+      expect(r.id == 9);
+      expect(r.name == "escaped");
+   };
+
+   "skip unknown array with chunked stream arrival"_test = [] {
+      std::string json = R"({"fill":[)";
+      for (int i = 0; i < 4096; ++i) {
+         json += std::to_string(i) + ",";
+      }
+      json.back() = ']';
+      json += R"(,"id":1,"name":"chunked"})";
+
+      slow_stringbuf sbuf(json, 100); // data arrives 100 bytes at a time
+      std::istream stream(&sbuf);
+      glz::istream_buffer<1024> buffer(stream);
+
+      Record r{};
+      auto ec = glz::read_streaming<glz::opts{.error_on_unknown_keys = false}>(r, buffer);
+      expect(!ec) << glz::format_error(ec, json);
+      expect(r.id == 1);
+      expect(r.name == "chunked");
+   };
+
+   "skip multiple unknown keys spanning refills"_test = [] {
+      std::string big_array = "[";
+      for (int i = 0; i < 2048; ++i) {
+         big_array += "1,";
+      }
+      big_array.back() = ']';
+
+      std::string json = R"({"a":)" + big_array + R"(,"id":5,"b":)" + big_array + R"(,"name":"multi","c":true})";
+
+      std::istringstream iss(json);
+      glz::istream_buffer<1024> buffer(iss);
+
+      Record r{};
+      auto ec = glz::read_streaming<glz::opts{.error_on_unknown_keys = false}>(r, buffer);
+      expect(!ec) << glz::format_error(ec, json);
+      expect(r.id == 5);
+      expect(r.name == "multi");
+   };
+
+   "unterminated unknown value still errors"_test = [] {
+      std::string json = R"({"fill":[)";
+      for (int i = 0; i < 2048; ++i) {
+         json += "0,";
+      }
+      // never closed
+
+      std::istringstream iss(json);
+      glz::istream_buffer<1024> buffer(iss);
+
+      Record r{};
+      auto ec = glz::read_streaming<glz::opts{.error_on_unknown_keys = false}>(r, buffer);
+      expect(bool(ec));
+      expect(ec.ec == glz::error_code::unexpected_end);
+   };
+};
+
 suite json_roundtrip_tests = [] {
    "JSON roundtrip - write to ostream, read from istream"_test = [] {
       ComplexObj original{.id = 42,


### PR DESCRIPTION
Fixes #2609

### Problem

When reading with `error_on_unknown_keys = false` from a streaming input buffer (`glz::read_streaming` with `glz::basic_istream_buffer`), skipping an unknown key's value failed with `unexpected_end` if the value extended past the currently buffered data. The streaming reader has refill checkpoints in the object/array parsing loops, but the skip routines (`skip_until_closed`, `skip_string`, etc.) reached via `parse<JSON>::handle_unknown` had no streaming awareness.

### Fix

- Added `skip_value_streaming<Opts>` in `include/glaze/json/skip.hpp`: a character-level scanner that tracks nesting depth, in-string, and escape state across buffer refills, calling `ctx.stream.consume_and_refill` whenever the buffer runs dry. Skipped values may now be arbitrarily larger than the buffer.
- `skip_value<JSON>::op` dispatches to it when the context has an enabled streaming state. The validating-skip path (`validate_skipped`, used by JSON pointer `parse_value`) is excluded because it returns a span into the buffer that refills would invalidate. Non-streaming parsing and the JSONC overload are untouched.
- Truncated (never-closed) values still correctly report `unexpected_end` at EOF.

### Tests

New `json_streaming_skip_unknown_tests` suite in `tests/istream_buffer_test` covering:
- unknown arrays, nested objects, and escape-heavy strings larger than the buffer
- chunked stream arrival (100 bytes per read)
- multiple unknown keys interleaved with known ones
- unterminated unknown value error case

The reproduction from #2609 now succeeds; it was verified to fail with `unexpected_end` before this change. All `istream_buffer_test` (208) and `json_test` (676) tests pass.