### PR TITLE
Add WebSocket autobahn client testsuite

### DIFF
--- a/.github/workflows/autobahn.yml
+++ b/.github/workflows/autobahn.yml
@@ -58,7 +58,7 @@ jobs:
              "url": "ws://127.0.0.1:9001",
              "outdir": "/reports",
              "cases": ["*"],
-             "exclude-cases": [],
+             "exclude-cases": ["9.*", "12.*", "13.*"],
              "exclude-agent-cases": {}
           }
           JSON

--- a/.github/workflows/autobahn.yml
+++ b/.github/workflows/autobahn.yml
@@ -24,6 +24,7 @@ jobs:
       CC: gcc-14
       CXX: g++-14
       AUTOBAHN_AGENT: glaze-websocket-client
+      AUTOBAHN_CASE_COUNT_FILE: ${{ github.workspace }}/autobahn-case-count.txt
       AUTOBAHN_IMAGE: crossbario/autobahn-testsuite
 
     steps:
@@ -85,6 +86,12 @@ jobs:
           import sys
 
           allowed = {"OK", "INFORMATIONAL"}
+          allowed_non_strict = {
+             ("6.4.1", "behavior"),
+             ("6.4.2", "behavior"),
+             ("6.4.3", "behavior"),
+             ("6.4.4", "behavior"),
+          }
           agent = os.environ["AUTOBAHN_AGENT"]
           reports = sorted(pathlib.Path("autobahn-reports").rglob("index.json"))
 
@@ -108,13 +115,31 @@ jobs:
              print(f"Autobahn report does not contain agent {agent!r}. Available agents: {available}", file=sys.stderr)
              sys.exit(1)
 
+          count_path = pathlib.Path(os.environ["AUTOBAHN_CASE_COUNT_FILE"])
+          try:
+             expected_count = int(count_path.read_text(encoding="utf-8").strip())
+          except (OSError, ValueError) as error:
+             print(f"Could not read Autobahn case count from {count_path}: {error}", file=sys.stderr)
+             sys.exit(1)
+
+          actual_count = len(report[agent])
+          if actual_count != expected_count:
+             print(
+                f"Autobahn report contains {actual_count} cases, but the server advertised {expected_count}",
+                file=sys.stderr,
+             )
+             sys.exit(1)
+
           failures = []
           for case_id, result in sorted(report[agent].items()):
              if not isinstance(result, dict):
+                failures.append((case_id, "result", type(result).__name__))
                 continue
              for field in ("behavior", "behaviorClose"):
                 value = result.get(field)
-                if value and value not in allowed:
+                if value == "NON-STRICT" and (case_id, field) in allowed_non_strict:
+                   continue
+                if value not in allowed:
                    failures.append((case_id, field, value))
 
           if failures:

