### PR TITLE
Serialize non-native BEVE map/pair keys via a generic-array fallback

### DIFF
--- a/docs/binary.md
+++ b/docs/binary.md
@@ -438,6 +438,23 @@ struct glz::meta<ModuleID> {
 };
 ```
 
+### Keys that are not numeric or string
+
+A BEVE object (map) header encodes a *single shared key type*, so the compact map encoding requires keys that reduce to a numeric or string type. When a key does not, such as a multi-field struct, the map/pair serializers automatically fall back to a **generic array of `[key, value]` entries**, where each key is written as a full BEVE value. The container still round-trips with no extra code:
+
+```c++
+struct CompositeKey {
+   int32_t id{};
+   std::string name{};
+   auto operator<=>(const CompositeKey&) const = default;
+};
+
+std::unordered_map<CompositeKey, int> m{{{1, "a"}, 10}, {{2, "b"}, 20}};
+glz::write_beve(m, beve); // a generic array of [key, value] entries
+```
+
+This applies to `std::map`, `std::unordered_map`, `std::vector<std::pair<Key, Value>>`, and a standalone `std::pair<Key, Value>`. The fallback is portable and self-describing, and each entry is encoded identically to `std::tuple<Key, Value>` (so a non-native `std::pair` and the corresponding `std::tuple` produce the same bytes). Native (numeric/string) keys are unaffected and keep the compact shared-header encoding.
+
 ## Partial Objects
 
 It is sometimes desirable to write out only a portion of an object. This is permitted via an array of JSON pointers, which indicate which parts of the object should be written out.

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -559,6 +559,23 @@ struct glz::meta<ModuleID> {
 };
 ```
 
+### Keys that are not numeric or string
+
+A BEVE object (map) header encodes a *single shared key type*, so the compact map encoding requires keys that reduce to a numeric or string type. When a key does not, such as a multi-field struct, the map/pair serializers automatically fall back to a **generic array of `[key, value]` entries**, where each key is written as a full BEVE value. The container still round-trips with no extra code:
+
+```c++
+struct CompositeKey {
+   int32_t id{};
+   std::string name{};
+   auto operator<=>(const CompositeKey&) const = default;
+};
+
+std::unordered_map<CompositeKey, int> m{{{1, "a"}, 10}, {{2, "b"}, 20}};
+glz::write_beve(m, beve); // a generic array of [key, value] entries
+```
+
+This applies to `std::map`, `std::unordered_map`, `std::vector<std::pair<Key, Value>>`, and a standalone `std::pair<Key, Value>`. The fallback is portable and self-describing, and each entry is encoded identically to `std::tuple<Key, Value>` (so a non-native `std::pair` and the corresponding `std::tuple` produce the same bytes). Native (numeric/string) keys are unaffected and keep the compact shared-header encoding.
+
 ## Partial Objects
 
 It is sometimes desirable to write out only a portion of an object. This is permitted via an array of JSON pointers, which indicate which parts of the object should be written out.

--- a/include/glaze/beve/key_traits.hpp
+++ b/include/glaze/beve/key_traits.hpp
@@ -76,6 +76,10 @@ namespace glz
       using numeric_type = typename beve_numeric_type<underlying>::type;
 
       static constexpr bool numeric = std::is_arithmetic_v<numeric_type>;
+      // A BEVE object header encodes a single shared key type, which must be numeric or string-like.
+      // Native keys use the compact object/map encoding; keys that reduce to neither (e.g. multi-field
+      // structs) fall back to a generic array of [key, value] entries in the map/pair serializers.
+      static constexpr bool native = numeric || str_t<underlying>;
       static constexpr bool as_string = str_t<underlying> || !numeric;
       static constexpr bool as_number = !as_string;
 

--- a/include/glaze/beve/key_traits.hpp
+++ b/include/glaze/beve/key_traits.hpp
@@ -56,6 +56,10 @@ namespace glz
       using numeric_type = typename beve_numeric_type<underlying>::type;
 
       static constexpr bool numeric = std::is_arithmetic_v<numeric_type>;
+      // A BEVE object header encodes a single shared key type, which must be numeric or string-like.
+      // Native keys use the compact object/map encoding; keys that reduce to neither (e.g. multi-field
+      // structs) fall back to a generic array of [key, value] entries in the map/pair serializers.
+      static constexpr bool native = numeric || str_t<underlying>;
       static constexpr bool as_string = str_t<underlying> || !numeric;
       static constexpr bool as_number = !as_string;
 

--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -1470,47 +1470,86 @@ namespace glz
          using Element = typename T::value_type;
          using Key = typename Element::first_type;
 
