### PR TITLE
guard eetf_to_json reads against end of input

### DIFF
--- a/include/glaze/eetf/eetf_to_json.hpp
+++ b/include/glaze/eetf/eetf_to_json.hpp
@@ -164,8 +164,10 @@ namespace glz
             if (invalid_end(ctx, it, end)) [[unlikely]] {
                return;
             }
-            const auto tag = get_type(ctx, it);
-            if (tag != ERL_NIL_EXT) {
+            // A proper list terminates with ERL_NIL_EXT, a single tag byte. Read that tag directly
+            // rather than through get_type/ei_get_type, which reads a 2-4 byte length header off the
+            // raw pointer (past end when the tail tag is the final byte) for any other term type.
+            if (uint8_t(*it) != ERL_NIL_EXT) {
                ctx.error = error_code::array_element_not_found;
                return;
             }
@@ -208,7 +210,12 @@ namespace glz
                if (invalid_end(ctx, it, end)) [[unlikely]] {
                   return;
                }
-               const auto key_type = get_type(ctx, it);
+               // Read the key tag directly rather than through get_type/ei_get_type, which reads a
+               // 2-4 byte length header off the raw pointer (past end when the tag is the final byte).
+               // is_string/is_atom accept the raw, un-normalized tag, and term_to_json_value re-reads
+               // and bounds-checks the full key below. Widen to int so the tag clears the int_t
+               // constraint on is_string/is_atom (uint8_t is a char type and would be rejected).
+               const int key_type = uint8_t(*it);
                // support only string or atom keys in json
                if (!eetf::is_string(key_type) && !eetf::is_atom(key_type)) {
                   ctx.error = error_code::syntax_error;

--- a/include/glaze/eetf/eetf_to_json.hpp
+++ b/include/glaze/eetf/eetf_to_json.hpp
@@ -156,8 +156,14 @@ namespace glz
                return;
             }
             write_sequence(arity, idx, ctx, it, end, out, ix, recursive_depth + 1);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
 
             // handle tail
+            if (invalid_end(ctx, it, end)) [[unlikely]] {
+               return;
+            }
             const auto tag = get_type(ctx, it);
             if (tag != ERL_NIL_EXT) {
                ctx.error = error_code::array_element_not_found;
@@ -199,6 +205,9 @@ namespace glz
 
             while (arity--) {
                // write key
+               if (invalid_end(ctx, it, end)) [[unlikely]] {
+                  return;
+               }
                const auto key_type = get_type(ctx, it);
                // support only string or atom keys in json
                if (!eetf::is_string(key_type) && !eetf::is_atom(key_type)) {
@@ -254,6 +263,9 @@ namespace glz
 
       // Check format version
       if constexpr (not check_no_header(Opts)) {
+         if (it == end) [[unlikely]] {
+            return {0, error_code::no_read_input};
+         }
          const auto version = decode_version(ctx, it);
          if (eetf_magic_version != version) {
             return {0, error_code::version_mismatch};

--- a/include/glaze/eetf/ei.hpp
+++ b/include/glaze/eetf/ei.hpp
@@ -117,6 +117,10 @@ namespace glz
    GLZ_ALWAYS_INLINE void decode_number(T&& value, Args&&... args) noexcept
    {
       using V = std::remove_cvref_t<T>;
+      // Cast the scratch value through V (the decayed value type), never T. T is a forwarding
+      // reference, so static_cast<T>(v) forms a reference cast that fails to compile when the
+      // scratch type (long / long long) is a distinct type of the same width as V -- e.g. on
+      // platforms where int64_t is long long while long is also 64-bit (macOS/LLP64-style).
       if constexpr (std::floating_point<std::remove_cvref_t<T>>) {
          double v;
          detail::decode_impl([&](const char* buf, int* index) { return ei_decode_double(buf, index, &v); },
@@ -129,13 +133,13 @@ namespace glz
                long long v;
                detail::decode_impl([&](const char* buf, int* index) { return ei_decode_longlong(buf, index, &v); },
                                    std::forward<Args>(args)...);
-               value = static_cast<T>(v);
+               value = static_cast<V>(v);
             }
             else {
                unsigned long long v;
                detail::decode_impl([&](const char* buf, int* index) { return ei_decode_ulonglong(buf, index, &v); },
                                    std::forward<Args>(args)...);
-               value = static_cast<T>(v);
+               value = static_cast<V>(v);
             }
          }
          else {
@@ -143,13 +147,13 @@ namespace glz
                long v;
                detail::decode_impl([&](const char* buf, int* index) { return ei_decode_long(buf, index, &v); },
                                    std::forward<Args>(args)...);
-               value = static_cast<T>(v);
+               value = static_cast<V>(v);
             }
             else {
                unsigned long v;
                detail::decode_impl([&](const char* buf, int* index) { return ei_decode_ulong(buf, index, &v); },
                                    std::forward<Args>(args)...);
-               value = static_cast<T>(v);
+               value = static_cast<V>(v);
             }
          }
       }

--- a/tests/eetf_test/eetf_test.cpp
+++ b/tests/eetf_test/eetf_test.cpp
@@ -455,6 +455,74 @@ suite eetf_to_json_tests = [] {
       expect_unexpected_end(partial_digits);
    };
 
+   "eetf_to_json empty buffer"_test = [] {
+      // No version byte at all: the entry guard rejects before decode_version reads the tag.
+      const std::string buffer{};
+      std::string json{};
+      const auto ec = glz::eetf_to_json(buffer, json);
+      expect(ec.ec == glz::error_code::no_read_input);
+   };
+
+   "eetf_to_json truncated map"_test = [] {
+      auto expect_unexpected_end = [](const auto& buffer) {
+         std::string json{};
+         const auto ec = glz::eetf_to_json(buffer, json);
+         expect(ec.ec == glz::error_code::unexpected_end);
+      };
+
+      // ERL_MAP_EXT declares arity 1 but the buffer ends before any key/value entry.
+      const std::array<std::uint8_t, 6> missing_entries{
+         uint8_t(glz::eetf_magic_version), uint8_t(ERL_MAP_EXT), 0, 0, 0, 1};
+      // ERL_MAP_EXT arity 1 with a key tag (ERL_ATOM_EXT) as the final byte: the tag must be
+      // classified without ei_get_type reading its 2-byte length header past the end.
+      const std::array<std::uint8_t, 7> truncated_key{
+         uint8_t(glz::eetf_magic_version), uint8_t(ERL_MAP_EXT), 0, 0, 0, 1, uint8_t(ERL_ATOM_EXT)};
+
+      expect_unexpected_end(missing_entries);
+      expect_unexpected_end(truncated_key);
+   };
+
+   "eetf_to_json list missing tail"_test = [] {
+      // ERL_LIST_EXT, one element (small integer 5), but the ERL_NIL_EXT tail is missing.
+      const std::array<std::uint8_t, 8> missing_tail{
+         uint8_t(glz::eetf_magic_version), uint8_t(ERL_LIST_EXT), 0, 0, 0, 1, uint8_t(ERL_SMALL_INTEGER_EXT), 5};
+      std::string json{};
+      const auto ec = glz::eetf_to_json(missing_tail, json);
+      expect(ec.ec == glz::error_code::unexpected_end);
+
+      // The same list with the NIL tail present parses cleanly: the tail guard must not reject it.
+      const std::array<std::uint8_t, 9> with_tail{uint8_t(glz::eetf_magic_version),
+                                                  uint8_t(ERL_LIST_EXT),
+                                                  0,
+                                                  0,
+                                                  0,
+                                                  1,
+                                                  uint8_t(ERL_SMALL_INTEGER_EXT),
+                                                  5,
+                                                  uint8_t(ERL_NIL_EXT)};
+      json.clear();
+      expect(!glz::eetf_to_json(with_tail, json));
+      expect(json == "[5]") << json;
+   };
+
+   "eetf_to_json list improper tail"_test = [] {
+      // ERL_LIST_EXT with one element and a non-NIL tail tag (ERL_MAP_EXT) as the final byte. The
+      // tail must be classified from its single tag byte without ei_get_type reading the 4-byte
+      // length header past the end of the buffer.
+      const std::array<std::uint8_t, 9> buffer{uint8_t(glz::eetf_magic_version),
+                                               uint8_t(ERL_LIST_EXT),
+                                               0,
+                                               0,
+                                               0,
+                                               1,
+                                               uint8_t(ERL_SMALL_INTEGER_EXT),
+                                               5,
+                                               uint8_t(ERL_MAP_EXT)};
+      std::string json{};
+      const auto ec = glz::eetf_to_json(buffer, json);
+      expect(ec.ec == glz::error_code::array_element_not_found);
+   };
+
    "eetf_to_json no header"_test = [] {
       constexpr int items = 3;
       std::vector<simple> v;


### PR DESCRIPTION
term_to_json_value reads each map key and the list tail through get_type, which forwards the raw iterator to ei_get_type with no bounds check. The list and tuple paths run through write_sequence, which calls invalid_end right after its advance, but the ERL_MAP_EXT branch and the ERL_LIST_EXT tail read skip that check, and eetf_to_json calls decode_version before confirming the buffer is non-empty. A truncated map whose header declares an arity but carries no entries, a list missing its NIL tail, or an empty buffer each leave the iterator at end and the next ei_* read runs past it.

Before, those inputs returned whatever error the over-read happened to produce (or faulted against an unmapped page); after, each ei read is gated on it < end and they return unexpected_end / no_read_input deterministically. The guards sit in eetf_to_json next to the reads they protect rather than in the shared ei wrappers, because ei_get_type and ei_decode_version must read the tag byte to do their work and cannot validate end on their own. read_eetf already rejects empty input upstream, so only the eetf_to_json entry point needed the version guard.