### PR TITLE
Reject obs-fold and whitespace-before-colon in request headers (RFC 7230 3.2.4)

### DIFF
--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -1762,6 +1762,18 @@ namespace glz
                return result;
             }
 
+            // RFC 7230 3.2.4: a header line beginning with SP/HTAB is obsolete line
+            // folding (obs-fold). Accepting it would store a continuation under a
+            // mangled key (e.g. "\ttransfer-encoding"), letting an obfuscated
+            // Transfer-Encoding/Content-Length slip past the header lookups that frame
+            // the body and desync this server from a folding-aware proxy (request
+            // smuggling). Reject with 400 and close.
+            if (data[pos] == ' ' || data[pos] == '\t') {
+               result.status = parse_status::error;
+               send_error_response_with_close(conn, 400, "Bad Request");
+               return result;
+            }
+
             // Find end of this header line
             size_t line_end = data.find("\r\n", pos);
             if (line_end == std::string_view::npos) return result; // incomplete
@@ -1771,6 +1783,16 @@ namespace glz
             auto colon_pos = line.find(':');
             if (colon_pos != std::string_view::npos) {
                std::string_view name_sv = line.substr(0, colon_pos);
+               // RFC 7230 3.2.4: no whitespace is allowed between the field-name and
+               // the colon. Tolerating it would store the name under a key with a
+               // trailing space/tab (e.g. "transfer-encoding ") that header lookups
+               // miss, so an obfuscated "Transfer-Encoding : chunked" would desync body
+               // framing (request smuggling). Reject with 400 and close.
+               if (!name_sv.empty() && (name_sv.back() == ' ' || name_sv.back() == '\t')) {
+                  result.status = parse_status::error;
+                  send_error_response_with_close(conn, 400, "Bad Request");
+                  return result;
+               }
                std::string_view value_sv = line.substr(colon_pos + 1);
                value_sv.remove_prefix((std::min)(value_sv.find_first_not_of(" \t"), value_sv.size()));
                std::string key(name_sv);

--- a/tests/networking_tests/CMakeLists.txt
+++ b/tests/networking_tests/CMakeLists.txt
@@ -7,6 +7,7 @@ option(glaze_BUILD_WEBSOCKET_AUTOBAHN_TEST "Build Autobahn WebSocket compliance 
 # HTTP Examples
 add_subdirectory(http_examples)
 add_subdirectory(http_server_post_test)
+add_subdirectory(http_header_strictness_test)
 
 # Networking Tests
 add_subdirectory(asio_repe)

--- a/tests/networking_tests/http_header_strictness_test/CMakeLists.txt
+++ b/tests/networking_tests/http_header_strictness_test/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.21)
+project(http_header_strictness_test)
+
+add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)
+target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+    glz_test_exceptions
+)
+
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/tests/networking_tests/http_header_strictness_test/http_header_strictness_test.cpp
+++ b/tests/networking_tests/http_header_strictness_test/http_header_strictness_test.cpp
@@ -1,0 +1,187 @@
+// Verifies RFC 7230 3.2.4 header-field strictness in glz::http_server: a header
+// line that uses obsolete line folding (obs-fold) or places whitespace between
+// the field-name and the colon is rejected with 400 and the connection is closed.
+//
+// Both forms are request-smuggling vectors: a folding-aware or whitespace-lenient
+// front-end proxy reads an obfuscated "Transfer-Encoding" and frames the body as
+// chunked, while a server that stores the header under a mangled key
+// ("transfer-encoding " / "\ttransfer-encoding") misses the lookup, treats the
+// body as empty, and reparses the leftover bytes as a second, smuggled request.
+// (The plain "Transfer-Encoding: chunked" case is handled separately in
+// finish_request; this test guards the obfuscated variants at the parser.)
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <string>
+#include <thread>
+#include <ut/ut.hpp>
+
+#include "glaze/net/http_server.hpp"
+
+#if defined(GLZ_USING_BOOST_ASIO)
+namespace asio
+{
+   using namespace boost::asio;
+   using error_code = boost::system::error_code;
+}
+#endif
+
+namespace
+{
+   using namespace ut;
+
+   constexpr char test_host[] = "127.0.0.1";
+
+   std::string read_response(asio::ip::tcp::socket& socket)
+   {
+      std::string resp;
+      std::array<char, 4096> buf{};
+      asio::error_code ec;
+      for (;;) {
+         std::size_t n = socket.read_some(asio::buffer(buf), ec);
+         if (n > 0) resp.append(buf.data(), n);
+         if (n == 0 || ec) break;
+      }
+      return resp;
+   }
+
+   // Connect (retrying briefly while the acceptor warms up) and send raw bytes,
+   // returning the full response read until the server closes the connection.
+   std::string send_raw(uint16_t port, const std::string& request)
+   {
+      asio::io_context io_ctx;
+      asio::ip::tcp::socket socket(io_ctx);
+      asio::ip::tcp::endpoint endpoint(asio::ip::make_address(test_host), port);
+      asio::error_code ec;
+      for (int tries = 0; tries < 50; ++tries) {
+         socket.connect(endpoint, ec);
+         if (!ec) break;
+         socket.close(ec);
+         std::this_thread::sleep_for(std::chrono::milliseconds(20));
+      }
+      if (ec) {
+         return "";
+      }
+      asio::write(socket, asio::buffer(request.data(), request.size()), ec);
+      return read_response(socket);
+   }
+
+   // Run send_raw under a hard timeout so a desync regression that hangs the
+   // connection fails the test instead of stalling it.
+   std::string send_raw_timed(uint16_t port, const std::string& request)
+   {
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(port, request); });
+      if (f.wait_for(std::chrono::seconds(5)) == std::future_status::ready) {
+         return f.get();
+      }
+      return "TIMEOUT";
+   }
+
+   // The bytes after the blank line are a complete second request. A desync would
+   // reparse them as a smuggled GET /smuggled.
+   const std::string smuggled_tail =
+      "GET /smuggled HTTP/1.1\r\n"
+      "Host: localhost\r\n"
+      "Connection: close\r\n"
+      "\r\n";
+
+} // namespace
+
+static void error_handler(std::error_code, std::source_location) {}
+
+suite http_header_strictness_suite = [] {
+   auto io_ctx = std::make_shared<asio::io_context>();
+   glz::http_server<false> server(io_ctx, error_handler);
+
+   std::atomic<int> smuggled_hits{0};
+
+   server.post("/front", [&](const glz::request&, glz::response& res) {
+      res.status(200);
+      res.body("front");
+   });
+   server.get("/smuggled", [&](const glz::request&, glz::response& res) {
+      smuggled_hits.fetch_add(1, std::memory_order_relaxed);
+      res.status(200);
+      res.body("smuggled");
+   });
+   server.get("/ok", [&](const glz::request&, glz::response& res) {
+      res.status(200);
+      res.body("ok");
+   });
+
+   // Bind to an ephemeral port and read it back, so the test never collides with
+   // another listener or a prior run stuck in TIME_WAIT.
+   server.bind(test_host, 0);
+   const uint16_t port = server.port();
+   server.start(0);
+   std::thread server_thr([&] { io_ctx->run(); });
+
+   "space before colon is rejected, not desynced"_test = [&] {
+      const std::string payload =
+         "POST /front HTTP/1.1\r\n"
+         "Host: localhost\r\n"
+         "Transfer-Encoding : chunked\r\n"
+         "Connection: keep-alive\r\n"
+         "\r\n" +
+         smuggled_tail;
+
+      const std::string response = send_raw_timed(port, payload);
+      expect(response.find("400") != std::string::npos) << "Expected 400 for whitespace before colon";
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      expect(smuggled_hits.load(std::memory_order_relaxed) == 0) << "Smuggled request reached a route handler";
+   };
+
+   "tab before colon is rejected, not desynced"_test = [&] {
+      const std::string payload =
+         "POST /front HTTP/1.1\r\n"
+         "Host: localhost\r\n"
+         "Transfer-Encoding\t: chunked\r\n"
+         "Connection: keep-alive\r\n"
+         "\r\n" +
+         smuggled_tail;
+
+      const std::string response = send_raw_timed(port, payload);
+      expect(response.find("400") != std::string::npos) << "Expected 400 for tab before colon";
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      expect(smuggled_hits.load(std::memory_order_relaxed) == 0) << "Smuggled request reached a route handler";
+   };
+
+   "obs-fold header continuation is rejected, not desynced"_test = [&] {
+      // Transfer-Encoding rides a folded continuation of X-Foo (line begins with a tab).
+      const std::string payload =
+         "POST /front HTTP/1.1\r\n"
+         "Host: localhost\r\n"
+         "X-Foo: bar\r\n"
+         "\tTransfer-Encoding: chunked\r\n"
+         "Connection: keep-alive\r\n"
+         "\r\n" +
+         smuggled_tail;
+
+      const std::string response = send_raw_timed(port, payload);
+      expect(response.find("400") != std::string::npos) << "Expected 400 for obs-fold continuation";
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      expect(smuggled_hits.load(std::memory_order_relaxed) == 0) << "Smuggled request reached a route handler";
+   };
+
+   "well-formed headers still parse and route"_test = [&] {
+      // Positive control: ordinary header names, and values that contain spaces
+      // and colons, must continue to parse normally (no over-rejection).
+      const std::string payload =
+         "GET /ok HTTP/1.1\r\n"
+         "Host: localhost:8080\r\n"
+         "User-Agent: glaze-test/1.0 (X11; check)\r\n"
+         "Accept: text/plain, application/json\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      const std::string response = send_raw_timed(port, payload);
+      expect(response.find("200") != std::string::npos) << "Well-formed request should return 200";
+      expect(response.find("ok") != std::string::npos) << "Handler body should be present";
+   };
+
+   server.stop();
+   io_ctx->stop();
+   if (server_thr.joinable()) server_thr.join();
+};
+
+int main() { return 0; }


