### PR TITLE
RFC 9112: validate Host header in HTTP server request parser

### DIFF
--- a/.github/workflows/boost-asio.yml
+++ b/.github/workflows/boost-asio.yml
@@ -77,6 +77,8 @@ jobs:
             http_client_test \
             http_client_pool_test \
             http_server_api_tests \
+            http_server_headers_validation_test \
+            ip_address_validation_test \
             https_test \
             jsonrpc_registry_test \
             openapi_test \
@@ -93,4 +95,4 @@ jobs:
 
       - name: Test
         working-directory: build
-        run: ctest -j $(nproc) --output-on-failure -R "^(asio_repe|http_examples|http_router_test|http_client_test|http_client_pool_test|http_server_api_tests|https_test|jsonrpc_registry_test|openapi_test|repe_buffer_test|repe_plugin_test|repe_test|registry_view_test|repe_to_jsonrpc_test|websocket_close_test|websocket_client_test|utf8_test|shared_context_bug_test|wss_test)$"
+        run: ctest -j $(nproc) --output-on-failure -R "^(asio_repe|http_examples|http_router_test|http_client_test|http_client_pool_test|http_server_api_tests|http_server_headers_validation_test|ip_address_validation_test|https_test|jsonrpc_registry_test|openapi_test|repe_buffer_test|repe_plugin_test|repe_test|registry_view_test|repe_to_jsonrpc_test|websocket_close_test|websocket_client_test|utf8_test|shared_context_bug_test|wss_test)$"

--- a/.github/workflows/standalone-asio.yml
+++ b/.github/workflows/standalone-asio.yml
@@ -64,6 +64,8 @@ jobs:
           http_router_test \
           http_client_test \
           http_server_api_tests \
+          http_server_headers_validation_test \
+          ip_address_validation_test \
           https_test \
           jsonrpc_registry_test \
           openapi_test \
@@ -79,4 +81,4 @@ jobs:
           wss_test
 
     - name: Test
-      run: ctest --output-on-failure --test-dir "$GITHUB_WORKSPACE/build" -R "^(asio_repe|http_examples|http_router_test|http_client_test|http_server_api_tests|https_test|jsonrpc_registry_test|openapi_test|repe_buffer_test|repe_plugin_test|repe_test|registry_view_test|repe_to_jsonrpc_test|websocket_close_test|websocket_client_test|utf8_test|shared_context_bug_test|wss_test)$"
+      run: ctest --output-on-failure --test-dir "$GITHUB_WORKSPACE/build" -R "^(asio_repe|http_examples|http_router_test|http_client_test|http_server_api_tests|http_server_headers_validation_test|ip_address_validation_test|https_test|jsonrpc_registry_test|openapi_test|repe_buffer_test|repe_plugin_test|repe_test|registry_view_test|repe_to_jsonrpc_test|websocket_close_test|websocket_client_test|utf8_test|shared_context_bug_test|wss_test)$"

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -147,5 +147,25 @@ if (GLZ_HAS_MALLOC_MALLOC_H)
   )
 endif()
 
+add_executable(ip_address_validation_benchmark ip_address_validation_benchmark.cpp)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
+include(glaze-asio)
+glaze_setup_asio()
+
+target_link_libraries(ip_address_validation_benchmark PRIVATE
+  glaze
+  glaze::asio
+  bencher::bencher
+)
+target_compile_definitions(ip_address_validation_benchmark PRIVATE
+  $<$<PLATFORM_ID:Windows>:WIN32_LEAN_AND_MEAN>
+  $<$<PLATFORM_ID:Windows>:NOMINMAX>
+)
+target_compile_options(ip_address_validation_benchmark PRIVATE
+  $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-O3 -march=native>
+  $<$<CXX_COMPILER_ID:MSVC>:/O2>
+)
+
 # HTTP server benchmark: Glaze vs Boost.Beast
 add_subdirectory(http_benchmark)

--- a/benchmarks/ip_address_validation_benchmark.cpp
+++ b/benchmarks/ip_address_validation_benchmark.cpp
@@ -10,7 +10,11 @@
 #include "glaze/net/http_server.hpp"
 
 #if defined(GLZ_USING_BOOST_ASIO)
-namespace asio = boost::asio;
+namespace asio
+{
+   using namespace boost::asio;
+   using error_code = boost::system::error_code;
+}
 #endif
 
 struct address_case

--- a/benchmarks/ip_address_validation_benchmark.cpp
+++ b/benchmarks/ip_address_validation_benchmark.cpp
@@ -122,7 +122,7 @@ void verify_case_set(const char* validator_name, const char* case_set_name, cons
 }
 
 template <size_t N, typename GlazeValidator, typename AsioValidator>
-void bench_case_set(const char* stage_name, const char* glaze_name, const char* asio_name, const char* svg_file_name,
+void bench_case_set(const char* stage_name, const char* glaze_name, const char* asio_name,
                     const std::array<address_case, N>& cases, GlazeValidator&& glaze_validator,
                     AsioValidator&& asio_validator)
 {
@@ -156,21 +156,19 @@ int main()
 
    std::printf("=== IPv4 Address Validation Benchmarks ===\n\n");
    bench_case_set("IPv4 valid literals", "glz::detail::validate_ipv4_address", "asio::ip::make_address_v4",
-                  "ip_address_validation_ipv4_valid.svg", ipv4_valid_cases, glaze_validate_ipv4, asio_validate_ipv4);
+                  ipv4_valid_cases, glaze_validate_ipv4, asio_validate_ipv4);
    bench_case_set("IPv4 invalid literals", "glz::detail::validate_ipv4_address", "asio::ip::make_address_v4",
-                  "ip_address_validation_ipv4_invalid.svg", ipv4_invalid_cases, glaze_validate_ipv4,
-                  asio_validate_ipv4);
+                  ipv4_invalid_cases, glaze_validate_ipv4, asio_validate_ipv4);
    bench_case_set("IPv4 mixed literals", "glz::detail::validate_ipv4_address", "asio::ip::make_address_v4",
-                  "ip_address_validation_ipv4_mixed.svg", ipv4_mixed_cases, glaze_validate_ipv4, asio_validate_ipv4);
+                  ipv4_mixed_cases, glaze_validate_ipv4, asio_validate_ipv4);
 
    std::printf("\n=== IPv6 Address Validation Benchmarks ===\n\n");
    bench_case_set("IPv6 valid literals", "glz::detail::validate_ipv6_address", "asio::ip::make_address_v6",
-                  "ip_address_validation_ipv6_valid.svg", ipv6_valid_cases, glaze_validate_ipv6, asio_validate_ipv6);
+                  ipv6_valid_cases, glaze_validate_ipv6, asio_validate_ipv6);
    bench_case_set("IPv6 invalid literals", "glz::detail::validate_ipv6_address", "asio::ip::make_address_v6",
-                  "ip_address_validation_ipv6_invalid.svg", ipv6_invalid_cases, glaze_validate_ipv6,
-                  asio_validate_ipv6);
+                  ipv6_invalid_cases, glaze_validate_ipv6, asio_validate_ipv6);
    bench_case_set("IPv6 mixed literals", "glz::detail::validate_ipv6_address", "asio::ip::make_address_v6",
-                  "ip_address_validation_ipv6_mixed.svg", ipv6_mixed_cases, glaze_validate_ipv6, asio_validate_ipv6);
+                  ipv6_mixed_cases, glaze_validate_ipv6, asio_validate_ipv6);
 
    return 0;
 }

