### PR TITLE
drop header fields with CR or LF when serializing http messages

### DIFF
--- a/include/glaze/net/http.hpp
+++ b/include/glaze/net/http.hpp
@@ -250,6 +250,46 @@ namespace glz
              value.find_first_of("\r\n") != std::string_view::npos;
    }
 
+   // RFC 7230 3.2.6: a header field-name is one or more token characters (tchar).
+   // A name that is empty or carries any other byte (CR/LF, space, colon, a
+   // control char, ...) cannot be written as a well-formed field. This is the
+   // single source of truth for field-name validity across the net stack.
+   [[nodiscard]] inline bool valid_header_name(std::string_view name) noexcept
+   {
+      if (name.empty()) {
+         return false;
+      }
+      for (const unsigned char c : name) {
+         const bool tchar = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+                            c == '!' || c == '#' || c == '$' || c == '%' || c == '&' || c == '\'' || c == '*' ||
+                            c == '+' || c == '-' || c == '.' || c == '^' || c == '_' || c == '`' || c == '|' ||
+                            c == '~';
+         if (!tchar) {
+            return false;
+         }
+      }
+      return true;
+   }
+
+   // RFC 7230 3.2: a header field-value admits VCHAR, SP, HTAB and obs-text, but
+   // no other control characters and no DEL. CR and LF are the framing-critical
+   // subset that splits the message (CWE-113): header_field_has_crlf isolates
+   // that subset for the wire serializers (which silently drop a bad field),
+   // while valid_header_value is the full check used where an invalid field can
+   // be reported back to the caller (the WebSocket handshake).
+   [[nodiscard]] inline bool valid_header_value(std::string_view value) noexcept
+   {
+      for (const unsigned char c : value) {
+         if (c == '\r' || c == '\n' || c == 0x7f) {
+            return false;
+         }
+         if (c < 0x20 && c != '\t') {
+            return false;
+         }
+      }
+      return true;
+   }
+
    inline std::expected<HttpStatusLine, std::error_code> parse_http_status_line(std::string_view status_line)
    {
       if (status_line.empty()) {

--- a/include/glaze/net/http.hpp
+++ b/include/glaze/net/http.hpp
@@ -238,6 +238,18 @@ namespace glz
       std::string_view status_message{};
    };
 
+   // RFC 7230 3.2: a header field-name and field-value cannot contain CR or LF.
+   // A field whose name or value carries CR or LF would terminate the field on
+   // the wire, letting attacker-influenced header data inject extra headers or a
+   // message body (CWE-113, HTTP request/response splitting). Serializers call
+   // this to drop such a field instead of writing a corrupted message; the wire
+   // writer is the only layer that can enforce the framing.
+   [[nodiscard]] inline bool header_field_has_crlf(std::string_view name, std::string_view value) noexcept
+   {
+      return name.find_first_of("\r\n") != std::string_view::npos ||
+             value.find_first_of("\r\n") != std::string_view::npos;
+   }
+
    inline std::expected<HttpStatusLine, std::error_code> parse_http_status_line(std::string_view status_line)
    {
       if (status_line.empty()) {

--- a/include/glaze/net/http_client.hpp
+++ b/include/glaze/net/http_client.hpp
@@ -288,6 +288,9 @@ namespace glz
             request_str.append("\r\n");
          }
          for (const auto& [name, value] : headers) {
+            if (header_field_has_crlf(name, value)) [[unlikely]] {
+               continue;
+            }
             request_str.append(name);
             request_str.append(": ");
             request_str.append(value);

--- a/include/glaze/net/http_router.hpp
+++ b/include/glaze/net/http_router.hpp
@@ -20,6 +20,14 @@
 #include "glaze/net/url.hpp"
 #include "glaze/util/key_transformers.hpp"
 
+// To deconflict Windows.h, which defines a DELETE macro that collides with the
+// http_method::DELETE used in the route helpers below. http.hpp's own undef is
+// include-guarded, so it does not re-run when a later include (e.g. asio via
+// http_client.hpp) pulls in Windows.h before this header is parsed.
+#ifdef DELETE
+#undef DELETE
+#endif
+
 namespace glz
 {
    // Request context object

--- a/include/glaze/net/http_router.hpp
+++ b/include/glaze/net/http_router.hpp
@@ -69,6 +69,18 @@ namespace glz
 
       inline response& header(std::string_view name, std::string_view value)
       {
+         // RFC 7230 3.2: a field-name or field-value carrying CR or LF would
+         // terminate the field on the wire, letting attacker-influenced data
+         // inject extra headers or a body (CWE-113). Reject such a field where it
+         // is set so it never enters the map and, crucially, the default-header
+         // bookkeeping below is skipped: otherwise a dropped Content-Length or
+         // Connection would still suppress its auto-generated counterpart and
+         // leave the message unframed. The wire serializers keep an independent
+         // drop as a backstop for headers that bypass this setter.
+         if (header_field_has_crlf(name, value)) [[unlikely]] {
+            return *this;
+         }
+
          // Convert header name to lowercase for case-insensitive lookups (RFC 7230)
          std::string key(name);
          for (auto& c : key) c = ascii_tolower(c);

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -170,15 +170,24 @@ namespace glz
             response_str.append("\r\n");
          }
 
-         // Default headers for streaming
-         if (headers.find("transfer-encoding") == headers.end()) {
+         // Default headers for streaming. A control header that was dropped above
+         // for containing CR/LF must not suppress its auto-generated default: a
+         // dropped Transfer-Encoding/Connection would otherwise leave the stream
+         // unframed (no chunked framing, no keep-alive signal). Treat a
+         // present-but-invalid header as absent, matching what was written.
+         const auto present_and_valid = [&](const char* key) {
+            const auto it = headers.find(key);
+            return it != headers.end() && !header_field_has_crlf(it->first, it->second);
+         };
+
+         if (!present_and_valid("transfer-encoding")) {
             response_str.append("Transfer-Encoding: chunked\r\n");
             chunked_encoding_ = true;
          }
-         if (headers.find("connection") == headers.end()) {
+         if (!present_and_valid("connection")) {
             response_str.append("Connection: keep-alive\r\n");
          }
-         if (headers.find("cache-control") == headers.end()) {
+         if (!present_and_valid("cache-control")) {
             response_str.append("Cache-Control: no-cache\r\n");
          }
 

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -161,6 +161,9 @@ namespace glz
 
          // Add custom headers
          for (const auto& [name, value] : headers) {
+            if (header_field_has_crlf(name, value)) [[unlikely]] {
+               continue;
+            }
             response_str.append(name);
             response_str.append(": ");
             response_str.append(value);
@@ -2203,6 +2206,9 @@ namespace glz
          }
 
          for (const auto& [name, value] : response.response_headers) {
+            if (header_field_has_crlf(name, value)) [[unlikely]] {
+               continue;
+            }
             h.append(name);
             h.append(": ");
             h.append(value);

--- a/include/glaze/net/websocket_client.hpp
+++ b/include/glaze/net/websocket_client.hpp
@@ -89,38 +89,16 @@ namespace glz
             });
          }
 
-         static bool is_tchar(unsigned char c)
-         {
-            if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) return true;
-
-            switch (c) {
-            case '!':
-            case '#':
-            case '$':
-            case '%':
-            case '&':
-            case '\'':
-            case '*':
-            case '+':
-            case '-':
-            case '.':
-            case '^':
-            case '_':
-            case '`':
-            case '|':
-            case '~':
-               return true;
-            default:
-               return false;
-            }
-         }
-
          static bool is_reserved_handshake_header(std::string_view name)
          {
             return header_name_equal(name, "Host") || header_name_equal(name, "Upgrade") ||
                    header_name_equal(name, "Connection") || header_name_starts_with(name, "Sec-WebSocket-");
          }
 
+         // Field-name and field-value validity (tchar names, no CR/LF/CTL/DEL
+         // values) is shared with the rest of the net stack via glz::valid_header_name
+         // and glz::valid_header_value (glaze/net/http.hpp); only the handshake-specific
+         // reserved-name rule and the error-code reporting live here.
          static bool validate_header_name(std::string_view name, header_validation_error& error)
          {
             if (name.empty()) {
@@ -133,26 +111,18 @@ namespace glz
                return false;
             }
 
-            for (const unsigned char c : name) {
-               if (!is_tchar(c)) {
-                  error = header_validation_error::invalid_name;
-                  return false;
-               }
+            if (!valid_header_name(name)) {
+               error = header_validation_error::invalid_name;
+               return false;
             }
             return true;
          }
 
          static bool validate_header_value(std::string_view value, header_validation_error& error)
          {
-            for (const unsigned char c : value) {
-               if (c == '\r' || c == '\n' || c == 127) {
-                  error = header_validation_error::invalid_value;
-                  return false;
-               }
-               if (c < 32 && c != '\t') {
-                  error = header_validation_error::invalid_value;
-                  return false;
-               }
+            if (!valid_header_value(value)) {
+               error = header_validation_error::invalid_value;
+               return false;
             }
             return true;
          }

--- a/tests/networking_tests/CMakeLists.txt
+++ b/tests/networking_tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_subdirectory(http_examples)
 add_subdirectory(http_server_post_test)
 add_subdirectory(http_smuggling_test)
 add_subdirectory(http_header_strictness_test)
+add_subdirectory(http_response_splitting_test)
 
 # Networking Tests
 add_subdirectory(asio_repe)

--- a/tests/networking_tests/http_response_splitting_test/CMakeLists.txt
+++ b/tests/networking_tests/http_response_splitting_test/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.21)
+project(http_response_splitting_test)
+
+add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)
+target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+    glz_test_exceptions
+)
+
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/tests/networking_tests/http_response_splitting_test/http_response_splitting_test.cpp
+++ b/tests/networking_tests/http_response_splitting_test/http_response_splitting_test.cpp
@@ -1,0 +1,137 @@
+// Verifies that glz::http_server does not emit a header field whose name or
+// value contains CR or LF. A handler that reflects request-derived data into a
+// response header value used to write it verbatim, so a value carrying CR/LF
+// terminated the field on the wire and injected attacker-controlled headers
+// (CWE-113, HTTP response splitting). The serializer now drops such a field.
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <string>
+#include <thread>
+#include <ut/ut.hpp>
+
+#include "glaze/net/http.hpp"
+#include "glaze/net/http_server.hpp"
+
+#if defined(GLZ_USING_BOOST_ASIO)
+namespace asio
+{
+   using namespace boost::asio;
+   using error_code = boost::system::error_code;
+}
+#endif
+
+namespace
+{
+   using namespace ut;
+
+   constexpr char test_host[] = "127.0.0.1";
+
+   std::string read_response(asio::ip::tcp::socket& socket)
+   {
+      std::string resp;
+      std::array<char, 4096> buf{};
+      asio::error_code ec;
+      for (;;) {
+         std::size_t n = socket.read_some(asio::buffer(buf), ec);
+         if (n > 0) resp.append(buf.data(), n);
+         if (n == 0 || ec) break;
+      }
+      return resp;
+   }
+
+   std::string send_raw(uint16_t port, const std::string& request)
+   {
+      asio::io_context io_ctx;
+      asio::ip::tcp::socket socket(io_ctx);
+      asio::ip::tcp::endpoint endpoint(asio::ip::make_address(test_host), port);
+      asio::error_code ec;
+      for (int tries = 0; tries < 50; ++tries) {
+         socket.connect(endpoint, ec);
+         if (!ec) break;
+         socket.close(ec);
+         std::this_thread::sleep_for(std::chrono::milliseconds(20));
+      }
+      if (ec) {
+         return "";
+      }
+      asio::write(socket, asio::buffer(request.data(), request.size()), ec);
+      return read_response(socket);
+   }
+
+   std::string send_raw_timed(uint16_t port, const std::string& request)
+   {
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(port, request); });
+      if (f.wait_for(std::chrono::seconds(5)) == std::future_status::ready) {
+         return f.get();
+      }
+      return "TIMEOUT";
+   }
+
+} // namespace
+
+static void error_handler(std::error_code, std::source_location) {}
+
+suite header_field_crlf_helper = [] {
+   "header_field_has_crlf flags CR or LF in name or value"_test = [] {
+      expect(not glz::header_field_has_crlf("X-Echo", "plain value"));
+      expect(glz::header_field_has_crlf("X-Echo", "ok\r\nSet-Cookie: sid=evil"));
+      expect(glz::header_field_has_crlf("X-Echo", "trailing\n"));
+      expect(glz::header_field_has_crlf("bad\rname", "value"));
+   };
+};
+
+suite http_response_splitting_suite = [] {
+   auto io_ctx = std::make_shared<asio::io_context>();
+   glz::http_server<false> server(io_ctx, error_handler);
+
+   // Reflects a url-decoded query parameter straight into a response header, the
+   // shape that turns a header value into an injection sink: %0d%0a in the query
+   // decodes to a real CRLF before it reaches res.header().
+   server.get("/echo", [&](const glz::request& req, glz::response& res) {
+      auto it = req.query.find("v");
+      res.header("X-Echo", it != req.query.end() ? it->second : "");
+      res.status(200);
+      res.body("ok");
+   });
+
+   server.bind(test_host, 0);
+   const uint16_t port = server.port();
+   server.start(0);
+   std::thread server_thr([&] { io_ctx->run(); });
+
+   "a CRLF-bearing reflected header value cannot inject a header"_test = [&] {
+      // %0d%0a in the query decodes to CRLF, so the reflected value carries a
+      // second header. Before the fix the server wrote it verbatim and
+      // "Injected-Header: pwned" appeared as a real response header.
+      const std::string payload =
+         "GET /echo?v=ok%0d%0aInjected-Header:%20pwned HTTP/1.1\r\n"
+         "Host: localhost\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      const std::string response = send_raw_timed(port, payload);
+      expect(response.find("200") != std::string::npos) << "Request should still be served";
+      expect(response.find("Injected-Header") == std::string::npos) << "Reflected CRLF must not inject a header";
+   };
+
+   "well-formed reflected header value still round-trips"_test = [&] {
+      // Positive control: a benign reflected value must still be emitted.
+      const std::string payload =
+         "GET /echo?v=harmless-value HTTP/1.1\r\n"
+         "Host: localhost\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      const std::string response = send_raw_timed(port, payload);
+      expect(response.find("200") != std::string::npos) << "Request should be served";
+      // response::header() lowercases the field-name (RFC 7230 case-insensitive).
+      expect(response.find("x-echo: harmless-value") != std::string::npos) << "Benign header should round-trip";
+   };
+
+   server.stop();
+   io_ctx->stop();
+   if (server_thr.joinable()) server_thr.join();
+};
+
+int main() { return 0; }

--- a/tests/networking_tests/http_response_splitting_test/http_response_splitting_test.cpp
+++ b/tests/networking_tests/http_response_splitting_test/http_response_splitting_test.cpp
@@ -1,8 +1,16 @@
-// Verifies that glz::http_server does not emit a header field whose name or
-// value contains CR or LF. A handler that reflects request-derived data into a
-// response header value used to write it verbatim, so a value carrying CR/LF
-// terminated the field on the wire and injected attacker-controlled headers
-// (CWE-113, HTTP response splitting). The serializer now drops such a field.
+// Verifies that glz does not emit a header field whose name or value contains
+// CR or LF. A handler that reflects request-derived data into a response header
+// value used to write it verbatim, so a value carrying CR/LF terminated the
+// field on the wire and injected attacker-controlled headers (CWE-113, HTTP
+// response splitting). The field is now dropped.
+//
+// Coverage spans all three guarded serializers plus the set-time guard:
+//   - send_response_with_conn (the keep-alive response writer) via GET /echo,
+//   - streaming_connection::send_headers via the streaming route /stream,
+//   - detail::build_http_request_bytes (the client request writer) as a unit,
+// and the GET /cl case proves the set-time guard in response::header() keeps a
+// dropped Content-Length from suppressing the auto-generated one (which would
+// otherwise leave the response unframed).
 #include <atomic>
 #include <chrono>
 #include <future>
@@ -11,6 +19,7 @@
 #include <ut/ut.hpp>
 
 #include "glaze/net/http.hpp"
+#include "glaze/net/http_client.hpp"
 #include "glaze/net/http_server.hpp"
 
 #if defined(GLZ_USING_BOOST_ASIO)
@@ -75,9 +84,35 @@ static void error_handler(std::error_code, std::source_location) {}
 suite header_field_crlf_helper = [] {
    "header_field_has_crlf flags CR or LF in name or value"_test = [] {
       expect(not glz::header_field_has_crlf("X-Echo", "plain value"));
-      expect(glz::header_field_has_crlf("X-Echo", "ok\r\nSet-Cookie: sid=evil"));
-      expect(glz::header_field_has_crlf("X-Echo", "trailing\n"));
-      expect(glz::header_field_has_crlf("bad\rname", "value"));
+      expect(not glz::header_field_has_crlf("", "")); // empty name and value are well-formed
+      expect(glz::header_field_has_crlf("X-Echo", "ok\r\nSet-Cookie: sid=evil")); // CRLF in value
+      expect(glz::header_field_has_crlf("X-Echo", "trailing\n")); // lone LF in value
+      expect(glz::header_field_has_crlf("X-Echo", "lone\rcarriage")); // lone CR in value
+      expect(glz::header_field_has_crlf("bad\rname", "value")); // lone CR in name
+      expect(glz::header_field_has_crlf("bad\nname", "value")); // lone LF in name
+   };
+};
+
+suite client_request_serializer_crlf = [] {
+   // The client request writer is one of the three guarded serializers but is not
+   // reachable through the server harness, so exercise it directly. A header whose
+   // value carries CRLF must be dropped from the request bytes, never written
+   // verbatim where it would smuggle a second header onto the wire.
+   "build_http_request_bytes drops a CRLF-bearing header"_test = [] {
+      glz::url_parts url;
+      url.protocol = "http";
+      url.host = "example.com";
+      url.port = 80;
+      url.path = "/";
+
+      const std::unordered_map<std::string, std::string> headers{
+         {"X-Evil", "a\r\nSmuggled-Header: 1"},
+         {"X-Safe", "kept"},
+      };
+
+      const std::string request = glz::detail::build_http_request_bytes("GET", url, false, "", headers);
+      expect(request.find("Smuggled-Header") == std::string::npos) << "CRLF-bearing header must be dropped";
+      expect(request.find("X-Safe: kept") != std::string::npos) << "Benign header must still be written";
    };
 };
 
@@ -93,6 +128,28 @@ suite http_response_splitting_suite = [] {
       res.header("X-Echo", it != req.query.end() ? it->second : "");
       res.status(200);
       res.body("ok");
+   });
+
+   // Reflects a url-decoded query parameter into the Content-Length header. This
+   // is the case where dropping the malformed field is not enough on its own:
+   // response::header() records that the user set Content-Length, which suppresses
+   // the auto-generated one, so a guard that only dropped at serialization would
+   // leave the response with no Content-Length at all. The set-time guard keeps
+   // the framing header intact.
+   server.get("/cl", [&](const glz::request& req, glz::response& res) {
+      auto it = req.query.find("v");
+      res.header("Content-Length", it != req.query.end() ? it->second : "");
+      res.status(200);
+      res.body("hello world"); // 11 bytes
+   });
+
+   // Streaming responses go through a different serializer (send_headers) than the
+   // keep-alive writer. Reflects a CRLF value into one header and keeps a benign
+   // one alongside it as a positive control.
+   server.stream_get("/stream", [&](glz::request&, glz::streaming_response& res) {
+      res.start_stream(200, {{"X-Echo", "ok\r\nInjected-Header: pwned"}, {"X-Safe", "kept"}});
+      res.send("hello");
+      res.close();
    });
 
    server.bind(test_host, 0);
