### PR TITLE
Fail fast after receiving invalid UTF-8 payload in WebSocket connection

### DIFF
--- a/.github/workflows/autobahn.yml
+++ b/.github/workflows/autobahn.yml
@@ -86,12 +86,6 @@ jobs:
           import sys
 
           allowed = {"OK", "INFORMATIONAL"}
-          allowed_non_strict = {
-             ("6.4.1", "behavior"),
-             ("6.4.2", "behavior"),
-             ("6.4.3", "behavior"),
-             ("6.4.4", "behavior"),
-          }
           agent = os.environ["AUTOBAHN_AGENT"]
           reports = sorted(pathlib.Path("autobahn-reports").rglob("index.json"))
 
@@ -137,8 +131,6 @@ jobs:
                 continue
              for field in ("behavior", "behaviorClose"):
                 value = result.get(field)
-                if value == "NON-STRICT" and (case_id, field) in allowed_non_strict:
-                   continue
                 if value not in allowed:
                    failures.append((case_id, field, value))
 

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -4,6 +4,10 @@ project(glaze_benchmarks)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if (PROJECT_IS_TOP_LEVEL)
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+endif()
+
 include(FetchContent)
 include(CheckIncludeFileCXX)
 

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -68,6 +68,17 @@ target_compile_options(skip_ws_benchmark PRIVATE
   $<$<CXX_COMPILER_ID:MSVC>:/O2>
 )
 
+# UTF-8 validation benchmark (stateless whole-buffer validator vs streaming validator)
+add_executable(utf8_benchmark utf8_benchmark.cpp)
+target_link_libraries(utf8_benchmark PRIVATE
+  glaze
+  bencher::bencher
+)
+target_compile_options(utf8_benchmark PRIVATE
+  $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-O3 -march=native>
+  $<$<CXX_COMPILER_ID:MSVC>:/O2>
+)
+
 # String write optimization benchmark (SWAR-only vs SIMD+SWAR)
 # The no-SIMD baseline is a shared library so the linker can't deduplicate
 # its glz::write template instantiation with the SIMD-enabled one.

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(FetchContent)
+include(CheckIncludeFileCXX)
 
 # Fetch bencher
 FetchContent_Declare(
@@ -119,14 +120,17 @@ target_compile_options(generic_benchmark PRIVATE
 )
 
 # Ordered map memory comparison
-add_executable(ordered_map_memory ordered_map_memory.cpp)
-target_link_libraries(ordered_map_memory PRIVATE
-  glaze
-)
-target_compile_options(ordered_map_memory PRIVATE
-  $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-O3 -march=native>
-  $<$<CXX_COMPILER_ID:MSVC>:/O2>
-)
+check_include_file_cxx("malloc/malloc.h" GLZ_HAS_MALLOC_MALLOC_H)
+if (GLZ_HAS_MALLOC_MALLOC_H)
+  add_executable(ordered_map_memory ordered_map_memory.cpp)
+  target_link_libraries(ordered_map_memory PRIVATE
+    glaze
+  )
+  target_compile_options(ordered_map_memory PRIVATE
+    $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-O3 -march=native>
+    $<$<CXX_COMPILER_ID:MSVC>:/O2>
+  )
+endif()
 
 # HTTP server benchmark: Glaze vs Boost.Beast
 add_subdirectory(http_benchmark)

--- a/benchmarks/ordered_map_benchmark.cpp
+++ b/benchmarks/ordered_map_benchmark.cpp
@@ -49,9 +49,9 @@ struct bench_row
    double std_map_iteration;
 };
 
-const char* pick_winner(double small, double ordered, double std_map)
+const char* pick_winner(double small_map, double ordered, double std_map)
 {
-   if (small >= ordered && small >= std_map) return "glz_small_map";
+   if (small_map >= ordered && small_map >= std_map) return "glz_small_map";
    if (ordered >= std_map) return "glz_map";
    return "std_map";
 }

--- a/benchmarks/string_write_no_simd.cpp
+++ b/benchmarks/string_write_no_simd.cpp
@@ -1,4 +1,7 @@
+// Silence possible warnings about macro redefinition
+#ifndef GLZ_DISABLE_SIMD
 #define GLZ_DISABLE_SIMD
+#endif
 #include "string_write_no_simd.hpp"
 
 #include "glaze/json.hpp"

--- a/benchmarks/string_write_no_simd.hpp
+++ b/benchmarks/string_write_no_simd.hpp
@@ -2,7 +2,17 @@
 
 #include <string>
 
+#if defined(_WIN32)
+#if defined(string_write_no_simd_EXPORTS)
+#define NO_SIMD_API __declspec(dllexport)
+#else
+#define NO_SIMD_API __declspec(dllimport)
+#endif
+#else
+#define NO_SIMD_API
+#endif
+
 namespace no_simd
 {
-   void write_json_string(const std::string& input, std::string& output);
+   NO_SIMD_API void write_json_string(const std::string& input, std::string& output);
 }