--- a/benchmarks/ip_address_validation_benchmark.cpp
+++ b/benchmarks/ip_address_validation_benchmark.cpp
@@ -1,0 +1,176 @@
+#include <array>
+#include <bencher/bar_chart.hpp>
+#include <cstddef>
+#include <cstdio>
+#include <cstdlib>
+#include <string_view>
+
+#include "bencher/bencher.hpp"
+#include "bencher/diagnostics.hpp"
+#include "glaze/net/http_server.hpp"
+
+#if defined(GLZ_USING_BOOST_ASIO)
+namespace asio = boost::asio;
+#endif
+
+struct address_case
+{
+   std::string_view input;
+   bool valid{};
+};
+
+constexpr std::array ipv4_valid_cases{
+   address_case{"0.0.0.0", true},   address_case{"1.2.3.4", true},     address_case{"10.0.0.1", true},
+   address_case{"127.0.0.1", true}, address_case{"192.168.0.1", true}, address_case{"255.255.255.255", true},
+};
+
+constexpr std::array ipv4_invalid_cases{
+   address_case{"", false},          address_case{"1.2.3.4.5", false}, address_case{"256.1.2.3", false},
+   address_case{"1.2.3.999", false}, address_case{"1.2.3.a", false},   address_case{"1..2.3", false},
+   address_case{"1.2.3.", false},    address_case{"1.2.3.-1", false},
+};
+
+constexpr std::array ipv4_mixed_cases{
+   address_case{"8.8.8.8", true},         address_case{"172.16.254.1", true},   address_case{"203.0.113.42", true},
+   address_case{"255.255.255.255", true}, address_case{"256.100.50.25", false}, address_case{"192.168.1.256", false},
+   address_case{"192.168..1", false},     address_case{"192.168.1.1 ", false},
+};
+
+constexpr std::array ipv6_valid_cases{
+   address_case{"::", true},
+   address_case{"::1", true},
+   address_case{"2001:db8::1", true},
+   address_case{"fe80::1234:5678:9abc:def0", true},
+   address_case{"2001:db8:85a3:0:0:8a2e:370:7334", true},
+   address_case{"::ffff:192.0.2.128", true},
+};
+
+constexpr std::array ipv6_invalid_cases{
+   address_case{"", false},
+   address_case{":", false},
+   address_case{"2001:db8:::1", false},
+   address_case{"2001:db8::1::1", false},
+   address_case{"2001:db8:85a3::8a2e:37023:7334", false},
+   address_case{"2001:db8::g", false},
+   address_case{"1:2:3:4:5:6:7", false},
+   address_case{"::ffff:999.0.2.128", false},
+};
+
+constexpr std::array ipv6_mixed_cases{
+   address_case{"::1", true},
+   address_case{"2001:db8::dead:beef", true},
+   address_case{"2001:db8:0:0:0:0:2:1", true},
+   address_case{"::ffff:203.0.113.9", true},
+   address_case{"2001:db8::1::2", false},
+   address_case{"2001:db8:85a3:0:0:8a2e:370:7334:1234", false},
+   address_case{"fe80::1::", false},
+   address_case{"::ffff:192.168.1.256", false},
+};
+
+bool glaze_validate_ipv4(const std::string_view input) noexcept { return glz::detail::validate_ipv4_address(input); }
+
+bool glaze_validate_ipv6(const std::string_view input) noexcept { return glz::detail::validate_ipv6_address(input); }
+
+bool asio_validate_ipv4(const std::string_view input) noexcept
+{
+   asio::error_code ec{};
+   const auto address = asio::ip::make_address_v4(input, ec);
+   bencher::do_not_optimize(address);
+   return !ec;
+}
+
+bool asio_validate_ipv6(const std::string_view input) noexcept
+{
+   asio::error_code ec{};
+   const auto address = asio::ip::make_address_v6(input, ec);
+   bencher::do_not_optimize(address);
+   return !ec;
+}
+
+template <size_t N, typename Validator>
+size_t run_case_set(const std::array<address_case, N>& cases, Validator&& validator, const size_t repetitions)
+{
+   size_t bytes_processed = 0;
+   size_t valid_count = 0;
+
+   for (size_t i = 0; i < repetitions; ++i) {
+      for (const auto& test_case : cases) {
+         const bool valid = validator(test_case.input);
+         bencher::do_not_optimize(valid);
+         bytes_processed += test_case.input.size();
+         valid_count += valid;
+      }
+   }
+
+   bencher::do_not_optimize(valid_count);
+   return bytes_processed;
+}
+
+template <size_t N, typename Validator>
+void verify_case_set(const char* validator_name, const char* case_set_name, const std::array<address_case, N>& cases,
+                     Validator&& validator)
+{
+   for (const auto& test_case : cases) {
+      const bool actual = validator(test_case.input);
+      if (actual != test_case.valid) {
+         std::fprintf(stderr, "%s returned %s for %s case %.*s, expected %s\n", validator_name,
+                      actual ? "valid" : "invalid", case_set_name, int(test_case.input.size()), test_case.input.data(),
+                      test_case.valid ? "valid" : "invalid");
+         std::abort();
+      }
+   }
+}
+
+template <size_t N, typename GlazeValidator, typename AsioValidator>
+void bench_case_set(const char* stage_name, const char* glaze_name, const char* asio_name, const char* svg_file_name,
+                    const std::array<address_case, N>& cases, GlazeValidator&& glaze_validator,
+                    AsioValidator&& asio_validator)
+{
+   constexpr size_t repetitions = 4096;
+
+   bencher::stage stage{stage_name};
+   stage.min_execution_count = 100;
+   stage.cold_cache = false;
+
+   stage.run(glaze_name, [&] { return run_case_set(cases, glaze_validator, repetitions); });
+   stage.run(asio_name, [&] { return run_case_set(cases, asio_validator, repetitions); });
+
+   bencher::print_results(stage);
+}
+
+int main()
+{
+   verify_case_set("glz::detail::validate_ipv4_address", "IPv4 valid", ipv4_valid_cases, glaze_validate_ipv4);
+   verify_case_set("asio::ip::make_address_v4", "IPv4 valid", ipv4_valid_cases, asio_validate_ipv4);
+   verify_case_set("glz::detail::validate_ipv4_address", "IPv4 invalid", ipv4_invalid_cases, glaze_validate_ipv4);
+   verify_case_set("asio::ip::make_address_v4", "IPv4 invalid", ipv4_invalid_cases, asio_validate_ipv4);
+   verify_case_set("glz::detail::validate_ipv4_address", "IPv4 mixed", ipv4_mixed_cases, glaze_validate_ipv4);
+   verify_case_set("asio::ip::make_address_v4", "IPv4 mixed", ipv4_mixed_cases, asio_validate_ipv4);
+
+   verify_case_set("glz::detail::validate_ipv6_address", "IPv6 valid", ipv6_valid_cases, glaze_validate_ipv6);
+   verify_case_set("asio::ip::make_address_v6", "IPv6 valid", ipv6_valid_cases, asio_validate_ipv6);
+   verify_case_set("glz::detail::validate_ipv6_address", "IPv6 invalid", ipv6_invalid_cases, glaze_validate_ipv6);
+   verify_case_set("asio::ip::make_address_v6", "IPv6 invalid", ipv6_invalid_cases, asio_validate_ipv6);
+   verify_case_set("glz::detail::validate_ipv6_address", "IPv6 mixed", ipv6_mixed_cases, glaze_validate_ipv6);
+   verify_case_set("asio::ip::make_address_v6", "IPv6 mixed", ipv6_mixed_cases, asio_validate_ipv6);
+
+   std::printf("=== IPv4 Address Validation Benchmarks ===\n\n");
+   bench_case_set("IPv4 valid literals", "glz::detail::validate_ipv4_address", "asio::ip::make_address_v4",
+                  "ip_address_validation_ipv4_valid.svg", ipv4_valid_cases, glaze_validate_ipv4, asio_validate_ipv4);
+   bench_case_set("IPv4 invalid literals", "glz::detail::validate_ipv4_address", "asio::ip::make_address_v4",
+                  "ip_address_validation_ipv4_invalid.svg", ipv4_invalid_cases, glaze_validate_ipv4,
+                  asio_validate_ipv4);
+   bench_case_set("IPv4 mixed literals", "glz::detail::validate_ipv4_address", "asio::ip::make_address_v4",
+                  "ip_address_validation_ipv4_mixed.svg", ipv4_mixed_cases, glaze_validate_ipv4, asio_validate_ipv4);
+
+   std::printf("\n=== IPv6 Address Validation Benchmarks ===\n\n");
+   bench_case_set("IPv6 valid literals", "glz::detail::validate_ipv6_address", "asio::ip::make_address_v6",
+                  "ip_address_validation_ipv6_valid.svg", ipv6_valid_cases, glaze_validate_ipv6, asio_validate_ipv6);
+   bench_case_set("IPv6 invalid literals", "glz::detail::validate_ipv6_address", "asio::ip::make_address_v6",
+                  "ip_address_validation_ipv6_invalid.svg", ipv6_invalid_cases, glaze_validate_ipv6,
+                  asio_validate_ipv6);
+   bench_case_set("IPv6 mixed literals", "glz::detail::validate_ipv6_address", "asio::ip::make_address_v6",
+                  "ip_address_validation_ipv6_mixed.svg", ipv6_mixed_cases, glaze_validate_ipv6, asio_validate_ipv6);
+
+   return 0;
+}

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -75,6 +75,473 @@ namespace glz
       template <typename T>
       inline constexpr bool is_ssl_stream<asio::ssl::stream<T>> = true;
 #endif
