### PR TITLE
Per-field chrono format wrappers: glz::date_format and glz::epoch_count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ pr_description.md
 /exterior
 pr.md
 /tmp/
+tmp/

--- a/docs/chrono.md
+++ b/docs/chrono.md
@@ -205,6 +205,19 @@ struct glz::meta<Event> {
 };
 ```
 
+The wrapper is bidirectional: the same pattern parses the value back on read.
+
+```cpp
+Event e{};
+e.start = std::chrono::sys_days{std::chrono::year{2026} / 6 / 18} + std::chrono::hours{12} +
+          std::chrono::minutes{34} + std::chrono::seconds{56};
+
+std::string json = glz::write_json(e).value();   // {"start":"2026-06-18 12:34:56","day":"..."}
+
+Event parsed{};
+auto ec = glz::read_json(parsed, json);           // parsed.start == e.start
+```
+
 The member pointer and pattern are passed as ordinary arguments (not template parameters), so fields that share a member type but differ in format do not each spin up a fresh set of template instantiations. The pattern is still a compile-time literal and is validated at compile time.
 
 Supported conversion specifiers (locale-independent by design):
@@ -226,6 +239,7 @@ The pattern is validated at compile time:
 Notes and limitations (MVP scope):
 
 - **Times are treated as UTC wall-clock.** There is no timezone token; the decomposed fields are UTC, matching the ISO 8601 writer.
+- **The four-digit-year range still applies.** As with the ISO 8601 writers, a year outside `[0000, 9999]` (or a non-`ok()` `year_month_day`) fails to serialize with `error_code::constraint_violated` rather than emitting wrap-around digits.
 - **`%S` writes integer seconds only.** Sub-second precision is truncated on write (the format you typed has nowhere to put it), so round-tripping a finer-than-seconds value through a `%S` pattern is lossy by design. Use the default ISO 8601 representation when you need sub-second fidelity. Explicit-width fraction tokens (`%3S`/`%6S`/`%9S`) are a planned extension.
 - **Text/JSON-family backends only.** `date_format` is a textual wrapper that routes through the JSON serializer, so it also works for the JSON-family text outputs (NDJSON, stencil/mustache). Serializing a field that uses it to a backend with its own native encoding (BEVE, CBOR, MsgPack, BSON, or TOML) is a compile error (an undefined `glz::to<Format, …>`) rather than a silent miscoding.
 

--- a/docs/chrono.md
+++ b/docs/chrono.md
@@ -225,7 +225,7 @@ Notes and limitations (MVP scope):
 
 - **Times are treated as UTC wall-clock.** There is no timezone token; the decomposed fields are UTC, matching the ISO 8601 writer.
 - **`%S` writes integer seconds only.** Sub-second precision is truncated on write (the format you typed has nowhere to put it), so round-tripping a finer-than-seconds value through a `%S` pattern is lossy by design. Use the default ISO 8601 representation when you need sub-second fidelity. Explicit-width fraction tokens (`%3S`/`%6S`/`%9S`) are a planned extension.
-- **JSON only.** `date_format` is a textual wrapper; serializing a field that uses it to a binary backend (BEVE, CBOR, MsgPack, BSON) is a compile error rather than a silent miscoding.
+- **Text/JSON-family backends only.** `date_format` is a textual wrapper that routes through the JSON serializer, so it also works for the JSON-family text outputs (NDJSON, stencil/mustache). Serializing a field that uses it to a backend with its own native encoding (BEVE, CBOR, MsgPack, BSON, or TOML) is a compile error (an undefined `glz::to<Format, …>`) rather than a silent miscoding.
 
 ### `glz::epoch_count` — per-field Unix timestamp
 
@@ -248,7 +248,9 @@ struct glz::meta<Reading> {
 };
 ```
 
-Unlike `glz::epoch_time<Duration>` (a storage type you declare your member as), `glz::epoch_count` wraps an ordinary `system_clock` time-point member in place, so you can keep the field's native type. Like `date_format`, it is JSON only.
+Unlike `glz::epoch_time<Duration>` (a storage type you declare your member as), `glz::epoch_count` wraps an ordinary `system_clock` time-point member in place, so you can keep the field's native type. Like `date_format`, it routes through the JSON serializer (so it also works for NDJSON and stencil output) and is a compile error under the native-encoding backends (BEVE, CBOR, MsgPack, BSON, TOML).
+
+The count is read as a JSON integer: exponent form (`1e3` → `1000`) is accepted, while fractional values (`1.5`) and quoted numbers (`"1500"`) are rejected with `error_code::parse_error`.
 
 ## Complete Example
 
@@ -333,6 +335,8 @@ TOML has native datetime types (not quoted strings). When using `glz::write_toml
 - `year_month_day` → TOML Local Date (`2024-06-15`)
 - `hh_mm_ss<Duration>` → TOML Local Time (`10:30:45.123`)
 - Durations and other time points → Numeric values
+
+> The per-field `glz::date_format` / `glz::epoch_count` wrappers are JSON-text-only and do **not** compile under `glz::write_toml`. Native (unwrapped) chrono members serialize as TOML datetimes as shown above; only the per-field format wrappers are restricted.
 
 See [TOML Documentation](./toml.md#datetime-support) for full details.
 

--- a/docs/chrono.md
+++ b/docs/chrono.md
@@ -180,6 +180,76 @@ struct Event {
 };
 ```
 
+## Per-Field Format Customization
+
+The clock type alone decides the default representation (ISO 8601 for `system_clock`, numeric count for `steady_clock`, and so on). When a single field needs a different shape, the per-field wrappers below decouple the *format* from the *type*. They are applied inside `glz::object(...)` within a `glz::meta<T>` specialization and require `#include "glaze/chrono.hpp"`.
+
+### `glz::date_format` — custom strftime-subset pattern
+
+`glz::date_format<&T::member, "pattern">` serializes a `system_clock` time point (or a `year_month_day`) using a `strftime`-style pattern instead of ISO 8601:
+
+```cpp
+#include "glaze/chrono.hpp"
+
+struct Event {
+    std::chrono::system_clock::time_point start{};
+    std::chrono::sys_days day{};
+};
+
+template <>
+struct glz::meta<Event> {
+    using T = Event;
+    static constexpr auto value = glz::object(
+        "start", glz::date_format<&T::start, "%Y-%m-%d %H:%M:%S">,  // "2026-06-18 12:34:56"
+        "day",   glz::date_format<&T::day,   "%Y/%m/%d">);          // "2026/06/18"
+};
+```
+
+Supported conversion specifiers (locale-independent by design):
+
+| Token | Meaning              | Token | Meaning                |
+|-------|----------------------|-------|------------------------|
+| `%Y`  | year (4 digits)      | `%H`  | hour, 24-hour (2)      |
+| `%m`  | month (2 digits)     | `%M`  | minute (2 digits)      |
+| `%d`  | day (2 digits)       | `%S`  | second (2 digits)      |
+| `%F`  | `%Y-%m-%d`           | `%T`  | `%H:%M:%S`             |
+| `%%`  | literal `%`          |       |                        |
+
+The pattern is validated at compile time:
+
+- An unsupported token (e.g. `%A`, `%j`, `%z`) is a hard compile error.
+- The pattern must contain a full calendar date (`%Y %m %d`, or `%F`); a time-only pattern cannot reconstruct an absolute time point and is rejected.
+- A `year_month_day` field rejects time tokens (`%H %M %S %T`).
+
+Notes and limitations (MVP scope):
+
+- **Times are treated as UTC wall-clock.** There is no timezone token; the decomposed fields are UTC, matching the ISO 8601 writer.
+- **`%S` writes integer seconds only.** Sub-second precision is truncated on write (the format you typed has nowhere to put it), so round-tripping a finer-than-seconds value through a `%S` pattern is lossy by design. Use the default ISO 8601 representation when you need sub-second fidelity. Explicit-width fraction tokens (`%3S`/`%6S`/`%9S`) are a planned extension.
+- **JSON only.** `date_format` is a textual wrapper; serializing a field that uses it to a binary backend (BEVE, CBOR, MsgPack, BSON) is a compile error rather than a silent miscoding.
+
+### `glz::epoch_count` — per-field Unix timestamp
+
+`glz::epoch_count<&T::member, Duration>` serializes a `system_clock` time point as a numeric Unix timestamp in units of `Duration`. It is the per-field counterpart to the `glz::epoch_time` storage wrapper, letting one field be an epoch count while others stay ISO 8601:
+
+```cpp
+#include "glaze/chrono.hpp"
+
+struct Reading {
+    std::chrono::system_clock::time_point observed{};   // ISO 8601 (default)
+    std::chrono::sys_time<std::chrono::milliseconds> logged{};
+};
+
+template <>
+struct glz::meta<Reading> {
+    using T = Reading;
+    static constexpr auto value = glz::object(
+        "observed", &T::observed,                                       // "2026-06-18T12:34:56Z"
+        "logged",   glz::epoch_count<&T::logged, std::chrono::milliseconds>);  // 1781786096789
+};
+```
+
+Unlike `glz::epoch_time<Duration>` (a storage type you declare your member as), `glz::epoch_count` wraps an ordinary `system_clock` time-point member in place, so you can keep the field's native type. Like `date_format`, it is JSON only.
+
 ## Complete Example
 
 ```cpp

--- a/docs/chrono.md
+++ b/docs/chrono.md
@@ -186,7 +186,7 @@ The clock type alone decides the default representation (ISO 8601 for `system_cl
 
 ### `glz::date_format` — custom strftime-subset pattern
 
