### PR TITLE
Bound eetf number and container-header reads against end of input

### DIFF
--- a/include/glaze/eetf/eetf_to_json.hpp
+++ b/include/glaze/eetf/eetf_to_json.hpp
@@ -85,6 +85,11 @@ namespace glz
             dump('[', out, ix);
             while (arity--) {
                term_to_json_value<Opts>(ctx, it, end, out, ix, recursive_depth);
+               // Stop on error instead of spinning the remaining (attacker-declared, up to 2^32)
+               // iterations once the input is exhausted.
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
                if (arity) {
                   dump(',', out, ix);
                   if constexpr (Opts.prettify) {
@@ -99,6 +104,9 @@ namespace glz
          switch (type) {
          case ERL_SMALL_INTEGER_EXT:
          case ERL_INTEGER_EXT: {
+            // ei_decode_long reads the tag plus a fixed payload (1 byte for SMALL_INTEGER_EXT,
+            // 4 for INTEGER_EXT) off the raw pointer; bound it before the decode.
+            if (check_invalid_offset(ctx, it, end, type == ERL_SMALL_INTEGER_EXT ? 2u : 5u)) return;
             term_to_json_number<Opts>(std::int64_t{}, ctx, it, end, out, ix);
             if (bool(ctx.error)) return;
             break;
@@ -112,6 +120,9 @@ namespace glz
 
          case ERL_FLOAT_EXT:
          case NEW_FLOAT_EXT: {
+            // ei_decode_double reads the tag plus a fixed payload (8 bytes for NEW_FLOAT_EXT, the
+            // 31-byte ASCII form for the legacy FLOAT_EXT) off the raw pointer; bound it first.
+            if (check_invalid_offset(ctx, it, end, type == NEW_FLOAT_EXT ? 9u : 32u)) return;
             term_to_json_number<Opts>(double{}, ctx, it, end, out, ix);
             if (bool(ctx.error)) return;
             break;
@@ -151,6 +162,8 @@ namespace glz
          }
 
          case ERL_LIST_EXT: {
+            // decode_list_header reads the tag plus a 4-byte arity off the raw pointer; bound it.
+            if (check_invalid_offset(ctx, it, end, 5u)) return;
             [[maybe_unused]] auto [arity, idx] = decode_list_header(ctx, it);
             if (bool(ctx.error)) {
                return;
@@ -183,6 +196,9 @@ namespace glz
 
          case ERL_SMALL_TUPLE_EXT:
          case ERL_LARGE_TUPLE_EXT: {
+            // decode_tuple_header reads the tag plus the arity (1 byte for SMALL_TUPLE_EXT, 4 for
+            // LARGE_TUPLE_EXT) off the raw pointer; bound it.
+            if (check_invalid_offset(ctx, it, end, type == ERL_SMALL_TUPLE_EXT ? 2u : 5u)) return;
             [[maybe_unused]] auto [arity, idx] = decode_tuple_header(ctx, it);
             if (bool(ctx.error)) {
                return;
@@ -192,6 +208,8 @@ namespace glz
          }
 
          case ERL_MAP_EXT: {
+            // decode_map_header reads the tag plus a 4-byte arity off the raw pointer; bound it.
+            if (check_invalid_offset(ctx, it, end, 5u)) return;
             [[maybe_unused]] auto [arity, idx] = decode_map_header(ctx, it);
             if (bool(ctx.error)) {
                return;

--- a/tests/eetf_test/eetf_test.cpp
+++ b/tests/eetf_test/eetf_test.cpp
@@ -523,6 +523,67 @@ suite eetf_to_json_tests = [] {
       expect(ec.ec == glz::error_code::array_element_not_found);
    };
 
+   "eetf_to_json truncated scalar"_test = [] {
+      auto expect_unexpected_end = [](const auto& buffer) {
+         std::string json{};
+         const auto ec = glz::eetf_to_json(buffer, json);
+         expect(ec.ec == glz::error_code::unexpected_end);
+      };
+
+      // Numeric tags whose fixed payload is cut off after the tag: ei_decode_long/double must not
+      // read it off the raw pointer before the bounds check.
+      const std::array<std::uint8_t, 2> small_int{uint8_t(glz::eetf_magic_version), uint8_t(ERL_SMALL_INTEGER_EXT)};
+      const std::array<std::uint8_t, 2> integer{uint8_t(glz::eetf_magic_version), uint8_t(ERL_INTEGER_EXT)};
+      const std::array<std::uint8_t, 4> integer_partial{uint8_t(glz::eetf_magic_version), uint8_t(ERL_INTEGER_EXT), 0,
+                                                        0};
+      const std::array<std::uint8_t, 2> new_float{uint8_t(glz::eetf_magic_version), uint8_t(NEW_FLOAT_EXT)};
+      const std::array<std::uint8_t, 2> old_float{uint8_t(glz::eetf_magic_version), uint8_t(ERL_FLOAT_EXT)};
+
+      expect_unexpected_end(small_int);
+      expect_unexpected_end(integer);
+      expect_unexpected_end(integer_partial);
+      expect_unexpected_end(new_float);
+      expect_unexpected_end(old_float);
+   };
+
+   "eetf_to_json truncated container header"_test = [] {
+      auto expect_unexpected_end = [](const auto& buffer) {
+         std::string json{};
+         const auto ec = glz::eetf_to_json(buffer, json);
+         expect(ec.ec == glz::error_code::unexpected_end);
+      };
+
+      // Container tags whose 1- or 4-byte arity is cut off after the tag: decode_*_header must not
+      // read it off the raw pointer before the bounds check.
+      const std::array<std::uint8_t, 2> list{uint8_t(glz::eetf_magic_version), uint8_t(ERL_LIST_EXT)};
+      const std::array<std::uint8_t, 4> list_partial{uint8_t(glz::eetf_magic_version), uint8_t(ERL_LIST_EXT), 0, 0};
+      const std::array<std::uint8_t, 2> map{uint8_t(glz::eetf_magic_version), uint8_t(ERL_MAP_EXT)};
+      const std::array<std::uint8_t, 2> small_tuple{uint8_t(glz::eetf_magic_version), uint8_t(ERL_SMALL_TUPLE_EXT)};
+      const std::array<std::uint8_t, 2> large_tuple{uint8_t(glz::eetf_magic_version), uint8_t(ERL_LARGE_TUPLE_EXT)};
+
+      expect_unexpected_end(list);
+      expect_unexpected_end(list_partial);
+      expect_unexpected_end(map);
+      expect_unexpected_end(small_tuple);
+      expect_unexpected_end(large_tuple);
+   };
+
+   "eetf_to_json oversized list arity terminates"_test = [] {
+      // List header declares 2^32-1 elements but only one is present. The sequence loop must stop
+      // on the first exhausted read rather than spinning through the declared arity.
+      const std::array<std::uint8_t, 8> buffer{uint8_t(glz::eetf_magic_version),
+                                               uint8_t(ERL_LIST_EXT),
+                                               0xFF,
+                                               0xFF,
+                                               0xFF,
+                                               0xFF,
+                                               uint8_t(ERL_SMALL_INTEGER_EXT),
+                                               1};
+      std::string json{};
+      const auto ec = glz::eetf_to_json(buffer, json);
+      expect(ec.ec == glz::error_code::unexpected_end);
+   };
+
    "eetf_to_json no header"_test = [] {
       constexpr int items = 3;
       std::vector<simple> v;


### PR DESCRIPTION
Follow-up to #2659 (merged), continuing the same end-of-input hardening for `eetf_to_json`.

### What

`term_to_json_value` dispatches on the tag byte (guaranteed present by the function-top `invalid_end`), but then hands the raw pointer to `ei_decode_long` / `ei_decode_double` and `decode_list/tuple/map_header`, which read a fixed payload *past* the tag before any bounds check. On truncated input that reads past `end`.

Since the tag is known at each call site, this gates the decode with `check_invalid_offset` for that tag's fixed width:

- `ei_decode_long`: 2 bytes (`SMALL_INTEGER_EXT`) / 5 (`INTEGER_EXT`)
- `ei_decode_double`: 9 (`NEW_FLOAT_EXT`) / 32 (legacy `FLOAT_EXT`)
- `decode_list_header` / `decode_map_header`: 5; `decode_tuple_header`: 2 (`SMALL_TUPLE_EXT`) / 5 (`LARGE_TUPLE_EXT`)

It also stops the `write_sequence` loop on error, so a header declaring up to 2^32 elements with a truncated body errors out at once instead of spinning the declared arity.

### Verification

Built against Erlang/OTP `ei` with AddressSanitizer.

- Guard-page harness (each truncated tag placed flush against an unmapped page): **7 SIGSEGV over-reads before → 0 after.**
- `eetf_test` suite: **34 tests / 142 asserts pass** under ASan.

New regression tests cover each truncated scalar, each truncated container header, and the oversized-arity case.

### Note

`ei_get_type` / `ei_decode_*` take a raw pointer with no end bound, so the eetf reader has to validate fixed widths caller-side per tag; this brings the number and header paths in line with the already-bounded string/atom/big-integer paths.
