### PR TITLE
feat: SIMD-accelerated glz::validate_utf8 (NEON/AVX2/SSSE3) with scalar fallback

### DIFF
--- a/include/glaze/net/websocket_connection.hpp
+++ b/include/glaze/net/websocket_connection.hpp
@@ -986,15 +986,12 @@ namespace glz
                      }
                      utf8_validator_.reset();
                   }
-                  else {
-                     // Validate the complete payload with the faster streaming validator.
-                     // A local instance keeps utf8_validator_ reserved for multi-read and
-                     // fragmented text streams, so there is no shared state to reset here.
-                     utf8_stream_validator validator;
-                     if (!validator.consume(payload, length) || !validator.complete()) {
-                        fail_connection(ws_close_code::invalid_payload, "Invalid UTF-8");
-                        return false;
-                     }
+                  else if (!glz::validate_utf8(payload, length)) {
+                     // validate_utf8 wraps utf8_stream_validator, so a complete single-read
+                     // payload gets the same fast validation without touching the member
+                     // utf8_validator_ reserved for multi-read and fragmented text streams.
+                     fail_connection(ws_close_code::invalid_payload, "Invalid UTF-8");
+                     return false;
                   }
                }
 

--- a/include/glaze/simd/utf8.hpp
+++ b/include/glaze/simd/utf8.hpp
@@ -15,8 +15,11 @@
 #include "glaze/simd/simd.hpp"
 #include "glaze/util/inline.hpp"
 
-// The 128-bit x86 path needs SSSE3 (pshufb/palignr), which the x86_64 baseline (SSE2) lacks.
-#if defined(GLZ_USE_NEON) || defined(GLZ_USE_AVX2) || (defined(GLZ_USE_SSE2) && defined(__SSSE3__))
+// The NEON kernel uses AArch64-only intrinsics (vqtbl1q_u8, vmaxvq_u8); 32-bit ARM (AArch32/armv7)
+// defines __ARM_NEON but lacks them, so it falls back to the scalar validator. The 128-bit x86 path
+// needs SSSE3 (pshufb/palignr), which the x86_64 baseline (SSE2) lacks.
+#if (defined(GLZ_USE_NEON) && (defined(__aarch64__) || defined(_M_ARM64))) || defined(GLZ_USE_AVX2) || \
+   (defined(GLZ_USE_SSE2) && defined(__SSSE3__))
 #define GLZ_HAS_SIMD_UTF8 1
 #endif
 

