### PR TITLE
Cap recursion depth in text-format readers and unify depth_guard

### DIFF
--- a/include/glaze/bson/read.hpp
+++ b/include/glaze/bson/read.hpp
@@ -34,31 +34,9 @@ namespace glz
 {
    namespace bson_detail
    {
-      // RAII guard bumping ctx.depth on entry to a document/array reader and
-      // popping on exit. Errors with exceeded_max_recursive_depth before the
-      // stack can overflow on adversarial input — pathologically nested BSON
-      // (e.g. `{"a": {"a": {...}}}`) is cheap to produce and a real DoS vector.
-      template <class Ctx>
-      struct depth_guard
-      {
-         Ctx& ctx;
-         bool entered = false;
-
-         depth_guard(Ctx& c) noexcept : ctx(c)
-         {
-            if (ctx.depth >= max_recursive_depth_limit) [[unlikely]] {
-               ctx.error = error_code::exceeded_max_recursive_depth;
-               return;
-            }
-            ++ctx.depth;
-            entered = true;
-         }
-         ~depth_guard()
-         {
-            if (entered) --ctx.depth;
-         }
-         explicit operator bool() const noexcept { return entered; }
-      };
+      // Document/array readers guard recursion depth with the shared glz::depth_guard
+      // (core/context.hpp): pathologically nested BSON (e.g. `{"a": {"a": {...}}}`) is cheap to
+      // produce and a real DoS vector on adversarial input.
 
       // --- Little-endian readers ----------------------------------------------
       //
@@ -1115,7 +1093,7 @@ namespace glz
             ctx.error = error_code::syntax_error;
             return;
          }
-         bson_detail::depth_guard guard{ctx};
+         depth_guard guard{ctx};
          if (!guard) return;
          It stop{};
          if (!bson_detail::read_document_stop(ctx, it, end, stop)) return;
@@ -1142,7 +1120,7 @@ namespace glz
          static_assert(str_t<key_t> || std::is_constructible_v<key_t, std::string_view>,
                        "BSON map keys must be string-like");
 
-         bson_detail::depth_guard guard{ctx};
+         depth_guard guard{ctx};
          if (!guard) return;
          It stop{};
          if (!bson_detail::read_document_stop(ctx, it, end, stop)) return;
@@ -1175,7 +1153,7 @@ namespace glz
             ctx.error = error_code::syntax_error;
             return;
          }
-         bson_detail::depth_guard guard{ctx};
+         depth_guard guard{ctx};
          if (!guard) return;
          It stop{};
          if (!bson_detail::read_document_stop(ctx, it, end, stop)) return;
@@ -1216,7 +1194,7 @@ namespace glz
             ctx.error = error_code::syntax_error;
             return;
          }
-         bson_detail::depth_guard guard{ctx};
+         depth_guard guard{ctx};
          if (!guard) return;
          It stop{};
          if (!bson_detail::read_document_stop(ctx, it, end, stop)) return;

--- a/include/glaze/core/context.hpp
+++ b/include/glaze/core/context.hpp
@@ -132,6 +132,32 @@ namespace glz
       { ctx.depth } -> std::same_as<uint32_t&>;
    };
 
+   // RAII guard for recursive descent: bumps ctx.depth on entry and restores it on exit,
+   // erroring out before the nesting reaches max_recursive_depth_limit so adversarial deeply
+   // nested input can't overflow the stack. Mirrors the per-reader guards already used by the
+   // BSON and JSONB binary readers; placed here so the text-format readers can share one copy.
+   template <class Ctx>
+   struct depth_guard
+   {
+      Ctx& ctx;
+      bool entered = false;
+
+      depth_guard(Ctx& c) noexcept : ctx(c)
+      {
+         if (ctx.depth >= max_recursive_depth_limit) [[unlikely]] {
+            ctx.error = error_code::exceeded_max_recursive_depth;
+            return;
+         }
+         ++ctx.depth;
+         entered = true;
+      }
+      ~depth_guard()
+      {
+         if (entered) --ctx.depth;
+      }
+      explicit operator bool() const noexcept { return entered; }
+   };
+
    // Runtime constraint concepts
    // These detect if a user-defined context has runtime constraint fields.
    // Users can inherit from glz::context and add these fields for runtime limits:

