### PR TITLE
Forward declare tuple_size/tuple_element and raw_json, move custom into forward.hpp

### DIFF
--- a/include/glaze/core/wrappers.hpp
+++ b/include/glaze/core/wrappers.hpp
@@ -57,14 +57,9 @@ namespace glz
       };
    }
 
-   // custom_t (user-customization wrapper for serialization members/functions)
-   // is defined in glaze/forward.hpp — it's pulled in transitively via opts.hpp.
-
-   template <auto From, auto To>
-   constexpr auto custom_impl() noexcept
-   {
-      return [](auto&& v) { return custom_t{v, From, To}; };
-   }
+   // custom_t (the user-customization wrapper) along with custom_impl() and the
+   // glz::custom customization point are defined in glaze/forward.hpp — pulled in
+   // transitively via opts.hpp.
 
    // When reading into an array that is appendable, the new data will be appended rather than overwrite
    template <auto MemPtr>
@@ -99,10 +94,6 @@ namespace glz
    // Reads into only existing fields and elements and then exits without parsing the rest of the input
    template <auto MemPtr>
    constexpr auto partial_read = opts_wrapper<MemPtr, &opts::partial_read>();
-
-   // Customize reading and writing
-   template <auto From, auto To>
-   constexpr auto custom = custom_impl<From, To>();
 
    template <auto MemPtr>
    inline constexpr decltype(auto) escape_bytes_impl() noexcept

--- a/include/glaze/forward.hpp
+++ b/include/glaze/forward.hpp
@@ -4,24 +4,30 @@
 // Lightweight forward declarations of Glaze's customization points.
 //
 // Include this header alone when you need to specialize glz::meta,
-// glz::to<Format, T>, glz::from<Format, T>, or construct glz::custom_t in
-// widely-included user headers. It pulls in no Glaze internals and only
-// <cstdint> from the standard library, so it's cheap to include broadly and
-// lets user code defer inclusion of the full Glaze headers (glaze/glaze.hpp,
-// glaze/json.hpp, glaze/core/common.hpp) to the translation units that
-// actually call read/write.
+// glz::to<Format, T>, glz::from<Format, T>, glz::tuple_size / glz::tuple_element,
+// or construct glz::custom_t / glz::raw_json in widely-included user headers.
+// It pulls in no Glaze internals and only a few lightweight standard headers
+// (<cstddef>, <cstdint>, <string>, <string_view>), so it's cheap to include
+// broadly and lets user code defer inclusion of the full Glaze headers
+// (glaze/glaze.hpp, glaze/json.hpp, glaze/core/common.hpp) to the translation
+// units that actually call read/write.
 //
 // Builders like glz::object(...), glz::array(...), and glz::enumerate(...),
 // along with the full definitions of glz::meta and the per-format glz::to /
 // glz::from specializations, live in glaze/core/meta.hpp, glaze/core/common.hpp,
-// and the respective format headers. glz::custom_t is fully defined below.
+// and the respective format headers. glz::custom_t, glz::custom, and the
+// glz::tuple_size / glz::tuple_element / glz::basic_raw_json forward
+// declarations are defined below.
 //
 // For the same lightweight-header pattern applied to glz::generic, see
 // glaze/json/generic_fwd.hpp.
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
+#include <string>
+#include <string_view>
 
 namespace glz
 {
@@ -97,4 +103,40 @@ namespace glz
 
    template <class T, class From, class To>
    custom_t(T&, From, To) -> custom_t<T, From, To>;
+
+   // Factory for the glz::custom serialization customization point. Defined here
+   // alongside custom_t because it depends on nothing else: it returns a generic
+   // lambda that constructs a custom_t via the deduction guide above. The full
+   // set of opts-based wrappers (quoted_num, unquoted, ...) lives in
+   // glaze/core/wrappers.hpp.
+   template <auto From, auto To>
+   constexpr auto custom_impl() noexcept
+   {
+      return [](auto&& v) { return custom_t{v, From, To}; };
+   }
+
+   // Customize reading and writing of a member.
+   template <auto From, auto To>
+   constexpr auto custom = custom_impl<From, To>();
+
+   // Tuple-protocol customization points. Glaze treats a type as tuple-like when
+   // glz::tuple_size / glz::tuple_element are specialized for it. The primary
+   // templates are left incomplete here so user headers can add specializations
+   // (and detect them) without pulling in glaze/tuplet/tuple.hpp, which provides
+   // the std:: specializations and the tuple_size_v / tuple_element_t helpers.
+   template <class... T>
+   struct tuple_size;
+
+   template <std::size_t I, class... T>
+   struct tuple_element;
+
+   // Raw, pre-serialized JSON passed through verbatim. Forward declared without a
+   // default template argument so glaze/core/common.hpp remains the sole owner of
+   // the default and the full definition; the aliases below let user headers name
+   // glz::raw_json (e.g. as a default template argument) without that definition.
+   template <class string_type>
+   struct basic_raw_json;
+
+   using raw_json = basic_raw_json<std::string>;
+   using raw_json_view = basic_raw_json<std::string_view>;
 }


### PR DESCRIPTION
Follow-up to the `glaze/forward.hpp` work, addressing the additional types raised in [review feedback on #2527](https://github.com/stephenberry/glaze/pull/2527#issuecomment-4621764232).

## What

- **`glz::tuple_size` / `glz::tuple_element`** — forward declare the primary templates (left incomplete) so user headers can register a tuple-like type via specialization without pulling in `glaze/tuplet/tuple.hpp`. The concrete `tuple_size_v` / `tuple_element_t` helpers and the `std::` specializations remain owned by `tuple.hpp`.
- **`glz::raw_json`** — forward declare `basic_raw_json` plus the `raw_json` / `raw_json_view` aliases, supporting use as a default template argument in a generic lambda, e.g.:
  ```cpp
  static constexpr auto value = our_glz_wrappers::custom<
    [](T& x, double v) { x = T(v); },
    []<typename raw_json = glz::raw_json>(T x) { return raw_json(our_custom_type_to_string(x)); }
  >;
  ```
  The declaration omits the default template argument (`std::string`), leaving `glaze/core/common.hpp` as the sole owner of the default and full definition.
- **`glz::custom`** — `custom_impl()` and the `custom` customization point move from `glaze/core/wrappers.hpp` into `forward.hpp`, next to `custom_t` (which already lived there). Both are trivial and depend only on `custom_t`.
- **`glz::error_code`** — intentionally left out; it doesn't appear to be used without its definition.

`forward.hpp` now also includes `<cstddef>`, `<string>`, and `<string_view>` alongside `<cstdint>`.

## Verification

- `forward.hpp` standalone compiles and exposes the new names (raw_json as a default template arg, a user `tuple_size`/`tuple_element` specialization, `glz::custom`).
- `forward.hpp` + full `glaze.hpp` compiles in both include orders with no redefinition or default-argument clashes.