### PR TITLE
reject lone surrogate escapes in yaml double-quoted scalars

### DIFF
--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -555,7 +555,7 @@ namespace glz
                         return;
                      }
                      const uint32_t codepoint = hex_to_u32(src);
-                     if (codepoint == 0xFFFFFFFFu) [[unlikely]] {
+                     if (codepoint == 0xFFFFFFFFu || (codepoint >= 0xD800 && codepoint <= 0xDFFF)) [[unlikely]] {
                         ctx.error = error_code::syntax_error;
                         return;
                      }
@@ -577,6 +577,10 @@ namespace glz
                      }
                      const uint32_t codepoint = (hi << 16) | lo;
                      src += 8;
+                     if (codepoint >= 0xD800 && codepoint <= 0xDFFF) [[unlikely]] {
+                        ctx.error = error_code::syntax_error;
+                        return;
+                     }
                      if (codepoint <= 0x10FFFF) {
                         dst += code_point_to_utf8(codepoint, dst);
                      }

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -1717,6 +1717,27 @@ suite yaml_tag_tests = [] {
       expect(bool(ec));
    };
 
+   "dq_reject_lone_high_surrogate_u"_test = [] {
+      std::string yaml = R"("\uD800")"; // lone high surrogate, not a scalar value
+      std::string value;
+      auto ec = glz::read_yaml(value, yaml);
+      expect(bool(ec));
+   };
+
+   "dq_reject_lone_low_surrogate_u"_test = [] {
+      std::string yaml = R"("\uDC00")"; // lone low surrogate
+      std::string value;
+      auto ec = glz::read_yaml(value, yaml);
+      expect(bool(ec));
+   };
+
+   "dq_reject_surrogate_unicode8"_test = [] {
+      std::string yaml = R"("\U0000D800")"; // surrogate via 8-digit escape
+      std::string value;
+      auto ec = glz::read_yaml(value, yaml);
+      expect(bool(ec));
+   };
+
    "dq_unterminated"_test = [] {
       std::string yaml = R"("hello)"; // no closing quote
       std::string value;


### PR DESCRIPTION
The double-quoted scalar reader decodes `\uXXXX` and `\UXXXXXXXX` and hands the value straight to `code_point_to_utf8`, with no check on the UTF-16 surrogate range U+D800..U+DFFF. Before: `read_yaml` of `"\uD800"` succeeds and emits the three bytes `ED A0 80`, a WTF-8 encoding of a lone surrogate that is not valid UTF-8. After: the same input is a syntax error, which is what the TOML reader (`append_toml_unicode_escape_u`/`_U`) and the JSON reader (`handle_unicode_code_point`) already do.

The check sits in the unescape step next to where the code point is assembled, so both the 4-digit and 8-digit forms are covered in one place rather than relying on a downstream UTF-8 validator that the scalar path does not run. Tradeoff: a YAML document that previously round-tripped a lone surrogate through Glaze now fails to parse, but that string was never well-formed UTF-8 to begin with, and the behavior now matches the other two text formats in the library.