### PR TITLE
bound cbor eigen matrix read to the matrix's storage

### DIFF
--- a/include/glaze/ext/eigen.hpp
+++ b/include/glaze/ext/eigen.hpp
@@ -245,13 +245,23 @@ namespace glz
          if (bool(ctx.error)) [[unlikely]]
             return;
 
-         // Resize if dynamic
+         // Resize dynamic matrices to the wire dimensions. A fixed-size matrix has exactly
+         // RowsAtCompileTime * ColsAtCompileTime scalars of storage, so a larger wire dimension
+         // would make the typed-array read below write past that fixed buffer; require the wire
+         // dimensions to match the compile-time extents.
          if constexpr (EigenType::RowsAtCompileTime < 0 || EigenType::ColsAtCompileTime < 0) {
             value.resize(static_cast<Eigen::Index>(rows), static_cast<Eigen::Index>(cols));
          }
+         else {
+            if (static_cast<Eigen::Index>(rows) != value.rows() ||
+                static_cast<Eigen::Index>(cols) != value.cols()) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+         }
 
-         // Read data as typed array
-         std::span<Scalar> view(value.data(), rows * cols);
+         // Read data as typed array, bounded by the matrix's own storage
+         std::span<Scalar> view(value.data(), static_cast<size_t>(value.size()));
          parse<CBOR>::op<Opts>(view, ctx, it, end);
       }
    };

--- a/tests/eigen_test/eigen_test.cpp
+++ b/tests/eigen_test/eigen_test.cpp
@@ -646,4 +646,19 @@ int main()
       expect(not glz::read_cbor(e, b));
       expect(m == e);
    };
+
+   // A fixed-size matrix must reject wire dimensions larger than its storage. The
+   // payload below declares 8x8 (64 doubles) but the target holds only 2x2; reading
+   // it must error instead of writing 64 doubles into the 32-byte fixed buffer.
+   "cbor fixed matrix oversized dims"_test = [] {
+      Eigen::MatrixXd big(8, 8);
+      big.setOnes();
+      std::string b;
+      expect(not glz::write_cbor(big, b));
+
+      Eigen::Matrix<double, 2, 2> e{};
+      e.setZero();
+      expect(bool(glz::read_cbor(e, b)));
+      expect(e == (Eigen::Matrix<double, 2, 2>::Zero()));
+   };
 }


### PR DESCRIPTION
The CBOR matrix reader takes `rows` and `cols` from the multi-dimensional-array header and builds the destination as `span(value.data(), rows * cols)`. A fixed-size Eigen matrix never resizes, so its storage stays at `RowsAtCompileTime * ColsAtCompileTime`; a document that declares larger dimensions makes the typed-array read run `rows*cols` scalars into that smaller buffer. Reading an 8x8 column-major matrix into a `Matrix<double,2,2>` writes 512 bytes into 32 (ASAN reports a buffer-overflow write).

Before, only dynamic matrices were sized from the wire and fixed matrices trusted the header. After, a fixed matrix requires the wire dimensions to equal its compile-time extents and the span is built from `value.size()`, so it can never exceed the storage. The BEVE and JSON fixed-size readers already get this from a static-extent span; the CBOR path used a dynamic-extent span, so the bound has to be enforced here. Tradeoff: a fixed matrix now rejects a document whose declared dimensions don't match its type rather than reading into a wrongly sized span, which lines up with how the other two formats treat the element count.
