### PR TITLE
bound get_view_json seek separator check against end of input

### DIFF
--- a/include/glaze/json/json_ptr.hpp
+++ b/include/glaze/json/json_ptr.hpp
@@ -104,8 +104,8 @@ namespace glz
                         if (bool(ctx.error)) [[unlikely]] {
                            return;
                         }
-                        if (*it != ',') {
-                           ctx.error = error_code::key_not_found;
+                        if (it >= end || *it != ',') {
+                           ctx.error = it >= end ? error_code::unexpected_end : error_code::key_not_found;
                            return;
                         }
                         ++it;
@@ -122,8 +122,8 @@ namespace glz
                         if (bool(ctx.error)) [[unlikely]] {
                            return;
                         }
-                        if (*it != ',') {
-                           ctx.error = error_code::array_element_not_found;
+                        if (it >= end || *it != ',') {
+                           ctx.error = it >= end ? error_code::unexpected_end : error_code::array_element_not_found;
                            return;
                         }
                         ++it;
@@ -186,8 +186,8 @@ namespace glz
                      if (bool(ctx.error)) [[unlikely]] {
                         return;
                      }
-                     if (*it != ',') {
-                        ctx.error = error_code::key_not_found;
+                     if (it >= end || *it != ',') {
+                        ctx.error = it >= end ? error_code::unexpected_end : error_code::key_not_found;
                         return;
                      }
                      ++it;

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -2418,6 +2418,30 @@ suite non_null_terminated_scanner_bounds = [] {
          expect(v == std::vector<int>{1, 2});
       }
    };
+
+   "nnt json-pointer seek over non-matching keys stays in bounds"_test = [] {
+      static constexpr glz::opts options{.null_terminated = false};
+      // The seek loop skips over non-target members and then tests for the ',' separator. When the
+      // document is truncated right after a skipped value the iterator sits at the end, so that test
+      // must be bounded rather than reading one past the buffer.
+      const auto resolves = [](std::string_view s) {
+         std::vector<char> buf{s.begin(), s.end()};
+         return glz::get_view_json<"/y", options>(std::string_view{buf.data(), buf.data() + buf.size()}).has_value();
+      };
+      expect(not resolves(R"({"x":1)")); // number value, truncated before the separator
+      expect(not resolves(R"({"x":true)")); // literal value
+      expect(not resolves(R"({"x":"ab")")); // string value
+      expect(not resolves(R"({"x":[1,2])")); // array value
+      expect(not resolves(R"({"x":{"z":1})")); // nested object value
+      expect(resolves(R"({"x":1,"y":2})")); // a later key still resolves
+
+      const auto resolves_index = [](std::string_view s) {
+         std::vector<char> buf{s.begin(), s.end()};
+         return glz::get_view_json<"/1", options>(std::string_view{buf.data(), buf.data() + buf.size()}).has_value();
+      };
+      expect(not resolves_index(R"([10)")); // truncated before the indexed element
+      expect(resolves_index(R"([10,20])")); // complete array resolves
+   };
 };
 
 suite minified_custom_object = [] {


### PR DESCRIPTION
The compile-time get_view_json seek skips over non-target members and array elements, then reads *it to find the ',' separator without bounding it against end. With opts.null_terminated false and a document truncated right after a skipped value, skip_value stops at end, so that read goes one byte past the buffer; ASAN flags a heap-buffer-overflow read at json_ptr.hpp:189 for a pointer like /y over {"x":true. The runtime get_view_json overload already bounds the same read with it < end, so only the compile-time path is affected.

Before, the separator test assumed a byte always follows the skipped value. After, the three sites (object string key, object numeric key, array index) check it >= end first and return unexpected_end, matching the runtime overload. The bound belongs in the seek loop rather than the skip primitives, since skip_value already stops correctly at end and the caller is what decides whether a missing separator is end-of-input. The tradeoff is that a truncated buffer now resolves to unexpected_end instead of key_not_found, which is the more accurate result.