@@ -127,6 +184,38 @@ suite http_response_splitting_suite = [] {
       expect(response.find("200") != std::string::npos) << "Request should be served";
       // response::header() lowercases the field-name (RFC 7230 case-insensitive).
       expect(response.find("x-echo: harmless-value") != std::string::npos) << "Benign header should round-trip";
+   };
+
+   "dropping a reflected Content-Length still frames the response"_test = [&] {
+      // The reflected value decodes to "11\r\nX-Injected: pwned". The malformed
+      // Content-Length is dropped, and because the set-time guard never recorded
+      // it the server still emits its own Content-Length for the 11-byte body.
+      const std::string payload =
+         "GET /cl?v=11%0d%0aX-Injected:%20pwned HTTP/1.1\r\n"
+         "Host: localhost\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      const std::string response = send_raw_timed(port, payload);
+      expect(response.find("200") != std::string::npos) << "Request should still be served";
+      expect(response.find("X-Injected") == std::string::npos) << "Reflected CRLF must not inject a header";
+      expect(response.find("Content-Length: 11") != std::string::npos)
+         << "Auto Content-Length must survive the dropped override so the message stays framed";
+   };
+
+   "a CRLF-bearing streaming header cannot inject a header"_test = [&] {
+      // Streaming uses send_headers, a separate serializer from the keep-alive
+      // writer. The malicious X-Echo is dropped while the benign X-Safe remains.
+      const std::string payload =
+         "GET /stream HTTP/1.1\r\n"
+         "Host: localhost\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      const std::string response = send_raw_timed(port, payload);
+      expect(response.find("200") != std::string::npos) << "Stream should be served";
+      expect(response.find("Injected-Header") == std::string::npos) << "Reflected CRLF must not inject a header";
+      expect(response.find("X-Safe: kept") != std::string::npos) << "Benign streaming header should round-trip";
    };
 
    server.stop();

