### PR TITLE
Provide diagnostics for asio winsock.h include issue on Windows

### DIFF
--- a/include/glaze/ext/glaze_asio.hpp
+++ b/include/glaze/ext/glaze_asio.hpp
@@ -13,9 +13,8 @@
 #endif
 
 #if defined(_WIN32) && defined(_WINSOCKAPI_) && !defined(_WINSOCK2API_)
-static_assert(false,
-              "glaze/ext/glaze_asio.hpp cannot be included after Windows.h has included Winsock.h."
-              "Define WIN32_LEAN_AND_MEAN before including Windows.h to prevent Windows.h from including Winsock.h.");
+#error glaze/ext/glaze_asio.hpp cannot be included after Windows.h has included Winsock.h. \
+       Define WIN32_LEAN_AND_MEAN before including Windows.h to prevent Windows.h from including Winsock.h.
 #endif
 
 // Two distinct, intentionally similar macros govern the Asio backend. Do not confuse them:

--- a/include/glaze/ext/glaze_asio.hpp
+++ b/include/glaze/ext/glaze_asio.hpp
@@ -12,6 +12,12 @@
 #define _WIN32_WINNT 0x0601
 #endif
 
+#if defined(_WIN32) && defined(_WINSOCKAPI_) && !defined(_WINSOCK2API_)
+static_assert(false,
+              "glaze/ext/glaze_asio.hpp cannot be included after Windows.h has included Winsock.h."
+              "Define WIN32_LEAN_AND_MEAN before including Windows.h to prevent Windows.h from including Winsock.h.");
+#endif
+
 // Two distinct, intentionally similar macros govern the Asio backend. Do not confuse them:
 //
 //   GLZ_USE_BOOST_ASIO   - INPUT (you set it, or CMake's glaze::asio target sets it).


### PR DESCRIPTION
This issue is quite common when building on Windows if `Windows.h` is included before Asio without `WIN32_LEAN_AND_MEAN`. Asio uses `winsock2.h`, but `Windows.h` includes `winsock.h`, which is not compatible with `winsock2.h`, resulting in confusing Asio error "WinSock.h has already been included", which, to be honest, doesn't help that much (unless you've encountered this issue before and you already know what's wrong). This PR will help users understand the exact cause of the problem and provide an immediate solution, rather than leaving them with this single asio error.

I didn't quite understand why Glaze uses `static_assert(false, "...")` instead of `#error ...`, but I thought it would make more sense to use a preprocessor error instead of `static_assert` in the preprocessor code. If you want me to use `static_assert` here, just let me know.