### PR TITLE
Add glz::reflect_array to serialize structs as arrays without enumerating members

### DIFF
--- a/docs/pure-reflection.md
+++ b/docs/pure-reflection.md
@@ -68,7 +68,7 @@ auto out = glz::write_json(p).value();
 
 ### Marking an entire type as a positional array
 
-`glz::as_array` requires a member to wrap, which doesn't help when the array-styled struct appears directly inside a container (e.g. an array of arrays). Use `glz::reflect_array<T>` to mark the type itself as positional, without enumerating its members the way `glz::array(&T::x, &T::y, ...)` requires:
+`glz::as_array` requires a member to wrap, which doesn't help when the array-styled struct appears directly inside a container (e.g. an array of arrays). Use a `glz::reflect_array{}` meta value to mark the type itself as positional, without enumerating its members the way `glz::array(&T::x, &T::y, ...)` requires:
 
 ```c++
 struct Point
@@ -81,7 +81,7 @@ struct Point
 template <>
 struct glz::meta<Point>
 {
-   static constexpr auto value = glz::reflect_array<Point>;
+   static constexpr auto value = glz::reflect_array{};
 };
 
 std::string_view payload = R"([[1,2,"a"],[3,4,"b"]])";
@@ -95,7 +95,7 @@ auto out = glz::write_json(points).value();
 // out == R"([[1,2,"a"],[3,4,"b"]])"
 ```
 
-`glz::reflect_array<T>` generates the same meta as an explicit `glz::array(...)` of all the members in declaration order, so the type behaves as a positional array everywhere, in every Glaze format.
+`glz::reflect_array{}` generates the same meta as an explicit `glz::array(...)` of all the members in declaration order, so the type behaves as a positional array everywhere, in every Glaze format. It also works in a local meta (`struct glaze { static constexpr auto value = glz::reflect_array{}; };`).
 
 > CUSTOMIZATION NOTE:
 >

--- a/docs/pure-reflection.md
+++ b/docs/pure-reflection.md
@@ -66,6 +66,37 @@ auto out = glz::write_json(p).value();
 
 `glz::as_array` relies on the wrapped type's reflection (pure reflection or an explicit `glz::meta`) to map each array element by index. Serialization uses that same order to emit an array, so you get positional reads and writes while the C++ type stays a struct. The wrapper works for JSON, BEVE, CSV, TOML, and any other Glaze format.
 