--- a/benchmarks/utf8_benchmark.cpp
+++ b/benchmarks/utf8_benchmark.cpp
@@ -1,0 +1,534 @@
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "bencher/bencher.hpp"
+#include "bencher/diagnostics.hpp"
+#include "glaze/util/parse.hpp"
+
+// Copied from
+// https://github.com/boostorg/beast/blob/develop/include/boost/beast/websocket/detail/utf8_checker.hpp
+class utf8_checker
+{
+   std::size_t need_ = 0; // chars we need to finish the code point
+   std::uint8_t* p_ = cp_; // current position in temp buffer
+   std::uint8_t cp_[4]; // a temp buffer for the code point
+
+  public:
+   /** Prepare to process text as valid utf8
+    */
+
+   void reset();
+
+   /** Check that all processed text is valid utf8
+    */
+
+   bool finish();
+
+   /** Check if text is valid UTF8
+
+       @return `true` if the text is valid utf8 or false otherwise.
+   */
+
+   bool write(const std::uint8_t* in, std::size_t size);
+
+   /** Check if text is valid UTF8
+
+       @return `true` if the text is valid utf8 or false otherwise.
+   */
+   template <class ConstBufferSequence>
+   bool write(const ConstBufferSequence& bs);
+};
+
+void utf8_checker::reset()
+{
+   need_ = 0;
+   p_ = cp_;
+}
+
+bool utf8_checker::finish()
+{
+   const auto success = need_ == 0;
+   reset();
+   return success;
+}
+
+bool utf8_checker::write(const std::uint8_t* in, std::size_t size)
+{
+   const auto valid = [](const std::uint8_t*& p) {
+      if (p[0] < 128) {
+         ++p;
+         return true;
+      }
+      if ((p[0] & 0xe0) == 0xc0) {
+         if ((p[1] & 0xc0) != 0x80 || (p[0] & 0x1e) == 0) // overlong
+            return false;
+         p += 2;
+         return true;
+      }
+      if ((p[0] & 0xf0) == 0xe0) {
+         if ((p[1] & 0xc0) != 0x80 || (p[2] & 0xc0) != 0x80 || (p[0] == 0xe0 && (p[1] & 0x20) == 0) // overlong
+             || (p[0] == 0xed && (p[1] & 0x20) == 0x20) // surrogate
+             //|| (p[0] == 0xef && p[1] == 0xbf && (p[2] & 0xfe) == 0xbe) // U+FFFE or U+FFFF
+         )
+            return false;
+         p += 3;
+         return true;
+      }
+      if ((p[0] & 0xf8) == 0xf0) {
+         if ((p[0] & 0x07) >= 0x05 // invalid F5...FF characters
+             || (p[1] & 0xc0) != 0x80 || (p[2] & 0xc0) != 0x80 || (p[3] & 0xc0) != 0x80 ||
+             (p[0] == 0xf0 && (p[1] & 0x30) == 0) // overlong
+             || (p[0] == 0xf4 && p[1] > 0x8f) || p[0] > 0xf4 // > U+10FFFF
+         )
+            return false;
+         p += 4;
+         return true;
+      }
+      return false;
+   };
+   const auto fail_fast = [&]() {
+      if (cp_[0] < 128) {
+         return false;
+      }
+
+      const auto& p = cp_; // alias, only to keep this code similar to valid() above
+      const auto known_only = p_ - cp_;
+      if (known_only == 1) {
+         if ((p[0] & 0xe0) == 0xc0) {
+            return ((p[0] & 0x1e) == 0); // overlong
+         }
+         if ((p[0] & 0xf0) == 0xe0) {
+            return false;
+         }
+         if ((p[0] & 0xf8) == 0xf0) {
+            return ((p[0] & 0x07) >= 0x05); // invalid F5...FF characters
+         }
+      }
+      else if (known_only == 2) {
+         if ((p[0] & 0xe0) == 0xc0) {
+            return ((p[1] & 0xc0) != 0x80 || (p[0] & 0x1e) == 0); // overlong
+         }
+         if ((p[0] & 0xf0) == 0xe0) {
+            return ((p[1] & 0xc0) != 0x80 || (p[0] == 0xe0 && (p[1] & 0x20) == 0) // overlong
+                    || (p[0] == 0xed && (p[1] & 0x20) == 0x20)); // surrogate
+         }
+         if ((p[0] & 0xf8) == 0xf0) {
+            return ((p[0] & 0x07) >= 0x05 // invalid F5...FF characters
+                    || (p[1] & 0xc0) != 0x80 || (p[0] == 0xf0 && (p[1] & 0x30) == 0) // overlong
+                    || (p[0] == 0xf4 && p[1] > 0x8f) || p[0] > 0xf4); // > U+10FFFF
+         }
+      }
+      else if (known_only == 3) {
+         if ((p[0] & 0xe0) == 0xc0) {
+            return ((p[1] & 0xc0) != 0x80 || (p[0] & 0x1e) == 0); // overlong
+         }
+         if ((p[0] & 0xf0) == 0xe0) {
+            return ((p[1] & 0xc0) != 0x80 || (p[2] & 0xc0) != 0x80 || (p[0] == 0xe0 && (p[1] & 0x20) == 0) // overlong
+                    || (p[0] == 0xed && (p[1] & 0x20) == 0x20)); // surrogate
+            //|| (p[0] == 0xef && p[1] == 0xbf && (p[2] & 0xfe) == 0xbe) // U+FFFE or U+FFFF
+         }
+         if ((p[0] & 0xf8) == 0xf0) {
+            return ((p[0] & 0x07) >= 0x05 // invalid F5...FF characters
+                    || (p[1] & 0xc0) != 0x80 || (p[2] & 0xc0) != 0x80 ||
+                    (p[0] == 0xf0 && (p[1] & 0x30) == 0) // overlong
+                    || (p[0] == 0xf4 && p[1] > 0x8f) || p[0] > 0xf4); // > U+10FFFF
+         }
+      }
+      return true;
+   };
+   const auto needed = [](const std::uint8_t v) {
+      if (v < 128) return 1;
+      if (v < 192) return 0;
+      if (v < 224) return 2;
+      if (v < 240) return 3;
+      if (v < 248) return 4;
+      return 0;
+   };
+
+   const auto end = in + size;
+
+   // Finish up any incomplete code point
+   if (need_ > 0) {
+      // Calculate what we have
+      auto n = (std::min)(size, need_);
+      size -= n;
+      need_ -= n;
+
+      // Add characters to the code point
+      while (n--) *p_++ = *in++;
+      assert(p_ <= cp_ + 4);
+
+      // Still incomplete?
+      if (need_ > 0) {
+         // Incomplete code point
+         assert(in == end);
+
+         // Do partial validation on the incomplete
+         // code point, this is called "Fail fast"
+         // in Autobahn|Testsuite parlance.
+         return !fail_fast();
+      }
+
+      // Complete code point, validate it
+      const std::uint8_t* p = &cp_[0];
+      if (!valid(p)) return false;
+      p_ = cp_;
+   }
+
+   if (size <= sizeof(std::size_t)) goto slow;
+
+   // Align `in` to sizeof(std::size_t) boundary
+   {
+      const auto in0 = in;
+      auto last = reinterpret_cast<const std::uint8_t*>(
+         ((reinterpret_cast<std::uintptr_t>(in) + sizeof(std::size_t) - 1) / sizeof(std::size_t)) *
+         sizeof(std::size_t));
+
+      // Check one character at a time for low-ASCII
+      while (in < last) {
+         if (*in & 0x80) {
+            // Not low-ASCII so switch to slow loop
+            size = size - (in - in0);
+            goto slow;
+         }
+         ++in;
+      }
+      size = size - (in - in0);
+   }
+
+   // Fast loop: Process 4 or 8 low-ASCII characters at a time
+   {
+      const auto in0 = in;
+      auto last = in + size - 7;
+      auto constexpr mask = static_cast<std::size_t>(0x8080808080808080 & ~std::size_t{0});
+      while (in < last) {
+#if 0
+            std::size_t temp;
+            std::memcpy(&temp, in, sizeof(temp));
+            if((temp & mask) != 0)
+#else
+         // Technically UB but works on all known platforms
+         if ((*reinterpret_cast<const std::size_t*>(in) & mask) != 0)
+#endif
+         {
+            size = size - (in - in0);
+            goto slow;
+         }
+         in += sizeof(std::size_t);
+      }
+      // There's at least one more full code point left
+      last += 4;
+      while (in < last)
+         if (!valid(in)) return false;
+      goto tail;
+   }
+
+slow:
+   // Slow loop: Full validation on one code point at a time
+   {
+      auto last = in + size - 3;
+      while (in < last)
+         if (!valid(in)) return false;
+   }
+
+tail:
+   // Handle the remaining bytes. The last
+   // characters could split a code point so
+   // we save the partial code point for later.
+   //
+   // On entry to the loop, `in` points to the
+   // beginning of a code point.
+   //
+   for (;;) {
+      // Number of chars left
+      auto n = end - in;
+      if (!n) break;
+
+      // Chars we need to finish this code point
+      const auto need = needed(*in);
+      if (need == 0) return false;
+      if (need <= n) {
+         // Check a whole code point
+         if (!valid(in)) return false;
+      }
+      else {
+         // Calculate how many chars we need
+         // to finish this partial code point
+         need_ = need - n;
+
+         // Save the partial code point
+         while (n--) *p_++ = *in++;
+         assert(in == end);
+         assert(p_ <= cp_ + 4);
+
+         // Do partial validation on the incomplete
+         // code point, this is called "Fail fast"
+         // in Autobahn|Testsuite parlance.
+         return !fail_fast();
+      }
+   }
+   return true;
+}
+
+bool check_utf8(const char* p, std::size_t n)
+{
+   utf8_checker c;
+   if (!c.write(reinterpret_cast<const uint8_t*>(p), n)) return false;
+   return c.finish();
+}
+
+struct websocket_payload_case
+{
+   const char* name;
+   std::string payload;
+   size_t fragment_size;
+};
+
+static std::string build_exact_payload(const std::string_view prefix, const std::string_view repeated,
+                                       const std::string_view suffix, const size_t target_size)
+{
+   assert(prefix.size() + suffix.size() <= target_size);
+
+   std::string out;
+   out.reserve(target_size);
+   out.append(prefix.data(), prefix.size());
+
+   while (out.size() + repeated.size() + suffix.size() <= target_size) {
+      out.append(repeated.data(), repeated.size());
+   }
+
+   static constexpr std::string_view ascii_pad =
+      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 .,:;_-";
+   while (out.size() + suffix.size() < target_size) {
+      const auto remaining = target_size - suffix.size() - out.size();
+      const auto n = (std::min)(remaining, ascii_pad.size());
+      out.append(ascii_pad.data(), n);
+   }
+
+   out.append(suffix.data(), suffix.size());
+   return out;
+}
+
+static std::vector<websocket_payload_case> build_websocket_payload_cases()
+{
+   std::vector<websocket_payload_case> cases;
+   cases.reserve(8);
+
+   cases.push_back({"WS subscribe JSON 124 B (small payload)",
+                    build_exact_payload(R"({"op":"subscribe","channel":"prices:eurusd","last_id":8321,"trace":")",
+                                        "a7c42", R"("})", 124),
+                    31});
+
+   cases.push_back(
+      {"WS subscribe ack 126 B (extended-16 boundary)",
+       build_exact_payload(R"({"op":"subscribed","channel":"prices:eurusd","server_ts":1718181024123,"cursor":")", "42",
+                           R"(","compression":"none"})", 126),
+       63});
+
+   cases.push_back(
+      {"WS chat message 512 B (emoji and text)",
+       build_exact_payload(R"({"type":"chat.message","room":"general","user":"mila","text":")",
+                           "thanks for the update \xF0\x9F\x91\x8D status looks good; next deploy at 14:00 CET. ",
+                           R"(","mentions":["ops"],"id":"msg-83421"})", 512),
+       125});
+
+   cases.push_back(
+      {"WS presence snapshot 1 KiB (mostly ASCII JSON)",
+       build_exact_payload(R"({"type":"presence.snapshot","room":"lobby","members":")",
+                           "u0001 online idle typing; u0002 away; u0003 online mobile; ", R"(","seq":1842203})", 1024),
+       256});
+
+   cases.push_back({"WS collaborative edit 4 KiB (mixed UTF-8)",
+                    build_exact_payload(R"({"type":"doc.patch","doc":"roadmap","ops_text":")",
+                                        "replace /sections/12/body with caf\xC3\xA9 notes "
+                                        "\xE2\x82\xAC budget marker and editor reaction \xF0\x9F\x93\x9D; ",
+                                        R"(","rev":4892})", 4 * 1024),
+                    512});
+
+   cases.push_back(
+      {"WS telemetry batch 16 KiB (ASCII log lines)",
+       build_exact_payload(R"({"type":"telemetry.batch","source":"edge-ws-17","lines":")",
+                           "INFO 2026-06-13T18:42:11Z ws route=/v1/stream latency_ms=4 bytes_out=918 status=ok\\n",
+                           R"(","dropped":0})", 16 * 1024),
+       4 * 1024});
+
+   cases.push_back(
+      {"WS app state snapshot 64 KiB+1 (extended-64 boundary)",
+       build_exact_payload(R"({"type":"state.snapshot","app":"trading","version":8891,"state":")",
+                           "EURUSD bid=1.08421 ask=1.08423 qty=125000; BTCUSD bid=67210.5 ask=67211.0 qty=0.42; ",
+                           R"(","complete":true})", 64 * 1024 + 1),
+       4 * 1024});
+
+   cases.push_back({"WS chat history 256 KiB (multilingual transcript)",
+                    build_exact_payload(R"({"type":"chat.history","room":"support","transcript":")",
+                                        "agent: received message \xF0\x9F\x93\xA8; user: "
+                                        "\xD0\x9F\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82"
+                                        " / "
+                                        "\xE4\xB8\x96\xE7\x95\x8C"
+                                        " / "
+                                        "\xE3\x81\x93\xE3\x82\x93\xE3\x81\xAB\xE3\x81\xA1\xE3\x81\xAF"
+                                        " status ok\\n",
+                                        R"(","page":7})", 256 * 1024),
+                    16 * 1024});
+
+   return cases;
+}
+
+static bool validate_stream_whole(const std::string_view s) noexcept
+{
+   glz::utf8_stream_validator validator;
+   return validator.consume(s.data(), s.size()) && validator.complete();
+}
+
+static bool validate_stream_chunks(const std::string_view s, const size_t chunk_size) noexcept
+{
+   glz::utf8_stream_validator validator;
+   size_t offset = 0;
+   while (offset < s.size()) {
+      const size_t n = (std::min)(chunk_size, s.size() - offset);
+      if (!validator.consume(s.data() + offset, n)) {
+         return false;
+      }
+      offset += n;
+   }
+   return validator.complete();
+}
+
+static bool validate_beast_chunks(const std::string_view s, const size_t chunk_size)
+{
+   utf8_checker checker;
+   size_t offset = 0;
+   while (offset < s.size()) {
+      const size_t n = (std::min)(chunk_size, s.size() - offset);
+      if (!checker.write(reinterpret_cast<const uint8_t*>(s.data() + offset), n)) {
+         return false;
+      }
+      offset += n;
+   }
+   return checker.finish();
+}
+
+static size_t repetitions_per_run(const size_t payload_size) noexcept
+{
+   if (payload_size < 256) return 256;
+   if (payload_size < 1024) return 64;
+   if (payload_size < 4 * 1024) return 16;
+   return 1;
+}
+
+static void bench_whole_buffer(const char* name, const std::string& input)
+{
+   bencher::stage stage{name};
+   stage.min_execution_count = 100;
+   const auto repetitions = repetitions_per_run(input.size());
+
+   stage.run("glz::validate_utf8", [&] {
+      bool valid = true;
+      for (size_t i = 0; i < repetitions; ++i) {
+         const bool iteration_valid = glz::validate_utf8(input.data(), input.size());
+         bencher::do_not_optimize(iteration_valid);
+         valid &= iteration_valid;
+      }
+      bencher::do_not_optimize(valid);
+      return input.size() * repetitions;
+   });
+
+   stage.run("utf8_stream_validator whole buffer", [&] {
+      bool valid = true;
+      for (size_t i = 0; i < repetitions; ++i) {
+         const bool iteration_valid = validate_stream_whole(input);
+         bencher::do_not_optimize(iteration_valid);
+         valid &= iteration_valid;
+      }
+      bencher::do_not_optimize(valid);
+      return input.size() * repetitions;
+   });
+
+   stage.run("boost.beast utf8_checker whole buffer", [&] {
+      bool valid = true;
+      for (size_t i = 0; i < repetitions; ++i) {
+         const bool iteration_valid = check_utf8(input.data(), input.size());
+         bencher::do_not_optimize(iteration_valid);
+         valid &= iteration_valid;
+      }
+      bencher::do_not_optimize(valid);
+      return input.size() * repetitions;
+   });
+
+   bencher::print_results(stage);
+}
+
+static void bench_fragmented(const char* name, const std::string& input, const size_t chunk_size)
+{
+   assert(chunk_size > 0);
+
+   bencher::stage stage{name};
+   stage.min_execution_count = 100;
+   const auto repetitions = repetitions_per_run(input.size());
+
+   stage.run("utf8_stream_validator chunks", [&] {
+      bool valid = true;
+      for (size_t i = 0; i < repetitions; ++i) {
+         const bool iteration_valid = validate_stream_chunks(input, chunk_size);
+         bencher::do_not_optimize(iteration_valid);
+         valid &= iteration_valid;
+      }
+      bencher::do_not_optimize(valid);
+      return input.size() * repetitions;
+   });
+
+   stage.run("boost.beast utf8_checker chunks", [&] {
+      bool valid = true;
+      for (size_t i = 0; i < repetitions; ++i) {
+         const bool iteration_valid = validate_beast_chunks(input, chunk_size);
+         bencher::do_not_optimize(iteration_valid);
+         valid &= iteration_valid;
+      }
+      bencher::do_not_optimize(valid);
+      return input.size() * repetitions;
+   });
+
+   bencher::print_results(stage);
+}
+
+static void verify_payload(const websocket_payload_case& payload_case)
+{
+   const auto input = std::string_view{payload_case.payload};
+   const bool glz_valid = glz::validate_utf8(input.data(), input.size());
+   const bool stream_valid = validate_stream_chunks(input, payload_case.fragment_size);
+   const bool beast_valid = validate_beast_chunks(input, payload_case.fragment_size);
+
+   if (!glz_valid || !stream_valid || !beast_valid) {
+      std::fprintf(stderr, "Invalid UTF-8 payload generated for case: %s\n", payload_case.name);
+      std::abort();
+   }
+}
+
+int main()
+{
+   const auto cases = build_websocket_payload_cases();
+
+   std::printf("=== WebSocket Text Payload UTF-8 Whole Buffer Validation Benchmarks ===\n\n");
+
+   for (const auto& payload_case : cases) {
+      verify_payload(payload_case);
+      bench_whole_buffer(payload_case.name, payload_case.payload);
+   }
+
+   std::printf("\n=== Fragmented WebSocket Text Payload UTF-8 Streaming Validator Benchmarks ===\n\n");
+
+   for (const auto& payload_case : cases) {
+      const auto name =
+         std::string{payload_case.name} + " / " + std::to_string(payload_case.fragment_size) + "-byte chunks";
+      bench_fragmented(name.c_str(), payload_case.payload, payload_case.fragment_size);
+   }
+
+   return 0;
+}

