### PR TITLE
Fix jmespath negative single index and negative-step slice bounds

### DIFF
--- a/include/glaze/json/jmespath.hpp
+++ b/include/glaze/json/jmespath.hpp
@@ -844,6 +844,11 @@ namespace glz
             static constexpr auto decomposed_key = jmespath::parse_jmespath_token(tokens[I]);
             static constexpr auto key = decomposed_key.key;
 
+            // A malformed token (e.g. an index/bound literal that overflows int32, or an
+            // invalid slice) is rejected at compile time, matching tokenize_as_array which
+            // already fails to compile on tokenization errors.
+            static_assert(not decomposed_key.error, "invalid JMESPath expression");
+
             if constexpr (decomposed_key.is_array_access) {
                // If we have a key, that means we're looking into an object like: key[0:5]
                if constexpr (key.empty()) {
@@ -1095,6 +1100,13 @@ namespace glz
             [&] {
                const auto decomposed_key = jmespath::parse_jmespath_token(tokens[I]);
                const auto& key = decomposed_key.key;
+
+               // A malformed token (e.g. an index/bound literal that overflows int32, or an
+               // invalid slice) must error rather than silently fall back to default bounds.
+               if (decomposed_key.error) {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
 
                if (decomposed_key.is_array_access) {
                   if (key.empty()) {

--- a/include/glaze/json/jmespath.hpp
+++ b/include/glaze/json/jmespath.hpp
@@ -393,7 +393,13 @@ namespace glz
                   result.error = true;
                }
                else {
+                  // A step of 0 is invalid. Preserve the value (rather than discarding it) so the
+                  // step==0 guard in handle_slice rejects it even though the read paths do not yet
+                  // consult `error`, and also flag the token as malformed for callers that do.
                   result.step = val;
+                  if (*val == 0) {
+                     result.error = true;
+                  }
                }
             }
          };
@@ -548,6 +554,70 @@ namespace glz
          ++it; // consume ']'
       }
 
+      // Advances `it` to the first character of array element `n`, resolving a negative index
+      // against the array length per JMESPath (e.g. [-1] is the last element). On entry `it`
+      // must point at the first element (just past '['), or at ']' for an empty array. On
+      // success `it` is positioned at element `n`; otherwise ctx.error is set.
+      template <auto Opts = opts{}>
+      inline void seek_array_index(int32_t n, context& ctx, auto&& it, auto end)
+      {
+         const auto at_end = [&]() -> bool {
+            if constexpr (not Opts.null_terminated) {
+               if (it == end) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return true;
+               }
+            }
+            return false;
+         };
+
+         if (n < 0) {
+            // A negative index counts from the back, so the length must be known first. Scan the
+            // array to count elements, then rewind and fall through to the forward skip below.
+            if (skip_ws<Opts>(ctx, it, end)) return;
+            auto* const array_start = it;
+            int32_t count = 0;
+            if (at_end()) return;
+            if (*it != ']') {
+               while (true) {
+                  skip_value<JSON>::op<Opts>(ctx, it, end);
+                  if (bool(ctx.error)) [[unlikely]]
+                     return;
+                  ++count;
+                  if (skip_ws<Opts>(ctx, it, end)) return;
+                  if (at_end()) return;
+                  if (*it == ']') break;
+                  if (*it != ',') {
+                     ctx.error = error_code::array_element_not_found;
+                     return;
+                  }
+                  ++it;
+                  if (skip_ws<Opts>(ctx, it, end)) return;
+               }
+            }
+            it = array_start;
+            n += count;
+            if (n < 0) {
+               ctx.error = error_code::array_element_not_found;
+               return;
+            }
+         }
+
+         for (int32_t i = 0; i < n; ++i) {
+            skip_value<JSON>::op<Opts>(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
+            if (skip_ws<Opts>(ctx, it, end)) return;
+            if (at_end()) return;
+            if (*it != ',') {
+               ctx.error = error_code::array_element_not_found;
+               return;
+            }
+            ++it;
+            if (skip_ws<Opts>(ctx, it, end)) return;
+         }
+      }
+
       template <auto Opts = opts{}, class T>
          requires(Opts.format == JSON && readable_array_t<T>)
       inline void handle_slice(const jmespath::ArrayParseResult& decomposed_key, T&& value, context& ctx, auto&& it,
@@ -572,6 +642,13 @@ namespace glz
          // Determine slice parameters
          int32_t step_idx = decomposed_key.step.value_or(1);
          bool has_negative_index = (decomposed_key.start.value_or(0) < 0) || (decomposed_key.end.value_or(0) < 0);
+
+         // A step of 0 is not a valid slice; without this guard the loops below would never
+         // terminate (the index never advances).
+         if (step_idx == 0) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return;
+         }
 
          // If we have negative indices or step != 1, fall back to the original method (read all then slice)
          if (step_idx != 1 || has_negative_index) {
@@ -610,13 +687,23 @@ namespace glz
 
             // Now do the slicing
             const int32_t size = static_cast<int32_t>(value.size());
+            const bool negative_step = step_idx < 0;
+
+            // Resolve a (possibly negative) bound to a concrete index following Python/JMESPath
+            // slice semantics. The valid range depends on direction: a forward step walks
+            // [0, size]; a negative step walks the range [size-1, -1], where the -1 sentinel
+            // means "past the front, include index 0".
+            const int32_t lower = negative_step ? -1 : 0;
+            const int32_t upper = negative_step ? size - 1 : size;
             auto wrap_index = [&](int32_t idx) {
                if (idx < 0) idx += size;
-               return std::clamp(idx, int32_t{0}, size);
+               return std::clamp(idx, lower, upper);
             };
 
-            const int32_t start_idx = wrap_index(decomposed_key.start.value_or(0));
-            const int32_t end_idx = wrap_index(decomposed_key.end.value_or(size));
+            // An omitted bound defaults to the start/end of the iteration range for the
+            // chosen direction (e.g. "[::-1]" reverses the whole array).
+            const int32_t start_idx = decomposed_key.start.has_value() ? wrap_index(*decomposed_key.start) : (negative_step ? upper : lower);
+            const int32_t end_idx = decomposed_key.end.has_value() ? wrap_index(*decomposed_key.end) : (negative_step ? lower : upper);
 
             if (step_idx == 1) {
                if (start_idx < end_idx) {
@@ -641,13 +728,12 @@ namespace glz
                value.resize(dest);
             }
             else {
-               // A negative step reads in reverse, so compacting in place would
-               // overwrite elements before they are read. wrap_index also clamps start
-               // to [0, size], and a start at or past the end would index one past the
-               // buffer on the first read. Build the slice in a separate buffer, taking
-               // the last element as the highest readable index.
+               // A negative step reads in reverse, so compacting in place would overwrite
+               // elements before they are read. Build the slice in a separate buffer instead.
+               // wrap_index already clamps start_idx to at most size-1 and end_idx to at
+               // least -1, so every read below stays within [0, size).
                std::decay_t<T> result;
-               for (int32_t i = (std::min)(start_idx, size - 1); i > end_idx; i += step_idx) {
+               for (int32_t i = start_idx; i > end_idx; i += step_idx) {
                   result.emplace_back(std::move(value[i]));
                }
                value = std::move(result);
@@ -778,49 +864,15 @@ namespace glz
                      if constexpr (decomposed_key.start.has_value()) {
                         constexpr auto n = decomposed_key.start.value();
 
+                        // Position `it` at element n (negative indices count from the back).
+                        detail::seek_array_index<Opts>(int32_t(n), ctx, it, end);
+                        if (bool(ctx.error)) [[unlikely]]
+                           return;
+
+                        // For the final token read the element into value; otherwise leave `it`
+                        // positioned so the next token can continue indexing into it.
                         if constexpr (I == (N - 1)) {
-                           // Skip until we reach the target element n
-                           for (int32_t i = 0; i < n; ++i) {
-                              skip_value<JSON>::op<Opts>(ctx, it, end);
-                              if (bool(ctx.error)) [[unlikely]]
-                                 return;
-
-                              if (skip_ws<Opts>(ctx, it, end)) {
-                                 return;
-                              }
-                              if (*it != ',') {
-                                 ctx.error = error_code::array_element_not_found;
-                                 return;
-                              }
-                              ++it;
-                              if (skip_ws<Opts>(ctx, it, end)) {
-                                 return;
-                              }
-                           }
-
-                           // Now read the element at index n
                            parse<Opts.format>::template op<Opts>(value, ctx, it, end);
-                        }
-                        else {
-                           // Not the last token. We must still parse the element at index n so the next indexing can
-                           // proceed.
-                           for (int32_t i = 0; i < n; ++i) {
-                              skip_value<JSON>::op<Opts>(ctx, it, end);
-                              if (bool(ctx.error)) [[unlikely]]
-                                 return;
-
-                              if (skip_ws<Opts>(ctx, it, end)) {
-                                 return;
-                              }
-                              if (*it != ',') {
-                                 ctx.error = error_code::array_element_not_found;
-                                 return;
-                              }
-                              ++it;
-                              if (skip_ws<Opts>(ctx, it, end)) {
-                                 return;
-                              }
-                           }
                         }
                      }
                      else {
@@ -874,25 +926,12 @@ namespace glz
                         else {
                            // SINGLE INDEX SCENARIO (colon_count == 0)
                            if constexpr (decomposed_key.start.has_value()) {
-                              // Skip until we reach the target element
                               constexpr auto n = decomposed_key.start.value();
-                              for (int32_t i = 0; i < n; ++i) {
-                                 skip_value<JSON>::op<Opts>(ctx, it, end);
-                                 if (bool(ctx.error)) [[unlikely]]
-                                    return;
 
-                                 if (skip_ws<Opts>(ctx, it, end)) {
-                                    return;
-                                 }
-                                 if (*it != ',') {
-                                    ctx.error = error_code::array_element_not_found;
-                                    return;
-                                 }
-                                 ++it;
-                                 if (skip_ws<Opts>(ctx, it, end)) {
-                                    return;
-                                 }
-                              }
+                              // Position `it` at element n (negative indices count from the back).
+                              detail::seek_array_index<Opts>(int32_t(n), ctx, it, end);
+                              if (bool(ctx.error)) [[unlikely]]
+                                 return;
 
                               if (skip_ws<Opts>(ctx, it, end)) {
                                  return;
@@ -1077,49 +1116,15 @@ namespace glz
                         if (decomposed_key.start.has_value()) {
                            const int32_t n = decomposed_key.start.value();
 
+                           // Position `it` at element n (negative indices count from the back).
+                           detail::seek_array_index<Opts>(n, ctx, it, end);
+                           if (bool(ctx.error)) [[unlikely]]
+                              return;
+
+                           // For the final token read the element into value; otherwise leave `it`
+                           // positioned so the next token can continue indexing into it.
                            if (I == (N - 1)) {
-                              // Skip until we reach the target element n
-                              for (int32_t i = 0; i < n; ++i) {
-                                 skip_value<JSON>::op<Opts>(ctx, it, end);
-                                 if (bool(ctx.error)) [[unlikely]]
-                                    return;
-
-                                 if (skip_ws<Opts>(ctx, it, end)) {
-                                    return;
-                                 }
-                                 if (*it != ',') {
-                                    ctx.error = error_code::array_element_not_found;
-                                    return;
-                                 }
-                                 ++it;
-                                 if (skip_ws<Opts>(ctx, it, end)) {
-                                    return;
-                                 }
-                              }
-
-                              // Now read the element at index n
                               parse<Opts.format>::template op<Opts>(value, ctx, it, end);
-                           }
-                           else {
-                              // Not the last token. We must still parse the element at index n so the next indexing can
-                              // proceed.
-                              for (int32_t i = 0; i < n; ++i) {
-                                 skip_value<JSON>::op<Opts>(ctx, it, end);
-                                 if (bool(ctx.error)) [[unlikely]]
-                                    return;
-
-                                 if (skip_ws<Opts>(ctx, it, end)) {
-                                    return;
-                                 }
-                                 if (*it != ',') {
-                                    ctx.error = error_code::array_element_not_found;
-                                    return;
-                                 }
-                                 ++it;
-                                 if (skip_ws<Opts>(ctx, it, end)) {
-                                    return;
-                                 }
-                              }
                            }
                         }
                         else {
@@ -1172,24 +1177,12 @@ namespace glz
                            else {
                               // Single index scenario
                               if (decomposed_key.start.has_value()) {
-                                 int32_t n = decomposed_key.start.value();
-                                 for (int32_t i = 0; i < n; ++i) {
-                                    skip_value<JSON>::op<Opts>(ctx, it, end);
-                                    if (bool(ctx.error)) [[unlikely]]
-                                       return;
+                                 const int32_t n = decomposed_key.start.value();
 
-                                    if (skip_ws<Opts>(ctx, it, end)) {
-                                       return;
-                                    }
-                                    if (*it != ',') {
-                                       ctx.error = error_code::array_element_not_found;
-                                       return;
-                                    }
-                                    ++it;
-                                    if (skip_ws<Opts>(ctx, it, end)) {
-                                       return;
-                                    }
-                                 }
+                                 // Position `it` at element n (negative indices count from the back).
+                                 detail::seek_array_index<Opts>(n, ctx, it, end);
+                                 if (bool(ctx.error)) [[unlikely]]
+                                    return;
 
                                  if (skip_ws<Opts>(ctx, it, end)) {
                                     return;

--- a/tests/jmespath/jmespath.cpp
+++ b/tests/jmespath/jmespath.cpp
@@ -269,6 +269,22 @@ suite jmespath_negative_slice_tests = [] {
       expect(glz::read_jmespath(glz::jmespath_expression{"[3:1:0]"}, out, buffer));
       expect(glz::read_jmespath(glz::jmespath_expression{"[::0]"}, out, buffer));
    };
+
+   "slice out-of-range literal is rejected"_test = [] {
+      // A bound/step/index literal that overflows int32 is malformed; it must error rather than
+      // silently fall back to default bounds (which previously returned the whole array).
+      std::vector<int> data{1, 2, 3, 4, 5};
+      std::string buffer{};
+      expect(not glz::write_json(data, buffer));
+
+      std::vector<int> out{};
+      expect(glz::read_jmespath(glz::jmespath_expression{"[::9999999999]"}, out, buffer));
+      expect(glz::read_jmespath(glz::jmespath_expression{"[9999999999:0:-1]"}, out, buffer));
+      expect(glz::read_jmespath(glz::jmespath_expression{"[0:9999999999]"}, out, buffer));
+
+      int v{};
+      expect(glz::read_jmespath(glz::jmespath_expression{"[9999999999]"}, v, buffer));
+   };
 };
 
 suite jmespath_negative_index_tests = [] {

--- a/tests/jmespath/jmespath.cpp
+++ b/tests/jmespath/jmespath.cpp
@@ -217,6 +217,116 @@ suite jmespath_slice_tests = [] {
    };
 };
 
+suite jmespath_negative_slice_tests = [] {
+   "slice omitted-end negative step reverses"_test = [] {
+      // With an omitted end and a negative step the slice descends to and includes index 0,
+      // so "[::-1]" reverses the whole array (previously it returned empty).
+      std::vector<int> data{1, 2, 3, 4, 5};
+      std::string buffer{};
+      expect(not glz::write_json(data, buffer));
+
+      std::vector<int> rev{};
+      expect(not glz::read_jmespath(glz::jmespath_expression{"[::-1]"}, rev, buffer));
+      expect(rev == (std::vector<int>{5, 4, 3, 2, 1}));
+
+      std::vector<int> rev_ct{};
+      expect(not glz::read_jmespath<"[::-1]">(rev_ct, buffer));
+      expect(rev_ct == (std::vector<int>{5, 4, 3, 2, 1}));
+
+      std::vector<int> from2{};
+      expect(not glz::read_jmespath<"[2::-1]">(from2, buffer));
+      expect(from2 == (std::vector<int>{3, 2, 1}));
+
+      std::vector<int> step2{};
+      expect(not glz::read_jmespath<"[4::-2]">(step2, buffer));
+      expect(step2 == (std::vector<int>{5, 3, 1}));
+   };
+
+   "slice negative end wraps to include index 0"_test = [] {
+      // A negative end that resolves below 0 means "include index 0"; it must not be clamped
+      // up to 0, which would drop the first element on a reverse slice.
+      std::vector<int> data{1, 2, 3, 4, 5};
+      std::string buffer{};
+      expect(not glz::write_json(data, buffer));
+
+      std::vector<int> all{};
+      expect(not glz::read_jmespath<"[4:-6:-1]">(all, buffer));
+      expect(all == (std::vector<int>{5, 4, 3, 2, 1}));
+
+      std::vector<int> neg_start{};
+      expect(not glz::read_jmespath<"[-1::-1]">(neg_start, buffer));
+      expect(neg_start == (std::vector<int>{5, 4, 3, 2, 1}));
+   };
+
+   "slice step of zero is rejected"_test = [] {
+      // A step of 0 is invalid; previously it spun in a non-terminating loop. It must error.
+      std::vector<int> data{1, 2, 3, 4, 5};
+      std::string buffer{};
+      expect(not glz::write_json(data, buffer));
+
+      std::vector<int> out{};
+      expect(glz::read_jmespath(glz::jmespath_expression{"[5:0:0]"}, out, buffer));
+      expect(glz::read_jmespath(glz::jmespath_expression{"[3:1:0]"}, out, buffer));
+      expect(glz::read_jmespath(glz::jmespath_expression{"[::0]"}, out, buffer));
+   };
+};
+
+suite jmespath_negative_index_tests = [] {
+   "negative single index"_test = [] {
+      // [-1] is the last element, [-n] counts back from the end.
+      std::vector<int> data{10, 20, 30, 40, 50};
+      std::string buffer{};
+      expect(not glz::write_json(data, buffer));
+
+      int v{};
+      expect(not glz::read_jmespath<"[-1]">(v, buffer));
+      expect(v == 50);
+      expect(not glz::read_jmespath<"[-2]">(v, buffer));
+      expect(v == 40);
+      expect(not glz::read_jmespath<"[-5]">(v, buffer));
+      expect(v == 10);
+
+      expect(not glz::read_jmespath(glz::jmespath_expression{"[-1]"}, v, buffer));
+      expect(v == 50);
+
+      // Out of range still errors rather than wrapping further.
+      int oob{};
+      expect(glz::read_jmespath<"[-6]">(oob, buffer));
+   };
+
+   "negative index on empty array errors"_test = [] {
+      std::vector<int> data{};
+      std::string buffer{};
+      expect(not glz::write_json(data, buffer));
+      int v{};
+      expect(glz::read_jmespath<"[-1]">(v, buffer));
+   };
+
+   "negative index after key"_test = [] {
+      std::string buffer = R"({"v":[10,20,30]})";
+      int v{};
+      expect(not glz::read_jmespath<"v[-1]">(v, buffer));
+      expect(v == 30);
+      expect(not glz::read_jmespath(glz::jmespath_expression{"v[-3]"}, v, buffer));
+      expect(v == 10);
+      expect(glz::read_jmespath<"v[-4]">(v, buffer));
+   };
+
+   "negative index nested"_test = [] {
+      std::vector<std::vector<int>> data{{1, 2}, {3, 4, 5}, {6, 7}};
+      std::string buffer{};
+      expect(not glz::write_json(data, buffer));
+
+      int v{};
+      expect(not glz::read_jmespath<"[-1][0]">(v, buffer));
+      expect(v == 6);
+      expect(not glz::read_jmespath<"[0][-1]">(v, buffer));
+      expect(v == 2);
+      expect(not glz::read_jmespath<"[-2][-1]">(v, buffer));
+      expect(v == 5);
+   };
+};
+
 // A test case for a GCC14 warning
 struct gcc_maybe_uninitialized_t
 {
@@ -352,6 +462,24 @@ suite non_null_terminated_slice_bounds = [] {
       expect(not ec);
       expect(std::get<0>(target) == 7);
       expect(std::get<1>(target) == 8);
+   };
+
+   "nnt single index stays in bounds"_test = [] {
+      // A negative index scans the whole array to resolve its length, and an out-of-range
+      // positive index scans past every element, so both must respect end on a
+      // non-null-terminated buffer rather than reading past it. (An in-range positive index
+      // short-circuits as soon as its element is complete, so it is not a truncation case.)
+      fuzz_slice_prefixes<int, "[-1]">("[10,20,30,40,50]");
+      fuzz_slice_prefixes<int, "[10]">("[10,20,30,40,50]");
+
+      std::vector<char> buf{};
+      const std::string_view complete = "[10,20,30]";
+      buf.assign(complete.begin(), complete.end());
+      int value{};
+      const auto ec =
+         glz::read_jmespath<"[-1]", options>(value, std::string_view{buf.data(), buf.data() + buf.size()});
+      expect(not ec);
+      expect(value == 30);
    };
 };
 


### PR DESCRIPTION
Follow-ups to #2670, fixing the remaining JMESPath slice/index correctness gaps in the same family. Each is a distinct, pre-existing bug; all fail on `main` today.

## Fixes

1. **`step == 0` no longer hangs.** `[5:0:0]`, `[3:1:0]`, `[::0]` previously spun in a non-terminating loop (an out-of-bounds write crash before #2670; an unbounded allocation after it). The parser flags a zero step and `handle_slice` guards against `step == 0` before any loop, returning `syntax_error`.

2. **Slice bounds are step-aware.** A negative step now walks the range `[size-1, -1]` (where the `-1` sentinel means "include index 0") instead of being clamped to `[0, size]`. Omitted bounds default per direction. This fixes:
   - Omitted-end reverse slices: `[::-1]`, `[2::-1]`, `[4::-2]` returned `[]` instead of reversing.
   - Negative ends that wrap below 0: `[4:-6:-1]` dropped index 0.

3. **Negative single indices.** `[-1]` is now the last element and `[-n]` counts back from the end (top-level, after a key, and nested like `[-1][0]`). A shared `detail::seek_array_index` helper replaces four previously-duplicated "skip to element n" loops across the compile-time/runtime and top-level/keyed paths. Out-of-range negatives error as before.

4. **Malformed tokens are rejected instead of silently mis-parsed.** `parse_jmespath_token` already flagged malformed tokens (a bound/step/index literal overflowing `int32`, an empty `[]`, an invalid integer, more than two colons) via `ArrayParseResult::error`, but no read path consulted it, so the bad field fell back to a default. For example `[::9999999999]` returned the whole array. Both read sites now consult `decomposed_key.error`: the runtime path returns `syntax_error`; the compile-time path `static_assert`s, matching `tokenize_as_array` which already fails to compile on tokenization errors.

## Verification

- Differential-tested against Python `data[start:end:step]` / list indexing: **12,544 slice cases + the full single-index matrix** (sizes 0–10, indices/bounds spanning ±range, every step), **0 mismatches**.
- Clean under **AddressSanitizer + UBSan**, including non-null-terminated buffers (every truncation prefix over exact-size heap buffers) and whitespace-laden JSON.
- Existing suite plus new regression tests: **28 tests / 225 asserts pass**; no new warnings under `-Wall -Wextra -pedantic`. The compile-time `static_assert` was confirmed to fire on an out-of-range literal while valid compile-time expressions still build.
- An independent adversarial review across ~18k cases could not refute correctness or memory safety, and found no regression.