+
+      inline bool validate_ipv4_address(std::string_view address) noexcept
+      {
+         // RFC 3986, Section 3.2.2:
+         // A host identified by an IPv4 literal address is represented in
+         // dotted-decimal notation (a sequence of four decimal numbers in
+         // the range 0 to 255, separated by ".")
+         // IPv4address = dec-octet "." dec-octet "." dec-octet "." dec-octet
+
+         constexpr size_t min_ipv4_length = 7; // "x.x.x.x"
+         constexpr size_t max_ipv4_length = 15; // "xxx.xxx.xxx.xxx"
+
+         if (address.size() < min_ipv4_length || address.size() > max_ipv4_length) {
+            return false;
+         }
+
+         size_t pos = 0;
+
+         // An IPv4 address contains exactly 4 octets separated by '.' (ignoring legacy forms)
+         for (int octet_index = 0; octet_index < 4; ++octet_index) {
+            if (pos == address.size()) {
+               return false;
+            }
+
+            size_t octet_start = pos;
+            uint32_t octet_value = 0;
+            uint32_t digit_count = 0;
+
+            while (pos < address.size() && address[pos] != '.') {
+               char ch = address[pos];
+
+               // IPv4 allows only numeric (0-9) and '.' chars
+               if (ch < '0' || ch > '9') [[unlikely]] {
+                  return false;
+               }
+
+               octet_value = (octet_value * 10) + static_cast<uint32_t>(ch - '0');
+               ++digit_count;
+               ++pos;
+
+               // An octet cannot be longer than 3 digits (0-255)
+               if (digit_count > 3) {
+                  return false;
+               }
+            }
+
+            // An octet should contain at least 1 digit
+            if (digit_count == 0) {
+               return false;
+            }
+
+            // IPv4 multi-digit octet cannot have leading zeros
+            if (digit_count > 1 && address[octet_start] == '0') {
+               return false;
+            }
+
+            // An octet must be in the range 0-255
+            if (octet_value > 255) {
+               return false;
+            }
+
+            if (octet_index < 3) {
+               // Parsed fewer than 4 octets, but the address already ended
+               if (pos == address.size()) {
+                  return false;
+               }
+
+               if (address[pos] != '.') {
+                  return false;
+               }
+
+               ++pos;
+            }
+            // All 4 octets have been parsed, so any remaining tail is invalid
+            else if (pos != address.size()) {
+               return false;
+            }
+         }
+
+         return true;
+      }
+
+      inline bool is_ipv6_hex_digit(char ch) noexcept
+      {
+         return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F');
+      }
+
+      inline bool count_ipv6_pieces(std::string_view text, size_t& piece_count) noexcept
+      {
+         piece_count = 0;
+
+         // Empty side is valid after splitting around "::".
+         // Examples: "::1", "1::", "::".
+         if (text.empty()) {
+            return true;
+         }
+
+         size_t pos = 0;
+
+         while (pos < text.size()) {
+            size_t digit_count = 0;
+
+            // Parse one explicit IPv6 piece.
+            // RFC 3986 grammar name:
+            // h16 = 1*4HEXDIG
+            while (pos < text.size() && text[pos] != ':') {
+               char ch = text[pos];
+
+               if (!is_ipv6_hex_digit(ch)) [[unlikely]] {
+                  return false;
+               }
+
+               ++digit_count;
+               ++pos;
+
+               if (digit_count > 4) [[unlikely]] {
+                  return false;
+               }
+            }
+
+            if (digit_count == 0) [[unlikely]] {
+               return false;
+            }
+
+            ++piece_count;
+
+            if (pos == text.size()) {
+               return true;
+            }
+
+            // Parser stopped before the end, so it must be at ':'
+            if (text[pos] != ':') [[unlikely]] {
+               return false;
+            }
+
+            ++pos;
+
+            // After a single ':' there must be another explicit piece.
+            // Valid "::" compression is handled before this function is called
+            if (pos == text.size()) [[unlikely]] {
+               return false;
+            }
+         }
+
+         return true;
+      }
+
+      inline bool validate_ipv6_address(std::string_view address) noexcept
+      {
+         constexpr size_t min_ipv6_length = 2; // "::"
+         constexpr size_t max_ipv6_length = 45; // "xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:255.255.255.255"
+
+         if (address.size() < min_ipv6_length || address.size() > max_ipv6_length) {
+            return false;
+         }
+
+         std::string_view ipv6_part = address;
+         size_t ipv4_tail_piece_count = 0;
+
+         // RFC 3986 describes IPv6 format in Section 3.2.2, stating that the last
+         // 32 bits of an IPv6 address (2 last parts) can be an IPv4 address
+         bool has_ipv4_tail = address.find('.') != std::string_view::npos;
+         if (has_ipv4_tail) {
+            // Find the last IPv6 separator before the IPv4 tail
+            size_t tail_separator_pos = address.rfind(':');
+            if (tail_separator_pos == std::string_view::npos) {
+               return false;
+            }
+
+            // Assume that everything after the last IPv6 separator is the
+            // IPv4 tail, the IPv4 validator will catch any issues
+            std::string_view ipv4_tail = address.substr(tail_separator_pos + 1); // +1 to skip ':'
+            if (!validate_ipv4_address(ipv4_tail)) {
+               return false;
+            }
+
+            size_t ipv6_part_size = tail_separator_pos;
+
+            // For cases such as "::xxx.x.x.x" we check if there is a compression
+            // token and do not count it as a part of IPv6
+            if (tail_separator_pos > 0 && address[tail_separator_pos - 1] == ':') {
+               ipv6_part_size = tail_separator_pos + 1;
+            }
+
+            // When an IPv4 tail is present, it takes 2 last pieces of IPv6 address (32 bits)
+            ipv4_tail_piece_count = 2;
+            ipv6_part = address.substr(0, ipv6_part_size);
+         }
+
+         size_t compression_pos = ipv6_part.find("::");
+         if (compression_pos != std::string_view::npos) {
+            std::string_view left_part = ipv6_part.substr(0, compression_pos);
+            std::string_view right_part = ipv6_part.substr(compression_pos + 2);
+
+            // Only one compression token is allowed in an IPv6 literal.
+            // Only the right side needs to be scanned because the first
+            // compression token has already been found
+            if (right_part.find("::") != std::string_view::npos) {
+               return false;
+            }
+
+            size_t left_piece_count = 0;
+            size_t right_piece_count = 0;
+
+            if (!count_ipv6_pieces(left_part, left_piece_count)) {
+               return false;
+            }
+
+            if (!count_ipv6_pieces(right_part, right_piece_count)) {
+               return false;
+            }
+
+            size_t piece_count = left_piece_count + right_piece_count + ipv4_tail_piece_count;
+
+            // Address must not have 8 pieces if compression token is present
+            return piece_count < 8;
+         }
+
+         // No compression token present, just count all of the IPv6 pieces
+         size_t piece_count = 0;
+         if (!count_ipv6_pieces(ipv6_part, piece_count)) {
+            return false;
+         }
+
+         // IPv6 pieces + optional 2 pieces from IPv4 tail
+         return piece_count + ipv4_tail_piece_count == 8;
+      }
+
+      inline bool is_ipv4_address_like(std::string_view host) noexcept
+      {
+         if (host.empty()) {
+            return false;
+         }
+
+         bool has_ipv4_separator = false;
+
+         for (char ch : host) {
+            if (ch == '.') {
+               has_ipv4_separator = true;
+               continue;
+            }
+
+            // IPv4 address can consist only of digits and '.'
+            bool is_digit = ch >= '0' && ch <= '9';
+            if (!is_digit) {
+               return false;
+            }
+         }
+
+         return has_ipv4_separator;
+      }
+
+      inline bool validate_hostname(std::string_view host) noexcept
+      {
+         // Current implementation accepts strict ASCII DNS-like hostnames, allows
+         // numeric-only DNS labels, while rejecting raw unicode and percent-encoding.
+
+         // Before implementing percent-encoding parser, we should weigh the
+         // pros and cons and accept the fact that it may create an additional
+         // attack surface for HTTP server routing.
+
+         // RFC 1035 limits a DNS name to 255 octets in DNS message form.
+         // For dotted text form used in Host, the maximum length without
+         // a trailing root dot is 253 characters:
+         // 63 "." 63 "." 63 "." 61
+         constexpr size_t max_host_name_length = 253;
+
+         // RFC 1035, Section 2.3.1:
+         // Labels must be 63 characters or less.
+         constexpr size_t max_dns_label_length = 63;
+
+         if (host.empty()) {
+            return false;
+         }
+
+         // Accept and normalize absolute hostnames that ends with '.'
+         if (host.ends_with('.')) {
+            host.remove_suffix(1);
+            if (host.empty()) {
+               return false;
+            }
+         }
+
+         if (host.empty() || host.size() > max_host_name_length) {
+            return false;
+         }
+
+         size_t dns_label_length = 0;
+         char prev_char = '\0';
+
+         for (char ch : host) {
+            if (ch == '.') {
+               // DNS label must not be empty
+               if (dns_label_length == 0) {
+                  return false;
+               }
+
+               // RFC 1035, Section 2.3.1:
+               // They must ... end with a letter or digit...
+               if (prev_char == '-') {
+                  return false;
+               }
+
+               dns_label_length = 0;
+               prev_char = ch;
+               continue;
+            }
+
+            // RFC 1035, Section 2.3.1:
+            // The labels must follow the rules for ARPANET host names. They must
+            // start with a letter, end with a letter or digit, and have as
+            // interior characters only letters, digits, and hyphen.
+            bool is_dns_label_char =
+               (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '-';
+            if (!is_dns_label_char) {
+               return false;
+            }
+
+            // RFC 1123, Section 2.1:
+            // One aspect of host name syntax is hereby changed: the restriction on the
+            // first character is relaxed to allow either a letter or a digit.
+            if (dns_label_length == 0 && ch == '-') {
+               return false;
+            }
+
+            ++dns_label_length;
+
+            if (dns_label_length > max_dns_label_length) {
+               return false;
+            }
+
+            prev_char = ch;
+         }
+
+         if (dns_label_length == 0) {
+            return false;
+         }
+
+         // RFC 1035, Section 2.3.1:
+         // They must ... end with a letter or digit...
+         if (prev_char == '-') {
+            return false;
+         }
+
+         return true;
+      }
+
+      inline bool validate_host_port(std::string_view port_str) noexcept
+      {
+         // RFC 3986, Section 3.2.3:
+         // port = *DIGIT
+         //
+         // RFC 9110, Section 4.2.1 and Section 4.2.2:
+         // If the port subcomponent is empty or not given, the default port is used.
+
+         if (port_str.empty()) {
+            return true;
+         }
+
+         constexpr uint32_t max_port = 65535;
+         uint32_t port_value = 0;
+
+         for (char ch : port_str) {
+            if (ch < '0' || ch > '9') [[unlikely]] {
+               return false;
+            }
+
+            port_value = (port_value * 10) + static_cast<uint32_t>(ch - '0');
+
+            if (port_value > max_port) [[unlikely]] {
+               return false;
+            }
+         }
+
+         return true;
+      }
+
+      inline bool validate_host_header(std::string_view host_header) noexcept
+      {
+         // RFC 9110, Section 7.2:
+         // Host = uri-host [ ":" port ]
+         std::string_view uri_host = host_header;
+
+         // RFC 9110, Section 4.2.1 and Section 4.2.2:
+         // A sender MUST NOT generate an "http" or "https" URI with an empty host
+         // identifier. A recipient that processes such URI reference must reject it.
+         if (host_header.empty()) {
+            return false;
+         }
+
+         // RFC 3986, Section 3.2.2:
+         // host = IP-literal / IPv4address / reg-name
+         // IP-literal = "[" ( IPv6address / IPvFuture  ) "]"
+
+         // URI Host inside brackets must be interpreted as an IPv6 literal
+         if (uri_host.starts_with('[')) {
+            size_t closing_bracket_pos = uri_host.find(']');
+            if (closing_bracket_pos == std::string_view::npos) {
+               return false;
+            }
+
+            // Bracketed IPv6 literal must not be empty
+            if (closing_bracket_pos == 1) {
+               return false;
+            }
+
+            std::string_view bracketless_ipv6 = uri_host.substr(1, closing_bracket_pos - 1);
+            if (!validate_ipv6_address(bracketless_ipv6)) {
+               return false;
+            }
+
+            // No port is present and IPv6 is validated - host is valid
+            if (closing_bracket_pos + 1 == uri_host.size()) {
+               return true;
+            }
+
+            std::string_view tail_after_ipv6 = uri_host.substr(closing_bracket_pos + 1);
+
+            // After the IPv6 brackets, only a port is allowed
+            if (!tail_after_ipv6.starts_with(':')) {
+               return false;
+            }
+
+            std::string_view port_str = tail_after_ipv6.substr(1);
+
+            return validate_host_port(port_str);
+         }
+
+         // RFC 9110, Section 4.2.3:
+         // If the port is equal to the default port for a scheme, the normal
+         // form is to omit the port subcomponent.
+         size_t port_delimiter_pos = host_header.find(':');
+         if (port_delimiter_pos != std::string_view::npos) {
+            // Only one port delimiter is allowed
+            if (host_header.find(':', port_delimiter_pos + 1) != std::string_view::npos) {
+               return false;
+            }
+
+            uri_host = host_header.substr(0, port_delimiter_pos);
+            std::string_view port_str = host_header.substr(port_delimiter_pos + 1);
+
+            if (uri_host.empty()) {
+               return false;
+            }
+
+            if (!validate_host_port(port_str)) {
+               return false;
+            }
+         }
+
+         // RFC 3986, Section 3.2.2:
+         // The syntax rule for host is ambiguous because it does not completely
+         // distinguish between an IPv4address and a reg-name.
+         // In order to disambiguate the syntax, we apply the "first-match-wins"
+         // algorithm: If host matches the rule for IPv4address, then it should
+         // be considered an IPv4 address literal and not a reg-name.
+         if (validate_ipv4_address(uri_host)) {
+            return true;
+         }
+
+         // A host that looks like an IPv4 address but failed IPv4 validation is invalid
+         if (is_ipv4_address_like(uri_host)) {
+            return false;
+         }
+
+         return validate_hostname(uri_host);
+      }
    }
 
    // Interface for streaming connections (type-erased for HTTP/HTTPS compatibility)
@@ -1758,12 +2225,25 @@ namespace glz
 
             // Empty line = end of headers
             if (data[pos] == '\r' && data[pos + 1] == '\n') {
-               // RFC 9112, 3.2: A server MUST respond with a 400 (Bad Request) status
-               // code to any HTTP/1.1 request message that lacks a Host header
-               if (result.is_http_11 && !headers.contains("host")) {
-                  result.status = parse_status::error;
-                  send_error_response_with_close(conn, 400, "Bad Request");
-                  return result;
+               if (result.is_http_11) {
+                  auto host_header_it = headers.find("host");
+
+                  // RFC 9112, 3.2: A server MUST respond with a 400 (Bad Request) status
+                  // code to any HTTP/1.1 request message that lacks a Host header...
+                  if (host_header_it == headers.end()) {
+                     result.status = parse_status::error;
+                     send_error_response_with_close(conn, 400, "Bad Request");
+                     return result;
+                  }
+
+                  // RFC 9112, 3.2: A server MUST respond with a 400 (Bad Request) status
+                  // code to any HTTP/1.1 request message that lacks a Host header ... or
+                  // a Host header field with an invalid field value.
+                  if (!detail::validate_host_header(host_header_it->second)) {
+                     result.status = parse_status::error;
+                     send_error_response_with_close(conn, 400, "Bad Request");
+                     return result;
+                  }
                }
 
                result.headers_end = pos + 2;

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -1750,6 +1750,7 @@ namespace glz
          // --- Parse headers line by line (single pass) ---
          size_t pos = rl_end + 2;
          auto& headers = conn->request_.headers;
+         bool host_header_parsed = false;
 
          while (true) {
             // Need at least 2 bytes to check for empty line
@@ -1757,6 +1758,14 @@ namespace glz
 
             // Empty line = end of headers
             if (data[pos] == '\r' && data[pos + 1] == '\n') {
+               // RFC 9112, 3.2: A server MUST respond with a 400 (Bad Request) status
+               // code to any HTTP/1.1 request message that lacks a Host header
+               if (result.is_http_11 && !headers.contains("host")) {
+                  result.status = parse_status::error;
+                  send_error_response_with_close(conn, 400, "Bad Request");
+                  return result;
+               }
+
                result.headers_end = pos + 2;
                result.status = parse_status::complete;
                return result;
@@ -1809,6 +1818,18 @@ namespace glz
                      return result;
                   }
                }
+
+               // RFC 9112, 3.2: A server MUST respond with a 400 (Bad Request) status code to
+               // any HTTP/1.1 request message that ... contains more than one Host header field.
+               if (result.is_http_11 && key == "host") {
+                  if (host_header_parsed) {
+                     result.status = parse_status::error;
+                     send_error_response_with_close(conn, 400, "Bad Request");
+                     return result;
+                  }
+                  host_header_parsed = true;
+               }
+
                headers[std::move(key)] = std::string(value_sv);
             }
 

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -434,6 +434,7 @@ namespace glz
             return true;
          }
 
+         constexpr uint32_t min_port = 1;
          constexpr uint32_t max_port = 65535;
          uint32_t port_value = 0;
 
@@ -449,7 +450,7 @@ namespace glz
             }
          }
 
-         return true;
+         return port_value >= min_port;
       }
 
       inline bool validate_host_header(std::string_view host_header) noexcept

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -2303,6 +2303,13 @@ namespace glz
                }
                std::string_view value_sv = line.substr(colon_pos + 1);
                value_sv.remove_prefix((std::min)(value_sv.find_first_not_of(" \t"), value_sv.size()));
