### PR TITLE
Unify CBOR std::byte and uint8_t byte-string handling

### DIFF
--- a/include/glaze/cbor/read.hpp
+++ b/include/glaze/cbor/read.hpp
@@ -615,10 +615,12 @@ namespace glz
       }
    };
 
-   // Byte strings - contiguous std::byte ranges (std::vector<std::byte>, std::array<std::byte, N>, ...)
+   // Byte strings - any contiguous byte-like range (std::vector<std::byte>, std::vector<uint8_t>,
+   // std::array<std::byte, N>, std::array<uint8_t, N>, ...). Handles both resizable and fixed-size
+   // targets (the latter bounds-checked with the remainder zero-filled); std::byte, unsigned char,
+   // and uint8_t ranges share one implementation (see glz::contiguous_byte_range / byte_like).
    template <class T>
-      requires(contiguous<std::remove_cvref_t<T>> && std::same_as<range_value_t<std::remove_cvref_t<T>>, std::byte> &&
-               !str_t<T>)
+      requires(contiguous_byte_range<std::remove_cvref_t<T>> && !str_t<T>)
    struct from<CBOR, T>
    {
       template <auto Opts>
@@ -753,229 +755,11 @@ namespace glz
       }
    };
 
-   // Byte strings - std::vector<uint8_t>
-   template <>
-   struct from<CBOR, std::vector<uint8_t>>
-   {
-      template <auto Opts>
-      static void op(auto& value, is_context auto& ctx, auto& it, auto end)
-      {
-         using namespace cbor;
-
-         if (it >= end) [[unlikely]] {
-            ctx.error = error_code::unexpected_end;
-            return;
-         }
-
-         uint8_t initial;
-         std::memcpy(&initial, it, 1);
-         ++it;
-
-         const uint8_t major_type = get_major_type(initial);
-         const uint8_t additional_info = get_additional_info(initial);
-
-         if (major_type != major::bstr) [[unlikely]] {
-            ctx.error = error_code::syntax_error;
-            return;
-         }
-
-         if (additional_info == info::indefinite) {
-            value.clear();
-            while (true) {
-               if (it >= end) [[unlikely]] {
-                  ctx.error = error_code::unexpected_end;
-                  return;
-               }
-
-               uint8_t chunk_initial;
-               std::memcpy(&chunk_initial, it, 1);
-
-               if (chunk_initial == initial_byte(major::simple, simple::break_code)) {
-                  ++it;
-                  break;
-               }
-
-               const uint8_t chunk_major = get_major_type(chunk_initial);
-               const uint8_t chunk_info = get_additional_info(chunk_initial);
-
-               if (chunk_major != major::bstr) [[unlikely]] {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-               if (chunk_info == info::indefinite) [[unlikely]] {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-
-               ++it;
-               uint64_t chunk_len = cbor_detail::decode_arg(ctx, it, end, chunk_info);
-               if (bool(ctx.error)) [[unlikely]]
-                  return;
-
-               if (static_cast<uint64_t>(end - it) < chunk_len) [[unlikely]] {
-                  ctx.error = error_code::unexpected_end;
-                  return;
-               }
-
-               const size_t old_size = value.size();
-               value.resize(old_size + static_cast<size_t>(chunk_len));
-               std::memcpy(value.data() + old_size, it, chunk_len);
-               it += chunk_len;
-            }
-         }
-         else {
-            uint64_t length = cbor_detail::decode_arg(ctx, it, end, additional_info);
-            if (bool(ctx.error)) [[unlikely]]
-               return;
-
-            if (static_cast<uint64_t>(end - it) < length) [[unlikely]] {
-               ctx.error = error_code::unexpected_end;
-               return;
-            }
-
-            // Check user-configured array size limit
-            if constexpr (check_max_array_size(Opts) > 0) {
-               if (length > check_max_array_size(Opts)) [[unlikely]] {
-                  ctx.error = error_code::invalid_length;
-                  return;
-               }
-            }
-            if constexpr (has_runtime_max_array_size<std::decay_t<decltype(ctx)>>) {
-               if (ctx.max_array_size > 0 && length > ctx.max_array_size) [[unlikely]] {
-                  ctx.error = error_code::invalid_length;
-                  return;
-               }
-            }
-
-            value.resize(static_cast<size_t>(length));
-            std::memcpy(value.data(), it, length);
-            it += length;
-         }
-      }
-   };
-
-   // Byte strings - std::array<uint8_t, N>
-   // The matching writer (to<CBOR, std::array<uint8_t, N>>) emits a byte string, so the reader
-   // must decode one into the fixed-size buffer (bounds-checked, remainder zero-filled), mirroring
-   // the std::vector<uint8_t> reader above and the std::array<std::byte, N> handling.
-   template <size_t N>
-   struct from<CBOR, std::array<uint8_t, N>>
-   {
-      template <auto Opts>
-      static void op(auto& value, is_context auto& ctx, auto& it, auto end)
-      {
-         using namespace cbor;
-
-         if (it >= end) [[unlikely]] {
-            ctx.error = error_code::unexpected_end;
-            return;
-         }
-
-         uint8_t initial;
-         std::memcpy(&initial, it, 1);
-         ++it;
-
-         const uint8_t major_type = get_major_type(initial);
-         const uint8_t additional_info = get_additional_info(initial);
-
-         if (major_type != major::bstr) [[unlikely]] {
-            ctx.error = error_code::syntax_error;
-            return;
-         }
-
-         if (additional_info == info::indefinite) {
-            size_t offset = 0; // fill position in the fixed-size buffer
-            while (true) {
-               if (it >= end) [[unlikely]] {
-                  ctx.error = error_code::unexpected_end;
-                  return;
-               }
-
-               uint8_t chunk_initial;
-               std::memcpy(&chunk_initial, it, 1);
-
-               if (chunk_initial == initial_byte(major::simple, simple::break_code)) {
-                  ++it;
-                  break;
-               }
-
-               const uint8_t chunk_major = get_major_type(chunk_initial);
-               const uint8_t chunk_info = get_additional_info(chunk_initial);
-
-               if (chunk_major != major::bstr) [[unlikely]] {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-               if (chunk_info == info::indefinite) [[unlikely]] {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-
-               ++it;
-               uint64_t chunk_len = cbor_detail::decode_arg(ctx, it, end, chunk_info);
-               if (bool(ctx.error)) [[unlikely]]
-                  return;
-
-               if (static_cast<uint64_t>(end - it) < chunk_len) [[unlikely]] {
-                  ctx.error = error_code::unexpected_end;
-                  return;
-               }
-
-               if (offset + chunk_len > value.size()) [[unlikely]] {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-               std::memcpy(value.data() + offset, it, chunk_len);
-               offset += static_cast<size_t>(chunk_len);
-               it += chunk_len;
-            }
-            if (offset < value.size()) {
-               std::memset(value.data() + offset, 0, value.size() - offset);
-            }
-         }
-         else {
-            uint64_t length = cbor_detail::decode_arg(ctx, it, end, additional_info);
-            if (bool(ctx.error)) [[unlikely]]
-               return;
-
-            if (static_cast<uint64_t>(end - it) < length) [[unlikely]] {
-               ctx.error = error_code::unexpected_end;
-               return;
-            }
-
-            // Check user-configured array size limit
-            if constexpr (check_max_array_size(Opts) > 0) {
-               if (length > check_max_array_size(Opts)) [[unlikely]] {
-                  ctx.error = error_code::invalid_length;
-                  return;
-               }
-            }
-            if constexpr (has_runtime_max_array_size<std::decay_t<decltype(ctx)>>) {
-               if (ctx.max_array_size > 0 && length > ctx.max_array_size) [[unlikely]] {
-                  ctx.error = error_code::invalid_length;
-                  return;
-               }
-            }
-
-            if (length > value.size()) [[unlikely]] {
-               ctx.error = error_code::syntax_error;
-               return;
-            }
-            std::memcpy(value.data(), it, length);
-            if (length < value.size()) {
-               std::memset(value.data() + static_cast<size_t>(length), 0, value.size() - static_cast<size_t>(length));
-            }
-            it += length;
-         }
-      }
-   };
-
    // Arrays (std::vector, std::deque, etc.)
    // Note: eigen_t types have their own specialization in glaze/ext/eigen.hpp
-   // Contiguous std::byte ranges are excluded here; they are read as CBOR byte strings above.
+   // Contiguous byte-like ranges are excluded here; they are read as CBOR byte strings above.
    template <readable_array_t T>
-      requires(!eigen_t<T> &&
-               !(contiguous<std::remove_cvref_t<T>> && std::same_as<range_value_t<std::remove_cvref_t<T>>, std::byte>))
+      requires(!eigen_t<T> && !contiguous_byte_range<std::remove_cvref_t<T>>)
    struct from<CBOR, T> final
    {
       template <auto Opts>

--- a/include/glaze/cbor/write.hpp
+++ b/include/glaze/cbor/write.hpp
@@ -380,10 +380,12 @@ namespace glz
       }
    };
 
-   // Byte strings (std::vector<std::byte>, std::span<std::byte>, etc.)
+   // Byte strings - any contiguous byte-like range (std::vector<std::byte>, std::vector<uint8_t>,
+   // std::array<std::byte, N>, std::array<uint8_t, N>, std::span<std::byte>, std::span<uint8_t>, ...).
+   // std::byte, unsigned char, and uint8_t ranges all encode as a CBOR byte string (major type 2),
+   // so they share a single specialization (see glz::contiguous_byte_range / byte_like).
    template <class T>
-      requires(contiguous<std::remove_cvref_t<T>> && std::same_as<range_value_t<std::remove_cvref_t<T>>, std::byte> &&
-               !str_t<T>)
+      requires(contiguous_byte_range<std::remove_cvref_t<T>> && !str_t<T>)
    struct to<CBOR, T> final
    {
       template <auto Opts>
@@ -404,76 +406,11 @@ namespace glz
       }
    };
 
-   // std::vector<uint8_t> as byte string
-   template <>
-   struct to<CBOR, std::vector<uint8_t>> final
-   {
-      template <auto Opts>
-      static void op(const auto& value, is_context auto&& ctx, auto&& b, auto& ix)
-      {
-         if (!cbor_detail::encode_arg(ctx, cbor::major::bstr, value.size(), b, ix)) [[unlikely]] {
-            return;
-         }
-
-         const auto n = value.size();
-         if (!ensure_space(ctx, b, ix + n + write_padding_bytes)) [[unlikely]] {
-            return;
-         }
-         if (n) {
-            std::memcpy(&b[ix], value.data(), n);
-            ix += n;
-         }
-      }
-   };
-
-   // std::array<std::byte, N> as byte string
-   template <size_t N>
-   struct to<CBOR, std::array<std::byte, N>> final
-   {
-      template <auto Opts>
-      static void op(const auto& value, is_context auto&& ctx, auto&& b, auto& ix)
-      {
-         if (!cbor_detail::encode_arg_cx<N>(ctx, cbor::major::bstr, b, ix)) [[unlikely]] {
-            return;
-         }
-
-         if (!ensure_space(ctx, b, ix + N + write_padding_bytes)) [[unlikely]] {
-            return;
-         }
-         if constexpr (N > 0) {
-            std::memcpy(&b[ix], value.data(), N);
-            ix += N;
-         }
-      }
-   };
-
-   // std::array<uint8_t, N> as byte string
-   template <size_t N>
-   struct to<CBOR, std::array<uint8_t, N>> final
-   {
-      template <auto Opts>
-      static void op(const auto& value, is_context auto&& ctx, auto&& b, auto& ix)
-      {
-         if (!cbor_detail::encode_arg_cx<N>(ctx, cbor::major::bstr, b, ix)) [[unlikely]] {
-            return;
-         }
-
-         if (!ensure_space(ctx, b, ix + N + write_padding_bytes)) [[unlikely]] {
-            return;
-         }
-         if constexpr (N > 0) {
-            std::memcpy(&b[ix], value.data(), N);
-            ix += N;
-         }
-      }
-   };
-
    // Arrays (std::vector, std::array, std::deque, etc.)
    // Note: eigen_t types have their own specialization in glaze/ext/eigen.hpp
-   // Contiguous std::byte ranges are excluded here; they are written as CBOR byte strings above.
+   // Contiguous byte-like ranges are excluded here; they are written as CBOR byte strings above.
    template <writable_array_t T>
-      requires(!eigen_t<T> &&
-               !(contiguous<std::remove_cvref_t<T>> && std::same_as<range_value_t<std::remove_cvref_t<T>>, std::byte>))
+      requires(!eigen_t<T> && !contiguous_byte_range<std::remove_cvref_t<T>>)
    struct to<CBOR, T> final
    {
       template <auto Opts>

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -3488,6 +3488,64 @@ suite cbor_byte_and_char_array_tests = [] {
    };
 };
 
+// Follow-up to #2650: CBOR treats std::byte and uint8_t/unsigned char ranges uniformly.
+// Every contiguous byte-like range encodes as a CBOR byte string (major type 2) regardless of
+// element type or container, and the variants are cross-readable on the wire.
+suite cbor_byte_uint8_unify_tests = [] {
+   "cbor uint8 and byte vectors produce identical bytes"_test = [] {
+      std::vector<uint8_t> v_u8{0x10, 0x20, 0x30, 0x40};
+      std::vector<std::byte> v_byte{std::byte{0x10}, std::byte{0x20}, std::byte{0x30}, std::byte{0x40}};
+      std::string buf_u8{};
+      std::string buf_byte{};
+      expect(not glz::write_cbor(v_u8, buf_u8));
+      expect(not glz::write_cbor(v_byte, buf_byte));
+      // Both are byte strings, so the encoded bytes match exactly.
+      expect(buf_u8 == buf_byte);
+      expect(static_cast<uint8_t>(buf_u8[0]) == 0x44); // bstr, length 4
+   };
+
+   "cbor std::span<uint8_t> encodes as a byte string"_test = [] {
+      std::array<uint8_t, 4> backing{0x01, 0x02, 0x03, 0x04};
+      std::span<uint8_t> sp{backing};
+      std::string buffer{};
+      expect(not glz::write_cbor(sp, buffer));
+      // Previously a uint8_t span fell through to an RFC 8746 typed array (tag + bstr); it must
+      // now be a plain byte string, matching std::span<std::byte> and std::vector<uint8_t>.
+      expect(buffer.size() == 5);
+      expect(static_cast<uint8_t>(buffer[0]) == 0x44);
+
+      std::array<std::byte, 4> backing_b{std::byte{1}, std::byte{2}, std::byte{3}, std::byte{4}};
+      std::span<std::byte> sp_b{backing_b};
+      std::string buffer_b{};
+      expect(not glz::write_cbor(sp_b, buffer_b));
+      expect(buffer == buffer_b);
+   };
+
+   "cbor byte/uint8 vectors are cross-readable"_test = [] {
+      std::vector<std::byte> src{std::byte{7}, std::byte{8}, std::byte{9}};
+      std::string buffer{};
+      expect(not glz::write_cbor(src, buffer));
+      std::vector<uint8_t> as_u8{};
+      expect(not glz::read_cbor(as_u8, buffer)); // byte string -> uint8_t vector
+      expect(as_u8 == (std::vector<uint8_t>{7, 8, 9}));
+
+      std::string buffer2{};
+      expect(not glz::write_cbor(as_u8, buffer2));
+      std::vector<std::byte> as_byte{};
+      expect(not glz::read_cbor(as_byte, buffer2)); // and back again
+      expect(as_byte == src);
+   };
+
+   "cbor byte/uint8 fixed arrays are cross-readable"_test = [] {
+      std::array<uint8_t, 4> src{0xAA, 0xBB, 0xCC, 0xDD};
+      std::string buffer{};
+      expect(not glz::write_cbor(src, buffer));
+      std::array<std::byte, 4> dst{};
+      expect(not glz::read_cbor(dst, buffer));
+      expect(dst == (std::array<std::byte, 4>{std::byte{0xAA}, std::byte{0xBB}, std::byte{0xCC}, std::byte{0xDD}}));
+   };
+};
+
 int main()
 {
    custom_variant_ambiguity_tests();


### PR DESCRIPTION
Follow-up to #2650. That PR fixed `std::byte` and fixed `std::array<char, N>` handling across the binary codecs, but left CBOR's `std::byte` and `uint8_t` byte handling **implemented two different ways**:

- `std::byte` ranges were handled by a single concept-based specialization (any contiguous `std::byte` range → byte string).
- `uint8_t` ranges were handled only by enumerated specializations for `std::vector<uint8_t>` and `std::array<uint8_t, N>`.

So any other contiguous `uint8_t` range (e.g. `std::span<uint8_t>`) silently fell through to the generic array writer and was encoded as an RFC 8746 **typed array** instead of a byte string, while the equivalent `std::span<std::byte>` was a byte string. MsgPack already treats these uniformly via `byte_like`; CBOR was the outlier.

## Change

Collapse the duplicated specializations into one read/write pair each, constrained on the existing `glz::contiguous_byte_range` concept (`byte_like` = `std::byte`, `unsigned char`, `uint8_t`), and widen the generic array specializations' exclusion to match:

- **write.hpp:** 4 byte-string writers (`std::byte` range + `std::vector<uint8_t>` + `std::array<std::byte, N>` + `std::array<uint8_t, N>`) → **1**.
- **read.hpp:** 3 byte-string readers (`std::byte` range + `std::vector<uint8_t>` + `std::array<uint8_t, N>`) → **1**. The existing `std::byte` reader already handled both resizable and fixed-size targets with the `max_array_size` safety checks, so the two `uint8_t` readers were redundant subsets of it.

Net **−293 / +72** lines.

## Behavior

Every contiguous byte-like range now encodes as a CBOR byte string (major type 2) and the variants are cross-readable on the wire, regardless of element type or container. `std::vector<uint8_t>` / `std::array<uint8_t, N>` round-trips and wire bytes are unchanged.

**One intentional wire-format change:** previously-uncovered `uint8_t` containers such as `std::span<uint8_t>` now encode as a byte string instead of an RFC 8746 typed array, making them consistent with `std::span<std::byte>`. (Numeric typed arrays for other element types, e.g. `int32_t`/`float`, are unaffected.)

## Tests

All existing CBOR tests pass (239), plus 4 new regression tests: identical byte/uint8 encodings, `std::span<uint8_t>` as a byte string, and byte ↔ uint8 cross-readability for vectors and fixed arrays. Verified locally under clang `-std=c++23`, plain and ASan+UBSan (243 tests / 961 asserts, 0 failures).
