### PR TITLE
Bound non-null-terminated value scanners against end of input

### DIFF
--- a/include/glaze/json/jmespath.hpp
+++ b/include/glaze/json/jmespath.hpp
@@ -450,9 +450,22 @@ namespace glz
             return;
          }
 
+         // A non-null-terminated buffer has no '\0' sentinel, so guard each structural *it read
+         // against the end of input. Compiles out entirely when null_terminated.
+         const auto at_end = [&]() -> bool {
+            if constexpr (not Opts.null_terminated) {
+               if (it == end) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return true;
+               }
+            }
+            return false;
+         };
+
          const int32_t start_idx = decomposed_key.start.value_or(0);
          const int32_t end_idx = decomposed_key.end.value_or((std::numeric_limits<int32_t>::max)());
 
+         if (at_end()) return;
          if (*it == ']') {
             ++it;
             return;
@@ -476,6 +489,7 @@ namespace glz
 
             // Skip until target_idx
             while (current_index < target_idx) {
+               if (at_end()) return;
                if (*it == ']') {
                   // Array ended before we reached target
                   ctx.error = error_code::array_element_not_found;
@@ -483,6 +497,7 @@ namespace glz
                }
                skip_value<JSON>::op<Opts>(ctx, it, end);
                if (bool(ctx.error)) return;
+               if (at_end()) return;
                if (*it == ',') {
                   ++it;
                   skip_ws<Opts>(ctx, it, end);
@@ -494,6 +509,7 @@ namespace glz
             }
 
             // Now current_index == target_idx
+            if (at_end()) return;
             if (*it == ']') {
                ctx.error = error_code::array_element_not_found;
                return;
@@ -507,6 +523,7 @@ namespace glz
             }
             if (bool(ctx.error)) return;
 
+            if (at_end()) return;
             if (*it == ',') {
                ++it;
                skip_ws<Opts>(ctx, it, end);
@@ -517,9 +534,12 @@ namespace glz
          if (bool(ctx.error)) return;
 
          // Consume remainder of array
-         while (*it != ']') {
+         while (true) {
+            if (at_end()) return;
+            if (*it == ']') break;
             skip_value<JSON>::op<Opts>(ctx, it, end);
             if (bool(ctx.error)) return;
+            if (at_end()) return;
             if (*it == ',') {
                ++it;
                skip_ws<Opts>(ctx, it, end);
@@ -537,6 +557,18 @@ namespace glz
             return;
          }
 
+         // A non-null-terminated buffer has no '\0' sentinel, so guard each structural *it read
+         // against the end of input. Compiles out entirely when null_terminated.
+         const auto at_end = [&]() -> bool {
+            if constexpr (not Opts.null_terminated) {
+               if (it == end) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return true;
+               }
+            }
+            return false;
+         };
+
          // Determine slice parameters
          int32_t step_idx = decomposed_key.step.value_or(1);
          bool has_negative_index = (decomposed_key.start.value_or(0) < 0) || (decomposed_key.end.value_or(0) < 0);
@@ -546,6 +578,7 @@ namespace glz
             // Original fallback behavior:
             // Read entire array into value first
             value.clear();
+            if (at_end()) return;
             if (*it == ']') {
                // empty array
                ++it; // consume ']'
@@ -559,6 +592,7 @@ namespace glz
                   if (skip_ws<Opts>(ctx, it, end)) {
                      return;
                   }
+                  if (at_end()) return;
                   if (*it == ']') {
                      ++it;
                      break;
@@ -623,6 +657,7 @@ namespace glz
          const int32_t end_idx = decomposed_key.end.value_or((std::numeric_limits<int32_t>::max)());
 
          // If empty array
+         if (at_end()) return;
          if (*it == ']') {
             ++it; // consume ']'
             return;
@@ -634,6 +669,7 @@ namespace glz
             if (skip_ws<Opts>(ctx, it, end)) {
                return;
             }
+            if (at_end()) return;
 
             // Decide whether we read or skip this element
             if (current_index < start_idx) {
@@ -658,6 +694,7 @@ namespace glz
             if (skip_ws<Opts>(ctx, it, end)) {
                return;
             }
+            if (at_end()) return;
             if (*it == ']') {
                ++it; // finished reading array
                break;

--- a/include/glaze/json/ndjson.hpp
+++ b/include/glaze/json/ndjson.hpp
@@ -56,18 +56,38 @@ namespace glz
          auto value_it = value.begin();
 
          auto read_new_lines = [&] {
-            while (*it == '\r') {
-               ++it;
-               if (*it == '\n') {
+            // A null-terminated buffer stops on the trailing '\0' sentinel. A non-null-terminated
+            // buffer has no sentinel, so bound the scan on it != end while consuming the line
+            // breaks between records.
+            if constexpr (Opts.null_terminated) {
+               while (*it == '\r') {
+                  ++it;
+                  if (*it == '\n') {
+                     ++it;
+                  }
+                  else {
+                     ctx.error = error_code::syntax_error; // Expected '\n' after '\r'
+                     return;
+                  }
+               }
+               while (*it == '\n') {
                   ++it;
                }
-               else {
-                  ctx.error = error_code::syntax_error; // Expected '\n' after '\r'
-                  return;
-               }
             }
-            while (*it == '\n') {
-               ++it;
+            else {
+               while (it != end && *it == '\r') {
+                  ++it;
+                  if (it != end && *it == '\n') {
+                     ++it;
+                  }
+                  else {
+                     ctx.error = error_code::syntax_error; // Expected '\n' after '\r'
+                     return;
+                  }
+               }
+               while (it != end && *it == '\n') {
+                  ++it;
+               }
             }
          };
 
@@ -126,18 +146,38 @@ namespace glz
          }();
 
          auto read_new_lines = [&] {
-            while (*it == '\r') {
-               ++it;
-               if (*it == '\n') {
+            // A null-terminated buffer stops on the trailing '\0' sentinel. A non-null-terminated
+            // buffer has no sentinel, so bound the scan on it != end while consuming the line
+            // breaks between records.
+            if constexpr (Opts.null_terminated) {
+               while (*it == '\r') {
+                  ++it;
+                  if (*it == '\n') {
+                     ++it;
+                  }
+                  else {
+                     ctx.error = error_code::syntax_error; // Expected '\n' after '\r'
+                     return;
+                  }
+               }
+               while (*it == '\n') {
                   ++it;
                }
-               else {
-                  ctx.error = error_code::syntax_error; // Expected '\n' after '\r'
-                  return;
-               }
             }
-            while (*it == '\n') {
-               ++it;
+            else {
+               while (it != end && *it == '\r') {
+                  ++it;
+                  if (it != end && *it == '\n') {
+                     ++it;
+                  }
+                  else {
+                     ctx.error = error_code::syntax_error; // Expected '\n' after '\r'
+                     return;
+                  }
+               }
+               while (it != end && *it == '\n') {
+                  ++it;
+               }
             }
          };
 

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2549,11 +2549,25 @@ namespace glz
       if (bool(ctx.error)) [[unlikely]]
          return {};
 
+      if constexpr (not Opts.null_terminated) {
+         if (it == end) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return {};
+         }
+      }
       if (*it == ']') [[unlikely]] {
          return 0;
       }
       size_t count = 1;
       while (true) {
+         // A null-terminated buffer falls out through the '\0' case below; a non-null-terminated
+         // buffer has no sentinel, so bound the scan here before dereferencing.
+         if constexpr (not Opts.null_terminated) {
+            if (it == end) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return {};
+            }
+         }
          switch (*it) {
          case ',': {
             ++count;

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2087,8 +2087,14 @@ namespace glz
 
             // Extract the string key
             const auto start = it;
-            while (*it != '"' && it != end) {
+            while (it != end && *it != '"') {
                ++it;
+            }
+            if constexpr (not Opts.null_terminated) {
+               if (it == end) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
             }
             const sv key{start, static_cast<size_t>(it - start)};
             ++it; // skip closing quote

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -745,18 +745,26 @@ namespace glz
       bool padded;
       bool opening_handled;
       bool validate_skipped;
+      bool null_terminated;
 
       // Convert from any opts-like type (consteval because check_* functions are consteval)
       template <typename T>
       consteval skip_string_opts(const T& opts) noexcept
          : padded{check_is_padded(opts)},
            opening_handled{check_opening_handled(opts)},
-           validate_skipped{check_validate_skipped(opts)}
+           validate_skipped{check_validate_skipped(opts)},
+           null_terminated{check_null_terminated(opts)}
       {}
 
-      // Direct construction - all values required
-      consteval skip_string_opts(bool padded_, bool opening_handled_, bool validate_skipped_) noexcept
-         : padded{padded_}, opening_handled{opening_handled_}, validate_skipped{validate_skipped_}
+      // Direct construction - null_terminated defaults to true for the structural (non-validating)
+      // skip_until_closed call sites, which route through the end-bounded skip_string_view path
+      // and so are independent of this flag.
+      consteval skip_string_opts(bool padded_, bool opening_handled_, bool validate_skipped_,
+                                 bool null_terminated_ = true) noexcept
+         : padded{padded_},
+           opening_handled{opening_handled_},
+           validate_skipped{validate_skipped_},
+           null_terminated{null_terminated_}
       {}
    };
 
@@ -863,6 +871,15 @@ namespace glz
 
       if constexpr (Opts.validate_skipped) {
          while (true) {
+            // A null-terminated buffer terminates on the trailing '\0' (caught by the control
+            // character check below); a non-null-terminated buffer has no sentinel, so bound the
+            // scan before each dereference.
+            if constexpr (not Opts.null_terminated) {
+               if (it == end) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
+            }
             if ((*it & 0b11100000) == 0) [[unlikely]] {
                ctx.error = error_code::syntax_error;
                return;
@@ -875,6 +892,12 @@ namespace glz
             }
             case '\\': {
                ++it;
+               if constexpr (not Opts.null_terminated) {
+                  if (it == end) [[unlikely]] {
+                     ctx.error = error_code::unexpected_end;
+                     return;
+                  }
+               }
                if (char_unescape_table[uint8_t(*it)]) {
                   ++it;
                   continue;
@@ -1239,12 +1262,17 @@ namespace glz
 
    GLZ_ALWAYS_INLINE void skip_number_with_validation(is_context auto&& ctx, auto&& it, auto end) noexcept
    {
-      it += *it == '-';
+      // Every standalone *it read below is guarded by it != end so the scan stays inside the
+      // buffer for non-null-terminated input (the std::find_if_not calls are already bounded by
+      // end). A null-terminated buffer is unaffected: it reaches end only once the number is
+      // fully consumed, where these guards short-circuit exactly as the trailing '\0' sentinel
+      // would have.
+      it += (it != end) && (*it == '-');
       const auto sig_start_it = it;
       auto frac_start_it = end;
-      if (*it == '0') {
+      if (it != end && *it == '0') {
          ++it;
-         if (*it != '.') {
+         if (it == end || *it != '.') {
             return;
          }
          ++it;
@@ -1255,11 +1283,11 @@ namespace glz
          ctx.error = error_code::syntax_error;
          return;
       }
-      if ((*it | ('E' ^ 'e')) == 'e') {
+      if (it != end && (*it | ('E' ^ 'e')) == 'e') {
          ++it;
          goto exp_start;
       }
-      if (*it != '.') return;
+      if (it == end || *it != '.') return;
       ++it;
    frac_start:
       frac_start_it = it;
@@ -1268,10 +1296,10 @@ namespace glz
          ctx.error = error_code::syntax_error;
          return;
       }
-      if ((*it | ('E' ^ 'e')) != 'e') return;
+      if (it == end || (*it | ('E' ^ 'e')) != 'e') return;
       ++it;
    exp_start:
-      it += *it == '+' || *it == '-';
+      it += (it != end) && (*it == '+' || *it == '-');
       const auto exp_start_it = it;
       it = std::find_if_not(it, end, is_digit);
       if (it == exp_start_it) {
@@ -1284,22 +1312,34 @@ namespace glz
    struct skip_number_opts
    {
       bool validate;
+      bool null_terminated;
 
-      // Convert from any opts-like type (consteval because check_validate_skipped is consteval)
+      // Convert from any opts-like type (consteval because check_* functions are consteval)
       template <typename T>
-      consteval skip_number_opts(const T& opts) noexcept : validate{check_validate_skipped(opts)}
+      consteval skip_number_opts(const T& opts) noexcept
+         : validate{check_validate_skipped(opts)}, null_terminated{check_null_terminated(opts)}
       {}
 
       // Direct construction
-      explicit consteval skip_number_opts(bool validate_) noexcept : validate{validate_} {}
+      explicit consteval skip_number_opts(bool validate_, bool null_terminated_ = true) noexcept
+         : validate{validate_}, null_terminated{null_terminated_}
+      {}
    };
 
    template <skip_number_opts Opts>
    GLZ_ALWAYS_INLINE void skip_number(is_context auto&& ctx, auto&& it, auto end) noexcept
    {
       if constexpr (not Opts.validate) {
-         while (numeric_table[uint8_t(*it)]) {
-            ++it;
+         if constexpr (Opts.null_terminated) {
+            // Relies on the trailing '\0' sentinel (numeric_table['\0'] == false) to terminate.
+            while (numeric_table[uint8_t(*it)]) {
+               ++it;
+            }
+         }
+         else {
+            while (it < end && numeric_table[uint8_t(*it)]) {
+               ++it;
+            }
          }
       }
       else {

--- a/tests/jmespath/jmespath.cpp
+++ b/tests/jmespath/jmespath.cpp
@@ -268,4 +268,58 @@ suite tuple_slice_tests = [] {
    };
 };
 
+// Read every truncation prefix of `complete`, each over its own exact-size heap buffer (so ASAN
+// flags any read past the end), with null_terminated = false. Every proper prefix of a complete
+// array is malformed, so each must error rather than over-read.
+template <class T, glz::string_literal Path>
+void fuzz_slice_prefixes(std::string_view complete)
+{
+   static constexpr glz::opts options{.null_terminated = false};
+   for (size_t n = 1; n < complete.size(); ++n) {
+      std::vector<char> buf{complete.begin(), complete.begin() + n};
+      T value{};
+      const auto ec = glz::read_jmespath<Path, options>(value, std::string_view{buf.data(), buf.data() + n});
+      expect(bool(ec)) << "expected truncation error at prefix length " << n;
+   }
+}
+
+// Bounds hardening for the JMESPath array-slice handlers (handle_slice). On a non-null-terminated
+// buffer there is no trailing '\0' sentinel, so the structural ']' / ',' scans must respect end
+// explicitly. Built under ASAN in CI, these cases catch reads past an exact-size buffer.
+suite non_null_terminated_slice_bounds = [] {
+   static constexpr glz::opts options{.null_terminated = false};
+
+   "nnt vector slice (partial-read) stays in bounds"_test = [] {
+      fuzz_slice_prefixes<std::vector<int>, "[0:2]">("[10,20,30,40,50]");
+      fuzz_slice_prefixes<std::vector<int>, "[1:3]">("[ 10 , 20 , 30 , 40 ]");
+
+      std::vector<char> buf{};
+      const std::string_view complete = "[10,20,30,40,50]";
+      buf.assign(complete.begin(), complete.end());
+      std::vector<int> slice{};
+      const auto ec = glz::read_jmespath<"[1:3]", options>(slice, std::string_view{buf.data(), buf.data() + buf.size()});
+      expect(not ec);
+      expect(slice == (std::vector<int>{20, 30}));
+   };
+
+   "nnt vector slice (read-all fallback) stays in bounds"_test = [] {
+      // A negative step routes through the read-entire-array fallback.
+      fuzz_slice_prefixes<std::vector<int>, "[::-1]">("[1,2,3,4,5]");
+   };
+
+   "nnt tuple slice stays in bounds"_test = [] {
+      fuzz_slice_prefixes<std::tuple<int, int>, "[0:2]">("[1,2,3,4,5]");
+      fuzz_slice_prefixes<std::tuple<int, int, int>, "[0:3]">("[1,2,3,4,5]");
+
+      std::vector<char> buf{};
+      const std::string_view complete = "[7,8,9]";
+      buf.assign(complete.begin(), complete.end());
+      std::tuple<int, int> target{};
+      const auto ec = glz::read_jmespath<"[0:2]", options>(target, std::string_view{buf.data(), buf.data() + buf.size()});
+      expect(not ec);
+      expect(std::get<0>(target) == 7);
+      expect(std::get<1>(target) == 8);
+   };
+};
+
 int main() { return 0; }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -2269,6 +2269,111 @@ suite early_end = [] {
    trace.end("early_end");
 };
 
+// Bounds hardening for value scanners that do not route through skip_ws. On a non-null-terminated
+// buffer there is no trailing '\0' sentinel, so each scanner below must respect end explicitly.
+// Built under ASAN in CI, these cases catch reads past an exact-size buffer.
+suite non_null_terminated_scanner_bounds = [] {
+   "nnt skip_number (raw_json) stays in bounds"_test = [] {
+      static constexpr glz::opts options{.null_terminated = false};
+      // Bare numbers that end exactly at the buffer end must parse without reading past it.
+      for (const std::string_view num : {"12345", "0", "3.14", "1e-12", "2.5E+9"}) {
+         std::vector<char> buf{num.begin(), num.end()};
+         const std::string_view view{buf.data(), buf.data() + buf.size()};
+         glz::raw_json value{};
+         const auto ec = glz::read<options>(value, view);
+         expect(not ec) << glz::format_error(ec, view);
+         expect(value.str == num);
+      }
+   };
+
+   "nnt number_of_array_elements stays in bounds"_test = [] {
+      static constexpr glz::opts options{.null_terminated = false};
+      // std::forward_list routes through the element pre-scan; truncated arrays must error rather
+      // than read past the end.
+      for (const std::string_view s : {"[1,2,3,4,5", "[1,2,", "[1", "["}) {
+         std::vector<char> buf{s.begin(), s.end()};
+         const std::string_view view{buf.data(), buf.data() + buf.size()};
+         std::forward_list<int> value{};
+         const auto ec = glz::read<options>(value, view);
+         expect(ec);
+         expect(ec.count <= view.size());
+      }
+      // A complete array still parses.
+      const std::string_view complete = "[1,2,3,4,5]";
+      std::vector<char> buf{complete.begin(), complete.end()};
+      const std::string_view view{buf.data(), buf.data() + buf.size()};
+      std::forward_list<int> value{};
+      const auto ec = glz::read<options>(value, view);
+      expect(not ec) << glz::format_error(ec, view);
+      expect(value == (std::forward_list<int>{1, 2, 3, 4, 5}));
+   };
+
+   "nnt validated number skip stays in bounds"_test = [] {
+      static constexpr glz::opts options{.null_terminated = false};
+      // The JSON-pointer path validates the located number; incomplete numbers must be rejected
+      // without scanning past the end, and complete numbers must still resolve.
+      const auto resolves = [](std::string_view s) {
+         std::vector<char> buf{s.begin(), s.end()};
+         return glz::get_view_json<"/x", options>(std::string_view{buf.data(), buf.data() + buf.size()}).has_value();
+      };
+      expect(not resolves(R"({"x":-)"));
+      expect(not resolves(R"({"x":1e)"));
+      expect(not resolves(R"({"x":1.)"));
+      expect(not resolves(R"({"x":1.5e)"));
+      expect(not resolves(R"({"x":1.5e+)"));
+      expect(resolves(R"({"x":0)"));
+      expect(resolves(R"({"x":12345)"));
+      expect(resolves(R"({"x":12345})"));
+   };
+
+   "nnt validated string skip stays in bounds"_test = [] {
+      static constexpr glz::opts options{.null_terminated = false};
+      // The validating skip path (here via a JSON pointer) must not scan past the end of an
+      // unterminated string value or a string truncated mid-escape.
+      const auto resolves = [](std::string_view s) {
+         std::vector<char> buf{s.begin(), s.end()};
+         return glz::get_view_json<"/x", options>(std::string_view{buf.data(), buf.data() + buf.size()}).has_value();
+      };
+      expect(not resolves(R"({"x":"abcdef)")); // no closing quote
+      expect(not resolves(R"({"x":"ab\)")); // trailing backslash at the end
+      expect(not resolves(R"({"x":"ab\u12)")); // truncated unicode escape
+      expect(resolves(R"({"x":"abc"})")); // complete string resolves
+   };
+
+   "nnt ndjson newline scan stays in bounds"_test = [] {
+      // Under null_terminated = false the record values use the end-bounded number parser and the
+      // inter-record newline scan is bounded too, so records with or without a trailing newline
+      // (and with '\r\n' line endings) stay inside the buffer.
+      static constexpr glz::opts options{.format = glz::NDJSON, .null_terminated = false};
+      const auto read_vec = [](std::string_view s) {
+         std::vector<char> buf{s.begin(), s.end()};
+         std::vector<int> value{};
+         const auto ec = glz::read<options>(value, std::string_view{buf.data(), buf.data() + buf.size()});
+         return std::pair{ec, value};
+      };
+      {
+         auto [ec, v] = read_vec("1");
+         expect(not ec);
+         expect(v == std::vector<int>{1});
+      }
+      {
+         auto [ec, v] = read_vec("1\n2\n");
+         expect(not ec);
+         expect(v == std::vector<int>{1, 2});
+      }
+      {
+         auto [ec, v] = read_vec("1\n2");
+         expect(not ec);
+         expect(v == std::vector<int>{1, 2});
+      }
+      {
+         auto [ec, v] = read_vec("1\r\n2\r\n");
+         expect(not ec);
+         expect(v == std::vector<int>{1, 2});
+      }
+   };
+};
+
 suite minified_custom_object = [] {
    using namespace ut;
 

--- a/tests/p2996_test/p2996_test.cpp
+++ b/tests/p2996_test/p2996_test.cpp
@@ -135,6 +135,35 @@ suite p2996_enums = [] {
       expect(not glz::read<reflect_enums_opts{}>(d2, dir_json));
       expect(d2 == Direction::East);
    };
+
+   // The reflective enum-by-name reader scans the quoted key directly (not via skip_ws), so on a
+   // non-null-terminated buffer (no trailing '\0' sentinel) it must respect end. Each input below
+   // is read over an exact-size buffer. A key missing its closing quote must error rather than
+   // scan past the end: with the unbounded scan, "North" (no closing quote) would read past the
+   // buffer and wrongly succeed, so expecting an error here pins the bounded behavior. Under the
+   // ASAN CI configuration this additionally catches the over-read itself.
+   "reflect_enums non-null-terminated bounds"_test = [] {
+      static constexpr auto options = [] {
+         reflect_enums_opts o{};
+         o.null_terminated = false;
+         return o;
+      }();
+
+      for (const std::string_view s : {"\"North", "\"Sou", "\""}) {
+         std::vector<char> buf{s.begin(), s.end()};
+         Direction d{};
+         const auto ec = glz::read<options>(d, std::string_view{buf.data(), buf.data() + buf.size()});
+         expect(bool(ec)) << "unterminated reflective enum key should error";
+      }
+
+      // A complete value still reads correctly over an exact-size buffer.
+      const std::string_view complete = "\"West\"";
+      std::vector<char> buf{complete.begin(), complete.end()};
+      Direction d{};
+      const auto ec = glz::read<options>(d, std::string_view{buf.data(), buf.data() + buf.size()});
+      expect(not ec);
+      expect(d == Direction::West);
+   };
 };
 
 // C-style array in struct tests (issue #1839)


### PR DESCRIPTION
## Summary

A class of JSON value scanners dereference `*it` without an `end` check, relying on the trailing `'\0'` sentinel that only exists for null-terminated buffers. When `opts.null_terminated = false` (no sentinel), truncated or boundary input reads past the end of the buffer — a heap-buffer-overflow under ASAN on an exact-size buffer.

This is the same bug class as the recent minified `skip_ws` end-guard work, but in scanners that never route through `skip_ws`, so they were not covered. Each fix preserves null-terminated behavior — the gated guards compile out entirely, and the few loop restructures are behavior-equivalent — and bounds only the non-null-terminated path.

## Fixes

| Scanner | File | Reached via |
|---|---|---|
| `skip_number` (non-validating) | `util/parse.hpp` | `glz::raw_json` field / value skip |
| `skip_number_with_validation` | `util/parse.hpp` | `get_view_json` / `validate_json` numbers |
| `number_of_array_elements` | `json/read.hpp` | resizable non-`emplace_back` arrays (e.g. `std::forward_list`) |
| `skip_string` (non-padded, validating) | `util/parse.hpp` | `get_view_json` / `validate_json` strings |
| NDJSON `read_new_lines` | `json/ndjson.hpp` | `read_ndjson` with `null_terminated = false` |
| `handle_slice` (JMESPath array slices) | `json/jmespath.hpp` | `read_jmespath` slices with `null_terminated = false` |
| enum-by-name reader (reflective) | `json/read.hpp` | `reflect_enums` enum values (C++26 P2996) with `null_terminated = false` |

- `skip_number` / `skip_string`: gated via `if constexpr (not Opts.null_terminated)` (their opts structs gain a `null_terminated` field); zero overhead on the default path.
- `skip_number_with_validation`: unconditional `it != end` guards on the standalone `*it` reads (the `find_if_not` scans were already `end`-bounded).
- `number_of_array_elements`: `if constexpr (not Opts.null_terminated)` end-checks before each dereference; compiles out by default.
- NDJSON `read_new_lines`: gated; the null-terminated path is unchanged.
- `handle_slice` (both the tuple and resizable-array overloads): a local `at_end()` guard — `if constexpr (not Opts.null_terminated)`, so it compiles out by default — runs before each structural `]` / `,` scan. Covers the partial-read path, the read-all fallback (negative step / negative indices), and the skip-to-slice-start pre-scan.
- enum-by-name reader: the key scan had its operands reversed (`*it` dereferenced before the `it != end` bound); swapped, plus a guard on the post-scan `++it` for an unterminated key. Gated behind `GLZ_REFLECTION26` + `reflect_enums`.

## Scope note

This hardens the `null_terminated = false` contract. Reading a non-null-terminated buffer under default options (`null_terminated = true`, e.g. a `std::string_view`/`std::span` over an exact-size region with no terminator) remains unsupported, as it is for the rest of the reader — the value parsers rely on the sentinel there.

## Tests

- `non_null_terminated_scanner_bounds` (`tests/json_test`): exercises each scanner above at its buffer boundary (truncated and complete inputs over exact-size buffers).
- `non_null_terminated_slice_bounds` (`tests/jmespath`): feeds every truncation prefix of a complete array through an exact-size buffer (tuple and vector targets, partial-read and read-all paths); the complete array still resolves.
- `reflect_enums non-null-terminated bounds` (`tests/p2996_test`): reads an unterminated reflective enum key over an exact-size buffer and asserts an error. With the unbounded scan, a valid name lacking its closing quote over-reads and wrongly succeeds, so the error assertion pins the bounded behavior even where that CI job runs without sanitizers; it runs in the dedicated C++26 reflection CI.

The JSON suites run under the existing ASAN CI job, which is what catches the over-reads. Verified locally: `json_test` passes under ASAN (685 tests, 0 failures), and the jmespath suite passes under ASAN (18 tests, 136 asserts); each pre-fix over-read was reproduced and is resolved.
