### PR TITLE
guard iterator against end in stencilcount

### DIFF
--- a/include/glaze/cbor/read.hpp
+++ b/include/glaze/cbor/read.hpp
@@ -1395,7 +1395,9 @@ namespace glz
             if constexpr (N > 0) {
                static constexpr auto HashInfo = hash_info<T>;
 
-               const auto index = decode_hash_with_size<CBOR, T, HashInfo, HashInfo.type>::op(it, end, key_len);
+               const auto index = key_len < HashInfo.min_length || key_len > HashInfo.max_length
+                                     ? N
+                                     : decode_hash_with_size<CBOR, T, HashInfo, HashInfo.type>::op(it, end, key_len);
 
                if (index < N) [[likely]] {
                   const sv key{reinterpret_cast<const char*>(it), static_cast<size_t>(key_len)};

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -2668,17 +2668,33 @@ namespace glz
    template <uint32_t Format, class T, auto HashInfo, hash_type Type>
    struct decode_hash_with_size;
 
+   template <auto HashInfo>
+   GLZ_ALWAYS_INLINE constexpr bool invalid_hash_key_size(auto&& it, auto&& end, const size_t n) noexcept
+   {
+      return n < HashInfo.min_length || n > HashInfo.max_length || (n != 0 && n > size_t(end - it));
+   }
+
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::single_element>
    {
-      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&&, auto&&, const size_t) noexcept { return 0; }
+      static constexpr auto N = reflect<T>::size;
+
+      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
+      {
+         return invalid_hash_key_size<HashInfo>(it, end, n) ? N : 0;
+      }
    };
 
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::mod4>
    {
-      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&&, const size_t) noexcept
+      static constexpr auto N = reflect<T>::size;
+
+      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
       {
+         if (invalid_hash_key_size<HashInfo>(it, end, n)) {
+            return N;
+         }
          return uint8_t(*it) % 4;
       }
    };
@@ -2686,10 +2702,14 @@ namespace glz
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::xor_mod4>
    {
+      static constexpr auto N = reflect<T>::size;
       static constexpr auto first_key_char = reflect<T>::keys[0][0];
 
-      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&&, const size_t) noexcept
+      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
       {
+         if (invalid_hash_key_size<HashInfo>(it, end, n)) {
+            return N;
+         }
          return (uint8_t(*it) ^ first_key_char) % 4;
       }
    };
@@ -2697,10 +2717,14 @@ namespace glz
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::minus_mod4>
    {
+      static constexpr auto N = reflect<T>::size;
       static constexpr auto first_key_char = reflect<T>::keys[0][0];
 
-      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&&, const size_t) noexcept
+      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
       {
+         if (invalid_hash_key_size<HashInfo>(it, end, n)) {
+            return N;
+         }
          return (uint8_t(*it) - first_key_char) % 4;
       }
    };
