### PR TITLE
fix out-of-bounds read in jmespath negative-step slice

### DIFF
--- a/include/glaze/json/jmespath.hpp
+++ b/include/glaze/json/jmespath.hpp
@@ -631,21 +631,26 @@ namespace glz
                   value.clear();
                }
             }
-            else {
-               // For steps != 1 (or negative steps), the fallback path was already chosen.
-               // Just apply the same logic as before.
+            else if (step_idx > 0) {
+               // Positive step compacts in place: the write index never overtakes the
+               // read index, so every read stays within the live range.
                std::size_t dest = 0;
-               if (step_idx > 0) {
-                  for (int32_t i = start_idx; i < end_idx; i += step_idx) {
-                     value[dest++] = std::move(value[i]);
-                  }
-               }
-               else {
-                  for (int32_t i = start_idx; i > end_idx; i += step_idx) {
-                     value[dest++] = std::move(value[i]);
-                  }
+               for (int32_t i = start_idx; i < end_idx; i += step_idx) {
+                  value[dest++] = std::move(value[i]);
                }
                value.resize(dest);
+            }
+            else {
+               // A negative step reads in reverse, so compacting in place would
+               // overwrite elements before they are read. wrap_index also clamps start
+               // to [0, size], and a start at or past the end would index one past the
+               // buffer on the first read. Build the slice in a separate buffer, taking
+               // the last element as the highest readable index.
+               std::decay_t<T> result;
+               for (int32_t i = (std::min)(start_idx, size - 1); i > end_idx; i += step_idx) {
+                  result.emplace_back(std::move(value[i]));
+               }
+               value = std::move(result);
             }
 
             return;

--- a/tests/jmespath/jmespath.cpp
+++ b/tests/jmespath/jmespath.cpp
@@ -165,6 +165,37 @@ suite jmespath_slice_tests = [] {
       expect(slice[4] == 4);
    };
 
+   "slice negative step start past end"_test = [] {
+      // [start:end:-1] with start >= size clamped the start index to size and read
+      // value[size] (one past the end) on the first move. The reversed read also
+      // aliased the in-place compaction, so even an in-bounds start returned garbage.
+      std::vector<int> data{1, 2, 3, 4, 5};
+      std::string buffer{};
+      expect(not glz::write_json(data, buffer));
+
+      std::vector<int> slice{};
+      glz::jmespath_expression expr{"[10:0:-1]"};
+      expect(not glz::read_jmespath(expr, slice, buffer));
+      expect(slice == (std::vector<int>{5, 4, 3, 2}));
+
+      std::vector<int> slice_ct{};
+      expect(not glz::read_jmespath<"[4:0:-1]">(slice_ct, buffer));
+      expect(slice_ct == (std::vector<int>{5, 4, 3, 2}));
+
+      std::vector<int> slice_step{};
+      expect(not glz::read_jmespath<"[5:0:-2]">(slice_step, buffer));
+      expect(slice_step == (std::vector<int>{5, 3}));
+
+      // Start past the end of a shorter array (the heap-buffer-overflow case).
+      std::vector<int> small{1, 2, 3};
+      std::string small_buf{};
+      expect(not glz::write_json(small, small_buf));
+      std::vector<int> slice_small{};
+      glz::jmespath_expression expr_small{"[5:0:-1]"};
+      expect(not glz::read_jmespath(expr_small, slice_small, small_buf));
+      expect(slice_small == (std::vector<int>{3, 2}));
+   };
+
    "slice compile-time multi-bracket"_test = [] {
       std::vector<std::vector<int>> data{{1, 2}, {3, 4, 5}, {6, 7}};
       std::string buffer{};


### PR DESCRIPTION
handle_slice's read-all fallback clamps the slice with wrap_index, which returns a value in [0, size]. For a negative step the loop starts at value[start_idx] and walks down, so a start index at or past the array length (`[5:0:-1]` on a 3-element array) reads `value[size]`, one byte-region past the end. That same loop compacts in place while reading in reverse, so the ascending write index also clobbers elements the descending read has not reached, and `[4:0:-1]` over `[1,2,3,4,5]` returned `[5,4,3,4]` instead of `[5,4,3,2]`.

Positive steps keep the in-place compaction since the write index never overtakes the read index. The negative step now builds the slice in a separate buffer and starts no later than the last element, which drops both the over-read and the aliasing at the cost of one temporary allocation. Behavior matches the usual `[start:stop:-1]` slice (`[10:0:-1]` over five elements gives `[5,4,3,2]`).