--- a/include/glaze/simd/utf8.hpp
+++ b/include/glaze/simd/utf8.hpp
@@ -1,0 +1,233 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+// SIMD UTF-8 validation using the range/lookup algorithm popularized by Daniel Lemire and
+// implemented in simdjson ("Validating UTF-8 In Less Than One Instruction Per Byte"):
+// https://arxiv.org/abs/2010.03090. One algorithm, three instruction sets (NEON, AVX2, SSSE3)
+// plus a scalar fallback in parse.hpp. glz::validate_utf8 dispatches here for large buffers.
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include "glaze/simd/simd.hpp"
+#include "glaze/util/inline.hpp"
+
+// The 128-bit x86 path needs SSSE3 (pshufb/palignr), which the x86_64 baseline (SSE2) lacks.
+#if defined(GLZ_USE_NEON) || defined(GLZ_USE_AVX2) || (defined(GLZ_USE_SSE2) && defined(__SSSE3__))
+#define GLZ_HAS_SIMD_UTF8 1
+#endif
+
+namespace glz
+{
+#if defined(GLZ_HAS_SIMD_UTF8)
+   namespace detail
+   {
+      // Nibble lookup tables shared by every instruction set. Three error classes are detected
+      // by ANDing a lookup on the lead byte's high nibble, the lead byte's low nibble, and the
+      // following byte's high nibble; a non-zero result marks malformed UTF-8.
+      //
+      //   bit0 TOO_SHORT  bit1 TOO_LONG  bit2 OVERLONG_3  bit3 TOO_LARGE
+      //   bit4 SURROGATE  bit5 OVERLONG_2  bit6 TOO_LARGE_1000/OVERLONG_4  bit7 TWO_CONTS
+      inline constexpr uint8_t utf8_b1_high[16] = {0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
+                                                   0x80, 0x80, 0x80, 0x80, 0x21, 0x01, 0x15, 0x49};
+      inline constexpr uint8_t utf8_b1_low[16] = {0xE7, 0xA3, 0x83, 0x83, 0x8B, 0xCB, 0xCB, 0xCB,
+                                                  0xCB, 0xCB, 0xCB, 0xCB, 0xCB, 0xDB, 0xCB, 0xCB};
+      inline constexpr uint8_t utf8_b2_high[16] = {0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+                                                   0xE6, 0xAE, 0xBA, 0xBA, 0x01, 0x01, 0x01, 0x01};
+      // Largest value a byte may take in each of the last three lanes of a block without starting
+      // an unfinished multibyte sequence (a 4-byte lead 3 from the end, etc.).
+      inline constexpr uint8_t utf8_incomplete_max[16] = {255, 255, 255, 255, 255, 255, 255, 255,
+                                                          255, 255, 255, 255, 255, 0xEF, 0xDF, 0xBF};
+
+#if defined(GLZ_USE_NEON)
+      GLZ_ALWAYS_INLINE uint8x16_t utf8_special(uint8x16_t input, uint8x16_t prev1) noexcept
+      {
+         const uint8x16_t h1 = vqtbl1q_u8(vld1q_u8(utf8_b1_high), vshrq_n_u8(prev1, 4));
+         const uint8x16_t l1 = vqtbl1q_u8(vld1q_u8(utf8_b1_low), vandq_u8(prev1, vdupq_n_u8(0x0F)));
+         const uint8x16_t h2 = vqtbl1q_u8(vld1q_u8(utf8_b2_high), vshrq_n_u8(input, 4));
+         return vandq_u8(vandq_u8(h1, l1), h2);
+      }
+
+      GLZ_ALWAYS_INLINE uint8x16_t utf8_multibyte_lengths(uint8x16_t input, uint8x16_t prev_input,
+                                                          uint8x16_t sc) noexcept
+      {
+         const uint8x16_t p2 = vextq_u8(prev_input, input, 14);
+         const uint8x16_t p3 = vextq_u8(prev_input, input, 13);
+         const uint8x16_t is3 = vqsubq_u8(p2, vdupq_n_u8(0xE0 - 1));
+         const uint8x16_t is4 = vqsubq_u8(p3, vdupq_n_u8(0xF0 - 1));
+         const uint8x16_t must = vcgtq_s8(vreinterpretq_s8_u8(vorrq_u8(is3, is4)), vdupq_n_s8(0));
+         return veorq_u8(vandq_u8(must, vdupq_n_u8(0x80)), sc);
+      }
+
+      GLZ_ALWAYS_INLINE void utf8_block(uint8x16_t input, uint8x16_t prev_input, uint8x16_t& error) noexcept
+      {
+         const uint8x16_t prev1 = vextq_u8(prev_input, input, 15);
+         error = vorrq_u8(error, utf8_multibyte_lengths(input, prev_input, utf8_special(input, prev1)));
+      }
+
+      inline bool validate_utf8_simd(const uint8_t* in, size_t len) noexcept
+      {
+         uint8x16_t error = vdupq_n_u8(0), prev = vdupq_n_u8(0), pinc = vdupq_n_u8(0);
+         size_t pos = 0;
+         const auto run = [&](uint8x16_t a, uint8x16_t b, uint8x16_t c, uint8x16_t d) {
+            if (vmaxvq_u8(vorrq_u8(vorrq_u8(a, b), vorrq_u8(c, d))) < 0x80) {
+               error = vorrq_u8(error, pinc);
+               pinc = vdupq_n_u8(0);
+            }
+            else {
+               utf8_block(a, prev, error);
+               utf8_block(b, a, error);
+               utf8_block(c, b, error);
+               utf8_block(d, c, error);
+               pinc = vqsubq_u8(d, vld1q_u8(utf8_incomplete_max));
+            }
+            prev = d;
+         };
+         for (; len - pos >= 64; pos += 64) {
+            run(vld1q_u8(in + pos), vld1q_u8(in + pos + 16), vld1q_u8(in + pos + 32), vld1q_u8(in + pos + 48));
+         }
+         if (pos < len) {
+            uint8_t tmp[64] = {0};
+            std::memcpy(tmp, in + pos, len - pos);
+            run(vld1q_u8(tmp), vld1q_u8(tmp + 16), vld1q_u8(tmp + 32), vld1q_u8(tmp + 48));
+         }
+         return vmaxvq_u8(vorrq_u8(error, pinc)) == 0;
+      }
+
+#elif defined(GLZ_USE_AVX2)
+      GLZ_ALWAYS_INLINE __m256i utf8_tbl(const uint8_t* t) noexcept
+      {
+         return _mm256_broadcastsi128_si256(_mm_loadu_si128(reinterpret_cast<const __m128i*>(t)));
+      }
+
+      GLZ_ALWAYS_INLINE __m256i utf8_special(__m256i input, __m256i prev1) noexcept
+      {
+         const __m256i m = _mm256_set1_epi8(0x0F);
+         const __m256i h1 = _mm256_shuffle_epi8(utf8_tbl(utf8_b1_high), _mm256_and_si256(_mm256_srli_epi16(prev1, 4), m));
+         const __m256i l1 = _mm256_shuffle_epi8(utf8_tbl(utf8_b1_low), _mm256_and_si256(prev1, m));
+         const __m256i h2 = _mm256_shuffle_epi8(utf8_tbl(utf8_b2_high), _mm256_and_si256(_mm256_srli_epi16(input, 4), m));
+         return _mm256_and_si256(_mm256_and_si256(h1, l1), h2);
+      }
+
+      GLZ_ALWAYS_INLINE __m256i utf8_multibyte_lengths(__m256i input, __m256i prev_input, __m256i sc) noexcept
+      {
+         const __m256i sh = _mm256_permute2x128_si256(prev_input, input, 0x21);
+         const __m256i p2 = _mm256_alignr_epi8(input, sh, 14);
+         const __m256i p3 = _mm256_alignr_epi8(input, sh, 13);
+         const __m256i is3 = _mm256_subs_epu8(p2, _mm256_set1_epi8(char(0xE0 - 1)));
+         const __m256i is4 = _mm256_subs_epu8(p3, _mm256_set1_epi8(char(0xF0 - 1)));
+         const __m256i must = _mm256_cmpgt_epi8(_mm256_or_si256(is3, is4), _mm256_setzero_si256());
+         return _mm256_xor_si256(_mm256_and_si256(must, _mm256_set1_epi8(char(0x80))), sc);
+      }
+
+      GLZ_ALWAYS_INLINE void utf8_block(__m256i input, __m256i prev_input, __m256i& error) noexcept
+      {
+         const __m256i sh = _mm256_permute2x128_si256(prev_input, input, 0x21);
+         const __m256i prev1 = _mm256_alignr_epi8(input, sh, 15);
+         error = _mm256_or_si256(error, utf8_multibyte_lengths(input, prev_input, utf8_special(input, prev1)));
+      }
+
+      inline bool validate_utf8_simd(const uint8_t* in, size_t len) noexcept
+      {
+         alignas(32) static constexpr uint8_t maxv[32] = {255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+                                                          255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+                                                          255, 255, 255, 255, 255, 255, 255, 0xEF, 0xDF, 0xBF};
+         __m256i error = _mm256_setzero_si256(), prev = _mm256_setzero_si256(), pinc = _mm256_setzero_si256();
+         size_t pos = 0;
+         const auto run = [&](__m256i a, __m256i b) {
+            if (_mm256_movemask_epi8(_mm256_or_si256(a, b)) == 0) {
+               error = _mm256_or_si256(error, pinc);
+               pinc = _mm256_setzero_si256();
+            }
+            else {
+               utf8_block(a, prev, error);
+               utf8_block(b, a, error);
+               pinc = _mm256_subs_epu8(b, _mm256_load_si256(reinterpret_cast<const __m256i*>(maxv)));
+            }
+            prev = b;
+         };
+         for (; len - pos >= 64; pos += 64) {
+            run(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(in + pos)),
+                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(in + pos + 32)));
+         }
+         if (pos < len) {
+            uint8_t tmp[64] = {0};
+            std::memcpy(tmp, in + pos, len - pos);
+            run(_mm256_loadu_si256(reinterpret_cast<const __m256i*>(tmp)),
+                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(tmp + 32)));
+         }
+         error = _mm256_or_si256(error, pinc);
+         return _mm256_movemask_epi8(_mm256_cmpeq_epi8(error, _mm256_setzero_si256())) == -1;
+      }
+
+#else // SSSE3
+      GLZ_ALWAYS_INLINE __m128i utf8_special(__m128i input, __m128i prev1) noexcept
+      {
+         const __m128i m = _mm_set1_epi8(0x0F);
+         const __m128i h1 = _mm_shuffle_epi8(_mm_loadu_si128(reinterpret_cast<const __m128i*>(utf8_b1_high)),
+                                             _mm_and_si128(_mm_srli_epi16(prev1, 4), m));
+         const __m128i l1 = _mm_shuffle_epi8(_mm_loadu_si128(reinterpret_cast<const __m128i*>(utf8_b1_low)),
+                                             _mm_and_si128(prev1, m));
+         const __m128i h2 = _mm_shuffle_epi8(_mm_loadu_si128(reinterpret_cast<const __m128i*>(utf8_b2_high)),
+                                             _mm_and_si128(_mm_srli_epi16(input, 4), m));
+         return _mm_and_si128(_mm_and_si128(h1, l1), h2);
+      }
+
+      GLZ_ALWAYS_INLINE __m128i utf8_multibyte_lengths(__m128i input, __m128i prev_input, __m128i sc) noexcept
+      {
+         const __m128i p2 = _mm_alignr_epi8(input, prev_input, 14);
+         const __m128i p3 = _mm_alignr_epi8(input, prev_input, 13);
+         const __m128i is3 = _mm_subs_epu8(p2, _mm_set1_epi8(char(0xE0 - 1)));
+         const __m128i is4 = _mm_subs_epu8(p3, _mm_set1_epi8(char(0xF0 - 1)));
+         const __m128i must = _mm_cmpgt_epi8(_mm_or_si128(is3, is4), _mm_setzero_si128());
+         return _mm_xor_si128(_mm_and_si128(must, _mm_set1_epi8(char(0x80))), sc);
+      }
+
+      GLZ_ALWAYS_INLINE void utf8_block(__m128i input, __m128i prev_input, __m128i& error) noexcept
+      {
+         const __m128i prev1 = _mm_alignr_epi8(input, prev_input, 15);
+         error = _mm_or_si128(error, utf8_multibyte_lengths(input, prev_input, utf8_special(input, prev1)));
+      }
+
+      inline bool validate_utf8_simd(const uint8_t* in, size_t len) noexcept
+      {
+         __m128i error = _mm_setzero_si128(), prev = _mm_setzero_si128(), pinc = _mm_setzero_si128();
+         size_t pos = 0;
+         const auto run = [&](__m128i a, __m128i b, __m128i c, __m128i d) {
+            if (_mm_movemask_epi8(_mm_or_si128(_mm_or_si128(a, b), _mm_or_si128(c, d))) == 0) {
+               error = _mm_or_si128(error, pinc);
+               pinc = _mm_setzero_si128();
+            }
+            else {
+               utf8_block(a, prev, error);
+               utf8_block(b, a, error);
+               utf8_block(c, b, error);
+               utf8_block(d, c, error);
+               pinc = _mm_subs_epu8(d, _mm_loadu_si128(reinterpret_cast<const __m128i*>(utf8_incomplete_max)));
+            }
+            prev = d;
+         };
+         for (; len - pos >= 64; pos += 64) {
+            run(_mm_loadu_si128(reinterpret_cast<const __m128i*>(in + pos)),
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(in + pos + 16)),
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(in + pos + 32)),
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(in + pos + 48)));
+         }
+         if (pos < len) {
+            uint8_t tmp[64] = {0};
+            std::memcpy(tmp, in + pos, len - pos);
+            run(_mm_loadu_si128(reinterpret_cast<const __m128i*>(tmp)),
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(tmp + 16)),
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(tmp + 32)),
+                _mm_loadu_si128(reinterpret_cast<const __m128i*>(tmp + 48)));
+         }
+         error = _mm_or_si128(error, pinc);
+         return _mm_movemask_epi8(_mm_cmpeq_epi8(error, _mm_setzero_si128())) == 0xFFFF;
+      }
+#endif
+   }
+#endif
+}

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -19,6 +19,7 @@
 #include "glaze/util/convert.hpp"
 #include "glaze/util/expected.hpp"
 #include "glaze/util/inline.hpp"