### PR DESCRIPTION
## Summary

Hardens `try_parse_request` to reject two malformed header-field forms that are HTTP request-smuggling vectors, per RFC 7230 §3.2.4:

1. **Obsolete line folding (obs-fold)** — a header line beginning with SP/HTAB.
2. **Whitespace between the field-name and the colon** — e.g. `Transfer-Encoding : chunked` or a tab before the colon.

Both are now answered with `400 Bad Request` + connection close.

## Why

The header parser lowercases names and looks them up exactly (`headers.find("transfer-encoding")`, `find("content-length")`). It previously stored names without trimming or rejecting malformed whitespace, so an obfuscated header was stored under a key the lookup misses:

- `Transfer-Encoding : chunked` → key `"transfer-encoding "` (trailing space)
- `Transfer-Encoding\t: chunked` → key `"transfer-encoding\t"`
- a folded continuation → key `"\ttransfer-encoding"`

In every case the server sees no `Transfer-Encoding`/`Content-Length`, frames the body as empty, and leaves the encoded payload in the keep-alive buffer, where it is reparsed as a second, smuggled request. A front-end proxy that *is* tolerant of folding/whitespace frames the body as chunked and forwards the lot as one request — a classic TE/CL desync.

This complements #2654, which rejects a **clean** `Transfer-Encoding` header. Each closes a different half of the same class:

| Variant | #2654 | This PR |
| --- | --- | --- |
| `Transfer-Encoding: chunked` | 501 + close | (unchanged) |
| `Transfer-Encoding : chunked` (space) | bypassed | **400 + close** |
| `Transfer-Encoding\t: chunked` (tab) | bypassed | **400 + close** |
| obs-fold continuation carrying TE | bypassed | **400 + close** |

Rejecting (rather than trimming) is deliberate: silently honoring `Content-Length : 5` where a peer might frame it differently would just reintroduce the ambiguity. Closing the connection discards the leftover bytes (same safe path the existing 400 responses use). obs-fold is deprecated and not emitted by conforming clients, so false-positive risk is negligible.

## Testing

New `http_header_strictness_test` (binds to an ephemeral port and reads it back via `server.port()`) covers all three smuggling vectors — asserting `400` and that the smuggled `GET /smuggled` never reaches a handler — plus a positive control proving well-formed requests with spaces/colons in header *values* still route and return `200`.

Verified locally (Release + sanitizers):
- `http_header_strictness_test`: 4 tests / 8 asserts pass.
- No regressions: `http_server_post_test`, `http_server_api_tests`, `http_chunked_test` (59/233), `http_router_test` (21/81), `cors_test` (5/13) all pass.