### PR TITLE
guard fixed-size arrays in beve bool and complex readers

### DIFF
--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -948,6 +948,12 @@ namespace glz
                   value.shrink_to_fit();
                }
             }
+            else {
+               if (n > value.size()) {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
+            }
 
             for (size_t byte_i{}, i{}; byte_i < num_bytes; ++byte_i, ++it) {
                if (invalid_end(ctx, it, end)) {
@@ -1342,6 +1348,12 @@ namespace glz
 
                if constexpr (check_shrink_to_fit(Opts)) {
                   value.shrink_to_fit();
+               }
+            }
+            else {
+               if (n > value.size()) {
+                  ctx.error = error_code::syntax_error;
+                  return;
                }
             }
 

--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -918,9 +918,13 @@ namespace glz
             }
 
             ++it;
-            const auto n = int_from_compressed(ctx, it, end);
+            std::conditional_t<Opts.partial_read, size_t, const size_t> n = int_from_compressed(ctx, it, end);
             if (bool(ctx.error)) [[unlikely]] {
                return;
+            }
+
+            if constexpr (Opts.partial_read) {
+               n = value.size();
             }
 
             const auto num_bytes = (n + 7) / 8;

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -6825,6 +6825,16 @@ suite beve_fixed_array_bounds_tests = [] {
       expect(bool(glz::read_beve(dst, buffer)));
    };
 
+   "beve fixed bool array supports partial reads"_test = [] {
+      std::vector<bool> src{true, false, true, true, false, true, false, false};
+      std::string buffer{};
+      expect(not glz::write_beve(src, buffer));
+      std::array<bool, 2> dst{};
+      constexpr glz::opts partial{.format = glz::BEVE, .partial_read = true};
+      expect(not glz::read<partial>(dst, buffer));
+      expect(dst == std::array{true, false});
+   };
+
    "beve fixed array exact-size typed arrays round trip"_test = [] {
       {
          std::array<std::complex<double>, 3> src{{{1, 2}, {3, 4}, {5, 6}}};

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -6808,6 +6808,43 @@ suite beve_fully_custom_variant_tests = [] {
    };
 };
 
+suite beve_fixed_array_bounds_tests = [] {
+   "beve fixed array rejects oversized complex typed array"_test = [] {
+      std::vector<std::complex<double>> src(8, std::complex<double>{1.0, 2.0});
+      std::string buffer{};
+      expect(not glz::write_beve(src, buffer));
+      std::array<std::complex<double>, 2> dst{};
+      expect(bool(glz::read_beve(dst, buffer)));
+   };
+
+   "beve fixed array rejects oversized bool typed array"_test = [] {
+      std::vector<bool> src(64, true);
+      std::string buffer{};
+      expect(not glz::write_beve(src, buffer));
+      std::array<bool, 2> dst{};
+      expect(bool(glz::read_beve(dst, buffer)));
+   };
+
+   "beve fixed array exact-size typed arrays round trip"_test = [] {
+      {
+         std::array<std::complex<double>, 3> src{{{1, 2}, {3, 4}, {5, 6}}};
+         std::string buffer{};
+         expect(not glz::write_beve(src, buffer));
+         std::array<std::complex<double>, 3> dst{};
+         expect(not glz::read_beve(dst, buffer));
+         expect(src == dst);
+      }
+      {
+         std::array<bool, 5> src{true, false, true, true, false};
+         std::string buffer{};
+         expect(not glz::write_beve(src, buffer));
+         std::array<bool, 5> dst{};
+         expect(not glz::read_beve(dst, buffer));
+         expect(src == dst);
+      }
+   };
+};
+
 int main()
 {
    trace.begin("binary_test");


### PR DESCRIPTION
Repro: read a BEVE bool or complex typed array into a fixed-size std::array smaller than the encoded element count. Writing a std::vector<std::complex<double>> of 8 and reading into std::array<…, 2> trips ASAN with a heap-buffer-overflow WRITE of 128 bytes at the bulk memcpy; the bool path overflows the same way through value[i], and a bool array needs only ceil(n/8) input bytes to drive n writes.

Cause: the typed-array reader resizes for resizable containers, but for a non-resizable target only the numeric branch checks n against value.size(). The bool and complex branches go straight to the write.

Fix: apply the numeric branch's existing non-resizable check (n > value.size()) in the bool and complex branches.

Before: an oversized n writes past the array. After: it reports syntax_error like the numeric path. Exact-size arrays and resizable containers are unaffected.