+               // RFC 9110 §5.5 / RFC 9112 §5: a field value excludes trailing OWS as well;
+               // recipients MUST strip it before evaluating (e.g. "Host: example.com " is legal
+               // and must not be rejected by the Host reg-name check). Leading OWS is already
+               // gone above, so an all-whitespace value is empty here and the guard no-ops.
+               if (const auto last = value_sv.find_last_not_of(" \t"); last != std::string_view::npos) {
+                  value_sv.remove_suffix(value_sv.size() - (last + 1));
+               }
                std::string key(name_sv);
                for (auto& c : key) c = ascii_tolower(c);
                // RFC 7230 3.3.2: multiple Content-Length fields with differing values make the

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -330,7 +330,23 @@ namespace glz
       inline bool validate_hostname(std::string_view host) noexcept
       {
          // Current implementation accepts strict ASCII DNS-like hostnames, allows
-         // numeric-only DNS labels, while rejecting raw unicode and percent-encoding.
+         // numeric-only DNS labels, and additionally permits the underscore '_',
+         // while rejecting raw unicode and percent-encoding.
+
+         // The underscore is not a valid DNS label character under RFC 1035, but it
+         // appears routinely in real-world Host values: internal service names
+         // (e.g. "my_service.internal") and underscore-prefixed labels such as "_dmarc"
+         // or the SRV form "_sip._tcp". Common servers (nginx, Go net/http, Node.js)
+         // tolerate it, and since this server does not route on the Host value, rejecting
+         // '_' is pure interop cost with no security benefit (it is inert as a delimiter).
+         // It is therefore treated as an ordinary label character valid at any position,
+         // including leading and trailing.
+         //
+         // We deliberately do NOT extend this to '~', the other character in RFC 3986's
+         // reg-name "unreserved" set that is likewise not a DNS label character: unlike
+         // '_', tilde does not occur in practice as a hostname character, so accepting it
+         // would widen the input surface with no interop gain. Unreserved-set membership
+         // alone is thus not the criterion here; real-world usage is.
 
          // Before implementing percent-encoding parser, we should weigh the
          // pros and cons and accept the fact that it may create an additional
@@ -387,8 +403,10 @@ namespace glz
             // The labels must follow the rules for ARPANET host names. They must
             // start with a letter, end with a letter or digit, and have as
             // interior characters only letters, digits, and hyphen.
-            bool is_dns_label_char =
-               (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '-';
+            // The underscore is permitted as a pragmatic superset (see note above);
+            // unlike hyphen it carries no start/end position restriction.
+            bool is_dns_label_char = (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') ||
+                                     (ch >= '0' && ch <= '9') || ch == '-' || ch == '_';
             if (!is_dns_label_char) {
                return false;
             }

--- a/tests/networking_tests/CMakeLists.txt
+++ b/tests/networking_tests/CMakeLists.txt
@@ -7,6 +7,7 @@ option(glaze_BUILD_WEBSOCKET_AUTOBAHN_TEST "Build Autobahn WebSocket compliance 
 # HTTP Examples
 add_subdirectory(http_examples)
 add_subdirectory(http_server_post_test)
+add_subdirectory(http_server_test)
 add_subdirectory(http_smuggling_test)
 add_subdirectory(http_header_strictness_test)
 

--- a/tests/networking_tests/http_server_test/CMakeLists.txt
+++ b/tests/networking_tests/http_server_test/CMakeLists.txt
@@ -1,0 +1,7 @@
+project(http_server_headers_validation_test)
+
+add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE glz_test_exceptions)
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/tests/networking_tests/http_server_test/CMakeLists.txt
+++ b/tests/networking_tests/http_server_test/CMakeLists.txt
@@ -1,7 +1,9 @@
 project(http_server_headers_validation_test)
-
 add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)
-
 target_link_libraries(${PROJECT_NAME} PRIVATE glz_test_exceptions)
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
 
+project(ip_address_validation_test)
+add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE glz_test_exceptions)
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/tests/networking_tests/http_server_test/http_server_headers_validation_test.cpp
+++ b/tests/networking_tests/http_server_test/http_server_headers_validation_test.cpp
@@ -85,6 +85,21 @@ suite http_server_host_header_value_validation_suite = [] {
       expect(validate_host_header("123.abc"));
       expect(validate_host_header("example.com."));
 
+      // Underscore is accepted as a pragmatic superset of RFC 1035 labels: it appears in
+      // real-world Host values (internal service names, underscore-prefixed labels like
+      // "_dmarc" / "_sip._tcp") and common servers tolerate it. Unlike hyphen, it is valid
+      // at any position within a label. Tilde '~' is in the same RFC 3986 unreserved set but
+      // is still rejected (see the reject cases below), since it has no such real-world use.
+      expect(validate_host_header("my_service.internal"));
+      expect(validate_host_header("db_primary"));
+      expect(validate_host_header("db_primary:5432"));
+      expect(validate_host_header("exa_mple.com"));
+      expect(validate_host_header("example_com"));
+      expect(validate_host_header("_dmarc.example.com"));
+      expect(validate_host_header("_sip._tcp.example.com"));
+      expect(validate_host_header("trailing_.example"));
+      expect(validate_host_header("_"));
+
       const std::string max_label(63, 'a');
       expect(validate_host_header(max_label));
       expect(validate_host_header(max_label + ".example"));
@@ -105,8 +120,6 @@ suite http_server_host_header_value_validation_suite = [] {
       expect(not validate_host_header("example-.com"));
       expect(not validate_host_header("example.-com"));
       expect(not validate_host_header("example.com-"));
-      expect(not validate_host_header("exa_mple.com"));
-      expect(not validate_host_header("example_com"));
       expect(not validate_host_header("example~com"));
       expect(not validate_host_header("example!$&'()*+,;=com"));
       expect(not validate_host_header("example.com/"));
@@ -413,7 +426,7 @@ suite http_server_headers_validation_suite = [] {
    "request with Host header outside DNS-like reg-name policy is rejected with 400 bad request"_test = [&] {
       std::string payload =
          "GET /front HTTP/1.1\r\n"
-         "Host: exa_mple.com\r\n"
+         "Host: example~com\r\n"
          "Connection: close\r\n"
          "\r\n";
 
@@ -425,6 +438,27 @@ suite http_server_headers_validation_suite = [] {
       }
 
       expect(response.contains("HTTP/1.1 400")) << "Expected 400 for Host header outside DNS-like reg-name policy";
+   };
+
+   "request with underscore Host header passes host validation"_test = [&] {
+      std::string payload =
+         "GET /front HTTP/1.1\r\n"
+         "Host: my_service.internal\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      // Host validation must accept the underscore; the request then reaches routing, and
+      // since no route is registered the unmatched path returns 404 (not the 400 a rejected
+      // Host would produce). Asserting the positive 404 also fails closed on an empty/timed-out
+      // response, unlike a bare "not 400" check which an empty string would satisfy vacuously.
+      expect(response.contains("HTTP/1.1 404")) << "Expected underscore Host to pass validation and reach routing (404)";
    };
 
    "request with Host header non-digit port is rejected with 400 bad request"_test = [&] {

--- a/tests/networking_tests/http_server_test/http_server_headers_validation_test.cpp
+++ b/tests/networking_tests/http_server_test/http_server_headers_validation_test.cpp
@@ -1,0 +1,140 @@
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <string>
+#include <thread>
+#include <ut/ut.hpp>
+
+#include "glaze/net/http_server.hpp"
+
+#if defined(GLZ_USING_BOOST_ASIO)
+namespace asio
+{
+   using namespace boost::asio;
+   using error_code = boost::system::error_code;
+}
+#endif
+
+using namespace ut;
+using namespace std::chrono_literals;
+
+constexpr int test_port = 8899;
+constexpr char test_host[] = "127.0.0.1";
+
+void wait_for_server_ready(int port, int max_tries = 50)
+{
+   for (int tries = 0; tries < max_tries; ++tries) {
+      try {
+         asio::io_context io_ctx;
+         asio::ip::tcp::socket sock(io_ctx);
+         asio::ip::tcp::endpoint endpoint(asio::ip::make_address(test_host), uint16_t(port));
+         asio::error_code ec;
+         sock.connect(endpoint, ec);
+         if (ec != asio::error::connection_refused) {
+            return;
+         }
+      }
+      catch (...) {
+      }
+      std::this_thread::sleep_for(40ms);
+   }
+   throw std::runtime_error("Server did not start in time");
+}
+
+std::string read_response(asio::ip::tcp::socket& socket)
+{
+   std::string resp;
+   std::array<char, 4096> buf{};
+   asio::error_code ec;
+   for (;;) {
+      std::size_t n = socket.read_some(asio::buffer(buf), ec);
+      if (n == 0 || ec) break;
+      resp.append(buf.data(), n);
+   }
+   return resp;
+}
+
+std::string send_raw(const std::string& request)
+{
+   wait_for_server_ready(test_port);
+   asio::io_context io_ctx;
+   asio::ip::tcp::socket socket(io_ctx);
+   asio::ip::tcp::endpoint endpoint(asio::ip::make_address(test_host), uint16_t(test_port));
+   asio::error_code ec;
+   socket.connect(endpoint, ec);
+   if (ec) {
+      return "";
+   }
+   asio::write(socket, asio::buffer(request.data(), request.size()));
+   return read_response(socket);
+}
+
+static void error_handler(std::error_code, std::source_location) {}
+
+suite http_server_headers_validation_suite = [] {
+   auto io_ctx = std::make_shared<asio::io_context>();
+   glz::http_server<> server(io_ctx, error_handler);
+
+   std::jthread server_thr([&] {
+      server.bind("0.0.0.0", test_port);
+      server.start(0);
+      io_ctx->run();
+   });
+
+   "request with missing Host header is rejected with 400 bad request"_test = [&] {
+      std::string payload =
+         "GET /front HTTP/1.1\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 400")) << "Expected 400 for missing Host header";
+   };
+
+   "request with multiple Host headers is rejected with 400 bad request"_test = [&] {
+      std::string payload =
+         "GET /front HTTP/1.1\r\n"
+         "Host: first\r\n"
+         "Host: second\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 400")) << "Expected 400 for multiple Host headers";
+   };
+
+   "request with case-insensitive multiple Host headers is rejected with 400 bad request"_test = [&] {
+      std::string payload =
+         "GET /front HTTP/1.1\r\n"
+         "Host: first\r\n"
+         "hoST: second\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 400")) << "Expected 400 for multiple Host headers";
+   };
+
+   server.stop();
+   io_ctx->stop();
+};
+
+int main() { return 0; }

