### PR TITLE
use end - it for length bounds checks in binary readers

### DIFF
--- a/include/glaze/beve/beve_to_json.hpp
+++ b/include/glaze/beve/beve_to_json.hpp
@@ -302,10 +302,7 @@ namespace glz
                   ctx.error = error_code::syntax_error;
                   return;
                }
-               if (uint64_t(end - it) < padding + byte_count_inner * n) [[unlikely]] {
-                  ctx.error = error_code::unexpected_end;
-                  return;
-               }
+               if (typed_array_out_of_bounds(ctx, it, end, n, byte_count_inner, padding)) return;
                it += padding;
 
                // Now decode as a normal numeric typed array

--- a/include/glaze/beve/header.hpp
+++ b/include/glaze/beve/header.hpp
@@ -28,6 +28,38 @@ namespace glz
       }
    }
 
+   // Bounds-checks a typed-array body of `count` elements of `element_size` bytes (element_size >= 1),
+   // optionally preceded by `padding` alignment bytes, against the bytes remaining in [it, end).
+   // Callers maintain it <= end (every advance is bounds-checked), so end - it is non-negative.
+   // Returns true and sets unexpected_end when the body does not fit.
+   //
+   // On 64-bit, int_from_compressed caps wire counts at 2^48 and element_size <= 128, so
+   // padding + count * element_size <= ~2^55 cannot overflow size_t: the fit is a single multiply
+   // and compare against end - it (which, unlike it + offset, is never out-of-bounds pointer
+   // arithmetic), so the 64-bit path pays nothing for the 32-bit safety. On 32-bit that product
+   // overflows size_t -- wrapping small so an oversized array would slip past the check -- so there
+   // the fit is tested as count > (remaining - padding) / element_size, a division that cannot
+   // overflow.
+   [[nodiscard]] GLZ_ALWAYS_INLINE bool typed_array_out_of_bounds(is_context auto& ctx, auto&& it, auto&& end,
+                                                                  size_t count, size_t element_size,
+                                                                  size_t padding = 0) noexcept
+   {
+      const uint64_t available = uint64_t(end - it);
+      if constexpr (sizeof(size_t) > sizeof(uint32_t)) {
+         if (available < padding + count * element_size) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return true;
+         }
+      }
+      else {
+         if (available < padding || count > (available - padding) / element_size) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return true;
+         }
+      }
+      return false;
+   }
+
    // Byteswaps a numeric value in-place for little-endian wire format compatibility.
    // Call ONLY inside: if constexpr (std::endian::native == std::endian::big) blocks.
    // On little-endian systems, this function is never instantiated (zero overhead).

--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -924,10 +924,7 @@ namespace glz
                return;
             }
 
-            if ((it + padding + n * sizeof(V)) > end) [[unlikely]] {
-               ctx.error = error_code::unexpected_end;
-               return;
-            }
+            if (typed_array_out_of_bounds(ctx, it, end, n, sizeof(V), padding)) return;
             it += padding;
 
             value = std::span<T, Extent>{reinterpret_cast<const V*>(&(*it)), n};
@@ -1060,10 +1057,7 @@ namespace glz
                   n = value.size();
                }
 
-               if ((it + n * element_size) > end) [[unlikely]] {
-                  ctx.error = error_code::unexpected_end;
-                  return 0;
-               }
+               if (typed_array_out_of_bounds(ctx, it, end, n, element_size)) return 0;
                if (!validate_and_resize(n)) {
                   return 0;
                }
@@ -1114,10 +1108,7 @@ namespace glz
                         ctx.error = error_code::syntax_error;
                         return;
                      }
-                     if ((it + padding + count * elem_byte_count) > end) [[unlikely]] {
-                        ctx.error = error_code::unexpected_end;
-                        return;
-                     }
+                     if (typed_array_out_of_bounds(ctx, it, end, count, elem_byte_count, padding)) return;
                      it += padding;
 
                      if (!validate_and_resize(count)) {
@@ -1156,10 +1147,7 @@ namespace glz
                   return;
                }
 
-               if ((it + padding + count * sizeof(V)) > end) [[unlikely]] {
-                  ctx.error = error_code::unexpected_end;
-                  return;
-               }
+               if (typed_array_out_of_bounds(ctx, it, end, count, sizeof(V), padding)) return;
                it += padding;
 
                if (!validate_and_resize(count)) {
@@ -1228,10 +1216,7 @@ namespace glz
                }
                else if constexpr (std::endian::native == std::endian::big && sizeof(V) > 1) {
                   // On big endian, read and swap each element
-                  if ((it + n * sizeof(V)) > end) [[unlikely]] {
-                     ctx.error = error_code::unexpected_end;
-                     return;
-                  }
+                  if (typed_array_out_of_bounds(ctx, it, end, n, sizeof(V))) return;
                   for (size_t i = 0; i < n; ++i) {
                      std::memcpy(&value[i], it, sizeof(V));
                      byteswap_le(value[i]);
@@ -1240,10 +1225,7 @@ namespace glz
                }
                else {
                   // Little endian or single-byte: bulk memcpy
-                  if ((it + n * sizeof(V)) > end) [[unlikely]] {
-                     ctx.error = error_code::unexpected_end;
-                     return;
-                  }
+                  if (typed_array_out_of_bounds(ctx, it, end, n, sizeof(V))) return;
                   std::memcpy(value.data(), it, n * sizeof(V));
                   it += n * sizeof(V);
                }
@@ -1371,10 +1353,7 @@ namespace glz
                n = value.size();
             }
 
