### PR TITLE
Add cmake option to optimize for size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,3 +108,8 @@ if(glaze_ENABLE_REFLECTION26)
   target_compile_definitions(glaze_glaze INTERFACE GLZ_REFLECTION26=1)
 endif(glaze_ENABLE_REFLECTION26)
 
+option(glaze_OPTIMIZE_SIZE "Optimize for size by not including itoa tables worth 40kb at the expense of throughput" OFF)
+
+if(glaze_OPTIMIZE_SIZE)
+  target_compile_definitions(glaze_glaze INTERFACE GLZ_OPTIMIZE_SIZE=1)
+endif(glaze_OPTIMIZE_SIZE)

--- a/include/glaze/core/write_chars.hpp
+++ b/include/glaze/core/write_chars.hpp
@@ -30,7 +30,9 @@
 #include "glaze/core/opts.hpp"
 #include "glaze/util/dump.hpp"
 #include "glaze/util/itoa.hpp"
+#ifndef GLZ_OPTIMIZE_SIZE
 #include "glaze/util/itoa_40kb.hpp"
+#endif
 #include "glaze/util/simple_float.hpp"
 #include "glaze/util/zmij.hpp"
 
@@ -351,8 +353,12 @@ namespace glz
                ix += size_t(end - start);
             }
             else {
+#ifndef GLZ_OPTIMIZE_SIZE
                // Normal mode: use to_chars_40kb (40KB digit_quads table)
                const auto end = glz::to_chars_40kb(start, value);
+#else
+               const auto end = glz::to_chars(start, value);
+#endif
                ix += size_t(end - start);
             }
          }
@@ -366,8 +372,12 @@ namespace glz
                ix += size_t(end - start);
             }
             else {
+#ifndef GLZ_OPTIMIZE_SIZE
                // Normal mode: use to_chars_40kb
                const auto end = glz::to_chars_40kb(start, static_cast<X>(value));
+#else
+               const auto end = glz::to_chars(start, static_cast<X>(value));
+#endif
                ix += size_t(end - start);
             }
          }


### PR DESCRIPTION
On embedded targets there is usually very limited flash available. The itoa 40kb tables cost 40kb of flash and provide a speedup for integer conversion, but json is almost never in the critical path for embedded code and saving flash becomes a more important need.

glaze_OPTIMIZE_SIZE when set to 1 doesn't include the 40kb header.

Tested by running unit tests.