### PR TITLE
guard eetf big integer sign byte read against end

### DIFF
--- a/include/glaze/eetf/eetf_to_json.hpp
+++ b/include/glaze/eetf/eetf_to_json.hpp
@@ -46,11 +46,13 @@ namespace glz
          auto tit = it;
          ++tit; // skip type
          const auto size = get8s(ctx, tit, end);
+         if (bool(ctx.error)) return;
          if (size > 8u) {
             ctx.error = error_code::no_matching_variant_type;
             return;
          }
 
+         if (check_invalid_offset(ctx, tit, end, 1)) return;
          const int sign = *tit++;
          if (sign) {
             term_to_json_number<Opts>(std::int64_t{}, ctx, it, end, out, ix);

--- a/include/glaze/eetf/eetf_to_json.hpp
+++ b/include/glaze/eetf/eetf_to_json.hpp
@@ -52,7 +52,7 @@ namespace glz
             return;
          }
 
-         if (check_invalid_offset(ctx, tit, end, 1)) return;
+         if (check_invalid_offset(ctx, tit, end, 1 + size)) return;
          const int sign = *tit++;
          if (sign) {
             term_to_json_number<Opts>(std::int64_t{}, ctx, it, end, out, ix);

--- a/include/glaze/eetf/ei.hpp
+++ b/include/glaze/eetf/ei.hpp
@@ -15,7 +15,10 @@ namespace glz
    template <class Ctx, class It0, class It1>
    [[nodiscard]] GLZ_ALWAYS_INLINE bool check_invalid_offset(Ctx&& ctx, It0&& it, It1&& end, size_t off) noexcept
    {
-      if (it > end || static_cast<size_t>(end - it) < off) [[unlikely]] {
+      // Callers maintain it <= end (every advance is bounds-checked or followed by invalid_end),
+      // so end - it is non-negative. Computing the remaining size as a subtraction avoids the
+      // out-of-bounds pointer arithmetic that (it + off) > end would incur for a large off.
+      if (static_cast<size_t>(end - it) < off) [[unlikely]] {
          ctx.error = error_code::unexpected_end;
          return true;
       }

--- a/include/glaze/eetf/ei.hpp
+++ b/include/glaze/eetf/ei.hpp
@@ -15,7 +15,7 @@ namespace glz
    template <class Ctx, class It0, class It1>
    [[nodiscard]] GLZ_ALWAYS_INLINE bool check_invalid_offset(Ctx&& ctx, It0&& it, It1&& end, size_t off) noexcept
    {
-      if ((it + off) > end) [[unlikely]] {
+      if (it > end || static_cast<size_t>(end - it) < off) [[unlikely]] {
          ctx.error = error_code::unexpected_end;
          return true;
       }

--- a/tests/eetf_test/eetf_test.cpp
+++ b/tests/eetf_test/eetf_test.cpp
@@ -428,8 +428,7 @@ suite eetf_to_json_tests = [] {
    };
 
    "eetf_to_json small big integer"_test = [] {
-      const std::array<std::uint8_t, 5> buffer{static_cast<std::uint8_t>(glz::eetf_magic_version),
-                                               static_cast<std::uint8_t>(ERL_SMALL_BIG_EXT), 1, 0, 42};
+      const std::array<std::uint8_t, 5> buffer{uint8_t(glz::eetf_magic_version), uint8_t(ERL_SMALL_BIG_EXT), 1, 0, 42};
 
       std::string json{};
       expect(!glz::eetf_to_json(buffer, json));
@@ -443,14 +442,12 @@ suite eetf_to_json_tests = [] {
          expect(ec.ec == glz::error_code::unexpected_end);
       };
 
-      const std::array<std::uint8_t, 2> missing_size{static_cast<std::uint8_t>(glz::eetf_magic_version),
-                                                     static_cast<std::uint8_t>(ERL_SMALL_BIG_EXT)};
-      const std::array<std::uint8_t, 3> missing_sign{static_cast<std::uint8_t>(glz::eetf_magic_version),
-                                                     static_cast<std::uint8_t>(ERL_SMALL_BIG_EXT), 1};
-      const std::array<std::uint8_t, 4> missing_digits{static_cast<std::uint8_t>(glz::eetf_magic_version),
-                                                       static_cast<std::uint8_t>(ERL_SMALL_BIG_EXT), 8, 0};
-      const std::array<std::uint8_t, 6> partial_digits{static_cast<std::uint8_t>(glz::eetf_magic_version),
-                                                       static_cast<std::uint8_t>(ERL_SMALL_BIG_EXT), 3, 0, 1, 2};
+      const std::array<std::uint8_t, 2> missing_size{uint8_t(glz::eetf_magic_version), uint8_t(ERL_SMALL_BIG_EXT)};
+      const std::array<std::uint8_t, 3> missing_sign{uint8_t(glz::eetf_magic_version), uint8_t(ERL_SMALL_BIG_EXT), 1};
+      const std::array<std::uint8_t, 4> missing_digits{uint8_t(glz::eetf_magic_version), uint8_t(ERL_SMALL_BIG_EXT), 8,
+                                                       0};
+      const std::array<std::uint8_t, 6> partial_digits{uint8_t(glz::eetf_magic_version), uint8_t(ERL_SMALL_BIG_EXT), 3,
+                                                       0, 1, 2};
 
       expect_unexpected_end(missing_size);
       expect_unexpected_end(missing_sign);

--- a/tests/eetf_test/eetf_test.cpp
+++ b/tests/eetf_test/eetf_test.cpp
@@ -427,6 +427,37 @@ suite eetf_to_json_tests = [] {
       expect(json == R"([99,"spiders"])") << json;
    };
 
+   "eetf_to_json small big integer"_test = [] {
+      const std::array<std::uint8_t, 5> buffer{static_cast<std::uint8_t>(glz::eetf_magic_version),
+                                               static_cast<std::uint8_t>(ERL_SMALL_BIG_EXT), 1, 0, 42};
+
+      std::string json{};
+      expect(!glz::eetf_to_json(buffer, json));
+      expect(json == "42") << json;
+   };
+
+   "eetf_to_json truncated small big integer"_test = [] {
+      auto expect_unexpected_end = [](const auto& buffer) {
+         std::string json{};
+         const auto ec = glz::eetf_to_json(buffer, json);
+         expect(ec.ec == glz::error_code::unexpected_end);
+      };
+
+      const std::array<std::uint8_t, 2> missing_size{static_cast<std::uint8_t>(glz::eetf_magic_version),
+                                                     static_cast<std::uint8_t>(ERL_SMALL_BIG_EXT)};
+      const std::array<std::uint8_t, 3> missing_sign{static_cast<std::uint8_t>(glz::eetf_magic_version),
+                                                     static_cast<std::uint8_t>(ERL_SMALL_BIG_EXT), 1};
+      const std::array<std::uint8_t, 4> missing_digits{static_cast<std::uint8_t>(glz::eetf_magic_version),
+                                                       static_cast<std::uint8_t>(ERL_SMALL_BIG_EXT), 8, 0};
+      const std::array<std::uint8_t, 6> partial_digits{static_cast<std::uint8_t>(glz::eetf_magic_version),
+                                                       static_cast<std::uint8_t>(ERL_SMALL_BIG_EXT), 3, 0, 1, 2};
+
+      expect_unexpected_end(missing_size);
+      expect_unexpected_end(missing_sign);
+      expect_unexpected_end(missing_digits);
+      expect_unexpected_end(partial_digits);
+   };
+
    "eetf_to_json no header"_test = [] {
       constexpr int items = 3;
       std::vector<simple> v;


### PR DESCRIPTION
term_to_json_big_integer reads the sign byte of a SMALL_BIG term with `const int sign = *tit++`, but get8s only validates and consumes the length byte that precedes it. A term that ends right after that length byte (the two bytes `6e 00`) leaves tit sitting at end, so the sign read runs one byte past the input buffer.

Before, the size byte is range checked but the sign byte right after it is read unconditionally. After, the error from get8s is honored and check_invalid_offset gates the sign read, the same guard the string and atom cases in this file already use. Keeping the check next to the read makes a truncated term fail with unexpected_end rather than touching memory past the buffer; the cost is a single comparison on a path that was already doing per-field bounds checks.