-            if (uint64_t(end - it) < n * sizeof(V)) [[unlikely]] {
-               ctx.error = error_code::unexpected_end;
-               return;
-            }
+            if (typed_array_out_of_bounds(ctx, it, end, n, sizeof(V))) return;
             if constexpr (check_max_array_size(Opts) > 0) {
                if (n > check_max_array_size(Opts)) [[unlikely]] {
                   ctx.error = error_code::invalid_length;

--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -868,7 +868,7 @@ namespace glz
                }
             }
 
-            if ((it + n) > end) [[unlikely]] {
+            if (uint64_t(end - it) < n) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return;
             }

--- a/include/glaze/beve/skip.hpp
+++ b/include/glaze/beve/skip.hpp
@@ -133,10 +133,7 @@ namespace glz
             ctx.error = error_code::syntax_error;
             return;
          }
-         if (uint64_t(end - it) < padding + elem_byte_count * n) [[unlikely]] {
-            ctx.error = error_code::unexpected_end;
-            return;
-         }
+         if (typed_array_out_of_bounds(ctx, it, end, n, elem_byte_count, padding)) return;
          it += padding + elem_byte_count * n;
          return;
       }
@@ -152,10 +149,7 @@ namespace glz
             return;
          }
          const uint8_t byte_count = byte_count_lookup[tag >> 5];
-         if (uint64_t(end - it) < byte_count * n) [[unlikely]] {
-            ctx.error = error_code::unexpected_end;
-            return;
-         }
+         if (typed_array_out_of_bounds(ctx, it, end, n, byte_count)) return;
          it += byte_count * n;
          break;
       }

--- a/include/glaze/cbor/read.hpp
+++ b/include/glaze/cbor/read.hpp
@@ -1200,8 +1200,11 @@ namespace glz
             if (bool(ctx.error)) [[unlikely]]
                return;
 
-            // Validate count against remaining buffer size (minimum 2 bytes per key-value pair)
-            if (count * 2 > static_cast<uint64_t>(end - it)) [[unlikely]] {
+            // Validate count against remaining buffer size (minimum 2 bytes per key-value pair).
+            // Tested as a division so count * 2 cannot overflow uint64_t for an attacker-supplied
+            // count (decode_arg returns an unclamped 64-bit value); this is equivalent to
+            // count * 2 > end - it.
+            if (count > static_cast<uint64_t>(end - it) / 2) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return;
             }

--- a/include/glaze/eetf/read.hpp
+++ b/include/glaze/eetf/read.hpp
@@ -47,10 +47,7 @@ namespace glz
                   return false;
                }
 
-               if ((it + header.second) > end) [[unlikely]] {
-                  ctx.error = error_code::unexpected_end;
-                  return false;
-               }
+               if (check_invalid_offset(ctx, it, end, header.second)) return false;
 
                std::advance(it, header.second);
             }
@@ -249,10 +246,7 @@ namespace glz
             return;
          }
 
-         if (it + index > end) {
-            ctx.error = error_code::unexpected_end;
-            return;
-         }
+         if (check_invalid_offset(ctx, it, end, index)) return;
 
          it += index;
 

--- a/include/glaze/msgpack/common.hpp
+++ b/include/glaze/msgpack/common.hpp
@@ -254,7 +254,7 @@ namespace glz::msgpack
       }
       type = static_cast<int8_t>(type_byte);
 
-      if ((it + length) > end) [[unlikely]] {
+      if (static_cast<size_t>(end - it) < length) [[unlikely]] {
          ctx.error = error_code::unexpected_end;
          return false;
       }
@@ -287,7 +287,7 @@ namespace glz::msgpack
    template <class It>
    GLZ_ALWAYS_INLINE bool skip_bytes(is_context auto& ctx, It& it, const It& end, size_t n) noexcept
    {
-      if ((it + n) > end) [[unlikely]] {
+      if (static_cast<size_t>(end - it) < n) [[unlikely]] {
          ctx.error = error_code::unexpected_end;
          return false;
       }

--- a/include/glaze/msgpack/read.hpp
+++ b/include/glaze/msgpack/read.hpp
@@ -129,7 +129,7 @@ namespace glz::msgpack::detail
       if (!read_str_length(ctx, tag, it, end, len)) {
          return false;
       }
-      if ((it + len) > end) [[unlikely]] {
+      if (static_cast<size_t>(end - it) < len) [[unlikely]] {
          ctx.error = error_code::unexpected_end;
          return false;
       }
@@ -146,7 +146,7 @@ namespace glz::msgpack::detail
       if (!read_bin_length(ctx, tag, it, end, len)) {
          return false;
       }
-      if ((it + len) > end) [[unlikely]] {
+      if (static_cast<size_t>(end - it) < len) [[unlikely]] {
          ctx.error = error_code::unexpected_end;
          return false;
       }


### PR DESCRIPTION
The msgpack, BEVE, and EETF readers check a length-prefixed field with `(it + len) > end`, where `len` comes straight from the input (msgpack str32/bin32/ext32 reach 4 GiB, BEVE and EETF counts are read as 64-bit). Forming `it + len` when `len` runs past the buffer is out-of-bounds pointer arithmetic, and on the 32-bit targets the project already builds (armv7, gcc-x86) it wraps the pointer, so an oversized length slips past the check and a multi-gigabyte `string_view` gets built over a handful of bytes.

Switch the checks to `static_cast<size_t>(end - it) < len`, the subtraction form already used in the bson/cbor readers, `beve/skip`, and the eetf `check_invalid_offset` helper whose comment notes it exists for exactly this reason; the two eetf sites now call that helper directly. Before, the bound relied on pointer arithmetic that is undefined on 64-bit and wrong on 32-bit. After, it is computed on the known-nonnegative `end - it` distance, so 64-bit behavior is unchanged and 32-bit is correct. The tradeoff is a subtraction in place of an addition, same cost, and no change for well-formed input.