### PR TITLE
cap recursion depth in yaml and toml generic value readers

### DIFF
--- a/include/glaze/core/context.hpp
+++ b/include/glaze/core/context.hpp
@@ -132,6 +132,32 @@ namespace glz
       { ctx.depth } -> std::same_as<uint32_t&>;
    };
 
+   // RAII guard for recursive descent: bumps ctx.depth on entry and restores it on exit,
+   // erroring out before the nesting reaches max_recursive_depth_limit so adversarial deeply
+   // nested input can't overflow the stack. Mirrors the per-reader guards already used by the
+   // BSON and JSONB binary readers; placed here so the text-format readers can share one copy.
+   template <class Ctx>
+   struct depth_guard
+   {
+      Ctx& ctx;
+      bool entered = false;
+
+      depth_guard(Ctx& c) noexcept : ctx(c)
+      {
+         if (ctx.depth >= max_recursive_depth_limit) [[unlikely]] {
+            ctx.error = error_code::exceeded_max_recursive_depth;
+            return;
+         }
+         ++ctx.depth;
+         entered = true;
+      }
+      ~depth_guard()
+      {
+         if (entered) --ctx.depth;
+      }
+      explicit operator bool() const noexcept { return entered; }
+   };
+
    // Runtime constraint concepts
    // These detect if a user-defined context has runtime constraint fields.
    // Users can inherit from glz::context and add these fields for runtime limits:

--- a/include/glaze/toml/read.hpp
+++ b/include/glaze/toml/read.hpp
@@ -2689,6 +2689,13 @@ namespace glz
             return;
          }
 
+         // Nested arrays and inline tables recurse back through this reader, so cap the depth
+         // here; a deeply nested value (e.g. "a=[[[[...") otherwise overflows the stack.
+         depth_guard guard{ctx};
+         if (!guard) [[unlikely]] {
+            return;
+         }
+
          skip_ws_and_comments(it, end);
 
          if (it == end) [[unlikely]] {

--- a/include/glaze/yaml/common.hpp
+++ b/include/glaze/yaml/common.hpp
@@ -118,6 +118,9 @@ namespace glz::yaml
          c.allow_indentless_sequence = allow_indentless_sequence;
          c.stream_begin = stream_begin;
          c.secondary_tag_handle_overridden = secondary_tag_handle_overridden;
+         // Carry the recursion depth so a speculative type-probe shares the parent's budget
+         // and can't reset the stack-overflow guard partway down a deeply nested value.
+         c.depth = depth;
          return c;
       }
    };

--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -5208,6 +5208,13 @@ namespace glz
          if (bool(ctx.error)) [[unlikely]]
             return;
 
+         // Every nested generic/variant value routes back through this reader, so bounding
+         // depth here caps flow-collection and flow-embedded mapping recursion that the
+         // indent stack does not cover.
+         depth_guard guard{ctx};
+         if (!guard) [[unlikely]]
+            return;
+
          // At root level (indent == -1), skip leading whitespace, newlines, and comments
          // For nested values, only skip inline whitespace to preserve block structure
          if (ctx.current_indent() < 0) {

--- a/tests/toml_test/toml_test.cpp
+++ b/tests/toml_test/toml_test.cpp
@@ -5787,4 +5787,23 @@ suite issue_2595_transparent_wrappers = [] {
    };
 };
 
+suite recursion_depth_tests = [] {
+   "deeply nested array is bounded"_test = [] {
+      const std::string toml = "a = " + std::string(100000, '[');
+      glz::generic value{};
+      auto ec = glz::read_toml(value, toml);
+      expect(ec.ec == glz::error_code::exceeded_max_recursive_depth);
+   };
+
+   "nesting within the limit still parses"_test = [] {
+      const std::string toml = "a = [1, [2, [3]]]";
+      glz::generic value{};
+      auto ec = glz::read_toml(value, toml);
+      expect(!ec) << glz::format_error(ec, toml);
+      std::string json{};
+      expect(!glz::write_json(value, json));
+      expect(json == R"({"a":[1,[2,[3]]]})") << json;
+   };
+};
+
 int main() { return 0; }

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -10029,4 +10029,30 @@ suite issue_2595_transparent_wrappers = [] {
    };
 };
 
+suite recursion_depth_tests = [] {
+   "deeply nested flow sequence is bounded"_test = [] {
+      const std::string yaml(100000, '[');
+      glz::generic value{};
+      auto ec = glz::read_yaml(value, yaml);
+      expect(ec.ec == glz::error_code::exceeded_max_recursive_depth);
+   };
+
+   "deeply nested flow mapping is bounded"_test = [] {
+      const std::string yaml(100000, '{');
+      glz::generic value{};
+      auto ec = glz::read_yaml(value, yaml);
+      expect(ec.ec == glz::error_code::exceeded_max_recursive_depth);
+   };
+
+   "nesting within the limit still parses"_test = [] {
+      const std::string yaml = "[1, 2, [3, [4, 5]]]";
+      glz::generic value{};
+      auto ec = glz::read_yaml(value, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      std::string json{};
+      expect(!glz::write_json(value, json));
+      expect(json == "[1,2,[3,[4,5]]]") << json;
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
The YAML and TOML readers parse a generic value by dispatching on the first byte and recursing back through the variant reader for each nested element. Block-style nesting is bounded by the indent stack, but flow collections (`[ ]`, `{ }`) and TOML arrays never touch that stack, so they recurse one level per opening bracket with nothing counting depth. A document that is a few thousand `[` therefore overflows the call stack and crashes (SIGSEGV) when read into `glz::generic`, which is reachable from any untrusted YAML or TOML input.

Before, flow nesting could only stop at the stack limit. After, the variant reader (the single point every nested generic value passes through) takes the same `depth_guard` the BSON and JSONB readers already use, so a value nested past `max_recursive_depth_limit` returns `exceeded_max_recursive_depth` rather than recursing further. Guarding the variant reader instead of each container parser keeps it to one site per format and also covers the block mappings reached from flow context, which the indent stack alone misses. The cost is a fixed 256 level cap on generic values, the same limit the block parsers and the binary readers already enforce.