### PR TITLE
Use size optimization for error formatting

### DIFF
--- a/include/glaze/util/validate.hpp
+++ b/include/glaze/util/validate.hpp
@@ -108,14 +108,14 @@ namespace glz
 
          if (info.context.empty()) {
             dump("index ", b, ix);
-            write_chars::op<opts{}>(info.index, ctx, b, ix);
+            write_chars::op<opts_size{}>(info.index, ctx, b, ix);
             dump(": ", b, ix);
             dump_maybe_empty(error, b, ix);
          }
          else {
-            write_chars::op<opts{}>(info.line, ctx, b, ix);
+            write_chars::op<opts_size{}>(info.line, ctx, b, ix);
             dump(':', b, ix);
-            write_chars::op<opts{}>(info.column, ctx, b, ix);
+            write_chars::op<opts_size{}>(info.column, ctx, b, ix);
             dump(": ", b, ix);
             dump_maybe_empty(error, b, ix);
             dump('\n', b, ix);


### PR DESCRIPTION
## Summary

- format diagnostic indices, lines, and columns with `opts_size`
- prevent `glz::format_error` from retaining the 40 KiB integer lookup table
- preserve existing formatted error output

This is a focused follow-up to the size concern discussed in #2614.

## Verification

- `cmake --build build --target json_test -j 4`
- `ctest --test-dir build -R '^json_test$' --output-on-failure`
- dead-stripped size reproducer: text segment reduced from 64 KiB to 16 KiB, with no `digit_quads` or `to_chars_40kb` symbol