### PR TITLE
Fix exception reads from generic JSON

### DIFF
--- a/include/glaze/json/generic.hpp
+++ b/include/glaze/json/generic.hpp
@@ -19,6 +19,17 @@ namespace glz
 
    template <num_mode Mode, template <class> class MapType>
       requires generic_map_type<MapType>
+   [[nodiscard]] std::string format_error(const error_ctx& ec, const generic_json<Mode, MapType>& source)
+   {
+      const auto buffer = source.dump();
+      if (buffer) {
+         return format_error(ec, *buffer);
+      }
+      return format_error(ec);
+   }
+
+   template <num_mode Mode, template <class> class MapType>
+      requires generic_map_type<MapType>
    template <class T>
       requires(assignable_generic_type<generic_json<Mode, MapType>, T>)
    generic_json<Mode, MapType>& generic_json<Mode, MapType>::operator=(T&& value)

--- a/tests/exceptions_test/exceptions_test.cpp
+++ b/tests/exceptions_test/exceptions_test.cpp
@@ -161,9 +161,35 @@ suite generic_read_tests = [] {
       expect(value.field == 42);
    };
 
-   "generic read invalid"_test = [] {
+   "generic read into object formats exception"_test = [] {
       const auto generic = glz::ex::read_json<glz::generic_u64>(R"({"field":"invalid"})");
-      expect(throws([&] { [[maybe_unused]] auto value = glz::ex::read_json<generic_read_struct>(generic); }));
+      generic_read_struct value{};
+      try {
+         glz::ex::read_json(value, generic);
+         expect(false) << "expected glz::ex::read_json to throw";
+      }
+      catch (const std::runtime_error& error) {
+         expect(std::string_view{error.what()} ==
+                "read_json error: 1:10: parse_number_failure\n"
+                "   {\"field\":\"invalid\"}\n"
+                "            ^")
+            << error.what();
+      }
+   };
+
+   "generic read value formats exception"_test = [] {
+      const auto generic = glz::ex::read_json<glz::generic_u64>(R"({"field":"invalid"})");
+      try {
+         [[maybe_unused]] auto value = glz::ex::read_json<generic_read_struct>(generic);
+         expect(false) << "expected glz::ex::read_json to throw";
+      }
+      catch (const std::runtime_error& error) {
+         expect(std::string_view{error.what()} ==
+                "read_json error: 1:10: parse_number_failure\n"
+                "   {\"field\":\"invalid\"}\n"
+                "            ^")
+            << error.what();
+      }
    };
 };
 

--- a/tests/exceptions_test/exceptions_test.cpp
+++ b/tests/exceptions_test/exceptions_test.cpp
@@ -149,6 +149,24 @@ suite basic_types = [] {
    };
 };
 
+struct generic_read_struct
+{
+   int field{};
+};
+
+suite generic_read_tests = [] {
+   "generic read valid"_test = [] {
+      const auto generic = glz::ex::read_json<glz::generic_u64>(R"({"field":42})");
+      const auto value = glz::ex::read_json<generic_read_struct>(generic);
+      expect(value.field == 42);
+   };
+
+   "generic read invalid"_test = [] {
+      const auto generic = glz::ex::read_json<glz::generic_u64>(R"({"field":"invalid"})");
+      expect(throws([&] { [[maybe_unused]] auto value = glz::ex::read_json<generic_read_struct>(generic); }));
+   };
+};
+
 struct file_struct
 {
    std::string name;


### PR DESCRIPTION
## Summary

- support formatting read errors when the source is `glz::generic_json`
- preserve source-context diagnostics by formatting against the serialized generic value
- add regression coverage for successful and failing `glz::ex::read_json` conversions

Closes #2621

## Testing

- `ctest --test-dir build -R "^(exceptions_test|generic_test)$" --output-on-failure`
- minimal issue reproducer compiled with GCC 14