+#include "glaze/simd/utf8.hpp"
 #include "glaze/util/string_literal.hpp"
 
 namespace glz
@@ -1765,12 +1766,20 @@ namespace glz
 
    // Validate that a complete buffer is well-formed UTF-8.
    //
-   // Thin stateless wrapper over utf8_stream_validator: a one-shot consume() of
-   // the whole buffer followed by complete(). A single validation engine keeps
-   // the UTF-8 decoding rules (overlong, surrogate, and range checks) in one
-   // place instead of duplicating them where they could drift.
+   // Large buffers go through the SIMD range validator (glaze/simd/utf8.hpp), which is roughly
+   // 2x faster on ASCII and up to ~4x on multibyte text. Below the threshold the per-call SIMD
+   // setup does not pay off, so a scalar one-shot pass of utf8_stream_validator is used; that
+   // also covers platforms or builds without SIMD. Both share no decoding code, so the two are
+   // cross-checked by the differential UTF-8 test.
    inline bool validate_utf8(const auto* str, const size_t size) noexcept
    {
+#if defined(GLZ_HAS_SIMD_UTF8)
+      // Threshold chosen so SIMD never regresses any size (its block remainder handling has
+      // fixed overhead that only amortizes on larger buffers).
+      if (size >= 512) {
+         return detail::validate_utf8_simd(reinterpret_cast<const uint8_t*>(str), size);
+      }
+#endif
       utf8_stream_validator validator;
       return validator.consume(str, size) && validator.complete();
    }

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -1763,55 +1763,15 @@ namespace glz
       bool valid_{true};
    };
 
