### PR TITLE
guard http_client chunked readers against chunk size overflow

### DIFF
--- a/include/glaze/net/http_client.hpp
+++ b/include/glaze/net/http_client.hpp
@@ -12,6 +12,7 @@
 #include <future>
 #include <glaze/glaze.hpp>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -1707,6 +1708,15 @@ namespace glz
                            http_data_handler on_data, http_error_handler on_error,
                            http_disconnect_handler on_disconnect)
       {
+         // A chunk size with no room for the trailing CRLF wraps chunk_size + 2 below, passes the
+         // buffered-size check with a tiny length, and hands on_data a view of chunk_size bytes
+         // over a few-byte buffer. Reject it as a malformed chunk.
+         if (chunk_size > (std::numeric_limits<size_t>::max)() - 2) [[unlikely]] {
+            on_error(std::make_error_code(std::errc::protocol_error));
+            if (on_disconnect) on_disconnect();
+            return;
+         }
+
          // We need to read 'chunk_size' bytes of data, plus 2 bytes for the trailing CRLF.
          size_t total_to_read = chunk_size + 2;
 
@@ -2090,6 +2100,14 @@ namespace glz
                   if (max_response_body_size_ > 0 && response_body.size() + chunk_size > max_response_body_size_) {
                      detail::close_socket(socket_var, connection_pool->graceful_ssl_shutdown());
                      r.outcome = std::unexpected(make_error_code(http_client_error::response_too_large));
+                     return r;
+                  }
+
+                  // A chunk size that leaves no room for the trailing CRLF wraps chunk_size + 2
+                  // below and appends with a bogus length, so reject it as malformed.
+                  if (chunk_size > (std::numeric_limits<size_t>::max)() - 2) {
+                     detail::close_socket(socket_var, connection_pool->graceful_ssl_shutdown());
+                     r.outcome = std::unexpected(std::make_error_code(std::errc::protocol_error));
                      return r;
                   }
 
@@ -2519,6 +2537,14 @@ namespace glz
          if (max_response_body_size_ > 0 && body->size() + chunk_size > max_response_body_size_) {
             detail::close_socket(*socket_var, connection_pool->graceful_ssl_shutdown());
             handler(std::unexpected(make_error_code(http_client_error::response_too_large)));
+            return;
+         }
+
+         // A chunk size that leaves no room for the trailing CRLF wraps chunk_size + 2 below
+         // and appends with a bogus length, so reject it as malformed.
+         if (chunk_size > (std::numeric_limits<size_t>::max)() - 2) {
+            detail::close_socket(*socket_var, connection_pool->graceful_ssl_shutdown());
+            handler(std::unexpected(std::make_error_code(std::errc::protocol_error)));
             return;
          }
 

--- a/tests/networking_tests/http_chunked_test/http_chunked_test.cpp
+++ b/tests/networking_tests/http_chunked_test/http_chunked_test.cpp
@@ -1699,6 +1699,60 @@ suite chunked_raw_socket_tests = [] {
       expect(!result.has_value()) << "Malformed chunk size should return an error";
    };
 
+   // A malicious server can send a chunk-size line near SIZE_MAX. chunk_size + 2 then wraps
+   // in the chunk-body reader, the buffered-size check passes with a tiny length, and the
+   // streaming reader would hand on_data a string_view of chunk_size bytes over a few-byte
+   // buffer. The client must reject the chunk instead of delivering an out-of-bounds view.
+   "raw_oversized_chunk_size_rejected"_test = [&] {
+      uint16_t port = 0;
+      std::string raw =
+         "HTTP/1.1 200 OK\r\n"
+         "Transfer-Encoding: chunked\r\n"
+         "Content-Type: text/plain\r\n"
+         "\r\n"
+         "ffffffffffffffff\r\n" // 2^64 - 1
+         "AAAA\r\n"
+         "0\r\n"
+         "\r\n";
+
+      auto server_thread = start_raw_server(port, raw);
+
+      glz::http_client client;
+      std::atomic<size_t> max_view{0};
+      std::atomic<bool> error_fired{false};
+      std::promise<void> done;
+      auto done_future = done.get_future();
+      std::atomic<bool> done_set{false};
+      auto finish = [&] {
+         if (!done_set.exchange(true)) done.set_value();
+      };
+
+      auto conn = client.stream_request_v2({
+         .url = "http://127.0.0.1:" + std::to_string(port) + "/test",
+         .body = {},
+         .headers = {},
+         .on_connect = {},
+         .on_disconnect = [&] { finish(); },
+         .on_data =
+            [&](std::string_view data) {
+               // Record only the claimed size; reading the bytes of an oversized view is
+               // the out-of-bounds access being guarded against.
+               size_t prev = max_view.load();
+               while (data.size() > prev && !max_view.compare_exchange_weak(prev, data.size())) {
+               }
+            },
+         .on_error = [&](std::error_code) { error_fired = true; },
+      });
+
+      done_future.wait_for(std::chrono::seconds(5));
+      server_thread.join();
+
+      // The whole crafted response is well under 1 KiB, so no legitimate chunk view can
+      // exceed that. Before the fix the reader reports a view of 2^64 - 1 bytes.
+      expect(max_view.load() <= 1024u) << "client delivered an oversized chunk view: " << max_view.load();
+      expect(error_fired.load()) << "malformed chunk size should surface an error";
+   };
+
    "raw_empty_chunk_size_line"_test = [&] {
       uint16_t port = 0;
       // Empty chunk size line (just CRLF where hex is expected)

--- a/tests/networking_tests/http_chunked_test/http_chunked_test.cpp
+++ b/tests/networking_tests/http_chunked_test/http_chunked_test.cpp
@@ -1753,6 +1753,31 @@ suite chunked_raw_socket_tests = [] {
       expect(error_fired.load()) << "malformed chunk size should surface an error";
    };
 
+   // Same overflow on the synchronous path: perform_sync_request_attempt computes chunk_size + 2,
+   // which wraps for a size near SIZE_MAX, so response_body.append would read chunk_size bytes off
+   // a few-byte buffer. The sync request must fail instead of performing the out-of-bounds read.
+   "raw_oversized_chunk_size_sync_rejected"_test = [&] {
+      uint16_t port = 0;
+      std::string raw =
+         "HTTP/1.1 200 OK\r\n"
+         "Transfer-Encoding: chunked\r\n"
+         "Content-Type: text/plain\r\n"
+         "\r\n"
+         "ffffffffffffffff\r\n" // 2^64 - 1
+         "AAAA\r\n"
+         "0\r\n"
+         "\r\n";
+
+      auto server_thread = start_raw_server(port, raw);
+
+      glz::http_client client;
+      auto result = client.get("http://127.0.0.1:" + std::to_string(port) + "/test");
+
+      server_thread.join();
+
+      expect(!result.has_value()) << "oversized chunk size should be rejected, not out-of-bounds read";
+   };
+
    "raw_empty_chunk_size_line"_test = [&] {
       uint16_t port = 0;
       // Empty chunk size line (just CRLF where hex is expected)


### PR DESCRIPTION
The chunked transfer decoder reads a hex chunk size from the response into a size_t, then computes chunk_size + 2 to account for the trailing CRLF. A server can send a size near SIZE_MAX such as ffffffffffffffff. Before this change that addition wraps to a tiny value, the buffered-size check passes, and the streaming reader hands on_data a string_view of chunk_size bytes over a few-byte buffer, which is an out-of-bounds read; read_chunk_body, perform_sync_request_attempt, and async_read_chunk_data all share the same arithmetic.

After this change each site rejects a chunk size that leaves no room for the CRLF (chunk_size > SIZE_MAX - 2) before the addition and returns a protocol error, matching the existing malformed-size path. The bound sits in the decoder because that is the only layer that sees the raw size before it feeds the length math. The tradeoff is that a pathological ~16 EB single chunk is now refused outright instead of streamed.