--- a/tests/networking_tests/http_server_test/http_server_headers_validation_test.cpp
+++ b/tests/networking_tests/http_server_test/http_server_headers_validation_test.cpp
@@ -75,7 +75,7 @@ suite http_server_headers_validation_suite = [] {
    auto io_ctx = std::make_shared<asio::io_context>();
    glz::http_server<> server(io_ctx, error_handler);
 
-   std::jthread server_thr([&] {
+   std::thread server_thr([&] {
       server.bind("0.0.0.0", test_port);
       server.start(0);
       io_ctx->run();
@@ -135,6 +135,7 @@ suite http_server_headers_validation_suite = [] {
 
    server.stop();
    io_ctx->stop();
+   if (server_thr.joinable()) server_thr.join();
 };
 
 int main() { return 0; }

--- a/tests/networking_tests/http_server_test/http_server_headers_validation_test.cpp
+++ b/tests/networking_tests/http_server_test/http_server_headers_validation_test.cpp
@@ -461,6 +461,28 @@ suite http_server_headers_validation_suite = [] {
       expect(response.contains("HTTP/1.1 404")) << "Expected underscore Host to pass validation and reach routing (404)";
    };
 
+   "request with trailing OWS in Host header passes host validation"_test = [&] {
+      // RFC 9110 §5.5 / RFC 9112 §5: trailing optional whitespace (SP/HTAB) is not part of the
+      // field value; a recipient MUST strip it before evaluating. The header parser must remove
+      // it so a spec-legal "Host: example.com " does not reach the reg-name check as "example.com "
+      // and get spuriously rejected. Both a trailing space and a trailing tab must be tolerated.
+      for (const std::string& host_line : {"Host: example.com \r\n", "Host: example.com\t\r\n"}) {
+         std::string payload = "GET /front HTTP/1.1\r\n" + host_line + "Connection: close\r\n\r\n";
+
+         std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+         std::string response;
+         if (f.wait_for(5s) == std::future_status::ready) {
+            response = f.get();
+         }
+
+         // Trailing OWS is stripped, so the Host passes validation and reaches routing; with no
+         // route registered the unmatched path returns 404 rather than the 400 a rejected Host
+         // would produce. The positive 404 also fails closed on an empty/timed-out response.
+         expect(response.contains("HTTP/1.1 404")) << "Expected trailing-OWS Host to pass validation and reach routing (404)";
+      }
+   };
+
    "request with Host header non-digit port is rejected with 400 bad request"_test = [&] {
       std::string payload =
          "GET /front HTTP/1.1\r\n"

--- a/tests/networking_tests/http_server_test/http_server_headers_validation_test.cpp
+++ b/tests/networking_tests/http_server_test/http_server_headers_validation_test.cpp
@@ -1,7 +1,7 @@
-#include <atomic>
 #include <chrono>
 #include <future>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <ut/ut.hpp>
 
@@ -17,6 +17,7 @@ namespace asio
 
 using namespace ut;
 using namespace std::chrono_literals;
+using glz::detail::validate_host_header;
 
 constexpr int test_port = 8899;
 constexpr char test_host[] = "127.0.0.1";
@@ -70,6 +71,175 @@ std::string send_raw(const std::string& request)
 }
 
 static void error_handler(std::error_code, std::source_location) {}
+
+suite http_server_host_header_value_validation_suite = [] {
+   "accepts valid Host header DNS-like reg-name values"_test = [] {
+      expect(validate_host_header("a"));
+      expect(validate_host_header("localhost"));
+      expect(validate_host_header("example.com"));
+      expect(validate_host_header("EXAMPLE.com"));
+      expect(validate_host_header("a-b.example"));
+      expect(validate_host_header("0"));
+      expect(validate_host_header("123"));
+      expect(validate_host_header("123.example"));
+      expect(validate_host_header("123.abc"));
+      expect(validate_host_header("example.com."));
+
+      const std::string max_label(63, 'a');
+      expect(validate_host_header(max_label));
+      expect(validate_host_header(max_label + ".example"));
+
+      const std::string max_host =
+         std::string(63, 'a') + "." + std::string(63, 'b') + "." + std::string(63, 'c') + "." + std::string(61, 'd');
+      expect(max_host.size() == 253);
+      expect(validate_host_header(max_host));
+   };
+
+   "rejects Host header reg-name values outside server DNS-like policy"_test = [] {
+      expect(not validate_host_header(""));
+      expect(not validate_host_header("."));
+      expect(not validate_host_header(".example.com"));
+      expect(not validate_host_header("example..com"));
+      expect(not validate_host_header("example.com.."));
+      expect(not validate_host_header("-example.com"));
+      expect(not validate_host_header("example-.com"));
+      expect(not validate_host_header("example.-com"));
+      expect(not validate_host_header("example.com-"));
+      expect(not validate_host_header("exa_mple.com"));
+      expect(not validate_host_header("example_com"));
+      expect(not validate_host_header("example~com"));
+      expect(not validate_host_header("example!$&'()*+,;=com"));
+      expect(not validate_host_header("example.com/"));
+      expect(not validate_host_header("example.com?x"));
+      expect(not validate_host_header("example.com#x"));
+      expect(not validate_host_header("user@example.com"));
+      expect(not validate_host_header("example%2ecom"));
+      expect(not validate_host_header("%41.example"));
+      expect(not validate_host_header("%F0%9F%92%A9.example"));
+      expect(not validate_host_header("example%"));
+      expect(not validate_host_header("example%2"));
+      expect(not validate_host_header("example%zz"));
+      expect(not validate_host_header("example com"));
+      expect(not validate_host_header(" example.com"));
+      expect(not validate_host_header("example.com "));
+      expect(not validate_host_header("\texample.com"));
+      expect(not validate_host_header("example.com\t"));
+      expect(not validate_host_header("example.com\n"));
+      expect(not validate_host_header(std::string_view{"example.com\0", 12}));
+
+      expect(not validate_host_header(std::string(64, 'a')));
+
+      const std::string too_long_host =
+         std::string(63, 'a') + "." + std::string(63, 'b') + "." + std::string(63, 'c') + "." + std::string(62, 'd');
+      expect(too_long_host.size() == 254);
+      expect(not validate_host_header(too_long_host));
+
+      std::string del_char_host = "exa";
+      del_char_host.push_back('\x7f');
+      del_char_host += "mple.com";
+      expect(not validate_host_header(del_char_host));
+
+      std::string non_ascii_host = "exa";
+      non_ascii_host.push_back(static_cast<char>(0x80));
+      non_ascii_host += "mple.com";
+      expect(not validate_host_header(non_ascii_host));
+   };
+
+   "accepts valid Host header port values"_test = [] {
+      expect(validate_host_header("example.com:"));
+      expect(validate_host_header("example.com:0"));
+      expect(validate_host_header("example.com:00080"));
+      expect(validate_host_header("example.com:80"));
+      expect(validate_host_header("example.com:65535"));
+      expect(validate_host_header("127.0.0.1:"));
+      expect(validate_host_header("127.0.0.1:443"));
+      expect(validate_host_header("[::1]:"));
+      expect(validate_host_header("[::1]:0"));
+      expect(validate_host_header("[::1]:65535"));
+   };
+
+   "rejects invalid Host header port values"_test = [] {
+      expect(not validate_host_header(":80"));
+      expect(not validate_host_header("example.com:65536"));
+      expect(not validate_host_header("example.com:99999"));
+      expect(not validate_host_header("example.com:80:90"));
+      expect(not validate_host_header("example.com:abc"));
+      expect(not validate_host_header("example.com:+80"));
+      expect(not validate_host_header("example.com:-1"));
+      expect(not validate_host_header("example.com: 80"));
+      expect(not validate_host_header("example.com:80 "));
+      expect(not validate_host_header("[::1]:65536"));
+      expect(not validate_host_header("[::1]:abc"));
+      expect(not validate_host_header("[::1]:-1"));
+      expect(not validate_host_header("[::1]:443:extra"));
+   };
+
+   "accepts valid Host header IPv4 literal values"_test = [] {
+      expect(validate_host_header("0.0.0.0"));
+      expect(validate_host_header("9.10.99.100"));
+      expect(validate_host_header("127.0.0.1"));
+      expect(validate_host_header("255.255.255.255"));
+      expect(validate_host_header("127.0.0.1:"));
+      expect(validate_host_header("127.0.0.1:80"));
+   };
+
+   "rejects invalid Host header IPv4-like values"_test = [] {
+      expect(not validate_host_header("256.0.0.1"));
+      expect(not validate_host_header("1.2.3"));
+      expect(not validate_host_header("127.1"));
+      expect(not validate_host_header("1.2.3.4.5"));
+      expect(not validate_host_header("1..2.3"));
+      expect(not validate_host_header(".1.2.3.4"));
+      expect(not validate_host_header("1.2.3.4."));
+      expect(not validate_host_header("01.2.3.4"));
+      expect(not validate_host_header("1.2.003.4"));
+      expect(not validate_host_header("1.2.3.04"));
+      expect(not validate_host_header("1.2.3.4:65536"));
+   };
+
+   "rejects invalid Host header IPv4 literal port values"_test = [] {
+      expect(not validate_host_header("1.2.3.4:abc"));
+      expect(not validate_host_header("1.2.3.4:80:90"));
+   };
+
+   "accepts valid Host header bracketed IPv6 literal values"_test = [] {
+      expect(validate_host_header("[::]"));
+      expect(validate_host_header("[::1]"));
+      expect(validate_host_header("[2001:db8::1]"));
+      expect(validate_host_header("[2001:db8::ff00:42:8329]"));
+      expect(validate_host_header("[::ffff:192.0.2.1]"));
+      expect(validate_host_header("[0:0:0:0:0:0:192.0.2.1]"));
+      expect(validate_host_header("[ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255]"));
+      expect(validate_host_header("[::1]:443"));
+      expect(validate_host_header("[2001:db8::1]:443"));
+   };
+
+   "rejects invalid Host header IPv6 literal values"_test = [] {
+      expect(not validate_host_header("::1"));
+      expect(not validate_host_header("2001:db8::1"));
+      expect(not validate_host_header("["));
+      expect(not validate_host_header("[]"));
+      expect(not validate_host_header("[::1"));
+      expect(not validate_host_header("[::1]]"));
+      expect(not validate_host_header("[::1]host"));
+      expect(not validate_host_header("[gggg::1]"));
+      expect(not validate_host_header("[12345::1]"));
+      expect(not validate_host_header("[::ffff:999.0.2.1]"));
+      expect(not validate_host_header("[::ffff:192.0.2.01]"));
+      expect(not validate_host_header("[1:2:3:4:5:6:7:8:9]"));
+      expect(not validate_host_header("[::1] :80"));
+   };
+
+   "rejects Host header IPvFuture literal values outside server policy"_test = [] {
+      expect(not validate_host_header("[v1.fe80]"));
+      expect(not validate_host_header("[vF.a:b]"));
+      expect(not validate_host_header("[v1.!$&'()*+,;=:_~-]"));
+      expect(not validate_host_header("[v1.fe80]:443"));
+      expect(not validate_host_header("[v.fe80]"));
+      expect(not validate_host_header("[vX.fe80]"));
+      expect(not validate_host_header("[v1.]"));
+   };
+};
 
 suite http_server_headers_validation_suite = [] {
    auto io_ctx = std::make_shared<asio::io_context>();
@@ -131,6 +301,244 @@ suite http_server_headers_validation_suite = [] {
       }
 
       expect(response.contains("HTTP/1.1 400")) << "Expected 400 for multiple Host headers";
+   };
+
+   "request with empty Host header value is rejected with 400 bad request"_test = [&] {
+      std::string payload =
+         "GET /front HTTP/1.1\r\n"
+         "Host:\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 400")) << "Expected 400 for empty Host header value";
+   };
+
+   "request with Host header userinfo is rejected with 400 bad request"_test = [&] {
+      std::string payload =
+         "GET /front HTTP/1.1\r\n"
+         "Host: user@example.com\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 400")) << "Expected 400 for Host header with userinfo";
+   };
+
+   "request with Host header path delimiter is rejected with 400 bad request"_test = [&] {
+      std::string payload =
+         "GET /front HTTP/1.1\r\n"
+         "Host: example.com/path\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 400")) << "Expected 400 for Host header with path delimiter";
+   };
+
+   "request with Host header query delimiter is rejected with 400 bad request"_test = [&] {
+      std::string payload =
+         "GET /front HTTP/1.1\r\n"
+         "Host: example.com?x=1\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 400")) << "Expected 400 for Host header with query delimiter";
+   };
+
+   "request with Host header malformed percent encoding is rejected with 400 bad request"_test = [&] {
+      std::string payload =
+         "GET /front HTTP/1.1\r\n"
+         "Host: example%zz.com\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 400")) << "Expected 400 for Host header with malformed percent encoding";
+   };
+
+   "request with percent-encoded Host header is rejected with 400 bad request"_test = [&] {
+      std::string payload =
+         "GET /front HTTP/1.1\r\n"
+         "Host: example%2ecom\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 400")) << "Expected 400 for percent-encoded Host header";
+   };
+
+   "request with Host header outside DNS-like reg-name policy is rejected with 400 bad request"_test = [&] {
+      std::string payload =
+         "GET /front HTTP/1.1\r\n"
+         "Host: exa_mple.com\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 400")) << "Expected 400 for Host header outside DNS-like reg-name policy";
+   };
+
+   "request with Host header non-digit port is rejected with 400 bad request"_test = [&] {
+      std::string payload =
+         "GET /front HTTP/1.1\r\n"
+         "Host: example.com:http\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 400")) << "Expected 400 for Host header with non-digit port";
+   };
+
+   "request with Host header port above server policy range is rejected with 400 bad request"_test = [&] {
+      std::string payload =
+         "GET /front HTTP/1.1\r\n"
+         "Host: example.com:65536\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 400")) << "Expected 400 for Host header port above server policy range";
+   };
+
+   "request with Host header repeated port delimiter is rejected with 400 bad request"_test = [&] {
+      std::string payload =
+         "GET /front HTTP/1.1\r\n"
+         "Host: example.com:80:90\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 400")) << "Expected 400 for Host header with repeated port delimiter";
+   };
+
+   "request with unbracketed IPv6 Host header is rejected with 400 bad request"_test = [&] {
+      std::string payload =
+         "GET /front HTTP/1.1\r\n"
+         "Host: 2001:db8::1\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 400")) << "Expected 400 for unbracketed IPv6 Host header";
+   };
+
+   "request with invalid bracketed IPv6 Host header is rejected with 400 bad request"_test = [&] {
+      std::string payload =
+         "GET /front HTTP/1.1\r\n"
+         "Host: [gggg::1]\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 400")) << "Expected 400 for invalid bracketed IPv6 Host header";
+   };
+
+   "request with IPvFuture Host header is rejected with 400 bad request"_test = [&] {
+      std::string payload =
+         "GET /front HTTP/1.1\r\n"
+         "Host: [v1.fe80]\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 400")) << "Expected 400 for IPvFuture Host header";
+   };
+
+   "request with invalid IPvFuture Host header is rejected with 400 bad request"_test = [&] {
+      std::string payload =
+         "GET /front HTTP/1.1\r\n"
+         "Host: [vX.fe80]\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 400")) << "Expected 400 for invalid IPvFuture Host header";
    };
 
    server.stop();