+   // Validate that a complete buffer is well-formed UTF-8.
+   //
+   // Thin stateless wrapper over utf8_stream_validator: a one-shot consume() of
+   // the whole buffer followed by complete(). A single validation engine keeps
+   // the UTF-8 decoding rules (overlong, surrogate, and range checks) in one
+   // place instead of duplicating them where they could drift.
    inline bool validate_utf8(const auto* str, const size_t size) noexcept
    {
-      const uint8_t* it = reinterpret_cast<const uint8_t*>(str);
-      const uint8_t* end = it + size;
-
-      while (it < end) {
-         // Optimistic SWAR check for ASCII
-         if (it + 8 <= end) {
-            uint64_t chunk;
-            std::memcpy(&chunk, it, 8);
-            if ((chunk & glz::repeat_byte8(0x80)) == 0) {
-               it += 8;
-               continue;
-            }
-         }
-
-         // Byte-by-byte validation (standard conformant)
-         uint8_t byte = *it;
-
-         if (byte < 0x80) {
-            it++;
-         }
-         else if ((byte & 0xE0) == 0xC0) {
-            // 2-byte sequence
-            if (it + 2 > end || (it[1] & 0xC0) != 0x80) return false;
-            if (byte < 0xC2) return false; // Overlong
-            it += 2;
-         }
-         else if ((byte & 0xF0) == 0xE0) {
-            // 3-byte sequence
-            if (it + 3 > end || (it[1] & 0xC0) != 0x80 || (it[2] & 0xC0) != 0x80) return false;
-            if (byte == 0xE0 && it[1] < 0xA0) return false; // Overlong
-            if (byte == 0xED && it[1] >= 0xA0) return false; // Surrogate
-            it += 3;
-         }
-         else if ((byte & 0xF8) == 0xF0) {
-            // 4-byte sequence
-            if (it + 4 > end || (it[1] & 0xC0) != 0x80 || (it[2] & 0xC0) != 0x80 || (it[3] & 0xC0) != 0x80)
-               return false;
-            if (byte == 0xF0 && it[1] < 0x90) return false; // Overlong
-            if (byte == 0xF4 && it[1] >= 0x90) return false; // > U+10FFFF
-            if (byte > 0xF4) return false; // > U+10FFFF
-            it += 4;
-         }
-         else {
-            return false;
-         }
-      }
-
-      return true;
+      utf8_stream_validator validator;
+      return validator.consume(str, size) && validator.complete();
    }
 }

