### PR TITLE
Fix std::byte and fixed std::array<char,N> handling in CBOR/MsgPack/BSON

### DIFF
--- a/include/glaze/bson/read.hpp
+++ b/include/glaze/bson/read.hpp
@@ -367,7 +367,18 @@ namespace glz
          }
          std::string_view sv{};
          if (!bson_detail::read_bson_string(ctx, it, end, sv)) return;
-         if constexpr (requires { value.assign(sv.data(), sv.size()); }) {
+         if constexpr (array_char_t<std::remove_cvref_t<decltype(value)>>) {
+            // Fixed-size std::array<char, N>: bounds-check, copy, zero-fill remainder.
+            if (sv.size() > value.size()) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            std::memcpy(value.data(), sv.data(), sv.size());
+            if (sv.size() < value.size()) {
+               std::memset(value.data() + sv.size(), 0, value.size() - sv.size());
+            }
+         }
+         else if constexpr (requires { value.assign(sv.data(), sv.size()); }) {
             value.assign(sv.data(), sv.size());
          }
          else {

--- a/include/glaze/cbor/read.hpp
+++ b/include/glaze/cbor/read.hpp
@@ -503,7 +503,10 @@ namespace glz
                return;
             }
             else {
-               value.clear();
+               if constexpr (resizable<T>) {
+                  value.clear();
+               }
+               size_t offset = 0; // fill position for fixed-size targets
                while (true) {
                   if (it >= end) [[unlikely]] {
                      ctx.error = error_code::unexpected_end;
@@ -542,8 +545,25 @@ namespace glz
                      return;
                   }
 
-                  value.append(reinterpret_cast<const char*>(it), chunk_len);
+                  if constexpr (array_char_t<T>) {
+                     // Fixed-size std::array<char, N>: accumulate with bounds checking.
+                     if (offset + chunk_len > value.size()) [[unlikely]] {
+                        ctx.error = error_code::syntax_error;
+                        return;
+                     }
+                     std::memcpy(value.data() + offset, it, chunk_len);
+                     offset += static_cast<size_t>(chunk_len);
+                  }
+                  else {
+                     value.append(reinterpret_cast<const char*>(it), chunk_len);
+                  }
                   it += chunk_len;
+               }
+               if constexpr (array_char_t<T>) {
+                  // Zero-fill any unused tail of the fixed-size buffer.
+                  if (offset < value.size()) {
+                     std::memset(value.data() + offset, 0, value.size() - offset);
+                  }
                }
             }
          }
@@ -575,6 +595,18 @@ namespace glz
             if constexpr (string_view_t<T>) {
                value = {reinterpret_cast<const char*>(it), static_cast<size_t>(length)};
             }
+            else if constexpr (array_char_t<T>) {
+               // Fixed-size std::array<char, N>: bounds-check, copy, zero-fill remainder.
+               if (length > value.size()) [[unlikely]] {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
+               std::memcpy(value.data(), it, length);
+               if (length < value.size()) {
+                  std::memset(value.data() + static_cast<size_t>(length), 0,
+                              value.size() - static_cast<size_t>(length));
+               }
+            }
             else {
                value.assign(reinterpret_cast<const char*>(it), length);
             }
@@ -583,9 +615,10 @@ namespace glz
       }
    };
 
-   // Byte strings - std::vector<std::byte>
+   // Byte strings - contiguous std::byte ranges (std::vector<std::byte>, std::array<std::byte, N>, ...)
    template <class T>