-         constexpr uint8_t header = beve_key_traits<Key>::header;
+         if constexpr (beve_key_traits<Key>::native) {
+            constexpr uint8_t header = beve_key_traits<Key>::header;
 
-         if (invalid_end(ctx, it, end)) {
-            return;
-         }
-         const auto tag = uint8_t(*it);
-         if (tag != header) [[unlikely]] {
-            if constexpr (check_allow_conversions(Opts)) {
-               const auto key_type = tag & 0b000'11'000;
-               if constexpr (beve_key_traits<Key>::as_string) {
-                  if (key_type != 0) {
-                     ctx.error = error_code::syntax_error;
-                     return;
+            if (invalid_end(ctx, it, end)) {
+               return;
+            }
+            const auto tag = uint8_t(*it);
+            if (tag != header) [[unlikely]] {
+               if constexpr (check_allow_conversions(Opts)) {
+                  const auto key_type = tag & 0b000'11'000;
+                  if constexpr (beve_key_traits<Key>::as_string) {
+                     if (key_type != 0) {
+                        ctx.error = error_code::syntax_error;
+                        return;
+                     }
+                  }
+                  else {
+                     if (key_type == 0) {
+                        ctx.error = error_code::syntax_error;
+                        return;
+                     }
                   }
                }
                else {
-                  if (key_type == 0) {
-                     ctx.error = error_code::syntax_error;
-                     return;
-                  }
+                  ctx.error = error_code::syntax_error;
+                  return;
                }
             }
-            else {
+
+            ++it;
+            const size_t n = int_from_compressed(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+
+            // Validate count against remaining buffer size (minimum 1 byte per key-value pair)
+            if (n > size_t(end - it)) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+
+            value.clear();
+
+            constexpr uint8_t key_tag = beve_key_traits<Key>::key_tag;
+            for (size_t i = 0; i < n; ++i) {
+               auto& item = value.emplace_back();
+               parse<BEVE>::op<no_header_on<Opts>()>(item.first, key_tag, ctx, it, end);
+               parse<BEVE>::op<Opts>(item.second, ctx, it, end);
+            }
+         }
+         else {
+            // Non-native key: read the generic-array fallback (an array of [key, value] entries; see
+            // the writer). Each entry is itself a generic array, identical to std::tuple<Key, Value>.
+            if (invalid_end(ctx, it, end)) {
+               return;
+            }
+            if (uint8_t(*it) != tag::generic_array) [[unlikely]] {
                ctx.error = error_code::syntax_error;
                return;
             }
-         }
+            ++it;
 
-         ++it;
-         const size_t n = int_from_compressed(ctx, it, end);
-         if (bool(ctx.error)) [[unlikely]] {
-            return;
-         }
+            const size_t n = int_from_compressed(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            // Validate count against remaining buffer size (minimum 1 byte per entry)
+            if (n > size_t(end - it)) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
 
-         value.clear();
-
-         constexpr uint8_t key_tag = beve_key_traits<Key>::key_tag;
-         for (size_t i = 0; i < n; ++i) {
-            auto& item = value.emplace_back();
-            parse<BEVE>::op<no_header_on<Opts>()>(item.first, key_tag, ctx, it, end);
-            parse<BEVE>::op<Opts>(item.second, ctx, it, end);
+            value.clear();
+            for (size_t i = 0; i < n; ++i) {
+               auto& item = value.emplace_back();
+               parse<BEVE>::op<Opts>(item, ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+            }
          }
       }
    };
@@ -1523,31 +1562,60 @@ namespace glz
       {
          using Key = typename T::first_type;
 
-         constexpr uint8_t header = beve_key_traits<Key>::header;
+         if constexpr (beve_key_traits<Key>::native) {
+            constexpr uint8_t header = beve_key_traits<Key>::header;
 
-         if (invalid_end(ctx, it, end)) {
-            return;
-         }
-         const auto tag = uint8_t(*it);
-         if (tag != header) [[unlikely]] {
-            ctx.error = error_code::syntax_error;
-            return;
-         }
+            if (invalid_end(ctx, it, end)) {
+               return;
+            }
+            const auto tag = uint8_t(*it);
+            if (tag != header) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
 
-         ++it;
-         const auto n = int_from_compressed(ctx, it, end);
-         if (bool(ctx.error)) [[unlikely]] {
-            return;
-         }
+            ++it;
+            const auto n = int_from_compressed(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
 
-         if (n != 1) [[unlikely]] {
-            ctx.error = error_code::syntax_error;
-            return;
-         }
+            if (n != 1) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
 
-         constexpr uint8_t key_tag = beve_key_traits<Key>::key_tag;
-         parse<BEVE>::op<no_header_on<Opts>()>(value.first, key_tag, ctx, it, end);
-         parse<BEVE>::op<Opts>(value.second, ctx, it, end);
+            constexpr uint8_t key_tag = beve_key_traits<Key>::key_tag;
+            parse<BEVE>::op<no_header_on<Opts>()>(value.first, key_tag, ctx, it, end);
+            parse<BEVE>::op<Opts>(value.second, ctx, it, end);
+         }
+         else {
+            // Non-native key: read the generic-array fallback [key, value], identical to
+            // std::tuple<Key, Value>. Each element carries its own header.
+            if (invalid_end(ctx, it, end)) {
+               return;
+            }
+            if (uint8_t(*it) != tag::generic_array) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            ++it;
+
+            const auto n = int_from_compressed(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            if (n != 2) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+
+            parse<BEVE>::op<Opts>(value.first, ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            parse<BEVE>::op<Opts>(value.second, ctx, it, end);
+         }
       }
    };
 
@@ -1558,6 +1626,84 @@ namespace glz
       static void op(auto&& value, is_context auto&& ctx, auto&& it, auto end)
       {
          using Key = typename T::key_type;
+
+         // Non-native key (e.g. a multi-field struct): a BEVE object header can't carry a struct key,
+         // so the writer emits a generic array of [key, value] entries. Read that fallback form here;
+         // native keys use the compact object/map encoding below.
+         if constexpr (not beve_key_traits<Key>::native) {
+            if (invalid_end(ctx, it, end)) {
+               return;
+            }
+            if (uint8_t(*it) != tag::generic_array) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            ++it;
+
+            const size_t n = int_from_compressed(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            // Validate count against remaining buffer size (minimum 1 byte per entry)
+            if (n > size_t(end - it)) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+            if constexpr (check_max_map_size(Opts) > 0) {
+               if (n > check_max_map_size(Opts)) [[unlikely]] {
+                  ctx.error = error_code::invalid_length;
+                  return;
+               }
+            }
+            if constexpr (has_runtime_max_map_size<std::decay_t<decltype(ctx)>>) {
+               if (ctx.max_map_size > 0 && n > ctx.max_map_size) [[unlikely]] {
+                  ctx.error = error_code::invalid_length;
+                  return;
+               }
+            }
+
+            for (size_t i = 0; i < n; ++i) {
+               // each entry is a generic array [key, value]
+               if (invalid_end(ctx, it, end)) {
+                  return;
+               }
+               if (uint8_t(*it) != tag::generic_array) [[unlikely]] {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
+               ++it;
+               const auto m = int_from_compressed(ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+               if (m != 2) [[unlikely]] {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
+
+               Key key{};
+               parse<BEVE>::op<Opts>(key, ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+               if constexpr (Opts.partial_read) {
+                  if (auto element = value.find(key); element != value.end()) {
+                     parse<BEVE>::op<Opts>(element->second, ctx, it, end);
+                  }
+                  else {
+                     typename T::mapped_type discard{};
+                     parse<BEVE>::op<Opts>(discard, ctx, it, end);
+                  }
+               }
+               else {
+                  parse<BEVE>::op<Opts>(value[key], ctx, it, end);
+               }
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+            }
+            return;
+         }
 
          constexpr uint8_t header = beve_key_traits<Key>::header;
 
@@ -1618,7 +1764,7 @@ namespace glz
             }
          }
 
-         constexpr uint8_t key_tag = beve_key_traits<Key>::key_tag;
+         [[maybe_unused]] constexpr uint8_t key_tag = beve_key_traits<Key>::key_tag;
 
          if constexpr (beve_key_traits<Key>::as_number) {
             Key key{}; // Value-initialize to silence false positive -Wmaybe-uninitialized
@@ -1651,7 +1797,7 @@ namespace glz
                }
             }
          }
-         else {
+         else if constexpr (beve_key_traits<Key>::native) {
             Key key;
             for (size_t i = 0; i < n; ++i) {
                if constexpr (Opts.partial_read) {

--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -2343,76 +2343,118 @@ namespace glz
          using Element = typename T::value_type;
          using Key = typename Element::first_type;
 
-         constexpr uint8_t header = beve_key_traits<Key>::header;
+         if constexpr (beve_key_traits<Key>::native) {
+            constexpr uint8_t header = beve_key_traits<Key>::header;
 
-         if (invalid_end(ctx, it, end)) {
-            return;
-         }
-         const auto tag = uint8_t(*it);
-         if (tag != header) [[unlikely]] {
-            if constexpr (check_allow_conversions(Opts)) {
-               // Every BEVE object/map has the object category in bits 0-2; only the key-type bits
-               // (3-4) may differ under conversions. Reject any non-object category so a non-object
-               // value (e.g. a typed array) is never mis-read as a map.
-               if ((tag & 0b00000'111) != tag::object) {
-                  ctx.error = error_code::syntax_error;
-                  return;
-               }
-               const auto key_type = tag & 0b000'11'000;
-               if constexpr (beve_key_traits<Key>::as_string) {
-                  if (key_type != 0) {
+            if (invalid_end(ctx, it, end)) {
+               return;
+            }
+            const auto tag = uint8_t(*it);
+            if (tag != header) [[unlikely]] {
+               if constexpr (check_allow_conversions(Opts)) {
+                  // Every BEVE object/map has the object category in bits 0-2; only the key-type bits
+                  // (3-4) may differ under conversions. Reject any non-object category so a non-object
+                  // value (e.g. a typed array) is never mis-read as a map.
+                  if ((tag & 0b00000'111) != tag::object) {
                      ctx.error = error_code::syntax_error;
                      return;
+                  }
+                  const auto key_type = tag & 0b000'11'000;
+                  if constexpr (beve_key_traits<Key>::as_string) {
+                     if (key_type != 0) {
+                        ctx.error = error_code::syntax_error;
+                        return;
+                     }
+                  }
+                  else {
+                     if (key_type == 0) {
+                        ctx.error = error_code::syntax_error;
+                        return;
+                     }
                   }
                }
                else {
-                  if (key_type == 0) {
-                     ctx.error = error_code::syntax_error;
-                     return;
-                  }
+                  ctx.error = error_code::syntax_error;
+                  return;
                }
             }
-            else {
+
+            depth_guard guard{ctx};
+            if (!guard) [[unlikely]] {
+               return;
+            }
+
+            ++it;
+            const size_t n = int_from_compressed(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+
+            // A pair costs at least one byte of input, so a count exceeding what remains cannot be
+            // honored -- the same bound the map reader applies. Bailing here (and on error in the loop)
+            // keeps a bogus count from emplacing its way through memory on a read that errors on the
+            // first element.
+            if (n > size_t(end - it)) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+
+            value.clear();
+
+            constexpr uint8_t key_tag = beve_key_traits<Key>::key_tag;
+            for (size_t i = 0; i < n; ++i) {
+               if (exceeds_capacity(value, i + 1, ctx)) [[unlikely]] {
+                  return;
+               }
+               auto& item = value.emplace_back();
+               parse<BEVE>::op<no_header_on<Opts>()>(item.first, key_tag, ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+               parse<BEVE>::op<Opts>(item.second, ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+            }
+         }
+         else {
+            // Non-native key: read the generic-array fallback (an array of [key, value] entries; see
+            // the writer). Each entry is itself a generic array, identical to std::tuple<Key, Value>.
+            if (invalid_end(ctx, it, end)) {
+               return;
+            }
+            if (uint8_t(*it) != tag::generic_array) [[unlikely]] {
                ctx.error = error_code::syntax_error;
                return;
             }
-         }
 
-         depth_guard guard{ctx};
-         if (!guard) [[unlikely]] {
-            return;
-         }
-
-         ++it;
-         const size_t n = int_from_compressed(ctx, it, end);
-         if (bool(ctx.error)) [[unlikely]] {
-            return;
-         }
-
-         // A pair costs at least one byte of input, so a count exceeding what remains cannot be
-         // honored -- the same bound the map reader applies. Bailing here (and on error in the loop)
-         // keeps a bogus count from emplacing its way through memory on a read that errors on the
-         // first element.
-         if (n > size_t(end - it)) [[unlikely]] {
-            ctx.error = error_code::unexpected_end;
-            return;
-         }
-
-         value.clear();
-
-         constexpr uint8_t key_tag = beve_key_traits<Key>::key_tag;
-         for (size_t i = 0; i < n; ++i) {
-            if (exceeds_capacity(value, i + 1, ctx)) [[unlikely]] {
+            depth_guard guard{ctx};
+            if (!guard) [[unlikely]] {
                return;
             }
-            auto& item = value.emplace_back();
-            parse<BEVE>::op<no_header_on<Opts>()>(item.first, key_tag, ctx, it, end);
+
+            ++it;
+            const size_t n = int_from_compressed(ctx, it, end);
             if (bool(ctx.error)) [[unlikely]] {
                return;
             }
-            parse<BEVE>::op<Opts>(item.second, ctx, it, end);
-            if (bool(ctx.error)) [[unlikely]] {
+            // An entry costs at least one byte of input, so a count exceeding what remains cannot be
+            // honored -- the same bound the native path above applies.
+            if (n > size_t(end - it)) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
                return;
+            }
+
+            value.clear();
+            for (size_t i = 0; i < n; ++i) {
+               if (exceeds_capacity(value, i + 1, ctx)) [[unlikely]] {
+                  return;
+               }
+               auto& item = value.emplace_back();
+               parse<BEVE>::op<Opts>(item, ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
             }
          }
       }
@@ -2426,36 +2468,70 @@ namespace glz
       {
          using Key = typename T::first_type;
 
-         constexpr uint8_t header = beve_key_traits<Key>::header;
+         if constexpr (beve_key_traits<Key>::native) {
+            constexpr uint8_t header = beve_key_traits<Key>::header;
 
-         if (invalid_end(ctx, it, end)) {
-            return;
-         }
-         const auto tag = uint8_t(*it);
-         if (tag != header) [[unlikely]] {
-            ctx.error = error_code::syntax_error;
-            return;
-         }
+            if (invalid_end(ctx, it, end)) {
+               return;
+            }
+            const auto tag = uint8_t(*it);
+            if (tag != header) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
 
-         depth_guard guard{ctx};
-         if (!guard) [[unlikely]] {
-            return;
-         }
+            depth_guard guard{ctx};
+            if (!guard) [[unlikely]] {
+               return;
+            }
 
-         ++it;
-         const auto n = int_from_compressed(ctx, it, end);
-         if (bool(ctx.error)) [[unlikely]] {
-            return;
-         }
+            ++it;
+            const auto n = int_from_compressed(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
 
-         if (n != 1) [[unlikely]] {
-            ctx.error = error_code::syntax_error;
-            return;
-         }
+            if (n != 1) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
 
-         constexpr uint8_t key_tag = beve_key_traits<Key>::key_tag;
-         parse<BEVE>::op<no_header_on<Opts>()>(value.first, key_tag, ctx, it, end);
-         parse<BEVE>::op<Opts>(value.second, ctx, it, end);
+            constexpr uint8_t key_tag = beve_key_traits<Key>::key_tag;
+            parse<BEVE>::op<no_header_on<Opts>()>(value.first, key_tag, ctx, it, end);
+            parse<BEVE>::op<Opts>(value.second, ctx, it, end);
+         }
+         else {
+            // Non-native key: read the generic-array fallback [key, value], identical to
+            // std::tuple<Key, Value>. Each element carries its own header.
+            if (invalid_end(ctx, it, end)) {
+               return;
+            }
+            if (uint8_t(*it) != tag::generic_array) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+
+            depth_guard guard{ctx};
+            if (!guard) [[unlikely]] {
+               return;
+            }
+
+            ++it;
+            const auto n = int_from_compressed(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            if (n != 2) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+
+            parse<BEVE>::op<Opts>(value.first, ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            parse<BEVE>::op<Opts>(value.second, ctx, it, end);
+         }
       }
    };
 
@@ -2466,6 +2542,89 @@ namespace glz
       static void op(auto&& value, is_context auto&& ctx, auto&& it, auto end)
       {
          using Key = typename T::key_type;
+
+         // Non-native key (e.g. a multi-field struct): a BEVE object header can't carry a struct key,
+         // so the writer emits a generic array of [key, value] entries. Read that fallback form here;
+         // native keys use the compact object/map encoding below.
+         if constexpr (not beve_key_traits<Key>::native) {
+            if (invalid_end(ctx, it, end)) {
+               return;
+            }
+            if (uint8_t(*it) != tag::generic_array) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+
+            depth_guard guard{ctx};
+            if (!guard) [[unlikely]] {
+               return;
+            }
+
+            ++it;
+            const size_t n = int_from_compressed(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            // Validate count against remaining buffer size (minimum 1 byte per entry)
+            if (n > size_t(end - it)) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+            if constexpr (check_max_map_size(Opts) > 0) {
+               if (n > check_max_map_size(Opts)) [[unlikely]] {
+                  ctx.error = error_code::invalid_length;
+                  return;
+               }
+            }
+            if constexpr (has_runtime_max_map_size<std::decay_t<decltype(ctx)>>) {
+               if (ctx.max_map_size > 0 && n > ctx.max_map_size) [[unlikely]] {
+                  ctx.error = error_code::invalid_length;
+                  return;
+               }
+            }
+
+            for (size_t i = 0; i < n; ++i) {
+               // each entry is a generic array [key, value]
+               if (invalid_end(ctx, it, end)) {
+                  return;
+               }
+               if (uint8_t(*it) != tag::generic_array) [[unlikely]] {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
+               ++it;
+               const auto m = int_from_compressed(ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+               if (m != 2) [[unlikely]] {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
+
+               Key key{};
+               parse<BEVE>::op<Opts>(key, ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+               if constexpr (Opts.partial_read) {
+                  if (auto element = value.find(key); element != value.end()) {
+                     parse<BEVE>::op<Opts>(element->second, ctx, it, end);
+                  }
+                  else {
+                     typename T::mapped_type discard{};
+                     parse<BEVE>::op<Opts>(discard, ctx, it, end);
+                  }
+               }
+               else {
+                  parse<BEVE>::op<Opts>(value[key], ctx, it, end);
+               }
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+            }
+            return;
+         }
 
          constexpr uint8_t header = beve_key_traits<Key>::header;
 
@@ -2538,7 +2697,7 @@ namespace glz
             }
          }
 
-         constexpr uint8_t key_tag = beve_key_traits<Key>::key_tag;
+         [[maybe_unused]] constexpr uint8_t key_tag = beve_key_traits<Key>::key_tag;
 
          if constexpr (beve_key_traits<Key>::as_number) {
             Key key{}; // Value-initialize to silence false positive -Wmaybe-uninitialized
@@ -2571,7 +2730,7 @@ namespace glz
                }
             }
          }
-         else {
+         else if constexpr (beve_key_traits<Key>::native) {
             Key key;
             for (size_t i = 0; i < n; ++i) {
                if constexpr (Opts.partial_read) {

--- a/include/glaze/beve/size.hpp
+++ b/include/glaze/beve/size.hpp
@@ -332,15 +332,30 @@ namespace glz
          requires(map_like_array && check_concatenate(Opts) == true)
       [[nodiscard]] static size_t op(auto&& value, size_t offset = 0)
       {
-         size_t result = 1; // tag byte
-         result += compressed_int_size(value.size()); // element count
+         using Key = typename range_value_t<std::decay_t<T>>::first_type;
+         if constexpr (beve_key_traits<Key>::native) {
+            size_t result = 1; // tag byte
+            result += compressed_int_size(value.size()); // element count
 
-         for (auto&& [k, v] : value) {
-            result += calculate_size<BEVE, void>::template no_header<Opts>(k, offset + result);
-            result += calculate_size<BEVE, void>::template op<Opts>(v, offset + result);
+            for (auto&& [k, v] : value) {
+               result += calculate_size<BEVE, void>::template no_header<Opts>(k, offset + result);
+               result += calculate_size<BEVE, void>::template op<Opts>(v, offset + result);
+            }
+
+            return result;
          }
+         else {
+            // Non-native key: sized as a generic array of [key, value] entries (each entry matches
+            // std::tuple<Key, Value>).
+            size_t result = 1; // generic_array tag
+            result += compressed_int_size(value.size()); // element count
 
-         return result;
+            for (auto&& entry : value) {
+               result += calculate_size<BEVE, void>::template op<Opts>(entry, offset + result);
+            }
+
+            return result;
+         }
       }
    };
 
@@ -350,14 +365,28 @@ namespace glz
       template <auto Opts>
       [[nodiscard]] GLZ_ALWAYS_INLINE static size_t op(auto&& value, size_t offset = 0)
       {
-         size_t result = 1; // tag byte
-         result += compressed_int_size<1>(); // count = 1
+         using Key = typename T::first_type;
+         if constexpr (beve_key_traits<Key>::native) {
+            size_t result = 1; // tag byte
+            result += compressed_int_size<1>(); // count = 1
 
-         const auto& [k, v] = value;
-         result += calculate_size<BEVE, void>::template no_header<Opts>(k, offset + result);
-         result += calculate_size<BEVE, void>::template op<Opts>(v, offset + result);
+            const auto& [k, v] = value;
+            result += calculate_size<BEVE, void>::template no_header<Opts>(k, offset + result);
+            result += calculate_size<BEVE, void>::template op<Opts>(v, offset + result);
 
-         return result;
+            return result;
+         }
+         else {
+            // Non-native key: sized as a generic array [key, value] (matches std::tuple<Key, Value>).
+            size_t result = 1; // generic_array tag
+            result += compressed_int_size<2>(); // count = 2
+
+            const auto& [k, v] = value;
+            result += calculate_size<BEVE, void>::template op<Opts>(k, offset + result);
+            result += calculate_size<BEVE, void>::template op<Opts>(v, offset + result);
+
+            return result;
+         }
       }
    };
 
@@ -367,15 +396,30 @@ namespace glz
       template <auto Opts>
       [[nodiscard]] static size_t op(auto&& value, size_t offset = 0)
       {
-         size_t result = 1; // tag byte
-         result += compressed_int_size(value.size()); // element count
+         using Key = typename T::key_type;
+         if constexpr (beve_key_traits<Key>::native) {
+            size_t result = 1; // tag byte
+            result += compressed_int_size(value.size()); // element count
 
-         for (auto&& [k, v] : value) {
-            result += calculate_size<BEVE, void>::template no_header<Opts>(k, offset + result);
-            result += calculate_size<BEVE, void>::template op<Opts>(v, offset + result);
+            for (auto&& [k, v] : value) {
+               result += calculate_size<BEVE, void>::template no_header<Opts>(k, offset + result);
+               result += calculate_size<BEVE, void>::template op<Opts>(v, offset + result);
+            }
+
+            return result;
          }
+         else {
+            // Non-native key: sized as a generic array of [key, value] entries (each entry matches
+            // std::tuple<Key, Value>).
+            size_t result = 1; // generic_array tag
+            result += compressed_int_size(value.size()); // element count
 
-         return result;
+            for (auto&& entry : value) {
+               result += calculate_size<BEVE, void>::template op<Opts>(entry, offset + result);
+            }
+
+            return result;
+         }
       }
    };
 

--- a/include/glaze/beve/size.hpp
+++ b/include/glaze/beve/size.hpp
@@ -459,15 +459,30 @@ namespace glz
          requires(map_like_array && check_concatenate(Opts) == true)
       [[nodiscard]] static size_t op(auto&& value, size_t offset = 0)
       {
-         size_t result = 1; // tag byte
-         result += compressed_int_size(value.size()); // element count
+         using Key = typename range_value_t<std::decay_t<T>>::first_type;
+         if constexpr (beve_key_traits<Key>::native) {
+            size_t result = 1; // tag byte
+            result += compressed_int_size(value.size()); // element count
 
-         for (auto&& [k, v] : value) {
-            result += calculate_size<BEVE, void>::template no_header<Opts>(k, offset + result);
-            result += calculate_size<BEVE, void>::template op<Opts>(v, offset + result);
+            for (auto&& [k, v] : value) {
+               result += calculate_size<BEVE, void>::template no_header<Opts>(k, offset + result);
+               result += calculate_size<BEVE, void>::template op<Opts>(v, offset + result);
+            }
+
+            return result;
          }
+         else {
+            // Non-native key: sized as a generic array of [key, value] entries (each entry matches
+            // std::tuple<Key, Value>).
+            size_t result = 1; // generic_array tag
+            result += compressed_int_size(value.size()); // element count
 
-         return result;
+            for (auto&& entry : value) {
+               result += calculate_size<BEVE, void>::template op<Opts>(entry, offset + result);
+            }
+
+            return result;
+         }
       }
    };
 
@@ -477,14 +492,28 @@ namespace glz
       template <auto Opts>
       [[nodiscard]] GLZ_ALWAYS_INLINE static size_t op(auto&& value, size_t offset = 0)
       {
-         size_t result = 1; // tag byte
-         result += compressed_int_size<1>(); // count = 1
+         using Key = typename T::first_type;
+         if constexpr (beve_key_traits<Key>::native) {
+            size_t result = 1; // tag byte
+            result += compressed_int_size<1>(); // count = 1
 
-         const auto& [k, v] = value;
-         result += calculate_size<BEVE, void>::template no_header<Opts>(k, offset + result);
-         result += calculate_size<BEVE, void>::template op<Opts>(v, offset + result);
+            const auto& [k, v] = value;
+            result += calculate_size<BEVE, void>::template no_header<Opts>(k, offset + result);
+            result += calculate_size<BEVE, void>::template op<Opts>(v, offset + result);
 
-         return result;
+            return result;
+         }
+         else {
+            // Non-native key: sized as a generic array [key, value] (matches std::tuple<Key, Value>).
+            size_t result = 1; // generic_array tag
+            result += compressed_int_size<2>(); // count = 2
+
+            const auto& [k, v] = value;
+            result += calculate_size<BEVE, void>::template op<Opts>(k, offset + result);
+            result += calculate_size<BEVE, void>::template op<Opts>(v, offset + result);
+
+            return result;
+         }
       }
    };
 
@@ -494,15 +523,30 @@ namespace glz
       template <auto Opts>
       [[nodiscard]] static size_t op(auto&& value, size_t offset = 0)
       {
-         size_t result = 1; // tag byte
-         result += compressed_int_size(value.size()); // element count
+         using Key = typename T::key_type;
+         if constexpr (beve_key_traits<Key>::native) {
+            size_t result = 1; // tag byte
+            result += compressed_int_size(value.size()); // element count
 
-         for (auto&& [k, v] : value) {
-            result += calculate_size<BEVE, void>::template no_header<Opts>(k, offset + result);
-            result += calculate_size<BEVE, void>::template op<Opts>(v, offset + result);
+            for (auto&& [k, v] : value) {
+               result += calculate_size<BEVE, void>::template no_header<Opts>(k, offset + result);
+               result += calculate_size<BEVE, void>::template op<Opts>(v, offset + result);
+            }
+
+            return result;
          }
+         else {
+            // Non-native key: sized as a generic array of [key, value] entries (each entry matches
+            // std::tuple<Key, Value>).
+            size_t result = 1; // generic_array tag
+            result += compressed_int_size(value.size()); // element count
 
-         return result;
+            for (auto&& entry : value) {
+               result += calculate_size<BEVE, void>::template op<Opts>(entry, offset + result);
+            }
+
+            return result;
+         }
       }
    };
 

--- a/include/glaze/beve/write.hpp
+++ b/include/glaze/beve/write.hpp
@@ -958,24 +958,44 @@ namespace glz
          using Element = typename T::value_type;
          using Key = typename Element::first_type;
 
-         constexpr uint8_t tag = beve_key_traits<Key>::header;
-         dump_type(ctx, tag, b, ix);
-         if (bool(ctx.error)) [[unlikely]] {
-            return;
-         }
-
-         dump_compressed_int(ctx, value.size(), b, ix);
-         if (bool(ctx.error)) [[unlikely]] {
-            return;
-         }
-         for (auto&& [k, v] : value) {
-            serialize<BEVE>::no_header<Opts>(k, ctx, b, ix);
+         if constexpr (beve_key_traits<Key>::native) {
+            constexpr uint8_t tag = beve_key_traits<Key>::header;
+            dump_type(ctx, tag, b, ix);
             if (bool(ctx.error)) [[unlikely]] {
                return;
             }
-            serialize<BEVE>::op<Opts>(v, ctx, b, ix);
+
+            dump_compressed_int(ctx, value.size(), b, ix);
             if (bool(ctx.error)) [[unlikely]] {
                return;
+            }
+            for (auto&& [k, v] : value) {
+               serialize<BEVE>::no_header<Opts>(k, ctx, b, ix);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+               serialize<BEVE>::op<Opts>(v, ctx, b, ix);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+            }
+         }
+         else {
+            // Non-native key: a BEVE object header can't carry a struct key, so write a generic array
+            // of [key, value] entries. This matches std::vector<std::tuple<Key, Value>> on the wire.
+            if (!ensure_space(ctx, b, ix + 1 + write_padding_bytes)) [[unlikely]] {
+               return;
+            }
+            dump<tag::generic_array>(b, ix);
+            dump_compressed_int(ctx, value.size(), b, ix);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            for (auto&& entry : value) {
+               serialize<BEVE>::op<Opts>(entry, ctx, b, ix);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
             }
          }
       }
@@ -989,22 +1009,42 @@ namespace glz
       {
          using Key = typename T::first_type;
 
-         constexpr uint8_t tag = beve_key_traits<Key>::header;
-         dump_type(ctx, tag, b, ix);
-         if (bool(ctx.error)) [[unlikely]] {
-            return;
-         }
+         if constexpr (beve_key_traits<Key>::native) {
+            constexpr uint8_t tag = beve_key_traits<Key>::header;
+            dump_type(ctx, tag, b, ix);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
 
-         dump_compressed_int<1>(ctx, b, ix);
-         if (bool(ctx.error)) [[unlikely]] {
-            return;
+            dump_compressed_int<1>(ctx, b, ix);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            const auto& [k, v] = value;
+            serialize<BEVE>::no_header<Opts>(k, ctx, b, ix);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            serialize<BEVE>::op<Opts>(v, ctx, b, ix);
          }
-         const auto& [k, v] = value;
-         serialize<BEVE>::no_header<Opts>(k, ctx, b, ix);
-         if (bool(ctx.error)) [[unlikely]] {
-            return;
+         else {
+            // Non-native key: write the pair as a generic array [key, value], identical to
+            // std::tuple<Key, Value>. Each element carries its own header.
+            if (!ensure_space(ctx, b, ix + 1 + write_padding_bytes)) [[unlikely]] {
+               return;
+            }
+            dump<tag::generic_array>(b, ix);
+            dump_compressed_int<2>(ctx, b, ix);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            const auto& [k, v] = value;
+            serialize<BEVE>::op<Opts>(k, ctx, b, ix);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            serialize<BEVE>::op<Opts>(v, ctx, b, ix);
          }
-         serialize<BEVE>::op<Opts>(v, ctx, b, ix);
       }
    };
 
@@ -1018,39 +1058,75 @@ namespace glz
          using val_t = std::remove_cvref_t<detail::iterator_second_type<T>>;
          constexpr bool may_skip = null_t<val_t> && Opts.skip_null_members;
 
-         constexpr uint8_t tag = beve_key_traits<Key>::header;
-         dump_type(ctx, tag, b, ix);
-         if (bool(ctx.error)) [[unlikely]] {
-            return;
-         }
-
-         size_t count = value.size();
-         if constexpr (may_skip) {
-            count = 0;
-            for (auto&& [k, v] : value) {
-               (void)k;
-               if (!skip_member<Opts>(v)) ++count;
+         if constexpr (beve_key_traits<Key>::native) {
+            constexpr uint8_t tag = beve_key_traits<Key>::header;
+            dump_type(ctx, tag, b, ix);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
             }
-         }
 
-         dump_compressed_int(ctx, count, b, ix);
-         if (bool(ctx.error)) [[unlikely]] {
-            return;
-         }
-         for (auto&& [k, v] : value) {
+            size_t count = value.size();
             if constexpr (may_skip) {
-               if (skip_member<Opts>(v)) continue;
+               count = 0;
+               for (auto&& [k, v] : value) {
+                  (void)k;
+                  if (!skip_member<Opts>(v)) ++count;
+               }
             }
-            serialize<BEVE>::no_header<Opts>(k, ctx, b, ix);
+
+            dump_compressed_int(ctx, count, b, ix);
             if (bool(ctx.error)) [[unlikely]] {
                return;
             }
-            serialize<BEVE>::op<Opts>(v, ctx, b, ix);
+            for (auto&& [k, v] : value) {
+               if constexpr (may_skip) {
+                  if (skip_member<Opts>(v)) continue;
+               }
+               serialize<BEVE>::no_header<Opts>(k, ctx, b, ix);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+               serialize<BEVE>::op<Opts>(v, ctx, b, ix);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+               if constexpr (is_output_streaming<std::remove_cvref_t<B>>) {
+                  flush_buffer(b, ix);
+               }
+            }
+         }
+         else {
+            // Non-native key: write a generic array of [key, value] entries (each entry identical to
+            // std::tuple<Key, Value>), since a BEVE object header can't carry a struct key.
+            if (!ensure_space(ctx, b, ix + 1 + write_padding_bytes)) [[unlikely]] {
+               return;
+            }
+            dump<tag::generic_array>(b, ix);
+
+            size_t count = value.size();
+            if constexpr (may_skip) {
+               count = 0;
+               for (auto&& [k, v] : value) {
+                  (void)k;
+                  if (!skip_member<Opts>(v)) ++count;
+               }
+            }
+
+            dump_compressed_int(ctx, count, b, ix);
             if (bool(ctx.error)) [[unlikely]] {
                return;
             }
-            if constexpr (is_output_streaming<std::remove_cvref_t<B>>) {
-               flush_buffer(b, ix);
+            for (auto&& entry : value) {
+               if constexpr (may_skip) {
+                  if (skip_member<Opts>(entry.second)) continue;
+               }
+               serialize<BEVE>::op<Opts>(entry, ctx, b, ix);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+               if constexpr (is_output_streaming<std::remove_cvref_t<B>>) {
+                  flush_buffer(b, ix);
+               }
             }
          }
       }

--- a/include/glaze/beve/write.hpp
+++ b/include/glaze/beve/write.hpp
@@ -1152,24 +1152,44 @@ namespace glz
          using Element = typename T::value_type;
          using Key = typename Element::first_type;
 
-         constexpr uint8_t tag = beve_key_traits<Key>::header;
-         dump_type(ctx, tag, b, ix);
-         if (bool(ctx.error)) [[unlikely]] {
-            return;
-         }
-
-         dump_compressed_int(ctx, value.size(), b, ix);
-         if (bool(ctx.error)) [[unlikely]] {
-            return;
-         }
-         for (auto&& [k, v] : value) {
-            serialize<BEVE>::no_header<Opts>(k, ctx, b, ix);
+         if constexpr (beve_key_traits<Key>::native) {
+            constexpr uint8_t tag = beve_key_traits<Key>::header;
+            dump_type(ctx, tag, b, ix);
             if (bool(ctx.error)) [[unlikely]] {
                return;
             }
-            serialize<BEVE>::op<Opts>(v, ctx, b, ix);
+
+            dump_compressed_int(ctx, value.size(), b, ix);
             if (bool(ctx.error)) [[unlikely]] {
                return;
+            }
+            for (auto&& [k, v] : value) {
+               serialize<BEVE>::no_header<Opts>(k, ctx, b, ix);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+               serialize<BEVE>::op<Opts>(v, ctx, b, ix);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+            }
+         }
+         else {
+            // Non-native key: a BEVE object header can't carry a struct key, so write a generic array
+            // of [key, value] entries. This matches std::vector<std::tuple<Key, Value>> on the wire.
+            if (!ensure_space(ctx, b, ix + 1 + write_padding_bytes)) [[unlikely]] {
+               return;
+            }
+            dump<tag::generic_array>(b, ix);
+            dump_compressed_int(ctx, value.size(), b, ix);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            for (auto&& entry : value) {
+               serialize<BEVE>::op<Opts>(entry, ctx, b, ix);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
             }
          }
       }
@@ -1183,22 +1203,42 @@ namespace glz
       {
          using Key = typename T::first_type;
 
-         constexpr uint8_t tag = beve_key_traits<Key>::header;
-         dump_type(ctx, tag, b, ix);
-         if (bool(ctx.error)) [[unlikely]] {
-            return;
-         }
+         if constexpr (beve_key_traits<Key>::native) {
+            constexpr uint8_t tag = beve_key_traits<Key>::header;
+            dump_type(ctx, tag, b, ix);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
 
-         dump_compressed_int<1>(ctx, b, ix);
-         if (bool(ctx.error)) [[unlikely]] {
-            return;
+            dump_compressed_int<1>(ctx, b, ix);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            const auto& [k, v] = value;
+            serialize<BEVE>::no_header<Opts>(k, ctx, b, ix);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            serialize<BEVE>::op<Opts>(v, ctx, b, ix);
          }
-         const auto& [k, v] = value;
-         serialize<BEVE>::no_header<Opts>(k, ctx, b, ix);
-         if (bool(ctx.error)) [[unlikely]] {
-            return;
+         else {
+            // Non-native key: write the pair as a generic array [key, value], identical to
+            // std::tuple<Key, Value>. Each element carries its own header.
+            if (!ensure_space(ctx, b, ix + 1 + write_padding_bytes)) [[unlikely]] {
+               return;
+            }
+            dump<tag::generic_array>(b, ix);
+            dump_compressed_int<2>(ctx, b, ix);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            const auto& [k, v] = value;
+            serialize<BEVE>::op<Opts>(k, ctx, b, ix);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            serialize<BEVE>::op<Opts>(v, ctx, b, ix);
          }
-         serialize<BEVE>::op<Opts>(v, ctx, b, ix);
       }
    };
 
@@ -1212,39 +1252,75 @@ namespace glz
          using val_t = std::remove_cvref_t<detail::iterator_second_type<T>>;
          constexpr bool may_skip = null_t<val_t> && Opts.skip_null_members;
 
-         constexpr uint8_t tag = beve_key_traits<Key>::header;
-         dump_type(ctx, tag, b, ix);
-         if (bool(ctx.error)) [[unlikely]] {
-            return;
-         }
-
-         size_t count = value.size();
-         if constexpr (may_skip) {
-            count = 0;
-            for (auto&& [k, v] : value) {
-               (void)k;
-               if (!skip_member<Opts>(v)) ++count;
+         if constexpr (beve_key_traits<Key>::native) {
+            constexpr uint8_t tag = beve_key_traits<Key>::header;
+            dump_type(ctx, tag, b, ix);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
             }
-         }
 
-         dump_compressed_int(ctx, count, b, ix);
-         if (bool(ctx.error)) [[unlikely]] {
-            return;
-         }
-         for (auto&& [k, v] : value) {
+            size_t count = value.size();
             if constexpr (may_skip) {
-               if (skip_member<Opts>(v)) continue;
+               count = 0;
+               for (auto&& [k, v] : value) {
+                  (void)k;
+                  if (!skip_member<Opts>(v)) ++count;
+               }
             }
-            serialize<BEVE>::no_header<Opts>(k, ctx, b, ix);
+
+            dump_compressed_int(ctx, count, b, ix);
             if (bool(ctx.error)) [[unlikely]] {
                return;
             }
-            serialize<BEVE>::op<Opts>(v, ctx, b, ix);
+            for (auto&& [k, v] : value) {
+               if constexpr (may_skip) {
+                  if (skip_member<Opts>(v)) continue;
+               }
+               serialize<BEVE>::no_header<Opts>(k, ctx, b, ix);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+               serialize<BEVE>::op<Opts>(v, ctx, b, ix);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+               if constexpr (is_output_streaming<std::remove_cvref_t<B>>) {
+                  flush_buffer(b, ix);
+               }
+            }
+         }
+         else {
+            // Non-native key: write a generic array of [key, value] entries (each entry identical to
+            // std::tuple<Key, Value>), since a BEVE object header can't carry a struct key.
+            if (!ensure_space(ctx, b, ix + 1 + write_padding_bytes)) [[unlikely]] {
+               return;
+            }
+            dump<tag::generic_array>(b, ix);
+
+            size_t count = value.size();
+            if constexpr (may_skip) {
+               count = 0;
+               for (auto&& [k, v] : value) {
+                  (void)k;
+                  if (!skip_member<Opts>(v)) ++count;
+               }
+            }
+
+            dump_compressed_int(ctx, count, b, ix);
             if (bool(ctx.error)) [[unlikely]] {
                return;
             }
-            if constexpr (is_output_streaming<std::remove_cvref_t<B>>) {
-               flush_buffer(b, ix);
+            for (auto&& entry : value) {
+               if constexpr (may_skip) {
+                  if (skip_member<Opts>(entry.second)) continue;
+               }
+               serialize<BEVE>::op<Opts>(entry, ctx, b, ix);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+               if constexpr (is_output_streaming<std::remove_cvref_t<B>>) {
+                  flush_buffer(b, ix);
+               }
             }
          }
       }

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -77,6 +77,35 @@ struct std::hash<CastModuleID>
    size_t operator()(const CastModuleID& id) const noexcept { return std::hash<uint64_t>{}(id.value); }
 };
 
+// A multi-field key that reduces to neither a numeric nor a string type. A BEVE object header encodes
+// a single shared key type, so this key can't use the compact map encoding; the serializers fall back
+// to a generic array of [key, value] entries instead. See issue #2666.
+struct CompositeKey
+{
+   int32_t id{};
+   std::string name{};
+
+   auto operator<=>(const CompositeKey&) const = default;
+};
+
+// An explicit entry struct, equivalent on the wire to the [key, value] fallback above.
+struct CompositeEntry
+{
+   CompositeKey key{};
+   int value{};
+
+   auto operator<=>(const CompositeEntry&) const = default;
+};
+
+template <>
+struct std::hash<CompositeKey>
+{
+   size_t operator()(const CompositeKey& k) const noexcept
+   {
+      return std::hash<int32_t>{}(k.id) ^ (std::hash<std::string>{}(k.name) << 1);
+   }
+};
+
 namespace
 {
    template <class ID>
@@ -2712,6 +2741,111 @@ suite beve_custom_key_tests = [] {
    "vector pair CastModuleID"_test = [] { verify_vector_pair_roundtrip<CastModuleID>(); };
 };
 
+// A BEVE object header encodes a single shared key type. Native (numeric/string-like) keys use the
+// compact map encoding; non-native keys (e.g. multi-field structs) fall back to a generic array of
+// [key, value] entries so they still round-trip. See issue #2666.
+suite beve_key_classification_tests = [] {
+   // Native keys reduce to a numeric or string type.
+   static_assert(glz::beve_key_traits<int>::native);
+   static_assert(glz::beve_key_traits<uint64_t>::native);
+   static_assert(glz::beve_key_traits<char>::native);
+   static_assert(glz::beve_key_traits<std::string>::native);
+   static_assert(glz::beve_key_traits<std::string_view>::native);
+   static_assert(glz::beve_key_traits<ModuleID>::native); // wraps a uint64_t via glz::meta
+   static_assert(glz::beve_key_traits<CastModuleID>::native);
+
+   // Multi-field structs are not native; they use the generic-array fallback rather than a map header.
+   static_assert(not glz::beve_key_traits<CompositeKey>::native);
+
+   // The exact case from issue #2666: a std::unordered_map keyed by a multi-field struct now serializes.
+   "unordered_map with struct key"_test = [] {
+      const std::unordered_map<CompositeKey, int> src{{{1, "a"}, 10}, {{2, "b"}, 20}, {{3, "c"}, 30}};
+
+      std::string buffer{};
+      expect(not glz::write_beve(src, buffer));
+      std::unordered_map<CompositeKey, int> dst{};
+      expect(!glz::read_beve(dst, buffer));
+      expect(dst == src);
+   };
+
+   "map with struct key"_test = [] {
+      const std::map<CompositeKey, int> src{{{1, "a"}, 10}, {{2, "b"}, 20}, {{3, "c"}, 30}};
+
+      std::string buffer{};
+      expect(not glz::write_beve(src, buffer));
+      std::map<CompositeKey, int> dst{};
+      expect(!glz::read_beve(dst, buffer));
+      expect(dst == src);
+
+      std::string untagged{};
+      expect(not glz::write_beve_untagged(src, untagged));
+      std::map<CompositeKey, int> dst2{};
+      expect(!glz::read_beve_untagged(dst2, untagged));
+      expect(dst2 == src);
+   };
+
+   "vector of pairs with struct key"_test = [] {
+      const std::vector<std::pair<CompositeKey, int>> src{{{1, "a"}, 10}, {{2, "b"}, 20}, {{3, "c"}, 30}};
+
+      std::string buffer{};
+      expect(not glz::write_beve(src, buffer));
+      std::vector<std::pair<CompositeKey, int>> dst{};
+      expect(!glz::read_beve(dst, buffer));
+      expect(dst == src);
+   };
+
+   "standalone pair with struct key"_test = [] {
+      const std::pair<CompositeKey, int> src{{9, "i"}, 42};
+
+      std::string buffer{};
+      expect(not glz::write_beve(src, buffer));
+      std::pair<CompositeKey, int> dst{};
+      expect(!glz::read_beve(dst, buffer));
+      expect(dst == src);
+   };
+
+   // The fallback encodes each entry exactly like std::tuple<Key, Value>: a non-native pair and the
+   // corresponding tuple must produce identical bytes.
+   "pair fallback matches tuple bytes"_test = [] {
+      const std::pair<CompositeKey, int> p{{9, "i"}, 42};
+      const std::tuple<CompositeKey, int> t{{9, "i"}, 42};
+
+      std::string pair_buffer{};
+      std::string tuple_buffer{};
+      expect(not glz::write_beve(p, pair_buffer));
+      expect(not glz::write_beve(t, tuple_buffer));
+      expect(pair_buffer == tuple_buffer);
+   };
+
+   // An explicit entry struct still works and is equivalent to the [key, value] fallback.
+   "vector of explicit entries"_test = [] {
+      const std::vector<CompositeEntry> src{{{1, "a"}, 10}, {{2, "b"}, 20}, {{3, "c"}, 30}};
+
+      std::string buffer{};
+      expect(not glz::write_beve(src, buffer));
+      std::vector<CompositeEntry> dst{};
+      expect(!glz::read_beve(dst, buffer));
+      expect(dst == src);
+
+      std::string untagged{};
+      expect(not glz::write_beve_untagged(src, untagged));
+      std::vector<CompositeEntry> dst2{};
+      expect(!glz::read_beve_untagged(dst2, untagged));
+      expect(dst2 == src);
+   };
+
+   // std::tuple already round-trips a non-native first element.
+   "tuple with struct first element"_test = [] {
+      const std::tuple<CompositeKey, int> src{{9, "i"}, 42};
+
+      std::string buffer{};
+      expect(not glz::write_beve(src, buffer));
+      std::tuple<CompositeKey, int> dst{};
+      expect(!glz::read_beve(dst, buffer));
+      expect(dst == src);
+   };
+};
+
 suite beve_to_json_tests = [] {
    "beve_to_json bool"_test = [] {
       bool b = true;
@@ -4903,6 +5037,29 @@ suite dos_prevention = [] {
       std::map<std::string, int> result;
       auto ec = glz::read_beve(result, truncated);
       expect(bool(ec)) << "Should fail on truncated map";
+   };
+
+   "vector-of-pairs with huge key count protection"_test = [] {
+      // std::vector<std::pair<...>> shares the concatenated-map encoding, but is read by a separate
+      // path than std::map. A buffer claiming a huge element count must be rejected before allocating.
+      std::vector<std::pair<std::string, int>> sample = {{"one", 1}, {"two", 2}};
+      std::string valid_buffer;
+      expect(not glz::write_beve(sample, valid_buffer));
+
+      // Reuse the object-header byte, then claim ~2^40 entries with no element data following. The
+      // count stays below the compressed-int safety limit (2^48) so it reaches the per-element bound.
+      std::string malicious;
+      malicious.push_back(valid_buffer.at(0)); // object header for a string-keyed map
+      const uint64_t huge_count = uint64_t(1) << 40;
+      const uint64_t encoded = (huge_count << 2) | 0b11; // 8-byte compressed int (config 3)
+      for (int i = 0; i < 8; ++i) {
+         malicious.push_back(char(uint8_t(encoded >> (8 * i))));
+      }
+
+      std::vector<std::pair<std::string, int>> result;
+      auto ec = glz::read_beve(result, malicious);
+      expect(bool(ec)) << "Should reject huge vector-of-pairs count, not allocate";
+      expect(result.empty());
    };
 };
 

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -80,6 +80,35 @@ struct std::hash<CastModuleID>
    size_t operator()(const CastModuleID& id) const noexcept { return std::hash<uint64_t>{}(id.value); }
 };
 
+// A multi-field key that reduces to neither a numeric nor a string type. A BEVE object header encodes
+// a single shared key type, so this key can't use the compact map encoding; the serializers fall back
+// to a generic array of [key, value] entries instead. See issue #2666.
+struct CompositeKey
+{
+   int32_t id{};
+   std::string name{};
+
+   auto operator<=>(const CompositeKey&) const = default;
+};
+
+// An explicit entry struct, equivalent on the wire to the [key, value] fallback above.
+struct CompositeEntry
+{
+   CompositeKey key{};
+   int value{};
+
+   auto operator<=>(const CompositeEntry&) const = default;
+};
+
+template <>
+struct std::hash<CompositeKey>
+{
+   size_t operator()(const CompositeKey& k) const noexcept
+   {
+      return std::hash<int32_t>{}(k.id) ^ (std::hash<std::string>{}(k.name) << 1);
+   }
+};
+
 namespace
 {
    template <class ID>
@@ -2806,6 +2835,111 @@ suite beve_custom_key_tests = [] {
 struct beve_escape_opts : glz::opts
 {
    bool escape_control_characters = true;
+};
+
+// A BEVE object header encodes a single shared key type. Native (numeric/string-like) keys use the
+// compact map encoding; non-native keys (e.g. multi-field structs) fall back to a generic array of
+// [key, value] entries so they still round-trip. See issue #2666.
+suite beve_key_classification_tests = [] {
+   // Native keys reduce to a numeric or string type.
+   static_assert(glz::beve_key_traits<int>::native);
+   static_assert(glz::beve_key_traits<uint64_t>::native);
+   static_assert(glz::beve_key_traits<char>::native);
+   static_assert(glz::beve_key_traits<std::string>::native);
+   static_assert(glz::beve_key_traits<std::string_view>::native);
+   static_assert(glz::beve_key_traits<ModuleID>::native); // wraps a uint64_t via glz::meta
+   static_assert(glz::beve_key_traits<CastModuleID>::native);
+
+   // Multi-field structs are not native; they use the generic-array fallback rather than a map header.
+   static_assert(not glz::beve_key_traits<CompositeKey>::native);
+
+   // The exact case from issue #2666: a std::unordered_map keyed by a multi-field struct now serializes.
+   "unordered_map with struct key"_test = [] {
+      const std::unordered_map<CompositeKey, int> src{{{1, "a"}, 10}, {{2, "b"}, 20}, {{3, "c"}, 30}};
+
+      std::string buffer{};
+      expect(not glz::write_beve(src, buffer));
+      std::unordered_map<CompositeKey, int> dst{};
+      expect(!glz::read_beve(dst, buffer));
+      expect(dst == src);
+   };
+
+   "map with struct key"_test = [] {
+      const std::map<CompositeKey, int> src{{{1, "a"}, 10}, {{2, "b"}, 20}, {{3, "c"}, 30}};
+
+      std::string buffer{};
+      expect(not glz::write_beve(src, buffer));
+      std::map<CompositeKey, int> dst{};
+      expect(!glz::read_beve(dst, buffer));
+      expect(dst == src);
+
+      std::string untagged{};
+      expect(not glz::write_beve_untagged(src, untagged));
+      std::map<CompositeKey, int> dst2{};
+      expect(!glz::read_beve_untagged(dst2, untagged));
+      expect(dst2 == src);
+   };
+
+   "vector of pairs with struct key"_test = [] {
+      const std::vector<std::pair<CompositeKey, int>> src{{{1, "a"}, 10}, {{2, "b"}, 20}, {{3, "c"}, 30}};
+
+      std::string buffer{};
+      expect(not glz::write_beve(src, buffer));
+      std::vector<std::pair<CompositeKey, int>> dst{};
+      expect(!glz::read_beve(dst, buffer));
+      expect(dst == src);
+   };
+
+   "standalone pair with struct key"_test = [] {
+      const std::pair<CompositeKey, int> src{{9, "i"}, 42};
+
+      std::string buffer{};
+      expect(not glz::write_beve(src, buffer));
+      std::pair<CompositeKey, int> dst{};
+      expect(!glz::read_beve(dst, buffer));
+      expect(dst == src);
+   };
+
+   // The fallback encodes each entry exactly like std::tuple<Key, Value>: a non-native pair and the
+   // corresponding tuple must produce identical bytes.
+   "pair fallback matches tuple bytes"_test = [] {
+      const std::pair<CompositeKey, int> p{{9, "i"}, 42};
+      const std::tuple<CompositeKey, int> t{{9, "i"}, 42};
+
+      std::string pair_buffer{};
+      std::string tuple_buffer{};
+      expect(not glz::write_beve(p, pair_buffer));
+      expect(not glz::write_beve(t, tuple_buffer));
+      expect(pair_buffer == tuple_buffer);
+   };
+
+   // An explicit entry struct still works and is equivalent to the [key, value] fallback.
+   "vector of explicit entries"_test = [] {
+      const std::vector<CompositeEntry> src{{{1, "a"}, 10}, {{2, "b"}, 20}, {{3, "c"}, 30}};
+
+      std::string buffer{};
+      expect(not glz::write_beve(src, buffer));
+      std::vector<CompositeEntry> dst{};
+      expect(!glz::read_beve(dst, buffer));
+      expect(dst == src);
+
+      std::string untagged{};
+      expect(not glz::write_beve_untagged(src, untagged));
+      std::vector<CompositeEntry> dst2{};
+      expect(!glz::read_beve_untagged(dst2, untagged));
+      expect(dst2 == src);
+   };
+
+   // std::tuple already round-trips a non-native first element.
+   "tuple with struct first element"_test = [] {
+      const std::tuple<CompositeKey, int> src{{9, "i"}, 42};
+
+      std::string buffer{};
+      expect(not glz::write_beve(src, buffer));
+      std::tuple<CompositeKey, int> dst{};
+      expect(!glz::read_beve(dst, buffer));
+      expect(dst == src);
+   };
 };
 
 suite beve_to_json_tests = [] {
@@ -6439,6 +6573,29 @@ suite dos_prevention = [] {
       std::map<std::string, int> result;
       auto ec = glz::read_beve(result, truncated);
       expect(bool(ec)) << "Should fail on truncated map";
+   };
+
+   "vector-of-pairs with huge key count protection"_test = [] {
+      // std::vector<std::pair<...>> shares the concatenated-map encoding, but is read by a separate
+      // path than std::map. A buffer claiming a huge element count must be rejected before allocating.
+      std::vector<std::pair<std::string, int>> sample = {{"one", 1}, {"two", 2}};
+      std::string valid_buffer;
+      expect(not glz::write_beve(sample, valid_buffer));
+
+      // Reuse the object-header byte, then claim ~2^40 entries with no element data following. The
+      // count stays below the compressed-int safety limit (2^48) so it reaches the per-element bound.
+      std::string malicious;
+      malicious.push_back(valid_buffer.at(0)); // object header for a string-keyed map
+      const uint64_t huge_count = uint64_t(1) << 40;
+      const uint64_t encoded = (huge_count << 2) | 0b11; // 8-byte compressed int (config 3)
+      for (int i = 0; i < 8; ++i) {
+         malicious.push_back(char(uint8_t(encoded >> (8 * i))));
+      }
+
+      std::vector<std::pair<std::string, int>> result;
+      auto ec = glz::read_beve(result, malicious);
+      expect(bool(ec)) << "Should reject huge vector-of-pairs count, not allocate";
+      expect(result.empty());
    };
 };
 


### PR DESCRIPTION
## Summary

A BEVE object (map) header encodes a single shared key type, so only numeric or string-like keys fit the compact map encoding. Keys that reduce to neither (e.g. a multi-field struct, as in `std::unordered_map<user_defined_key, int>`) previously failed deep inside the serializers with a cryptic template error.

Rather than requiring users to restructure such keys by hand, the map/pair serializers now **fall back to a generic array of `[key, value]` entries** when the key isn't native. Each key is written as a full BEVE value, so the container round-trips with no code changes. Each entry is encoded identically to `std::tuple<Key, Value>` (a non-native `std::pair` and the matching `std::tuple` produce the same bytes). Native (numeric/string) keys are unaffected and keep the compact shared-header encoding.

Covers `std::map`, `std::unordered_map`, `std::vector<std::pair<Key, Value>>`, and a standalone `std::pair<Key, Value>`. Documented in `docs/binary.md`.

## Hardening

Bound the element count against the remaining buffer before allocating, on both the native vector-of-pairs reader and the new entry-array readers, mirroring the guard the `std::map` reader already has. Previously a hostile count drove unbounded `emplace_back` (OOM/DoS).

## Testing

- `beve_test` builds clean under `-Wall -Wextra -pedantic` with ASan + UBSan.
- 389 tests / 9665 asserts pass.
- New round-trip tests: the issue's `std::unordered_map<CompositeKey, int>` case, `std::map`, `std::vector<std::pair>`, a standalone `std::pair`, an explicit entry struct, `std::tuple`, and a `pair == tuple` byte-identity check.
- DoS-protection test for the vector-of-pairs reader (passes under a 4 GB memory cap).

Closes #2666.