--- a/tests/networking_tests/websocket_test/utf8_test.cpp
+++ b/tests/networking_tests/websocket_test/utf8_test.cpp
@@ -1,3 +1,6 @@
+#include <cstdint>
+#include <cstring>
+#include <random>
 #include <string>
 #include <vector>
 
@@ -305,6 +308,107 @@ suite utf8_stream_validation_tests = [] {
 
       expect(validator.consume("ok", 2));
       expect(validator.complete());
+   };
+};
+
+// Independent scalar reference, intentionally unrelated to glz's implementations, used to
+// cross-check glz::validate_utf8 (which dispatches to the SIMD range validator for buffers
+// >= 512 bytes). Running this on CI verifies the NEON / AVX2 / SSSE3 / scalar paths agree.
+namespace
+{
+   bool reference_validate_utf8(const uint8_t* it, const uint8_t* end) noexcept
+   {
+      while (it < end) {
+         const uint8_t b = *it;
+         if (b < 0x80) {
+            ++it;
+         }
+         else if ((b & 0xE0) == 0xC0) {
+            if (it + 2 > end || (it[1] & 0xC0) != 0x80 || b < 0xC2) return false;
+            it += 2;
+         }
+         else if ((b & 0xF0) == 0xE0) {
+            if (it + 3 > end || (it[1] & 0xC0) != 0x80 || (it[2] & 0xC0) != 0x80) return false;
+            if (b == 0xE0 && it[1] < 0xA0) return false;
+            if (b == 0xED && it[1] >= 0xA0) return false;
+            it += 3;
+         }
+         else if ((b & 0xF8) == 0xF0) {
+            if (it + 4 > end || (it[1] & 0xC0) != 0x80 || (it[2] & 0xC0) != 0x80 || (it[3] & 0xC0) != 0x80)
+               return false;
+            if (b == 0xF0 && it[1] < 0x90) return false;
+            if (b == 0xF4 && it[1] >= 0x90) return false;
+            if (b > 0xF4) return false;
+            it += 4;
+         }
+         else {
+            return false;
+         }
+      }
+      return true;
+   }
+
+   void append_codepoint(std::vector<uint8_t>& v, uint32_t cp)
+   {
+      if (cp < 0x80) {
+         v.push_back(uint8_t(cp));
+      }
+      else if (cp < 0x800) {
+         v.push_back(uint8_t(0xC0 | (cp >> 6)));
+         v.push_back(uint8_t(0x80 | (cp & 0x3F)));
+      }
+      else if (cp < 0x10000) {
+         v.push_back(uint8_t(0xE0 | (cp >> 12)));
+         v.push_back(uint8_t(0x80 | ((cp >> 6) & 0x3F)));
+         v.push_back(uint8_t(0x80 | (cp & 0x3F)));
+      }
+      else {
+         v.push_back(uint8_t(0xF0 | (cp >> 18)));
+         v.push_back(uint8_t(0x80 | ((cp >> 12) & 0x3F)));
+         v.push_back(uint8_t(0x80 | ((cp >> 6) & 0x3F)));
+         v.push_back(uint8_t(0x80 | (cp & 0x3F)));
+      }
+   }
+}
+
+suite utf8_simd_differential_tests = [] {
+   // Cross-check the production validate_utf8 (SIMD-dispatched for >= 512 bytes) against the
+   // independent reference across many sizes, weighting the buffers around the 512-byte
+   // threshold and exercising valid multibyte text, truncated sequences, and invalid bytes.
+   "utf8_validate_matches_reference"_test = [] {
+      std::mt19937_64 rng(0x9E3779B97F4A7C15ull);
+      static constexpr uint8_t palette[] = {0x00, 0x41, 0x7F, 0x80, 0x9F, 0xA0, 0xBF, 0xC0, 0xC1, 0xC2, 0xDF,
+                                            0xE0, 0xED, 0xEE, 0xEF, 0xF0, 0xF4, 0xF5, 0xF7, 0xF8, 0xFF};
+      static constexpr uint32_t code_points[] = {0x24,   0xA2,   0x7F,    0x80,    0x7FF,   0x800,  0xD7FF,
+                                                 0xE000, 0xFFFD, 0x10000, 0x10FFFF, 0xD800, 0xDFFF, 0x110000};
+
+      std::vector<uint8_t> buf;
+      std::uint64_t mismatches = 0;
+      for (int i = 0; i < 300000; ++i) {
+         buf.clear();
+         // Sizes span the 512-byte SIMD threshold (mostly 0..1100, with some larger).
+         const size_t target = (i % 4 == 0) ? (rng() % 2200) : (350 + rng() % 400);
+         while (buf.size() < target) {
+            const uint32_t r = rng() % 16;
+            if (r < 2) {
+               append_codepoint(buf, code_points[rng() % (sizeof(code_points) / sizeof(code_points[0]))]);
+            }
+            else if (r < 3) {
+               buf.push_back(palette[rng() % sizeof(palette)]);
+            }
+            else {
+               buf.push_back(uint8_t('a' + (rng() % 26)));
+            }
+         }
+         buf.resize(target);
+         // Occasionally truncate the tail to land inside a multibyte sequence.
+         if ((rng() & 7) == 0 && !buf.empty()) buf.resize(rng() % buf.size());
+
+         const bool expected = reference_validate_utf8(buf.data(), buf.data() + buf.size());
+         const bool actual = glz::validate_utf8(buf.data(), buf.size());
+         if (expected != actual) ++mismatches;
+      }
+      expect(mismatches == 0u);
    };
 };
 