-      requires(std::same_as<typename T::value_type, std::byte> && resizable<T>)
+      requires(contiguous<std::remove_cvref_t<T>> && std::same_as<range_value_t<std::remove_cvref_t<T>>, std::byte> &&
+               !str_t<T>)
    struct from<CBOR, T>
    {
       template <auto Opts>
@@ -612,7 +645,10 @@ namespace glz
 
          if (additional_info == info::indefinite) {
             // Indefinite-length byte string
-            value.clear();
+            if constexpr (resizable<T>) {
+               value.clear();
+            }
+            size_t offset = 0; // fill position for fixed-size targets
             while (true) {
                if (it >= end) [[unlikely]] {
                   ctx.error = error_code::unexpected_end;
@@ -649,10 +685,27 @@ namespace glz
                   return;
                }
 
-               const size_t old_size = value.size();
-               value.resize(old_size + static_cast<size_t>(chunk_len));
-               std::memcpy(value.data() + old_size, it, chunk_len);
+               if constexpr (resizable<T>) {
+                  const size_t old_size = value.size();
+                  value.resize(old_size + static_cast<size_t>(chunk_len));
+                  std::memcpy(value.data() + old_size, it, chunk_len);
+               }
+               else {
+                  // Fixed-size std::array<std::byte, N>: accumulate with bounds checking.
+                  if (offset + chunk_len > value.size()) [[unlikely]] {
+                     ctx.error = error_code::syntax_error;
+                     return;
+                  }
+                  std::memcpy(value.data() + offset, it, chunk_len);
+                  offset += static_cast<size_t>(chunk_len);
+               }
                it += chunk_len;
+            }
+            if constexpr (!resizable<T>) {
+               // Zero-fill any unused tail of the fixed-size buffer.
+               if (offset < value.size()) {
+                  std::memset(value.data() + offset, 0, value.size() - offset);
+               }
             }
          }
          else {
@@ -679,8 +732,22 @@ namespace glz
                }
             }
 
-            value.resize(static_cast<size_t>(length));
-            std::memcpy(value.data(), it, length);
+            if constexpr (resizable<T>) {
+               value.resize(static_cast<size_t>(length));
+               std::memcpy(value.data(), it, length);
+            }
+            else {
+               // Fixed-size std::array<std::byte, N>: bounds-check, copy, zero-fill remainder.
+               if (length > value.size()) [[unlikely]] {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
+               std::memcpy(value.data(), it, length);
+               if (length < value.size()) {
+                  std::memset(value.data() + static_cast<size_t>(length), 0,
+                              value.size() - static_cast<size_t>(length));
+               }
+            }
             it += length;
          }
       }
@@ -787,10 +854,129 @@ namespace glz
       }
    };
 