--- a/tests/networking_tests/http_server_test/http_server_headers_validation_test.cpp
+++ b/tests/networking_tests/http_server_test/http_server_headers_validation_test.cpp
@@ -147,19 +147,20 @@ suite http_server_host_header_value_validation_suite = [] {
 
    "accepts valid Host header port values"_test = [] {
       expect(validate_host_header("example.com:"));
-      expect(validate_host_header("example.com:0"));
       expect(validate_host_header("example.com:00080"));
       expect(validate_host_header("example.com:80"));
       expect(validate_host_header("example.com:65535"));
       expect(validate_host_header("127.0.0.1:"));
       expect(validate_host_header("127.0.0.1:443"));
       expect(validate_host_header("[::1]:"));
-      expect(validate_host_header("[::1]:0"));
       expect(validate_host_header("[::1]:65535"));
    };
 
    "rejects invalid Host header port values"_test = [] {
       expect(not validate_host_header(":80"));
+      expect(not validate_host_header("example.com:0"));
+      expect(not validate_host_header("example.com:00"));
+      expect(not validate_host_header("example.com:00000"));
       expect(not validate_host_header("example.com:65536"));
       expect(not validate_host_header("example.com:99999"));
       expect(not validate_host_header("example.com:80:90"));
@@ -168,6 +169,10 @@ suite http_server_host_header_value_validation_suite = [] {
       expect(not validate_host_header("example.com:-1"));
       expect(not validate_host_header("example.com: 80"));
       expect(not validate_host_header("example.com:80 "));
+      expect(not validate_host_header("127.0.0.1:0"));
+      expect(not validate_host_header("127.0.0.1:00000"));
+      expect(not validate_host_header("[::1]:0"));
+      expect(not validate_host_header("[::1]:00000"));
       expect(not validate_host_header("[::1]:65536"));
       expect(not validate_host_header("[::1]:abc"));
       expect(not validate_host_header("[::1]:-1"));
@@ -437,6 +442,40 @@ suite http_server_headers_validation_suite = [] {
       }
 
       expect(response.contains("HTTP/1.1 400")) << "Expected 400 for Host header with non-digit port";
+   };
+
+   "request with Host header zero port is rejected with 400 bad request"_test = [&] {
+      std::string payload =
+         "GET /front HTTP/1.1\r\n"
+         "Host: example.com:0\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 400")) << "Expected 400 for Host header with zero port";
+   };
+
+   "request with bracketed IPv6 Host header zero port is rejected with 400 bad request"_test = [&] {
+      std::string payload =
+         "GET /front HTTP/1.1\r\n"
+         "Host: [::1]:0\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 400")) << "Expected 400 for bracketed IPv6 Host header with zero port";
    };
 
    "request with Host header port above server policy range is rejected with 400 bad request"_test = [&] {

--- a/tests/networking_tests/http_server_test/ip_address_validation_test.cpp
+++ b/tests/networking_tests/http_server_test/ip_address_validation_test.cpp
@@ -1,0 +1,166 @@
+#include <string_view>
+#include <ut/ut.hpp>
+
+#include "glaze/net/http_server.hpp"
+
+using namespace ut;
+using glz::detail::validate_ipv4_address;
+using glz::detail::validate_ipv6_address;
+
+int main()
+{
+   suite http_server_ipv4_address_validation = [] {
+      "rejects invalid IPv4 literals"_test = [] {
+         expect(not validate_ipv4_address(""));
+         expect(not validate_ipv4_address("256.0.0.1"));
+         expect(not validate_ipv4_address("1.2.3.256"));
+         expect(not validate_ipv4_address("999.0.0.1"));
+         expect(not validate_ipv4_address("1.2.3.4:80"));
+         expect(not validate_ipv4_address("1.2.3"));
+         expect(not validate_ipv4_address("1.2.3.4.5"));
+         expect(not validate_ipv4_address("1..2.3"));
+         expect(not validate_ipv4_address("1.2..4"));
+         expect(not validate_ipv4_address(".1.2.3.4"));
+         expect(not validate_ipv4_address("1.2.3.4."));
+         expect(not validate_ipv4_address("01.2.3.4"));
+         expect(not validate_ipv4_address("00.2.3.4"));
+         expect(not validate_ipv4_address("1.02.3.4"));
+         expect(not validate_ipv4_address("1.2.003.4"));
+         expect(not validate_ipv4_address("001.2.3.4"));
+         expect(not validate_ipv4_address("1.2.3.04"));
+         expect(not validate_ipv4_address("1.2.3.004"));
+         expect(not validate_ipv4_address("1.2.3.1234"));
+         expect(not validate_ipv4_address("1.2.3.-4"));
+         expect(not validate_ipv4_address("+1.2.3.4"));
+         expect(not validate_ipv4_address("1.+2.3.4"));
+         expect(not validate_ipv4_address(" 1.2.3.4"));
+         expect(not validate_ipv4_address("1.2.3.4 "));
+         expect(not validate_ipv4_address("\t1.2.3.4"));
+         expect(not validate_ipv4_address("1.2.3.4\t"));
+         expect(not validate_ipv4_address("1.2.3.4\n"));
+         expect(not validate_ipv4_address("b1.2.3.4"));
+         expect(not validate_ipv4_address("a.e.r.o"));
+         expect(not validate_ipv4_address("1.2.a.4"));
+         expect(not validate_ipv4_address("1.2.3.4/32"));
+         expect(not validate_ipv4_address("[1.2.3.4]"));
+         expect(not validate_ipv4_address(std::string_view{"1.2.3.4\0", 8}));
+      };
+
+      "rejects legacy IPv4 forms"_test = [] {
+         expect(not validate_ipv4_address("127.1"));
+         expect(not validate_ipv4_address("127.0.1"));
+         expect(not validate_ipv4_address("2130706433"));
+         expect(not validate_ipv4_address("0177.0.0.1"));
+         expect(not validate_ipv4_address("127.000.000.001"));
+         expect(not validate_ipv4_address("0x7f.0.0.1"));
+         expect(not validate_ipv4_address("0x7f000001"));
+      };
+
+      "accepts valid IPv4 literals"_test = [] {
+         expect(validate_ipv4_address("0.0.0.0"));
+         expect(validate_ipv4_address("9.10.99.100"));
+         expect(validate_ipv4_address("127.0.0.1"));
+         expect(validate_ipv4_address("1.2.3.4"));
+         expect(validate_ipv4_address("192.168.0.1"));
+         expect(validate_ipv4_address("199.200.249.250"));
+         expect(validate_ipv4_address("255.255.255.255"));
+      };
+   };
+
+   suite http_server_ipv6_address_validation = [] {
+      "rejects invalid IPv6 literals"_test = [] {
+         expect(not validate_ipv6_address(""));
+         expect(not validate_ipv6_address(":"));
+         expect(not validate_ipv6_address(":::"));
+         expect(not validate_ipv6_address(":1"));
+         expect(not validate_ipv6_address("1:"));
+         expect(not validate_ipv6_address("1:::2"));
+         expect(not validate_ipv6_address("1::2::3"));
+         expect(not validate_ipv6_address("1:2:3:4:5:6"));
+         expect(not validate_ipv6_address("1:2:3:4:5:6:7"));
+         expect(not validate_ipv6_address("1:2:3:4:5:6:7:8:9"));
+         expect(not validate_ipv6_address("1:2:3:4:5:6:7:8::"));
+         expect(not validate_ipv6_address("::1:2:3:4:5:6:7:8"));
+         expect(not validate_ipv6_address("1:2:3:4::5:6:7:8"));
+         expect(not validate_ipv6_address("1:2:3:4:5::6:7:8"));
+         expect(not validate_ipv6_address("1:2:3:4:5:6:7::8"));
+         expect(not validate_ipv6_address("12345::1"));
+         expect(not validate_ipv6_address("2001:db8:0:0:0:0:0:00000"));
+         expect(not validate_ipv6_address("gggg::1"));
+         expect(not validate_ipv6_address("2001:db8::-1"));
+         expect(not validate_ipv6_address("2001:db8::+1"));
+         expect(not validate_ipv6_address("+2001:db8::1"));
+         expect(not validate_ipv6_address("2001:db8::0x1"));
+         expect(not validate_ipv6_address("2001:db8::1/64"));
+         expect(not validate_ipv6_address("2001:db8::1%eth0"));
+         expect(not validate_ipv6_address("2001:db8::1%25eth0"));
+         expect(not validate_ipv6_address("2001:db8::1?x"));
+         expect(not validate_ipv6_address("2001:db8::1#x"));
+         expect(not validate_ipv6_address(" 2001:db8::1"));
+         expect(not validate_ipv6_address("2001:db8::1 "));
+         expect(not validate_ipv6_address("\t2001:db8::1"));
+         expect(not validate_ipv6_address("2001:db8::1\t"));
+         expect(not validate_ipv6_address("2001:db8::1\n"));
+         expect(not validate_ipv6_address("[2001:db8::1]"));
+         expect(not validate_ipv6_address("[2001:db8::1]:443"));
+         expect(not validate_ipv6_address(std::string_view{"2001:db8::1\0", 12}));
+      };
+
+      "accepts valid IPv6 literals without compression"_test = [] {
+         expect(validate_ipv6_address("0:0:0:0:0:0:0:0"));
+         expect(validate_ipv6_address("0:0:0:0:0:0:0:1"));
+         expect(validate_ipv6_address("1:2:3:4:5:6:7:8"));
+         expect(validate_ipv6_address("2001:db8:0:0:0:0:0:1"));
+         expect(validate_ipv6_address("2001:0DB8:0000:0000:0000:0000:0000:0001"));
+         expect(validate_ipv6_address("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"));
+      };
+
+      "accepts valid IPv6 literals with compression"_test = [] {
+         expect(validate_ipv6_address("::"));
+         expect(validate_ipv6_address("::1"));
+         expect(validate_ipv6_address("1::"));
+         expect(validate_ipv6_address("FE80::1"));
+         expect(validate_ipv6_address("2001::0"));
+         expect(validate_ipv6_address("2001:db8::"));
+         expect(validate_ipv6_address("2001:db8::1"));
+         expect(validate_ipv6_address("2001:db8::ff00:42:8329"));
+         expect(validate_ipv6_address("1:2:3:4::6:7:8"));
+         expect(validate_ipv6_address("1:2:3:4:5:6:7::"));
+         expect(validate_ipv6_address("2001:db8::1:80"));
+      };
+
+      "rejects invalid IPv6 literals with IPv4 tail"_test = [] {
+         expect(not validate_ipv6_address("192.0.2.1"));
+         expect(not validate_ipv6_address("::ffff:999.0.2.1"));
+         expect(not validate_ipv6_address("::ffff:192.0.2"));
+         expect(not validate_ipv6_address("::ffff:192.0.2.1.5"));
+         expect(not validate_ipv6_address("::ffff:192.168.001.1"));
+         expect(not validate_ipv6_address("::ffff:192.0.2.01"));
+         expect(not validate_ipv6_address("::ffff:0x7f.0.0.1"));
+         expect(not validate_ipv6_address("::ffff:192.0.2.1."));
+         expect(not validate_ipv6_address("::ffff:192.0.2.1:80"));
+         expect(not validate_ipv6_address("::ffff:192.0.2.-1"));
+         expect(not validate_ipv6_address("::ffff:+192.0.2.1"));
+         expect(not validate_ipv6_address("::ffff:192.0.2.1 "));
+         expect(not validate_ipv6_address("192.0.2.1::"));
+         expect(not validate_ipv6_address("2001:db8:192.0.2.1:1"));
+         expect(not validate_ipv6_address("1:2:3:4:5:192.0.2.1"));
+         expect(not validate_ipv6_address("0:0:0:0:0:0:0:192.0.2.1"));
+         expect(not validate_ipv6_address("1:2:3:4:5:6::192.0.2.1"));
+         expect(not validate_ipv6_address("::1:2:3:4:5:6:192.0.2.1"));
+         expect(not validate_ipv6_address("1:2:3:4:5::6:192.0.2.1"));
+      };
+
+      "accepts valid IPv6 literals with IPv4 tail"_test = [] {
+         expect(validate_ipv6_address("::0.0.0.0"));
+         expect(validate_ipv6_address("::192.0.2.1"));
+         expect(validate_ipv6_address("::255.255.255.255"));
+         expect(validate_ipv6_address("::ffff:192.0.2.1"));
+         expect(validate_ipv6_address("2001:db8::192.0.2.1"));
+         expect(validate_ipv6_address("0:0:0:0:0:0:192.0.2.1"));
+         expect(validate_ipv6_address("1:2:3:4:5:6:192.0.2.1"));
+         expect(validate_ipv6_address("1:2:3:4:5::192.0.2.1"));
+         expect(validate_ipv6_address("ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255"));
+      };
+   };
+}

--- a/tests/networking_tests/http_server_test/ip_address_validation_test.cpp
+++ b/tests/networking_tests/http_server_test/ip_address_validation_test.cpp
@@ -161,3 +161,5 @@ suite http_server_ipv6_address_validation = [] {
       expect(validate_ipv6_address("ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255"));
    };
 };