--- a/include/glaze/jsonb/read.hpp
+++ b/include/glaze/jsonb/read.hpp
@@ -33,31 +33,9 @@ namespace glz
       // decode_json_escape, decode_json5_escape, and decode_text moved to text_decode.hpp
       // so the JSONB→JSON converter can reuse them.
 
-      // RAII guard that bumps ctx.depth on entry to a container reader and pops it on
-      // destruction. Errors with exceeded_max_recursive_depth if the cap (256) would be
-      // exceeded — deeply nested blobs can stack-overflow otherwise, and untrusted blobs
-      // (e.g. from user-supplied SQLite JSONB columns) are a real DoS vector.
-      template <class Ctx>
-      struct depth_guard
-      {
-         Ctx& ctx;
-         bool entered = false;
-
-         depth_guard(Ctx& c) : ctx(c)
-         {
-            if (ctx.depth >= max_recursive_depth_limit) [[unlikely]] {
-               ctx.error = error_code::exceeded_max_recursive_depth;
-               return;
-            }
-            ++ctx.depth;
-            entered = true;
-         }
-         ~depth_guard()
-         {
-            if (entered) --ctx.depth;
-         }
-         explicit operator bool() const noexcept { return entered; }
-      };
+      // Container readers guard recursion depth with the shared glz::depth_guard
+      // (core/context.hpp): deeply nested blobs can stack-overflow otherwise, and untrusted
+      // blobs (e.g. from user-supplied SQLite JSONB columns) are a real DoS vector.
 
       // Parse a JSONB integer payload (INT or INT5) and store into target.
       template <class T>