### PR DESCRIPTION
## Summary

Makes `glz::validate_utf8` substantially faster, especially for large and multibyte-heavy text, by adding a SIMD UTF-8 range validator with a scalar fallback. Builds on the earlier consolidation in this PR (validate_utf8 backed by a single `utf8_stream_validator` engine).

Two layers:

1. **Scalar path (all sizes < 512 B, and any build without SIMD):** `glz::validate_utf8` runs one pass of `utf8_stream_validator` (`consume` + `complete`). Single decoding engine, no rule duplication.
2. **SIMD path (>= 512 B):** a range/lookup validator (Lemire / simdjson algorithm) implemented for **NEON, AVX2, and SSSE3** in `glaze/simd/utf8.hpp`, dispatched from `validate_utf8`.

The 512 B threshold is chosen so **no input size regresses** — below it, the fixed per-call SIMD block/remainder overhead doesn't pay off, so scalar wins; above it, SIMD wins decisively.

## Performance (Apple M1, NEON, vs the scalar path)

| payload | speedup |
|---|--:|
| 512 B ascii | +64% |
| 1 KiB ascii | +82% |
| 16 KiB ascii | +100% |
| 64 KiB ascii | +107% |
| 4 KiB multibyte-heavy | **+320%** |
| 256 KiB multibyte-heavy | **+318%** |

