### PR TITLE
Generalize std::chrono serialization across all formats (#2671)

### DIFF
--- a/docs/binary.md
+++ b/docs/binary.md
@@ -392,6 +392,21 @@ ALIGNED_HEADER | NUMERIC_HEADER | SIZE | PADDING_LENGTH | PADDING | DATA
 
 The overhead is 2 extra bytes (numeric header + padding length) plus at most `alignment - 1` bytes of padding. For large arrays this is negligible.
 
+## std::chrono Durations
+
+`std::chrono::duration` values serialize as their bare numeric count (the `rep`), so a duration is written byte-for-byte like the equivalent BEVE number. This makes a duration interchangeable with a numeric field in a shared schema:
+
+```c++
+std::chrono::milliseconds ms{12345};
+std::string buffer{};
+glz::write_beve(ms, buffer);
+
+std::chrono::milliseconds decoded{};
+glz::read_beve(decoded, buffer); // decoded.count() == 12345
+```
+
+Because the encoding is the numeric `rep`, durations also work as numeric BEVE map and pair keys (e.g. `std::map<std::chrono::seconds, V>`), producing the same wire form as the equivalent rep-keyed container. See [std::chrono Support](./chrono.md#durations) for the full cross-format behavior.
+
 ## Untagged Binary
 
 By default Glaze will handle structs as tagged objects, meaning that keys will be written/read. However, structs can be written/read without tags by using the option `structs_as_arrays` or the functions `glz::write_beve_untagged` and `glz::read_beve_untagged`.

--- a/docs/bson.md
+++ b/docs/bson.md
@@ -120,6 +120,21 @@ event e{"login", std::chrono::system_clock::now()};
 auto encoded = glz::write_bson(e);
 ```
 
+## `std::chrono::duration`
+
+A duration is **not** a datetime. It encodes as its bare numeric count (the `rep`) using the BSON number element that matches the rep type: `int32` (0x10) for reps up to 32 signed bits, `int64` (0x12) for wider or unsigned reps, and `double` (0x01) for floating-point reps. Because BSON's root is always a document, durations are supported as struct/map fields rather than as a bare top-level value. See [std::chrono Support](./chrono.md#durations).
+
+```cpp
+struct timings
+{
+   std::chrono::milliseconds elapsed{};   // int64 element
+   std::chrono::duration<int32_t, std::milli> budget{}; // int32 element
+};
+
+timings t{std::chrono::milliseconds{1500}, std::chrono::duration<int32_t, std::milli>{200}};
+auto encoded = glz::write_bson(t);
+```
+
 ## `glz::bson::timestamp`
 
 MongoDB-internal timestamp used for replication and sharding. Distinct from `datetime`: the wire format is a uint64 with the low 32 bits holding an increment counter and the high 32 bits seconds since epoch.

--- a/docs/chrono.md
+++ b/docs/chrono.md
@@ -6,7 +6,7 @@ Glaze provides first-class support for `std::chrono` types, enabling seamless se
 
 ### Durations
 
-All `std::chrono::duration` types are supported and serialize as their numeric count value:
+All `std::chrono::duration` types are supported and serialize as their numeric count value (the `rep`, expressed in the duration's own period). This representation is shared by every Glaze format (JSON, BEVE, CBOR, MsgPack, BSON, TOML, YAML, CSV, JSONB, EETF), so the same type round-trips between any of them interchangeably:
 
 ```cpp
 std::chrono::milliseconds ms{12345};
@@ -14,7 +14,16 @@ std::string json = glz::write_json(ms).value();  // "12345"
 
 std::chrono::milliseconds parsed{};
 glz::read_json(parsed, json);  // parsed.count() == 12345
+
+// The same value over a binary format: BEVE encodes the duration byte-for-byte
+// like its underlying integer rep.
+std::string beve{};
+glz::write_beve(ms, beve);
+std::chrono::milliseconds from_beve{};
+glz::read_beve(from_beve, beve);  // from_beve == ms
 ```
+
+> In BSON, whose document root cannot be a bare scalar, a duration is supported as a struct/map field (encoded as the rep's native BSON number type) rather than as a top-level value.
 
 This works with any duration type, including custom periods:
 

--- a/docs/chrono.md
+++ b/docs/chrono.md
@@ -136,6 +136,24 @@ glz::read_json(parsed, json);
 // Exact roundtrip - no precision loss
 ```
 
+### High Resolution Clock Time Points
+
+`std::chrono::high_resolution_clock` is not a distinct clock in any mainstream standard library. It is an alias, and **which clock it aliases differs by implementation**:
+
+| Standard library | `high_resolution_clock` is | `high_resolution_clock::time_point` behaves as |
+|------------------|----------------------------|------------------------------------------------|
+| libc++ (Clang), MSVC STL | `steady_clock` | numeric count, supported by every format |
+| libstdc++ (GCC) | `system_clock` | ISO 8601 string, only in the formats that support `system_clock::time_point` |
+
+Because the alias makes the two types *identical*, Glaze cannot give them different behavior. The practical consequence is that a type containing an `hrc::time_point` can compile on one platform and fail on another: under libstdc++ it is a `system_clock::time_point`, which BEVE, YAML, CSV, and JSONB do not support (see [Format Support](#format-support)).
+
+Prefer naming the clock you actually mean:
+
+```cpp
+std::chrono::steady_clock::time_point t;  // portable: numeric count in every format
+std::chrono::system_clock::time_point w;  // portable: wall clock, format support varies
+```
+
 ## Epoch Time Wrappers
 
 For APIs that expect Unix timestamps (numeric epoch time) instead of ISO 8601 strings, Glaze provides `epoch_time<Duration>` wrappers:
@@ -343,6 +361,23 @@ Output:
 | `glz::epoch_millis` | Unix milliseconds | `1702481400123` |
 | `glz::epoch_micros` | Unix microseconds | `1702481400123456` |
 | `glz::epoch_nanos` | Unix nanoseconds | `1702481400123456789` |
+
+## Format Support
+
+Durations and count-based time points use one representation shared by every format, so they interchange freely: the same meta schema can target JSON and BEVE. Calendar types are format-specific, because a wall-clock instant has no single natural encoding across text and binary formats.
+
+| Type | JSON | BEVE | CBOR | MsgPack | BSON | TOML | YAML | CSV | JSONB |
+|------|:----:|:----:|:----:|:-------:|:----:|:----:|:----:|:---:|:-----:|
+| `std::chrono::duration<Rep, Period>` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `steady_clock::time_point` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `system_clock::time_point` | ✅ | — | ✅ | ✅ | ✅ | ✅ | — | — | — |
+| `sys_days` (`sys_time<days>`) | ✅ | — | ✅ | — | — | ✅ | — | — | — |
+| `year_month_day` | ✅ | — | — | — | — | ✅ | — | — | — |
+| `glz::epoch_time<D>` | ✅ | — | ✅ | — | — | — | — | — | — |
+
+`high_resolution_clock::time_point` is not listed because it is an alias: it follows the `steady_clock` row under libc++ and MSVC, and the `system_clock` row under libstdc++. See [High Resolution Clock Time Points](#high-resolution-clock-time-points).
+
+An unsupported combination is a compile-time error (`write_supported` / `read_supported` report `false`), never a silent fallback. To carry a wall-clock instant through a format that lacks calendar support, store it as a duration since a known epoch (for example a `std::chrono::milliseconds` field), which every format encodes identically.
 
 ## Notes
 

--- a/docs/msgpack.md
+++ b/docs/msgpack.md
@@ -137,6 +137,19 @@ event e{"user_login", {1700000000, 0}};
 auto encoded = glz::write_msgpack(e);
 ```
 
+### `std::chrono::duration`
+
+Durations serialize as their bare numeric count (the `rep`), exactly as the equivalent integer or floating-point value would, so a duration field interoperates with a schema that reads it back as a number. See [std::chrono Support](./chrono.md#durations) for the cross-format details.
+
+```cpp
+std::chrono::milliseconds ms{12345};
+std::string buffer;
+glz::write_msgpack(ms, buffer);
+
+std::chrono::milliseconds decoded{};
+glz::read_msgpack(decoded, buffer); // decoded.count() == 12345
+```
+
 ## Binary Buffers
 
 Glaze automatically emits the compact MessagePack `bin*` tags for contiguous byte buffers such as

--- a/include/glaze/beve/header.hpp
+++ b/include/glaze/beve/header.hpp
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <cstring>
 #include <iterator>
+#include <type_traits>
 
 #include "glaze/concepts/container_concepts.hpp"
 #include "glaze/core/chrono.hpp"
@@ -157,6 +158,16 @@ namespace glz
    // a numeric typed array of the rep -- byte-identical to an array of the rep itself, and
    // far more compact than a generic array (which writes a type tag per element). These
    // helpers map an element type to that wire `rep` type and convert between the two.
+   //
+   // The typed-array fast paths take that bit-compatibility literally: both sides bulk-memcpy
+   // between the element storage and the wire bytes, and the zero-copy span read aliases the
+   // buffer as an array of elements. Every implementation stores a duration as exactly one
+   // `rep` member, but the standard specifies that member as exposition-only, so the property
+   // is asserted rather than assumed -- a violation would silently emit corrupt bytes instead
+   // of failing to compile.
+   template <class T, class Rep>
+   concept beve_rep_layout_compatible = sizeof(T) == sizeof(Rep) && std::is_trivially_copyable_v<T>;
+
    template <class V>
    struct beve_num_array_value
    {
@@ -166,11 +177,17 @@ namespace glz
    struct beve_num_array_value<V>
    {
       using type = typename std::remove_cvref_t<V>::rep;
+      static_assert(beve_rep_layout_compatible<std::remove_cvref_t<V>, type>,
+                    "BEVE typed-array packing requires std::chrono::duration to be a trivially copyable "
+                    "wrapper the size of its rep");
    };
    template <is_count_time_point V>
    struct beve_num_array_value<V>
    {
       using type = typename std::remove_cvref_t<V>::rep;
+      static_assert(beve_rep_layout_compatible<std::remove_cvref_t<V>, type>,
+                    "BEVE typed-array packing requires std::chrono::time_point to be a trivially copyable "
+                    "wrapper the size of its rep");
    };
    template <class V>
    using beve_num_array_value_t = typename beve_num_array_value<V>::type;

--- a/include/glaze/beve/header.hpp
+++ b/include/glaze/beve/header.hpp
@@ -12,6 +12,7 @@
 #include <iterator>
 
 #include "glaze/concepts/container_concepts.hpp"
+#include "glaze/core/chrono.hpp"
 #include "glaze/core/context.hpp"
 #include "glaze/util/inline.hpp"
 
@@ -150,6 +151,66 @@ namespace glz
    // instead of an inflated generic array that stores a type header per element.
    template <class T>
    concept beve_num_t = num_t<T> || std::same_as<std::remove_cvref_t<T>, std::byte>;
+
+   // A std::chrono::duration / steady-or-high-res time point is bit-compatible with its
+   // `rep` (a single arithmetic member, no padding), so an array of them can be packed into
+   // a numeric typed array of the rep -- byte-identical to an array of the rep itself, and
+   // far more compact than a generic array (which writes a type tag per element). These
+   // helpers map an element type to that wire `rep` type and convert between the two.
+   template <class V>
+   struct beve_num_array_value
+   {
+      using type = std::remove_cvref_t<V>;
+   };
+   template <is_duration V>
+   struct beve_num_array_value<V>
+   {
+      using type = typename std::remove_cvref_t<V>::rep;
+   };
+   template <is_count_time_point V>
+   struct beve_num_array_value<V>
+   {
+      using type = typename std::remove_cvref_t<V>::rep;
+   };
+   template <class V>
+   using beve_num_array_value_t = typename beve_num_array_value<V>::type;
+
+   // True when V lays out as a numeric typed-array element: a number/byte, or a chrono type
+   // that reduces to one.
+   template <class V>
+   concept beve_num_array_t = beve_num_t<beve_num_array_value_t<V>>;
+
+   // Extract the wire `rep` value from an element (identity for plain numbers).
+   template <class V>
+   GLZ_ALWAYS_INLINE constexpr auto beve_num_array_extract(const V& x) noexcept
+   {
+      using D = std::remove_cvref_t<V>;
+      if constexpr (is_duration<D>) {
+         return x.count();
+      }
+      else if constexpr (is_count_time_point<D>) {
+         return x.time_since_epoch().count();
+      }
+      else {
+         return x;
+      }
+   }
+
+   // Construct an element from a wire `rep` value (identity for plain numbers).
+   template <class V>
+   GLZ_ALWAYS_INLINE constexpr std::remove_cvref_t<V> beve_num_array_construct(beve_num_array_value_t<V> nv) noexcept
+   {
+      using D = std::remove_cvref_t<V>;
+      if constexpr (is_duration<D>) {
+         return D(nv);
+      }
+      else if constexpr (is_count_time_point<D>) {
+         return D(typename D::duration(nv));
+      }
+      else {
+         return nv;
+      }
+   }
 
    [[nodiscard]] GLZ_ALWAYS_INLINE constexpr size_t int_from_compressed(auto&& ctx, auto&& it, auto end) noexcept
    {

--- a/include/glaze/beve/key_traits.hpp
+++ b/include/glaze/beve/key_traits.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "glaze/beve/header.hpp"
+#include "glaze/core/chrono.hpp"
 #include "glaze/core/common.hpp"
 
 namespace glz
@@ -21,16 +22,35 @@ namespace glz
       using type = std::remove_cvref_t<typename cast_member::cast_type>;
    };
 
-   template <class T, bool = std::is_enum_v<std::remove_cvref_t<T>>>
+   // Resolves a BEVE map key to the arithmetic type that drives its numeric header
+   // and key tag. Enums unwrap to their underlying integer; durations and count-based
+   // time points (steady_clock / high_resolution_clock) unwrap to their `rep` so such a
+   // key encodes (and round-trips) as a plain numeric key, matching the bare-count
+   // encoding the generic to/from<Format, is_duration / is_count_time_point> emits for the
+   // key bytes. Without these cases the header would advertise a string key while the key
+   // bytes are numeric, producing an unreadable buffer.
+   template <class T, class = void>
    struct beve_numeric_type
    {
       using type = std::remove_cvref_t<T>;
    };
 
    template <class T>
-   struct beve_numeric_type<T, true>
+   struct beve_numeric_type<T, std::enable_if_t<std::is_enum_v<std::remove_cvref_t<T>>>>
    {
       using type = std::underlying_type_t<std::remove_cvref_t<T>>;
+   };
+
+   template <class T>
+   struct beve_numeric_type<T, std::enable_if_t<is_duration<std::remove_cvref_t<T>>>>
+   {
+      using type = typename std::remove_cvref_t<T>::rep;
+   };
+
+   template <class T>
+   struct beve_numeric_type<T, std::enable_if_t<is_count_time_point<std::remove_cvref_t<T>>>>
+   {
+      using type = typename std::remove_cvref_t<T>::rep;
    };
 
    template <class T, class = void>

--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -6,6 +6,7 @@
 #include "glaze/beve/header.hpp"
 #include "glaze/beve/key_traits.hpp"
 #include "glaze/beve/skip.hpp"
+#include "glaze/core/chrono.hpp"
 #include "glaze/core/opts.hpp"
 #include "glaze/core/read.hpp"
 #include "glaze/core/reflect.hpp"
@@ -730,9 +731,12 @@ namespace glz
                }
             }
          }
-         else if constexpr (beve_num_t<V>) {
-            constexpr uint8_t type = std::floating_point<V> ? 0 : (std::is_signed_v<V> ? 0b000'01'000 : 0b000'10'000);
-            constexpr uint8_t header = tag::typed_array | type | (byte_count<V> << 5);
+         else if constexpr (beve_num_array_t<V>) {
+            // NV is the arithmetic wire type: V for plain numbers, the rep for chrono
+            // durations / count-based time points (which are bit-compatible with it).
+            using NV = beve_num_array_value_t<V>;
+            constexpr uint8_t type = std::floating_point<NV> ? 0 : (std::is_signed_v<NV> ? 0b000'01'000 : 0b000'10'000);
+            constexpr uint8_t header = tag::typed_array | type | (byte_count<NV> << 5);
 
             if (tag != header) [[unlikely]] {
                ctx.error = error_code::syntax_error;
@@ -753,13 +757,13 @@ namespace glz
                   return;
                }
 
-               V x;
-               std::memcpy(&x, it, sizeof(V));
+               NV temp;
+               std::memcpy(&temp, it, sizeof(NV));
                if constexpr (std::endian::native == std::endian::big) {
-                  byteswap_le(x);
+                  byteswap_le(temp);
                }
-               it += sizeof(V);
-               value.emplace(x);
+               it += sizeof(NV);
+               value.emplace(beve_num_array_construct<V>(temp));
             }
          }
          else if constexpr (str_t<V>) {
@@ -833,10 +837,15 @@ namespace glz
    // For multi-byte types: requires an aligned typed array and little-endian host.
    // For single-byte types: accepts standard typed arrays on any endianness.
    template <class T, size_t Extent>
-      requires(std::is_const_v<T> && num_t<std::remove_const_t<T>>)
+      requires(std::is_const_v<T> && beve_num_array_t<std::remove_const_t<T>>)
    struct from<BEVE, std::span<T, Extent>> final
    {
       using V = std::remove_const_t<T>;
+      // Wire arithmetic type: V for plain numbers, the rep for chrono durations / count-based
+      // time points. The header bits must be computed from NV (e.g. std::is_signed_v<duration>
+      // is false, but a duration's rep can be signed), while the zero-copy view still points
+      // at V objects (which are bit-identical to NV, so sizeof and layout match).
+      using NV = beve_num_array_value_t<V>;
 
       template <auto Opts>
       static void op(std::span<T, Extent>& value, is_context auto&& ctx, auto&& it, auto end)
@@ -848,8 +857,8 @@ namespace glz
 
          if constexpr (sizeof(V) == 1) {
             // Single-byte types: accept standard typed arrays (no alignment or endian concerns)
-            constexpr uint8_t type = std::floating_point<V> ? 0 : (std::is_signed_v<V> ? 0b000'01'000 : 0b000'10'000);
-            constexpr uint8_t expected_header = tag::typed_array | type | (byte_count<V> << 5);
+            constexpr uint8_t type = std::floating_point<NV> ? 0 : (std::is_signed_v<NV> ? 0b000'01'000 : 0b000'10'000);
+            constexpr uint8_t expected_header = tag::typed_array | type | (byte_count<NV> << 5);
             if (tag != expected_header) [[unlikely]] {
                ctx.error = error_code::syntax_error;
                return;
@@ -893,8 +902,8 @@ namespace glz
                return;
             }
             const auto numeric_tag = uint8_t(*it);
-            constexpr uint8_t type = std::floating_point<V> ? 0 : (std::is_signed_v<V> ? 0b000'01'000 : 0b000'10'000);
-            constexpr uint8_t expected_header = tag::typed_array | type | (byte_count<V> << 5);
+            constexpr uint8_t type = std::floating_point<NV> ? 0 : (std::is_signed_v<NV> ? 0b000'01'000 : 0b000'10'000);
+            constexpr uint8_t expected_header = tag::typed_array | type | (byte_count<NV> << 5);
             if (numeric_tag != expected_header) [[unlikely]] {
                ctx.error = error_code::syntax_error;
                return;
@@ -1008,9 +1017,12 @@ namespace glz
                }
             }
          }
-         else if constexpr (beve_num_t<V>) {
-            constexpr uint8_t type = std::floating_point<V> ? 0 : (std::is_signed_v<V> ? 0b000'01'000 : 0b000'10'000);
-            constexpr uint8_t header = tag::typed_array | type | (byte_count<V> << 5);
+         else if constexpr (beve_num_array_t<V>) {
+            // NV is the arithmetic wire type: V for plain numbers, the rep for chrono
+            // durations / count-based time points (which are bit-compatible with it).
+            using NV = beve_num_array_value_t<V>;
+            constexpr uint8_t type = std::floating_point<NV> ? 0 : (std::is_signed_v<NV> ? 0b000'01'000 : 0b000'10'000);
+            constexpr uint8_t header = tag::typed_array | type | (byte_count<NV> << 5);
 
             auto validate_and_resize = [&](size_t n) -> bool {
                if constexpr (check_max_array_size(Opts) > 0) {
@@ -1205,26 +1217,30 @@ namespace glz
                         return;
                      }
 
-                     V temp;
-                     std::memcpy(&temp, it, sizeof(V));
+                     NV temp;
+                     std::memcpy(&temp, it, sizeof(NV));
                      if constexpr (std::endian::native == std::endian::big) {
                         byteswap_le(temp);
                      }
-                     value[i] = temp;
-                     it += sizeof(V);
+                     value[i] = beve_num_array_construct<V>(temp);
+                     it += sizeof(NV);
                   }
                }
                else if constexpr (std::endian::native == std::endian::big && sizeof(V) > 1) {
-                  // On big endian, read and swap each element
+                  // On big endian, read and swap each element (through the rep so a chrono
+                  // element is byteswapped as its underlying number).
                   if (typed_array_out_of_bounds(ctx, it, end, n, sizeof(V))) return;
                   for (size_t i = 0; i < n; ++i) {
-                     std::memcpy(&value[i], it, sizeof(V));
-                     byteswap_le(value[i]);
-                     it += sizeof(V);
+                     NV temp;
+                     std::memcpy(&temp, it, sizeof(NV));
+                     byteswap_le(temp);
+                     value[i] = beve_num_array_construct<V>(temp);
+                     it += sizeof(NV);
                   }
                }
                else {
-                  // Little endian or single-byte: bulk memcpy
+                  // Little endian or single-byte: bulk memcpy. A chrono element is
+                  // bit-identical to its rep, so the raw wire bytes populate it directly.
                   if (typed_array_out_of_bounds(ctx, it, end, n, sizeof(V))) return;
                   if (n) {
                      std::memcpy(value.data(), it, n * sizeof(V));
@@ -1239,11 +1255,13 @@ namespace glz
                      return;
                   }
 
-                  std::memcpy(&x, it, sizeof(V));
+                  NV temp;
+                  std::memcpy(&temp, it, sizeof(NV));
                   if constexpr (std::endian::native == std::endian::big) {
-                     byteswap_le(x);
+                     byteswap_le(temp);
                   }
-                  it += sizeof(V);
+                  x = beve_num_array_construct<V>(temp);
+                  it += sizeof(NV);
                }
             }
          }

--- a/include/glaze/beve/size.hpp
+++ b/include/glaze/beve/size.hpp
@@ -226,6 +226,27 @@ namespace glz
       }
    };
 
+   // std::chrono::duration / steady-or-high-res time_point encode as their bare `rep`
+   // (tag + rep value), matching the generic to<BEVE, ...> writer.
+   template <class T>
+      requires(is_duration<T> || is_count_time_point<T>)
+   struct calculate_size<BEVE, T>
+   {
+      using Rep = typename std::remove_cvref_t<T>::rep;
+
+      template <auto Opts>
+      [[nodiscard]] GLZ_ALWAYS_INLINE static size_t op(auto&&, size_t = 0) noexcept
+      {
+         return 1 + sizeof(Rep); // tag + value
+      }
+
+      template <auto Opts>
+      [[nodiscard]] GLZ_ALWAYS_INLINE static size_t no_header(auto&&, size_t = 0) noexcept
+      {
+         return sizeof(Rep); // value only
+      }
+   };
+
    template <complex_t T>
    struct calculate_size<BEVE, T>
    {
@@ -295,7 +316,9 @@ namespace glz
             const auto num_bytes = (value.size() + 7) / 8;
             result += num_bytes;
          }
-         else if constexpr (beve_num_t<V>) {
+         else if constexpr (beve_num_array_t<V>) {
+            // A chrono element packs as its rep; sizeof(V) == sizeof(rep) so the byte counts
+            // below match the numeric typed array the writer emits.
             if constexpr (check_aligned_arrays(Opts) && sizeof(V) > 1) {
                result += 1; // extra numeric header byte
                result += 1; // padding length byte

--- a/include/glaze/beve/write.hpp
+++ b/include/glaze/beve/write.hpp
@@ -8,6 +8,7 @@
 #include "glaze/beve/header.hpp"
 #include "glaze/beve/key_traits.hpp"
 #include "glaze/core/buffer_traits.hpp"
+#include "glaze/core/chrono.hpp"
 #include "glaze/core/opts.hpp"
 #include "glaze/core/reflect.hpp"
 #include "glaze/core/seek.hpp"
@@ -748,9 +749,12 @@ namespace glz
                static_assert(false_v<T>);
             }
          }
-         else if constexpr (beve_num_t<V>) {
-            constexpr uint8_t type = std::floating_point<V> ? 0 : (std::is_signed_v<V> ? 0b000'01'000 : 0b000'10'000);
-            constexpr uint8_t numeric_header = tag::typed_array | type | (byte_count<V> << 5);
+         else if constexpr (beve_num_array_t<V>) {
+            // NV is the arithmetic wire type: V for plain numbers, the rep for chrono
+            // durations / count-based time points (which are bit-compatible with it).
+            using NV = beve_num_array_value_t<V>;
+            constexpr uint8_t type = std::floating_point<NV> ? 0 : (std::is_signed_v<NV> ? 0b000'01'000 : 0b000'10'000);
+            constexpr uint8_t numeric_header = tag::typed_array | type | (byte_count<NV> << 5);
 
             if constexpr (check_aligned_arrays(Opts) && sizeof(V) > 1) {
                // Aligned typed array: ALIGNED_HEADER | NUMERIC_HEADER | SIZE | PADDING_LENGTH | PADDING | DATA
@@ -805,26 +809,28 @@ namespace glz
                if constexpr (is_volatile) {
                   const auto n_elements = value.size();
                   for (size_t i = 0; i < n_elements; ++i) {
-                     V temp = value[i];
+                     V elem = value[i]; // copy out of volatile storage first
+                     NV temp = beve_num_array_extract(elem);
                      if constexpr (std::endian::native == std::endian::big) {
                         byteswap_le(temp);
                      }
-                     std::memcpy(&b[ix], &temp, sizeof(V));
-                     ix += sizeof(V);
+                     std::memcpy(&b[ix], &temp, sizeof(NV));
+                     ix += sizeof(NV);
                   }
                }
                else if constexpr (std::endian::native == std::endian::big && sizeof(V) > 1) {
                   // On big endian, swap each element
                   const auto n_elements = static_cast<size_t>(value.size());
                   for (size_t i = 0; i < n_elements; ++i) {
-                     V temp = value[i];
+                     NV temp = beve_num_array_extract(value[i]);
                      byteswap_le(temp);
-                     std::memcpy(&b[ix], &temp, sizeof(V));
-                     ix += sizeof(V);
+                     std::memcpy(&b[ix], &temp, sizeof(NV));
+                     ix += sizeof(NV);
                   }
                }
                else {
-                  // Little endian or single-byte: bulk memcpy
+                  // Little endian or single-byte: bulk memcpy. A chrono element is
+                  // bit-identical to its rep, so the raw bytes are already the wire form.
                   if (n) {
                      std::memcpy(&b[ix], value.data(), n);
                      ix += n;
@@ -837,7 +843,7 @@ namespace glz
                   return;
                }
                for (auto& x : value) {
-                  dump_type(ctx, x, b, ix);
+                  dump_type(ctx, beve_num_array_extract(x), b, ix);
                }
             }
          }

--- a/include/glaze/bson/read.hpp
+++ b/include/glaze/bson/read.hpp
@@ -14,6 +14,7 @@
 
 #include "glaze/bson/header.hpp"
 #include "glaze/bson/skip.hpp"
+#include "glaze/core/chrono.hpp"
 #include "glaze/core/opts.hpp"
 #include "glaze/core/read.hpp"
 #include "glaze/core/reflect.hpp"
@@ -329,6 +330,46 @@ namespace glz
          from<BSON, U>::template op<Opts>(u, tag, ctx, it, end);
          if (bool(ctx.error)) return;
          value = static_cast<T>(u);
+      }
+   };
+
+   // --- std::chrono::duration ------------------------------------------------
+   //
+   // Read as the bare integer/double rep count written by the BSON duration
+   // writer; mirrors the enum delegation above.
+   template <is_duration T>
+      requires(not custom_read<T>)
+   struct from<BSON, T>
+   {
+      template <auto Opts, class It, class End>
+      static void op(auto& value, uint8_t tag, is_context auto& ctx, It& it, const End& end) noexcept
+      {
+         using V = std::remove_cvref_t<T>;
+         typename V::rep count{};
+         from<BSON, typename V::rep>::template op<Opts>(count, tag, ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+         value = V(count);
+      }
+   };
+
+   // --- steady_clock / high_resolution_clock time_point ----------------------
+   //
+   // Read as the bare rep count written by the BSON time_point writer above.
+   template <is_count_time_point T>
+      requires(not custom_read<T>)
+   struct from<BSON, T>
+   {
+      template <auto Opts, class It, class End>
+      static void op(auto& value, uint8_t tag, is_context auto& ctx, It& it, const End& end) noexcept
+      {
+         using V = std::remove_cvref_t<T>;
+         using Duration = typename V::duration;
+         typename V::rep count{};
+         from<BSON, typename V::rep>::template op<Opts>(count, tag, ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+         value = V(Duration(count));
       }
    };
 

--- a/include/glaze/bson/write.hpp
+++ b/include/glaze/bson/write.hpp
@@ -15,6 +15,7 @@
 
 #include "glaze/bson/header.hpp"
 #include "glaze/core/buffer_traits.hpp"
+#include "glaze/core/chrono.hpp"
 #include "glaze/core/opts.hpp"
 #include "glaze/core/reflect.hpp"
 #include "glaze/core/to.hpp"
@@ -370,6 +371,46 @@ namespace glz
       GLZ_ALWAYS_INLINE static void op(T value, is_context auto&& ctx, auto&& b, auto& ix) noexcept
       {
          to<BSON, U>::template op<Opts>(static_cast<U>(value), ctx, b, ix);
+      }
+   };
+
+   // --- std::chrono::duration ------------------------------------------------
+   //
+   // A duration has no calendar meaning, so it is encoded as its bare integer or
+   // floating-point `rep` count, reusing the BSON mapping of the underlying
+   // arithmetic type (int32/int64/double). BSON's element model requires a
+   // per-type `type_code`, so this delegates to the rep type's writer rather than
+   // the generic cross-format duration specialization in core/chrono.hpp.
+   template <is_duration T>
+      requires(not custom_write<T>)
+   struct to<BSON, T>
+   {
+      using Rep = typename std::remove_cvref_t<T>::rep;
+      static constexpr uint8_t type_code = to<BSON, Rep>::type_code;
+
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& b, auto& ix) noexcept
+      {
+         to<BSON, Rep>::template op<Opts>(value.count(), ctx, b, ix);
+      }
+   };
+
+   // --- steady_clock / high_resolution_clock time_point ----------------------
+   //
+   // Implementation-defined epoch, so encoded as the bare count of the time point's
+   // duration since epoch (same rule as a duration). Like the duration writer above,
+   // BSON needs a per-type `type_code`, so it delegates to the rep type's writer.
+   template <is_count_time_point T>
+      requires(not custom_write<T>)
+   struct to<BSON, T>
+   {
+      using Rep = typename std::remove_cvref_t<T>::rep;
+      static constexpr uint8_t type_code = to<BSON, Rep>::type_code;
+
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& b, auto& ix) noexcept
+      {
+         to<BSON, Rep>::template op<Opts>(value.time_since_epoch().count(), ctx, b, ix);
       }
    };
 

--- a/include/glaze/cbor/read.hpp
+++ b/include/glaze/cbor/read.hpp
@@ -1953,21 +1953,8 @@ namespace glz
       }
    };
 
-   // std::chrono::duration - bare numeric count in the duration's native units
-   template <is_duration T>
-   struct from<CBOR, T>
-   {
-      template <auto Opts>
-      GLZ_ALWAYS_INLINE static void op(auto& value, is_context auto& ctx, auto& it, auto end) noexcept
-      {
-         using Rep = typename std::remove_cvref_t<T>::rep;
-         Rep count{};
-         from<CBOR, Rep>::template op<Opts>(count, ctx, it, end);
-         if (bool(ctx.error)) [[unlikely]]
-            return;
-         value = std::remove_cvref_t<T>(count);
-      }
-   };
+   // std::chrono::duration - parsed generically (from the bare rep count) by the
+   // from<uint32_t Format, is_duration T> specialization in core/chrono.hpp.
 
    namespace cbor_detail
    {
@@ -2122,39 +2109,8 @@ namespace glz
       }
    };
 
-   // steady_clock::time_point - bare count in native duration
-   template <is_steady_time_point T>
-   struct from<CBOR, T>
-   {
-      template <auto Opts>
-      GLZ_ALWAYS_INLINE static void op(auto& value, is_context auto& ctx, auto& it, auto end) noexcept
-      {
-         using Duration = typename std::remove_cvref_t<T>::duration;
-         using Rep = typename Duration::rep;
-         Rep count{};
-         from<CBOR, Rep>::template op<Opts>(count, ctx, it, end);
-         if (bool(ctx.error)) [[unlikely]]
-            return;
-         value = std::remove_cvref_t<T>(Duration(count));
-      }
-   };
-
-   // high_resolution_clock::time_point when it's a distinct type (rare)
-   template <is_high_res_time_point T>
-   struct from<CBOR, T>
-   {
-      template <auto Opts>
-      GLZ_ALWAYS_INLINE static void op(auto& value, is_context auto& ctx, auto& it, auto end) noexcept
-      {
-         using Duration = typename std::remove_cvref_t<T>::duration;
-         using Rep = typename Duration::rep;
-         Rep count{};
-         from<CBOR, Rep>::template op<Opts>(count, ctx, it, end);
-         if (bool(ctx.error)) [[unlikely]]
-            return;
-         value = std::remove_cvref_t<T>(Duration(count));
-      }
-   };
+   // steady_clock / high_resolution_clock time_points: parsed generically (from the bare
+   // count) by the from<uint32_t Format, is_count_time_point T> specialization in core/chrono.hpp.
 
    // epoch_time wrapper - decoder accepts:
    //   - tag 1 + integer seconds (RFC 8949 §3.4.2; what glaze writes for Period >= 1s)

--- a/include/glaze/cbor/write.hpp
+++ b/include/glaze/cbor/write.hpp
@@ -1073,17 +1073,8 @@ namespace glz
       }
    };
 
-   // std::chrono::duration - bare numeric count in the duration's native units
-   template <is_duration T>
-   struct to<CBOR, T> final
-   {
-      template <auto Opts>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& b, auto& ix)
-      {
-         using Rep = typename std::remove_cvref_t<T>::rep;
-         to<CBOR, Rep>::template op<Opts>(value.count(), ctx, b, ix);
-      }
-   };
+   // std::chrono::duration - serialized generically (as the bare rep count) by the
+   // to<uint32_t Format, is_duration T> specialization in core/chrono.hpp.
 
    // system_clock::time_point - tag 0 (RFC 3339 date/time string)
    template <is_system_time_point T>
@@ -1183,31 +1174,8 @@ namespace glz
       }
    };
 
-   // steady_clock::time_point - bare count in native duration (epoch is implementation-defined)
-   template <is_steady_time_point T>
-   struct to<CBOR, T> final
-   {
-      template <auto Opts>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& b, auto& ix)
-      {
-         using Duration = typename std::remove_cvref_t<T>::duration;
-         using Rep = typename Duration::rep;
-         to<CBOR, Rep>::template op<Opts>(value.time_since_epoch().count(), ctx, b, ix);
-      }
-   };
-
-   // high_resolution_clock::time_point when it's a distinct type (rare)
-   template <is_high_res_time_point T>
-   struct to<CBOR, T> final
-   {
-      template <auto Opts>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& b, auto& ix)
-      {
-         using Duration = typename std::remove_cvref_t<T>::duration;
-         using Rep = typename Duration::rep;
-         to<CBOR, Rep>::template op<Opts>(value.time_since_epoch().count(), ctx, b, ix);
-      }
-   };
+   // steady_clock / high_resolution_clock time_points: serialized generically (as the bare
+   // count) by the to<uint32_t Format, is_count_time_point T> specialization in core/chrono.hpp.
 
    // epoch_time wrapper - RFC 8949 §3.4.2 tag 1 (epoch-based date/time).
    // Per §3.4.2 the tag 1 content MUST be an unsigned/negative integer (major types 0 or 1)

--- a/include/glaze/core/chrono.hpp
+++ b/include/glaze/core/chrono.hpp
@@ -9,6 +9,7 @@
 #include <type_traits>
 
 #include "glaze/core/context.hpp"
+#include "glaze/core/meta.hpp"
 #include "glaze/core/traits.hpp"
 
 namespace glz
@@ -48,6 +49,14 @@ namespace glz
    concept is_high_res_time_point =
       is_time_point<T> && std::is_same_v<typename std::remove_cvref_t<T>::clock, std::chrono::high_resolution_clock> &&
       !hrc_is_system && !hrc_is_steady;
+
+   // Concept for time points that serialize as a bare numeric count: steady_clock and a
+   // distinct high_resolution_clock. Their epochs are implementation-defined, so (unlike
+   // system_clock) there is no portable calendar representation -- the count in the time
+   // point's own duration period is the payload. The two clocks are mutually exclusive and
+   // both disjoint from system_clock.
+   template <class T>
+   concept is_count_time_point = is_steady_time_point<T> || is_high_res_time_point<T>;
 
    // ============================================
    // epoch_time wrapper for Unix timestamp format
@@ -125,6 +134,138 @@ namespace glz
    template <class Duration>
    struct specified<epoch_time<Duration>> : std::true_type
    {};
+
+   // ============================================
+   // std::chrono::duration generic serialization
+   // ============================================
+   //
+   // A duration carries no calendar semantics, so every format serializes it as
+   // the bare numeric `rep` count expressed in the duration's own period. The
+   // conversion is identical across formats, so it is defined once here generically
+   // (parameterized over Format) rather than repeated per format. Round-trips are
+   // exact: the count is read and written at the duration's native precision with
+   // no unit conversion.
+   //
+   // Every format's read/write header includes this file, so the generic applies
+   // uniformly: a duration round-trips identically through every Glaze format. BSON
+   // is the one exception: it overrides this generic with a more specialized
+   // to<BSON, T>/from<BSON, T> (which wins under partial ordering) because its
+   // element model requires a per-type `type_code`, so it delegates to the rep
+   // type's writer itself.
+
+   template <uint32_t Format, is_duration T>
+      requires(not custom_write<T>)
+   struct to<Format, T>
+   {
+      template <auto Opts, class... Args>
+      static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+      {
+         using Rep = typename std::remove_cvref_t<T>::rep;
+         to<Format, Rep>::template op<Opts>(value.count(), ctx, std::forward<Args>(args)...);
+      }
+
+      // Used by binary formats (e.g. BEVE) that elide the per-value type tag in
+      // certain contexts, such as numeric map keys. Only instantiated when such a
+      // context applies, so formats without a no_header concept (e.g. JSON, CBOR,
+      // MsgPack) never require to<Format, Rep>::no_header to exist.
+      template <auto Opts, class... Args>
+      static void no_header(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+      {
+         using Rep = typename std::remove_cvref_t<T>::rep;
+         to<Format, Rep>::template no_header<Opts>(value.count(), ctx, std::forward<Args>(args)...);
+      }
+   };
+
+   template <uint32_t Format, is_duration T>
+      requires(not custom_read<T>)
+   struct from<Format, T>
+   {
+      // Standard path: the type tag (if any) is still in the stream. Used by text
+      // formats (JSON, CBOR) and by tagged binary formats reading with the header
+      // present (e.g. BEVE outside a no_header context).
+      template <auto Opts, class... Args>
+      static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+      {
+         using V = std::remove_cvref_t<T>;
+         typename V::rep count{};
+         from<Format, typename V::rep>::template op<Opts>(count, ctx, std::forward<Args>(args)...);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+         value = V(count);
+      }
+
+      // Pre-read-tag path: the caller has already consumed the type tag and passes
+      // it through. MsgPack uses this for every value; BEVE uses it inside
+      // no_header contexts. Selected unambiguously over the overload above because
+      // its second parameter is the tag byte rather than the context.
+      template <auto Opts, class... Args>
+      static void op(auto&& value, const uint8_t tag, is_context auto&& ctx, Args&&... args) noexcept
+      {
+         using V = std::remove_cvref_t<T>;
+         typename V::rep count{};
+         from<Format, typename V::rep>::template op<Opts>(count, tag, ctx, std::forward<Args>(args)...);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+         value = V(count);
+      }
+   };
+
+   // ============================================
+   // steady_clock / high_resolution_clock time_point generic serialization
+   // ============================================
+   //
+   // These clocks have implementation-defined epochs, so they serialize as the bare count
+   // of their duration since epoch -- the same numeric form as a duration. The conversion
+   // is format-agnostic and defined once here. As with durations, BSON overrides it with a
+   // type_code-bearing specialization; every other format uses this generic.
+
+   template <uint32_t Format, is_count_time_point T>
+      requires(not custom_write<T>)
+   struct to<Format, T>
+   {
+      template <auto Opts, class... Args>
+      static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+      {
+         using Rep = typename std::remove_cvref_t<T>::rep;
+         to<Format, Rep>::template op<Opts>(value.time_since_epoch().count(), ctx, std::forward<Args>(args)...);
+      }
+
+      template <auto Opts, class... Args>
+      static void no_header(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+      {
+         using Rep = typename std::remove_cvref_t<T>::rep;
+         to<Format, Rep>::template no_header<Opts>(value.time_since_epoch().count(), ctx, std::forward<Args>(args)...);
+      }
+   };
+
+   template <uint32_t Format, is_count_time_point T>
+      requires(not custom_read<T>)
+   struct from<Format, T>
+   {
+      template <auto Opts, class... Args>
+      static void op(auto&& value, is_context auto&& ctx, Args&&... args) noexcept
+      {
+         using V = std::remove_cvref_t<T>;
+         using Duration = typename V::duration;
+         typename V::rep count{};
+         from<Format, typename V::rep>::template op<Opts>(count, ctx, std::forward<Args>(args)...);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+         value = V(Duration(count));
+      }
+
+      template <auto Opts, class... Args>
+      static void op(auto&& value, const uint8_t tag, is_context auto&& ctx, Args&&... args) noexcept
+      {
+         using V = std::remove_cvref_t<T>;
+         using Duration = typename V::duration;
+         typename V::rep count{};
+         from<Format, typename V::rep>::template op<Opts>(count, tag, ctx, std::forward<Args>(args)...);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+         value = V(Duration(count));
+      }
+   };
 
    namespace chrono_detail
    {

--- a/include/glaze/csv/read.hpp
+++ b/include/glaze/csv/read.hpp
@@ -5,6 +5,7 @@
 
 #include <charconv>
 
+#include "glaze/core/chrono.hpp"
 #include "glaze/core/opts.hpp"
 #include "glaze/core/read.hpp"
 #include "glaze/core/reflect.hpp"

--- a/include/glaze/csv/write.hpp
+++ b/include/glaze/csv/write.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "glaze/core/buffer_traits.hpp"
+#include "glaze/core/chrono.hpp"
 #include "glaze/core/opts.hpp"
 #include "glaze/core/write.hpp"
 #include "glaze/core/write_chars.hpp"

--- a/include/glaze/eetf/read.hpp
+++ b/include/glaze/eetf/read.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <glaze/core/chrono.hpp>
 #include <glaze/core/read.hpp>
 #include <glaze/core/reflect.hpp>
 

--- a/include/glaze/eetf/write.hpp
+++ b/include/glaze/eetf/write.hpp
@@ -3,6 +3,7 @@
 #include "defs.hpp"
 #include "ei.hpp"
 #include "glaze/core/buffer_traits.hpp"
+#include "glaze/core/chrono.hpp"
 #include "glaze/core/reflect.hpp"
 #include "glaze/core/write.hpp"
 #include "glaze/util/variant.hpp"

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -4779,22 +4779,8 @@ namespace glz
    // std::chrono deserialization
    // ============================================
 
-   // Duration: parse from count
-   template <is_duration T>
-      requires(not custom_read<T>)
-   struct from<JSON, T>
-   {
-      template <auto Opts, class It0, class It1>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, It0&& it, It1 end) noexcept
-      {
-         using Rep = typename std::remove_cvref_t<T>::rep;
-         Rep count{};
-         from<JSON, Rep>::template op<Opts>(count, ctx, it, end);
-         if (bool(ctx.error)) [[unlikely]]
-            return;
-         value = std::remove_cvref_t<T>(count);
-      }
-   };
+   // Duration: parsed generically (from the bare rep count) by the
+   // from<uint32_t Format, is_duration T> specialization in core/chrono.hpp.
 
    // system_clock::time_point: parse from ISO 8601 string.
    // Time points whose Duration period is exactly `days` (e.g. std::chrono::sys_days)
@@ -4846,42 +4832,8 @@ namespace glz
       }
    };
 
-   // steady_clock::time_point: parse as count in the time_point's native duration
-   template <is_steady_time_point T>
-      requires(not custom_read<T>)
-   struct from<JSON, T>
-   {
-      template <auto Opts, class It0, class It1>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, It0&& it, It1 end) noexcept
-      {
-         using Duration = typename std::remove_cvref_t<T>::duration;
-         using Rep = typename Duration::rep;
-         Rep count{};
-         from<JSON, Rep>::template op<Opts>(count, ctx, it, end);
-         if (bool(ctx.error)) [[unlikely]]
-            return;
-         value = std::remove_cvref_t<T>(Duration(count));
-      }
-   };
-
-   // high_resolution_clock::time_point when it's a distinct type (rare)
-   template <is_high_res_time_point T>
-      requires(not custom_read<T>)
-   struct from<JSON, T>
-   {
-      template <auto Opts, class It0, class It1>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, It0&& it, It1 end) noexcept
-      {
-         // Treat like steady_clock - parse as count
-         using Duration = typename std::remove_cvref_t<T>::duration;
-         using Rep = typename Duration::rep;
-         Rep count{};
-         from<JSON, Rep>::template op<Opts>(count, ctx, it, end);
-         if (bool(ctx.error)) [[unlikely]]
-            return;
-         value = std::remove_cvref_t<T>(Duration(count));
-      }
-   };
+   // steady_clock / high_resolution_clock time_points: parsed generically (from the bare
+   // count) by the from<uint32_t Format, is_count_time_point T> specialization in core/chrono.hpp.
 
    // epoch_time wrapper: parse as numeric Unix timestamp
    template <class Duration>

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -2436,18 +2436,8 @@ namespace glz
    // std::chrono serialization
    // ============================================
 
-   // Duration: serialize as count
-   template <is_duration T>
-      requires(not custom_write<T>)
-   struct to<JSON, T>
-   {
-      template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix) noexcept
-      {
-         using Rep = typename std::remove_cvref_t<T>::rep;
-         to<JSON, Rep>::template op<Opts>(value.count(), ctx, b, ix);
-      }
-   };
+   // Duration: serialized generically (as the bare rep count) by the
+   // to<uint32_t Format, is_duration T> specialization in core/chrono.hpp.
 
    // system_clock::time_point: serialize as ISO 8601 string.
    // Zero-allocation implementation writing directly to buffer.
@@ -2610,36 +2600,8 @@ namespace glz
       }
    };
 
-   // steady_clock::time_point: serialize as count in the time_point's native duration
-   template <is_steady_time_point T>
-      requires(not custom_write<T>)
-   struct to<JSON, T>
-   {
-      template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix) noexcept
-      {
-         using Duration = typename std::remove_cvref_t<T>::duration;
-         using Rep = typename Duration::rep;
-         const auto count = value.time_since_epoch().count();
-         to<JSON, Rep>::template op<Opts>(count, ctx, b, ix);
-      }
-   };
-
-   // high_resolution_clock::time_point when it's a distinct type (rare)
-   template <is_high_res_time_point T>
-      requires(not custom_write<T>)
-   struct to<JSON, T>
-   {
-      template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix) noexcept
-      {
-         // Treat like steady_clock - serialize as count since epoch is implementation-defined
-         using Duration = typename std::remove_cvref_t<T>::duration;
-         using Rep = typename Duration::rep;
-         const auto count = value.time_since_epoch().count();
-         to<JSON, Rep>::template op<Opts>(count, ctx, b, ix);
-      }
-   };
+   // steady_clock / high_resolution_clock time_points: serialized generically (as the bare
+   // count) by the to<uint32_t Format, is_count_time_point T> specialization in core/chrono.hpp.
 
    // epoch_time wrapper: serialize as numeric Unix timestamp
    template <class Duration>

--- a/include/glaze/jsonb/read.hpp
+++ b/include/glaze/jsonb/read.hpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <utility>
 
+#include "glaze/core/chrono.hpp"
 #include "glaze/core/opts.hpp"
 #include "glaze/core/read.hpp"
 #include "glaze/core/reflect.hpp"

--- a/include/glaze/jsonb/write.hpp
+++ b/include/glaze/jsonb/write.hpp
@@ -11,6 +11,7 @@
 #include <limits>
 
 #include "glaze/core/buffer_traits.hpp"
+#include "glaze/core/chrono.hpp"
 #include "glaze/core/opts.hpp"
 #include "glaze/core/reflect.hpp"
 #include "glaze/core/to.hpp"
@@ -112,7 +113,11 @@ namespace glz
       {
          // int64_t max is 20 chars including sign. uint64_t max is 20 chars.
          std::array<char, 32> tmp;
-         auto* end_ptr = glz::to_chars(tmp.data(), static_cast<T>(value));
+         // Normalize to a fixed-width integer so glz::to_chars (specialized on exact
+         // widths) accepts platform integer types such as `long` that are distinct from
+         // int32_t/int64_t. Mirrors the JSON number writer's sized_integer_conversion.
+         using X = std::decay_t<decltype(sized_integer_conversion<T>())>;
+         auto* end_ptr = glz::to_chars(tmp.data(), static_cast<X>(value));
          const size_t n = static_cast<size_t>(end_ptr - tmp.data());
          jsonb_detail::write_scalar(ctx, jsonb::type::int_, tmp.data(), n, b, ix);
       }

--- a/include/glaze/msgpack/read.hpp
+++ b/include/glaze/msgpack/read.hpp
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "glaze/core/chrono.hpp"
 #include "glaze/core/common.hpp"
 #include "glaze/core/meta.hpp"
 #include "glaze/core/opts.hpp"

--- a/include/glaze/msgpack/write.hpp
+++ b/include/glaze/msgpack/write.hpp
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "glaze/core/buffer_traits.hpp"
+#include "glaze/core/chrono.hpp"
 #include "glaze/core/opts.hpp"
 #include "glaze/core/reflect.hpp"
 #include "glaze/core/seek.hpp"

--- a/include/glaze/toml/read.hpp
+++ b/include/glaze/toml/read.hpp
@@ -1008,22 +1008,8 @@ namespace glz
    // std::chrono deserialization
    // ============================================
 
-   // Duration: parse from count
-   template <is_duration T>
-      requires(not custom_read<T>)
-   struct from<TOML, T>
-   {
-      template <auto Opts, class It0, class It1>
-      static void op(auto&& value, is_context auto&& ctx, It0&& it, It1 end) noexcept
-      {
-         using Rep = typename std::remove_cvref_t<T>::rep;
-         Rep count{};
-         from<TOML, Rep>::template op<Opts>(count, ctx, it, end);
-         if (bool(ctx.error)) [[unlikely]]
-            return;
-         value = std::remove_cvref_t<T>(count);
-      }
-   };
+   // Duration: parsed generically (from the bare rep count) by the
+   // from<uint32_t Format, is_duration T> specialization in core/chrono.hpp.
 
    // system_clock::time_point: parse from TOML native datetime (RFC 3339)
    // TOML datetimes are NOT quoted - they're native values
@@ -1375,42 +1361,8 @@ namespace glz
       }
    };
 
-   // steady_clock::time_point: parse as count in the time_point's native duration
-   template <is_steady_time_point T>
-      requires(not custom_read<T>)
-   struct from<TOML, T>
-   {
-      template <auto Opts, class It0, class It1>
-      static void op(auto&& value, is_context auto&& ctx, It0&& it, It1 end) noexcept
-      {
-         using Duration = typename std::remove_cvref_t<T>::duration;
-         using Rep = typename Duration::rep;
-         Rep count{};
-         from<TOML, Rep>::template op<Opts>(count, ctx, it, end);
-         if (bool(ctx.error)) [[unlikely]]
-            return;
-         value = std::remove_cvref_t<T>(Duration(count));
-      }
-   };
-
-   // high_resolution_clock::time_point when it's a distinct type (rare)
-   template <is_high_res_time_point T>
-      requires(not custom_read<T>)
-   struct from<TOML, T>
-   {
-      template <auto Opts, class It0, class It1>
-      static void op(auto&& value, is_context auto&& ctx, It0&& it, It1 end) noexcept
-      {
-         // Treat like steady_clock - parse as count
-         using Duration = typename std::remove_cvref_t<T>::duration;
-         using Rep = typename Duration::rep;
-         Rep count{};
-         from<TOML, Rep>::template op<Opts>(count, ctx, it, end);
-         if (bool(ctx.error)) [[unlikely]]
-            return;
-         value = std::remove_cvref_t<T>(Duration(count));
-      }
-   };
+   // steady_clock / high_resolution_clock time_points: parsed generically (from the bare
+   // count) by the from<uint32_t Format, is_count_time_point T> specialization in core/chrono.hpp.
 
    // for set types (emplaceable but not emplace_backable)
    template <class T>

--- a/include/glaze/toml/write.hpp
+++ b/include/glaze/toml/write.hpp
@@ -194,18 +194,8 @@ namespace glz
    // std::chrono serialization
    // ============================================
 
-   // Duration: serialize as count
-   template <is_duration T>
-      requires(not custom_write<T>)
-   struct to<TOML, T>
-   {
-      template <auto Opts, class B>
-      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix) noexcept
-      {
-         using Rep = typename std::remove_cvref_t<T>::rep;
-         to<TOML, Rep>::template op<Opts>(value.count(), ctx, b, ix);
-      }
-   };
+   // Duration: serialized generically (as the bare rep count) by the
+   // to<uint32_t Format, is_duration T> specialization in core/chrono.hpp.
 
    // system_clock::time_point: serialize as TOML native datetime (RFC 3339)
    // TOML datetimes are NOT quoted - they're native values
@@ -405,36 +395,8 @@ namespace glz
       }
    };
 
-   // steady_clock::time_point: serialize as count in the time_point's native duration
-   template <is_steady_time_point T>
-      requires(not custom_write<T>)
-   struct to<TOML, T>
-   {
-      template <auto Opts, class B>
-      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix) noexcept
-      {
-         using Duration = typename std::remove_cvref_t<T>::duration;
-         using Rep = typename Duration::rep;
-         const auto count = value.time_since_epoch().count();
-         to<TOML, Rep>::template op<Opts>(count, ctx, b, ix);
-      }
-   };
-
-   // high_resolution_clock::time_point when it's a distinct type (rare)
-   template <is_high_res_time_point T>
-      requires(not custom_write<T>)
-   struct to<TOML, T>
-   {
-      template <auto Opts, class B>
-      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix) noexcept
-      {
-         // Treat like steady_clock - serialize as count since epoch is implementation-defined
-         using Duration = typename std::remove_cvref_t<T>::duration;
-         using Rep = typename Duration::rep;
-         const auto count = value.time_since_epoch().count();
-         to<TOML, Rep>::template op<Opts>(count, ctx, b, ix);
-      }
-   };
+   // steady_clock / high_resolution_clock time_points: serialized generically (as the bare
+   // count) by the to<uint32_t Format, is_count_time_point T> specialization in core/chrono.hpp.
 
    template <class T>
       requires str_t<T> || char_t<T>

--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -6,6 +6,7 @@
 #include <cctype>
 #include <charconv>
 
+#include "glaze/core/chrono.hpp"
 #include "glaze/core/common.hpp"
 #include "glaze/core/read.hpp"
 #include "glaze/core/reflect.hpp"

--- a/include/glaze/yaml/write.hpp
+++ b/include/glaze/yaml/write.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "glaze/core/buffer_traits.hpp"
+#include "glaze/core/chrono.hpp"
 #include "glaze/core/custom_meta.hpp"
 #include "glaze/core/opts.hpp"
 #include "glaze/core/reflect.hpp"

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -6995,6 +6995,197 @@ suite beve_byte_and_char_array_tests = [] {
    };
 };
 
+struct beve_durations_s
+{
+   std::chrono::milliseconds ms{};
+   std::chrono::seconds s{};
+   std::chrono::duration<double, std::milli> dms{};
+   bool operator==(const beve_durations_s&) const = default;
+};
+
+suite beve_chrono_duration_tests = [] {
+   "duration roundtrip"_test = [] {
+      using namespace std::chrono;
+      auto check = [](auto v) {
+         std::string buffer{};
+         expect(not glz::write_beve(v, buffer));
+         decltype(v) decoded{};
+         expect(not glz::read_beve(decoded, buffer));
+         expect(decoded == v);
+      };
+      check(seconds{3600});
+      check(milliseconds{12345});
+      check(seconds{-42});
+      check(nanoseconds{987654321});
+      check(duration<double, std::milli>{123.5});
+      check(duration<int64_t, std::ratio<1, 60>>{90});
+   };
+
+   // A duration must serialize byte-for-byte like its underlying rep so a shared
+   // meta schema can target JSON and BEVE interchangeably (issue #2671).
+   "duration matches rep encoding"_test = [] {
+      const std::chrono::milliseconds d{123456};
+      const int64_t raw = d.count();
+      std::string a{}, b{};
+      expect(not glz::write_beve(d, a));
+      expect(not glz::write_beve(raw, b));
+      expect(a == b);
+   };
+
+   "duration in struct"_test = [] {
+      beve_durations_s original{std::chrono::milliseconds{7}, std::chrono::seconds{8},
+                                std::chrono::duration<double, std::milli>{9.5}};
+      std::string buffer{};
+      expect(not glz::write_beve(original, buffer));
+      beve_durations_s decoded{};
+      expect(not glz::read_beve(decoded, buffer));
+      expect(decoded == original);
+   };
+
+   // Duration map/pair keys must use a numeric key header (matching the bare-count
+   // key bytes), so the buffer is self-consistent and round-trips. A regression here
+   // previously produced a string-key header over numeric key bytes.
+   "duration map and pair keys"_test = [] {
+      using namespace std::chrono;
+      std::map<seconds, int> m{{seconds{1}, 10}, {seconds{5}, 50}, {seconds{-3}, -30}};
+      std::string buffer{};
+      expect(not glz::write_beve(m, buffer));
+      std::map<seconds, int> decoded{};
+      expect(not glz::read_beve(decoded, buffer));
+      expect(decoded == m);
+
+      // Identical encoding to the equivalent rep-keyed map.
+      std::map<int64_t, int> raw{{1, 10}, {5, 50}, {-3, -30}};
+      std::string rawbuffer{};
+      expect(not glz::write_beve(raw, rawbuffer));
+      expect(buffer == rawbuffer);
+
+      std::pair<milliseconds, int> p{milliseconds{7}, 99};
+      std::string pbuffer{};
+      expect(not glz::write_beve(p, pbuffer));
+      std::pair<milliseconds, int> pdecoded{};
+      expect(not glz::read_beve(pdecoded, pbuffer));
+      expect(pdecoded == p);
+   };
+
+   // A range of durations packs into a numeric typed array of the rep, byte-identical to a
+   // range of the rep itself (not an inflated generic array with a tag per element).
+   "duration ranges pack as typed arrays"_test = [] {
+      using namespace std::chrono;
+      {
+         std::vector<seconds> v{seconds{1}, seconds{2}, seconds{-3}, seconds{1000000}};
+         std::string buffer{};
+         expect(not glz::write_beve(v, buffer));
+         std::vector<seconds> decoded{};
+         expect(not glz::read_beve(decoded, buffer));
+         expect(decoded == v);
+
+         std::vector<int64_t> rep{1, 2, -3, 1000000};
+         std::string repbuffer{};
+         expect(not glz::write_beve(rep, repbuffer));
+         expect(buffer == repbuffer); // packed, byte-identical to vector<rep>
+      }
+      {
+         std::vector<duration<double, std::milli>> v{duration<double, std::milli>{1.5},
+                                                     duration<double, std::milli>{2.5}};
+         std::string buffer{};
+         expect(not glz::write_beve(v, buffer));
+         std::vector<duration<double, std::milli>> decoded{};
+         expect(not glz::read_beve(decoded, buffer));
+         expect(decoded == v);
+
+         std::vector<double> rep{1.5, 2.5};
+         std::string repbuffer{};
+         expect(not glz::write_beve(rep, repbuffer));
+         expect(buffer == repbuffer);
+      }
+      {
+         std::array<seconds, 3> v{seconds{1}, seconds{2}, seconds{3}};
+         std::string buffer{};
+         expect(not glz::write_beve(v, buffer));
+         std::array<seconds, 3> decoded{};
+         expect(not glz::read_beve(decoded, buffer));
+         expect(decoded == v);
+      }
+      {
+         using sc = steady_clock;
+         std::vector<sc::time_point> v{sc::time_point{sc::duration{5}}, sc::time_point{sc::duration{99}}};
+         std::string buffer{};
+         expect(not glz::write_beve(v, buffer));
+         std::vector<sc::time_point> decoded{};
+         expect(not glz::read_beve(decoded, buffer));
+         expect(decoded == v);
+
+         std::vector<sc::duration::rep> rep{5, 99};
+         std::string repbuffer{};
+         expect(not glz::write_beve(rep, repbuffer));
+         expect(buffer == repbuffer);
+      }
+   };
+
+   // beve_size must agree with the packed typed-array writer for chrono scalars and ranges.
+   "duration beve_size matches written size"_test = [] {
+      using namespace std::chrono;
+      {
+         milliseconds d{12345};
+         std::string b{};
+         expect(not glz::write_beve(d, b));
+         expect(glz::beve_size(d) == b.size());
+      }
+      {
+         std::vector<seconds> v{seconds{1}, seconds{2}, seconds{-3}};
+         std::string b{};
+         expect(not glz::write_beve(v, b));
+         expect(glz::beve_size(v) == b.size());
+      }
+      {
+         using sc = steady_clock;
+         const sc::time_point tp{sc::duration{77}};
+         std::string b{};
+         expect(not glz::write_beve(tp, b));
+         expect(glz::beve_size(tp) == b.size());
+      }
+   };
+
+   // A steady_clock time_point key must encode as a numeric key (like a duration key), not a
+   // string-key object over numeric bytes.
+   "count time_point map and pair keys"_test = [] {
+      using sc = std::chrono::steady_clock;
+      std::map<sc::time_point, int> m{{sc::time_point{sc::duration{1}}, 10}, {sc::time_point{sc::duration{5}}, 50}};
+      std::string buffer{};
+      expect(not glz::write_beve(m, buffer));
+      std::map<sc::time_point, int> decoded{};
+      expect(not glz::read_beve(decoded, buffer));
+      expect(decoded == m);
+
+      std::map<sc::duration::rep, int> raw{{1, 10}, {5, 50}};
+      std::string rawbuffer{};
+      expect(not glz::write_beve(raw, rawbuffer));
+      expect(buffer == rawbuffer);
+
+      std::pair<sc::time_point, int> p{sc::time_point{sc::duration{7}}, 99};
+      std::string pbuffer{};
+      expect(not glz::write_beve(p, pbuffer));
+      std::pair<sc::time_point, int> pdecoded{};
+      expect(not glz::read_beve(pdecoded, pbuffer));
+      expect(pdecoded == p);
+   };
+
+   // A std::span<const duration> can read a packed aligned typed array zero-copy (the view
+   // points into the buffer, which is bit-identical to a span of the rep).
+   "duration span zero-copy read"_test = [] {
+      using namespace std::chrono;
+      std::vector<milliseconds> src{milliseconds{10}, milliseconds{20}, milliseconds{30}};
+      std::string buffer{};
+      expect(not glz::write<aligned_beve_opts>(src, buffer));
+      std::span<const milliseconds> sp{};
+      expect(not glz::read<aligned_beve_opts>(sp, buffer));
+      expect(sp.size() == 3);
+      expect(sp[0] == milliseconds{10});
+      expect(sp[2] == milliseconds{30});
+   };
+};
+
 int main()
 {
    trace.begin("binary_test");

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -7219,18 +7219,22 @@ suite beve_chrono_duration_tests = [] {
    };
 
    // A std::span<const duration> can read a packed aligned typed array zero-copy (the view
-   // points into the buffer, which is bit-identical to a span of the rep).
-   "duration span zero-copy read"_test = [] {
-      using namespace std::chrono;
-      std::vector<milliseconds> src{milliseconds{10}, milliseconds{20}, milliseconds{30}};
-      std::string buffer{};
-      expect(not glz::write<aligned_beve_opts>(src, buffer));
-      std::span<const milliseconds> sp{};
-      expect(not glz::read<aligned_beve_opts>(sp, buffer));
-      expect(sp.size() == 3);
-      expect(sp[0] == milliseconds{10});
-      expect(sp[2] == milliseconds{30});
-   };
+   // points into the buffer, which is bit-identical to a span of the rep). Like every other
+   // multi-byte zero-copy span read, this requires a little-endian host because the view
+   // aliases the little-endian wire bytes directly.
+   if constexpr (std::endian::native == std::endian::little) {
+      "duration span zero-copy read"_test = [] {
+         using namespace std::chrono;
+         std::vector<milliseconds> src{milliseconds{10}, milliseconds{20}, milliseconds{30}};
+         std::string buffer{};
+         expect(not glz::write<aligned_beve_opts>(src, buffer));
+         std::span<const milliseconds> sp{};
+         expect(not glz::read<aligned_beve_opts>(sp, buffer));
+         expect(sp.size() == 3);
+         expect(sp[0] == milliseconds{10});
+         expect(sp[2] == milliseconds{30});
+      };
+   }
 };
 
 struct beve_shrink_opts : glz::opts

--- a/tests/bson_test/bson_test.cpp
+++ b/tests/bson_test/bson_test.cpp
@@ -158,6 +158,18 @@ namespace bson_test
       bool operator==(const time_s&) const = default;
    };
 
+   struct duration_s
+   {
+      std::chrono::milliseconds ms{}; // int64 element
+      std::chrono::seconds s{}; // int64 element
+      std::chrono::nanoseconds ns{}; // int64 element
+      std::chrono::duration<double, std::milli> dms{}; // double element
+      std::chrono::duration<int32_t, std::milli> i32{}; // int32 element
+      std::chrono::duration<int16_t, std::ratio<1, 60>> i16{}; // int32 element (small signed)
+      std::chrono::duration<uint32_t, std::milli> u32{}; // int64 element (unsigned widened)
+      bool operator==(const duration_s&) const = default;
+   };
+
    struct oid_s
    {
       glz::bson::object_id id{};
@@ -631,6 +643,18 @@ namespace
       "roundtrip-chrono"_test = [] {
          using namespace std::chrono;
          time_s v{system_clock::time_point{milliseconds{1700000000000LL}}};
+         expect_roundtrip_equal(v);
+      };
+
+      "roundtrip-duration"_test = [] {
+         using namespace std::chrono;
+         duration_s v{milliseconds{12345},
+                      seconds{-42},
+                      nanoseconds{987654321},
+                      duration<double, std::milli>{123.5},
+                      duration<int32_t, std::milli>{-123456},
+                      duration<int16_t, std::ratio<1, 60>>{-3000},
+                      duration<uint32_t, std::milli>{4000000000u}};
          expect_roundtrip_equal(v);
       };
 

--- a/tests/chrono_test/chrono_test.cpp
+++ b/tests/chrono_test/chrono_test.cpp
@@ -4,9 +4,19 @@
 #include "glaze/chrono.hpp"
 
 #include <chrono>
+#include <map>
 #include <thread>
+#include <utility>
+#include <vector>
 
+#include "glaze/bson.hpp"
+#include "glaze/cbor.hpp"
+#include "glaze/csv.hpp"
 #include "glaze/glaze.hpp"
+#include "glaze/jsonb.hpp"
+#include "glaze/msgpack.hpp"
+#include "glaze/toml.hpp"
+#include "glaze/yaml.hpp"
 #include "ut/ut.hpp"
 
 using namespace ut;
@@ -23,6 +33,47 @@ struct Record
 {
    glz::epoch_seconds created_at;
    glz::epoch_millis updated_at;
+};
+
+struct DurationBag
+{
+   std::chrono::milliseconds ms{};
+   std::chrono::seconds s{};
+   std::chrono::nanoseconds ns{};
+   std::chrono::duration<double, std::milli> dms{};
+   std::chrono::duration<int32_t, std::milli> i32{}; // BSON int32 type_code
+   std::chrono::duration<int16_t, std::ratio<1, 60>> i16{}; // BSON int32 type_code (small signed)
+   std::chrono::duration<uint32_t, std::milli> u32{}; // unsigned rep -> BSON int64 widening
+   bool operator==(const DurationBag&) const = default;
+};
+
+// Single-field structs for the BSON/MsgPack wire-equivalence checks and the CSV column
+// test. Glaze reflection requires reflected structs to have linkage, so these live at
+// namespace scope rather than inside the test lambdas.
+struct one_duration
+{
+   std::chrono::milliseconds v{};
+   bool operator==(const one_duration&) const = default;
+};
+
+struct one_integer
+{
+   int64_t v{};
+   bool operator==(const one_integer&) const = default;
+};
+
+struct duration_rows
+{
+   std::vector<std::chrono::milliseconds> ms{std::chrono::milliseconds{1}, std::chrono::milliseconds{2},
+                                             std::chrono::milliseconds{3}};
+   bool operator==(const duration_rows&) const = default;
+};
+
+struct steady_bag
+{
+   std::chrono::steady_clock::time_point t{};
+   std::chrono::time_point<std::chrono::steady_clock, std::chrono::milliseconds> ms{};
+   bool operator==(const steady_bag&) const = default;
 };
 
 suite chrono_duration_tests = [] {
@@ -96,6 +147,209 @@ suite chrono_duration_tests = [] {
       frames parsed{};
       expect(!glz::read_json(parsed, json.value()));
       expect(parsed == f);
+   };
+};
+
+// Durations and count-based time points (steady_clock / high_resolution_clock) are
+// serialized once generically (core/chrono.hpp) as the bare rep count, so every format
+// that accepts a top-level scalar must round-trip identically. BSON has no bare-scalar
+// root and is exercised separately via struct members. These tests guard that the
+// previously per-format JSON/CBOR/TOML implementations and the lifted generic stay in
+// agreement across all formats.
+template <class D>
+void check_chrono_scalar_roundtrip(const D& value)
+{
+   {
+      std::string buf{};
+      expect(not glz::write_beve(value, buf));
+      D out{};
+      expect(not glz::read_beve(out, buf));
+      expect(out == value);
+   }
+   {
+      std::string buf{};
+      expect(not glz::write_msgpack(value, buf));
+      D out{};
+      expect(not glz::read_msgpack(out, buf));
+      expect(out == value);
+   }
+   {
+      std::string buf{};
+      expect(not glz::write_cbor(value, buf));
+      D out{};
+      expect(not glz::read_cbor(out, buf));
+      expect(out == value);
+   }
+   {
+      std::string buf{};
+      expect(not glz::write_json(value, buf));
+      D out{};
+      expect(not glz::read_json(out, buf));
+      expect(out == value);
+   }
+   {
+      std::string buf{};
+      expect(not glz::write_toml(value, buf));
+      D out{};
+      expect(not glz::read_toml(out, buf));
+      expect(out == value);
+   }
+   {
+      std::string buf{};
+      expect(not glz::write_yaml(value, buf));
+      D out{};
+      expect(not glz::read_yaml(out, buf));
+      expect(out == value);
+   }
+   {
+      std::string buf{};
+      expect(not glz::write_jsonb(value, buf));
+      D out{};
+      expect(not glz::read_jsonb(out, buf));
+      expect(out == value);
+   }
+}
+
+suite chrono_duration_cross_format_tests = [] {
+   "duration_seconds_all_formats"_test = [] { check_chrono_scalar_roundtrip(std::chrono::seconds{3600}); };
+
+   "duration_milliseconds_all_formats"_test = [] { check_chrono_scalar_roundtrip(std::chrono::milliseconds{12345}); };
+
+   "duration_negative_all_formats"_test = [] { check_chrono_scalar_roundtrip(std::chrono::seconds{-42}); };
+
+   "duration_nanoseconds_all_formats"_test = [] { check_chrono_scalar_roundtrip(std::chrono::nanoseconds{987654321}); };
+
+   "duration_hours_all_formats"_test = [] { check_chrono_scalar_roundtrip(std::chrono::hours{24}); };
+
+   "duration_float_rep_all_formats"_test = [] {
+      check_chrono_scalar_roundtrip(std::chrono::duration<double, std::milli>{123.5});
+   };
+
+   "duration_custom_period_all_formats"_test = [] {
+      using frames = std::chrono::duration<int64_t, std::ratio<1, 60>>;
+      check_chrono_scalar_roundtrip(frames{90});
+   };
+
+   "duration_small_signed_rep_all_formats"_test = [] {
+      check_chrono_scalar_roundtrip(std::chrono::duration<int32_t, std::milli>{-123456});
+      check_chrono_scalar_roundtrip(std::chrono::duration<int16_t, std::ratio<1, 60>>{-3000});
+   };
+
+   "duration_unsigned_rep_all_formats"_test = [] {
+      // Exceeds INT32_MAX so the unsigned path (and BSON's uint32 -> int64 widening) is exercised.
+      check_chrono_scalar_roundtrip(std::chrono::duration<uint32_t, std::milli>{4000000000u});
+   };
+
+   // A duration must encode in BEVE byte-for-byte like its underlying rep. This is
+   // exactly what lets one meta schema serialize to JSON and BEVE interchangeably,
+   // which is the use case from issue #2671.
+   "duration_beve_matches_rep_encoding"_test = [] {
+      const std::chrono::milliseconds d{123456};
+      const int64_t raw = d.count();
+      std::string a{}, b{};
+      expect(not glz::write_beve(d, a));
+      expect(not glz::write_beve(raw, b));
+      expect(a == b);
+   };
+
+   // The same wire-identity guarantee for the self-describing binary formats.
+   "duration_msgpack_bson_match_rep_encoding"_test = [] {
+      const std::chrono::milliseconds d{123456};
+      const int64_t raw = d.count();
+      {
+         std::string a{}, b{};
+         expect(not glz::write_msgpack(d, a));
+         expect(not glz::write_msgpack(raw, b));
+         expect(a == b);
+      }
+      // BSON has no bare-scalar root, so compare the element encoding inside a document.
+      std::string a{}, b{};
+      expect(not glz::write_bson(one_duration{d}, a));
+      expect(not glz::write_bson(one_integer{raw}, b));
+      expect(a == b);
+   };
+
+   // CSV is tabular, so durations are exercised as a column.
+   "duration_csv_column"_test = [] {
+      const duration_rows in{};
+      std::string buf{};
+      expect(not glz::write_csv(in, buf));
+      duration_rows out{};
+      out.ms.clear();
+      expect(not glz::read_csv(out, buf));
+      expect(out == in);
+   };
+
+   // Durations used as BEVE map / pair keys must encode as numeric keys (matching the
+   // bare-count value encoding), not as the default string-keyed object.
+   "duration_beve_map_and_pair_keys"_test = [] {
+      using namespace std::chrono;
+      std::map<seconds, int> m{{seconds{1}, 10}, {seconds{5}, 50}, {seconds{-3}, -30}};
+      std::string buf{};
+      expect(not glz::write_beve(m, buf));
+      std::map<seconds, int> out{};
+      expect(not glz::read_beve(out, buf));
+      expect(out == m);
+
+      // A duration-keyed map encodes identically to the equivalent rep-keyed map.
+      std::map<int64_t, int> raw{{1, 10}, {5, 50}, {-3, -30}};
+      std::string rawbuf{};
+      expect(not glz::write_beve(raw, rawbuf));
+      expect(buf == rawbuf);
+
+      std::pair<milliseconds, int> p{milliseconds{7}, 99};
+      std::string pbuf{};
+      expect(not glz::write_beve(p, pbuf));
+      std::pair<milliseconds, int> pout{};
+      expect(not glz::read_beve(pout, pbuf));
+      expect(pout == p);
+   };
+
+   // Durations as struct members, including BSON (whose root is always a document
+   // so a bare top-level scalar is not representable).
+   "duration_struct_members_all_formats"_test = [] {
+      const DurationBag in{std::chrono::milliseconds{7},
+                           std::chrono::seconds{8},
+                           std::chrono::nanoseconds{9},
+                           std::chrono::duration<double, std::milli>{10.25},
+                           std::chrono::duration<int32_t, std::milli>{-123456},
+                           std::chrono::duration<int16_t, std::ratio<1, 60>>{-3000},
+                           std::chrono::duration<uint32_t, std::milli>{4000000000u}};
+      {
+         std::string buf{};
+         expect(not glz::write_beve(in, buf));
+         DurationBag out{};
+         expect(not glz::read_beve(out, buf));
+         expect(out == in);
+      }
+      {
+         std::string buf{};
+         expect(not glz::write_msgpack(in, buf));
+         DurationBag out{};
+         expect(not glz::read_msgpack(out, buf));
+         expect(out == in);
+      }
+      {
+         std::string buf{};
+         expect(not glz::write_cbor(in, buf));
+         DurationBag out{};
+         expect(not glz::read_cbor(out, buf));
+         expect(out == in);
+      }
+      {
+         std::string buf{};
+         expect(not glz::write_json(in, buf));
+         DurationBag out{};
+         expect(not glz::read_json(out, buf));
+         expect(out == in);
+      }
+      {
+         std::string buf{};
+         expect(not glz::write_bson(in, buf));
+         DurationBag out{};
+         expect(not glz::read_bson(out, buf));
+         expect(out == in);
+      }
    };
 };
 
@@ -187,6 +441,52 @@ suite chrono_steady_clock_tests = [] {
       ms_steady parsed;
       expect(!glz::read_json(parsed, json.value()));
       expect(parsed == original);
+   };
+
+   // steady_clock time points are now serialized by the same generic count conversion
+   // across every format (not just JSON/CBOR/TOML), matching durations.
+   "steady_clock_all_formats"_test = [] {
+      using sc = std::chrono::steady_clock;
+      check_chrono_scalar_roundtrip(sc::time_point{sc::duration{123456789}});
+      using ms_steady = std::chrono::time_point<sc, std::chrono::milliseconds>;
+      check_chrono_scalar_roundtrip(ms_steady{std::chrono::milliseconds{-987654}});
+   };
+
+   "steady_clock_beve_matches_rep_encoding"_test = [] {
+      using sc = std::chrono::steady_clock;
+      const sc::time_point tp{sc::duration{123456789}};
+      std::string a{}, b{};
+      expect(not glz::write_beve(tp, a));
+      expect(not glz::write_beve(tp.time_since_epoch().count(), b));
+      expect(a == b);
+   };
+
+   // Struct members, including BSON (whose root is always a document).
+   "steady_clock_struct_members_all_formats"_test = [] {
+      using sc = std::chrono::steady_clock;
+      const steady_bag in{sc::time_point{sc::duration{555}},
+                          std::chrono::time_point<sc, std::chrono::milliseconds>{std::chrono::milliseconds{777}}};
+      {
+         std::string buf{};
+         expect(not glz::write_beve(in, buf));
+         steady_bag out{};
+         expect(not glz::read_beve(out, buf));
+         expect(out == in);
+      }
+      {
+         std::string buf{};
+         expect(not glz::write_msgpack(in, buf));
+         steady_bag out{};
+         expect(not glz::read_msgpack(out, buf));
+         expect(out == in);
+      }
+      {
+         std::string buf{};
+         expect(not glz::write_bson(in, buf));
+         steady_bag out{};
+         expect(not glz::read_bson(out, buf));
+         expect(out == in);
+      }
    };
 };
 

--- a/tests/msgpack_test/msgpack_test.cpp
+++ b/tests/msgpack_test/msgpack_test.cpp
@@ -1042,6 +1042,23 @@ int main()
       expect(decoded == epoch);
    };
 
+   "chrono duration roundtrip"_test = [] {
+      using namespace std::chrono;
+      auto check = [](auto v) {
+         std::string buffer{};
+         expect(not glz::write_msgpack(v, buffer));
+         decltype(v) decoded{};
+         expect(not glz::read_msgpack(decoded, buffer));
+         expect(decoded == v);
+      };
+      check(seconds{3600});
+      check(milliseconds{12345});
+      check(seconds{-42});
+      check(nanoseconds{987654321});
+      check(duration<double, std::milli>{123.5});
+      check(duration<int64_t, std::ratio<1, 60>>{90});
+   };
+
    "timestamp in struct"_test = [] {
       struct event
       {


### PR DESCRIPTION
Closes #2671.

## Motivation

`std::chrono::duration` was supported only in JSON, CBOR, and TOML, each with its own copy of the same "serialize as the numeric count" logic, and unsupported in BEVE/MsgPack/BSON. The issue asks to lift this to a single conversion that is generic for all formats, so the same meta schema can target (e.g.) JSON and BEVE interchangeably.

## What changed

**Generic chrono serialization (`core/chrono.hpp`).** `std::chrono::duration` and the count-based clocks (`steady_clock` / a distinct `high_resolution_clock`) now serialize through a single generic `to`/`from<uint32_t Format, ...>` as their bare `rep` count. The duplicated per-format specializations in JSON/CBOR/TOML are removed. BSON keeps a dedicated specialization because its element model requires a per-type `type_code`.

**Uniform, deterministic support.** `core/chrono.hpp` is now included by every format's `read`/`write` (BEVE, MsgPack, BSON, CSV, JSONB, YAML, EETF in addition to JSON/CBOR/TOML), so a duration / count-time-point round-trips identically through all of them. Previously the binary formats lacked support entirely and the generic's reach depended on include order.

**BEVE array packing.** A range of durations / count time points now encodes as a numeric typed array of the `rep` — byte-for-byte identical to a range of the `rep` itself — rather than a generic array with a type tag per element. The hot little-endian bulk-memcpy path is untouched and the plain-numeric path is unchanged (`beve_num_array_t<num> == beve_num_t<num>`). Duration / time-point **map and pair keys** encode as numeric keys, and `beve_size` plus zero-copy `std::span<const T>` reads handle them too.

**Incidental fix.** The JSONB integer writer could not serialize a plain `long` (distinct from `long long` on LP64); this surfaced via `std::chrono::hours` and is fixed at the root with the same `sized_integer_conversion` the JSON writer uses.

## Behavior

| Type | Representation |
|------|----------------|
| `std::chrono::duration<Rep, Period>` | the `Rep` count, in the duration's own period |
| `steady_clock` / `high_resolution_clock` `time_point` | count since (implementation-defined) epoch |

`system_clock::time_point`, `sys_days`, `year_month_day`, `hh_mm_ss`, and the `epoch_time` / `date_format` / `epoch_count` wrappers are unchanged.

## Testing

Round-trip and wire-equivalence tests added/extended across JSON, BEVE, CBOR, MsgPack, BSON, TOML, YAML, JSONB, and CSV: integer/float/custom-period/unsigned/narrow reps, struct members (incl. BSON's int32/int64 `type_code` branches), BEVE byte-identity with the rep (scalars, arrays, map keys), `beve_size` agreement, and zero-copy `span<const duration>`. All affected suites pass under `-Werror` + ASan + UBSan locally.

> Note: EETF received the include for consistency but could not be built locally (no Erlang `ei` library on this machine); its number-op signatures match the generic, so it is expected to compile — CI will confirm.