--- a/benchmarks/utf8_benchmark.cpp
+++ b/benchmarks/utf8_benchmark.cpp
@@ -12,8 +12,15 @@
 #include "bencher/diagnostics.hpp"
 #include "glaze/util/parse.hpp"
 
-// Copied from
+//
+// The utf8_checker class below is copied/adapted from Boost.Beast:
 // https://github.com/boostorg/beast/blob/develop/include/boost/beast/websocket/detail/utf8_checker.hpp
+//
+// Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0.
+// See LICENSE-BOOST-1.0.txt in this repository or https://www.boost.org/LICENSE_1_0.txt
+//
 class utf8_checker
 {
    std::size_t need_ = 0; // chars we need to finish the code point

--- a/include/glaze/net/websocket_connection.hpp
+++ b/include/glaze/net/websocket_connection.hpp
@@ -739,6 +739,98 @@ namespace glz
          }
       }
 
+      // Tracks one text frame whose payload arrives across multiple reads
+      struct incomplete_text_frame_state
+      {
+         bool active{};
+         ws_opcode opcode{ws_opcode::continuation};
+         bool fin{};
+         bool masked{};
+         std::size_t header_size{};
+         std::size_t expected_payload_size{};
+         std::size_t consumed_payload_size{};
+         std::array<uint8_t, 4> mask_key{};
+      };
+
+      // Only text message payloads need UTF-8 checks before the full frame is buffered
+      inline bool has_text_message_payload(ws_opcode opcode) const
+      {
+         return (opcode == ws_opcode::text && !is_reading_frame_) ||
+                (opcode == ws_opcode::continuation && is_reading_frame_ && current_opcode_ == ws_opcode::text);
+      }
+
+      // Clear tracking after the incomplete frame is consumed
+      inline void clear_incomplete_text_frame() { incomplete_text_frame_ = {}; }
+
+      // Save metadata for a new incomplete frame, or verify the frame already being tracked
+      inline bool prepare_incomplete_text_frame(ws_opcode opcode, bool fin, bool masked, std::size_t header_size,
+                                                std::size_t expected_payload_size,
+                                                const std::array<uint8_t, 4>& mask_key)
+      {
+         if (!incomplete_text_frame_.active) {
+            incomplete_text_frame_.active = true;
+            incomplete_text_frame_.opcode = opcode;
+            incomplete_text_frame_.fin = fin;
+            incomplete_text_frame_.masked = masked;
+            incomplete_text_frame_.header_size = header_size;
+            incomplete_text_frame_.expected_payload_size = expected_payload_size;
+            incomplete_text_frame_.consumed_payload_size = 0;
+            incomplete_text_frame_.mask_key = mask_key;
+
+            // A text frame starts a new UTF-8 message stream
+            if (opcode == ws_opcode::text) {
+               utf8_validator_.reset();
+            }
+
+            return true;
+         }
+
+         // Re-parsed frame metadata have to match the saved state before more bytes are consumed
+         if (incomplete_text_frame_.opcode != opcode || incomplete_text_frame_.fin != fin ||
+             incomplete_text_frame_.masked != masked || incomplete_text_frame_.header_size != header_size ||
+             incomplete_text_frame_.expected_payload_size != expected_payload_size ||
+             incomplete_text_frame_.mask_key != mask_key) {
+            fail_connection(ws_close_code::protocol_error, "Invalid incomplete frame state");
+            return false;
+         }
+
+         return true;
+      }
+
+      // Consume only new payload bytes that arrived since the previous read
+      inline bool consume_incomplete_text_payload(ws_opcode opcode, bool fin, bool masked, std::size_t header_size,
+                                                  std::size_t expected_payload_size,
+                                                  const std::array<uint8_t, 4>& mask_key, uint8_t* payload,
+                                                  std::size_t available_payload_size)
+      {
+         if (!prepare_incomplete_text_frame(opcode, fin, masked, header_size, expected_payload_size, mask_key)) {
+            return false;
+         }
+
+         // A read can contain the complete header and no payload bytes
+         if (available_payload_size <= incomplete_text_frame_.consumed_payload_size) {
+            return true;
+         }
+
+         const auto consumed_payload_size = incomplete_text_frame_.consumed_payload_size;
+         const auto new_payload_size = available_payload_size - consumed_payload_size;
+
+         // Unmask only new bytes because previous bytes are already unmasked in-place
+         if (masked) {
+            for (std::size_t i = consumed_payload_size; i < available_payload_size; ++i) {
+               payload[i] ^= mask_key[i % 4];
+            }
+         }
+
+         if (!utf8_validator_.consume(payload + consumed_payload_size, new_payload_size)) {
+            fail_connection(ws_close_code::invalid_payload, "Invalid UTF-8");
+            return false;
+         }
+
+         incomplete_text_frame_.consumed_payload_size = available_payload_size;
+         return true;
+      }
+
       inline size_t process_frames(uint8_t* data, std::size_t length)
       {
          std::size_t offset = 0;
@@ -790,30 +882,57 @@ namespace glz
                header_size += 4;
             }
 
-            // Check if we have the complete payload
-            if (length - offset < header_size + payload_length) {
+            // A WebSocket frame can be split across multiple reads
+            uint8_t* payload_ptr = data + offset + header_size;
+            const auto payload_size = static_cast<size_t>(payload_length);
+            const auto available_frame_size = length - offset;
+            const auto available_payload_size =
+               available_frame_size > header_size ? (std::min)(payload_size, available_frame_size - header_size) : 0;
+            const bool payload_is_complete = available_payload_size == payload_size;
+            const bool has_text_payload = has_text_message_payload(header.opcode());
+            bool text_payload_consumed = false;
+
+            // Check received text bytes before waiting for the rest of the frame
+            if (has_text_payload && (!payload_is_complete || incomplete_text_frame_.active)) {
+               if (!consume_incomplete_text_payload(header.opcode(), header.fin(), header.mask(), header_size,
+                                                    payload_size, mask_key, payload_ptr, available_payload_size)) {
+                  return length;
+               }
+               text_payload_consumed = payload_is_complete;
+            }
+
+            if (!payload_is_complete) {
+               // Keep the incomplete frame in frame_buffer_ for the next read
                break;
             }
 
-            // Get pointer to payload in frame buffer and unmask in-place
-            uint8_t* payload_ptr = data + offset + header_size;
-            const auto payload_size = static_cast<size_t>(payload_length);
-
-            if (header.mask() && payload_size > 0) {
+            // Unmask here only when the stream validator has not already unmasked this payload
+            if (header.mask() && payload_size > 0 && !text_payload_consumed) {
                for (std::size_t i = 0; i < payload_size; ++i) {
                   payload_ptr[i] ^= mask_key[i % 4];
                }
             }
 
-            // Handle the frame
-            handle_frame(header.opcode(), payload_ptr, payload_size, header.fin());
+            if (text_payload_consumed) {
+               // The complete payload was already passed to utf8_validator_
+               // Clear only the per-frame state; handle_frame() owns the UTF-8 stream state
+               clear_incomplete_text_frame();
+            }
+
+            handle_frame(header.opcode(), payload_ptr, payload_size, header.fin(), text_payload_consumed);
 
             offset += header_size + static_cast<size_t>(payload_length);
+
+            // Stop processing later frames from the same buffer that failed or closed the connection
+            if (is_closing_.load() || closed_.load()) {
+               return length;
+            }
          }
          return offset;
       }
 
