### PR TITLE
guard eetf_to_json length readers against char sign extension

### DIFF
--- a/include/glaze/eetf/eetf_to_json.hpp
+++ b/include/glaze/eetf/eetf_to_json.hpp
@@ -18,15 +18,15 @@ namespace glz
       GLZ_ALWAYS_INLINE size_t get8s(auto&& ctx, It0&& it, It1&& end) noexcept
       {
          if (check_invalid_offset(ctx, it, end, 1)) return 0;
-         return std::size_t(*it++);
+         return std::size_t(static_cast<uint8_t>(*it++));
       }
 
       template <class It0, class It1>
       GLZ_ALWAYS_INLINE size_t get16be(auto&& ctx, It0&& it, It1&& end) noexcept
       {
          if (check_invalid_offset(ctx, it, end, 2)) return 0;
-         const std::size_t b1 = (*it++) << 8;
-         return b1 | *it++;
+         const std::size_t b1 = std::size_t(static_cast<uint8_t>(*it++)) << 8;
+         return b1 | static_cast<uint8_t>(*it++);
       }
 
       template <auto Opts, typename I>


### PR DESCRIPTION
`get8s` and `get16be` read EETF length fields by dereferencing the input iterator straight into `size_t` (`std::size_t(*it++)`, `(*it++) << 8 | *it++`). When `char` is signed, a length byte with the high bit set sign extends: a legal small-atom length of `0x80` decodes as 18446744073709551488 rather than 128. That value slips past the following `check_invalid_offset` test, since `it + len` wraps the pointer below `end`, so a string_view covering most of the address space reaches the JSON writer and gets read out of bounds. Reachable from `eetf_to_json` on any atom or string whose declared length byte is >= 0x80.

Before, the byte widens as a signed `char` and the sign bit leaks into the length. After, each byte is cast to `uint8_t` before widening, the same `static_cast<uint8_t>(*it)` shape the msgpack and bson readers already use. Putting the cast inside the two byte readers fixes every caller (atom, string, and the small-integer size) at once; the tradeoff is two extra casts on what used to be a single load.