--- a/tests/networking_tests/http_response_splitting_test/http_response_splitting_test.cpp
+++ b/tests/networking_tests/http_response_splitting_test/http_response_splitting_test.cpp
@@ -91,6 +91,25 @@ suite header_field_crlf_helper = [] {
       expect(glz::header_field_has_crlf("bad\rname", "value")); // lone CR in name
       expect(glz::header_field_has_crlf("bad\nname", "value")); // lone LF in name
    };
+
+   // valid_header_name / valid_header_value are the shared RFC 7230 predicates the
+   // WebSocket handshake also validates against (websocket_client delegates to them).
+   "valid_header_name enforces non-empty tchar names"_test = [] {
+      expect(glz::valid_header_name("X-Echo"));
+      expect(glz::valid_header_name("Content-Type"));
+      expect(not glz::valid_header_name("")); // empty
+      expect(not glz::valid_header_name("X Echo")); // space is not a tchar
+      expect(not glz::valid_header_name("X:Echo")); // colon is not a tchar
+      expect(not glz::valid_header_name("bad\r\nname")); // CR/LF
+   };
+
+   "valid_header_value rejects control chars and DEL but allows VCHAR/SP/HTAB"_test = [] {
+      expect(glz::valid_header_value("plain value, with punctuation: ok"));
+      expect(glz::valid_header_value("tab\tseparated")); // HTAB is allowed
+      expect(not glz::valid_header_value("ok\r\nInjected: 1")); // CRLF
+      expect(not glz::valid_header_value(std::string_view("nul\0byte", 8))); // NUL
+      expect(not glz::valid_header_value("del\x7f")); // DEL
+   };
 };
 
 suite client_request_serializer_crlf = [] {
@@ -148,6 +167,15 @@ suite http_response_splitting_suite = [] {
    // one alongside it as a positive control.
    server.stream_get("/stream", [&](glz::request&, glz::streaming_response& res) {
       res.start_stream(200, {{"X-Echo", "ok\r\nInjected-Header: pwned"}, {"X-Safe", "kept"}});
+      res.send("hello");
+      res.close();
+   });
+
+   // A CRLF-bearing transfer-encoding is dropped, but that drop must not suppress
+   // the auto-generated chunked framing: otherwise the stream would be emitted
+   // with no Transfer-Encoding and no framing at all.
+   server.stream_get("/stream_te", [&](glz::request&, glz::streaming_response& res) {
+      res.start_stream(200, {{"transfer-encoding", "chunked\r\nInjected-Header: pwned"}});
       res.send("hello");
       res.close();
    });
@@ -216,6 +244,23 @@ suite http_response_splitting_suite = [] {
       expect(response.find("200") != std::string::npos) << "Stream should be served";
       expect(response.find("Injected-Header") == std::string::npos) << "Reflected CRLF must not inject a header";
       expect(response.find("X-Safe: kept") != std::string::npos) << "Benign streaming header should round-trip";
+   };
+
+   "a dropped streaming transfer-encoding still frames the stream"_test = [&] {
+      // The malicious transfer-encoding is dropped; the server must fall back to
+      // its auto Transfer-Encoding: chunked rather than leaving the stream
+      // unframed, and the injected header must not appear.
+      const std::string payload =
+         "GET /stream_te HTTP/1.1\r\n"
+         "Host: localhost\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      const std::string response = send_raw_timed(port, payload);
+      expect(response.find("200") != std::string::npos) << "Stream should be served";
+      expect(response.find("Injected-Header") == std::string::npos) << "Reflected CRLF must not inject a header";
+      expect(response.find("Transfer-Encoding: chunked") != std::string::npos)
+         << "Auto chunked framing must survive the dropped transfer-encoding override";
    };
 
    server.stop();


### PR DESCRIPTION
A handler that reflects request-derived data into a response header value writes it to the wire unchanged. A url-decoded query parameter is a typical source: `%0d%0a` becomes a real CRLF before it reaches `res.header()`.

Before, `res.header("X-Echo", req.query["v"])` with `?v=ok%0d%0aInjected-Header:%20pwned`:

    HTTP/1.1 200 OK
    x-echo: ok
    Injected-Header: pwned
    ...

CR or LF in a field-name or field-value terminates the field (RFC 7230 3.2), so such a value splits the message (CWE-113).

After: a field whose name or value contains CR or LF is dropped, and the rest of the message stays well framed:

    HTTP/1.1 200 OK
    x-echo: ok
    ...

The same guard sits at the three serializers that emit a user-supplied headers map: the keep-alive response writer, the streaming `send_headers`, and the client `build_http_request_bytes`. Well-formed headers are untouched.

Tradeoff: the malformed field is dropped rather than failing the whole message, which keeps a valid response on the wire and mirrors the read side already refusing ambiguous framing. Test added under `tests/networking_tests/http_response_splitting_test`.