-      inline void handle_frame(ws_opcode opcode, const uint8_t* payload, std::size_t length, bool fin)
+      inline void handle_frame(ws_opcode opcode, const uint8_t* payload, std::size_t length, bool fin,
+                               bool text_payload_consumed = false)
       {
          // RFC 6455 Section 5.5: "All control frames ... MUST NOT be fragmented."
          // A fragmented control frame (FIN == 0) is a protocol error and the connection must fail.
@@ -845,8 +964,16 @@ namespace glz
             if (fin) {
                // Complete single-frame message - deliver directly (zero-copy)
                if (opcode == ws_opcode::text) {
-                  if (!glz::validate_utf8(payload, length)) {
-                     close(ws_close_code::invalid_payload, "Invalid UTF-8");
+                  if (text_payload_consumed) {
+                     // Finish the UTF-8 stream without scanning the same bytes again
+                     if (!utf8_validator_.complete()) {
+                        fail_connection(ws_close_code::invalid_payload, "Invalid UTF-8");
+                        return;
+                     }
+                     utf8_validator_.reset();
+                  }
+                  else if (!glz::validate_utf8(payload, length)) {
+                     fail_connection(ws_close_code::invalid_payload, "Invalid UTF-8");
                      return;
                   }
                }
@@ -860,6 +987,14 @@ namespace glz
             }
             else {
                // Fragmented message - must buffer for reassembly
+               if (opcode == ws_opcode::text && !text_payload_consumed) {
+                  utf8_validator_.reset();
+                  if (!utf8_validator_.consume(payload, length)) {
+                     fail_connection(ws_close_code::invalid_payload, "Invalid UTF-8");
+                     return;
+                  }
+               }
+
                current_opcode_ = opcode;
                message_buffer_.assign(payload, payload + length);
                is_reading_frame_ = true;
@@ -877,18 +1012,24 @@ namespace glz
                return;
             }
 
+            if (current_opcode_ == ws_opcode::text) {
+               if (text_payload_consumed) {
+                  // Finish the UTF-8 stream only at the end of the fragmented message
+                  if (fin && !utf8_validator_.complete()) {
+                     fail_connection(ws_close_code::invalid_payload, "Invalid UTF-8");
+                     return;
+                  }
+               }
+               else if (!utf8_validator_.consume(payload, length) || (fin && !utf8_validator_.complete())) {
+                  fail_connection(ws_close_code::invalid_payload, "Invalid UTF-8");
+                  return;
+               }
+            }
+
             message_buffer_.insert(message_buffer_.end(), payload, payload + length);
 
             if (fin) {
                is_reading_frame_ = false;
-
-               // Validate UTF-8 for text frames
-               if (current_opcode_ == ws_opcode::text) {
-                  if (!glz::validate_utf8(message_buffer_.data(), message_buffer_.size())) {
-                     close(ws_close_code::invalid_payload, "Invalid UTF-8");
-                     return;
-                  }
-               }
 
                std::string_view message_view(reinterpret_cast<const char*>(message_buffer_.data()),
                                              message_buffer_.size());
@@ -899,6 +1040,7 @@ namespace glz
                }
                message_buffer_.clear();
                current_opcode_ = ws_opcode::continuation;
+               utf8_validator_.reset();
             }
             break;
 
@@ -1298,6 +1440,8 @@ namespace glz
       std::array<uint8_t, 16384> read_buffer_;
       std::vector<uint8_t> frame_buffer_;
       std::vector<uint8_t> message_buffer_;
+      utf8_stream_validator utf8_validator_;
+      incomplete_text_frame_state incomplete_text_frame_;
       ws_opcode current_opcode_{ws_opcode::continuation};
       bool is_reading_frame_{false};
       std::atomic<bool> is_closing_{false};

--- a/include/glaze/net/websocket_connection.hpp
+++ b/include/glaze/net/websocket_connection.hpp
@@ -986,9 +986,15 @@ namespace glz
                      }
                      utf8_validator_.reset();
                   }
-                  else if (!glz::validate_utf8(payload, length)) {
-                     fail_connection(ws_close_code::invalid_payload, "Invalid UTF-8");
-                     return false;
+                  else {
+                     // Validate the complete payload with the faster streaming validator.
+                     // A local instance keeps utf8_validator_ reserved for multi-read and
+                     // fragmented text streams, so there is no shared state to reset here.
+                     utf8_stream_validator validator;
+                     if (!validator.consume(payload, length) || !validator.complete()) {
+                        fail_connection(ws_close_code::invalid_payload, "Invalid UTF-8");
+                        return false;
+                     }
                   }
                }
 

--- a/include/glaze/net/websocket_connection.hpp
+++ b/include/glaze/net/websocket_connection.hpp
@@ -846,6 +846,19 @@ namespace glz
             header.data[1] = data[offset + 1];
             size_t header_size = 2;
 
+            // After sending a Close frame, only the peer's Close response is relevant, so
+            // discard any other coalesced frames (RFC 6455 Section 7.1.1 permits dropping
+            // data once a Close has been initiated).
+            //
+            // Note: this discards the rest of the buffer on the first non-Close frame, so a
+            // peer's Close response that is coalesced *behind* another frame in the same read
+            // (e.g. [data][ping][close]) is dropped here rather than completing the handshake
+            // via handle_frame(). That case falls back to on_read()'s error path when the peer
+            // tears down the TCP connection, which still invokes do_close() and fires on_close.
+            if (is_closing_.load() && header.opcode() != ws_opcode::close) {
+               return length;
+            }
+
             // Check reserved bits
             if ((header.data[0] & 0x70) != 0) {
                close(ws_close_code::protocol_error, "Reserved bits set");
@@ -919,19 +932,20 @@ namespace glz
                clear_incomplete_text_frame();
             }
 
-            handle_frame(header.opcode(), payload_ptr, payload_size, header.fin(), text_payload_consumed);
+            const bool continue_processing =
+               handle_frame(header.opcode(), payload_ptr, payload_size, header.fin(), text_payload_consumed);
 
             offset += header_size + static_cast<size_t>(payload_length);
 
-            // Stop processing later frames from the same buffer that failed or closed the connection
-            if (is_closing_.load() || closed_.load()) {
+            // A locally initiated close may have its peer response later in this same buffer.
+            if (!continue_processing || closed_.load()) {
                return length;
             }
          }
          return offset;
       }
 
-      inline void handle_frame(ws_opcode opcode, const uint8_t* payload, std::size_t length, bool fin,
+      inline bool handle_frame(ws_opcode opcode, const uint8_t* payload, std::size_t length, bool fin,
                                bool text_payload_consumed = false)
       {
          // RFC 6455 Section 5.5: "All control frames ... MUST NOT be fragmented."
@@ -939,13 +953,13 @@ namespace glz
          // https://datatracker.ietf.org/doc/html/rfc6455#section-5.5
          if (!fin && ws_util::is_control_frame(opcode)) [[unlikely]] {
             fail_connection(ws_close_code::protocol_error, "Fragmented control frame");
-            return;
+            return false;
          }
 
          // RFC 6455 Section 5.5: "All control frames MUST have a payload length of 125 bytes or less."
          if (length > 125 && ws_util::is_control_frame(opcode)) [[unlikely]] {
             fail_connection(ws_close_code::protocol_error, "Invalid control frame payload length");
-            return;
+            return false;
          }
 
          switch (opcode) {
@@ -953,12 +967,12 @@ namespace glz
          case ws_opcode::binary:
             if (is_reading_frame_) {
                close(ws_close_code::protocol_error, "Unexpected data frame");
-               return;
+               return false;
             }
 
             if (length > max_message_size_) {
                close(ws_close_code::message_too_big, "Message too big");
-               return;
+               return false;
             }
 
             if (fin) {
@@ -968,13 +982,13 @@ namespace glz
                      // Finish the UTF-8 stream without scanning the same bytes again
                      if (!utf8_validator_.complete()) {
                         fail_connection(ws_close_code::invalid_payload, "Invalid UTF-8");
-                        return;
+                        return false;
                      }
                      utf8_validator_.reset();
                   }
                   else if (!glz::validate_utf8(payload, length)) {
                      fail_connection(ws_close_code::invalid_payload, "Invalid UTF-8");
-                     return;
+                     return false;
                   }
                }
 
@@ -991,7 +1005,7 @@ namespace glz
                   utf8_validator_.reset();
                   if (!utf8_validator_.consume(payload, length)) {
                      fail_connection(ws_close_code::invalid_payload, "Invalid UTF-8");
-                     return;
+                     return false;
                   }
                }
 
@@ -1004,12 +1018,12 @@ namespace glz
          case ws_opcode::continuation:
             if (!is_reading_frame_) {
                close(ws_close_code::protocol_error, "Unexpected continuation frame");
-               return;
+               return false;
             }
 
             if (message_buffer_.size() + length > max_message_size_) {
                close(ws_close_code::message_too_big, "Message too big");
-               return;
+               return false;
             }
 
             if (current_opcode_ == ws_opcode::text) {
@@ -1017,12 +1031,12 @@ namespace glz
                   // Finish the UTF-8 stream only at the end of the fragmented message
                   if (fin && !utf8_validator_.complete()) {
                      fail_connection(ws_close_code::invalid_payload, "Invalid UTF-8");
-                     return;
+                     return false;
                   }
                }
                else if (!utf8_validator_.consume(payload, length) || (fin && !utf8_validator_.complete())) {
                   fail_connection(ws_close_code::invalid_payload, "Invalid UTF-8");
-                  return;
+                  return false;
                }
             }
 
@@ -1057,7 +1071,7 @@ namespace glz
             // the body MUST be a 2-byte unsigned integer ..."
             if (length == 1) {
                fail_connection(ws_close_code::protocol_error, "Invalid close payload length");
-               return;
+               return false;
             }
 
             if (length >= 2) {
@@ -1074,14 +1088,14 @@ namespace glz
             // 3. Section 10.7: "Incoming data MUST always be validated by both clients and servers".
             if (!ws_util::is_valid_close_code(code_value)) {
                fail_connection(ws_close_code::protocol_error, "Invalid close code");
-               return;
+               return false;
             }
 
             // RFC 6455 Section 5.5.1: "Following the 2-byte integer, the body MAY contain
             // UTF-8-encoded data with value /reason/"
             if (!reason.empty() && !glz::validate_utf8(reason.c_str(), reason.size())) {
                fail_connection(ws_close_code::invalid_payload, "Invalid close reason");
-               return;
+               return false;
             }
 
             // Store close code and reason for callback
@@ -1103,7 +1117,8 @@ namespace glz
                // control frame, that endpoint SHOULD Close the WebSocket Connection"
                do_close();
             }
-         } break;
+            return false;
+         }
 
          case ws_opcode::ping:
             send_pong(std::string_view(reinterpret_cast<const char*>(payload), length));
@@ -1115,8 +1130,10 @@ namespace glz
 
          default:
             close(ws_close_code::protocol_error, "Unknown opcode");
-            break;
+            return false;
          }
+
+         return true;
       }
 
       inline void send_frame(ws_opcode opcode, std::string_view payload, bool fin = true, bool close_after = false)

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -1431,22 +1431,22 @@ namespace glz
       [[nodiscard]] GLZ_ALWAYS_INLINE bool complete() const noexcept { return valid_ && remaining_ == 0; }
 
      private:
-      static GLZ_ALWAYS_INLINE bool is_continuation(const uint32_t byte) noexcept { return (byte & 0xC0) == 0x80; }
+      GLZ_ALWAYS_INLINE static bool is_continuation(const uint32_t byte) noexcept { return (byte & 0xC0) == 0x80; }
 
-      static GLZ_ALWAYS_INLINE bool is_in_range(const uint32_t byte, const uint32_t lower_bound,
+      GLZ_ALWAYS_INLINE static bool is_in_range(const uint32_t byte, const uint32_t lower_bound,
                                                 const uint32_t upper_bound) noexcept
       {
          return byte - lower_bound <= upper_bound - lower_bound;
       }
 
-      static GLZ_ALWAYS_INLINE uint64_t load_u64(const uint8_t* ptr) noexcept
+      GLZ_ALWAYS_INLINE static uint64_t load_u64(const uint8_t* ptr) noexcept
       {
          uint64_t value;
          std::memcpy(&value, ptr, sizeof(value));
          return value;
       }
 
-      static GLZ_ALWAYS_INLINE size_t first_non_ascii_offset(const uint64_t high_bits) noexcept
+      GLZ_ALWAYS_INLINE static size_t first_non_ascii_offset(const uint64_t high_bits) noexcept
       {
          // REVIEW: Not sure whether this needed or not, does Glaze support middle-endian?
          static_assert(std::endian::native == std::endian::little || std::endian::native == std::endian::big);
@@ -1460,7 +1460,7 @@ namespace glz
          }
       }
 
