### PR TITLE
reject conflicting content-length headers in try_parse_request

### DIFF
--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -1797,6 +1797,18 @@ namespace glz
                value_sv.remove_prefix((std::min)(value_sv.find_first_not_of(" \t"), value_sv.size()));
                std::string key(name_sv);
                for (auto& c : key) c = ascii_tolower(c);
+               // RFC 7230 3.3.2: multiple Content-Length fields with differing values make the
+               // body framing unrecoverable. The header map keeps last-wins, so a second
+               // Content-Length would silently override the first; a proxy that frames the body
+               // by the first value then desyncs from this server (CL.CL request smuggling).
+               // Reject with 400 and close. Identical repeats are tolerated.
+               if (key == "content-length") {
+                  if (auto existing = headers.find(key); existing != headers.end() && existing->second != value_sv) {
+                     result.status = parse_status::error;
+                     send_error_response_with_close(conn, 400, "Bad Request");
+                     return result;
+                  }
+               }
                headers[std::move(key)] = std::string(value_sv);
             }
 

--- a/tests/networking_tests/http_smuggling_test/http_smuggling_test.cpp
+++ b/tests/networking_tests/http_smuggling_test/http_smuggling_test.cpp
@@ -126,6 +126,37 @@ suite http_smuggling_suite = [] {
       expect(smuggled_hits.load(std::memory_order_relaxed) == 0) << "Smuggled request reached a route handler";
    };
 
+   "Conflicting Content-Length headers are refused, not desynced"_test = [&] {
+      // Two Content-Length values disagree (53 vs 7). The header map keeps the last value (7),
+      // so the server used to frame only "BLOCKED" as the body and re-parse the trailing bytes
+      // as a smuggled GET /smuggled. A proxy framing by the first value (53) would have passed
+      // the whole region through as one body, so the split is a CL.CL desync.
+      std::string payload =
+         "POST /front HTTP/1.1\r\n"
+         "Host: localhost\r\n"
+         "Content-Length: 53\r\n"
+         "Content-Length: 7\r\n"
+         "Connection: keep-alive\r\n"
+         "\r\n"
+         "BLOCKED"
+         "GET /smuggled HTTP/1.1\r\n"
+         "Host: localhost\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      auto future_timeout = std::chrono::system_clock::now() + std::chrono::seconds(5);
+      std::string response;
+      if (std::future_status::ready == f.wait_until(future_timeout)) {
+         response = f.get();
+      }
+
+      expect(response.find("400") != std::string::npos) << "Expected 400 for conflicting Content-Length";
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      expect(smuggled_hits.load(std::memory_order_relaxed) == 0) << "Smuggled request reached a route handler";
+   };
+
    server.stop();
    io_ctx->stop();
    if (server_thr.joinable()) server_thr.join();

--- a/tests/networking_tests/http_smuggling_test/http_smuggling_test.cpp
+++ b/tests/networking_tests/http_smuggling_test/http_smuggling_test.cpp
@@ -152,7 +152,68 @@ suite http_smuggling_suite = [] {
          response = f.get();
       }
 
-      expect(response.find("400") != std::string::npos) << "Expected 400 for conflicting Content-Length";
+      // Match the status line, not a bare "400" substring, so an unrelated rejection
+      // (or a "400" appearing in a body) cannot make this pass for the wrong reason.
+      expect(response.find("HTTP/1.1 400") != std::string::npos) << "Expected 400 for conflicting Content-Length";
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      expect(smuggled_hits.load(std::memory_order_relaxed) == 0) << "Smuggled request reached a route handler";
+   };
+
+   "Identical duplicate Content-Length headers are tolerated"_test = [&] {
+      // RFC 7230 3.3.2 permits collapsing repeated Content-Length fields that carry the same
+      // value, so a lenient-but-honest client that sends the header twice must still be served.
+      // This pins the "identical repeats are tolerated" branch of the fix: a regression that
+      // rejected all duplicate Content-Length headers would break such clients, and the only
+      // thing catching it would be this test.
+      std::string payload =
+         "POST /front HTTP/1.1\r\n"
+         "Host: localhost\r\n"
+         "Content-Length: 5\r\n"
+         "Content-Length: 5\r\n"
+         "Connection: close\r\n"
+         "\r\n"
+         "HELLO";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      auto future_timeout = std::chrono::system_clock::now() + std::chrono::seconds(5);
+      std::string response;
+      if (std::future_status::ready == f.wait_until(future_timeout)) {
+         response = f.get();
+      }
+
+      expect(response.find("HTTP/1.1 200") != std::string::npos)
+         << "Identical duplicate Content-Length should be accepted";
+   };
+
+   "Case-varied duplicate Content-Length headers are refused, not desynced"_test = [&] {
+      // The duplicate check lowercases the field-name before the map lookup, so varying the
+      // case ("Content-Length" vs "content-length") must not land two distinct keys that would
+      // let a conflicting value slip past conflict detection. Same CL.CL desync as above, only
+      // obfuscated by case.
+      std::string payload =
+         "POST /front HTTP/1.1\r\n"
+         "Host: localhost\r\n"
+         "Content-Length: 53\r\n"
+         "content-length: 7\r\n"
+         "Connection: keep-alive\r\n"
+         "\r\n"
+         "BLOCKED"
+         "GET /smuggled HTTP/1.1\r\n"
+         "Host: localhost\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      auto future_timeout = std::chrono::system_clock::now() + std::chrono::seconds(5);
+      std::string response;
+      if (std::future_status::ready == f.wait_until(future_timeout)) {
+         response = f.get();
+      }
+
+      expect(response.find("HTTP/1.1 400") != std::string::npos)
+         << "Expected 400 for case-varied conflicting Content-Length";
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
       expect(smuggled_hits.load(std::memory_order_relaxed) == 0) << "Smuggled request reached a route handler";
    };


### PR DESCRIPTION
Repro: a POST with `Content-Length: 53` then `Content-Length: 7`, with a pipelined `GET /smuggled` packed into the bytes after the headers. The server frames a 7-byte body and routes the trailing bytes as a second request.
Cause: request headers land in an `unordered_map`, so the second Content-Length overwrites the first rather than being refused. RFC 7230 3.3.2 treats differing Content-Length values as unrecoverable framing and requires 400 + close.
Fix: detect a duplicate `content-length` with a differing value in the header loop and answer 400, the same shape as the existing Transfer-Encoding rejection.

Before: last value wins, so body framing disagrees with a proxy that uses the first value (CL.CL desync, the smuggled request reaches a handler).
After: conflicting values are refused before a body is framed.

Tradeoff: identical repeated Content-Length lines are still tolerated, so lenient-but-honest clients keep working while the desync is closed.