### PR TITLE
Fix HTTP date formatting data race

### DIFF
--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -57,15 +57,15 @@ namespace glz
          char buffer[64];
          const auto size = std::snprintf(
             buffer, sizeof(buffer), "%.*s, %02u %.*s %04d %02u:%02u:%02u GMT",
-            static_cast<int32_t>(weekdays[weekday.c_encoding()].size()), weekdays[weekday.c_encoding()].data(),
-            static_cast<uint32_t>(date.day()), static_cast<int32_t>(months[static_cast<uint32_t>(date.month()) - 1].size()),
-            months[static_cast<uint32_t>(date.month()) - 1].data(), static_cast<int32_t>(date.year()),
-            static_cast<uint32_t>(time_of_day.hours().count()), static_cast<uint32_t>(time_of_day.minutes().count()),
-            static_cast<uint32_t>(time_of_day.seconds().count()));
-         if (size < 0 || static_cast<size_t>(size) >= sizeof(buffer)) {
+            int32_t(weekdays[weekday.c_encoding()].size()), weekdays[weekday.c_encoding()].data(),
+            uint32_t(date.day()), int32_t(months[uint32_t(date.month()) - 1].size()),
+            months[uint32_t(date.month()) - 1].data(), int32_t(date.year()),
+            uint32_t(time_of_day.hours().count()), uint32_t(time_of_day.minutes().count()),
+            uint32_t(time_of_day.seconds().count()));
+         if (size < 0 || size_t(size) >= sizeof(buffer)) {
             return {};
          }
-         return {buffer, static_cast<size_t>(size)};
+         return {buffer, size_t(size)};
       }
 
       // Type trait to detect SSL streams

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -4,11 +4,13 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <cctype>
 #include <charconv>
 #include <chrono>
 #include <condition_variable>
+#include <cstdio>
 #include <cstring>
 #include <expected>
 #include <functional>