@@ -2714,11 +2738,11 @@ namespace glz
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
       {
-         if constexpr (HashInfo.sized_hash) {
-            if (n == 0 || n > HashInfo.max_length) {
-               return N; // error
-            }
+         if (invalid_hash_key_size<HashInfo>(it, end, n)) {
+            return N;
+         }
 
+         if constexpr (HashInfo.sized_hash) {
             const auto h = bitmix(uint16_t(it[HashInfo.unique_index]) | (uint16_t(n) << 8), HashInfo.seed);
             return HashInfo.table[h % bsize];
          }
@@ -2747,8 +2771,12 @@ namespace glz
       static constexpr auto N = reflect<T>::size;
       static constexpr auto uindex = HashInfo.unique_index;
 
-      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t) noexcept
+      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
       {
+         if (invalid_hash_key_size<HashInfo>(it, end, n)) {
+            return N;
+         }
+
          if constexpr (uindex > 0) {
             if ((it + uindex) >= end) [[unlikely]] {
                return N; // error
@@ -2766,8 +2794,12 @@ namespace glz
       static constexpr auto N = reflect<T>::size;
       static constexpr auto bsize = bucket_size(hash_type::front_hash, N);
 
-      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&&, const size_t) noexcept
+      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
       {
+         if (invalid_hash_key_size<HashInfo>(it, end, n)) {
+            return N;
+         }
+
          if constexpr (HashInfo.front_hash_bytes == 2) {
             uint16_t h;
             if consteval {
@@ -2830,6 +2862,10 @@ namespace glz
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
       {
+         if (invalid_hash_key_size<HashInfo>(it, end, n)) {
+            return N;
+         }
+
          const auto pos = per_length_info<T>.unique_index[uint8_t(n)];
          if ((it + pos) >= end) [[unlikely]] {
             return N; // error
@@ -2845,8 +2881,12 @@ namespace glz
       static constexpr auto N = reflect<T>::size;
       static constexpr auto bsize = bucket_size(hash_type::full_flat, N);
 
-      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&&, const size_t n) noexcept
+      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
       {
+         if (invalid_hash_key_size<HashInfo>(it, end, n)) {
+            return N;
+         }
+
          const auto h = full_hash<HashInfo.min_length, HashInfo.max_length, HashInfo.seed>(it, n);
          return HashInfo.table[h % bsize];
       }

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -2668,33 +2668,17 @@ namespace glz
    template <uint32_t Format, class T, auto HashInfo, hash_type Type>
    struct decode_hash_with_size;
 
-   template <auto HashInfo>
-   GLZ_ALWAYS_INLINE constexpr bool invalid_hash_key_size(auto&& it, auto&& end, const size_t n) noexcept
-   {
-      return n < HashInfo.min_length || n > HashInfo.max_length || (n != 0 && n > size_t(end - it));
-   }
-
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::single_element>
    {
-      static constexpr auto N = reflect<T>::size;
-
-      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
-      {
-         return invalid_hash_key_size<HashInfo>(it, end, n) ? N : 0;
-      }
+      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&&, auto&&, const size_t) noexcept { return 0; }
    };
 
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::mod4>
    {
-      static constexpr auto N = reflect<T>::size;
-
-      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
+      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&&, const size_t) noexcept
       {
-         if (invalid_hash_key_size<HashInfo>(it, end, n)) {
-            return N;
-         }
          return uint8_t(*it) % 4;
       }
    };
@@ -2702,14 +2686,10 @@ namespace glz
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::xor_mod4>
    {
-      static constexpr auto N = reflect<T>::size;
       static constexpr auto first_key_char = reflect<T>::keys[0][0];
 
-      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
+      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&&, const size_t) noexcept
       {
-         if (invalid_hash_key_size<HashInfo>(it, end, n)) {
-            return N;
-         }
          return (uint8_t(*it) ^ first_key_char) % 4;
       }
    };
@@ -2717,14 +2697,10 @@ namespace glz
    template <uint32_t Format, class T, auto HashInfo>
    struct decode_hash_with_size<Format, T, HashInfo, hash_type::minus_mod4>
    {
-      static constexpr auto N = reflect<T>::size;
       static constexpr auto first_key_char = reflect<T>::keys[0][0];
 
-      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
+      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&&, const size_t) noexcept
       {
-         if (invalid_hash_key_size<HashInfo>(it, end, n)) {
-            return N;
-         }
          return (uint8_t(*it) - first_key_char) % 4;
       }
    };
@@ -2738,11 +2714,11 @@ namespace glz
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
       {
-         if (invalid_hash_key_size<HashInfo>(it, end, n)) {
-            return N;
-         }
-
          if constexpr (HashInfo.sized_hash) {
+            if (n == 0 || n > HashInfo.max_length) {
+               return N; // error
+            }
+
             const auto h = bitmix(uint16_t(it[HashInfo.unique_index]) | (uint16_t(n) << 8), HashInfo.seed);
             return HashInfo.table[h % bsize];
          }
@@ -2771,12 +2747,8 @@ namespace glz
       static constexpr auto N = reflect<T>::size;
       static constexpr auto uindex = HashInfo.unique_index;
 
-      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
+      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t) noexcept
       {
-         if (invalid_hash_key_size<HashInfo>(it, end, n)) {
-            return N;
-         }
-
          if constexpr (uindex > 0) {
             if ((it + uindex) >= end) [[unlikely]] {
                return N; // error
@@ -2794,12 +2766,8 @@ namespace glz
       static constexpr auto N = reflect<T>::size;
       static constexpr auto bsize = bucket_size(hash_type::front_hash, N);
 
-      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
+      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&&, const size_t) noexcept
       {
-         if (invalid_hash_key_size<HashInfo>(it, end, n)) {
-            return N;
-         }
-
          if constexpr (HashInfo.front_hash_bytes == 2) {
             uint16_t h;
             if consteval {
@@ -2862,10 +2830,6 @@ namespace glz
 
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
       {
-         if (invalid_hash_key_size<HashInfo>(it, end, n)) {
-            return N;
-         }
-
          const auto pos = per_length_info<T>.unique_index[uint8_t(n)];
          if ((it + pos) >= end) [[unlikely]] {
             return N; // error
@@ -2881,12 +2845,8 @@ namespace glz
       static constexpr auto N = reflect<T>::size;
       static constexpr auto bsize = bucket_size(hash_type::full_flat, N);
 
-      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t n) noexcept
+      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&&, const size_t n) noexcept
       {
-         if (invalid_hash_key_size<HashInfo>(it, end, n)) {
-            return N;
-         }
-
          const auto h = full_hash<HashInfo.min_length, HashInfo.max_length, HashInfo.seed>(it, n);
          return HashInfo.table[h % bsize];
       }

--- a/include/glaze/stencil/stencilcount.hpp
+++ b/include/glaze/stencil/stencilcount.hpp
@@ -104,12 +104,8 @@ namespace glz
                   static constexpr auto N = reflect<T>::size;
                   static constexpr auto HashInfo = hash_info<T>;
 
-                  const auto index = [&] {
-                     if (key.size() < HashInfo.min_length || key.size() > HashInfo.max_length) {
-                        return N;
-                     }
-                     return decode_hash_with_size<STENCIL, T, HashInfo, HashInfo.type>::op(start, end, key.size());
-                  }();
+                  const auto index =
+                     decode_hash_with_size<STENCIL, T, HashInfo, HashInfo.type>::op(start, end, key.size());
 
                   if (index < N) [[likely]] {
                      std::string temp{};

--- a/include/glaze/stencil/stencilcount.hpp
+++ b/include/glaze/stencil/stencilcount.hpp
@@ -27,7 +27,7 @@ namespace glz
       }
       if (not bool(ctx.error)) [[likely]] {
          auto skip_whitespace = [&] {
-            while (whitespace_table[uint8_t(*it)]) {
+            while (it < end && whitespace_table[uint8_t(*it)]) {
                ++it;
             }
          };
@@ -40,12 +40,12 @@ namespace glz
             switch (*it) {
             case '{': {
                ++it;
-               if (*it == '{') {
+               if (it != end && *it == '{') {
                   ++it;
                   skip_whitespace();
 
                   uint64_t count{};
-                  while (*it == '+') {
+                  while (it != end && *it == '+') {
                      ++it;
                      ++count;
                   }
@@ -76,9 +76,9 @@ namespace glz
                      prev_count = count;
                   }
 
-                  if (*it == '}') {
+                  if (it != end && *it == '}') {
                      ++it;
-                     if (*it == '}') {
+                     if (it != end && *it == '}') {
                         ++it;
                         break;
                      }
@@ -137,9 +137,9 @@ namespace glz
 
                   skip_whitespace();
 
-                  if (*it == '}') {
+                  if (it != end && *it == '}') {
                      ++it;
-                     if (*it == '}') {
+                     if (it != end && *it == '}') {
                         ++it;
                         break;
                      }

--- a/include/glaze/stencil/stencilcount.hpp
+++ b/include/glaze/stencil/stencilcount.hpp
@@ -93,6 +93,10 @@ namespace glz
                      ++it;
                   }
 
+                  if (it == end) {
+                     break;
+                  }
+
                   const sv key{start, size_t(it - start)};
 
                   skip_whitespace();

--- a/include/glaze/stencil/stencilcount.hpp
+++ b/include/glaze/stencil/stencilcount.hpp
@@ -104,8 +104,12 @@ namespace glz
                   static constexpr auto N = reflect<T>::size;
                   static constexpr auto HashInfo = hash_info<T>;
 
-                  const auto index =
-                     decode_hash_with_size<STENCIL, T, HashInfo, HashInfo.type>::op(start, end, key.size());
+                  const auto index = [&] {
+                     if (key.size() < HashInfo.min_length || key.size() > HashInfo.max_length) {
+                        return N;
+                     }
+                     return decode_hash_with_size<STENCIL, T, HashInfo, HashInfo.type>::op(start, end, key.size());
+                  }();
 
                   if (index < N) [[likely]] {
                      std::string temp{};

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -29,6 +29,22 @@ struct my_struct
    std::array<uint64_t, 3> arr = {1, 2, 3};
 };
 
+struct cbor_mod4_object
+{
+   int x{};
+   int y{};
+   int z{};
+};
+
+struct cbor_front_hash_object
+{
+   int aaaa{};
+   int aaab{};
+   int aaba{};
+   int aabb{};
+   int abaa{};
+};
+
 template <>
 struct glz::meta<my_struct>
 {
@@ -2258,6 +2274,26 @@ void past_fuzzing_issues()
 
 void error_tests()
 {
+   const auto read_exact = []<class T, size_t N>(const std::array<uint8_t, N>& input) {
+      auto buffer = std::make_unique_for_overwrite<char[]>(N);
+      std::copy_n(reinterpret_cast<const char*>(input.data()), N, buffer.get());
+      T value{};
+      return glz::read_cbor(value, std::string_view{buffer.get(), N});
+   };
+
+   "empty object key stays within the buffer"_test = [=] {
+      static_assert(glz::hash_info<cbor_mod4_object>.type == glz::hash_type::mod4);
+      constexpr std::array<uint8_t, 3> input{0xa1, 0x60, 0x00};
+      expect(read_exact.template operator()<cbor_mod4_object>(input).ec == glz::error_code::unknown_key);
+   };
+
+   "short front hash key stays within the buffer"_test = [=] {
+      static_assert(glz::hash_info<cbor_front_hash_object>.type == glz::hash_type::front_hash);
+      static_assert(glz::hash_info<cbor_front_hash_object>.front_hash_bytes == 4);
+      constexpr std::array<uint8_t, 4> input{0xa1, 0x61, 'a', 0x00};
+      expect(read_exact.template operator()<cbor_front_hash_object>(input).ec == glz::error_code::unknown_key);
+   };
+
    "truncated_input"_test = [] {
       std::string buffer;
       buffer.push_back(static_cast<char>(glz::cbor::initial_byte(glz::cbor::major::uint, 24)));

--- a/tests/stencil/stencil_test.cpp
+++ b/tests/stencil/stencil_test.cpp
@@ -663,6 +663,13 @@ suite mustache_list_template_tests = [] {
 
 #include "glaze/stencil/stencilcount.hpp"
 
+struct stencilcount_point
+{
+   int x{};
+   int y{};
+   int z{};
+};
+
 suite stencilcount_tests = [] {
    "basic docstencil"_test = [] {
       std::string_view layout = R"(# About
@@ -710,7 +717,8 @@ suite stencilcount_tests = [] {
       // Each layout is copied into an exact-size buffer with no trailing null
       // terminator, so a read past `end` trips the sanitizer build instead of
       // landing on benign padding.
-      person p{"Henry", "Foster", 34};
+      static_assert(glz::hash_info<stencilcount_point>.type == glz::hash_type::mod4);
+      stencilcount_point p{};
       for (const std::string_view tpl : {"{", "{{", "{{+", "{{++", "{{ ", "{{+}", "{{first_name"}) {
          std::vector<char> buf(tpl.begin(), tpl.end());
          const std::string_view layout{buf.data(), buf.size()};

--- a/tests/stencil/stencil_test.cpp
+++ b/tests/stencil/stencil_test.cpp
@@ -724,6 +724,11 @@ suite stencilcount_tests = [] {
 
    "truncated tags stay within the buffer"_test = [] {
       static_assert(glz::hash_info<stencilcount_point>.type == glz::hash_type::mod4);
+      static_assert(
+         glz::decode_hash_with_size<glz::STENCIL, stencilcount_point, glz::hash_info<stencilcount_point>,
+                                    glz::hash_type::mod4>::op(static_cast<const char*>(nullptr),
+                                                             static_cast<const char*>(nullptr), 0) ==
+         glz::reflect<stencilcount_point>::size);
 
       constexpr std::array cases{
          std::pair<std::string_view, std::string_view>{"{{x}}", "42"},
@@ -752,6 +757,13 @@ suite stencilcount_tests = [] {
 
       static_assert(glz::hash_info<stencilcount_front_hash>.type == glz::hash_type::front_hash);
       static_assert(glz::hash_info<stencilcount_front_hash>.front_hash_bytes == 4);
+      static_assert([] {
+         constexpr std::string_view short_key = "a";
+         return glz::decode_hash_with_size<
+                   glz::STENCIL, stencilcount_front_hash, glz::hash_info<stencilcount_front_hash>,
+                   glz::hash_type::front_hash>::op(short_key.data(), short_key.data() + short_key.size(),
+                                                   short_key.size()) == glz::reflect<stencilcount_front_hash>::size;
+      }());
 
       stencilcount_front_hash front_hash_value{.aaaa = 42};
       for (const std::string_view layout : {"{{a}", "{{a}}", "{{a }", "{{aaaa}}"}) {

--- a/tests/stencil/stencil_test.cpp
+++ b/tests/stencil/stencil_test.cpp
@@ -670,6 +670,15 @@ struct stencilcount_point
    int z{};
 };
 
+struct stencilcount_front_hash
+{
+   int aaaa{};
+   int aaab{};
+   int aaba{};
+   int aabb{};
+   int abaa{};
+};
+
 suite stencilcount_tests = [] {
    "basic docstencil"_test = [] {
       std::string_view layout = R"(# About
@@ -714,16 +723,45 @@ suite stencilcount_tests = [] {
    };
 
    "truncated tags stay within the buffer"_test = [] {
-      // Each layout is copied into an exact-size buffer with no trailing null
-      // terminator, so a read past `end` trips the sanitizer build instead of
-      // landing on benign padding.
       static_assert(glz::hash_info<stencilcount_point>.type == glz::hash_type::mod4);
-      stencilcount_point p{};
-      for (const std::string_view tpl : {"{", "{{", "{{+", "{{++", "{{ ", "{{+}", "{{first_name"}) {
-         std::vector<char> buf(tpl.begin(), tpl.end());
-         const std::string_view layout{buf.data(), buf.size()};
-         auto result = glz::stencilcount(layout, p);
-         expect(result.has_value()) << tpl;
+
+      constexpr std::array cases{
+         std::pair<std::string_view, std::string_view>{"{{x}}", "42"},
+         std::pair<std::string_view, std::string_view>{"{{ x }}", "42"},
+         std::pair<std::string_view, std::string_view>{"{{\tx\t}}", "42"},
+         std::pair<std::string_view, std::string_view>{"{{+++}}", "0.0.1"},
+         std::pair<std::string_view, std::string_view>{"before {{x}} after", "before 42 after"},
+      };
+
+      const auto render_prefix = []<class T>(const std::string_view layout, const size_t size, T& value) {
+         auto buffer = std::make_unique_for_overwrite<char[]>(size);
+         std::copy_n(layout.data(), size, buffer.get());
+         return glz::stencilcount(std::string_view{buffer.get(), size}, value);
+      };
+
+      stencilcount_point point{.x = 42};
+      for (const auto& [layout, expected] : cases) {
+         for (size_t size = 1; size <= layout.size(); ++size) {
+            auto result = render_prefix(layout, size, point);
+            expect(result.has_value()) << layout << " prefix size " << size;
+            if (size == layout.size()) {
+               expect(result.value_or("") == expected) << layout;
+            }
+         }
+      }
+
+      static_assert(glz::hash_info<stencilcount_front_hash>.type == glz::hash_type::front_hash);
+      static_assert(glz::hash_info<stencilcount_front_hash>.front_hash_bytes == 4);
+
+      stencilcount_front_hash front_hash_value{.aaaa = 42};
+      for (const std::string_view layout : {"{{a}", "{{a}}", "{{a }", "{{aaaa}}"}) {
+         for (size_t size = 1; size <= layout.size(); ++size) {
+            auto result = render_prefix(layout, size, front_hash_value);
+            expect(result.has_value()) << layout << " prefix size " << size;
+            if (size == layout.size() && layout == "{{aaaa}}") {
+               expect(result.value_or("") == "42");
+            }
+         }
       }
    };
 };

--- a/tests/stencil/stencil_test.cpp
+++ b/tests/stencil/stencil_test.cpp
@@ -705,6 +705,19 @@ suite stencilcount_tests = [] {
 3.1.2 English
 )") << result;
    };
+
+   "truncated tags stay within the buffer"_test = [] {
+      // Each layout is copied into an exact-size buffer with no trailing null
+      // terminator, so a read past `end` trips the sanitizer build instead of
+      // landing on benign padding.
+      person p{"Henry", "Foster", 34};
+      for (const std::string_view tpl : {"{", "{{", "{{+", "{{++", "{{ ", "{{+}", "{{first_name"}) {
+         std::vector<char> buf(tpl.begin(), tpl.end());
+         const std::string_view layout{buf.data(), buf.size()};
+         auto result = glz::stencilcount(layout, p);
+         expect(result.has_value()) << tpl;
+      }
+   };
 };
 
 int main() { return 0; }

--- a/tests/stencil/stencil_test.cpp
+++ b/tests/stencil/stencil_test.cpp
@@ -724,11 +724,6 @@ suite stencilcount_tests = [] {
 
    "truncated tags stay within the buffer"_test = [] {
       static_assert(glz::hash_info<stencilcount_point>.type == glz::hash_type::mod4);
-      static_assert(
-         glz::decode_hash_with_size<glz::STENCIL, stencilcount_point, glz::hash_info<stencilcount_point>,
-                                    glz::hash_type::mod4>::op(static_cast<const char*>(nullptr),
-                                                             static_cast<const char*>(nullptr), 0) ==
-         glz::reflect<stencilcount_point>::size);
 
       constexpr std::array cases{
          std::pair<std::string_view, std::string_view>{"{{x}}", "42"},
@@ -757,13 +752,6 @@ suite stencilcount_tests = [] {
 
       static_assert(glz::hash_info<stencilcount_front_hash>.type == glz::hash_type::front_hash);
       static_assert(glz::hash_info<stencilcount_front_hash>.front_hash_bytes == 4);
-      static_assert([] {
-         constexpr std::string_view short_key = "a";
-         return glz::decode_hash_with_size<
-                   glz::STENCIL, stencilcount_front_hash, glz::hash_info<stencilcount_front_hash>,
-                   glz::hash_type::front_hash>::op(short_key.data(), short_key.data() + short_key.size(),
-                                                   short_key.size()) == glz::reflect<stencilcount_front_hash>::size;
-      }());
 
       stencilcount_front_hash front_hash_value{.aaaa = 42};
       for (const std::string_view layout : {"{{a}", "{{a}}", "{{a }", "{{aaaa}}"}) {


### PR DESCRIPTION
Repro: call glz::stencilcount with a non-null-terminated string_view that ends inside a tag, e.g. "{" or "{{+". A sanitizer build reports a heap-buffer-overflow read in stencilcount.hpp.
Cause: the parser dereferences *it without an it < end check in the skip_whitespace lambda, the second-brace test after '{', the '+' counting loop, and both closing-brace tests. read_iterators hands back end = data() + size() with no padding, so those reads run past the buffer.
Fix: gate each of those reads on it != end / it < end, matching what stencil() and mustache() already do in the sibling file.

Before: a template truncated inside a tag reads past the end of the input.
After: the scan stops at end and returns the text accumulated so far.

No change for well-formed templates. The cost is one comparison per brace, which the sibling reader already pays. Added a regression case that runs the parser over exact-size, non-null-terminated buffers so the over-read is caught under the address sanitizer.