@@ -433,7 +411,7 @@ namespace glz
       template <auto Opts>
       static void op(auto& value, is_context auto& ctx, auto& it, auto end)
       {
-         jsonb_detail::depth_guard g{ctx};
+         depth_guard g{ctx};
          if (!g) return;
          uint8_t tc{};
          uint64_t sz{};
@@ -494,7 +472,7 @@ namespace glz
       template <auto Opts>
       static void op(auto& value, is_context auto& ctx, auto& it, auto end)
       {
-         jsonb_detail::depth_guard g{ctx};
+         depth_guard g{ctx};
          if (!g) return;
          using Key = typename std::remove_cvref_t<T>::key_type;
          static_assert(str_t<Key> || std::same_as<Key, std::string>,
@@ -549,7 +527,7 @@ namespace glz
       template <auto Opts>
       static void op(T& value, is_context auto& ctx, auto& it, auto end)
       {
-         jsonb_detail::depth_guard g{ctx};
+         depth_guard g{ctx};
          if (!g) return;
          uint8_t tc{};
          uint64_t sz{};
@@ -731,7 +709,7 @@ namespace glz
       template <auto Opts>
       static void op(auto& value, is_context auto& ctx, auto& it, auto end)
       {
-         jsonb_detail::depth_guard g{ctx};
+         depth_guard g{ctx};
          if (!g) return;
          uint8_t tc{};
          uint64_t sz{};
@@ -757,7 +735,7 @@ namespace glz
       template <auto Opts>
       static void op(auto& value, is_context auto& ctx, auto& it, auto end)
       {
-         jsonb_detail::depth_guard g{ctx};
+         depth_guard g{ctx};
          if (!g) return;
          uint8_t tc{};
          uint64_t sz{};
@@ -802,7 +780,7 @@ namespace glz
       template <auto Opts>
       static void op(auto& value, is_context auto& ctx, auto& it, auto end)
       {
-         jsonb_detail::depth_guard g{ctx};
+         depth_guard g{ctx};
          if (!g) return;
          uint8_t tc{};
          uint64_t sz{};
@@ -920,7 +898,7 @@ namespace glz
       template <auto Opts>
       static void op(auto& value, is_context auto& ctx, auto& it, auto end)
       {
-         jsonb_detail::depth_guard g{ctx};
+         depth_guard g{ctx};
          if (!g) return;
          if (it >= end) [[unlikely]] {
             ctx.error = error_code::unexpected_end;
@@ -1099,7 +1077,7 @@ namespace glz
       template <auto Opts>
       static void op(auto& value, is_context auto& ctx, auto& it, auto end)
       {
-         jsonb_detail::depth_guard g{ctx};
+         depth_guard g{ctx};
          if (!g) return;
 
          if (it >= end) [[unlikely]] {

--- a/include/glaze/toml/read.hpp
+++ b/include/glaze/toml/read.hpp
@@ -2689,6 +2689,13 @@ namespace glz
             return;
          }
 
+         // Nested arrays and inline tables recurse back through this reader, so cap the depth
+         // here; a deeply nested value (e.g. "a=[[[[...") otherwise overflows the stack.
+         depth_guard guard{ctx};
+         if (!guard) [[unlikely]] {
+            return;
+         }
+
          skip_ws_and_comments(it, end);
 
          if (it == end) [[unlikely]] {

--- a/include/glaze/toml/read.hpp
+++ b/include/glaze/toml/read.hpp
@@ -1923,6 +1923,14 @@ namespace glz
       template <auto Opts, class T>
       bool resolve_nested_map(T& root, std::span<std::string> path, auto& ctx, auto& it, auto& end)
       {
+         // A dotted key recurses one frame per path segment, with nothing else bounding the
+         // descent, so an adversarial key like "a.a.a.…=1" otherwise overflows the stack. Share
+         // the same depth budget the variant reader uses so combined nesting is bounded too.
+         depth_guard guard{ctx};
+         if (!guard) [[unlikely]] {
+            return false;
+         }
+
          if (path.empty()) {
             ctx.error = error_code::syntax_error;
             return false;
@@ -2014,6 +2022,13 @@ namespace glz
       template <auto Opts, class T>
       bool ensure_map_path(T& root, std::span<std::string> path, auto& ctx)
       {
+         // A table header "[a.a.a.…]" recurses one frame per path segment with nothing bounding
+         // the descent, so cap it on the shared depth budget to avoid a stack overflow.
+         depth_guard guard{ctx};
+         if (!guard) [[unlikely]] {
+            return false;
+         }
+
          if (path.empty()) {
             return true;
          }

--- a/include/glaze/yaml/common.hpp
+++ b/include/glaze/yaml/common.hpp
@@ -118,6 +118,9 @@ namespace glz::yaml
          c.allow_indentless_sequence = allow_indentless_sequence;
          c.stream_begin = stream_begin;
          c.secondary_tag_handle_overridden = secondary_tag_handle_overridden;
+         // Carry the recursion depth so a speculative type-probe shares the parent's budget
+         // and can't reset the stack-overflow guard partway down a deeply nested value.
+         c.depth = depth;
          return c;
       }
    };

--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -5208,6 +5208,13 @@ namespace glz
          if (bool(ctx.error)) [[unlikely]]
             return;
 
+         // Every nested generic/variant value routes back through this reader, so bounding
+         // depth here caps flow-collection and flow-embedded mapping recursion that the
+         // indent stack does not cover.
+         depth_guard guard{ctx};
+         if (!guard) [[unlikely]]
+            return;
+
          // At root level (indent == -1), skip leading whitespace, newlines, and comments
          // For nested values, only skip inline whitespace to preserve block structure
          if (ctx.current_indent() < 0) {

--- a/include/glaze/yaml/skip.hpp
+++ b/include/glaze/yaml/skip.hpp
@@ -131,6 +131,14 @@ namespace glz::yaml
    template <class It, class End, class Ctx>
    inline void skip_flow_content(It& it, End end, Ctx& ctx, char open, char close) noexcept
    {
+      // Nested flow collections with alternating delimiters ("[{[{...") recurse one frame per
+      // delimiter, so bound the recursion to stop adversarial skipped input from overflowing the
+      // stack. Same-delimiter nesting ("[[[[") is handled by the loop below without recursing.
+      depth_guard guard{ctx};
+      if (!guard) [[unlikely]] {
+         return;
+      }
+
       if (it == end || *it != open) [[unlikely]] {
          ctx.error = error_code::syntax_error;
          return;

--- a/tests/toml_test/toml_test.cpp
+++ b/tests/toml_test/toml_test.cpp
@@ -5787,4 +5787,23 @@ suite issue_2595_transparent_wrappers = [] {
    };
 };
 
+suite recursion_depth_tests = [] {
+   "deeply nested array is bounded"_test = [] {
+      const std::string toml = "a = " + std::string(100000, '[');
+      glz::generic value{};
+      auto ec = glz::read_toml(value, toml);
+      expect(ec.ec == glz::error_code::exceeded_max_recursive_depth);
+   };
+
+   "nesting within the limit still parses"_test = [] {
+      const std::string toml = "a = [1, [2, [3]]]";
+      glz::generic value{};
+      auto ec = glz::read_toml(value, toml);
+      expect(!ec) << glz::format_error(ec, toml);
+      std::string json{};
+      expect(!glz::write_json(value, json));
+      expect(json == R"({"a":[1,[2,[3]]]})") << json;
+   };
+};
+
 int main() { return 0; }

--- a/tests/toml_test/toml_test.cpp
+++ b/tests/toml_test/toml_test.cpp
@@ -5804,6 +5804,38 @@ suite recursion_depth_tests = [] {
       expect(!glz::write_json(value, json));
       expect(json == R"({"a":[1,[2,[3]]]})") << json;
    };
+
+   "deeply nested dotted key is bounded"_test = [] {
+      // A dotted key recurses through resolve_nested_map, one frame per segment, not through
+      // the variant reader, so it needs its own depth bound.
+      std::string toml = "a";
+      for (int i = 0; i < 100000; ++i) toml += ".a";
+      toml += " = 1";
+      glz::generic value{};
+      auto ec = glz::read_toml(value, toml);
+      expect(ec.ec == glz::error_code::exceeded_max_recursive_depth);
+   };
+
+   "deeply nested table header is bounded"_test = [] {
+      // A table header recurses through ensure_map_path, one frame per segment. A leading key-value
+      // line is required so the document map reader is active when the header is parsed.
+      std::string toml = "x = 1\n[a";
+      for (int i = 0; i < 100000; ++i) toml += ".a";
+      toml += "]\n";
+      glz::generic value{};
+      auto ec = glz::read_toml(value, toml);
+      expect(ec.ec == glz::error_code::exceeded_max_recursive_depth);
+   };
+
+   "dotted key within the limit still parses"_test = [] {
+      const std::string toml = "a.b.c = 1";
+      glz::generic value{};
+      auto ec = glz::read_toml(value, toml);
+      expect(!ec) << glz::format_error(ec, toml);
+      std::string json{};
+      expect(!glz::write_json(value, json));
+      expect(json == R"({"a":{"b":{"c":1}}})") << json;
+   };
 };
 
 int main() { return 0; }

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -10029,6 +10029,18 @@ suite issue_2595_transparent_wrappers = [] {
    };
 };
 
+struct skip_depth_probe
+{
+   int known{};
+};
+
+template <>
+struct glz::meta<skip_depth_probe>
+{
+   using T = skip_depth_probe;
+   static constexpr auto value = object("known", &T::known);
+};
+
 suite recursion_depth_tests = [] {
    "deeply nested flow sequence is bounded"_test = [] {
       const std::string yaml(100000, '[');
@@ -10091,6 +10103,18 @@ suite recursion_depth_tests = [] {
       std::string json{};
       expect(!glz::write_json(value, json));
       expect(json == R"({"k":[1,[2,[3]]]})") << json;
+   };
+
+   "skipped alternating flow content is bounded"_test = [] {
+      // Skipping an unknown key routes through skip_flow_content; alternating delimiters "[{[{..."
+      // recurse one frame per delimiter (unlike same-delimiter nesting, which loops). The descent
+      // must stay bounded rather than overflow the stack.
+      std::string yaml = "unknown: ";
+      for (int i = 0; i < 100000; ++i) yaml += "[{";
+      yaml += "\nknown: 1";
+      skip_depth_probe value{};
+      auto ec = glz::read_yaml<glz::opts{.error_on_unknown_keys = false}>(value, yaml);
+      expect(ec.ec == glz::error_code::exceeded_max_recursive_depth);
    };
 };
 

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -10029,4 +10029,30 @@ suite issue_2595_transparent_wrappers = [] {
    };
 };
 
+suite recursion_depth_tests = [] {
+   "deeply nested flow sequence is bounded"_test = [] {
+      const std::string yaml(100000, '[');
+      glz::generic value{};
+      auto ec = glz::read_yaml(value, yaml);
+      expect(ec.ec == glz::error_code::exceeded_max_recursive_depth);
+   };
+
+   "deeply nested flow mapping is bounded"_test = [] {
+      const std::string yaml(100000, '{');
+      glz::generic value{};
+      auto ec = glz::read_yaml(value, yaml);
+      expect(ec.ec == glz::error_code::exceeded_max_recursive_depth);
+   };
+
+   "nesting within the limit still parses"_test = [] {
+      const std::string yaml = "[1, 2, [3, [4, 5]]]";
+      glz::generic value{};
+      auto ec = glz::read_yaml(value, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      std::string json{};
+      expect(!glz::write_json(value, json));
+      expect(json == "[1,2,[3,[4,5]]]") << json;
+   };
+};
+
 int main() { return 0; }

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -10053,6 +10053,45 @@ suite recursion_depth_tests = [] {
       expect(!glz::write_json(value, json));
       expect(json == "[1,2,[3,[4,5]]]") << json;
    };
+
+   "flow nesting at the depth limit boundary"_test = [] {
+      // Pin the exact contract against the named constant: a generic value nested exactly to the
+      // limit parses, one level deeper is rejected. The bracket-count-based deep tests above sit far
+      // from the boundary and would not catch an off-by-one in the guard.
+      constexpr size_t limit = glz::max_recursive_depth_limit;
+      {
+         const std::string yaml = std::string(limit, '[') + std::string(limit, ']');
+         glz::generic value{};
+         auto ec = glz::read_yaml(value, yaml);
+         expect(!ec) << glz::format_error(ec, yaml);
+      }
+      {
+         const std::string yaml = std::string(limit + 1, '[') + std::string(limit + 1, ']');
+         glz::generic value{};
+         auto ec = glz::read_yaml(value, yaml);
+         expect(ec.ec == glz::error_code::exceeded_max_recursive_depth);
+      }
+   };
+
+   "deeply nested value under a block mapping is bounded"_test = [] {
+      // The deep flow tests above take the single-category direct branch and never touch the
+      // speculative block-mapping probe (try_parse_block_mapping_into_variant -> make_speculative).
+      // A block-mapping value routes through that probe; confirm the descent stays bounded there too.
+      const std::string yaml = "k:\n  " + std::string(100000, '[');
+      glz::generic value{};
+      auto ec = glz::read_yaml(value, yaml);
+      expect(ec.ec == glz::error_code::exceeded_max_recursive_depth);
+   };
+
+   "block mapping value within the limit still parses"_test = [] {
+      const std::string yaml = "k:\n  [1, [2, [3]]]";
+      glz::generic value{};
+      auto ec = glz::read_yaml(value, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      std::string json{};
+      expect(!glz::write_json(value, json));
+      expect(json == R"({"k":[1,[2,[3]]]})") << json;
+   };
 };
 
 int main() { return 0; }


### PR DESCRIPTION
Builds on #2660 by @uwezkhan (its commit is included here). That PR caps recursion depth in the YAML and TOML generic/variant readers so deeply nested flow collections (`[[[…`, `{{{…`) and TOML inline arrays/tables can't overflow the stack on untrusted input. This branch extends the same protection to the recursion paths #2660 did not reach, and removes duplication.

### Added on top of #2660

- **TOML dotted keys & table headers.** `resolve_nested_map` (`a.a.a…=1`) and `ensure_map_path` (`[a.a.a…]`) recurse one frame per path segment with nothing bounding the descent — both still overflowed the stack. Guarded with the shared `depth_guard`.
- **YAML `skip_flow_content`.** Skipping an unknown key (`error_on_unknown_keys=false`) or scanning a tagged discriminator whose value is alternating `[{[{…` recursed one frame per delimiter and overflowed. Now bounded. (Same-delimiter `[[[[` already looped without recursing.)
- **Unify `depth_guard`.** The BSON and JSONB readers each carried a near-identical copy of the guard; both now use the single `glz::depth_guard` in `core/context.hpp`. No behavior change.
- **Tests.** Boundary test tied to `glz::max_recursive_depth_limit`, block-mapping speculative-path coverage, plus TOML dotted-key / table-header and a YAML skip regression test.

### Verification

All local (Apple Clang, C++23): yaml 668/668, toml 389/389, bson 120/120, jsonb 151/151. Each new guard was confirmed against a standalone repro that crashed (SIGSEGV) before and returns `exceeded_max_recursive_depth` after.