--- a/.github/workflows/autobahn.yml
+++ b/.github/workflows/autobahn.yml
@@ -1,0 +1,157 @@
+name: autobahn
+
+on:
+  push:
+    branches:
+      - main
+      - feature/*
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    env:
+      CC: gcc-14
+      CXX: g++-14
+      AUTOBAHN_AGENT: glaze-websocket-client
+      AUTOBAHN_IMAGE: crossbario/autobahn-testsuite
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++-14 ninja-build
+
+      - name: Configure CMake
+        run: |
+          cmake -B ${{github.workspace}}/build \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_CXX_STANDARD=23 \
+            -DCMAKE_C_COMPILER=${{env.CC}} \
+            -DCMAKE_CXX_COMPILER=${{env.CXX}} \
+            -Dglaze_ENABLE_FUZZING=OFF \
+            -Dglaze_BUILD_PERFORMANCE_TESTS=OFF \
+            -Dglaze_BUILD_SSL_TESTS=OFF \
+            -Dglaze_DISABLE_SQLITE_TESTS=ON \
+            -Dglaze_BUILD_WEBSOCKET_AUTOBAHN_TEST=ON
+
+      - name: Build
+        run: cmake --build build -j $(nproc) --target websocket_autobahn_test
+
+      - name: Configure Autobahn
+        run: |
+          mkdir -p autobahn-config autobahn-reports
+          cat > autobahn-config/fuzzingserver.json <<'JSON'
+          {
+             "url": "ws://127.0.0.1:9001",
+             "outdir": "/reports",
+             "cases": ["*"],
+             "exclude-cases": [],
+             "exclude-agent-cases": {}
+          }
+          JSON
+
+      - name: Start Autobahn fuzzingserver
+        run: |
+          docker run --rm -d \
+            --name autobahn \
+            -p 9001:9001 \
+            -v "$GITHUB_WORKSPACE/autobahn-config:/config:ro" \
+            -v "$GITHUB_WORKSPACE/autobahn-reports:/reports" \
+            "$AUTOBAHN_IMAGE" \
+            wstest -m fuzzingserver -s /config/fuzzingserver.json
+
+          python3 - <<'PY'
+          import socket
+          import sys
+          import time
+
+          deadline = time.time() + 30
+          while time.time() < deadline:
+             try:
+                with socket.create_connection(("127.0.0.1", 9001), timeout=1):
+                   sys.exit(0)
+             except OSError:
+                time.sleep(1)
+
+          print("Autobahn fuzzingserver did not start within 30 seconds", file=sys.stderr)
+          sys.exit(1)
+          PY
+
+      - name: Test
+        run: ctest --output-on-failure --test-dir build -R "^websocket_autobahn_test$" --timeout 1800 --no-tests=error
+
+      - name: Check Autobahn reports
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import pathlib
+          import sys
+
+          allowed = {"OK", "INFORMATIONAL"}
+          agent = os.environ["AUTOBAHN_AGENT"]
+          reports = sorted(pathlib.Path("autobahn-reports").rglob("index.json"))
+
+          if not reports:
+             print("Autobahn did not produce an index.json report", file=sys.stderr)
+             sys.exit(1)
+
+          report_path = None
+          report = None
+          for path in reports:
+             with path.open(encoding="utf-8") as file:
+                candidate = json.load(file)
+             if agent in candidate:
+                report_path = path
+                report = candidate
+                break
+
+          if report is None:
+             available = sorted({key for path in reports for key in json.loads(path.read_text(encoding="utf-8")).keys()})
+             available = ", ".join(available)
+             print(f"Autobahn report does not contain agent {agent!r}. Available agents: {available}", file=sys.stderr)
+             sys.exit(1)
+
+          failures = []
+          for case_id, result in sorted(report[agent].items()):
+             if not isinstance(result, dict):
+                continue
+             for field in ("behavior", "behaviorClose"):
+                value = result.get(field)
+                if value and value not in allowed:
+                   failures.append((case_id, field, value))
+
+          if failures:
+             for case_id, field, value in failures:
+                print(f"Autobahn case {case_id} has {field}={value}", file=sys.stderr)
+             sys.exit(1)
+
+          print(f"Autobahn report passed for {agent}: {len(report[agent])} cases checked in {report_path}")
+          PY
+
+      - name: Show Autobahn logs
+        if: ${{ failure() }}
+        run: docker logs autobahn || true
+
+      - name: Stop Autobahn fuzzingserver
+        if: ${{ always() }}
+        run: docker rm -f autobahn || true
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: autobahn-reports
+          path: autobahn-reports/

--- a/.github/workflows/autobahn.yml
+++ b/.github/workflows/autobahn.yml
@@ -55,7 +55,7 @@ jobs:
           mkdir -p autobahn-config autobahn-reports
           cat > autobahn-config/fuzzingserver.json <<'JSON'
           {
-             "url": "ws://127.0.0.1:9001",
+             "url": "ws://0.0.0.0:9001",
              "outdir": "/reports",
              "cases": ["*"],
              "exclude-cases": ["9.*", "12.*", "13.*"],
@@ -72,23 +72,6 @@ jobs:
             -v "$GITHUB_WORKSPACE/autobahn-reports:/reports" \
             "$AUTOBAHN_IMAGE" \
             wstest -m fuzzingserver -s /config/fuzzingserver.json
-
-          python3 - <<'PY'
-          import socket
-          import sys
-          import time
-
-          deadline = time.time() + 30
-          while time.time() < deadline:
-             try:
-                with socket.create_connection(("127.0.0.1", 9001), timeout=1):
-                   sys.exit(0)
-             except OSError:
-                time.sleep(1)
-
-          print("Autobahn fuzzingserver did not start within 30 seconds", file=sys.stderr)
-          sys.exit(1)
-          PY
 
       - name: Test
         run: ctest --output-on-failure --test-dir build -R "^websocket_autobahn_test$" --timeout 1800 --no-tests=error

--- a/tests/networking_tests/CMakeLists.txt
+++ b/tests/networking_tests/CMakeLists.txt
@@ -2,6 +2,7 @@
 # glaze_setup_asio() (cmake/glaze-asio.cmake).
 
 option(glaze_BUILD_SSL_TESTS "Build SSL/TLS tests (requires OpenSSL headers matching target architecture)" ON)
+option(glaze_BUILD_WEBSOCKET_AUTOBAHN_TEST "Build Autobahn WebSocket compliance test" OFF)
 
 # HTTP Examples
 add_subdirectory(http_examples)
@@ -30,4 +31,7 @@ add_subdirectory(repe_test)
 add_subdirectory(registry_view_test)
 add_subdirectory(repe_to_jsonrpc_test)
 add_subdirectory(rest_test)
+if(glaze_BUILD_WEBSOCKET_AUTOBAHN_TEST)
+    add_subdirectory(websocket_autobahn_test)
+endif()
 add_subdirectory(websocket_test)

--- a/tests/networking_tests/websocket_autobahn_test/CMakeLists.txt
+++ b/tests/networking_tests/websocket_autobahn_test/CMakeLists.txt
@@ -1,0 +1,10 @@
+message(STATUS "Autobahn WebSocket test will be built")
+
+project(websocket_autobahn_test)
+
+add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE glz_test_exceptions)
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
+set_tests_properties(${PROJECT_NAME} PROPERTIES TIMEOUT 1800)

--- a/tests/networking_tests/websocket_autobahn_test/websocket_autobahn_test.cpp
+++ b/tests/networking_tests/websocket_autobahn_test/websocket_autobahn_test.cpp
@@ -22,6 +22,7 @@ constexpr std::string_view autobahn_url = "ws://127.0.0.1:9001";
 constexpr std::string_view glaze_agent = "glaze-websocket-client";
 constexpr size_t autobahn_max_message_size = 64ZU * 1024ZU * 1024ZU;
 constexpr auto autobahn_count_timeout = 5s;
+constexpr auto autobahn_startup_timeout = 30s;
 constexpr auto autobahn_case_timeout = 1min;
 constexpr auto autobahn_report_timeout = 10s;
 
@@ -131,6 +132,23 @@ single_message_result read_one_text_message(std::string_view url, std::chrono::m
 
    ctx->stop();
    client_thread.join();
+
+   return result;
+}
+
+single_message_result read_case_count()
+{
+   const auto url = std::format("{}/getCaseCount", autobahn_url);
+   const auto deadline = std::chrono::steady_clock::now() + autobahn_startup_timeout;
+   single_message_result result{single_message_status::timeout};
+
+   do {
+      result = read_one_text_message(url, autobahn_count_timeout);
+      if (result.status == single_message_status::ok) {
+         return result;
+      }
+      std::this_thread::sleep_for(500ms);
+   } while (std::chrono::steady_clock::now() < deadline);
 
    return result;
 }
@@ -248,8 +266,7 @@ bool update_reports(std::chrono::milliseconds timeout)
 
 suite websocket_autobahn_tests = [] {
    "autobahn_fuzzingclient"_test = [] {
-      const auto count_message =
-         read_one_text_message(std::format("{}/getCaseCount", autobahn_url), autobahn_count_timeout);
+      const auto count_message = read_case_count();
       if (count_message.status != single_message_status::ok) {
          std::cerr << "[autobahn] Could not read /getCaseCount from " << autobahn_url
                    << " (status=" << status_name(count_message.status);

--- a/tests/networking_tests/websocket_autobahn_test/websocket_autobahn_test.cpp
+++ b/tests/networking_tests/websocket_autobahn_test/websocket_autobahn_test.cpp
@@ -1,0 +1,296 @@
+#include <atomic>
+#include <charconv>
+#include <chrono>
+#include <cstdint>
+#include <format>
+#include <iostream>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <thread>
+
+#include "glaze/net/websocket_client.hpp"
+#include "ut/ut.hpp"
+
+using namespace ut;
+using namespace glz;
+using namespace std::chrono_literals;
+
+constexpr std::string_view autobahn_url = "ws://127.0.0.1:9001";
+constexpr std::string_view glaze_agent = "glaze-websocket-client";
+constexpr size_t autobahn_max_message_size = 64ZU * 1024ZU * 1024ZU;
+constexpr auto autobahn_count_timeout = 5s;
+constexpr auto autobahn_case_timeout = 1min;
+constexpr auto autobahn_report_timeout = 10s;
+
+template <typename Predicate>
+bool wait_for_condition(Predicate pred, std::chrono::milliseconds timeout)
+{
+   auto start = std::chrono::steady_clock::now();
+   while (!pred()) {
+      if (std::chrono::steady_clock::now() - start > timeout) {
+         return false;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+   }
+   return true;
+}
+
+std::optional<uint32_t> parse_u32(std::string_view text)
+{
+   uint32_t value{};
+   const auto [ptr, ec] = std::from_chars(text.data(), text.data() + text.size(), value);
+   if (ec != std::errc{} || ptr != text.data() + text.size()) return std::nullopt;
+   return value;
+}
+
+enum class single_message_status : uint8_t {
+   ok,
+   timeout,
+   error,
+   closed_without_message,
+   non_text_message,
+};
+
+struct single_message_result
+{
+   single_message_status status{};
+   std::string message{};
+   std::error_code error{};
+};
+
+std::string_view status_name(single_message_status status)
+{
+   switch (status) {
+   case single_message_status::ok:
+      return "ok";
+   case single_message_status::timeout:
+      return "timeout";
+   case single_message_status::error:
+      return "error";
+   case single_message_status::closed_without_message:
+      return "closed_without_message";
+   case single_message_status::non_text_message:
+      return "non_text_message";
+   }
+   return "unknown";
+}
+
+single_message_result read_one_text_message(std::string_view url, std::chrono::milliseconds timeout)
+{
+   auto ctx = std::make_shared<asio::io_context>();
+   websocket_client client{ctx};
+   client.set_max_message_size(autobahn_max_message_size);
+
+   std::atomic<bool> finished{false};
+   std::mutex mu;
+   single_message_result result{single_message_status::closed_without_message};
+
+   client.on_message([&](std::string_view message, ws_opcode opcode) {
+      {
+         std::scoped_lock lock(mu);
+         if (opcode == ws_opcode::text) {
+            result.status = single_message_status::ok;
+            result.message.assign(message);
+         }
+         else {
+            result.status = single_message_status::non_text_message;
+         }
+      }
+      finished = true;
+      client.close();
+      ctx->stop();
+   });
+
+   client.on_close([&](ws_close_code, std::string_view) {
+      finished = true;
+      ctx->stop();
+   });
+
+   client.on_error([&](std::error_code ec) {
+      {
+         std::scoped_lock lock(mu);
+         result.status = single_message_status::error;
+         result.error = ec;
+      }
+      finished = true;
+      ctx->stop();
+   });
+
+   client.connect(url);
+   std::jthread client_thread([&] { ctx->run(); });
+
+   if (!wait_for_condition([&] { return finished.load(); }, timeout)) {
+      {
+         std::scoped_lock lock(mu);
+         result.status = single_message_status::timeout;
+      }
+   }
+
+   ctx->stop();
+   client_thread.join();
+
+   return result;
+}
+
+enum class case_status : uint8_t {
+   ok,
+   timeout,
+   error_before_open,
+   error_after_open,
+};
+
+struct case_result
+{
+   case_status status{};
+   std::error_code error{};
+   uint64_t echoed_messages{};
+};
+
+case_result run_case(uint32_t case_id, std::chrono::milliseconds timeout)
+{
+   auto ctx = std::make_shared<asio::io_context>();
+   websocket_client client{ctx};
+   client.set_max_message_size(autobahn_max_message_size);
+
+   std::atomic<bool> opened{false};
+   std::atomic<bool> finished{false};
+   std::atomic<uint64_t> echoed_messages{0};
+   std::mutex mu;
+   case_result result{case_status::ok};
+
+   client.on_open([&] { opened = true; });
+
+   client.on_message([&](std::string_view message, ws_opcode opcode) {
+      if (opcode == ws_opcode::text) {
+         std::string payload{message};
+         client.send(payload);
+         ++echoed_messages;
+      }
+      else if (opcode == ws_opcode::binary) {
+         std::string payload{message};
+         client.send_binary(payload);
+         ++echoed_messages;
+      }
+   });
+
+   client.on_close([&](ws_close_code, std::string_view) {
+      finished = true;
+      ctx->stop();
+   });
+
+   client.on_error([&](std::error_code ec) {
+      {
+         std::scoped_lock lock(mu);
+         result.status = opened.load() ? case_status::error_after_open : case_status::error_before_open;
+         result.error = ec;
+      }
+      finished = true;
+      ctx->stop();
+   });
+
+   const auto url = std::format("{}/runCase?case={}&agent={}", autobahn_url, case_id, glaze_agent);
+   client.connect(url);
+
+   std::jthread client_thread([&] { ctx->run(); });
+
+   if (!wait_for_condition([&] { return finished.load(); }, timeout)) {
+      {
+         std::scoped_lock lock(mu);
+         result.status = case_status::timeout;
+      }
+   }
+
+   ctx->stop();
+   client_thread.join();
+
+   result.echoed_messages = echoed_messages.load();
+   return result;
+}
+
+bool update_reports(std::chrono::milliseconds timeout)
+{
+   auto ctx = std::make_shared<asio::io_context>();
+   websocket_client client{ctx};
+
+   std::atomic<bool> opened{false};
+   std::atomic<bool> finished{false};
+   std::atomic<bool> failed{false};
+
+   client.on_open([&] { opened = true; });
+   client.on_close([&](ws_close_code, std::string_view) {
+      finished = true;
+      ctx->stop();
+   });
+   client.on_error([&](std::error_code) {
+      failed = !opened.load();
+      finished = true;
+      ctx->stop();
+   });
+
+   const auto url = std::format("{}/updateReports?agent={}", autobahn_url, glaze_agent);
+   client.connect(url);
+
+   std::jthread client_thread([&] { ctx->run(); });
+
+   const bool completed = wait_for_condition([&] { return finished.load(); }, timeout);
+   if (!completed) {
+      failed = true;
+      ctx->stop();
+   }
+
+   ctx->stop();
+
+   return completed && !failed.load();
+}
+
+suite websocket_autobahn_tests = [] {
+   "autobahn_fuzzingclient"_test = [] {
+      const auto count_message =
+         read_one_text_message(std::format("{}/getCaseCount", autobahn_url), autobahn_count_timeout);
+      if (count_message.status != single_message_status::ok) {
+         std::cerr << "[autobahn] Could not read /getCaseCount from " << autobahn_url
+                   << " (status=" << status_name(count_message.status);
+         if (count_message.error) {
+            std::cerr << ", error=" << count_message.error.message();
+         }
+         std::cerr << ")\n";
+         expect(false) << "Autobahn fuzzingserver is not available";
+         return;
+      }
+
+      const auto case_count = parse_u32(count_message.message);
+      expect(case_count.has_value()) << "Autobahn /getCaseCount returned a non-integer payload";
+      if (!case_count) return;
+
+      std::cout << "[autobahn] Running " << *case_count << " cases as " << glaze_agent << "\n";
+
+      uint32_t timeouts = 0;
+      uint32_t failed_opens = 0;
+
+      for (uint32_t case_id = 1; case_id <= *case_count; ++case_id) {
+         const auto result = run_case(case_id, autobahn_case_timeout);
+         if (result.status == case_status::timeout) {
+            ++timeouts;
+            std::cerr << "[autobahn] Case " << case_id << " timed out after echoing " << result.echoed_messages
+                      << " messages\n";
+         }
+         else if (result.status == case_status::error_before_open) {
+            ++failed_opens;
+            std::cerr << "[autobahn] Case " << case_id << " failed before open: " << result.error.message() << "\n";
+         }
+
+         std::cout << "[autobahn] Completed " << case_id << "/" << *case_count << " cases\n";
+      }
+
+      const bool reports_updated = update_reports(autobahn_report_timeout);
+
+      expect(timeouts == 0) << "Autobahn run had " << timeouts << " timed-out cases";
+      expect(failed_opens == 0) << "Autobahn run had " << failed_opens << " cases that failed before opening";
+      expect(reports_updated) << "Autobahn /updateReports failed";
+   };
+};
+
+int main() {}

--- a/tests/networking_tests/websocket_autobahn_test/websocket_autobahn_test.cpp
+++ b/tests/networking_tests/websocket_autobahn_test/websocket_autobahn_test.cpp
@@ -2,6 +2,8 @@
 #include <charconv>
 #include <chrono>
 #include <cstdint>
+#include <cstdlib>
+#include <fstream>
 #include <format>
 #include <iostream>
 #include <mutex>
@@ -45,6 +47,26 @@ std::optional<uint32_t> parse_u32(std::string_view text)
    const auto [ptr, ec] = std::from_chars(text.data(), text.data() + text.size(), value);
    if (ec != std::errc{} || ptr != text.data() + text.size()) return std::nullopt;
    return value;
+}
+
+bool write_case_count(uint32_t case_count)
+{
+   const char* path = std::getenv("AUTOBAHN_CASE_COUNT_FILE");
+   if (path == nullptr || *path == '\0') return true;
+
+   std::ofstream output{path, std::ios::trunc};
+   if (!output) {
+      std::cerr << "[autobahn] Could not open case count file: " << path << "\n";
+      return false;
+   }
+
+   output << case_count << '\n';
+   if (!output) {
+      std::cerr << "[autobahn] Could not write case count file: " << path << "\n";
+      return false;
+   }
+
+   return true;
 }
 
 enum class single_message_status : uint8_t {
@@ -281,6 +303,10 @@ suite websocket_autobahn_tests = [] {
       const auto case_count = parse_u32(count_message.message);
       expect(case_count.has_value()) << "Autobahn /getCaseCount returned a non-integer payload";
       if (!case_count) return;
+
+      const bool case_count_written = write_case_count(*case_count);
+      expect(case_count_written) << "Could not persist the Autobahn case count";
+      if (!case_count_written) return;
 
       std::cout << "[autobahn] Running " << *case_count << " cases as " << glaze_agent << "\n";
 


### PR DESCRIPTION
[Autobahn](https://github.com/crossbario/autobahn-testsuite) is used to test the correctness of WebSocket protocol implementations by industry giants such as Mozilla Firefox, Google Chrome, WebSocket++, Java-WebSocket, Boost-Beast, Facebook Tornado, [and others](https://github.com/crossbario/autobahn-testsuite#users). This test will be extremely helpful in preventing regressions during future development of the client-side WebSocket component of Glaze. Fortunately, at this point, autobahn detects only 4 non-strict cases related to UTF-8 stream validation for incoming continuation frames.

A non-strict case according to autobahn is:

> Test case was executed and passed non-strictly. A non-strict behavior is one that does not adhere to a SHOULD-behavior as described in the protocol specification or a well-defined, canonical behavior that appears to be desirable but left open in the protocol specification. An implementation with non-strict behavior is still conformant to the protocol specification.

... and all other test cases have a "Pass" status, which is certainly good news.

Passing all of the autobahn tests is a strong indicator that the implementation is likely trustworthy, which we can mention in the README in the future, so I think this is another reason why it will be useful for Glaze.

Let me know if you need to add an autobahn fuzzingclient workflow to validate the correctness of the `glz::websocket_server` implementation, or if you need a PR with fix for the "Non-strict" behavior section that arose in 6.4, I’d be happy to help.