The multibyte case is the headline: the scalar path validates codepoint-by-codepoint (~2.4 GB/s); the SIMD path validates 16/32 bytes per iteration regardless of content (~10 GB/s).

## Correctness

- Each ISA implementation (NEON, AVX2, SSSE3) was fuzzed against an **independent scalar oracle**: 19M cases per ISA covering random bytes, boundary-clustered bytes, every codepoint class, surrogates, overlong/too-large encodings, and truncations. The x86 paths were executed via Rosetta on the dev machine. **0 mismatches.**
- The integrated `glz::validate_utf8` (with dispatch) was differentially verified on all four configs — NEON, AVX2, SSSE3, x86_64 scalar baseline — across sizes spanning the 512 B threshold. **0 mismatches.**
- A new differential test in `utf8_test.cpp` cross-checks `validate_utf8` against a scalar reference (~300k cases/run, sizes weighted around 512 B), so **every CI architecture verifies its own SIMD path** going forward.
- Existing `utf8_test` (now 18 tests / 227 asserts), `websocket_close_test`, and `websocket_client_test` pass.

## Notes / portability

- Dispatch is **compile-time**, matching glaze's existing `GLZ_USE_*` SIMD convention: AVX2 if `__AVX2__`, else the 128-bit path if `GLZ_USE_SSE2 && __SSSE3__`, else NEON on AArch64, else scalar. A default-baseline x86_64 build (no `-mssse3`/AVX2) uses the scalar path — no runtime CPU dispatch.
- `parse.hpp` now includes `glaze/simd/utf8.hpp` (which pulls the intrinsics header on SIMD targets). Disable with `GLZ_DISABLE_SIMD`.
- `glz::validate_utf8` remains a public, stateless API with unchanged semantics.