+   // Byte strings - std::array<uint8_t, N>
+   // The matching writer (to<CBOR, std::array<uint8_t, N>>) emits a byte string, so the reader
+   // must decode one into the fixed-size buffer (bounds-checked, remainder zero-filled), mirroring
+   // the std::vector<uint8_t> reader above and the std::array<std::byte, N> handling.
+   template <size_t N>
+   struct from<CBOR, std::array<uint8_t, N>>
+   {
+      template <auto Opts>
+      static void op(auto& value, is_context auto& ctx, auto& it, auto end)
+      {
+         using namespace cbor;
+
+         if (it >= end) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return;
+         }
+
+         uint8_t initial;
+         std::memcpy(&initial, it, 1);
+         ++it;
+
+         const uint8_t major_type = get_major_type(initial);
+         const uint8_t additional_info = get_additional_info(initial);
+
+         if (major_type != major::bstr) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+
+         if (additional_info == info::indefinite) {
+            size_t offset = 0; // fill position in the fixed-size buffer
+            while (true) {
+               if (it >= end) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
+
+               uint8_t chunk_initial;
+               std::memcpy(&chunk_initial, it, 1);
+
+               if (chunk_initial == initial_byte(major::simple, simple::break_code)) {
+                  ++it;
+                  break;
+               }
+
+               const uint8_t chunk_major = get_major_type(chunk_initial);
+               const uint8_t chunk_info = get_additional_info(chunk_initial);
+
+               if (chunk_major != major::bstr) [[unlikely]] {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
+               if (chunk_info == info::indefinite) [[unlikely]] {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
+
+               ++it;
+               uint64_t chunk_len = cbor_detail::decode_arg(ctx, it, end, chunk_info);
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
+
+               if (static_cast<uint64_t>(end - it) < chunk_len) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
+
+               if (offset + chunk_len > value.size()) [[unlikely]] {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
+               std::memcpy(value.data() + offset, it, chunk_len);
+               offset += static_cast<size_t>(chunk_len);
+               it += chunk_len;
+            }
+            if (offset < value.size()) {
+               std::memset(value.data() + offset, 0, value.size() - offset);
+            }
+         }
+         else {
+            uint64_t length = cbor_detail::decode_arg(ctx, it, end, additional_info);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
+
+            if (static_cast<uint64_t>(end - it) < length) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+
+            // Check user-configured array size limit
+            if constexpr (check_max_array_size(Opts) > 0) {
+               if (length > check_max_array_size(Opts)) [[unlikely]] {
+                  ctx.error = error_code::invalid_length;
+                  return;
+               }
+            }
+            if constexpr (has_runtime_max_array_size<std::decay_t<decltype(ctx)>>) {
+               if (ctx.max_array_size > 0 && length > ctx.max_array_size) [[unlikely]] {
+                  ctx.error = error_code::invalid_length;
+                  return;
+               }
+            }
+
+            if (length > value.size()) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            std::memcpy(value.data(), it, length);
+            if (length < value.size()) {
+               std::memset(value.data() + static_cast<size_t>(length), 0,
+                           value.size() - static_cast<size_t>(length));
+            }
+            it += length;
+         }
+      }
+   };
+
    // Arrays (std::vector, std::deque, etc.)
    // Note: eigen_t types have their own specialization in glaze/ext/eigen.hpp
+   // Contiguous std::byte ranges are excluded here; they are read as CBOR byte strings above.
    template <readable_array_t T>
-      requires(!eigen_t<T>)
+      requires(!eigen_t<T> &&
+               !(contiguous<std::remove_cvref_t<T>> && std::same_as<range_value_t<std::remove_cvref_t<T>>, std::byte>))
    struct from<CBOR, T> final
    {
       template <auto Opts>

--- a/include/glaze/cbor/write.hpp
+++ b/include/glaze/cbor/write.hpp
@@ -382,7 +382,8 @@ namespace glz
 
    // Byte strings (std::vector<std::byte>, std::span<std::byte>, etc.)
    template <class T>
-      requires(std::same_as<typename T::value_type, std::byte> && !str_t<T>)
+      requires(contiguous<std::remove_cvref_t<T>> && std::same_as<range_value_t<std::remove_cvref_t<T>>, std::byte> &&
+               !str_t<T>)
    struct to<CBOR, T> final
    {
       template <auto Opts>
@@ -469,8 +470,10 @@ namespace glz
 
    // Arrays (std::vector, std::array, std::deque, etc.)
    // Note: eigen_t types have their own specialization in glaze/ext/eigen.hpp
+   // Contiguous std::byte ranges are excluded here; they are written as CBOR byte strings above.
    template <writable_array_t T>
-      requires(!eigen_t<T>)
+      requires(!eigen_t<T> &&
+               !(contiguous<std::remove_cvref_t<T>> && std::same_as<range_value_t<std::remove_cvref_t<T>>, std::byte>))
    struct to<CBOR, T> final
    {
       template <auto Opts>

--- a/include/glaze/msgpack/read.hpp
+++ b/include/glaze/msgpack/read.hpp
@@ -560,6 +560,29 @@ namespace glz
       }
    };
 
+   // Fixed-size std::array<char, N>: read the string into the buffer, bounds-checked,
+   // zero-filling any unused tail so a shorter payload yields a deterministic buffer.
+   template <array_char_t T>
+   struct from<MSGPACK, T>
+   {
+      template <auto Opts, class Value, is_context Ctx, class It, class End>
+      GLZ_ALWAYS_INLINE static void op(Value&& value, uint8_t tag, Ctx&& ctx, It& it, const End& end) noexcept
+      {
+         std::string_view sv{};
+         if (!msgpack::detail::read_string_view(ctx, tag, it, end, sv)) {
+            return;
+         }
+         if (sv.size() > value.size()) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+         std::memcpy(value.data(), sv.data(), sv.size());
+         if (sv.size() < value.size()) {
+            std::memset(value.data() + sv.size(), 0, value.size() - sv.size());
+         }
+      }
+   };
+
    template <glaze_object_t T>
       requires(!custom_read<T>)
    struct from<MSGPACK, T>

--- a/tests/bson_test/bson_test.cpp
+++ b/tests/bson_test/bson_test.cpp
@@ -1780,4 +1780,65 @@ suite bson_hash_bounds_suite = [] {
    };
 };
 
+// Regression coverage for https://github.com/stephenberry/glaze/issues/2647
+// A fixed std::array<char, N> string member must round trip (previously a
+// "no viable operator=" compile error in the BSON string reader).
+struct bson_char_array_rec
+{
+   std::array<char, 8> name{};
+   int id{};
+};
+
+struct bson_string_src
+{
+   std::string name{};
+};
+
+struct bson_short_code
+{
+   std::array<char, 4> code{};
+};
+
+struct bson_long_code_src
+{
+   std::string code{};
+};
+
+suite bson_char_array_tests = [] {
+   "bson std::array<char, N> member round trips"_test = [] {
+      bson_char_array_rec src{};
+      src.name = {'h', 'i'};
+      src.id = 7;
+      std::string buffer{};
+      expect(not glz::write_bson(src, buffer));
+      bson_char_array_rec dst{};
+      expect(not glz::read_bson(dst, buffer));
+      expect(dst.name == src.name);
+      expect(dst.id == src.id);
+   };
+
+   "bson std::array<char, N> member zero-fills a shorter string"_test = [] {
+      bson_string_src src{};
+      src.name = "ab";
+      std::string buffer{};
+      expect(not glz::write_bson(src, buffer));
+      bson_char_array_rec dst{};
+      dst.name = {'Z', 'Z', 'Z', 'Z', 'Z', 'Z', 'Z', 'Z'};
+      expect(not glz::read_bson(dst, buffer));
+      expect(std::string_view(dst.name.data(), 2) == "ab");
+      for (size_t i = 2; i < dst.name.size(); ++i) {
+         expect(dst.name[i] == '\0');
+      }
+   };
+
+   "bson std::array<char, N> member rejects an oversized string"_test = [] {
+      bson_long_code_src src{};
+      src.code = "toolong";
+      std::string buffer{};
+      expect(not glz::write_bson(src, buffer));
+      bson_short_code dst{};
+      expect(bool(glz::read_bson(dst, buffer)));
+   };
+};
+
 int main() { return 0; }

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -3405,6 +3405,89 @@ void custom_variant_ambiguity_tests()
    };
 }
 