-      static GLZ_ALWAYS_INLINE const uint8_t* skip_ascii8(const uint8_t* it, const uint8_t* end) noexcept
+      GLZ_ALWAYS_INLINE static const uint8_t* skip_ascii8(const uint8_t* it, const uint8_t* end) noexcept
       {
          constexpr uint64_t mask = glz::repeat_byte8(0x80);
 
@@ -1481,7 +1481,7 @@ namespace glz
          return it;
       }
 
-      static GLZ_ALWAYS_INLINE const uint8_t* skip_ascii_adaptive(const uint8_t* it, const uint8_t* end) noexcept
+      GLZ_ALWAYS_INLINE static const uint8_t* skip_ascii_adaptive(const uint8_t* it, const uint8_t* end) noexcept
       {
          constexpr uint64_t mask = glz::repeat_byte8(0x80);
 
@@ -1535,7 +1535,7 @@ namespace glz
          return skip_ascii8(it, end);
       }
 
-      static GLZ_ALWAYS_INLINE bool consume_full_non_ascii(const uint8_t*& it, const uint32_t byte0) noexcept
+      GLZ_ALWAYS_INLINE static bool consume_full_non_ascii(const uint8_t*& it, const uint32_t byte0) noexcept
       {
          // Called only when at least four bytes remaining, so
          // no boundary checks are needed here
@@ -1587,7 +1587,7 @@ namespace glz
          return false;
       }
 