-`glz::date_format<&T::member, "pattern">` serializes a `system_clock` time point (or a `year_month_day`) using a `strftime`-style pattern instead of ISO 8601:
+`glz::date_format(&T::member, "pattern")` serializes a `system_clock` time point (or a `year_month_day`) using a `strftime`-style pattern instead of ISO 8601:
 
 ```cpp
 #include "glaze/chrono.hpp"
@@ -200,10 +200,12 @@ template <>
 struct glz::meta<Event> {
     using T = Event;
     static constexpr auto value = glz::object(
-        "start", glz::date_format<&T::start, "%Y-%m-%d %H:%M:%S">,  // "2026-06-18 12:34:56"
-        "day",   glz::date_format<&T::day,   "%Y/%m/%d">);          // "2026/06/18"
+        "start", glz::date_format(&T::start, "%Y-%m-%d %H:%M:%S"),  // "2026-06-18 12:34:56"
+        "day",   glz::date_format(&T::day,   "%Y/%m/%d"));          // "2026/06/18"
 };
 ```
+
+The member pointer and pattern are passed as ordinary arguments (not template parameters), so fields that share a member type but differ in format do not each spin up a fresh set of template instantiations. The pattern is still a compile-time literal and is validated at compile time.
 
 Supported conversion specifiers (locale-independent by design):
 
@@ -229,7 +231,7 @@ Notes and limitations (MVP scope):
 
 ### `glz::epoch_count` — per-field Unix timestamp
 
-`glz::epoch_count<&T::member, Duration>` serializes a `system_clock` time point as a numeric Unix timestamp in units of `Duration`. It is the per-field counterpart to the `glz::epoch_time` storage wrapper, letting one field be an epoch count while others stay ISO 8601:
+`glz::epoch_count<Duration>(&T::member)` serializes a `system_clock` time point as a numeric Unix timestamp in units of `Duration`. It is the per-field counterpart to the `glz::epoch_time` storage wrapper, letting one field be an epoch count while others stay ISO 8601:
 
 ```cpp
 #include "glaze/chrono.hpp"
@@ -244,7 +246,7 @@ struct glz::meta<Reading> {
     using T = Reading;
     static constexpr auto value = glz::object(
         "observed", &T::observed,                                       // "2026-06-18T12:34:56Z"
-        "logged",   glz::epoch_count<&T::logged, std::chrono::milliseconds>);  // 1781786096789
+        "logged",   glz::epoch_count<std::chrono::milliseconds>(&T::logged));  // 1781786096789
 };
 ```
 

--- a/docs/wrappers.md
+++ b/docs/wrappers.md
@@ -34,7 +34,14 @@ glz::custom<&T::read, &T::write> // Calls custom read and write std::functions, 
 glz::manage<&T::x, &T::read_x, &T::write_x> // Calls read_x() after reading x and calls write_x() before writing x
 glz::as_array<&T::member> // Treat a reflected/member-annotated type as a positional array for read and write
 glz::flatten_map<&T::member> // Flatten map-like containers into a JSON array [key..., value, ...]
+
+// Per-field std::chrono wrappers (require #include "glaze/chrono.hpp"; JSON-text backends only)
+glz::date_format(&T::time_point, "%Y-%m-%d %H:%M:%S") // Format a system_clock time point or year_month_day with a strftime-subset pattern
+glz::epoch_count<std::chrono::milliseconds>(&T::time_point) // Write a system_clock time point as a numeric Unix timestamp in the given units
 ```
+
+> [!NOTE]
+> Unlike the wrappers above, `glz::date_format` and `glz::epoch_count` take the member pointer as a value argument rather than a non-type template parameter, and they live in `#include "glaze/chrono.hpp"`. See [std::chrono Support](chrono.md#per-field-format-customization) for the supported tokens, compile-time validation, and limitations.
 
 ## Associated glz::opts
 

--- a/include/glaze/chrono.hpp
+++ b/include/glaze/chrono.hpp
@@ -7,5 +7,6 @@
 // Includes all necessary headers for chrono serialization
 
 #include "glaze/core/chrono.hpp"
+#include "glaze/json/chrono_format.hpp"
 #include "glaze/json/read.hpp"
 #include "glaze/json/write.hpp"

--- a/include/glaze/core/chrono.hpp
+++ b/include/glaze/core/chrono.hpp
@@ -421,8 +421,10 @@ namespace glz
          return false;
       }
 
-      // Render decomposed fields through the format string. Caller must ensure the
-      // buffer has space for at least fmt.size() * 4 + a small constant bytes.
+      // Render decomposed fields through the format string. Caller must ensure the buffer has
+      // space for at least fmt.size() * 5 + a small constant bytes: the widest token, %F,
+      // expands its two source characters to the 10-byte "YYYY-MM-DD" (5 bytes per source char).
+      // The JSON caller reserves fmt.size() * 6 + 4 (extra slack plus the surrounding quotes).
       template <class B>
       inline void write_date_format(std::string_view fmt, const date_time_fields& f, B& b, auto& ix) noexcept
       {

--- a/include/glaze/core/chrono.hpp
+++ b/include/glaze/core/chrono.hpp
@@ -314,5 +314,313 @@ namespace glz
          using Duration = typename std::remove_cvref_t<TP>::duration;
          value = time_point_cast<Duration>(tp);
       }
+
+      // ============================================
+      // strftime-subset format support (glz::date_format)
+      // ============================================
+      //
+      // Glaze deliberately hand-rolls a small, locale-independent strftime subset
+      // rather than relying on std::chrono::format / std::chrono::parse, whose
+      // calendar-type support is uneven across the supported compiler matrix
+      // (libstdc++ / libc++ / MSVC). The subset reuses the same write_digits /
+      // parse_digits primitives as the ISO 8601 path so the [0000,9999] year and
+      // component-range guarantees are preserved.
+      //
+      // Supported conversion specifiers:
+      //   %Y  year   (4 digits)        %H  hour   (2 digits, 24-hour)
+      //   %m  month  (2 digits)        %M  minute (2 digits)
+      //   %d  day    (2 digits)        %S  second (2 digits)
+      //   %F  = %Y-%m-%d               %T  = %H:%M:%S
+      //   %%  literal '%'
+      //
+      // Times are treated as UTC wall-clock (no timezone token in this subset).
+      // %S writes integer seconds only, matching POSIX strftime: sub-second
+      // precision is truncated on write. Round-tripping a value finer than seconds
+      // through a %S format is therefore lossy by design (the format the user typed
+      // has no place to put the fraction). Explicit-width fraction tokens
+      // (%3S/%6S/%9S) are a planned extension. Locale-dependent tokens
+      // (%A, %B, %p, ...) are intentionally unsupported.
+
+      // Decomposed UTC wall-clock fields shared by the date_format writer and parser.
+      struct date_time_fields
+      {
+         int year{};
+         int month{};
+         int day{};
+         int hour{};
+         int minute{};
+         int second{};
+      };
+
+      // Compile-time validation: every '%' must introduce a supported token.
+      inline consteval bool date_format_tokens_valid(std::string_view fmt) noexcept
+      {
+         for (size_t i = 0; i < fmt.size(); ++i) {
+            if (fmt[i] != '%') continue;
+            if (i + 1 >= fmt.size()) return false; // dangling '%'
+            switch (fmt[i + 1]) {
+            case 'Y':
+            case 'm':
+            case 'd':
+            case 'H':
+            case 'M':
+            case 'S':
+            case 'F':
+            case 'T':
+            case '%':
+               ++i;
+               break;
+            default:
+               return false;
+            }
+         }
+         return true;
+      }
+
+      // Compile-time check: the format supplies a full calendar date (year, month,
+      // day) either explicitly or via %F. A time_point cannot be reconstructed on
+      // read without one, so this is enforced where date_format is applied.
+      inline consteval bool date_format_has_full_date(std::string_view fmt) noexcept
+      {
+         bool y = false, mo = false, d = false, f = false;
+         for (size_t i = 0; i < fmt.size(); ++i) {
+            if (fmt[i] != '%' || i + 1 >= fmt.size()) continue;
+            switch (fmt[i + 1]) {
+            case 'Y':
+               y = true;
+               break;
+            case 'm':
+               mo = true;
+               break;
+            case 'd':
+               d = true;
+               break;
+            case 'F':
+               f = true;
+               break;
+            }
+            ++i;
+         }
+         return f || (y && mo && d);
+      }
+
+      // Compile-time check: the format references any time-of-day field.
+      inline consteval bool date_format_has_time(std::string_view fmt) noexcept
+      {
+         for (size_t i = 0; i < fmt.size(); ++i) {
+            if (fmt[i] != '%' || i + 1 >= fmt.size()) continue;
+            switch (fmt[i + 1]) {
+            case 'H':
+            case 'M':
+            case 'S':
+            case 'T':
+               return true;
+            }
+            ++i;
+         }
+         return false;
+      }
+
+      // Render decomposed fields through the format string. Caller must ensure the
+      // buffer has space for at least fmt.size() * 4 + a small constant bytes.
+      template <class B>
+      inline void write_date_format(std::string_view fmt, const date_time_fields& f, B& b, auto& ix) noexcept
+      {
+         for (size_t i = 0; i < fmt.size(); ++i) {
+            const char c = fmt[i];
+            if (c != '%') {
+               b[ix++] = c;
+               continue;
+            }
+            switch (fmt[++i]) {
+            case 'Y':
+               write_digits<4>(b, ix, static_cast<uint64_t>(f.year));
+               break;
+            case 'm':
+               write_digits<2>(b, ix, static_cast<uint64_t>(f.month));
+               break;
+            case 'd':
+               write_digits<2>(b, ix, static_cast<uint64_t>(f.day));
+               break;
+            case 'H':
+               write_digits<2>(b, ix, static_cast<uint64_t>(f.hour));
+               break;
+            case 'M':
+               write_digits<2>(b, ix, static_cast<uint64_t>(f.minute));
+               break;
+            case 'S':
+               write_digits<2>(b, ix, static_cast<uint64_t>(f.second));
+               break;
+            case 'F':
+               write_digits<4>(b, ix, static_cast<uint64_t>(f.year));
+               b[ix++] = '-';
+               write_digits<2>(b, ix, static_cast<uint64_t>(f.month));
+               b[ix++] = '-';
+               write_digits<2>(b, ix, static_cast<uint64_t>(f.day));
+               break;
+            case 'T':
+               write_digits<2>(b, ix, static_cast<uint64_t>(f.hour));
+               b[ix++] = ':';
+               write_digits<2>(b, ix, static_cast<uint64_t>(f.minute));
+               b[ix++] = ':';
+               write_digits<2>(b, ix, static_cast<uint64_t>(f.second));
+               break;
+            case '%':
+               b[ix++] = '%';
+               break;
+            }
+         }
+      }
+
+      // Parse a string against the format string into decomposed fields. Component
+      // ranges are validated the same way parse_iso8601 validates them; on failure
+      // ec is set to parse_error and fields are left partially written.
+      inline void parse_date_format(std::string_view fmt, std::string_view str, date_time_fields& f,
+                                    error_code& ec) noexcept
+      {
+         const char* s = str.data();
+         const size_t n = str.size();
+         size_t si = 0;
+
+         // Consume exactly `count` digits at the current position, advancing si on
+         // success. Returns -1 on non-digit or if fewer than `count` chars remain.
+         const auto take = [&](size_t count) -> int {
+            if (si + count > n) return -1;
+            const int v = parse_digits(s, si, count);
+            if (v >= 0) si += count;
+            return v;
+         };
+
+         // Parse the seconds field (2 digits). Sub-second fractions are not part of
+         // the %S contract; a trailing fraction is left for the format/literal to
+         // consume, and otherwise surfaces as unconsumed trailing input.
+         const auto parse_seconds = [&]() -> bool {
+            const int sec = take(2);
+            if (sec < 0 || sec > 59) return false;
+            f.second = sec;
+            return true;
+         };
+
+         const auto expect_literal = [&](char c) -> bool {
+            if (si >= n || s[si] != c) return false;
+            ++si;
+            return true;
+         };
+
+         for (size_t i = 0; i < fmt.size(); ++i) {
+            const char c = fmt[i];
+            if (c != '%') {
+               if (!expect_literal(c)) {
+                  ec = error_code::parse_error;
+                  return;
+               }
+               continue;
+            }
+            switch (fmt[++i]) {
+            case 'Y': {
+               const int v = take(4);
+               if (v < 0) {
+                  ec = error_code::parse_error;
+                  return;
+               }
+               f.year = v;
+               break;
+            }
+            case 'm': {
+               const int v = take(2);
+               if (v < 1 || v > 12) {
+                  ec = error_code::parse_error;
+                  return;
+               }
+               f.month = v;
+               break;
+            }
+            case 'd': {
+               const int v = take(2);
+               if (v < 1 || v > 31) {
+                  ec = error_code::parse_error;
+                  return;
+               }
+               f.day = v;
+               break;
+            }
+            case 'H': {
+               const int v = take(2);
+               if (v < 0 || v > 23) {
+                  ec = error_code::parse_error;
+                  return;
+               }
+               f.hour = v;
+               break;
+            }
+            case 'M': {
+               const int v = take(2);
+               if (v < 0 || v > 59) {
+                  ec = error_code::parse_error;
+                  return;
+               }
+               f.minute = v;
+               break;
+            }
+            case 'S':
+               if (!parse_seconds()) {
+                  ec = error_code::parse_error;
+                  return;
+               }
+               break;
+            case 'F': {
+               const int y = take(4);
+               if (y < 0 || !expect_literal('-')) {
+                  ec = error_code::parse_error;
+                  return;
+               }
+               const int mo = take(2);
+               if (mo < 1 || mo > 12 || !expect_literal('-')) {
+                  ec = error_code::parse_error;
+                  return;
+               }
+               const int d = take(2);
+               if (d < 1 || d > 31) {
+                  ec = error_code::parse_error;
+                  return;
+               }
+               f.year = y;
+               f.month = mo;
+               f.day = d;
+               break;
+            }
+            case 'T': {
+               const int h = take(2);
+               if (h < 0 || h > 23 || !expect_literal(':')) {
+                  ec = error_code::parse_error;
+                  return;
+               }
+               const int mi = take(2);
+               if (mi < 0 || mi > 59 || !expect_literal(':')) {
+                  ec = error_code::parse_error;
+                  return;
+               }
+               f.hour = h;
+               f.minute = mi;
+               if (!parse_seconds()) {
+                  ec = error_code::parse_error;
+                  return;
+               }
+               break;
+            }
+            case '%':
+               if (!expect_literal('%')) {
+                  ec = error_code::parse_error;
+                  return;
+               }
+               break;
+            }
+         }
+
+         // Reject trailing input the format did not consume.
+         if (si != n) {
+            ec = error_code::parse_error;
+         }
+      }
    }
 }