+### Marking an entire type as a positional array
+
+`glz::as_array` requires a member to wrap, which doesn't help when the array-styled struct appears directly inside a container (e.g. an array of arrays). Use `glz::reflect_array<T>` to mark the type itself as positional, without enumerating its members the way `glz::array(&T::x, &T::y, ...)` requires:
+
+```c++
+struct Point
+{
+   double x{};
+   double y{};
+   std::string label{};
+};
+
+template <>
+struct glz::meta<Point>
+{
+   static constexpr auto value = glz::reflect_array<Point>;
+};
+
+std::string_view payload = R"([[1,2,"a"],[3,4,"b"]])";
+
+std::vector<Point> points{};
+if (auto ec = glz::read_json(points, payload); ec) {
+   throw std::runtime_error(glz::format_error(ec, payload));
+}
+
+auto out = glz::write_json(points).value();
+// out == R"([[1,2,"a"],[3,4,"b"]])"
+```
+
+`glz::reflect_array<T>` generates the same meta as an explicit `glz::array(...)` of all the members in declaration order, so the type behaves as a positional array everywhere, in every Glaze format.
+
 > CUSTOMIZATION NOTE:
 >
 > When writing custom serializers specializing `to<JSON>` or `from<JSON>`, your concepts for custom types might not take precedence over the reflection engine (when you haven't written a `glz::meta` for your type). The reflection engine tries to discern that no specialization occurs for your type, but this is not always possible.

--- a/docs/wrappers.md
+++ b/docs/wrappers.md
@@ -276,7 +276,7 @@ expect(written ==
 );
 ```
 
-To mark an entire type as a positional array (rather than a particular member), give it a `glz::meta` with `static constexpr auto value = glz::reflect_array<T>;`. This generates the equivalent of `glz::array(...)` over all members via reflection, so the type serializes positionally even inside containers like `std::vector<T>`. See [Pure Reflection](pure-reflection.md#marking-an-entire-type-as-a-positional-array).
+To mark an entire type as a positional array (rather than a particular member), give it a `glz::meta` with `static constexpr auto value = glz::reflect_array{};`. This generates the equivalent of `glz::array(...)` over all members via reflection, so the type serializes positionally even inside containers like `std::vector<T>`. See [Pure Reflection](pure-reflection.md#marking-an-entire-type-as-a-positional-array).
 
 ## flatten_map
 

--- a/docs/wrappers.md
+++ b/docs/wrappers.md
@@ -276,6 +276,8 @@ expect(written ==
 );
 ```
 
+To mark an entire type as a positional array (rather than a particular member), give it a `glz::meta` with `static constexpr auto value = glz::reflect_array<T>;`. This generates the equivalent of `glz::array(...)` over all members via reflection, so the type serializes positionally even inside containers like `std::vector<T>`. See [Pure Reflection](pure-reflection.md#marking-an-entire-type-as-a-positional-array).
+
 ## flatten_map
 
 Flatten a map-like container or range of pairs into a JSON array. This wrapper lives in the optional header `glaze/json/flatten_map.hpp`.

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -706,6 +706,34 @@ namespace glz
 
    constexpr auto flags(auto&&... args) noexcept { return detail::Flags{tuple{args...}}; }
 
+   namespace detail
+   {
+      template <class T, size_t... I>
+      constexpr auto reflect_array_impl(std::index_sequence<I...>) noexcept
+      {
+#if GLZ_REFLECTION26
+         // P2996 reflection splices each member directly
+         return Array{glz::tuple{[](auto&& self) -> decltype(auto) { return get_member_ref<I>(self); }...}};
+#else
+         return Array{glz::tuple{[](auto&& self) -> decltype(auto) {
+            auto tie = to_tie(self);
+            return glz::get<I>(tie); // returns a reference to a member of self
+         }...}};
+#endif
+      }
+   }
+
+   // Produces a glz::array(...) meta from pure reflection, so that a struct is
+   // serialized/parsed as an array of its members without enumerating them:
+   //
+   //   template <> struct glz::meta<my_struct> {
+   //      static constexpr auto value = glz::reflect_array<my_struct>;
+   //   };
+   template <class T>
+      requires(std::is_class_v<std::remove_cvref_t<T>>)
+   inline constexpr auto reflect_array = detail::reflect_array_impl<std::remove_cvref_t<T>>(
+      std::make_index_sequence<detail::count_members<std::remove_cvref_t<T>>>{});
+
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -706,34 +706,6 @@ namespace glz
 
    constexpr auto flags(auto&&... args) noexcept { return detail::Flags{tuple{args...}}; }
 
-   namespace detail
-   {
-      template <class T, size_t... I>
-      constexpr auto reflect_array_impl(std::index_sequence<I...>) noexcept
-      {
-#if GLZ_REFLECTION26
-         // P2996 reflection splices each member directly
-         return Array{glz::tuple{[](auto&& self) -> decltype(auto) { return get_member_ref<I>(self); }...}};
-#else
-         return Array{glz::tuple{[](auto&& self) -> decltype(auto) {
-            auto tie = to_tie(self);
-            return glz::get<I>(tie); // returns a reference to a member of self
-         }...}};
-#endif
-      }
-   }
-
-   // Produces a glz::array(...) meta from pure reflection, so that a struct is
-   // serialized/parsed as an array of its members without enumerating them:
-   //
-   //   template <> struct glz::meta<my_struct> {
-   //      static constexpr auto value = glz::reflect_array<my_struct>;
-   //   };
-   template <class T>
-      requires(std::is_class_v<std::remove_cvref_t<T>>)
-   inline constexpr auto reflect_array = detail::reflect_array_impl<std::remove_cvref_t<T>>(
-      std::make_index_sequence<detail::count_members<std::remove_cvref_t<T>>>{});
-
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif

--- a/include/glaze/core/meta.hpp
+++ b/include/glaze/core/meta.hpp
@@ -89,6 +89,42 @@ namespace glz
       Flags(T) -> Flags<T>;
    }
 
+   // Declares that a struct is serialized/parsed as a positional array of its
+   // members via reflection, without enumerating them:
+   //
+   //   template <> struct glz::meta<my_struct> {
+   //      static constexpr auto value = glz::reflect_array{};
+   //   };
+   //
+   // meta_wrapper_v replaces this tag with a glz::array(...) equivalent generated
+   // from reflection, so the type behaves as glaze_array_t in every format.
+   struct reflect_array
+   {};
+
+   namespace detail
+   {
+      template <class T, size_t... I>
+      constexpr auto reflect_array_impl(std::index_sequence<I...>) noexcept
+      {
+#if GLZ_REFLECTION26
+         // P2996 reflection splices each member directly
+         return Array{glz::tuple{[](auto&& self) -> decltype(auto) { return get_member_ref<I>(self); }...}};
+#else
+         return Array{glz::tuple{[](auto&& self) -> decltype(auto) {
+            auto tie = to_tie(self);
+            return glz::get<I>(tie); // returns a reference to a member of self
+         }...}};
+#endif
+      }
+
+      template <class T>
+      constexpr auto make_reflect_array() noexcept
+      {
+         using V = std::remove_cvref_t<T>;
+         return reflect_array_impl<V>(std::make_index_sequence<count_members<V>>{});
+      }
+   }
+
    template <class T>
    concept local_construct_t = requires { T::glaze::construct; };
 
@@ -442,10 +478,20 @@ namespace glz
    template <class T>
    inline constexpr decltype(auto) meta_wrapper_v = [] {
       if constexpr (local_meta_t<T>) {
-         return T::glaze::value;
+         if constexpr (std::same_as<std::remove_cvref_t<decltype(T::glaze::value)>, reflect_array>) {
+            return detail::make_reflect_array<T>();
+         }
+         else {
+            return T::glaze::value;
+         }
       }
       else if constexpr (global_meta_t<T>) {
-         return meta<T>::value;
+         if constexpr (std::same_as<std::remove_cvref_t<decltype(meta<T>::value)>, reflect_array>) {
+            return detail::make_reflect_array<T>();
+         }
+         else {
+            return meta<T>::value;
+         }
       }
       else if constexpr (modify_t<T>) {
          return detail::make_modified_object<std::decay_t<T>>();

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -167,10 +167,23 @@ struct reflect_array_point
 template <>
 struct glz::meta<reflect_array_point>
 {
-   static constexpr auto value = glz::reflect_array<reflect_array_point>;
+   static constexpr auto value = glz::reflect_array{};
 };
 
 static_assert(glz::glaze_array_t<reflect_array_point>);
+
+struct reflect_array_local
+{
+   int a{};
+   int b{};
+
+   struct glaze
+   {
+      static constexpr auto value = glz::reflect_array{};
+   };
+};
+
+static_assert(glz::glaze_array_t<reflect_array_local>);
 
 suite reflect_array_tests = [] {
    "reflect_array round trip"_test = [] {
@@ -203,6 +216,17 @@ suite reflect_array_tests = [] {
       reflect_array_point value{};
       std::string buffer = R"({"x":1})";
       expect(bool(glz::read_json(value, buffer))); // an object should fail to parse
+   };
+
+   "reflect_array local glaze meta"_test = [] {
+      reflect_array_local value{1, 2};
+      auto written = glz::write_json(value).value();
+      expect(written == R"([1,2])") << written;
+
+      reflect_array_local parsed{};
+      expect(!glz::read_json(parsed, R"([3,4])"));
+      expect(parsed.a == 3);
+      expect(parsed.b == 4);
    };
 };
 

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -157,6 +157,55 @@ suite as_array_wrapper_tests = [] {
    };
 };
 
+struct reflect_array_point
+{
+   double x{};
+   double y{};
+   std::string label{};
+};
+
+template <>
+struct glz::meta<reflect_array_point>
+{
+   static constexpr auto value = glz::reflect_array<reflect_array_point>;
+};
+
+static_assert(glz::glaze_array_t<reflect_array_point>);
+
+suite reflect_array_tests = [] {
+   "reflect_array round trip"_test = [] {
+      reflect_array_point value{1.5, 2.5, "origin"};
+      auto written = glz::write_json(value).value();
+      expect(written == R"([1.5,2.5,"origin"])") << written;
+
+      reflect_array_point parsed{};
+      expect(!glz::read_json(parsed, written));
+      expect(parsed.x == 1.5);
+      expect(parsed.y == 2.5);
+      expect(parsed.label == "origin");
+   };
+
+   "reflect_array within array of arrays"_test = [] {
+      std::string buffer = R"([[1,2,"a"],[3,4,"b"]])";
+      std::vector<reflect_array_point> values{};
+      expect(!glz::read_json(values, buffer));
+      expect(values.size() == 2);
+      expect(values[0].x == 1.0);
+      expect(values[0].label == "a");
+      expect(values[1].y == 4.0);
+      expect(values[1].label == "b");
+
+      auto written = glz::write_json(values).value();
+      expect(written == R"([[1,2,"a"],[3,4,"b"]])") << written;
+   };
+
+   "reflect_array invalid input"_test = [] {
+      reflect_array_point value{};
+      std::string buffer = R"({"x":1})";
+      expect(bool(glz::read_json(value, buffer))); // an object should fail to parse
+   };
+};
+
 struct my_struct
 {
    int i = 287;

--- a/tests/p2996_test/p2996_test.cpp
+++ b/tests/p2996_test/p2996_test.cpp
@@ -344,7 +344,7 @@ struct PositionalPoint
 template <>
 struct glz::meta<PositionalPoint>
 {
-   static constexpr auto value = glz::reflect_array<PositionalPoint>;
+   static constexpr auto value = glz::reflect_array{};
 };
 
 static_assert(glz::glaze_array_t<PositionalPoint>);

--- a/tests/p2996_test/p2996_test.cpp
+++ b/tests/p2996_test/p2996_test.cpp
@@ -333,4 +333,46 @@ suite c_style_array_of_structs = [] {
    };
 };
 
+// reflect_array marks a type as a positional array without enumerating its members
+struct PositionalPoint
+{
+   double x{};
+   double y{};
+   std::string label{};
+};
+
+template <>
+struct glz::meta<PositionalPoint>
+{
+   static constexpr auto value = glz::reflect_array<PositionalPoint>;
+};
+
+static_assert(glz::glaze_array_t<PositionalPoint>);
+
+suite p2996_reflect_array = [] {
+   "reflect_array json round-trip"_test = [] {
+      std::vector<PositionalPoint> values{};
+      std::string buffer = R"([[1,2,"a"],[3,4,"b"]])";
+      expect(!glz::read_json(values, buffer));
+      expect(values.size() == 2);
+      expect(values[1].y == 4.0);
+      expect(values[1].label == "b");
+
+      auto written = glz::write_json(values).value_or("error");
+      expect(written == buffer) << written;
+   };
+
+   "reflect_array beve round-trip"_test = [] {
+      PositionalPoint obj{1.5, 2.5, "origin"};
+      std::string s{};
+      expect(not glz::write_beve(obj, s));
+
+      PositionalPoint obj2{};
+      expect(not glz::read_beve(obj2, s));
+      expect(obj2.x == 1.5);
+      expect(obj2.y == 2.5);
+      expect(obj2.label == "origin");
+   };
+};
+
 int main() {}


### PR DESCRIPTION
Resolves #2602

## Summary

Adds `glz::reflect_array`, a tag value that generates a `glz::array(...)` meta from pure reflection so a struct can be serialized/parsed as a positional array without enumerating its members:

```cpp
struct Point
{
   double x{};
   double y{};
   std::string label{};
};

template <>
struct glz::meta<Point>
{
   static constexpr auto value = glz::reflect_array{};
};

// std::vector<Point> now round-trips as [[1,2,"a"],[3,4,"b"]]
```

This covers the case from #2602 where the data is an array of arrays: `glz::as_array<&T::member>` requires a member to wrap, so it cannot mark the element type of a container as positional.

It works from both a global `glz::meta` specialization and a local `glaze` meta:

```cpp
struct Point
{
   double x{};
   double y{};
   struct glaze
   {
      static constexpr auto value = glz::reflect_array{};
   };
};
```

## Implementation

`glz::reflect_array{}` is an empty tag struct used as a meta `value`. `meta_wrapper_v` detects it (for both global and local meta) and replaces it with a `detail::Array` whose tuple holds one accessor lambda per member. Since `get_member` already supports invocables, the type satisfies `glaze_array_t<T>` and flows through every existing array code path untouched: no serializer changes, and the feature works across all formats (JSON, BEVE, etc.) automatically.

- Pre-C++26: each accessor returns `glz::get<I>(to_tie(self))`
- With P2996 reflection (`GLZ_REFLECTION26`): each accessor splices its member directly via `detail::get_member_ref<I>(self)`, avoiding the per-lambda tie instantiation and the 128-member structured-bindings cap

## Testing

- `json_test`: `reflect_array_tests` suite (round trip, array-of-arrays into `std::vector<T>`, rejection of object input, and a local `glaze` meta case)
- `p2996_test`: `p2996_reflect_array` suite (JSON and BEVE round trips); passes under the Bloomberg `clang-p2996` compiler using the same `vsavkov/clang-p2996:amd64` image as the `p2996-reflection` workflow
- Docs: "Marking an entire type as a positional array" section in `docs/pure-reflection.md`, cross-referenced from the `as_array` section of `docs/wrappers.md`