-      static GLZ_ALWAYS_INLINE bool consume_non_ascii_checked(const uint8_t*& it, const uint8_t* end,
+      GLZ_ALWAYS_INLINE static bool consume_non_ascii_checked(const uint8_t*& it, const uint8_t* end,
                                                               uint32_t& remaining, uint32_t& lower_bound,
                                                               uint32_t& upper_bound) noexcept
       {
@@ -1679,7 +1679,7 @@ namespace glz
          return false;
       }
 
-      static GLZ_ALWAYS_INLINE bool consume_small(const uint8_t*& it, const uint8_t* end, uint32_t& remaining,
+      GLZ_ALWAYS_INLINE static bool consume_small(const uint8_t*& it, const uint8_t* end, uint32_t& remaining,
                                                   uint32_t& lower_bound, uint32_t& upper_bound) noexcept
       {
          // Small-buffer path. Avoid the larger bulk-loop setup and still
@@ -1705,7 +1705,7 @@ namespace glz
          return true;
       }
 
-      static GLZ_ALWAYS_INLINE bool consume_tail(const uint8_t*& it, const uint8_t* end, uint32_t& remaining,
+      GLZ_ALWAYS_INLINE static bool consume_tail(const uint8_t*& it, const uint8_t* end, uint32_t& remaining,
                                                  uint32_t& lower_bound, uint32_t& upper_bound) noexcept
       {
          // Tail normally should be 0..3 bytes after bulk loop
@@ -1727,7 +1727,7 @@ namespace glz
          return true;
       }
 
-      static GLZ_ALWAYS_INLINE bool consume_pending(const uint8_t*& it, const uint8_t* end, uint32_t& remaining,
+      GLZ_ALWAYS_INLINE static bool consume_pending(const uint8_t*& it, const uint8_t* end, uint32_t& remaining,
                                                     uint32_t& lower_bound, uint32_t& upper_bound) noexcept
       {
          // Continue a partially consumed codepoint.

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -1448,15 +1448,12 @@ namespace glz
 
       GLZ_ALWAYS_INLINE static size_t first_non_ascii_offset(const uint64_t high_bits) noexcept
       {
-         // REVIEW: Not sure whether this needed or not, does Glaze support middle-endian?
-         static_assert(std::endian::native == std::endian::little || std::endian::native == std::endian::big);
-
-         // Find the first non-ASCII byte inside the 8-byte word
-         if constexpr (std::endian::native == std::endian::little) {
-            return static_cast<size_t>(std::countr_zero(high_bits) >> 3);
+         // Offset of the first non-ASCII byte within the 8-byte word
+         if constexpr (std::endian::native == std::endian::big) {
+            return static_cast<size_t>(std::countl_zero(high_bits) >> 3);
          }
          else {
-            return static_cast<size_t>(std::countl_zero(high_bits) >> 3);
+            return static_cast<size_t>(std::countr_zero(high_bits) >> 3);
          }
       }
 

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -5,10 +5,10 @@
 
 #include <algorithm>
 #include <bit>
-#include <charconv>
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <iterator>
-#include <span>
 
 #include "glaze/core/context.hpp"
 #include "glaze/core/meta.hpp"
@@ -1329,6 +1329,442 @@ namespace glz
    {
       return val + (multiple - (val % multiple)) % multiple;
    }
+
+   struct utf8_stream_validator
+   {
+      GLZ_ALWAYS_INLINE void reset() noexcept
+      {
+         remaining_ = 0;
+         lower_bound_ = 0x80;
+         upper_bound_ = 0xBF;
+         valid_ = true;
+      }
+
+      GLZ_ALWAYS_INLINE bool consume(const auto* str, const size_t size) noexcept
+      {
+         if (!valid_) [[unlikely]] {
+            return false;
+         }
+
+         if (size == 0) {
+            return true;
+         }
+
+         const uint8_t* it = reinterpret_cast<const uint8_t*>(str);
+         const uint8_t* end = it + size;
+
+         // Copy state to locals to avoid intermediate stores to 'this' in the hot loop.
+         // When uint8_t == unsigned char, '*it' may alias the object representation of
+         // this validator, so the compiler cannot reliably move direct member updates
+         // out of the loop on its own since loop reads '*it' between writes
+         uint32_t remaining = remaining_;
+         uint32_t lower_bound = lower_bound_;
+         uint32_t upper_bound = upper_bound_;
+         const bool had_pending = remaining != 0;
+
+         // First finish a codepoint that was saved from the previous .consume()
+         if (remaining != 0) [[unlikely]] {
+            if (!consume_pending(it, end, remaining, lower_bound, upper_bound)) {
+               return fail();
+            }
+
+            if (it == end) {
+               store_pending(remaining, lower_bound, upper_bound);
+               return true;
+            }
+         }
+
+         // Small chunks probably won't benefit much from the wider bulk loop
+         if (static_cast<size_t>(end - it) <= 32) {
+            if (!consume_small(it, end, remaining, lower_bound, upper_bound)) [[unlikely]] {
+               return fail();
+            }
+
+            if (remaining != 0 || had_pending) {
+               store_pending(remaining, lower_bound, upper_bound);
+            }
+
+            return true;
+         }
+
+         // Bulk path. Four bytes for checking any complete UTF-8 code point safely
+         while (static_cast<size_t>(end - it) >= 4) {
+            uint32_t byte = *it;
+
+            // Avoid wide ASCII probes when already at a non-ASCII byte
+            if (byte < 0x80) {
+               it = skip_ascii_adaptive(it, end);
+               if (static_cast<size_t>(end - it) < 4) {
+                  break;
+               }
+
+               byte = *it;
+            }
+
+            // Non-ASCII, keep validating full codepoints until ASCII
+            // appears or the safe bulk window ends
+            do {
+               if (!consume_full_non_ascii(it, byte)) [[unlikely]] {
+                  return fail();
+               }
+
+               if (static_cast<size_t>(end - it) < 4) {
+                  break;
+               }
+
+               byte = *it;
+            } while (byte >= 0x80);
+         }
+
+         // Finish the last 0..3 bytes and save incomplete codepoint if present
+         if (!consume_tail(it, end, remaining, lower_bound, upper_bound)) [[unlikely]] {
+            return fail();
+         }
+
+         if (remaining != 0 || had_pending) {
+            store_pending(remaining, lower_bound, upper_bound);
+         }
+
+         return true;
+      }
+
+      [[nodiscard]] GLZ_ALWAYS_INLINE bool complete() const noexcept { return valid_ && remaining_ == 0; }
+
+     private:
+      static GLZ_ALWAYS_INLINE bool is_continuation(const uint32_t byte) noexcept { return (byte & 0xC0) == 0x80; }
+
+      static GLZ_ALWAYS_INLINE bool is_in_range(const uint32_t byte, const uint32_t lower_bound,
+                                                const uint32_t upper_bound) noexcept
+      {
+         return byte - lower_bound <= upper_bound - lower_bound;
+      }
+
+      static GLZ_ALWAYS_INLINE uint64_t load_u64(const uint8_t* ptr) noexcept
+      {
+         uint64_t value;
+         std::memcpy(&value, ptr, sizeof(value));
+         return value;
+      }
+
+      static GLZ_ALWAYS_INLINE size_t first_non_ascii_offset(const uint64_t high_bits) noexcept
+      {
+         // REVIEW: Not sure whether this needed or not, does Glaze support middle-endian?
+         static_assert(std::endian::native == std::endian::little || std::endian::native == std::endian::big);
+
+         // Find the first non-ASCII byte inside the 8-byte word
+         if constexpr (std::endian::native == std::endian::little) {
+            return static_cast<size_t>(std::countr_zero(high_bits) >> 3);
+         }
+         else {
+            return static_cast<size_t>(std::countl_zero(high_bits) >> 3);
+         }
+      }
+
+      static GLZ_ALWAYS_INLINE const uint8_t* skip_ascii8(const uint8_t* it, const uint8_t* end) noexcept
+      {
+         constexpr uint64_t mask = glz::repeat_byte8(0x80);
+
+         // Cheap scanner for small buffers
+         while (static_cast<size_t>(end - it) >= 8) {
+            const uint64_t high_bits = load_u64(it) & mask;
+            if (high_bits != 0) {
+               return it + first_non_ascii_offset(high_bits);
+            }
+
+            it += 8;
+         }
+
+         while (it != end && *it < 0x80) {
+            ++it;
+         }
+
+         return it;
+      }
+
+      static GLZ_ALWAYS_INLINE const uint8_t* skip_ascii_adaptive(const uint8_t* it, const uint8_t* end) noexcept
+      {
+         constexpr uint64_t mask = glz::repeat_byte8(0x80);
+
+         // Probe the first few chunks one at a time. This will make short ASCII
+         // runs cheaper, which matters for mixed cases
+         for (uint32_t checked_chunks = 0; checked_chunks < 4; ++checked_chunks) {
+            if (static_cast<size_t>(end - it) < 8) {
+               while (it != end && *it < 0x80) {
+                  ++it;
+               }
+
+               return it;
+            }
+
+            const uint64_t high_bits = load_u64(it) & mask;
+            if (high_bits != 0) {
+               return it + first_non_ascii_offset(high_bits);
+            }
+
+            it += 8;
+         }
+
+         // After 32 ASCII bytes, assume this is a longer ASCII run and use the
+         // wider scanner to reduce loop overhead
+         while (static_cast<size_t>(end - it) >= 32) {
+            const uint64_t first_high_bits = load_u64(it) & mask;
+            const uint64_t second_high_bits = load_u64(it + 8) & mask;
+            const uint64_t third_high_bits = load_u64(it + 16) & mask;
+            const uint64_t fourth_high_bits = load_u64(it + 24) & mask;
+
+            if ((first_high_bits | second_high_bits | third_high_bits | fourth_high_bits) == 0) {
+               it += 32;
+               continue;
+            }
+
+            if (first_high_bits != 0) {
+               return it + first_non_ascii_offset(first_high_bits);
+            }
+
+            if (second_high_bits != 0) {
+               return it + 8 + first_non_ascii_offset(second_high_bits);
+            }
+
+            if (third_high_bits != 0) {
+               return it + 16 + first_non_ascii_offset(third_high_bits);
+            }
+
+            return it + 24 + first_non_ascii_offset(fourth_high_bits);
+         }
+
+         return skip_ascii8(it, end);
+      }
+
+      static GLZ_ALWAYS_INLINE bool consume_full_non_ascii(const uint8_t*& it, const uint32_t byte0) noexcept
+      {
+         // Called only when at least four bytes remaining, so
+         // no boundary checks are needed here
+
+         if ((byte0 & 0xE0) == 0xC0) {
+            const uint32_t byte1 = it[1];
+
+            // C0/C1 would be overlong encodings for ASCII
+            if (((byte1 & 0xC0) != 0x80) || ((byte0 & 0x1E) == 0)) [[unlikely]] {
+               return false;
+            }
+
+            it += 2;
+            return true;
+         }
+
+         if ((byte0 & 0xF0) == 0xE0) {
+            const uint32_t byte1 = it[1];
+            const uint32_t byte2 = it[2];
+
+            // E0 requires A0-BF to reject overlong 3-byte sequences.
+            // ED requires 80-9F to reject UTF-16 surrogate codepoints
+            if (((byte1 & 0xC0) != 0x80) || ((byte2 & 0xC0) != 0x80) || (byte0 == 0xE0 && (byte1 & 0x20) == 0) ||
+                (byte0 == 0xED && (byte1 & 0x20) != 0)) [[unlikely]] {
+               return false;
+            }
+
+            it += 3;
+            return true;
+         }
+
+         if ((byte0 & 0xF8) == 0xF0) {
+            const uint32_t byte1 = it[1];
+            const uint32_t byte2 = it[2];
+            const uint32_t byte3 = it[3];
+
+            // F5..FF are invalid. F0 requires 90-BF to reject overlong sequences.
+            // F4 requires 80-8F to keep the decoded value within U+10FFFF
+            if (((byte0 & 0x07) >= 0x05) || ((byte1 & 0xC0) != 0x80) || ((byte2 & 0xC0) != 0x80) ||
+                ((byte3 & 0xC0) != 0x80) || (byte0 == 0xF0 && (byte1 & 0x30) == 0) || (byte0 == 0xF4 && byte1 > 0x8F))
+               [[unlikely]] {
+               return false;
+            }
+
+            it += 4;
+            return true;
+         }
+
+         return false;
+      }
+
+      static GLZ_ALWAYS_INLINE bool consume_non_ascii_checked(const uint8_t*& it, const uint8_t* end,
+                                                              uint32_t& remaining, uint32_t& lower_bound,
+                                                              uint32_t& upper_bound) noexcept
+      {
+         // Boundary-safe version for small chunks and tails.
+         // May leave pending state instead of failing at the buffer end
+
+         const uint32_t byte0 = *it++;
+
+         if ((byte0 & 0xE0) == 0xC0) {
+            // C0/C1 would be overlong encodings for ASCII
+            if ((byte0 & 0x1E) == 0) [[unlikely]] {
+               return false;
+            }
+
+            if (it == end) {
+               remaining = 1;
+               lower_bound = 0x80;
+               upper_bound = 0xBF;
+               return true;
+            }
+
+            const uint32_t byte1 = *it++;
+
+            if (!is_continuation(byte1)) [[unlikely]] {
+               return false;
+            }
+
+            return true;
+         }
+
+         if ((byte0 & 0xF0) == 0xE0) {
+            // Normal 3-byte starts use 80-BF for the first continuation.
+            // E0 and ED are special to preserve shortest form and reject surrogates
+            const uint32_t first_lower_bound = byte0 == 0xE0 ? 0xA0 : 0x80;
+            const uint32_t first_upper_bound = byte0 == 0xED ? 0x9F : 0xBF;
+
+            // Not enough bytes to finish this codepoint in the current buffer.
+            // Validate what is available and keep the remaining bounds as state
+            if (static_cast<size_t>(end - it) < 2) [[unlikely]] {
+               remaining = 2;
+               lower_bound = first_lower_bound;
+               upper_bound = first_upper_bound;
+               return consume_pending(it, end, remaining, lower_bound, upper_bound);
+            }
+
+            const uint32_t byte1 = *it++;
+            const uint32_t byte2 = *it++;
+
+            if (!is_in_range(byte1, first_lower_bound, first_upper_bound) || !is_continuation(byte2)) [[unlikely]] {
+               return false;
+            }
+
+            return true;
+         }
+
+         if ((byte0 & 0xF8) == 0xF0) {
+            // F5..FF are not valid UTF-8 lead bytes.
+            if ((byte0 & 0x07) >= 0x05) [[unlikely]] {
+               return false;
+            }
+
+            // Normal 4-byte starts use 80-BF for the first continuation.
+            // F0 rejects overlong sequences
+            const uint32_t first_lower_bound = byte0 == 0xF0 ? 0x90 : 0x80;
+            // F4 rejects values above U+10FFFF
+            const uint32_t first_upper_bound = byte0 == 0xF4 ? 0x8F : 0xBF;
+
+            // Same split-sequence handling as the 3-byte path but with three
+            // continuation bytes in total
+            if (static_cast<size_t>(end - it) < 3) [[unlikely]] {
+               remaining = 3;
+               lower_bound = first_lower_bound;
+               upper_bound = first_upper_bound;
+               return consume_pending(it, end, remaining, lower_bound, upper_bound);
+            }
+
+            const uint32_t byte1 = *it++;
+            const uint32_t byte2 = *it++;
+            const uint32_t byte3 = *it++;
+
+            if (!is_in_range(byte1, first_lower_bound, first_upper_bound) || !is_continuation(byte2) ||
+                !is_continuation(byte3)) [[unlikely]] {
+               return false;
+            }
+
+            return true;
+         }
+
+         return false;
+      }
+
+      static GLZ_ALWAYS_INLINE bool consume_small(const uint8_t*& it, const uint8_t* end, uint32_t& remaining,
+                                                  uint32_t& lower_bound, uint32_t& upper_bound) noexcept
+      {
+         // Small-buffer path. Avoid the larger bulk-loop setup and still
+         // use 8-byte ASCII skipping when useful
+         while (it != end) {
+            if (*it < 0x80) {
+               it = skip_ascii8(it, end);
+
+               if (it == end) {
+                  return true;
+               }
+            }
+
+            if (!consume_non_ascii_checked(it, end, remaining, lower_bound, upper_bound)) [[unlikely]] {
+               return false;
+            }
+
+            if (remaining != 0) {
+               return true;
+            }
+         }
+
+         return true;
+      }
+
+      static GLZ_ALWAYS_INLINE bool consume_tail(const uint8_t*& it, const uint8_t* end, uint32_t& remaining,
+                                                 uint32_t& lower_bound, uint32_t& upper_bound) noexcept
+      {
+         // Tail normally should be 0..3 bytes after bulk loop
+         while (it != end) {
+            if (*it < 0x80) {
+               ++it;
+               continue;
+            }
+
+            if (!consume_non_ascii_checked(it, end, remaining, lower_bound, upper_bound)) [[unlikely]] {
+               return false;
+            }
+
+            if (remaining != 0) {
+               return true;
+            }
+         }
+
+         return true;
+      }
+
+      static GLZ_ALWAYS_INLINE bool consume_pending(const uint8_t*& it, const uint8_t* end, uint32_t& remaining,
+                                                    uint32_t& lower_bound, uint32_t& upper_bound) noexcept
+      {
+         // Continue a partially consumed codepoint.
+         // Only the first continuation byte may have a tightened bound
+         while (remaining != 0 && it != end) {
+            const uint32_t byte = *it++;
+            if (!is_in_range(byte, lower_bound, upper_bound)) [[unlikely]] {
+               return false;
+            }
+
+            --remaining;
+            lower_bound = 0x80;
+            upper_bound = 0xBF;
+         }
+
+         return true;
+      }
+
+      GLZ_ALWAYS_INLINE void store_pending(const uint32_t remaining, const uint32_t lower_bound,
+                                           const uint32_t upper_bound) noexcept
+      {
+         remaining_ = static_cast<uint8_t>(remaining);
+         lower_bound_ = static_cast<uint8_t>(lower_bound);
+         upper_bound_ = static_cast<uint8_t>(upper_bound);
+      }
+
+      GLZ_ALWAYS_INLINE bool fail() noexcept
+      {
+         valid_ = false;
+         return false;
+      }
+
+      uint8_t remaining_{};
+      uint8_t lower_bound_{0x80};
+      uint8_t upper_bound_{0xBF};
+      bool valid_{true};
+   };
 
    inline bool validate_utf8(const auto* str, const size_t size) noexcept
    {

--- a/tests/networking_tests/websocket_test/utf8_test.cpp
+++ b/tests/networking_tests/websocket_test/utf8_test.cpp
@@ -134,4 +134,178 @@ suite utf8_validation_tests = [] {
    };
 };
 
+suite utf8_stream_validation_tests = [] {
+   "utf8_stream_split_sequences"_test = [] {
+      glz::utf8_stream_validator validator;
+
+      const char part1[] = "\xF0\x9F";
+      expect(validator.consume(part1, 2));
+      expect(!validator.complete());
+
+      const char part2[] = "\x92\xA9";
+      expect(validator.consume(part2, 2));
+      expect(validator.complete());
+
+      validator.reset();
+      const char euro_part1[] = "\xE2\x82";
+      const char euro_part2[] =
+         "\xAC"
+         " hello";
+      expect(validator.consume(euro_part1, 2));
+      expect(!validator.complete());
+      expect(validator.consume(euro_part2, 7));
+      expect(validator.complete());
+   };
+
+   "utf8_stream_invalid_across_chunks"_test = [] {
+      glz::utf8_stream_validator validator;
+
+      const char lead[] = "\xC2";
+      expect(validator.consume(lead, 1));
+      expect(!validator.complete());
+      expect(!validator.consume(" ", 1));
+
+      validator.reset();
+      const char overlong_part1[] = "\xF0";
+      const char overlong_part2[] = "\x8F\xBF\xBF";
+      expect(validator.consume(overlong_part1, 1));
+      expect(!validator.consume(overlong_part2, 3));
+
+      validator.reset();
+      const char truncated[] = "\xE2\x82";
+      expect(validator.consume(truncated, 2));
+      expect(!validator.complete());
+   };
+
+   "utf8_stream_valid_boundaries_and_all_splits"_test = [] {
+      auto expect_valid_for_all_splits = [](const char* bytes, size_t size) {
+         for (size_t split = 0; split <= size; ++split) {
+            glz::utf8_stream_validator validator;
+
+            expect(validator.consume(bytes, split));
+
+            if (split > 0 && split < size) {
+               expect(!validator.complete());
+            }
+
+            expect(validator.consume(bytes + split, size - split));
+            expect(validator.complete());
+         }
+      };
+
+      expect_valid_for_all_splits("\x7F", 1);
+      expect_valid_for_all_splits("\xC2\x80", 2);
+      expect_valid_for_all_splits("\xDF\xBF", 2);
+      expect_valid_for_all_splits("\xE0\xA0\x80", 3);
+      expect_valid_for_all_splits("\xED\x9F\xBF", 3);
+      expect_valid_for_all_splits("\xEE\x80\x80", 3);
+      expect_valid_for_all_splits("\xEF\xBF\xBF", 3);
+      expect_valid_for_all_splits("\xF0\x90\x80\x80", 4);
+      expect_valid_for_all_splits("\xF4\x8F\xBF\xBF", 4);
+   };
+
+   "utf8_stream_invalid_boundaries"_test = [] {
+      auto expect_invalid = [](const char* bytes, size_t size) {
+         glz::utf8_stream_validator validator;
+         expect(!validator.consume(bytes, size));
+      };
+
+      expect_invalid("\x80", 1);
+      expect_invalid("\xBF", 1);
+
+      expect_invalid("\xC0\x80", 2);
+      expect_invalid("\xC1\xBF", 2);
+
+      expect_invalid("\xE0\x80\x80", 3);
+      expect_invalid("\xE0\x9F\xBF", 3);
+
+      expect_invalid("\xED\xA0\x80", 3);
+      expect_invalid("\xED\xBF\xBF", 3);
+
+      expect_invalid("\xF0\x80\x80\x80", 4);
+      expect_invalid("\xF0\x8F\xBF\xBF", 4);
+
+      expect_invalid("\xF4\x90\x80\x80", 4);
+      expect_invalid("\xF4\xBF\xBF\xBF", 4);
+
+      expect_invalid("\xF5\x80\x80\x80", 4);
+      expect_invalid("\xFE", 1);
+      expect_invalid("\xFF", 1);
+   };
+
+   "utf8_stream_invalid_continuation_positions"_test = [] {
+      auto expect_invalid = [](const char* bytes, size_t size) {
+         glz::utf8_stream_validator validator;
+         expect(!validator.consume(bytes, size));
+      };
+
+      expect_invalid("\xC2\x20", 2);
+
+      expect_invalid("\xE2\x20\x80", 3);
+      expect_invalid("\xE2\x82\x20", 3);
+
+      expect_invalid("\xF0\x90\x20\x80", 4);
+      expect_invalid("\xF0\x90\x80\x20", 4);
+   };
+
+   "utf8_stream_invalid_boundary_rules_across_chunks"_test = [] {
+      auto expect_invalid_across_chunks = [](const char* first, size_t first_size, const char* second,
+                                             size_t second_size) {
+         glz::utf8_stream_validator validator;
+
+         expect(validator.consume(first, first_size));
+         expect(!validator.complete());
+         expect(!validator.consume(second, second_size));
+      };
+
+      expect_invalid_across_chunks("\xC2", 1, "\x20", 1);
+
+      expect_invalid_across_chunks("\xE0", 1, "\x9F\x80", 2);
+      expect_invalid_across_chunks("\xED", 1, "\xA0\x80", 2);
+
+      expect_invalid_across_chunks("\xF0", 1, "\x8F\xBF\xBF", 3);
+      expect_invalid_across_chunks("\xF4", 1, "\x90\x80\x80", 3);
+
+      expect_invalid_across_chunks("\xE2\x82", 2, "\x20", 1);
+      expect_invalid_across_chunks("\xF0\x90\x80", 3, "\x20", 1);
+   };
+
+   "utf8_stream_truncated_sequences"_test = [] {
+      auto expect_incomplete = [](const char* bytes, size_t size) {
+         glz::utf8_stream_validator validator;
+
+         expect(validator.consume(bytes, size));
+         expect(!validator.complete());
+      };
+
+      expect_incomplete("\xC2", 1);
+
+      expect_incomplete("\xE0", 1);
+      expect_incomplete("\xE0\xA0", 2);
+
+      expect_incomplete("\xF0", 1);
+      expect_incomplete("\xF0\x90", 2);
+      expect_incomplete("\xF0\x90\x80", 3);
+   };
+
+   "utf8_stream_empty_ascii_and_reset"_test = [] {
+      glz::utf8_stream_validator validator;
+
+      expect(validator.consume("", 0));
+      expect(validator.complete());
+
+      expect(validator.consume("hello", 5));
+      expect(validator.complete());
+
+      expect(validator.consume("\xE2", 1));
+      expect(!validator.complete());
+
+      validator.reset();
+      expect(validator.complete());
+
+      expect(validator.consume("ok", 2));
+      expect(validator.complete());
+   };
+};
+
 int main() {}

--- a/tests/networking_tests/websocket_test/websocket_close_test.cpp
+++ b/tests/networking_tests/websocket_test/websocket_close_test.cpp
@@ -266,6 +266,66 @@ uint16_t close_code_from_frame(const websocket_frame& frame)
 }
 
 suite websocket_close_frame_tests = [] {
+   "coalesced_close_response_is_processed"_test = [] {
+      constexpr uint16_t port = 18088;
+      std::atomic<bool> server_ready{false};
+      std::atomic<bool> server_closed{false};
+      std::atomic<int> message_count{0};
+
+      auto ws_server = std::make_shared<websocket_server>();
+      ws_server->on_message([&](auto conn, std::string_view, ws_opcode) {
+         ++message_count;
+         conn->close(ws_close_code::normal);
+      });
+      ws_server->on_close([&](auto, ws_close_code, std::string_view) { server_closed = true; });
+
+      http_server server;
+      server.websocket("/ws", ws_server);
+
+      std::thread server_thread([&]() {
+         server.bind(port);
+         server_ready = true;
+         server.start();
+      });
+
+      expect(wait_for_condition([&] { return server_ready.load(); })) << "Server should start";
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+      asio::io_context io_context;
+      asio::ip::tcp::socket socket(io_context);
+      auto handshake_response = connect_raw_websocket(io_context, socket, port);
+      expect(handshake_response.response.find("101 Switching Protocols") != std::string::npos)
+         << "Handshake should succeed";
+
+      const std::vector<uint8_t> message_payload{'c', 'l', 'o', 's', 'e'};
+      auto message_frame = make_masked_client_frame(0x01, message_payload);
+      const std::vector<uint8_t> close_payload{0x03, 0xE8};
+      auto close_frame = make_masked_client_frame(0x08, close_payload);
+      message_frame.insert(message_frame.end(), close_frame.begin(), close_frame.end());
+
+      asio::write(socket, asio::buffer(message_frame));
+
+      expect(wait_for_condition([&] { return message_count.load() == 1; })) << "Text message should be delivered";
+      expect(wait_for_condition([&] { return server_closed.load(); }))
+         << "Coalesced close response should complete the server's close handshake";
+
+      // The client must still receive the server's close frame echoing the normal close code.
+      socket.non_blocking(true);
+      std::vector<uint8_t> pending = std::move(handshake_response.leftover);
+      auto server_close_frame = poll_for_frame(socket, pending, std::chrono::milliseconds(1000));
+      expect(server_close_frame.has_value()) << "Server should send a close frame to the client";
+      expect(server_close_frame && server_close_frame->opcode == 0x08) << "Server frame should be a close frame";
+      if (server_close_frame) {
+         expect(close_code_from_frame(*server_close_frame) == 1000) << "Server close code should be 1000 (normal)";
+      }
+
+      socket.close();
+      server.stop();
+      server_thread.join();
+
+      std::this_thread::sleep_for(std::chrono::milliseconds(500));
+   };
+
    "close_frame_is_sent"_test = [] {
       std::atomic<bool> close_frame_received{false};
       std::atomic<bool> on_close_called{false};

--- a/tests/networking_tests/websocket_test/websocket_close_test.cpp
+++ b/tests/networking_tests/websocket_test/websocket_close_test.cpp
@@ -8,9 +8,11 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <string>
 #include <string_view>
 #include <thread>
 #include <vector>
@@ -189,6 +191,78 @@ void send_close_frame(asio::ip::tcp::socket& socket, uint16_t code = 1000)
                                  static_cast<uint8_t>(code_bytes[1] ^ mask[1])};
 
    asio::write(socket, asio::buffer(frame));
+}
+
+handshake_result connect_raw_websocket(asio::io_context& io_context, asio::ip::tcp::socket& socket, uint16_t port)
+{
+   asio::ip::tcp::resolver resolver(io_context);
+   auto endpoints = resolver.resolve("127.0.0.1", std::to_string(port));
+   asio::connect(socket, endpoints);
+
+   std::string handshake =
+      "GET /ws HTTP/1.1\r\n"
+      "Host: localhost:" +
+      std::to_string(port) +
+      "\r\n"
+      "Upgrade: websocket\r\n"
+      "Connection: Upgrade\r\n"
+      "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+      "Sec-WebSocket-Version: 13\r\n\r\n";
+
+   asio::write(socket, asio::buffer(handshake));
+   return read_handshake_response(socket);
+}
+
+std::size_t masked_client_frame_header_size(std::size_t payload_length)
+{
+   if (payload_length < 126) {
+      return 6;
+   }
+   if (payload_length <= 0xFFFF) {
+      return 8;
+   }
+   return 14;
+}
+
+std::vector<uint8_t> make_masked_client_frame(uint8_t opcode, const std::vector<uint8_t>& payload, bool fin = true)
+{
+   std::vector<uint8_t> frame;
+   frame.reserve(masked_client_frame_header_size(payload.size()) + payload.size());
+
+   frame.push_back(static_cast<uint8_t>((fin ? 0x80 : 0x00) | (opcode & 0x0F)));
+
+   if (payload.size() < 126) {
+      frame.push_back(static_cast<uint8_t>(0x80 | payload.size()));
+   }
+   else if (payload.size() <= 0xFFFF) {
+      frame.push_back(0xFE);
+      frame.push_back(static_cast<uint8_t>(payload.size() >> 8));
+      frame.push_back(static_cast<uint8_t>(payload.size() & 0xFF));
+   }
+   else {
+      frame.push_back(0xFF);
+      const auto payload_length = static_cast<uint64_t>(payload.size());
+      for (int i = 7; i >= 0; --i) {
+         frame.push_back(static_cast<uint8_t>(payload_length >> (8 * i)));
+      }
+   }
+
+   const std::array<uint8_t, 4> mask_key{0x12, 0x34, 0x56, 0x78};
+   frame.insert(frame.end(), mask_key.begin(), mask_key.end());
+
+   for (std::size_t i = 0; i < payload.size(); ++i) {
+      frame.push_back(static_cast<uint8_t>(payload[i] ^ mask_key[i % mask_key.size()]));
+   }
+
+   return frame;
+}
+
+uint16_t close_code_from_frame(const websocket_frame& frame)
+{
+   if (frame.payload.size() < 2) {
+      return 0;
+   }
+   return static_cast<uint16_t>((static_cast<uint16_t>(frame.payload[0]) << 8) | frame.payload[1]);
 }
 
 suite websocket_close_frame_tests = [] {
@@ -573,6 +647,139 @@ suite websocket_error_handling_tests = [] {
 
       expect(close_frame_count == 1) << "Should only receive one close frame despite multiple close() calls";
       expect(on_close_call_count.load() == 1) << "on_close should only be called once";
+   };
+};
+
+suite websocket_utf8_fail_fast_tests = [] {
+   "invalid_utf8_in_incomplete_text_frame_fails_fast"_test = [] {
+      constexpr uint16_t port = 18086;
+      std::atomic<bool> server_ready{false};
+      std::atomic<bool> server_closed{false};
+      std::atomic<int> message_count{0};
+      std::atomic<uint16_t> server_close_code{0};
+
+      auto ws_server = std::make_shared<websocket_server>();
+      ws_server->on_message([&](auto, std::string_view, ws_opcode) { ++message_count; });
+      ws_server->on_close([&](auto, ws_close_code code, std::string_view) {
+         server_close_code = static_cast<uint16_t>(code);
+         server_closed = true;
+      });
+
+      http_server server;
+      server.websocket("/ws", ws_server);
+
+      std::thread server_thread([&]() {
+         server.bind(port);
+         server_ready = true;
+         server.start();
+      });
+
+      expect(wait_for_condition([&] { return server_ready.load(); })) << "Server should start";
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+      asio::io_context io_context;
+      asio::ip::tcp::socket socket(io_context);
+      auto handshake_response = connect_raw_websocket(io_context, socket, port);
+      expect(handshake_response.response.find("101 Switching Protocols") != std::string::npos)
+         << "Handshake should succeed";
+
+      std::vector<uint8_t> payload(32768, static_cast<uint8_t>('a'));
+      payload[0] = 0xFF;
+      auto frame = make_masked_client_frame(0x01, payload);
+      const auto header_size = masked_client_frame_header_size(payload.size());
+
+      asio::write(socket, asio::buffer(frame.data(), header_size + 1));
+
+      socket.non_blocking(true);
+      std::vector<uint8_t> pending = std::move(handshake_response.leftover);
+      auto close_frame = poll_for_frame(socket, pending, std::chrono::milliseconds(1000));
+
+      expect(close_frame.has_value()) << "Server should fail fast before the full text frame arrives";
+      expect(close_frame && close_frame->opcode == 0x08) << "Server should send a close frame";
+      if (close_frame) {
+         expect(close_code_from_frame(*close_frame) == 1007) << "Invalid UTF-8 should close with 1007";
+      }
+
+      expect(message_count.load() == 0) << "Invalid text payload must not be delivered";
+      expect(wait_for_condition([&] { return server_closed.load(); })) << "Server on_close should be called";
+      expect(server_close_code.load() == 1007) << "Server on_close should report 1007";
+
+      socket.close();
+      server.stop();
+      server_thread.join();
+
+      std::this_thread::sleep_for(std::chrono::milliseconds(500));
+   };
+
+   "split_masked_text_frame_preserves_utf8_payload"_test = [] {
+      constexpr uint16_t port = 18087;
+      std::atomic<bool> server_ready{false};
+      std::atomic<int> message_count{0};
+      std::mutex received_mutex;
+      std::string received_message;
+
+      auto ws_server = std::make_shared<websocket_server>();
+      ws_server->on_message([&](auto, std::string_view message, ws_opcode opcode) {
+         if (opcode == ws_opcode::text) {
+            std::lock_guard<std::mutex> lock(received_mutex);
+            received_message.assign(message);
+            ++message_count;
+         }
+      });
+      ws_server->on_close([](auto, ws_close_code, std::string_view) {});
+
+      http_server server;
+      server.websocket("/ws", ws_server);
+
+      std::thread server_thread([&]() {
+         server.bind(port);
+         server_ready = true;
+         server.start();
+      });
+
+      expect(wait_for_condition([&] { return server_ready.load(); })) << "Server should start";
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+      asio::io_context io_context;
+      asio::ip::tcp::socket socket(io_context);
+      auto handshake_response = connect_raw_websocket(io_context, socket, port);
+      expect(handshake_response.response.find("101 Switching Protocols") != std::string::npos)
+         << "Handshake should succeed";
+
+      std::vector<uint8_t> payload;
+      const std::string prefix = "txt: ";
+      payload.insert(payload.end(), prefix.begin(), prefix.end());
+      const std::array<uint8_t, 4> split_code_point{0xF0, 0x9F, 0x92, 0xA9};
+      payload.insert(payload.end(), split_code_point.begin(), split_code_point.end());
+      const std::string suffix = " after split ";
+      payload.insert(payload.end(), suffix.begin(), suffix.end());
+      payload.insert(payload.end(), 64, static_cast<uint8_t>('x'));
+
+      const std::string expected(payload.begin(), payload.end());
+      auto frame = make_masked_client_frame(0x01, payload);
+      const auto header_size = masked_client_frame_header_size(payload.size());
+      const auto first_payload_bytes = prefix.size() + 2;
+
+      asio::write(socket, asio::buffer(frame.data(), header_size + first_payload_bytes));
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      asio::write(socket,
+                  asio::buffer(frame.data() + header_size + first_payload_bytes,
+                               frame.size() - header_size - first_payload_bytes));
+
+      expect(wait_for_condition([&] { return message_count.load() == 1; })) << "Split text frame should be delivered";
+
+      {
+         std::lock_guard<std::mutex> lock(received_mutex);
+         expect(received_message == expected) << "Split masked text frame payload should be preserved";
+      }
+
+      send_close_frame(socket, 1000);
+      socket.close();
+
+      server.stop();
+      server_thread.join();
+
+      std::this_thread::sleep_for(std::chrono::milliseconds(500));
    };
 };
 


### PR DESCRIPTION
Fixes NON-STRICT 6.4 autobahn fuzzingserver cases discovered in #2615
This PR also fixes benchmark builds for Windows, if necessary, I can separate these into different PRs

## New UTF-8 stream validator
To be honest, I'm actually quite pleased with the result here, since my main goal was to beat the `utf8_checker` from boost-beast (based on my benchmarks and tests, I'll avoid making too confident claims about real-world scenarios). Although I'm pretty sure it's possible to make it faster even without SIMD.

When writing `glz::utf8_stream_validator`, the main goal was to maximize performance mainly for mixed UTF-8 and ASCII-only paths, since I believe these will be the most common scenarios for WebSocket messages. Also, perhaps for this reason, it might be worth considering moving `glz::utf8_stream_validator` to the `namespace ws_util` due to this domain-specific optimizations, unless you plan to change the current optimization path.

If described briefly in pseudocode, the logic behind the current validator would look like this:
```
bulk loop:
  while at least 4 bytes remain:
    check current byte

    if current byte is ASCII:
      skip ASCII:
        first probe up to 4 x 8-byte chunks one by one
        if those 32 bytes are ASCII:
          assume buffer is a long ASCII run and start the 32-byte ASCII loop

    if current byte is non-ASCII:
      validate one UTF-8 code point
      keep validating adjacent non-ASCII code points
      stop when ASCII appears or less than 4 bytes remain

tail:
  handle the final 0..3 bytes with boundary checks
  save pending state if the buffer ends inside a UTF-8 sequence
```

`glz::utf8_stream_validator` contains quite a few comments - some to explain the optimizations, and others to help guide the reader through the code's logic more smoothly (I completely understand if you find some of the comments unnecessary)

---
### UTF-8 validator benchmarks
The benchmarks were run locally on my machine:
```
CPU: AMD Ryzen 5 5600 6-Core (3.50 GHz)
Compiler: clang-cl, x64, -O3
```
If it's not too much trouble, I'd appreciate it if you could run these benchmarks in your usual benchmarking environment.

> Throughput below in all of the cases is presented in MB/s

#### WebSocket Text Payload UTF-8 Whole Buffer Validation
Speedup shown in parentheses is relative to `glz::validate_utf8`.
| Payload | `glz::validate_utf8` | `utf8_stream_validator` | Boost.Beast `utf8_checker` |
|---|---:|---:|---:|
| WS subscribe JSON 124 B | 11,644 | **20,182 (+73.3%)** | 13,761 |
| WS subscribe ack 126 B | 10,986 | **18,095 (+64.7%)** | 12,305 |
| WS chat message 512 B | 8,681 | **16,447 (+89.5%)** | 2,155 |
| WS presence snapshot 1 KiB | 15,625 | **39,062 (+150.0%)** | 26,042 |
| WS collaborative edit 4 KiB | 5,580 | **7,812 (+40.0%)** | 2,056 |
| WS telemetry batch 16 KiB | 15,625 | **39,062 (+150.0%)** | 31,250 |
| WS app state snapshot 64 KiB+1 | 16,892 | **44,644 (+164.3%)** | 32,895 |
| WS chat history 256 KiB | 3,149 | **4,000 (+27.0%)** | 2,246 |

#### Fragmented WebSocket Text Payload UTF-8 Streaming Validator
Speedup shown in parentheses is relative to Boost.Beast `utf8_checker`.
| Payload / chunking | `utf8_stream_validator` | Boost.Beast `utf8_checker` |
|---|---:|---:|
| WS subscribe JSON 124 B / 31-byte chunks | **5,220 (+12.1%)** | 4,657 |
| WS subscribe ack 126 B / 63-byte chunks | **8,545 (+11.1%)** | 7,690 |
| WS chat message 512 B / 125-byte chunks | **10,081 (+229.0%)** | 3,064 |
| WS presence snapshot 1 KiB / 256-byte chunks | **26,042 (+16.7%)** | 22,321 |
| WS collaborative edit 4 KiB / 512-byte chunks | **6,510 (+216.7%)** | 2,056 |
| WS telemetry batch 16 KiB / 4096-byte chunks | **39,062 (+25.0%)** | 31,250 |
| WS app state snapshot 64 KiB+1 / 4096-byte chunks | **39,063 (+25.0%)** | 31,250 |
| WS chat history 256 KiB / 16384-byte chunks | **3,782 (+71.7%)** | 2,203 |

---
### A few thoughts

In fact, I believe this part of code is one of the key areas (alongside with masking/unmasking) where Glaze could pull even further ahead in terms of performance and outpace boost-beast and other C++ WebSocket implementations even more. If this validator were ported to SIMD and properly optimized (I'm not very strong in SIMD, so I haven't tried to touch optimizations at that level), I **think** the difference in benchmark results could potentially be very significant.

I also wanted to ask if you'd mind if I use this validator in my own open-source [networking project](https://github.com/blazeauth/aero)?