### PR TITLE
guard front_hash key lookup against keys shorter than the prefix

### DIFF
--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -2766,8 +2766,16 @@ namespace glz
       static constexpr auto N = reflect<T>::size;
       static constexpr auto bsize = bucket_size(hash_type::front_hash, N);
 
-      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&&, const size_t) noexcept
+      GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto&& end, const size_t) noexcept
       {
+         // front_hash is only chosen when every key is at least front_hash_bytes long, so a
+         // shorter key cannot match and reading the prefix would run past it. The non-padded
+         // readers (BSON, MessagePack, CBOR, CSV, TOML) pass end = key.data() + key.size(),
+         // so an unguarded read here is an out-of-bounds read of the input buffer. The
+         // decode_hash<JSON> front_hash variant already guards each read against end.
+         if (static_cast<size_t>(end - it) < HashInfo.front_hash_bytes) [[unlikely]] {
+            return N;
+         }
          if constexpr (HashInfo.front_hash_bytes == 2) {
             uint16_t h;
             if consteval {

--- a/tests/bson_test/bson_test.cpp
+++ b/tests/bson_test/bson_test.cpp
@@ -6,9 +6,11 @@
 #include <array>
 #include <chrono>
 #include <cstdint>
+#include <cstring>
 #include <filesystem>
 #include <limits>
 #include <map>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -1628,6 +1630,52 @@ suite bson_skip_marker_suite = [] {
       expect(decoded.active == false);
       expect(decoded.count == 7);
       expect(decoded.name == "world");
+   };
+};
+
+namespace bson_front_hash_tests
+{
+   // All keys are 8 bytes and are distinguished only by their first 8 bytes, which
+   // selects the front_hash key lookup with front_hash_bytes == 8.
+   struct front_hash_keys
+   {
+      int alphaaa1{};
+      int alphaaa2{};
+      int alphaab1{};
+      int alphaab2{};
+      int betaaaa1{};
+      int betaaaa2{};
+   };
+}
+
+// A document key shorter than front_hash_bytes must not make the key hash read past
+// the end of the (unpadded) input buffer. The buffer is an exact-size heap allocation
+// so the over-read lands in ASAN's redzone when the bound is missing.
+suite bson_front_hash_bounds_suite = [] {
+   using namespace bson_front_hash_tests;
+
+   "front_hash short key stays in bounds"_test = [] {
+      // { "x": null } : int32 len=8 | 0x0A null tag | "x"\0 | 0x00 terminator
+      static constexpr unsigned char doc[] = {0x08, 0x00, 0x00, 0x00, 0x0A, 0x78, 0x00, 0x00};
+      auto buffer = std::make_unique<char[]>(sizeof(doc));
+      std::memcpy(buffer.get(), doc, sizeof(doc));
+      const std::string_view view(buffer.get(), sizeof(doc));
+
+      front_hash_keys value{};
+      const auto ec = glz::read_bson(value, view);
+      expect(bool(ec)); // a one-byte key matches no field
+   };
+
+   "front_hash exact-length key still matches"_test = [] {
+      const front_hash_keys original{1, 2, 3, 4, 5, 6};
+      const auto encoded = glz::write_bson(original);
+      expect(encoded.has_value());
+
+      front_hash_keys decoded{};
+      const auto ec = glz::read_bson(decoded, *encoded);
+      expect(!ec);
+      expect(decoded.alphaaa1 == 1);
+      expect(decoded.betaaaa2 == 6);
    };
 };
 


### PR DESCRIPTION
`decode_hash_with_size` selects a `front_hash` path for key sets distinguished by their first 2, 4, or 8 bytes, and that specialization reads `front_hash_bytes` from the key with `memcpy` without checking the key length, unlike every sibling hash type which guards its read against `end`. BSON, MessagePack, CBOR, CSV, and TOML decode in place and call it with `end = key.data() + key.size()`, so a document key shorter than `front_hash_bytes` reads past the key and off the end of the input buffer. A one-byte key at the tail of a minimal BSON document reads seven bytes past the allocation, which ASAN flags as a heap-buffer-overflow read of size 8.

The guard rejects keys shorter than `front_hash_bytes` before the read and returns the not-found index. `front_hash` is only chosen when every key is at least `front_hash_bytes` long, so before the change a valid key always carried enough bytes, and after it the only keys turned away are ones too short to match any field, which leaves correct lookups unchanged. Putting the bound in the shared hash callee covers all five readers in one place rather than each reader, and it mirrors the `decode_hash<JSON>` `front_hash` variant that already guards against `end`.
