### PR TITLE
Fix compile error in tests, fix UBSan errors in BEVE read path

### DIFF
--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -1226,8 +1226,10 @@ namespace glz
                else {
                   // Little endian or single-byte: bulk memcpy
                   if (typed_array_out_of_bounds(ctx, it, end, n, sizeof(V))) return;
-                  std::memcpy(value.data(), it, n * sizeof(V));
-                  it += n * sizeof(V);
+                  if (n) {
+                     std::memcpy(value.data(), it, n * sizeof(V));
+                     it += n * sizeof(V);
+                  }
                }
             }
             else {
@@ -1396,8 +1398,10 @@ namespace glz
                }
                else {
                   // Little endian or single-byte: bulk memcpy
-                  std::memcpy(value.data(), it, n * sizeof(V));
-                  it += n * sizeof(V);
+                  if (n) {
+                     std::memcpy(value.data(), it, n * sizeof(V));
+                     it += n * sizeof(V);
+                  }
                }
             }
             else {

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -3286,9 +3286,9 @@ suite strong_id_json_tests = [] {
 template <typename Pair_key, typename Pair_value>
 struct Write_pair_test_case
 {
-   Pair_key key{};
-   Pair_value value{};
-   std::string_view expected_json{};
+   Pair_key key;
+   Pair_value value;
+   std::string_view expected_json;
 };
 template <typename Pair_key, typename Pair_value>
 Write_pair_test_case(Pair_key, Pair_value, std::string_view) -> Write_pair_test_case<Pair_key, Pair_value>;


### PR DESCRIPTION
Detected when compiling under clang 20, and running the tests with sanitizers