--- a/include/glaze/core/format_str.hpp
+++ b/include/glaze/core/format_str.hpp
@@ -1,0 +1,25 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <string_view>
+
+namespace glz
+{
+   // Compile-time string for use as a non-type template parameter.
+   // Captures a string literal (including its null terminator) so that format
+   // specifications can be carried through the type system, e.g.
+   // glz::float_format<&T::x, "{:.2f}"> or glz::date_format<&T::t, "%Y-%m-%d">.
+   template <size_t N>
+   struct format_str
+   {
+      char data[N]{};
+
+      consteval format_str(const char (&str)[N]) noexcept { std::copy_n(str, N, data); }
+
+      constexpr operator std::string_view() const noexcept { return {data, N - 1}; }
+   };
+}

--- a/include/glaze/core/format_str.hpp
+++ b/include/glaze/core/format_str.hpp
@@ -12,7 +12,7 @@ namespace glz
    // Compile-time string for use as a non-type template parameter.
    // Captures a string literal (including its null terminator) so that format
    // specifications can be carried through the type system, e.g.
-   // glz::float_format<&T::x, "{:.2f}"> or glz::date_format<&T::t, "%Y-%m-%d">.
+   // glz::float_format<&T::x, "{:.2f}">.
    template <size_t N>
    struct format_str
    {

--- a/include/glaze/json/chrono_format.hpp
+++ b/include/glaze/json/chrono_format.hpp
@@ -71,6 +71,18 @@ namespace glz
                           "glz::date_format: a year_month_day field must not include time tokens (%H %M %S %T)");
          }
       }
+
+      // Compile-time guards shared by the epoch_count read and write paths. Validates both
+      // axes (the member type and the Duration unit) so a misuse on either surfaces as a
+      // friendly message rather than a deep cascade out of `typename Duration::rep`.
+      template <class Duration, class V>
+      consteval void validate_epoch_count() noexcept
+      {
+         static_assert(is_system_time_point<V>,
+                       "glz::epoch_count requires a std::chrono::system_clock time_point member");
+         static_assert(is_duration<Duration>,
+                       "glz::epoch_count requires a std::chrono::duration unit (e.g. std::chrono::milliseconds)");
+      }
    }
 
    template <format_str Fmt, class T>
@@ -86,6 +98,13 @@ namespace glz
          chrono_detail::date_time_fields f{};
 
          if constexpr (is_year_month_day<V>) {
+            // Reject a default/invalid year_month_day (month 0, day 0, Feb 30, ...) on write so the
+            // wrapper never emits a string its own reader would reject, and so an out-of-range
+            // month/day cannot slip past write_digits<2> as silently truncated low digits.
+            if (!wrapper.val.ok()) [[unlikely]] {
+               ctx.error = error_code::constraint_violated;
+               return;
+            }
             f.year = static_cast<int>(wrapper.val.year());
             f.month = static_cast<int>(static_cast<unsigned>(wrapper.val.month()));
             f.day = static_cast<int>(static_cast<unsigned>(wrapper.val.day()));
@@ -111,12 +130,16 @@ namespace glz
             return;
          }
 