+// Regression coverage for https://github.com/stephenberry/glaze/issues/2647
+// std::byte ranges must encode as CBOR byte strings (not be ambiguous), and fixed
+// std::array<char, N> / std::array<std::byte, N> must round trip.
+suite cbor_byte_and_char_array_tests = [] {
+   "cbor std::vector<std::byte> is a byte string"_test = [] {
+      std::vector<std::byte> src{std::byte{1}, std::byte{2}, std::byte{0xFF}, std::byte{0}};
+      std::string buffer{};
+      expect(not glz::write_cbor(src, buffer));
+      // Major type 2 (byte string), length 4: initial byte 0x44, then 4 data bytes.
+      expect(buffer.size() == 5);
+      expect(static_cast<uint8_t>(buffer[0]) == 0x44);
+      std::vector<std::byte> dst{};
+      expect(not glz::read_cbor(dst, buffer));
+      expect(dst == src);
+   };
+
+   "cbor std::array<std::byte, N> round trips"_test = [] {
+      std::array<std::byte, 4> src{std::byte{1}, std::byte{2}, std::byte{3}, std::byte{4}};
+      std::string buffer{};
+      expect(not glz::write_cbor(src, buffer));
+      std::array<std::byte, 4> dst{};
+      expect(not glz::read_cbor(dst, buffer));
+      expect(dst == src);
+   };
+
+   "cbor std::array<std::byte, N> zero-fills and rejects oversize"_test = [] {
+      std::vector<std::byte> short_src{std::byte{5}, std::byte{6}};
+      std::string buffer{};
+      expect(not glz::write_cbor(short_src, buffer));
+      std::array<std::byte, 4> dst{std::byte{0x77}, std::byte{0x77}, std::byte{0x77}, std::byte{0x77}};
+      expect(not glz::read_cbor(dst, buffer));
+      expect(dst == (std::array<std::byte, 4>{std::byte{5}, std::byte{6}, std::byte{0}, std::byte{0}}));
+
+      std::vector<std::byte> big_src(10, std::byte{1});
+      std::string big_buffer{};
+      expect(not glz::write_cbor(big_src, big_buffer));
+      std::array<std::byte, 4> small{};
+      expect(bool(glz::read_cbor(small, big_buffer)));
+   };
+
+   "cbor std::array<uint8_t, N> round trips as a byte string"_test = [] {
+      std::array<uint8_t, 4> src{1, 2, 3, 255};
+      std::string buffer{};
+      expect(not glz::write_cbor(src, buffer));
+      expect(buffer.size() == 5);
+      expect(static_cast<uint8_t>(buffer[0]) == 0x44);
+      std::array<uint8_t, 4> dst{};
+      expect(not glz::read_cbor(dst, buffer));
+      expect(dst == src);
+      // Cross-readable with std::vector<uint8_t> (both byte strings).
+      std::vector<uint8_t> as_vec{};
+      expect(not glz::read_cbor(as_vec, buffer));
+      expect(as_vec == (std::vector<uint8_t>{1, 2, 3, 255}));
+   };
+
+   "cbor std::array<char, N> round trips"_test = [] {
+      std::array<char, 16> src{'h', 'e', 'l', 'l', 'o'};
+      std::string buffer{};
+      expect(not glz::write_cbor(src, buffer));
+      std::array<char, 16> dst{};
+      expect(not glz::read_cbor(dst, buffer));
+      expect(dst == src);
+   };
+
+   "cbor std::array<char, N> zero-fills and rejects oversize"_test = [] {
+      std::string short_src = "abc";
+      std::string buffer{};
+      expect(not glz::write_cbor(short_src, buffer));
+      std::array<char, 8> dst{'Z', 'Z', 'Z', 'Z', 'Z', 'Z', 'Z', 'Z'};
+      expect(not glz::read_cbor(dst, buffer));
+      expect(std::string_view(dst.data(), 3) == "abc");
+      for (size_t i = 3; i < dst.size(); ++i) {
+         expect(dst[i] == '\0');
+      }
+
+      std::string big_src = "0123456789";
+      std::string big_buffer{};
+      expect(not glz::write_cbor(big_src, big_buffer));
+      std::array<char, 4> small{};
+      expect(bool(glz::read_cbor(small, big_buffer)));
+   };
+};
+
 int main()
 {
    custom_variant_ambiguity_tests();

--- a/tests/msgpack_test/msgpack_test.cpp
+++ b/tests/msgpack_test/msgpack_test.cpp
@@ -387,6 +387,55 @@ struct glz::to<Format, mp_fc_variant>
    }
 };
 