+
+int main() { return 0; }

--- a/tests/networking_tests/http_server_test/ip_address_validation_test.cpp
+++ b/tests/networking_tests/http_server_test/ip_address_validation_test.cpp
@@ -7,160 +7,157 @@ using namespace ut;
 using glz::detail::validate_ipv4_address;
 using glz::detail::validate_ipv6_address;
 
-int main()
-{
-   suite http_server_ipv4_address_validation = [] {
-      "rejects invalid IPv4 literals"_test = [] {
-         expect(not validate_ipv4_address(""));
-         expect(not validate_ipv4_address("256.0.0.1"));
-         expect(not validate_ipv4_address("1.2.3.256"));
-         expect(not validate_ipv4_address("999.0.0.1"));
-         expect(not validate_ipv4_address("1.2.3.4:80"));
-         expect(not validate_ipv4_address("1.2.3"));
-         expect(not validate_ipv4_address("1.2.3.4.5"));
-         expect(not validate_ipv4_address("1..2.3"));
-         expect(not validate_ipv4_address("1.2..4"));
-         expect(not validate_ipv4_address(".1.2.3.4"));
-         expect(not validate_ipv4_address("1.2.3.4."));
-         expect(not validate_ipv4_address("01.2.3.4"));
-         expect(not validate_ipv4_address("00.2.3.4"));
-         expect(not validate_ipv4_address("1.02.3.4"));
-         expect(not validate_ipv4_address("1.2.003.4"));
-         expect(not validate_ipv4_address("001.2.3.4"));
-         expect(not validate_ipv4_address("1.2.3.04"));
-         expect(not validate_ipv4_address("1.2.3.004"));
-         expect(not validate_ipv4_address("1.2.3.1234"));
-         expect(not validate_ipv4_address("1.2.3.-4"));
-         expect(not validate_ipv4_address("+1.2.3.4"));
-         expect(not validate_ipv4_address("1.+2.3.4"));
-         expect(not validate_ipv4_address(" 1.2.3.4"));
-         expect(not validate_ipv4_address("1.2.3.4 "));
-         expect(not validate_ipv4_address("\t1.2.3.4"));
-         expect(not validate_ipv4_address("1.2.3.4\t"));
-         expect(not validate_ipv4_address("1.2.3.4\n"));
-         expect(not validate_ipv4_address("b1.2.3.4"));
-         expect(not validate_ipv4_address("a.e.r.o"));
-         expect(not validate_ipv4_address("1.2.a.4"));
-         expect(not validate_ipv4_address("1.2.3.4/32"));
-         expect(not validate_ipv4_address("[1.2.3.4]"));
-         expect(not validate_ipv4_address(std::string_view{"1.2.3.4\0", 8}));
-      };
-
-      "rejects legacy IPv4 forms"_test = [] {
-         expect(not validate_ipv4_address("127.1"));
-         expect(not validate_ipv4_address("127.0.1"));
-         expect(not validate_ipv4_address("2130706433"));
-         expect(not validate_ipv4_address("0177.0.0.1"));
-         expect(not validate_ipv4_address("127.000.000.001"));
-         expect(not validate_ipv4_address("0x7f.0.0.1"));
-         expect(not validate_ipv4_address("0x7f000001"));
-      };
-
-      "accepts valid IPv4 literals"_test = [] {
-         expect(validate_ipv4_address("0.0.0.0"));
-         expect(validate_ipv4_address("9.10.99.100"));
-         expect(validate_ipv4_address("127.0.0.1"));
-         expect(validate_ipv4_address("1.2.3.4"));
-         expect(validate_ipv4_address("192.168.0.1"));
-         expect(validate_ipv4_address("199.200.249.250"));
-         expect(validate_ipv4_address("255.255.255.255"));
-      };
+suite http_server_ipv4_address_validation = [] {
+   "rejects invalid IPv4 literals"_test = [] {
+      expect(not validate_ipv4_address(""));
+      expect(not validate_ipv4_address("256.0.0.1"));
+      expect(not validate_ipv4_address("1.2.3.256"));
+      expect(not validate_ipv4_address("999.0.0.1"));
+      expect(not validate_ipv4_address("1.2.3.4:80"));
+      expect(not validate_ipv4_address("1.2.3"));
+      expect(not validate_ipv4_address("1.2.3.4.5"));
+      expect(not validate_ipv4_address("1..2.3"));
+      expect(not validate_ipv4_address("1.2..4"));
+      expect(not validate_ipv4_address(".1.2.3.4"));
+      expect(not validate_ipv4_address("1.2.3.4."));
+      expect(not validate_ipv4_address("01.2.3.4"));
+      expect(not validate_ipv4_address("00.2.3.4"));
+      expect(not validate_ipv4_address("1.02.3.4"));
+      expect(not validate_ipv4_address("1.2.003.4"));
+      expect(not validate_ipv4_address("001.2.3.4"));
+      expect(not validate_ipv4_address("1.2.3.04"));
+      expect(not validate_ipv4_address("1.2.3.004"));
+      expect(not validate_ipv4_address("1.2.3.1234"));
+      expect(not validate_ipv4_address("1.2.3.-4"));
+      expect(not validate_ipv4_address("+1.2.3.4"));
+      expect(not validate_ipv4_address("1.+2.3.4"));
+      expect(not validate_ipv4_address(" 1.2.3.4"));
+      expect(not validate_ipv4_address("1.2.3.4 "));
+      expect(not validate_ipv4_address("\t1.2.3.4"));
+      expect(not validate_ipv4_address("1.2.3.4\t"));
+      expect(not validate_ipv4_address("1.2.3.4\n"));
+      expect(not validate_ipv4_address("b1.2.3.4"));
+      expect(not validate_ipv4_address("a.e.r.o"));
+      expect(not validate_ipv4_address("1.2.a.4"));
+      expect(not validate_ipv4_address("1.2.3.4/32"));
+      expect(not validate_ipv4_address("[1.2.3.4]"));
+      expect(not validate_ipv4_address(std::string_view{"1.2.3.4\0", 8}));
    };
 
-   suite http_server_ipv6_address_validation = [] {
-      "rejects invalid IPv6 literals"_test = [] {
-         expect(not validate_ipv6_address(""));
-         expect(not validate_ipv6_address(":"));
-         expect(not validate_ipv6_address(":::"));
-         expect(not validate_ipv6_address(":1"));
-         expect(not validate_ipv6_address("1:"));
-         expect(not validate_ipv6_address("1:::2"));
-         expect(not validate_ipv6_address("1::2::3"));
-         expect(not validate_ipv6_address("1:2:3:4:5:6"));
-         expect(not validate_ipv6_address("1:2:3:4:5:6:7"));
-         expect(not validate_ipv6_address("1:2:3:4:5:6:7:8:9"));
-         expect(not validate_ipv6_address("1:2:3:4:5:6:7:8::"));
-         expect(not validate_ipv6_address("::1:2:3:4:5:6:7:8"));
-         expect(not validate_ipv6_address("1:2:3:4::5:6:7:8"));
-         expect(not validate_ipv6_address("1:2:3:4:5::6:7:8"));
-         expect(not validate_ipv6_address("1:2:3:4:5:6:7::8"));
-         expect(not validate_ipv6_address("12345::1"));
-         expect(not validate_ipv6_address("2001:db8:0:0:0:0:0:00000"));
-         expect(not validate_ipv6_address("gggg::1"));
-         expect(not validate_ipv6_address("2001:db8::-1"));
-         expect(not validate_ipv6_address("2001:db8::+1"));
-         expect(not validate_ipv6_address("+2001:db8::1"));
-         expect(not validate_ipv6_address("2001:db8::0x1"));
-         expect(not validate_ipv6_address("2001:db8::1/64"));
-         expect(not validate_ipv6_address("2001:db8::1%eth0"));
-         expect(not validate_ipv6_address("2001:db8::1%25eth0"));
-         expect(not validate_ipv6_address("2001:db8::1?x"));
-         expect(not validate_ipv6_address("2001:db8::1#x"));
-         expect(not validate_ipv6_address(" 2001:db8::1"));
-         expect(not validate_ipv6_address("2001:db8::1 "));
-         expect(not validate_ipv6_address("\t2001:db8::1"));
-         expect(not validate_ipv6_address("2001:db8::1\t"));
-         expect(not validate_ipv6_address("2001:db8::1\n"));
-         expect(not validate_ipv6_address("[2001:db8::1]"));
-         expect(not validate_ipv6_address("[2001:db8::1]:443"));
-         expect(not validate_ipv6_address(std::string_view{"2001:db8::1\0", 12}));
-      };
-
-      "accepts valid IPv6 literals without compression"_test = [] {
-         expect(validate_ipv6_address("0:0:0:0:0:0:0:0"));
-         expect(validate_ipv6_address("0:0:0:0:0:0:0:1"));
-         expect(validate_ipv6_address("1:2:3:4:5:6:7:8"));
-         expect(validate_ipv6_address("2001:db8:0:0:0:0:0:1"));
-         expect(validate_ipv6_address("2001:0DB8:0000:0000:0000:0000:0000:0001"));
-         expect(validate_ipv6_address("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"));
-      };
-
-      "accepts valid IPv6 literals with compression"_test = [] {
-         expect(validate_ipv6_address("::"));
-         expect(validate_ipv6_address("::1"));
-         expect(validate_ipv6_address("1::"));
-         expect(validate_ipv6_address("FE80::1"));
-         expect(validate_ipv6_address("2001::0"));
-         expect(validate_ipv6_address("2001:db8::"));
-         expect(validate_ipv6_address("2001:db8::1"));
-         expect(validate_ipv6_address("2001:db8::ff00:42:8329"));
-         expect(validate_ipv6_address("1:2:3:4::6:7:8"));
-         expect(validate_ipv6_address("1:2:3:4:5:6:7::"));
-         expect(validate_ipv6_address("2001:db8::1:80"));
-      };
-
-      "rejects invalid IPv6 literals with IPv4 tail"_test = [] {
-         expect(not validate_ipv6_address("192.0.2.1"));
-         expect(not validate_ipv6_address("::ffff:999.0.2.1"));
-         expect(not validate_ipv6_address("::ffff:192.0.2"));
-         expect(not validate_ipv6_address("::ffff:192.0.2.1.5"));
-         expect(not validate_ipv6_address("::ffff:192.168.001.1"));
-         expect(not validate_ipv6_address("::ffff:192.0.2.01"));
-         expect(not validate_ipv6_address("::ffff:0x7f.0.0.1"));
-         expect(not validate_ipv6_address("::ffff:192.0.2.1."));
-         expect(not validate_ipv6_address("::ffff:192.0.2.1:80"));
-         expect(not validate_ipv6_address("::ffff:192.0.2.-1"));
-         expect(not validate_ipv6_address("::ffff:+192.0.2.1"));
-         expect(not validate_ipv6_address("::ffff:192.0.2.1 "));
-         expect(not validate_ipv6_address("192.0.2.1::"));
-         expect(not validate_ipv6_address("2001:db8:192.0.2.1:1"));
-         expect(not validate_ipv6_address("1:2:3:4:5:192.0.2.1"));
-         expect(not validate_ipv6_address("0:0:0:0:0:0:0:192.0.2.1"));
-         expect(not validate_ipv6_address("1:2:3:4:5:6::192.0.2.1"));
-         expect(not validate_ipv6_address("::1:2:3:4:5:6:192.0.2.1"));
-         expect(not validate_ipv6_address("1:2:3:4:5::6:192.0.2.1"));
-      };
-
-      "accepts valid IPv6 literals with IPv4 tail"_test = [] {
-         expect(validate_ipv6_address("::0.0.0.0"));
-         expect(validate_ipv6_address("::192.0.2.1"));
-         expect(validate_ipv6_address("::255.255.255.255"));
-         expect(validate_ipv6_address("::ffff:192.0.2.1"));
-         expect(validate_ipv6_address("2001:db8::192.0.2.1"));
-         expect(validate_ipv6_address("0:0:0:0:0:0:192.0.2.1"));
-         expect(validate_ipv6_address("1:2:3:4:5:6:192.0.2.1"));
-         expect(validate_ipv6_address("1:2:3:4:5::192.0.2.1"));
-         expect(validate_ipv6_address("ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255"));
-      };
+   "rejects legacy IPv4 forms"_test = [] {
+      expect(not validate_ipv4_address("127.1"));
+      expect(not validate_ipv4_address("127.0.1"));
+      expect(not validate_ipv4_address("2130706433"));
+      expect(not validate_ipv4_address("0177.0.0.1"));
+      expect(not validate_ipv4_address("127.000.000.001"));
+      expect(not validate_ipv4_address("0x7f.0.0.1"));
+      expect(not validate_ipv4_address("0x7f000001"));
    };
-}
+
+   "accepts valid IPv4 literals"_test = [] {
+      expect(validate_ipv4_address("0.0.0.0"));
+      expect(validate_ipv4_address("9.10.99.100"));
+      expect(validate_ipv4_address("127.0.0.1"));
+      expect(validate_ipv4_address("1.2.3.4"));
+      expect(validate_ipv4_address("192.168.0.1"));
+      expect(validate_ipv4_address("199.200.249.250"));
+      expect(validate_ipv4_address("255.255.255.255"));
+   };
+};
+
+suite http_server_ipv6_address_validation = [] {
+   "rejects invalid IPv6 literals"_test = [] {
+      expect(not validate_ipv6_address(""));
+      expect(not validate_ipv6_address(":"));
+      expect(not validate_ipv6_address(":::"));
+      expect(not validate_ipv6_address(":1"));
+      expect(not validate_ipv6_address("1:"));
+      expect(not validate_ipv6_address("1:::2"));
+      expect(not validate_ipv6_address("1::2::3"));
+      expect(not validate_ipv6_address("1:2:3:4:5:6"));
+      expect(not validate_ipv6_address("1:2:3:4:5:6:7"));
+      expect(not validate_ipv6_address("1:2:3:4:5:6:7:8:9"));
+      expect(not validate_ipv6_address("1:2:3:4:5:6:7:8::"));
+      expect(not validate_ipv6_address("::1:2:3:4:5:6:7:8"));
+      expect(not validate_ipv6_address("1:2:3:4::5:6:7:8"));
+      expect(not validate_ipv6_address("1:2:3:4:5::6:7:8"));
+      expect(not validate_ipv6_address("1:2:3:4:5:6:7::8"));
+      expect(not validate_ipv6_address("12345::1"));
+      expect(not validate_ipv6_address("2001:db8:0:0:0:0:0:00000"));
+      expect(not validate_ipv6_address("gggg::1"));
+      expect(not validate_ipv6_address("2001:db8::-1"));
+      expect(not validate_ipv6_address("2001:db8::+1"));
+      expect(not validate_ipv6_address("+2001:db8::1"));
+      expect(not validate_ipv6_address("2001:db8::0x1"));
+      expect(not validate_ipv6_address("2001:db8::1/64"));
+      expect(not validate_ipv6_address("2001:db8::1%eth0"));
+      expect(not validate_ipv6_address("2001:db8::1%25eth0"));
+      expect(not validate_ipv6_address("2001:db8::1?x"));
+      expect(not validate_ipv6_address("2001:db8::1#x"));
+      expect(not validate_ipv6_address(" 2001:db8::1"));
+      expect(not validate_ipv6_address("2001:db8::1 "));
+      expect(not validate_ipv6_address("\t2001:db8::1"));
+      expect(not validate_ipv6_address("2001:db8::1\t"));
+      expect(not validate_ipv6_address("2001:db8::1\n"));
+      expect(not validate_ipv6_address("[2001:db8::1]"));
+      expect(not validate_ipv6_address("[2001:db8::1]:443"));
+      expect(not validate_ipv6_address(std::string_view{"2001:db8::1\0", 12}));
+   };
+
+   "accepts valid IPv6 literals without compression"_test = [] {
+      expect(validate_ipv6_address("0:0:0:0:0:0:0:0"));
+      expect(validate_ipv6_address("0:0:0:0:0:0:0:1"));
+      expect(validate_ipv6_address("1:2:3:4:5:6:7:8"));
+      expect(validate_ipv6_address("2001:db8:0:0:0:0:0:1"));
+      expect(validate_ipv6_address("2001:0DB8:0000:0000:0000:0000:0000:0001"));
+      expect(validate_ipv6_address("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"));
+   };
+
+   "accepts valid IPv6 literals with compression"_test = [] {
+      expect(validate_ipv6_address("::"));
+      expect(validate_ipv6_address("::1"));
+      expect(validate_ipv6_address("1::"));
+      expect(validate_ipv6_address("FE80::1"));
+      expect(validate_ipv6_address("2001::0"));
+      expect(validate_ipv6_address("2001:db8::"));
+      expect(validate_ipv6_address("2001:db8::1"));
+      expect(validate_ipv6_address("2001:db8::ff00:42:8329"));
+      expect(validate_ipv6_address("1:2:3:4::6:7:8"));
+      expect(validate_ipv6_address("1:2:3:4:5:6:7::"));
+      expect(validate_ipv6_address("2001:db8::1:80"));
+   };
+
+   "rejects invalid IPv6 literals with IPv4 tail"_test = [] {
+      expect(not validate_ipv6_address("192.0.2.1"));
+      expect(not validate_ipv6_address("::ffff:999.0.2.1"));
+      expect(not validate_ipv6_address("::ffff:192.0.2"));
+      expect(not validate_ipv6_address("::ffff:192.0.2.1.5"));
+      expect(not validate_ipv6_address("::ffff:192.168.001.1"));
+      expect(not validate_ipv6_address("::ffff:192.0.2.01"));
+      expect(not validate_ipv6_address("::ffff:0x7f.0.0.1"));
+      expect(not validate_ipv6_address("::ffff:192.0.2.1."));
+      expect(not validate_ipv6_address("::ffff:192.0.2.1:80"));
+      expect(not validate_ipv6_address("::ffff:192.0.2.-1"));
+      expect(not validate_ipv6_address("::ffff:+192.0.2.1"));
+      expect(not validate_ipv6_address("::ffff:192.0.2.1 "));
+      expect(not validate_ipv6_address("192.0.2.1::"));
+      expect(not validate_ipv6_address("2001:db8:192.0.2.1:1"));
+      expect(not validate_ipv6_address("1:2:3:4:5:192.0.2.1"));
+      expect(not validate_ipv6_address("0:0:0:0:0:0:0:192.0.2.1"));
+      expect(not validate_ipv6_address("1:2:3:4:5:6::192.0.2.1"));
+      expect(not validate_ipv6_address("::1:2:3:4:5:6:192.0.2.1"));
+      expect(not validate_ipv6_address("1:2:3:4:5::6:192.0.2.1"));
+   };
+
+   "accepts valid IPv6 literals with IPv4 tail"_test = [] {
+      expect(validate_ipv6_address("::0.0.0.0"));
+      expect(validate_ipv6_address("::192.0.2.1"));
+      expect(validate_ipv6_address("::255.255.255.255"));
+      expect(validate_ipv6_address("::ffff:192.0.2.1"));
+      expect(validate_ipv6_address("2001:db8::192.0.2.1"));
+      expect(validate_ipv6_address("0:0:0:0:0:0:192.0.2.1"));
+      expect(validate_ipv6_address("1:2:3:4:5:6:192.0.2.1"));
+      expect(validate_ipv6_address("1:2:3:4:5::192.0.2.1"));
+      expect(validate_ipv6_address("ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255"));
+   };
+};


### PR DESCRIPTION
## RFC 9112, Section 3.2:

> A server MUST respond with a 400 (Bad Request) status code to any HTTP/1.1 request message that lacks a Host header field and to any request message that contains more than one Host header field line or a Host header field with an invalid field value.

- [x] A server MUST respond with a 400 (Bad Request) status code to any HTTP/1.1 request message that lacks a Host header field.
- [x] A server MUST respond with a 400 (Bad Request) status code to any HTTP/1.1 request message that ... contains more than one Host header field line.
- [x] A server MUST respond with a 400 (Bad Request) status code to any HTTP/1.1 request message that ... contains a Host header field with an invalid field value.

---

This PR partially addresses the issue with MUST validation of Host headers, but even with this PR (at the current stage) Glaze still does not validate the Host header field value as required by RFC 9112.

I haven't implemented this as part of the PR yet, since I haven't gotten around to implementing it in my project.
I'm currently writing a project that implements a HTTP/1.1 server according to the RFC as strictly as I can, and I plan to check after each implemented part and after reading the RFC whether Glaze meets the MUST or SHOULD requirements. If not, I will fix it or at least notify you of any non-compliance. Of course, it's impossible to guarantee that I won't miss a single HTTP/1.1 server detail, but I hope this will at least partially help in achieving the goal of full RFC compliance.

If you don't consider this a urgent issue and don't plan to address it yourself - I plan to write such validator for my project within the next couple of days or so, and I'll be able to port it to Glaze if it's still relevant by then.