### PR TITLE
guard char escape read against end of non-null-terminated input

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -1929,6 +1929,12 @@ namespace glz
 
          if (*it == '\\') [[unlikely]] {
             ++it;
+            if constexpr (not Opts.null_terminated) {
+               if (it == end) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
+            }
             switch (*it) {
             case '\0': {
                ctx.error = error_code::unexpected_end;

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -2442,6 +2442,32 @@ suite non_null_terminated_scanner_bounds = [] {
       expect(not resolves_index(R"([10)")); // truncated before the indexed element
       expect(resolves_index(R"([10,20])")); // complete array resolves
    };
+
+   "nnt char scalar escape stays in bounds"_test = [] {
+      static constexpr glz::opts options{.null_terminated = false};
+      // The char reader consumes the backslash before reading the escaped char. A value truncated
+      // right after the backslash leaves the iterator at the end, so that read must be bounded
+      // rather than reading one past the buffer.
+      const auto read_char = [](std::string_view s) {
+         std::vector<char> buf{s.begin(), s.end()};
+         char value{};
+         return glz::read<options>(value, std::string_view{buf.data(), buf.data() + buf.size()});
+      };
+      expect(read_char(R"("\)")); // trailing backslash at the end
+      expect(read_char(R"("a)")); // unterminated single char
+      // Complete char values still parse.
+      const auto value_of = [](std::string_view s) {
+         std::vector<char> buf{s.begin(), s.end()};
+         char value{};
+         const auto ec = glz::read<options>(value, std::string_view{buf.data(), buf.data() + buf.size()});
+         expect(not ec);
+         return value;
+      };
+      expect(value_of(R"("a")") == 'a');
+      expect(value_of(R"("\n")") == '\n');
+      expect(value_of(R"("\\")") == '\\');
+      expect(value_of(R"("")") == '\0');
+   };
 };
 
 suite minified_custom_object = [] {


### PR DESCRIPTION
The char scalar reader consumes the opening quote, then on a backslash advances and decodes the escape with switch(*it) without a bounds check. Under null_terminated=false over a non-padded buffer (a string_view or span) whose value is truncated right after the backslash, the advance leaves the iterator at end and the switch reads one byte past the input. Reachable from glz::read into a char; the string and skip_string paths already guard the same post-backslash read, so the char reader was the one site that missed it.

Add the same not-null_terminated end check between the advance and the switch. Before, a value ending in a lone backslash over-reads the buffer; after, it returns unexpected_end, matching what the null-terminated and padded paths already report for that input. Valid escapes are unchanged, and the cost is one comparison on the rare escape branch, paid in the reader so callers reading into a char do not each need a padded buffer.