+// Regression coverage for https://github.com/stephenberry/glaze/issues/2647
+// Fixed std::array<char, N> must round trip (previously its read was undefined).
+struct mp_char_array_rec
+{
+   std::array<char, 8> name{};
+   int id{};
+};
+
+suite msgpack_char_array_tests = [] {
+   "msgpack std::array<char, N> round trips"_test = [] {
+      std::array<char, 16> src{'h', 'e', 'l', 'l', 'o'};
+      std::string buffer{};
+      expect(not glz::write_msgpack(src, buffer));
+      std::array<char, 16> dst{};
+      expect(not glz::read_msgpack(dst, buffer));
+      expect(dst == src);
+   };
+
+   "msgpack std::array<char, N> zero-fills and rejects oversize"_test = [] {
+      std::string short_src = "abc";
+      std::string buffer{};
+      expect(not glz::write_msgpack(short_src, buffer));
+      std::array<char, 8> dst{'Z', 'Z', 'Z', 'Z', 'Z', 'Z', 'Z', 'Z'};
+      expect(not glz::read_msgpack(dst, buffer));
+      expect(std::string_view(dst.data(), 3) == "abc");
+      for (size_t i = 3; i < dst.size(); ++i) {
+         expect(dst[i] == '\0');
+      }
+
+      std::string big_src = "0123456789";
+      std::string big_buffer{};
+      expect(not glz::write_msgpack(big_src, big_buffer));
+      std::array<char, 4> small{};
+      expect(bool(glz::read_msgpack(small, big_buffer)));
+   };
+
+   "msgpack std::array<char, N> as a struct member"_test = [] {
+      mp_char_array_rec src{};
+      src.name = {'h', 'i'};
+      src.id = 7;
+      std::string buffer{};
+      expect(not glz::write_msgpack(src, buffer));
+      mp_char_array_rec dst{};
+      expect(not glz::read_msgpack(dst, buffer));
+      expect(dst.name == src.name);
+      expect(dst.id == src.id);
+   };
+};
+
 int main()
 {
    // Only the write side is exercised here: MessagePack passes its type-tag byte


### PR DESCRIPTION
Follow-up to #2649 (the BEVE fix for #2647), addressing the **same family of issues** in the other binary codecs. Found by reproducing each case against CBOR, MsgPack, and BSON.

## Summary

| | `std::byte` ranges | `std::array<char,N>` read |
|---|---|---|
| **CBOR** | ❌ ambiguous (vector/span) / unreadable (array) → **fixed** | ❌ compile error → **fixed** |
| **MsgPack** | ✅ already compact (`bin`) | ❌ undefined read → **fixed** |
| **BSON** | ✅ already compact (binary) | ❌ `no viable operator=` → **fixed** |

## CBOR

- **`std::vector<std::byte>` / `std::span<std::byte>` were ambiguous** (the byte-string specialization tied with the generic array specialization) and did not compile on write *or* read. The byte-string specs now require a contiguous `std::byte` range, and the generic array specs exclude contiguous `std::byte` ranges, so exactly one matches.
- **`std::array<std::byte,N>` wrote a valid byte string but couldn't read it back.** The byte-string reader is generalized to store into a fixed-size buffer (bounds-checked, remainder zero-filled), for both definite- and indefinite-length byte strings.
- **`std::array<uint8_t,N>` had the same write/read asymmetry** (a pre-existing gap surfaced during review): it wrote a byte string with no matching reader. Added a dedicated reader mirroring the existing `std::vector<uint8_t>` one. `std::array<uint8_t,N>` and `std::vector<uint8_t>` are now cross-readable.
- **`std::array<char,N>` failed to compile on read** (the text reader called `resize`/`append`/`assign`). The text reader now handles fixed char arrays.

## MsgPack

- `std::byte` ranges were already encoded as the compact `bin` format. Only **`std::array<char,N>` read** was missing (write produced a string; read was an undefined template). Added a `from<MSGPACK, array_char_t>` reader.

## BSON

- `std::byte` ranges were already compact binary. A **`std::array<char,N>` string member** failed to compile on read (`no viable operator=`); the string reader now handles fixed char arrays.

## Semantics

Consistent with #2649: reading a payload longer than a fixed array yields `error_code::syntax_error`; a shorter payload is copied and the remainder zero-filled. Wire-driven paths and non-contiguous byte ranges (e.g. `std::deque<std::byte>` → CBOR array of numbers) are unchanged.

## Tests

11 regression tests added (CBOR 6, MsgPack 3, BSON 3 — incl. the `uint8_t` array case): compact/byte-string encoding, cross-readability, fixed `std::array<std::byte,N>`/`std::array<char,N>` round trips, short-payload zero-fill, oversize-payload rejection, and struct members. All existing suites pass: CBOR 235, MsgPack 54, BSON 120.

## Verification

Reviewed by an adversarial multi-agent pass (overload-resolution, memory-safety/bounds, round-trip semantics). No new defects; round-trips verified exact under ASan+UBSan. The `std::array<uint8_t,N>` reader was added in response to that review.