-         // Upper bound on rendered size: the widest token (%T) expands two source
-         // characters to "HH:MM:SS" (8 bytes) and %F two chars to "YYYY-MM-DD"
-         // (10 bytes), i.e. < 6 bytes per source char; plus the surrounding quotes.
-         const size_t max_size = std::string_view(Fmt).size() * 6 + 4;
-         if (!ensure_space(ctx, b, ix + max_size)) [[unlikely]] {
-            return;
+         // Upper bound on rendered size: the widest token is %F, which expands two source
+         // characters to "YYYY-MM-DD" (10 bytes, 5 per source char); %T expands two to
+         // "HH:MM:SS" (8 bytes, 4 per source char). *6 bounds both with room to spare, plus a
+         // small constant for the surrounding quotes. Skipped on the write_unchecked fast path,
+         // where the caller has already reserved the space (matches to<JSON, num_t>).
+         if constexpr (not check_write_unchecked(Opts)) {
+            const size_t max_size = std::string_view(Fmt).size() * 6 + 4;
+            if (!ensure_space(ctx, b, ix + max_size)) [[unlikely]] {
+               return;
+            }
          }
 
          if constexpr (not check_unquoted(Opts)) {
@@ -200,8 +223,7 @@ namespace glz
       static void op(auto&& wrapper, is_context auto&& ctx, B&& b, auto& ix) noexcept
       {
          using V = std::remove_cvref_t<T>;
-         static_assert(is_system_time_point<V>,
-                       "glz::epoch_count requires a std::chrono::system_clock time_point member");
+         chrono_detail::validate_epoch_count<Duration, V>();
          using Rep = typename Duration::rep;
          const auto count = std::chrono::duration_cast<Duration>(wrapper.val.time_since_epoch()).count();
          to<JSON, Rep>::template op<Opts>(count, ctx, b, ix);
@@ -215,8 +237,7 @@ namespace glz
       static void op(auto&& wrapper, is_context auto&& ctx, auto&&... args) noexcept
       {
          using V = std::remove_cvref_t<T>;
-         static_assert(is_system_time_point<V>,
-                       "glz::epoch_count requires a std::chrono::system_clock time_point member");
+         chrono_detail::validate_epoch_count<Duration, V>();
          using Rep = typename Duration::rep;
          Rep count{};
          from<JSON, Rep>::template op<Opts>(count, ctx, args...);

--- a/include/glaze/json/chrono_format.hpp
+++ b/include/glaze/json/chrono_format.hpp
@@ -177,25 +177,42 @@ namespace glz
 
    namespace chrono_detail
    {
+      // Compile-time error reporting for the consteval date_format() factory.
+      //
+      // These are intentionally NOT constexpr: when validate_date_format() takes an error
+      // branch during constant evaluation, calling one makes the surrounding immediate
+      // invocation non-constant, which the compiler reports as a hard error naming the
+      // function (the function name is the diagnostic). We cannot use `throw` here — it is
+      // ill-formed under -fno-exceptions even inside an immediate function, and glaze's
+      // test-suite (and many consumers) build with exceptions disabled. We cannot use
+      // static_assert either, because a function parameter is never a constant expression
+      // within the function body.
+      //
+      //   supported tokens: %Y %m %d %H %M %S %F %T %%
+      //   a full date (%Y %m %d, or %F) is required
+      //   a year_month_day field must not include time tokens (%H %M %S %T)
+      inline void glaze_date_format_unsupported_token() {}
+      inline void glaze_date_format_missing_full_date() {}
+      inline void glaze_date_format_time_tokens_on_year_month_day() {}
+
       // Compile-time validation for date_format(). Rejects unsupported tokens, a missing
       // calendar date, and time tokens applied to a year_month_day field. Runs inside the
       // consteval date_format() factory, where the literal is a constant expression, even
-      // though the format is carried onward as a runtime value (a throw on the error path
-      // makes the surrounding immediate invocation non-constant, i.e. a hard compile error).
+      // though the format is carried onward as a runtime value.
       template <class Mem>
       consteval void validate_date_format(std::string_view fmt)
       {
          static_assert(is_system_time_point<Mem> || is_year_month_day<Mem>,
                        "glz::date_format requires a std::chrono::system_clock time_point or year_month_day member");
          if (!date_format_tokens_valid(fmt)) {
-            throw "glz::date_format: unsupported format token (supported: %Y %m %d %H %M %S %F %T %%)";
+            glaze_date_format_unsupported_token();
          }
          if (!date_format_has_full_date(fmt)) {
-            throw "glz::date_format: format must include a full date (%Y %m %d, or %F)";
+            glaze_date_format_missing_full_date();
          }
          if constexpr (is_year_month_day<Mem>) {
             if (date_format_has_time(fmt)) {
-               throw "glz::date_format: a year_month_day field must not include time tokens (%H %M %S %T)";
+               glaze_date_format_time_tokens_on_year_month_day();
             }
          }
       }

--- a/include/glaze/json/chrono_format.hpp
+++ b/include/glaze/json/chrono_format.hpp
@@ -184,7 +184,13 @@ namespace glz
          }
          else {
             using Duration = typename V::duration;
-            const auto tp = sys_days{ymd} + hours{f.hour} + minutes{f.minute} + seconds{f.second};
+            // Anchor the day at seconds precision before adding the time-of-day. MSVC's
+            // std::chrono::hours and minutes use a 32-bit rep, so `sys_days + hours + minutes`
+            // overflows the intermediate minutes count (days * 24 * 60 exceeds INT_MAX for
+            // far-future years, e.g. ~4.2e9 at year 9999) and silently wraps to a bogus
+            // instant. sys_seconds widens the arithmetic to 64 bits before the time-of-day
+            // is folded in, so the reconstruction is exact on every supported standard library.
+            const auto tp = sys_seconds{sys_days{ymd}} + hours{f.hour} + minutes{f.minute} + seconds{f.second};
             wrapper.val = time_point_cast<Duration>(tp);
          }
       }

--- a/include/glaze/json/chrono_format.hpp
+++ b/include/glaze/json/chrono_format.hpp
@@ -1,0 +1,241 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include <chrono>
+#include <string_view>
+#include <type_traits>
+
+#include "glaze/core/chrono.hpp"
+#include "glaze/core/format_str.hpp"
+#include "glaze/json/read.hpp"
+#include "glaze/json/write.hpp"
+
+// Per-field chrono customization wrappers.
+//
+// These decouple the *format* from the chrono *type*, addressing the limitation
+// that the clock type alone dictates the wire representation. They follow the
+// established field-wrapper precedents (glz::float_format for the NTTP format
+// string, glz::quoted for the fully-custom read+write pair) and are applied
+// inside glz::object(...) within a glz::meta<T> specialization:
+//
+//   template <> struct glz::meta<event> {
+//      using T = event;
+//      static constexpr auto value = glz::object(
+//         "start",  glz::date_format<&T::start, "%Y-%m-%d %H:%M:%S">,
+//         "logged", glz::epoch_count<&T::logged, std::chrono::milliseconds>);
+//   };
+//
+// Scope (MVP): JSON only. date_format supports system_clock time_points and
+// year_month_day; epoch_count supports system_clock time_points. utc_time and
+// the binary backends are intentionally out of scope here.
+
+namespace glz
+{
+   // ============================================
+   // glz::date_format — per-field strftime-subset format string
+   // ============================================
+
+   // Wrapper carrying the compile-time format string and a reference to the field.
+   // Both directions are fully custom (no meta<>::value indirection) because the
+   // underlying chrono parser only understands ISO 8601 and cannot honor Fmt.
+   //
+   // glaze_reflect = false keeps the binary backends from silently reflecting the
+   // wrapper as an aggregate: date_format is a textual, JSON-only wrapper, so a
+   // binary serialization should fail loudly (undefined to<BEVE, ...>) rather than
+   // emit a meaningless encoding of the wrapper struct.
+   template <format_str Fmt, class T>
+   struct date_format_t
+   {
+      static constexpr bool glaze_wrapper = true;
+      static constexpr bool glaze_reflect = false;
+      using value_type = T;
+      T& val;
+   };
+
+   namespace chrono_detail
+   {
+      // Compile-time guards shared by the date_format read and write paths.
+      template <format_str Fmt, class V>
+      consteval void validate_date_format() noexcept
+      {
+         static_assert(is_system_time_point<V> || is_year_month_day<V>,
+                       "glz::date_format requires a std::chrono::system_clock time_point or year_month_day member");
+         static_assert(date_format_tokens_valid(std::string_view(Fmt)),
+                       "glz::date_format: unsupported format token (supported: %Y %m %d %H %M %S %F %T %%)");
+         static_assert(date_format_has_full_date(std::string_view(Fmt)),
+                       "glz::date_format: format must include a full date (%Y %m %d, or %F)");
+         if constexpr (is_year_month_day<V>) {
+            static_assert(!date_format_has_time(std::string_view(Fmt)),
+                          "glz::date_format: a year_month_day field must not include time tokens (%H %M %S %T)");
+         }
+      }
+   }
+
+   template <format_str Fmt, class T>
+   struct to<JSON, date_format_t<Fmt, T>>
+   {
+      template <auto Opts, class B>
+      static void op(auto&& wrapper, is_context auto&& ctx, B&& b, auto& ix) noexcept
+      {
+         using namespace std::chrono;
+         using V = std::remove_cvref_t<T>;
+         chrono_detail::validate_date_format<Fmt, V>();
+
+         chrono_detail::date_time_fields f{};
+
+         if constexpr (is_year_month_day<V>) {
+            f.year = static_cast<int>(wrapper.val.year());
+            f.month = static_cast<int>(static_cast<unsigned>(wrapper.val.month()));
+            f.day = static_cast<int>(static_cast<unsigned>(wrapper.val.day()));
+         }
+         else {
+            const auto tp = wrapper.val;
+            const auto dp = floor<days>(tp);
+            const year_month_day ymd{dp};
+            f.year = static_cast<int>(ymd.year());
+            f.month = static_cast<int>(static_cast<unsigned>(ymd.month()));
+            f.day = static_cast<int>(static_cast<unsigned>(ymd.day()));
+
+            // hh_mm_ss at seconds precision: %S emits integer seconds only.
+            const hh_mm_ss tod{floor<seconds>(tp - dp)};
+            f.hour = static_cast<int>(tod.hours().count());
+            f.minute = static_cast<int>(tod.minutes().count());
+            f.second = static_cast<int>(tod.seconds().count());
+         }
+
+         // Same RFC 3339 constraint as the ISO 8601 writers: a 4-digit year only.
+         if (f.year < 0 || f.year > 9999) [[unlikely]] {
+            ctx.error = error_code::constraint_violated;
+            return;
+         }
+
+         // Upper bound on rendered size: the widest token (%T) expands two source
+         // characters to "HH:MM:SS" (8 bytes) and %F two chars to "YYYY-MM-DD"
+         // (10 bytes), i.e. < 6 bytes per source char; plus the surrounding quotes.
+         const size_t max_size = std::string_view(Fmt).size() * 6 + 4;
+         if (!ensure_space(ctx, b, ix + max_size)) [[unlikely]] {
+            return;
+         }
+
+         if constexpr (not check_unquoted(Opts)) {
+            b[ix++] = '"';
+         }
+         chrono_detail::write_date_format(std::string_view(Fmt), f, b, ix);
+         if constexpr (not check_unquoted(Opts)) {
+            b[ix++] = '"';
+         }
+      }
+   };
+
+   template <format_str Fmt, class T>
+   struct from<JSON, date_format_t<Fmt, T>>
+   {
+      template <auto Opts>
+      static void op(auto&& wrapper, is_context auto&& ctx, auto&&... args) noexcept
+      {
+         using namespace std::chrono;
+         using V = std::remove_cvref_t<T>;
+         chrono_detail::validate_date_format<Fmt, V>();
+
+         std::string_view str;
+         from<JSON, std::string_view>::template op<Opts>(str, ctx, args...);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+
+         chrono_detail::date_time_fields f{};
+         chrono_detail::parse_date_format(std::string_view(Fmt), str, f, ctx.error);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+
+         const year_month_day ymd{year{f.year}, month{static_cast<unsigned>(f.month)},
+                                  day{static_cast<unsigned>(f.day)}};
+         if (!ymd.ok()) [[unlikely]] {
+            ctx.error = error_code::parse_error;
+            return;
+         }
+
+         if constexpr (is_year_month_day<V>) {
+            wrapper.val = ymd;
+         }
+         else {
+            using Duration = typename V::duration;
+            const auto tp = sys_days{ymd} + hours{f.hour} + minutes{f.minute} + seconds{f.second};
+            wrapper.val = time_point_cast<Duration>(tp);
+         }
+      }
+   };
+
+   template <auto MemPtr, format_str Fmt>
+   inline constexpr decltype(auto) date_format_impl() noexcept
+   {
+      return [](auto&& val) { return date_format_t<Fmt, std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
+   }
+
+   // Usage: glz::date_format<&T::member, "%Y-%m-%d %H:%M:%S">
+   template <auto MemPtr, format_str Fmt>
+   constexpr auto date_format = date_format_impl<MemPtr, Fmt>();
+
+   // ============================================
+   // glz::epoch_count — per-field Unix timestamp count
+   // ============================================
+
+   // Serializes a system_clock time_point field as a numeric Unix timestamp in
+   // units of Duration, the per-field counterpart to the glz::epoch_time storage
+   // wrapper (so one field can be an epoch count while others stay ISO 8601).
+   template <class Duration, class T>
+   struct epoch_count_t
+   {
+      static constexpr bool glaze_wrapper = true;
+      static constexpr bool glaze_reflect = false;
+      using value_type = T;
+      T& val;
+   };
+
+   template <class Duration, class T>
+   struct to<JSON, epoch_count_t<Duration, T>>
+   {
+      template <auto Opts, class B>
+      static void op(auto&& wrapper, is_context auto&& ctx, B&& b, auto& ix) noexcept
+      {
+         using V = std::remove_cvref_t<T>;
+         static_assert(is_system_time_point<V>,
+                       "glz::epoch_count requires a std::chrono::system_clock time_point member");
+         using Rep = typename Duration::rep;
+         const auto count = std::chrono::duration_cast<Duration>(wrapper.val.time_since_epoch()).count();
+         to<JSON, Rep>::template op<Opts>(count, ctx, b, ix);
+      }
+   };
+
+   template <class Duration, class T>
+   struct from<JSON, epoch_count_t<Duration, T>>
+   {
+      template <auto Opts>
+      static void op(auto&& wrapper, is_context auto&& ctx, auto&&... args) noexcept
+      {
+         using V = std::remove_cvref_t<T>;
+         static_assert(is_system_time_point<V>,
+                       "glz::epoch_count requires a std::chrono::system_clock time_point member");
+         using Rep = typename Duration::rep;
+         Rep count{};
+         from<JSON, Rep>::template op<Opts>(count, ctx, args...);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+         using TPDuration = typename V::duration;
+         wrapper.val = V{std::chrono::duration_cast<TPDuration>(Duration{count})};
+      }
+   };
+
+   template <auto MemPtr, class Duration>
+   inline constexpr decltype(auto) epoch_count_impl() noexcept
+   {
+      return [](auto&& val) {
+         return epoch_count_t<Duration, std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr};
+      };
+   }
+
+   // Usage: glz::epoch_count<&T::member, std::chrono::milliseconds>
+   template <auto MemPtr, class Duration>
+   constexpr auto epoch_count = epoch_count_impl<MemPtr, Duration>();
+}

--- a/include/glaze/json/chrono_format.hpp
+++ b/include/glaze/json/chrono_format.hpp
@@ -8,24 +8,31 @@
 #include <type_traits>
 
 #include "glaze/core/chrono.hpp"
-#include "glaze/core/format_str.hpp"
 #include "glaze/json/read.hpp"
 #include "glaze/json/write.hpp"
 
 // Per-field chrono customization wrappers.
 //
 // These decouple the *format* from the chrono *type*, addressing the limitation
-// that the clock type alone dictates the wire representation. They follow the
-// established field-wrapper precedents (glz::float_format for the NTTP format
-// string, glz::quoted for the fully-custom read+write pair) and are applied
+// that the clock type alone dictates the wire representation. They are applied
 // inside glz::object(...) within a glz::meta<T> specialization:
 //
 //   template <> struct glz::meta<event> {
 //      using T = event;
 //      static constexpr auto value = glz::object(
-//         "start",  glz::date_format<&T::start, "%Y-%m-%d %H:%M:%S">,
-//         "logged", glz::epoch_count<&T::logged, std::chrono::milliseconds>);
+//         "start",  glz::date_format(&T::start, "%Y-%m-%d %H:%M:%S"),
+//         "logged", glz::epoch_count<std::chrono::milliseconds>(&T::logged));
 //   };
+//
+// Both take the member pointer as a value argument. The format string (date_format)
+// and member pointer live as data rather than as non-type template parameters, so a
+// struct with many distinct formats does not multiply the wrapper's template
+// instantiations: the view type is keyed on the member type alone, and the format is
+// carried as a runtime std::string_view. The strftime pattern is still validated at
+// compile time — a consteval guard in the date_format() factory rejects unsupported
+// tokens, a missing calendar date, or time tokens on a year_month_day field. (glz::
+// float_format keeps its NTTP form because it leans on std::format's compile-time
+// format checking, which date_format's hand-rolled runtime walk does not need.)
 //
 // Scope (MVP): JSON only. date_format supports system_clock time_points and
 // year_month_day; epoch_count supports system_clock time_points. utc_time and
@@ -37,64 +44,36 @@ namespace glz
    // glz::date_format — per-field strftime-subset format string
    // ============================================
 
-   // Wrapper carrying the compile-time format string and a reference to the field.
-   // Both directions are fully custom (no meta<>::value indirection) because the
-   // underlying chrono parser only understands ISO 8601 and cannot honor Fmt.
+   // View carrying the bound member and the (runtime) format string. Parameterized on the
+   // member type alone, so two fields that differ only in their format string share one set
+   // of to<>/from<> instantiations.
    //
    // glaze_reflect = false keeps the binary backends from silently reflecting the
    // wrapper as an aggregate: date_format is a textual, JSON-only wrapper, so a
    // binary serialization should fail loudly (undefined to<BEVE, ...>) rather than
    // emit a meaningless encoding of the wrapper struct.
-   template <format_str Fmt, class T>
+   template <class T>
    struct date_format_t
    {
       static constexpr bool glaze_wrapper = true;
       static constexpr bool glaze_reflect = false;
       using value_type = T;
       T& val;
+      std::string_view fmt;
    };
 
-   namespace chrono_detail
-   {
-      // Compile-time guards shared by the date_format read and write paths.
-      template <format_str Fmt, class V>
-      consteval void validate_date_format() noexcept
-      {
-         static_assert(is_system_time_point<V> || is_year_month_day<V>,
-                       "glz::date_format requires a std::chrono::system_clock time_point or year_month_day member");
-         static_assert(date_format_tokens_valid(std::string_view(Fmt)),
-                       "glz::date_format: unsupported format token (supported: %Y %m %d %H %M %S %F %T %%)");
-         static_assert(date_format_has_full_date(std::string_view(Fmt)),
-                       "glz::date_format: format must include a full date (%Y %m %d, or %F)");
-         if constexpr (is_year_month_day<V>) {
-            static_assert(!date_format_has_time(std::string_view(Fmt)),
-                          "glz::date_format: a year_month_day field must not include time tokens (%H %M %S %T)");
-         }
-      }
-
-      // Compile-time guards shared by the epoch_count read and write paths. Validates both
-      // axes (the member type and the Duration unit) so a misuse on either surfaces as a
-      // friendly message rather than a deep cascade out of `typename Duration::rep`.
-      template <class Duration, class V>
-      consteval void validate_epoch_count() noexcept
-      {
-         static_assert(is_system_time_point<V>,
-                       "glz::epoch_count requires a std::chrono::system_clock time_point member");
-         static_assert(is_duration<Duration>,
-                       "glz::epoch_count requires a std::chrono::duration unit (e.g. std::chrono::milliseconds)");
-      }
-   }
-
-   template <format_str Fmt, class T>
-   struct to<JSON, date_format_t<Fmt, T>>
+   template <class T>
+   struct to<JSON, date_format_t<T>>
    {
       template <auto Opts, class B>
       static void op(auto&& wrapper, is_context auto&& ctx, B&& b, auto& ix) noexcept
       {
          using namespace std::chrono;
          using V = std::remove_cvref_t<T>;
-         chrono_detail::validate_date_format<Fmt, V>();
+         static_assert(is_system_time_point<V> || is_year_month_day<V>,
+                       "glz::date_format requires a std::chrono::system_clock time_point or year_month_day member");
 
+         const std::string_view fmt = wrapper.fmt;
          chrono_detail::date_time_fields f{};
 
          if constexpr (is_year_month_day<V>) {
@@ -131,12 +110,11 @@ namespace glz
          }
 
          // Upper bound on rendered size: the widest token is %F, which expands two source
-         // characters to "YYYY-MM-DD" (10 bytes, 5 per source char); %T expands two to
-         // "HH:MM:SS" (8 bytes, 4 per source char). *6 bounds both with room to spare, plus a
-         // small constant for the surrounding quotes. Skipped on the write_unchecked fast path,
-         // where the caller has already reserved the space (matches to<JSON, num_t>).
+         // characters to "YYYY-MM-DD" (10 bytes, 5 per source char). *6 bounds it with room
+         // to spare, plus a small constant for the surrounding quotes. Skipped on the
+         // write_unchecked fast path, where the caller has already reserved the space.
          if constexpr (not check_write_unchecked(Opts)) {
-            const size_t max_size = std::string_view(Fmt).size() * 6 + 4;
+            const size_t max_size = fmt.size() * 6 + 4;
             if (!ensure_space(ctx, b, ix + max_size)) [[unlikely]] {
                return;
             }
@@ -145,22 +123,23 @@ namespace glz
          if constexpr (not check_unquoted(Opts)) {
             b[ix++] = '"';
          }
-         chrono_detail::write_date_format(std::string_view(Fmt), f, b, ix);
+         chrono_detail::write_date_format(fmt, f, b, ix);
          if constexpr (not check_unquoted(Opts)) {
             b[ix++] = '"';
          }
       }
    };
 
-   template <format_str Fmt, class T>
-   struct from<JSON, date_format_t<Fmt, T>>
+   template <class T>
+   struct from<JSON, date_format_t<T>>
    {
       template <auto Opts>
       static void op(auto&& wrapper, is_context auto&& ctx, auto&&... args) noexcept
       {
          using namespace std::chrono;
          using V = std::remove_cvref_t<T>;
-         chrono_detail::validate_date_format<Fmt, V>();
+         static_assert(is_system_time_point<V> || is_year_month_day<V>,
+                       "glz::date_format requires a std::chrono::system_clock time_point or year_month_day member");
 
          std::string_view str;
          from<JSON, std::string_view>::template op<Opts>(str, ctx, args...);
@@ -168,7 +147,7 @@ namespace glz
             return;
 
          chrono_detail::date_time_fields f{};
-         chrono_detail::parse_date_format(std::string_view(Fmt), str, f, ctx.error);
+         chrono_detail::parse_date_format(wrapper.fmt, str, f, ctx.error);
          if (bool(ctx.error)) [[unlikely]]
             return;
 
@@ -196,23 +175,65 @@ namespace glz
       }
    };
 
-   template <auto MemPtr, format_str Fmt>
-   inline constexpr decltype(auto) date_format_impl() noexcept
+   namespace chrono_detail
    {
-      return [](auto&& val) { return date_format_t<Fmt, std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr}; };
+      // Compile-time validation for date_format(). Rejects unsupported tokens, a missing
+      // calendar date, and time tokens applied to a year_month_day field. Runs inside the
+      // consteval date_format() factory, where the literal is a constant expression, even
+      // though the format is carried onward as a runtime value (a throw on the error path
+      // makes the surrounding immediate invocation non-constant, i.e. a hard compile error).
+      template <class Mem>
+      consteval void validate_date_format(std::string_view fmt)
+      {
+         static_assert(is_system_time_point<Mem> || is_year_month_day<Mem>,
+                       "glz::date_format requires a std::chrono::system_clock time_point or year_month_day member");
+         if (!date_format_tokens_valid(fmt)) {
+            throw "glz::date_format: unsupported format token (supported: %Y %m %d %H %M %S %F %T %%)";
+         }
+         if (!date_format_has_full_date(fmt)) {
+            throw "glz::date_format: format must include a full date (%Y %m %d, or %F)";
+         }
+         if constexpr (is_year_month_day<Mem>) {
+            if (date_format_has_time(fmt)) {
+               throw "glz::date_format: a year_month_day field must not include time tokens (%H %M %S %T)";
+            }
+         }
+      }
    }
 
-   // Usage: glz::date_format<&T::member, "%Y-%m-%d %H:%M:%S">
-   template <auto MemPtr, format_str Fmt>
-   constexpr auto date_format = date_format_impl<MemPtr, Fmt>();
+   // The object element: an invocable value carrying the member pointer + format. When the
+   // serializer iterates the meta object it calls this with the live instance (the same
+   // std::invocable dispatch every glaze field wrapper uses) to bind the member by reference.
+   template <class MemPtr>
+   struct date_format_spec
+   {
+      MemPtr ptr;
+      std::string_view fmt;
+
+      constexpr auto operator()(auto&& parent) const
+      {
+         using Mem = std::remove_reference_t<decltype(parent.*ptr)>;
+         return date_format_t<Mem>{parent.*ptr, fmt};
+      }
+   };
+
+   // Usage: glz::date_format(&T::member, "%Y-%m-%d %H:%M:%S")
+   template <class MemPtr>
+   consteval auto date_format(MemPtr ptr, const char* fmt)
+   {
+      using Mem = std::remove_cvref_t<typename unwrap_pointer<MemPtr>::type>;
+      const std::string_view sv{fmt};
+      chrono_detail::validate_date_format<Mem>(sv);
+      return date_format_spec<MemPtr>{ptr, sv};
+   }
 
    // ============================================
    // glz::epoch_count — per-field Unix timestamp count
    // ============================================
 
-   // Serializes a system_clock time_point field as a numeric Unix timestamp in
-   // units of Duration, the per-field counterpart to the glz::epoch_time storage
-   // wrapper (so one field can be an epoch count while others stay ISO 8601).
+   // View serializing a system_clock time_point field as a numeric Unix timestamp in units
+   // of Duration, the per-field counterpart to the glz::epoch_time storage wrapper (so one
+   // field can be an epoch count while others stay ISO 8601).
    template <class Duration, class T>
    struct epoch_count_t
    {
@@ -229,7 +250,10 @@ namespace glz
       static void op(auto&& wrapper, is_context auto&& ctx, B&& b, auto& ix) noexcept
       {
          using V = std::remove_cvref_t<T>;
-         chrono_detail::validate_epoch_count<Duration, V>();
+         static_assert(is_system_time_point<V>,
+                       "glz::epoch_count requires a std::chrono::system_clock time_point member");
+         static_assert(is_duration<Duration>,
+                       "glz::epoch_count requires a std::chrono::duration unit (e.g. std::chrono::milliseconds)");
          using Rep = typename Duration::rep;
          const auto count = std::chrono::duration_cast<Duration>(wrapper.val.time_since_epoch()).count();
          to<JSON, Rep>::template op<Opts>(count, ctx, b, ix);
@@ -243,7 +267,10 @@ namespace glz
       static void op(auto&& wrapper, is_context auto&& ctx, auto&&... args) noexcept
       {
          using V = std::remove_cvref_t<T>;
-         chrono_detail::validate_epoch_count<Duration, V>();
+         static_assert(is_system_time_point<V>,
+                       "glz::epoch_count requires a std::chrono::system_clock time_point member");
+         static_assert(is_duration<Duration>,
+                       "glz::epoch_count requires a std::chrono::duration unit (e.g. std::chrono::milliseconds)");
          using Rep = typename Duration::rep;
          Rep count{};
          from<JSON, Rep>::template op<Opts>(count, ctx, args...);
@@ -254,15 +281,27 @@ namespace glz
       }
    };
 
-   template <auto MemPtr, class Duration>
-   inline constexpr decltype(auto) epoch_count_impl() noexcept
+   template <class Duration, class MemPtr>
+   struct epoch_count_spec
    {
-      return [](auto&& val) {
-         return epoch_count_t<Duration, std::remove_reference_t<decltype(val.*MemPtr)>>{val.*MemPtr};
-      };
-   }
+      MemPtr ptr;
 
-   // Usage: glz::epoch_count<&T::member, std::chrono::milliseconds>
-   template <auto MemPtr, class Duration>
-   constexpr auto epoch_count = epoch_count_impl<MemPtr, Duration>();
+      constexpr auto operator()(auto&& parent) const
+      {
+         using Mem = std::remove_reference_t<decltype(parent.*ptr)>;
+         return epoch_count_t<Duration, Mem>{parent.*ptr};
+      }
+   };
+
+   // Usage: glz::epoch_count<std::chrono::milliseconds>(&T::member)
+   template <class Duration, class MemPtr>
+   constexpr auto epoch_count(MemPtr ptr)
+   {
+      using Mem = std::remove_cvref_t<typename unwrap_pointer<MemPtr>::type>;
+      static_assert(is_system_time_point<Mem>,
+                    "glz::epoch_count requires a std::chrono::system_clock time_point member");
+      static_assert(is_duration<Duration>,
+                    "glz::epoch_count requires a std::chrono::duration unit (e.g. std::chrono::milliseconds)");
+      return epoch_count_spec<Duration, MemPtr>{ptr};
+   }
 }

--- a/include/glaze/json/float_format.hpp
+++ b/include/glaze/json/float_format.hpp
@@ -6,6 +6,7 @@
 #include <string_view>
 #include <type_traits>
 
+#include "glaze/core/format_str.hpp"
 #include "glaze/core/opts.hpp"
 #include "glaze/json/read.hpp"
 #include "glaze/json/write.hpp"
@@ -20,16 +21,7 @@
 
 namespace glz
 {
-   // Compile-time string for use as template parameter
-   template <size_t N>
-   struct format_str
-   {
-      char data[N]{};
-
-      consteval format_str(const char (&str)[N]) noexcept { std::copy_n(str, N, data); }
-
-      constexpr operator std::string_view() const noexcept { return {data, N - 1}; }
-   };
+   // format_str (compile-time format string NTTP) lives in glaze/core/format_str.hpp
 
    // Wrapper for formatting floats with a specific format string
    template <format_str Fmt, class T>

--- a/tests/chrono_test/chrono_test.cpp
+++ b/tests/chrono_test/chrono_test.cpp
@@ -1338,7 +1338,10 @@ suite date_format_tests = [] {
    "date_format_year_boundaries"_test = [] {
       {
          CompactTime c;
-         c.tp = sys_days{9999y / December / 31} + 23h + 59min + 59s;
+         // Anchor at seconds precision before adding the time-of-day: MSVC's chrono hours and
+         // minutes use a 32-bit rep, so `sys_days{9999y...} + 23h + 59min` overflows the
+         // intermediate minutes count (~4.2e9 > INT_MAX) and would otherwise build a bogus instant.
+         c.tp = sys_time<seconds>{sys_days{9999y / December / 31}} + 23h + 59min + 59s;
          std::string json;
          expect(!glz::write_json(c, json));
          expect(json == R"({"tp":"9999-12-31T23:59:59"})") << json;

--- a/tests/chrono_test/chrono_test.cpp
+++ b/tests/chrono_test/chrono_test.cpp
@@ -1187,6 +1187,49 @@ struct glz::meta<CompactTime>
    static constexpr auto value = glz::object("tp", glz::date_format<&T::tp, "%FT%T">);
 };
 
+struct PercentLiteral
+{
+   std::chrono::sys_time<std::chrono::seconds> tp{};
+};
+
+template <>
+struct glz::meta<PercentLiteral>
+{
+   using T = PercentLiteral;
+   // %% renders a literal '%' on write and consumes a literal '%' on read.
+   static constexpr auto value = glz::object("tp", glz::date_format<&T::tp, "%Y-%m-%d %H%%">);
+};
+
+struct CoarseLog
+{
+   // Member is seconds-precision; epoch_count emits milliseconds (cross-precision).
+   std::chrono::sys_time<std::chrono::seconds> at{};
+};
+
+template <>
+struct glz::meta<CoarseLog>
+{
+   using T = CoarseLog;
+   static constexpr auto value = glz::object("at", glz::epoch_count<&T::at, std::chrono::milliseconds>);
+};
+
+// Compile-time guards exercised directly (the wrapper-level static_assert *messages* in
+// validate_date_format / validate_epoch_count can only be observed via an actual compile
+// failure, so they are not asserted live; testing the consteval validators is the equivalent
+// stable coverage for docs/chrono.md's three documented date_format guarantees).
+static_assert(glz::chrono_detail::date_format_tokens_valid("%Y-%m-%d %H:%M:%S"));
+static_assert(glz::chrono_detail::date_format_tokens_valid("%F %T %%"));
+static_assert(!glz::chrono_detail::date_format_tokens_valid("%A"));
+static_assert(!glz::chrono_detail::date_format_tokens_valid("%j"));
+static_assert(!glz::chrono_detail::date_format_tokens_valid("%z"));
+static_assert(!glz::chrono_detail::date_format_tokens_valid("ends-with-%"));
+static_assert(glz::chrono_detail::date_format_has_full_date("%F"));
+static_assert(glz::chrono_detail::date_format_has_full_date("%Y-%m-%d"));
+static_assert(!glz::chrono_detail::date_format_has_full_date("%H:%M:%S"));
+static_assert(glz::chrono_detail::date_format_has_time("%T"));
+static_assert(glz::chrono_detail::date_format_has_time("%H"));
+static_assert(!glz::chrono_detail::date_format_has_time("%F"));
+
 suite date_format_tests = [] {
    using namespace std::chrono;
 
@@ -1290,6 +1333,115 @@ suite date_format_tests = [] {
          expect(!glz::read_json(r, json));
          expect(r.tp == c.tp) << json;
       }
+   };
+
+   "date_format_year_boundaries"_test = [] {
+      {
+         CompactTime c;
+         c.tp = sys_days{9999y / December / 31} + 23h + 59min + 59s;
+         std::string json;
+         expect(!glz::write_json(c, json));
+         expect(json == R"({"tp":"9999-12-31T23:59:59"})") << json;
+         CompactTime r;
+         expect(!glz::read_json(r, json));
+         expect(r.tp == c.tp);
+      }
+      {
+         CompactTime c;
+         c.tp = sys_days{0000y / January / 1};
+         std::string json;
+         expect(!glz::write_json(c, json));
+         expect(json == R"({"tp":"0000-01-01T00:00:00"})") << json;
+         CompactTime r;
+         expect(!glz::read_json(r, json));
+         expect(r.tp == c.tp);
+      }
+      {
+         // Year >= 10000 must fail to serialize (constraint_violated), not wrap around.
+         CompactTime c;
+         c.tp = sys_days{year{10000} / January / 1};
+         std::string json;
+         expect(bool(glz::write_json(c, json)));
+      }
+      {
+         // A 5-digit year on read is rejected ('0' where the '-' separator is expected).
+         CompactTime r;
+         expect(bool(glz::read_json(r, R"({"tp":"10000-01-01T00:00:00"})")));
+      }
+   };
+
+   "date_format_pre_1970_roundtrip"_test = [] {
+      // floor<days> + hh_mm_ss{floor<seconds>(tp - dp)} must handle negative time_since_epoch.
+      CompactTime c;
+      c.tp = sys_days{1969y / December / 31} + 23h + 59min + 59s;
+      std::string json;
+      expect(!glz::write_json(c, json));
+      expect(json == R"({"tp":"1969-12-31T23:59:59"})") << json;
+      CompactTime r;
+      expect(!glz::read_json(r, json));
+      expect(r.tp == c.tp);
+
+      // Pre-epoch with a non-midnight time-of-day exercises the intra-day remainder.
+      CompactTime c2;
+      c2.tp = sys_days{1900y / July / 4} + 13h + 25min + 47s;
+      std::string j2;
+      expect(!glz::write_json(c2, j2));
+      CompactTime r2;
+      expect(!glz::read_json(r2, j2));
+      expect(r2.tp == c2.tp);
+   };
+
+   "date_format_percent_literal"_test = [] {
+      PercentLiteral p;
+      p.tp = sys_days{2026y / June / 18} + 9h;
+      std::string json;
+      expect(!glz::write_json(p, json));
+      expect(json == R"({"tp":"2026-06-18 09%"})") << json;
+      PercentLiteral r;
+      expect(!glz::read_json(r, json));
+      expect(r.tp == p.tp);
+   };
+
+   "date_format_subsecond_readback_zeroed"_test = [] {
+      // The write side truncates the millisecond fraction; the read side reconstructs at
+      // seconds precision, so the round-tripped instant differs from the original by < 1s.
+      FormattedEvent e;
+      e.start = sys_days{2026y / June / 18} + 12h + 34min + 56s + 789ms;
+      e.logged = time_point_cast<milliseconds>(sys_days{2026y / June / 18});
+      e.day = sys_days{2026y / June / 18};
+      std::string json;
+      expect(!glz::write_json(e, json));
+      FormattedEvent r;
+      expect(!glz::read_json(r, json));
+      const auto seconds_floor = sys_days{2026y / June / 18} + 12h + 34min + 56s;
+      expect(r.start == seconds_floor) << json;
+      expect(r.start != e.start); // the 789ms fraction was lost by design
+   };
+
+   "epoch_count_cross_precision"_test = [] {
+      // A seconds-precision member emitted as a millisecond count, and the duration_cast
+      // truncation that brings a sub-second count back to the member's coarser precision.
+      CoarseLog c;
+      c.at = time_point_cast<seconds>(sys_days{1970y / January / 1} + 5s);
+      std::string json;
+      expect(!glz::write_json(c, json));
+      expect(json == R"({"at":5000})") << json;
+      CoarseLog r;
+      expect(!glz::read_json(r, json));
+      expect(r.at == c.at);
+
+      // 1500ms truncates toward the member's seconds precision (-> 1s).
+      CoarseLog r2;
+      expect(!glz::read_json(r2, R"({"at":1500})"));
+      expect(r2.at == time_point_cast<seconds>(sys_days{1970y / January / 1} + 1s)) << "1500ms -> 1s";
+   };
+
+   "date_format_invalid_ymd_write_errors"_test = [] {
+      // A default-constructed year_month_day (month 0 / day 0) is not ok(); the writer must
+      // fail with constraint_violated rather than emit an unreadable "0000/00/00".
+      YmdSlashed y{};
+      std::string json;
+      expect(bool(glz::write_json(y, json))) << "expected constraint_violated for invalid ymd";
    };
 };
 

--- a/tests/chrono_test/chrono_test.cpp
+++ b/tests/chrono_test/chrono_test.cpp
@@ -1,6 +1,8 @@
 // Glaze Library
 // For the license information refer to glaze.hpp
 
+#include "glaze/chrono.hpp"
+
 #include <chrono>
 #include <thread>
 
@@ -1136,6 +1138,158 @@ suite chrono_date_only_tests = [] {
       sys_days parsed{};
       expect(!glz::read_json(parsed, "\"2024-06-15T23:59:59.999999999+00:00\""));
       expect(parsed == sys_days{year{2024} / month{6} / day{15}});
+   };
+};
+
+// ============================================
+// Per-field chrono format wrappers (glz::date_format / glz::epoch_count)
+// ============================================
+
+struct FormattedEvent
+{
+   std::chrono::system_clock::time_point start{};
+   std::chrono::sys_time<std::chrono::milliseconds> logged{};
+   std::chrono::sys_days day{};
+};
+
+template <>
+struct glz::meta<FormattedEvent>
+{
+   using T = FormattedEvent;
+   static constexpr auto value = glz::object( //
+      "start", glz::date_format<&T::start, "%Y-%m-%d %H:%M:%S">, //
+      "logged", glz::epoch_count<&T::logged, std::chrono::milliseconds>, //
+      "day", glz::date_format<&T::day, "%Y-%m-%d">);
+};
+
+struct YmdSlashed
+{
+   std::chrono::year_month_day ymd{};
+};
+
+template <>
+struct glz::meta<YmdSlashed>
+{
+   using T = YmdSlashed;
+   static constexpr auto value = glz::object("ymd", glz::date_format<&T::ymd, "%Y/%m/%d">);
+};
+
+struct CompactTime
+{
+   // %F and %T aliases, no separators between date and time other than a literal 'T'
+   std::chrono::sys_time<std::chrono::seconds> tp{};
+};
+
+template <>
+struct glz::meta<CompactTime>
+{
+   using T = CompactTime;
+   static constexpr auto value = glz::object("tp", glz::date_format<&T::tp, "%FT%T">);
+};
+
+suite date_format_tests = [] {
+   using namespace std::chrono;
+
+   "date_format_custom_separators"_test = [] {
+      FormattedEvent e;
+      e.start = sys_days{2026y / June / 18} + 12h + 34min + 56s;
+      e.logged = time_point_cast<milliseconds>(sys_days{2026y / June / 18} + 1h + 789ms);
+      e.day = sys_days{2026y / June / 18};
+
+      std::string json;
+      expect(!glz::write_json(e, json));
+
+      const long long ms = duration_cast<milliseconds>(e.logged.time_since_epoch()).count();
+      const std::string expected =
+         std::string{R"({"start":"2026-06-18 12:34:56","logged":)"} + std::to_string(ms) + R"(,"day":"2026-06-18"})";
+      expect(json == expected) << json;
+
+      FormattedEvent r;
+      expect(!glz::read_json(r, json));
+      expect(r.start == e.start);
+      expect(r.logged == e.logged);
+      expect(r.day == e.day);
+   };
+
+   "date_format_year_month_day_slashed"_test = [] {
+      YmdSlashed y{year_month_day{2026y / December / 31}};
+      std::string json;
+      expect(!glz::write_json(y, json));
+      expect(json == R"({"ymd":"2026/12/31"})") << json;
+
+      YmdSlashed r;
+      expect(!glz::read_json(r, json));
+      expect(r.ymd == y.ymd);
+   };
+
+   "date_format_F_T_aliases"_test = [] {
+      CompactTime c;
+      c.tp = sys_days{2024y / February / 29} + 23h + 59min + 7s; // leap day
+      std::string json;
+      expect(!glz::write_json(c, json));
+      expect(json == R"({"tp":"2024-02-29T23:59:07"})") << json;
+
+      CompactTime r;
+      expect(!glz::read_json(r, json));
+      expect(r.tp == c.tp);
+   };
+
+   "date_format_subsecond_truncates_on_write"_test = [] {
+      // %S emits integer seconds; the millisecond component is dropped on write.
+      FormattedEvent e;
+      e.start = sys_days{2026y / June / 18} + 12h + 34min + 56s + 500ms;
+      std::string json;
+      expect(!glz::write_json(e, json));
+      expect(json.find("12:34:56\"") != std::string::npos) << json;
+   };
+
+   "date_format_rejects_malformed_input"_test = [] {
+      FormattedEvent r;
+      expect(bool(glz::read_json(r, R"({"start":"not-a-date","logged":0,"day":"2026-06-18"})")));
+   };
+
+   "date_format_rejects_wrong_separator"_test = [] {
+      // The format demands '/', but the input uses '-'.
+      YmdSlashed r;
+      expect(bool(glz::read_json(r, R"({"ymd":"2026-12-31"})")));
+   };
+
+   "date_format_rejects_trailing_input"_test = [] {
+      // Extra characters past the format must not be silently ignored.
+      YmdSlashed r;
+      expect(bool(glz::read_json(r, R"({"ymd":"2026/12/31 extra"})")));
+   };
+
+   "date_format_rejects_invalid_calendar_date"_test = [] {
+      // Feb 30 parses field-wise but fails year_month_day::ok().
+      YmdSlashed r;
+      expect(bool(glz::read_json(r, R"({"ymd":"2026/02/30"})")));
+   };
+
+   "epoch_count_per_field_roundtrip"_test = [] {
+      FormattedEvent e;
+      e.logged = time_point_cast<milliseconds>(sys_days{1970y / January / 1} + 1234ms);
+      std::string json;
+      expect(!glz::write_json(e, json));
+      expect(json.find("\"logged\":1234") != std::string::npos) << json;
+
+      FormattedEvent r;
+      expect(!glz::read_json(r, json));
+      expect(r.logged == e.logged);
+   };
+
+   "date_format_roundtrip_stress"_test = [] {
+      // Many distinct seconds-precision instants must round-trip exactly.
+      auto base = sys_days{2000y / January / 1};
+      for (int i = 0; i < 1000; ++i) {
+         CompactTime c;
+         c.tp = time_point_cast<seconds>(base + hours{i * 37} + minutes{i % 60} + seconds{i % 60});
+         std::string json;
+         expect(!glz::write_json(c, json));
+         CompactTime r;
+         expect(!glz::read_json(r, json));
+         expect(r.tp == c.tp) << json;
+      }
    };
 };
 

--- a/tests/chrono_test/chrono_test.cpp
+++ b/tests/chrono_test/chrono_test.cpp
@@ -1157,9 +1157,9 @@ struct glz::meta<FormattedEvent>
 {
    using T = FormattedEvent;
    static constexpr auto value = glz::object( //
-      "start", glz::date_format<&T::start, "%Y-%m-%d %H:%M:%S">, //
-      "logged", glz::epoch_count<&T::logged, std::chrono::milliseconds>, //
-      "day", glz::date_format<&T::day, "%Y-%m-%d">);
+      "start", glz::date_format(&T::start, "%Y-%m-%d %H:%M:%S"), //
+      "logged", glz::epoch_count<std::chrono::milliseconds>(&T::logged), //
+      "day", glz::date_format(&T::day, "%Y-%m-%d"));
 };
 
 struct YmdSlashed
@@ -1171,7 +1171,7 @@ template <>
 struct glz::meta<YmdSlashed>
 {
    using T = YmdSlashed;
-   static constexpr auto value = glz::object("ymd", glz::date_format<&T::ymd, "%Y/%m/%d">);
+   static constexpr auto value = glz::object("ymd", glz::date_format(&T::ymd, "%Y/%m/%d"));
 };
 
 struct CompactTime
@@ -1184,7 +1184,7 @@ template <>
 struct glz::meta<CompactTime>
 {
    using T = CompactTime;
-   static constexpr auto value = glz::object("tp", glz::date_format<&T::tp, "%FT%T">);
+   static constexpr auto value = glz::object("tp", glz::date_format(&T::tp, "%FT%T"));
 };
 
 struct PercentLiteral
@@ -1197,7 +1197,7 @@ struct glz::meta<PercentLiteral>
 {
    using T = PercentLiteral;
    // %% renders a literal '%' on write and consumes a literal '%' on read.
-   static constexpr auto value = glz::object("tp", glz::date_format<&T::tp, "%Y-%m-%d %H%%">);
+   static constexpr auto value = glz::object("tp", glz::date_format(&T::tp, "%Y-%m-%d %H%%"));
 };
 
 struct CoarseLog
@@ -1210,7 +1210,7 @@ template <>
 struct glz::meta<CoarseLog>
 {
    using T = CoarseLog;
-   static constexpr auto value = glz::object("at", glz::epoch_count<&T::at, std::chrono::milliseconds>);
+   static constexpr auto value = glz::object("at", glz::epoch_count<std::chrono::milliseconds>(&T::at));
 };
 
 // Compile-time guards exercised directly (the wrapper-level static_assert *messages* in


### PR DESCRIPTION
Addresses #2640. Decouples the *format* of a chrono field from its *type*, so a single field can opt into a custom representation while others keep the type-driven default. (`std::chrono::utc_time` support from #2640 is tracked separately in #2657.)

## What

Two per-field wrappers, applied inside `glz::object(...)` in a `glz::meta<T>` specialization:

- **`glz::date_format(&T::member, "pattern")`** — serializes a `system_clock` time point (or a `year_month_day`) with a locale-independent `strftime`-subset pattern instead of ISO 8601.
- **`glz::epoch_count<Duration>(&T::member)`** — serializes a `system_clock` time point as a numeric Unix timestamp in `Duration` units (the per-field counterpart to the `glz::epoch_time` storage wrapper).

```cpp
struct Event {
   std::chrono::system_clock::time_point start{};
   std::chrono::sys_time<std::chrono::milliseconds> logged{};
};
template <> struct glz::meta<Event> {
   using T = Event;
   static constexpr auto value = glz::object(
      "start",  glz::date_format(&T::start, "%Y-%m-%d %H:%M:%S"),          // "2026-06-18 12:34:56"
      "logged", glz::epoch_count<std::chrono::milliseconds>(&T::logged));  // 1781786096789
};
```

The member pointer is a value argument (and for `date_format` so is the pattern), not a non-type template parameter — see Implementation notes for why.

Supported tokens (compile-time validated): `%Y %m %d %H %M %S %F %T %%`. Unsupported tokens, a missing calendar date, or time tokens on a `year_month_day` field are hard compile errors.

## Scope

- **JSON / text backends only.** These are textual wrappers that route through the JSON serializer, so NDJSON and stencil output work too. A field using them under a native-encoding backend (BEVE, CBOR, MsgPack, BSON, TOML) is a compile error (undefined `glz::to<Format, …>`), not a silent miscoding.
- **`%S` writes integer seconds**; sub-second precision is truncated on write (a `%S` pattern has nowhere to put a fraction). Use the default ISO 8601 representation for sub-second fidelity.
- **UTC wall-clock**, no timezone token.

## Guarantees

- The year is constrained to `[0000, 9999]` on both read and write, matching the ISO 8601 path.
- `date_format` rejects an invalid/default `year_month_day` on write (`constraint_violated`), so the writer never emits a string its own reader would reject and an out-of-range month/day cannot slip past `write_digits<2>`.
- `epoch_count` validates both its member type and its `Duration` unit at compile time, so misuse produces a clear diagnostic rather than a deep template cascade.

## Implementation notes

- **Value-carried, not NTTP.** The member pointer (and `date_format`'s pattern) are passed as values, so the view type is keyed on the member type alone and the format lives as a runtime `std::string_view`. Fields that differ only in their format string no longer each instantiate a fresh `date_format_t` / `to` / `from` / closure — on a synthetic struct of N same-typed members with distinct formats this removes ~40% of the wrapper's template instantiations and makes the per-distinct-format compile cost flat. The pattern stays a compile-time literal: a `consteval` guard in the `date_format(...)` factory rejects unsupported tokens, a missing date, or time tokens on a `year_month_day`. (`glz::float_format` keeps the NTTP form because it relies on `std::format`'s compile-time format checking; `date_format`'s strftime walk is already runtime, so it has no such dependency.)
- The strftime subset is a small, locale-independent hand-roll in `core/chrono.hpp` that reuses the existing `parse_digits` / `write_digits` primitives, so the `[0000, 9999]` year and component-range guarantees match the ISO 8601 path.
- The `date_format` reader anchors its time-point reconstruction at seconds precision (`sys_seconds`) before folding in the time-of-day. MSVC's `std::chrono::hours`/`minutes` use a 32-bit representation, so the natural `sys_days + hours + minutes` idiom overflows the intermediate minutes count for far-future years; the seconds anchor keeps the arithmetic in 64 bits and the reconstruction exact across libstdc++, libc++, and MSVC.
- `float_format`'s compile-time format-string helper was factored out of `json/float_format.hpp` into `core/format_str.hpp` (no behavioral change).

## Follow-ups (tracked separately)

- #2657 — `std::chrono::utc_time` / `utc_clock` support (the remaining part of #2640).
- #2655 — per-field wrappers should peek through `std::optional`.
- #2656 — field wrappers emit an incorrect JSON Schema (catch-all union instead of the wire type).