@@ -39,6 +41,31 @@ namespace glz
 {
    namespace detail
    {
+      inline std::string format_http_date(const std::chrono::sys_seconds time)
+      {
+         static constexpr std::array<std::string_view, 7> weekdays = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+         static constexpr std::array<std::string_view, 12> months = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                                                                     "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+
+         const auto day_point = std::chrono::floor<std::chrono::days>(time);
+         const std::chrono::year_month_day date{day_point};
+         const std::chrono::weekday weekday{day_point};
+         const std::chrono::hh_mm_ss time_of_day{time - day_point};
+
+         char buffer[64];
+         const auto size = std::snprintf(
+            buffer, sizeof(buffer), "%.*s, %02u %.*s %04d %02u:%02u:%02u GMT",
+            static_cast<int>(weekdays[weekday.c_encoding()].size()), weekdays[weekday.c_encoding()].data(),
+            static_cast<unsigned>(date.day()), static_cast<int>(months[static_cast<unsigned>(date.month()) - 1].size()),
+            months[static_cast<unsigned>(date.month()) - 1].data(), static_cast<int>(date.year()),
+            static_cast<unsigned>(time_of_day.hours().count()), static_cast<unsigned>(time_of_day.minutes().count()),
+            static_cast<unsigned>(time_of_day.seconds().count()));
+         if (size < 0 || static_cast<size_t>(size) >= sizeof(buffer)) {
+            return {};
+         }
+         return {buffer, static_cast<size_t>(size)};
+      }
+
       // Type trait to detect SSL streams
       template <typename T>
       inline constexpr bool is_ssl_stream = false;
@@ -2339,21 +2366,11 @@ namespace glz
       inline const std::string& get_current_date()
       {
          static thread_local std::string cached;
-         static thread_local std::chrono::seconds cached_sec{};
-         auto now = std::chrono::system_clock::now();
-         auto sec = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch());
-         if (sec != cached_sec) {
-            cached_sec = sec;
-            auto time_t_now = std::chrono::system_clock::to_time_t(now);
-            char buf[64];
-#ifdef _MSC_VER
-            std::tm tm_buf;
-            gmtime_s(&tm_buf, &time_t_now);
-            std::strftime(buf, sizeof(buf), "%a, %d %b %Y %H:%M:%S GMT", &tm_buf);
-#else
-            std::strftime(buf, sizeof(buf), "%a, %d %b %Y %H:%M:%S GMT", std::gmtime(&time_t_now));
-#endif
-            cached = buf;
+         static thread_local std::chrono::sys_seconds cached_time{};
+         const auto now = std::chrono::floor<std::chrono::seconds>(std::chrono::system_clock::now());
+         if (cached.empty() || now != cached_time) {
+            cached_time = now;
+            cached = detail::format_http_date(now);
          }
          return cached;
       }

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -42,7 +42,8 @@ namespace glz
 {
    namespace detail
    {
-      inline std::string format_http_date(const std::chrono::sys_seconds time)
+      // Produces an RFC 7231 §7.1.1.1 IMF-fixdate formatted HTTP date string
+      [[nodiscard]] inline std::string format_http_date(const std::chrono::sys_seconds time)
       {
          static constexpr std::array<std::string_view, 7> weekdays = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
          static constexpr std::array<std::string_view, 12> months = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -10,6 +10,7 @@
 #include <charconv>
 #include <chrono>
 #include <condition_variable>
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <expected>
@@ -55,11 +56,11 @@ namespace glz
          char buffer[64];
          const auto size = std::snprintf(
             buffer, sizeof(buffer), "%.*s, %02u %.*s %04d %02u:%02u:%02u GMT",
-            static_cast<int>(weekdays[weekday.c_encoding()].size()), weekdays[weekday.c_encoding()].data(),
-            static_cast<unsigned>(date.day()), static_cast<int>(months[static_cast<unsigned>(date.month()) - 1].size()),
-            months[static_cast<unsigned>(date.month()) - 1].data(), static_cast<int>(date.year()),
-            static_cast<unsigned>(time_of_day.hours().count()), static_cast<unsigned>(time_of_day.minutes().count()),
-            static_cast<unsigned>(time_of_day.seconds().count()));
+            static_cast<int32_t>(weekdays[weekday.c_encoding()].size()), weekdays[weekday.c_encoding()].data(),
+            static_cast<uint32_t>(date.day()), static_cast<int32_t>(months[static_cast<uint32_t>(date.month()) - 1].size()),
+            months[static_cast<uint32_t>(date.month()) - 1].data(), static_cast<int32_t>(date.year()),
+            static_cast<uint32_t>(time_of_day.hours().count()), static_cast<uint32_t>(time_of_day.minutes().count()),
+            static_cast<uint32_t>(time_of_day.seconds().count()));
          if (size < 0 || static_cast<size_t>(size) >= sizeof(buffer)) {
             return {};
          }

--- a/tests/networking_tests/http_server_api_tests/http_server_api_tests.cpp
+++ b/tests/networking_tests/http_server_api_tests/http_server_api_tests.cpp
@@ -28,6 +28,14 @@ namespace asio
 
 using namespace ut;
 
+suite http_date_tests = [] {
+   "formats_imf_fixdate"_test = [] {
+      using namespace std::chrono;
+      const sys_seconds time = sys_days{year{1994} / month{11} / day{6}} + hours{8} + minutes{49} + seconds{37};
+      expect(glz::detail::format_http_date(time) == "Sun, 06 Nov 1994 08:49:37 GMT");
+   };
+};
+
 // Test data structures
 struct AsyncResult
 {

--- a/tests/networking_tests/http_server_api_tests/http_server_api_tests.cpp
+++ b/tests/networking_tests/http_server_api_tests/http_server_api_tests.cpp
@@ -34,6 +34,59 @@ suite http_date_tests = [] {
       const sys_seconds time = sys_days{year{1994} / month{11} / day{6}} + hours{8} + minutes{49} + seconds{37};
       expect(glz::detail::format_http_date(time) == "Sun, 06 Nov 1994 08:49:37 GMT");
    };
+
+   "unix_epoch"_test = [] {
+      using namespace std::chrono;
+      const sys_seconds epoch{seconds{0}};
+      expect(glz::detail::format_http_date(epoch) == "Thu, 01 Jan 1970 00:00:00 GMT");
+   };
+
+   "y2k"_test = [] {
+      using namespace std::chrono;
+      const sys_seconds time = sys_days{year{2000} / month{1} / day{1}};
+      expect(glz::detail::format_http_date(time) == "Sat, 01 Jan 2000 00:00:00 GMT");
+   };
+
+   "leap_day"_test = [] {
+      using namespace std::chrono;
+      const sys_seconds time = sys_days{year{2024} / month{2} / day{29}} + hours{12} + minutes{0} + seconds{0};
+      expect(glz::detail::format_http_date(time) == "Thu, 29 Feb 2024 12:00:00 GMT");
+   };
+
+   "end_of_year"_test = [] {
+      using namespace std::chrono;
+      const sys_seconds time = sys_days{year{2023} / month{12} / day{31}} + hours{23} + minutes{59} + seconds{59};
+      expect(glz::detail::format_http_date(time) == "Sun, 31 Dec 2023 23:59:59 GMT");
+   };
+
+   "single_digit_day"_test = [] {
+      using namespace std::chrono;
+      const sys_seconds time = sys_days{year{2025} / month{3} / day{5}} + hours{7} + minutes{30} + seconds{15};
+      expect(glz::detail::format_http_date(time) == "Wed, 05 Mar 2025 07:30:15 GMT");
+   };
+
+   "all_weekdays_covered"_test = [] {
+      // 2024-01-01 is a Monday, test Mon through Sun
+      using namespace std::chrono;
+      const std::array<std::string_view, 7> expected_days = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
+      for (uint32_t i = 0; i < 7; ++i) {
+         const sys_seconds time = sys_days{year{2024} / month{1} / day{1 + i}};
+         const auto result = glz::detail::format_http_date(time);
+         expect(result.substr(0, 3) == expected_days[i]) << "day offset " << i;
+      }
+   };
+
+   "all_months_covered"_test = [] {
+      using namespace std::chrono;
+      const std::array<std::string_view, 12> expected_months = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                                                                 "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+      for (uint32_t m = 1; m <= 12; ++m) {
+         const sys_seconds time = sys_days{year{2024} / month{m} / day{15}};
+         const auto result = glz::detail::format_http_date(time);
+         // Month name starts at position 8 in "Xxx, DD Mon YYYY HH:MM:SS GMT"
+         expect(result.substr(8, 3) == expected_months[m - 1]) << "month " << m;
+      }
+   };
 };
 
 // Test data structures


### PR DESCRIPTION
## Summary

- replace `std::gmtime` and `std::strftime` with thread-safe chrono-based HTTP date formatting
- preserve the per-thread one-second date cache
- add an IMF-fixdate regression test

Fixes #2618

## Testing

- `ctest --test-dir build-noexc -R ^http_server_api_tests$ --output-on-failure`
- `ctest --test-dir build-pr2605 -R ^http_server_api_tests$ --output-on-failure`