### PR TITLE
lazy JSON: opt-in streaming cursor for read_into + sequential iteration

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -35,6 +35,29 @@ target_compile_options(lazy_benchmark PRIVATE
   $<$<CXX_COMPILER_ID:MSVC>:/O2>
 )
 
+# Tabular bulk-load pattern (nested arrays-of-arrays + scalar read_into)
+add_executable(lazy_load_benchmark lazy_load_benchmark.cpp)
+target_link_libraries(lazy_load_benchmark PRIVATE
+  glaze
+  bencher::bencher
+)
+target_compile_options(lazy_load_benchmark PRIVATE
+  $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-O3 -march=native>
+  $<$<CXX_COMPILER_ID:MSVC>:/O2>
+)
+
+# Header-scan stage on large split-catalog fixture (skip/iterator guard; no row read_into loop)
+add_executable(lazy_load_scalar lazy_load_scalar.cpp)
+target_compile_definitions(lazy_load_scalar PRIVATE GLAZE_LAZY_LOAD_FORK)
+target_link_libraries(lazy_load_scalar PRIVATE
+  glaze
+  bencher::bencher
+)
+target_compile_options(lazy_load_scalar PRIVATE
+  $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-O3 -march=native>
+  $<$<CXX_COMPILER_ID:MSVC>:/O2>
+)
+
 # Simple float benchmark
 add_executable(simple_float_benchmark simple_float_benchmark.cpp)
 target_link_libraries(simple_float_benchmark PRIVATE

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -46,6 +46,14 @@ target_compile_options(lazy_load_benchmark PRIVATE
   $<$<CXX_COMPILER_ID:MSVC>:/O2>
 )
 
+# Single-config GB-scale ingest, selected by argv, for interleaved separate-process A/B
+add_executable(flat_ingest_single flat_ingest_single.cpp)
+target_link_libraries(flat_ingest_single PRIVATE glaze)
+target_compile_options(flat_ingest_single PRIVATE
+  $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-O3 -march=native>
+  $<$<CXX_COMPILER_ID:MSVC>:/O2>
+)
+
 # Header-scan stage on large split-catalog fixture (skip/iterator guard; no row read_into loop)
 add_executable(lazy_load_scalar lazy_load_scalar.cpp)
 target_compile_definitions(lazy_load_scalar PRIVATE GLAZE_LAZY_LOAD_FORK)

--- a/benchmarks/flat_ingest_single.cpp
+++ b/benchmarks/flat_ingest_single.cpp
@@ -1,0 +1,101 @@
+// Single-config GB-scale flat-tables ingest, selected by argv[1], for interleaved
+// separate-process A/B measurement (avoids the sequential-arm ordering/thermal confound of
+// running all four configs in one process). Prints one line: "<cfg> cpu_ms=<n> MB/s=<n>".
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#include "lazy_load_common.hpp"
+
+namespace
+{
+   using namespace lazy_load_bench;
+
+   template <auto Opts>
+   long timed_ingest(const std::string& json, double& ms)
+   {
+      auto doc = glz::lazy_json<Opts>(json);
+      if (!doc) {
+         std::abort();
+      }
+      const auto t0 = std::chrono::steady_clock::now();
+      const auto sum = load_flat_tables_scalars<Opts>((*doc)["tables"]);
+      const auto t1 = std::chrono::steady_clock::now();
+      ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+      return static_cast<long>(sum);
+   }
+
+   // Models RAMA config A: iterate with the full-view iterator, but per cell round-trip the
+   // value through a 24-byte {doc,data,parse_pos} handle and reconstruct a FULL view to read
+   // through (as RAMA's makeValue/GlzViewHandle::view() does). Opts must be a FULL-view opts.
+   template <auto Opts>
+   long timed_ingest_recon(const std::string& json, double& ms)
+   {
+      auto doc = glz::lazy_json<Opts>(json);
+      if (!doc) {
+         std::abort();
+      }
+      struct SlimHandle
+      {
+         const glz::lazy_document<Opts>* d{};
+         const char* data{};
+         const char* pp{};
+      };
+      long sum = 0;
+      std::size_t nulls = 0;
+      const auto t0 = std::chrono::steady_clock::now();
+      for (auto& table : (*doc)["tables"]) {
+         auto rows = table["rows"];
+         for (auto& row : rows) {
+            for (auto& cell : row) {
+               // deref -> slim 24-byte handle -> reconstruct full view -> read (RAMA's path)
+               const SlimHandle h{cell.document(), cell.data(), cell.parse_pos()};
+               glz::lazy_json_view<Opts> v{h.d, h.data};
+               v.set_parse_pos(h.pp);
+               sum += ingest_cell<Opts>(v, nulls);
+            }
+         }
+      }
+      const auto t1 = std::chrono::steady_clock::now();
+      ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+      return sum + static_cast<long>(nulls);
+   }
+} // namespace
+
+int main(int argc, char** argv)
+{
+   const char* cfg = (argc > 1) ? argv[1] : "full-on";
+
+   // ~1.14 GB flat cell-heavy fixture (same shape as lazy_load_benchmark's GB-scale stage).
+   const auto json = generate_flat_tables_json(60, 120000, lazy_load_bench::k_default_cols_per_row);
+
+   double ms = 0;
+   long sum = 0;
+   if (std::strcmp(cfg, "full-off") == 0) {
+      sum = timed_ingest<kEndBounded>(json, ms);
+   }
+   else if (std::strcmp(cfg, "full-on") == 0) {
+      sum = timed_ingest<kStreamingEnabled>(json, ms);
+   }
+   else if (std::strcmp(cfg, "slim-off") == 0) {
+      sum = timed_ingest<kEndBoundedSlim>(json, ms);
+   }
+   else if (std::strcmp(cfg, "slim-on") == 0) {
+      sum = timed_ingest<kStreamingEnabledSlim>(json, ms);
+   }
+   else if (std::strcmp(cfg, "recon-off") == 0) {
+      sum = timed_ingest_recon<kEndBounded>(json, ms); // RAMA slim-handle + fat view, streaming off
+   }
+   else if (std::strcmp(cfg, "recon-on") == 0) {
+      sum = timed_ingest_recon<kStreamingEnabled>(json, ms); // RAMA slim-handle + fat view, streaming on
+   }
+   else {
+      std::printf("unknown cfg '%s'\n", cfg);
+      return 2;
+   }
+
+   const double mb = static_cast<double>(json.size()) / (1024.0 * 1024.0);
+   std::printf("%s cpu_ms=%.1f MB/s=%.1f sum=%ld\n", cfg, ms, mb / (ms / 1000.0), sum);
+   return 0;
+}

--- a/benchmarks/lazy_benchmark.cpp
+++ b/benchmarks/lazy_benchmark.cpp
@@ -4,6 +4,7 @@
 
 #include "bencher/bencher.hpp"
 #include "bencher/diagnostics.hpp"
+#include "glaze/core/lazy_streaming_cursor_policy.hpp"
 #include "glaze/json.hpp"
 
 // Struct for deserialization benchmarks
@@ -491,6 +492,68 @@ int main()
             if (!ec) sum += u.score;
          }
          if (sum != 45000) std::abort();
+         return large_json.size();
+      });
+
+      bencher::print_results(stage);
+   }
+
+   // ========================================================================
+   // Benchmark: streaming cursor enabled (read_into + forward iteration)
+   // ========================================================================
+   {
+      struct streaming_opts : glz::opts {
+         glz::lazy_streaming_cursor_policy lazy_streaming_cursor =
+            glz::lazy_streaming_cursor_policy::enabled;
+      };
+      static constexpr streaming_opts kStreaming{};
+
+      bencher::stage stage;
+      stage.name = "Streaming cursor ON (enabled) — read_into + iteration";
+
+      stage.run("read_into() streaming OFF (default opts)", [&] {
+         auto result = glz::lazy_json(large_json);
+         auto users = (*result)["users"];
+         int64_t sum = 0;
+         size_t count = 0;
+         for (auto& user : users) {
+            BenchUser u{};
+            auto ec = user.read_into(u);
+            if (!ec) {
+               sum += u.score;
+               ++count;
+            }
+         }
+         if (sum != 4995000 || count != 1000) std::abort();
+         return large_json.size();
+      });
+
+      stage.run("read_into() streaming ON (enabled)", [&] {
+         auto result = glz::lazy_json<kStreaming>(large_json);
+         auto users = (*result)["users"];
+         int64_t sum = 0;
+         size_t count = 0;
+         for (auto& user : users) {
+            BenchUser u{};
+            auto ec = user.read_into(u);
+            if (!ec) {
+               sum += u.score;
+               ++count;
+            }
+         }
+         if (sum != 4995000 || count != 1000) std::abort();
+         return large_json.size();
+      });
+
+      stage.run("Iterate All & Sum Scores (iterator)", [&] {
+         auto result = glz::lazy_json<kStreaming>(large_json);
+         auto users = (*result)["users"];
+         int64_t sum = 0;
+         for (auto& user : users) {
+            auto score = user["score"].get<int64_t>();
+            if (score) sum += *score;
+         }
+         if (sum != 4995000) std::abort();
          return large_json.size();
       });
 

--- a/benchmarks/lazy_load_benchmark.cpp
+++ b/benchmarks/lazy_load_benchmark.cpp
@@ -43,6 +43,9 @@ namespace
 
 int main()
 {
+   std::cerr << "sizeof(lazy_json_view) full = " << sizeof(glz::lazy_json_view<lazy_load_bench::kStreamingEnabled>)
+             << " bytes, slim = " << sizeof(glz::lazy_json_view<lazy_load_bench::kStreamingEnabledSlim>) << " bytes\n";
+
    constexpr std::size_t k_prefix = 120;
    constexpr std::size_t k_prefix_rows = lazy_load_bench::k_default_cols_per_row;
    constexpr std::size_t k_payload = 500;
@@ -65,6 +68,19 @@ int main()
                                                     lazy_load_bench::k_flat_smoke_rows_per_table,
                                                     lazy_load_bench::k_flat_smoke_cols_per_row);
 
+   // GB-scale, pure-scalar-cell fixture: millions of small numeric/string cells, no giant
+   // blobs, out of cache — isolates the effect of lazy_json_view size on cell-heavy ingest.
+   constexpr std::size_t k_flat_big_num_tables = 60;
+   constexpr std::size_t k_flat_big_rows_per_table = 120000;
+   constexpr std::size_t k_flat_big_cols_per_row = lazy_load_bench::k_default_cols_per_row; // 12
+   std::cerr << "generating GB-scale flat-tables fixture (" << k_flat_big_num_tables << " tables x "
+             << k_flat_big_rows_per_table << " rows x " << k_flat_big_cols_per_row << " cols)...\n";
+   const auto flat_big_json =
+      generate_flat_tables_json(k_flat_big_num_tables, k_flat_big_rows_per_table, k_flat_big_cols_per_row);
+   const auto flat_big_label = format_megabytes(flat_big_json.size());
+   std::cerr << "GB-scale flat-tables fixture ready: " << flat_big_label << " (" << flat_big_json.size()
+             << " bytes)\n";
+
    std::int64_t expected_warehouse{};
    {
       auto doc = glz::lazy_json<kStreamingEnabled>(warehouse_json);
@@ -84,6 +100,13 @@ int main()
       auto doc = glz::lazy_json<kEndBounded>(flat_json);
       if (!doc) std::abort();
       expected_flat = load_flat_tables_scalars<kEndBounded>((*doc)["tables"]);
+   }
+
+   std::int64_t expected_flat_big{};
+   {
+      auto doc = glz::lazy_json<kEndBounded>(flat_big_json);
+      if (!doc) std::abort();
+      expected_flat_big = load_flat_tables_scalars<kEndBounded>((*doc)["tables"]);
    }
 
    {
@@ -134,6 +157,24 @@ int main()
                                                [](const glz::lazy_document<kStreamingEnabled>& doc) {
                                                   return load_flat_tables_scalars<kStreamingEnabled>(doc["tables"]);
                                                });
+
+      bencher::print_results(stage);
+   }
+
+   {
+      bencher::stage stage;
+      configure_large_load_stage(stage);
+      stage.name = std::string("GB-scale flat-tables cell-heavy ingest (~") + flat_big_label +
+                   "): pure scalar cells, out of cache, streaming off vs on";
+
+      bench_scalar_ingest<kEndBounded>(stage, "streaming off (default opts)", flat_big_json, expected_flat_big,
+                                       [](const glz::lazy_document<kEndBounded>& doc) {
+                                          return load_flat_tables_scalars<kEndBounded>(doc["tables"]);
+                                       });
+      bench_scalar_ingest<kStreamingEnabled>(stage, "streaming on (enabled)", flat_big_json, expected_flat_big,
+                                             [](const glz::lazy_document<kStreamingEnabled>& doc) {
+                                                return load_flat_tables_scalars<kStreamingEnabled>(doc["tables"]);
+                                             });
 
       bencher::print_results(stage);
    }

--- a/benchmarks/lazy_load_benchmark.cpp
+++ b/benchmarks/lazy_load_benchmark.cpp
@@ -1,0 +1,142 @@
+// Benchmark lazy JSON bulk ingest: heterogeneous split-catalog JSON with mixed row
+// kinds (scalar cells, object records, numeric rows) and per-row materialization heap
+// traffic between parse steps — closer to warehouse build than a uniform micro-loop.
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+
+#include "bencher/bencher.hpp"
+#include "bencher/diagnostics.hpp"
+#include "lazy_load_common.hpp"
+
+namespace
+{
+   using namespace lazy_load_bench;
+
+   template <auto Opts, typename LoadFn>
+   void bench_scalar_ingest(bencher::stage& stage, const char* label, const std::string& json, std::int64_t expected,
+                            LoadFn load_fn)
+   {
+      stage.run(label, [&] {
+         auto result = glz::lazy_json<Opts>(json);
+         if (!result) std::abort();
+         const auto sum = load_fn(*result);
+         if (sum != expected) std::abort();
+         return json.size();
+      });
+   }
+
+   void configure_large_load_stage(bencher::stage& stage)
+   {
+      stage.min_execution_count = 1;
+      stage.max_execution_count = 1;
+      stage.warmup_duration_ms = 0;
+   }
+
+   inline std::string format_megabytes(std::size_t bytes)
+   {
+      const double mb = static_cast<double>(bytes) / static_cast<double>(lazy_load_bench::k_bytes_per_mib);
+      return std::to_string(static_cast<int>(mb + 0.5)) + " MB";
+   }
+} // namespace
+
+int main()
+{
+   constexpr std::size_t k_prefix = 120;
+   constexpr std::size_t k_prefix_rows = lazy_load_bench::k_default_cols_per_row;
+   constexpr std::size_t k_payload = 500;
+   constexpr std::size_t k_heavy = 12;
+   constexpr std::size_t k_heavy_entity_bytes = 180 * lazy_load_bench::k_bytes_per_mib;
+   constexpr std::size_t k_scalar_heavy_rows = 12000;
+   constexpr std::size_t k_cols = lazy_load_bench::k_default_cols_per_row;
+
+   std::cerr << "generating mixed-warehouse fixture...\n";
+   const auto warehouse_json =
+      generate_mixed_warehouse_json(k_prefix, k_prefix_rows, k_payload, k_heavy, k_heavy_entity_bytes);
+   const auto warehouse_label = format_megabytes(warehouse_json.size());
+   std::cerr << "mixed-warehouse fixture ready: " << warehouse_label << " (" << warehouse_json.size() << " bytes)\n";
+
+   const auto catalog_json =
+      generate_split_catalog_json(k_prefix, k_prefix_rows, k_payload, k_heavy, k_scalar_heavy_rows, k_cols);
+   const auto catalog_label = format_megabytes(catalog_json.size());
+
+   const auto flat_json = generate_flat_tables_json(lazy_load_bench::k_flat_smoke_num_tables,
+                                                    lazy_load_bench::k_flat_smoke_rows_per_table,
+                                                    lazy_load_bench::k_flat_smoke_cols_per_row);
+
+   std::int64_t expected_warehouse{};
+   {
+      auto doc = glz::lazy_json<kStreamingEnabled>(warehouse_json);
+      if (!doc) std::abort();
+      expected_warehouse = load_mixed_warehouse_catalog<kStreamingEnabled>(*doc);
+   }
+
+   std::int64_t expected_catalog{};
+   {
+      auto doc = glz::lazy_json<kStreamingEnabled>(catalog_json);
+      if (!doc) std::abort();
+      expected_catalog = load_split_catalog_scalars<kStreamingEnabled>(*doc);
+   }
+
+   std::int64_t expected_flat{};
+   {
+      auto doc = glz::lazy_json<kEndBounded>(flat_json);
+      if (!doc) std::abort();
+      expected_flat = load_flat_tables_scalars<kEndBounded>((*doc)["tables"]);
+   }
+
+   {
+      bencher::stage stage;
+      configure_large_load_stage(stage);
+      stage.name = std::string("Mixed-warehouse ingest (~") + warehouse_label +
+                   "): heterogeneous rows + materialization heap, streaming off vs on";
+
+      bench_scalar_ingest<kEndBounded>(stage, "streaming off (default opts)", warehouse_json, expected_warehouse,
+                                       [](const glz::lazy_document<kEndBounded>& doc) {
+                                          return load_mixed_warehouse_catalog<kEndBounded>(doc);
+                                       });
+      bench_scalar_ingest<kStreamingEnabled>(stage, "streaming on (enabled)", warehouse_json, expected_warehouse,
+                                             [](const glz::lazy_document<kStreamingEnabled>& doc) {
+                                                return load_mixed_warehouse_catalog<kStreamingEnabled>(doc);
+                                             });
+
+      bencher::print_results(stage);
+   }
+
+   {
+      bencher::stage stage;
+      configure_large_load_stage(stage);
+      stage.name = std::string("Split-catalog scalar-cell load (~") + catalog_label +
+                   "): streaming cursor off vs on";
+
+      bench_scalar_ingest<kEndBounded>(stage, "streaming off (default opts)", catalog_json, expected_catalog,
+                                       [](const glz::lazy_document<kEndBounded>& doc) {
+                                          return load_split_catalog_scalars<kEndBounded>(doc);
+                                       });
+      bench_scalar_ingest<kStreamingEnabled>(stage, "streaming on (enabled)", catalog_json, expected_catalog,
+                                             [](const glz::lazy_document<kStreamingEnabled>& doc) {
+                                                return load_split_catalog_scalars<kStreamingEnabled>(doc);
+                                             });
+
+      bencher::print_results(stage);
+   }
+
+   {
+      bencher::stage stage;
+      stage.name = "Flat tables smoke (~3.8 MB): streaming off vs on";
+
+      bench_scalar_ingest<kEndBounded>(stage, "streaming off", flat_json, expected_flat,
+                                       [](const glz::lazy_document<kEndBounded>& doc) {
+                                          return load_flat_tables_scalars<kEndBounded>(doc["tables"]);
+                                       });
+      bench_scalar_ingest<kStreamingEnabled>(stage, "streaming on (enabled)", flat_json, expected_flat,
+                                               [](const glz::lazy_document<kStreamingEnabled>& doc) {
+                                                  return load_flat_tables_scalars<kStreamingEnabled>(doc["tables"]);
+                                               });
+
+      bencher::print_results(stage);
+   }
+
+   return 0;
+}

--- a/benchmarks/lazy_load_benchmark.cpp
+++ b/benchmarks/lazy_load_benchmark.cpp
@@ -43,6 +43,12 @@ namespace
 
 int main()
 {
+   // Confirm the slim opts still carry the streaming cursor (rule out silent streaming-off).
+   static_assert(glz::lazy_streaming_cursor_active(lazy_load_bench::kStreamingEnabled), "full: streaming expected ON");
+   static_assert(glz::lazy_streaming_cursor_active(lazy_load_bench::kStreamingEnabledSlim),
+                 "slim: streaming expected ON");
+   static_assert(!glz::lazy_streaming_cursor_active(lazy_load_bench::kEndBoundedSlim), "slim end-bounded: streaming OFF");
+
    std::cerr << "sizeof(lazy_json_view) full = " << sizeof(glz::lazy_json_view<lazy_load_bench::kStreamingEnabled>)
              << " bytes, slim = " << sizeof(glz::lazy_json_view<lazy_load_bench::kStreamingEnabledSlim>) << " bytes\n";
 
@@ -176,6 +182,49 @@ int main()
                                                 return load_flat_tables_scalars<kStreamingEnabled>(doc["tables"]);
                                              });
 
+      bencher::print_results(stage);
+   }
+
+   // Full (48-byte) vs slim (24-byte) lazy_json_view on the same realistic ingest loop
+   // (streaming on for both, so the only variable is the value view size). This is the
+   // faithful A/B: the actual read_into-per-cell workload, no synthetic copy harness.
+   {
+      bencher::stage stage;
+      configure_large_load_stage(stage);
+      stage.name = std::string("Split-catalog scalar-cell load (~") + catalog_label +
+                   "): full 48B view vs slim 24B view, streaming on";
+      bench_scalar_ingest<kStreamingEnabled>(stage, "full view (48 B)", catalog_json, expected_catalog,
+                                             [](const glz::lazy_document<kStreamingEnabled>& doc) {
+                                                return load_split_catalog_scalars<kStreamingEnabled>(doc);
+                                             });
+      bench_scalar_ingest<kStreamingEnabledSlim>(stage, "slim view (24 B)", catalog_json, expected_catalog,
+                                                 [](const glz::lazy_document<kStreamingEnabledSlim>& doc) {
+                                                    return load_split_catalog_scalars<kStreamingEnabledSlim>(doc);
+                                                 });
+      bencher::print_results(stage);
+   }
+
+   {
+      bencher::stage stage;
+      configure_large_load_stage(stage);
+      stage.name = std::string("GB-scale flat-tables cell-heavy ingest (~") + flat_big_label +
+                   "): full vs slim view x streaming off/on (4-way isolation)";
+      bench_scalar_ingest<kEndBounded>(stage, "full 48B, streaming OFF", flat_big_json, expected_flat_big,
+                                       [](const glz::lazy_document<kEndBounded>& doc) {
+                                          return load_flat_tables_scalars<kEndBounded>(doc["tables"]);
+                                       });
+      bench_scalar_ingest<kStreamingEnabled>(stage, "full 48B, streaming ON", flat_big_json, expected_flat_big,
+                                             [](const glz::lazy_document<kStreamingEnabled>& doc) {
+                                                return load_flat_tables_scalars<kStreamingEnabled>(doc["tables"]);
+                                             });
+      bench_scalar_ingest<kEndBoundedSlim>(stage, "slim 24B, streaming OFF", flat_big_json, expected_flat_big,
+                                           [](const glz::lazy_document<kEndBoundedSlim>& doc) {
+                                              return load_flat_tables_scalars<kEndBoundedSlim>(doc["tables"]);
+                                           });
+      bench_scalar_ingest<kStreamingEnabledSlim>(stage, "slim 24B, streaming ON", flat_big_json, expected_flat_big,
+                                                 [](const glz::lazy_document<kStreamingEnabledSlim>& doc) {
+                                                    return load_flat_tables_scalars<kStreamingEnabledSlim>(doc["tables"]);
+                                                 });
       bencher::print_results(stage);
    }
 

--- a/benchmarks/lazy_load_common.hpp
+++ b/benchmarks/lazy_load_common.hpp
@@ -1,0 +1,808 @@
+// Shared generators and ingest loops for lazy_load_benchmark / lazy_load_scalar.
+#pragma once
+
+#include <cstdint>
+#include <array>
+#include <string>
+#include <vector>
+
+#include "glaze/json.hpp"
+#if __has_include("glaze/core/lazy_streaming_cursor_policy.hpp")
+#include "glaze/core/lazy_streaming_cursor_policy.hpp"
+#define GLZ_LAZY_LOAD_HAS_STREAMING_POLICY 1
+#else
+#define GLZ_LAZY_LOAD_HAS_STREAMING_POLICY 0
+#endif
+
+namespace lazy_load_bench
+{
+   // --- Row shape ---
+   inline constexpr std::size_t k_default_cols_per_row = 12;
+   using numeric_row = std::array<double, k_default_cols_per_row>;
+
+   // Rough per-row `reserve()` size estimates (chars).
+   inline constexpr std::size_t k_mixed_row_estimated_cell_chars = 14;
+   inline constexpr std::size_t k_mixed_row_estimated_framing_chars = 4; // `[` `]` commas
+   inline constexpr std::size_t k_numeric_row_estimated_chars = 128;
+   inline constexpr std::size_t k_object_row_estimated_chars = 120;
+   inline constexpr std::size_t k_entity_header_estimated_chars = 384;
+   inline constexpr std::size_t k_split_catalog_cell_chars_estimate = 10;
+   inline constexpr std::size_t k_split_catalog_row_framing_chars = 8;
+
+   // Heavy-entity row counts derived from target byte budget.
+   inline constexpr std::size_t k_scalar_row_bytes_estimate = 110;
+   inline constexpr std::size_t k_object_row_bytes_estimate = 900;
+   inline constexpr std::size_t k_numeric_row_bytes_estimate = 160;
+
+   // Deterministic mixed-row cell patterns.
+   inline constexpr std::size_t k_null_cell_row_period = 19;
+   inline constexpr std::size_t k_string_cell_col_stride = 4;
+
+   // Legacy flat-tables cell patterns.
+   inline constexpr std::size_t k_legacy_null_cell_row_period = 17;
+   inline constexpr std::size_t k_legacy_string_cell_col_stride = 3;
+   inline constexpr double k_legacy_numeric_cell_col_scale = 0.25;
+
+   // Entity / cell value encoding.
+   inline constexpr std::size_t k_label_group_modulus = 17;
+   inline constexpr std::size_t k_category_modulus = 64;
+   inline constexpr std::size_t k_disabled_row_period = 3;
+   inline constexpr std::size_t k_object_fixed_payload_chars = 1024;
+   inline constexpr std::size_t k_score_row_multiplier = 10;
+   inline constexpr std::int64_t k_entity_id_scale = 1'000'000;
+   inline constexpr std::int64_t k_numeric_cell_entity_scale = 100'000;
+   // Row stride in numeric cell values — one char shy of mixed cell estimate.
+   inline constexpr std::size_t k_numeric_cell_row_stride = k_mixed_row_estimated_cell_chars - 1;
+
+   // Variable-length object payloads.
+   inline constexpr std::size_t k_variable_payload_base_chars = 256;
+   inline constexpr std::size_t k_variable_payload_span_chars = 1792;
+
+   // Catalog layout.
+   inline constexpr std::size_t k_row_kind_count = 3;
+   inline constexpr std::size_t k_payload_id_base = 10'000;
+   inline constexpr std::size_t k_mixed_warehouse_prefix_reserve = 4096;
+   inline constexpr std::size_t k_mixed_warehouse_payload_reserve = 512;
+
+   // Materialization heap / checksum helpers.
+   inline constexpr std::size_t k_heap_words_base = 8;
+   inline constexpr std::size_t k_heap_words_span = 24;
+   inline constexpr std::uint64_t k_heap_lcg_multiplier = 6364136223846793005ULL;
+   inline constexpr std::size_t k_heap_checksum_stride = 64;
+   inline constexpr std::uint64_t k_checksum_low_bits_mask = 0xFFFFULL;
+   inline constexpr double k_number_checksum_scale = 1000.0;
+
+   // Cache-churn scratch stride (one cache line).
+   inline constexpr std::size_t k_cache_line_bytes = 4096;
+   inline constexpr std::size_t k_bytes_per_kib = 1024;
+   inline constexpr std::size_t k_bytes_per_mib = k_bytes_per_kib * k_bytes_per_kib;
+
+   // Legacy flat tables[] smoke fixture sizing.
+   inline constexpr std::size_t k_flat_smoke_num_tables = 20;
+   inline constexpr std::size_t k_flat_smoke_rows_per_table = 2000;
+   inline constexpr std::size_t k_flat_smoke_cols_per_row = 8;
+
+   // Payload string fill alphabet.
+   inline constexpr std::size_t k_alphabet_size = 26;
+   inline constexpr char k_alphabet_base = 'a';
+
+   enum class row_kind : std::uint8_t { scalar = 0, object = 1, numeric = 2 };
+
+   struct end_bounded_opts : glz::opts {
+      bool null_terminated = false;
+   };
+
+   struct streaming_enabled_opts : end_bounded_opts {
+#if GLZ_LAZY_LOAD_HAS_STREAMING_POLICY
+      glz::lazy_streaming_cursor_policy lazy_streaming_cursor = glz::lazy_streaming_cursor_policy::enabled;
+#endif
+   };
+
+   inline constexpr end_bounded_opts kEndBounded{};
+   inline constexpr streaming_enabled_opts kStreamingEnabled{};
+
+   struct generic_record
+   {
+      std::int64_t id{};
+      std::string name{};
+      std::string label{};
+      std::int64_t category{};
+      bool enabled{};
+      std::int64_t score{};
+   };
+
+   inline void append_row_array(std::string& json, std::size_t rows, std::size_t cols, std::size_t entity_idx)
+   {
+      json += R"(,"rows":[)";
+      if (rows == 0) {
+         json += ']';
+         return;
+      }
+
+      json.reserve(json.size() + rows * (cols * k_mixed_row_estimated_cell_chars + k_mixed_row_estimated_framing_chars));
+      for (std::size_t r = 0; r < rows; ++r) {
+         if (r > 0) json += ',';
+         json += '[';
+         for (std::size_t c = 0; c < cols; ++c) {
+            if (c > 0) json += ',';
+            if (c == 0 && (r % k_null_cell_row_period == 0)) {
+               json += "null";
+            }
+            else if (c % k_string_cell_col_stride == 0) {
+               json += "\"c";
+               json += std::to_string(entity_idx);
+               json += '_';
+               json += std::to_string(r);
+               json += '"';
+            }
+            else {
+               json += std::to_string(r + c + entity_idx);
+            }
+         }
+         json += ']';
+      }
+      json += ']';
+   }
+
+   inline void append_numeric_row_array(std::string& json, std::size_t rows, std::size_t entity_idx)
+   {
+      json += R"(,"rows":[)";
+      if (rows == 0) {
+         json += ']';
+         return;
+      }
+
+      json.reserve(json.size() + rows * k_numeric_row_estimated_chars);
+      for (std::size_t r = 0; r < rows; ++r) {
+         if (r > 0) json += ',';
+         json += '[';
+         for (std::size_t c = 0; c < numeric_row{}.size(); ++c) {
+            if (c > 0) json += ',';
+            json += std::to_string((entity_idx + 1) * k_numeric_cell_entity_scale + r * k_numeric_cell_row_stride + c);
+         }
+         json += ']';
+      }
+      json += ']';
+   }
+
+   inline void append_object_row_array(std::string& json, std::size_t rows, std::size_t entity_idx)
+   {
+      json += R"(,"rows":[)";
+      if (rows == 0) {
+         json += ']';
+         return;
+      }
+
+      json.reserve(json.size() + rows * k_object_row_estimated_chars);
+      for (std::size_t r = 0; r < rows; ++r) {
+         if (r > 0) json += ',';
+         json += R"({"id":)";
+         json += std::to_string(entity_idx * k_entity_id_scale + r);
+         json += R"(,"name":"record )";
+         json += std::to_string(r);
+         json += R"(","label":"group )";
+         json += std::to_string(entity_idx % k_label_group_modulus);
+         json += R"(","category":)";
+         json += std::to_string((entity_idx + r) % k_category_modulus);
+         json += R"(,"enabled":)";
+         json += (r % k_disabled_row_period == 0) ? "false" : "true";
+         json += R"(,"payload":")";
+         for (std::size_t i = 0; i < k_object_fixed_payload_chars; ++i) {
+            json += static_cast<char>(k_alphabet_base + ((r + i + entity_idx) % k_alphabet_size));
+         }
+         json += '"';
+         json += R"(,"score":)";
+         json += std::to_string(static_cast<std::int64_t>(r * k_score_row_multiplier + entity_idx));
+         json += '}';
+      }
+      json += ']';
+   }
+
+   // Generic object header: int + strings + bools + int[] + row_kind before nested rows.
+   inline void append_entity_header(std::string& json, std::size_t id, std::size_t entity_idx, bool extended,
+                                    row_kind kind)
+   {
+      json += R"({"id":)";
+      json += std::to_string(id);
+      json += R"(,"name":"item_ )";
+      json += std::to_string(entity_idx);
+      json += R"(","note":"note for )";
+      json += std::to_string(entity_idx);
+      json += R"(","caption":"sample text block )";
+      json += std::to_string(entity_idx);
+      json += R"JSON(","kind":1,"enabled":true,"locked":false)JSON";
+      if (extended) {
+         json += R"JSON(,"opt_a":false,"opt_b":true)JSON";
+      }
+      json += R"(,"refs":[0,1,2,3],"row_kind":)";
+      json += std::to_string(static_cast<unsigned>(kind));
+   }
+
+   inline void append_entity_header(std::string& json, std::size_t id, std::size_t entity_idx, bool extended)
+   {
+      append_entity_header(json, id, entity_idx, extended, row_kind::scalar);
+   }
+
+   inline void append_object_row_array_variable(std::string& json, std::size_t rows, std::size_t entity_idx)
+   {
+      json += R"(,"rows":[)";
+      if (rows == 0) {
+         json += ']';
+         return;
+      }
+
+      for (std::size_t r = 0; r < rows; ++r) {
+         if (r > 0) json += ',';
+         const std::size_t payload_len =
+            k_variable_payload_base_chars + ((r * k_label_group_modulus + entity_idx) % k_variable_payload_span_chars);
+         json += R"({"id":)";
+         json += std::to_string(entity_idx * k_entity_id_scale + r);
+         json += R"(,"name":"record )";
+         json += std::to_string(r);
+         json += R"(","label":"group )";
+         json += std::to_string(entity_idx % k_label_group_modulus);
+         json += R"(","category":)";
+         json += std::to_string((entity_idx + r) % k_category_modulus);
+         json += R"(,"enabled":)";
+         json += (r % k_disabled_row_period == 0) ? "false" : "true";
+         json += R"(,"payload":")";
+         for (std::size_t i = 0; i < payload_len; ++i) {
+            json += static_cast<char>(k_alphabet_base + ((r + i + entity_idx) % k_alphabet_size));
+         }
+         json += '"';
+         json += R"(,"score":)";
+         json += std::to_string(static_cast<std::int64_t>(r * k_score_row_multiplier + entity_idx));
+         json += '}';
+      }
+      json += ']';
+   }
+
+   inline void append_rows_for_kind(std::string& json, row_kind kind, std::size_t rows, std::size_t entity_idx,
+                                    std::size_t cols = k_default_cols_per_row)
+   {
+      switch (kind) {
+      case row_kind::scalar:
+         append_row_array(json, rows, cols, entity_idx);
+         break;
+      case row_kind::object:
+         append_object_row_array_variable(json, rows, entity_idx);
+         break;
+      case row_kind::numeric:
+         append_numeric_row_array(json, rows, entity_idx);
+         break;
+      default:
+         break;
+      }
+   }
+
+   inline std::size_t heavy_rows_for_kind(row_kind kind, std::size_t target_entity_bytes)
+   {
+      switch (kind) {
+      case row_kind::scalar:
+         return target_entity_bytes / k_scalar_row_bytes_estimate;
+      case row_kind::object:
+         return target_entity_bytes / k_object_row_bytes_estimate;
+      case row_kind::numeric:
+         return target_entity_bytes / k_numeric_row_bytes_estimate;
+      default:
+         return 0;
+      }
+   }
+
+   // Mixed row kinds per entity + split prefix/payload catalog. Heavy payload entities
+   // rotate scalar / object / numeric matrices to mimic heterogeneous warehouse dumps.
+   inline std::string generate_mixed_warehouse_json(std::size_t num_prefix, std::size_t prefix_rows_per_entity,
+                                                    std::size_t num_payload, std::size_t heavy_payload,
+                                                    std::size_t heavy_entity_bytes)
+   {
+      std::string json;
+      json.reserve(num_prefix * k_mixed_warehouse_prefix_reserve + num_payload * k_mixed_warehouse_payload_reserve +
+                   heavy_payload * heavy_entity_bytes);
+
+      json += R"({"prefix":[)";
+      for (std::size_t e = 0; e < num_prefix; ++e) {
+         if (e > 0) json += ',';
+         const auto kind = static_cast<row_kind>(e % k_row_kind_count);
+         append_entity_header(json, e, e, false, kind);
+         append_rows_for_kind(json, kind, prefix_rows_per_entity, e);
+         json += '}';
+      }
+
+      json += R"(],"payload":[)";
+      for (std::size_t e = 0; e < num_payload; ++e) {
+         if (e > 0) json += ',';
+         const auto kind = static_cast<row_kind>((e + 1) % k_row_kind_count);
+         append_entity_header(json, k_payload_id_base + e, e, true, kind);
+         const std::size_t rows =
+            (e >= num_payload - heavy_payload) ? heavy_rows_for_kind(kind, heavy_entity_bytes) : 0;
+         append_rows_for_kind(json, kind, rows, e);
+         json += '}';
+      }
+      json += "]}";
+      return json;
+   }
+
+   template <auto Opts>
+   void ingest_entity_header(glz::lazy_json_view<Opts> entity, std::int64_t& checksum)
+   {
+      std::int64_t id{};
+      if (!entity["id"].read_into(id)) {
+         checksum += id;
+      }
+
+      std::string name{};
+      if (!entity["name"].read_into(name)) {
+         checksum += static_cast<std::int64_t>(name.size());
+      }
+
+      std::string caption{};
+      if (!entity["caption"].read_into(caption)) {
+         checksum += static_cast<std::int64_t>(caption.size());
+      }
+
+      bool enabled{};
+      if (!entity["enabled"].read_into(enabled)) {
+         checksum += enabled ? 1 : 0;
+      }
+
+      for (auto& ref : entity["refs"]) {
+         std::int32_t v{};
+         if (!ref.read_into(v)) {
+            checksum += v;
+         }
+      }
+   }
+
+   template <auto Opts>
+   std::int64_t ingest_cell(glz::lazy_json_view<Opts> cell, std::size_t& nulls)
+   {
+      if (cell.is_null()) {
+         ++nulls;
+         return 0;
+      }
+      if (cell.is_number()) {
+         double v{};
+         if (!cell.read_into(v)) {
+            return static_cast<std::int64_t>(v * k_number_checksum_scale);
+         }
+      }
+      else if (cell.is_string()) {
+         std::string s{};
+         if (!cell.read_into(s)) {
+            return static_cast<std::int64_t>(s.size());
+         }
+      }
+      return 0;
+   }
+
+   struct materialization_heap
+   {
+      std::vector<std::uint64_t> store{};
+
+      void touch(std::int64_t seed, std::size_t weight)
+      {
+         const std::size_t words = k_heap_words_base + (weight % k_heap_words_span);
+         const std::size_t base = store.size();
+         store.resize(base + words);
+         for (std::size_t i = 0; i < words; ++i) {
+            store[base + i] =
+               static_cast<std::uint64_t>(seed + static_cast<std::int64_t>(i)) * k_heap_lcg_multiplier;
+         }
+      }
+
+      [[nodiscard]] std::int64_t checksum() const noexcept
+      {
+         std::int64_t sum{};
+         for (std::size_t i = 0; i < store.size(); i += k_heap_checksum_stride) {
+            sum += static_cast<std::int64_t>(store[i] & k_checksum_low_bits_mask);
+         }
+         return sum;
+      }
+   };
+
+   template <auto Opts>
+   std::int64_t load_entity_rows(glz::lazy_json_view<Opts> entity, row_kind kind, materialization_heap& heap)
+   {
+      std::int64_t checksum{};
+      std::size_t nulls{};
+      std::size_t row_count{};
+
+      switch (kind) {
+      case row_kind::scalar: {
+         for (auto& row : entity["rows"]) {
+            ++row_count;
+            for (auto& cell : row) {
+               checksum += ingest_cell<Opts>(cell, nulls);
+            }
+            heap.touch(checksum, row_count);
+         }
+         break;
+      }
+      case row_kind::object: {
+         for (auto& row : entity["rows"]) {
+            generic_record record{};
+            if (!row.read_into(record)) {
+               ++row_count;
+               checksum += record.score + static_cast<std::int64_t>(record.name.size() + record.label.size());
+               heap.touch(checksum, record.name.size() + record.label.size());
+            }
+         }
+         break;
+      }
+      case row_kind::numeric: {
+         for (auto& row : entity["rows"]) {
+            numeric_row values{};
+            if (!row.read_into(values)) {
+               ++row_count;
+               checksum += static_cast<std::int64_t>(values[0] + values.back());
+               heap.touch(checksum, static_cast<std::size_t>(values[0]));
+            }
+         }
+         break;
+      }
+      default:
+         break;
+      }
+
+      checksum += static_cast<std::int64_t>(nulls);
+      checksum += static_cast<std::int64_t>(row_count);
+      checksum += heap.checksum();
+      return checksum;
+   }
+
+   template <auto Opts>
+   std::int64_t load_mixed_warehouse_catalog(glz::lazy_json_view<Opts> root)
+   {
+      std::int64_t checksum{};
+      materialization_heap heap{};
+      for (const char* section : {"prefix", "payload"}) {
+         for (auto& entity : root[section]) {
+            ingest_entity_header<Opts>(entity, checksum);
+            std::uint64_t kind_u{};
+            if (!entity["row_kind"].read_into(kind_u)) {
+               checksum += load_entity_rows<Opts>(entity, static_cast<row_kind>(kind_u), heap);
+            }
+         }
+      }
+      return checksum;
+   }
+
+   template <auto Opts>
+   std::int64_t load_mixed_warehouse_catalog(const glz::lazy_document<Opts>& doc)
+   {
+      return load_mixed_warehouse_catalog<Opts>(doc.root());
+   }
+
+   // Two top-level arrays: a smaller prefix section, then a payload section where
+   // most entries have empty rows and a few carry large row matrices.
+   inline std::string generate_split_catalog_json(std::size_t num_prefix, std::size_t prefix_rows_per_entity,
+                                                  std::size_t num_payload, std::size_t heavy_payload,
+                                                  std::size_t heavy_rows_per_entity, std::size_t cols_per_row)
+   {
+      std::string json;
+      const std::size_t row_chars =
+         cols_per_row * k_split_catalog_cell_chars_estimate + k_split_catalog_row_framing_chars;
+      json.reserve(num_prefix * (prefix_rows_per_entity * row_chars + k_entity_header_estimated_chars) +
+                   num_payload * k_entity_header_estimated_chars + heavy_payload * heavy_rows_per_entity * row_chars);
+
+      json += R"({"prefix":[)";
+      for (std::size_t e = 0; e < num_prefix; ++e) {
+         if (e > 0) json += ',';
+         append_entity_header(json, e, e, false);
+         append_row_array(json, prefix_rows_per_entity, cols_per_row, e);
+         json += '}';
+      }
+
+      json += R"(],"payload":[)";
+      for (std::size_t e = 0; e < num_payload; ++e) {
+         if (e > 0) json += ',';
+         append_entity_header(json, k_payload_id_base + e, e, true);
+         const std::size_t rows = (e >= num_payload - heavy_payload) ? heavy_rows_per_entity : 0;
+         append_row_array(json, rows, cols_per_row, e);
+         json += '}';
+      }
+      json += "]}";
+      return json;
+   }
+
+   // Same generic envelope, but rows are fixed-width numeric records consumed
+   // as whole row values. This isolates the read_into + iterator-advance win:
+   // without a streaming cursor, advancing the row iterator re-skips the row
+   // array that read_into just parsed.
+   inline std::string generate_record_rows_json(std::size_t num_prefix, std::size_t prefix_rows_per_entity,
+                                                std::size_t num_payload, std::size_t heavy_payload,
+                                                std::size_t heavy_rows_per_entity)
+   {
+      std::string json;
+      json.reserve(num_prefix * (prefix_rows_per_entity * k_numeric_row_estimated_chars + k_entity_header_estimated_chars) +
+                   num_payload * k_entity_header_estimated_chars +
+                   heavy_payload * heavy_rows_per_entity * k_numeric_row_estimated_chars);
+
+      json += R"({"prefix":[)";
+      for (std::size_t e = 0; e < num_prefix; ++e) {
+         if (e > 0) json += ',';
+         append_entity_header(json, e, e, false);
+         append_numeric_row_array(json, prefix_rows_per_entity, e);
+         json += '}';
+      }
+
+      json += R"(],"payload":[)";
+      for (std::size_t e = 0; e < num_payload; ++e) {
+         if (e > 0) json += ',';
+         append_entity_header(json, k_payload_id_base + e, e, true);
+         const std::size_t rows = (e >= num_payload - heavy_payload) ? heavy_rows_per_entity : 0;
+         append_numeric_row_array(json, rows, e);
+         json += '}';
+      }
+      json += "]}";
+      return json;
+   }
+
+   inline std::string generate_object_record_rows_json(std::size_t num_prefix, std::size_t prefix_rows_per_entity,
+                                                       std::size_t num_payload, std::size_t heavy_payload,
+                                                       std::size_t heavy_rows_per_entity)
+   {
+      std::string json;
+      json.reserve(num_prefix * (prefix_rows_per_entity * k_object_row_estimated_chars + k_entity_header_estimated_chars) +
+                   num_payload * k_entity_header_estimated_chars +
+                   heavy_payload * heavy_rows_per_entity * k_object_row_estimated_chars);
+
+      json += R"({"prefix":[)";
+      for (std::size_t e = 0; e < num_prefix; ++e) {
+         if (e > 0) json += ',';
+         append_entity_header(json, e, e, false);
+         append_object_row_array(json, prefix_rows_per_entity, e);
+         json += '}';
+      }
+
+      json += R"(],"payload":[)";
+      for (std::size_t e = 0; e < num_payload; ++e) {
+         if (e > 0) json += ',';
+         append_entity_header(json, k_payload_id_base + e, e, true);
+         const std::size_t rows = (e >= num_payload - heavy_payload) ? heavy_rows_per_entity : 0;
+         append_object_row_array(json, rows, e);
+         json += '}';
+      }
+      json += "]}";
+      return json;
+   }
+
+   // Legacy flat tables[] fixture (~3.8 MB) — kept for quick smoke / historical comparison.
+   inline std::string generate_flat_tables_json(std::size_t num_tables, std::size_t rows_per_table,
+                                                std::size_t cols_per_row)
+   {
+      std::string json = R"({"tables":[)";
+      for (std::size_t t = 0; t < num_tables; ++t) {
+         if (t > 0) json += ',';
+         json += R"({"name":"T)";
+         json += std::to_string(t);
+         json += R"(","rows":[)";
+         for (std::size_t r = 0; r < rows_per_table; ++r) {
+            if (r > 0) json += ',';
+            json += '[';
+            for (std::size_t c = 0; c < cols_per_row; ++c) {
+               if (c > 0) json += ',';
+               if (c == 0 && (r % k_legacy_null_cell_row_period == 0)) {
+                  json += "null";
+               }
+               else if (c % k_legacy_string_cell_col_stride == 0) {
+                  json += '"';
+                  json += "cell_";
+                  json += std::to_string(r);
+                  json += '_';
+                  json += std::to_string(c);
+                  json += '"';
+               }
+               else {
+                  json += std::to_string(static_cast<double>(r) +
+                                         static_cast<double>(c) * k_legacy_numeric_cell_col_scale);
+               }
+            }
+            json += ']';
+         }
+         json += "]}";
+      }
+      json += "]}";
+      return json;
+   }
+
+   template <auto Opts>
+   std::int64_t load_split_catalog_scalars(glz::lazy_json_view<Opts> root)
+   {
+      std::int64_t checksum{};
+      std::size_t nulls{};
+      std::size_t row_count{};
+      for (const char* section : {"prefix", "payload"}) {
+         for (auto& entity : root[section]) {
+            ingest_entity_header<Opts>(entity, checksum);
+            auto rows = entity["rows"];
+            for (auto& row : rows) {
+               ++row_count;
+               for (auto& cell : row) {
+                  checksum += ingest_cell<Opts>(cell, nulls);
+               }
+            }
+         }
+      }
+      checksum += static_cast<std::int64_t>(nulls);
+      checksum += static_cast<std::int64_t>(row_count);
+      return checksum;
+   }
+
+   template <auto Opts>
+   std::int64_t load_split_catalog_scalars(const glz::lazy_document<Opts>& doc)
+   {
+      return load_split_catalog_scalars<Opts>(doc.root());
+   }
+
+   template <auto Opts>
+   std::int64_t load_record_rows(glz::lazy_json_view<Opts> root)
+   {
+      std::int64_t checksum{};
+      std::size_t row_count{};
+      for (const char* section : {"prefix", "payload"}) {
+         for (auto& entity : root[section]) {
+            ingest_entity_header<Opts>(entity, checksum);
+            for (auto& row : entity["rows"]) {
+               numeric_row values{};
+               if (!row.read_into(values)) {
+                  ++row_count;
+                  checksum += static_cast<std::int64_t>(values[0] + values[values.size() - 1]);
+               }
+            }
+         }
+      }
+      checksum += static_cast<std::int64_t>(row_count);
+      return checksum;
+   }
+
+   template <auto Opts>
+   std::int64_t load_record_rows(const glz::lazy_document<Opts>& doc)
+   {
+      return load_record_rows<Opts>(doc.root());
+   }
+
+   template <auto Opts>
+   std::int64_t load_object_record_rows(glz::lazy_json_view<Opts> root)
+   {
+      std::int64_t checksum{};
+      std::size_t row_count{};
+      for (const char* section : {"prefix", "payload"}) {
+         for (auto& entity : root[section]) {
+            ingest_entity_header<Opts>(entity, checksum);
+            for (auto& row : entity["rows"]) {
+               generic_record record{};
+               if (!row.read_into(record)) {
+                  ++row_count;
+                  checksum += record.score + static_cast<std::int64_t>(record.name.size() + record.label.size());
+               }
+            }
+         }
+      }
+      checksum += static_cast<std::int64_t>(row_count);
+      return checksum;
+   }
+
+   template <auto Opts>
+   std::int64_t load_object_record_rows(const glz::lazy_document<Opts>& doc)
+   {
+      return load_object_record_rows<Opts>(doc.root());
+   }
+
+   // Touch a separate working-set buffer between entity reads to approximate DB
+   // materialization evicting the JSON buffer from CPU cache between parse steps.
+   inline void churn_working_set(std::vector<std::uint64_t>& scratch, std::size_t entity_idx, std::int64_t& checksum)
+   {
+      if (scratch.empty()) {
+         return;
+      }
+      std::uint64_t acc{};
+      const std::size_t stride = k_cache_line_bytes / sizeof(std::uint64_t);
+      for (std::size_t i = entity_idx % stride; i < scratch.size(); i += stride) {
+         scratch[i] = scratch[i] * k_heap_lcg_multiplier + static_cast<std::uint64_t>(i + entity_idx);
+         acc += scratch[i];
+      }
+      checksum += static_cast<std::int64_t>(acc & k_checksum_low_bits_mask);
+   }
+
+   template <auto Opts>
+   std::int64_t load_object_record_rows_with_cache_churn(glz::lazy_json_view<Opts> root, std::size_t scratch_mb)
+   {
+      std::vector<std::uint64_t> scratch((scratch_mb * k_bytes_per_mib) / sizeof(std::uint64_t), 1ULL);
+      std::int64_t checksum{};
+      std::size_t row_count{};
+      std::size_t entity_idx{};
+      for (const char* section : {"prefix", "payload"}) {
+         for (auto& entity : root[section]) {
+            ingest_entity_header<Opts>(entity, checksum);
+            for (auto& row : entity["rows"]) {
+               generic_record record{};
+               if (!row.read_into(record)) {
+                  ++row_count;
+                  checksum += record.score + static_cast<std::int64_t>(record.name.size() + record.label.size());
+               }
+            }
+            churn_working_set(scratch, entity_idx++, checksum);
+         }
+      }
+      checksum += static_cast<std::int64_t>(row_count);
+      return checksum;
+   }
+
+   template <auto Opts>
+   std::int64_t load_object_record_rows_with_cache_churn(const glz::lazy_document<Opts>& doc, std::size_t scratch_mb)
+   {
+      return load_object_record_rows_with_cache_churn<Opts>(doc.root(), scratch_mb);
+   }
+
+   template <auto Opts>
+   std::int64_t scan_headers_skip_rows(glz::lazy_json_view<Opts> root)
+   {
+      std::int64_t checksum{};
+      for (const char* section : {"prefix", "payload"}) {
+         for (auto& entity : root[section]) {
+            ingest_entity_header<Opts>(entity, checksum);
+         }
+      }
+      return checksum;
+   }
+
+   template <auto Opts>
+   std::int64_t scan_headers_skip_rows(const glz::lazy_document<Opts>& doc)
+   {
+      return scan_headers_skip_rows<Opts>(doc.root());
+   }
+
+   template <auto Opts>
+   std::int64_t load_flat_tables_scalars(glz::lazy_json_view<Opts> tables)
+   {
+      std::int64_t checksum{};
+      std::size_t nulls{};
+      std::size_t row_count{};
+      for (auto& table : tables) {
+         auto rows = table["rows"];
+         for (auto& row : rows) {
+            ++row_count;
+            for (auto& cell : row) {
+               checksum += ingest_cell<Opts>(cell, nulls);
+            }
+         }
+      }
+      checksum += static_cast<std::int64_t>(nulls);
+      checksum += static_cast<std::int64_t>(row_count);
+      return checksum;
+   }
+
+   template <auto Opts>
+   std::int64_t load_payload_row_rewind(glz::lazy_json_view<Opts> root)
+   {
+      std::int64_t checksum{};
+      std::size_t row_count{};
+      for (auto& entity : root["payload"]) {
+         ingest_entity_header<Opts>(entity, checksum);
+         auto rows = entity["rows"];
+         for (auto& row : rows) {
+            ++row_count;
+         }
+         rows = entity["rows"];
+         for (auto& row : rows) {
+            for (auto& cell : row) {
+               if (cell.is_number()) {
+                  double v{};
+                  if (!cell.read_into(v)) {
+                     checksum += static_cast<std::int64_t>(v);
+                  }
+               }
+            }
+         }
+      }
+      checksum += static_cast<std::int64_t>(row_count);
+      return checksum;
+   }
+
+   template <auto Opts>
+   std::int64_t load_payload_row_rewind(const glz::lazy_document<Opts>& doc)
+   {
+      return load_payload_row_rewind<Opts>(doc.root());
+   }
+} // namespace lazy_load_bench

--- a/benchmarks/lazy_load_common.hpp
+++ b/benchmarks/lazy_load_common.hpp
@@ -106,9 +106,18 @@ namespace lazy_load_bench
 #endif
    };
 
+   // Slim view + streaming OFF, to isolate the slim view's effect from the streaming cursor.
+   struct end_bounded_slim_opts : end_bounded_opts
+   {
+#if GLZ_LAZY_LOAD_HAS_STREAMING_POLICY
+      bool lazy_slim_view = true;
+#endif
+   };
+
    inline constexpr end_bounded_opts kEndBounded{};
    inline constexpr streaming_enabled_opts kStreamingEnabled{};
    inline constexpr streaming_enabled_slim_opts kStreamingEnabledSlim{};
+   inline constexpr end_bounded_slim_opts kEndBoundedSlim{};
 
    struct generic_record
    {

--- a/benchmarks/lazy_load_common.hpp
+++ b/benchmarks/lazy_load_common.hpp
@@ -419,13 +419,22 @@ namespace lazy_load_bench
          break;
       }
       case row_kind::object: {
+         // Consume object records key-by-key via operator[] rather than
+         // read_into<struct>. This mirrors a materialization layer that maps
+         // named JSON fields onto its own storage (positional/columnar) instead
+         // of Glaze reflection — the streaming cursor does not accelerate this
+         // shape, so keeping it here prevents the headline from being inflated
+         // by a read_into pattern such a consumer never exercises.
          for (auto& row : entity["rows"]) {
-            generic_record record{};
-            if (!row.read_into(record)) {
-               ++row_count;
-               checksum += record.score + static_cast<std::int64_t>(record.name.size() + record.label.size());
-               heap.touch(checksum, record.name.size() + record.label.size());
-            }
+            std::int64_t   score{};
+            std::string    name{};
+            std::string    label{};
+            row["score"].read_into(score);
+            row["name" ].read_into(name);
+            row["label"].read_into(label);
+            ++row_count;
+            checksum += score + static_cast<std::int64_t>(name.size() + label.size());
+            heap.touch(checksum, name.size() + label.size());
          }
          break;
       }

--- a/benchmarks/lazy_load_common.hpp
+++ b/benchmarks/lazy_load_common.hpp
@@ -98,8 +98,17 @@ namespace lazy_load_bench
 #endif
    };
 
+   // Same as streaming_enabled_opts but opts into the slim (24-byte) lazy_json_view.
+   // Used for the size/throughput A/B against the full 48-byte layout.
+   struct streaming_enabled_slim_opts : streaming_enabled_opts {
+#if GLZ_LAZY_LOAD_HAS_STREAMING_POLICY
+      bool lazy_slim_view = true;
+#endif
+   };
+
    inline constexpr end_bounded_opts kEndBounded{};
    inline constexpr streaming_enabled_opts kStreamingEnabled{};
+   inline constexpr streaming_enabled_slim_opts kStreamingEnabledSlim{};
 
    struct generic_record
    {

--- a/benchmarks/lazy_load_scalar.cpp
+++ b/benchmarks/lazy_load_scalar.cpp
@@ -1,0 +1,76 @@
+// Scalar-ingest only — builds against fork or upstream Glaze headers for A/B comparison.
+#include <cstdint>
+#include <string>
+
+#include "bencher/bencher.hpp"
+#include "bencher/diagnostics.hpp"
+#include "lazy_load_common.hpp"
+
+namespace
+{
+   using namespace lazy_load_bench;
+
+#if defined(GLAZE_LAZY_LOAD_FORK)
+   struct streaming_enabled_opts_fork : end_bounded_opts {
+      glz::lazy_streaming_cursor_policy lazy_streaming_cursor = glz::lazy_streaming_cursor_policy::enabled;
+   };
+   inline constexpr streaming_enabled_opts_fork kStreaming{};
+#endif
+} // namespace
+
+int main()
+{
+   constexpr std::size_t k_prefix = 120;
+   constexpr std::size_t k_prefix_rows = lazy_load_bench::k_default_cols_per_row;
+   constexpr std::size_t k_payload = 500;
+   constexpr std::size_t k_heavy = 10;
+   constexpr std::size_t k_heavy_rows = 1200000;
+   constexpr std::size_t k_cols = lazy_load_bench::k_default_cols_per_row;
+   const auto json = generate_split_catalog_json(k_prefix, k_prefix_rows, k_payload, k_heavy, k_heavy_rows, k_cols);
+
+#if defined(GLAZE_LAZY_LOAD_FORK)
+   std::int64_t expected_stream{};
+   {
+      auto doc = glz::lazy_json<kStreaming>(json);
+      if (!doc) std::abort();
+      expected_stream = scan_headers_skip_rows<kStreaming>(*doc);
+   }
+#endif
+
+   std::int64_t expected_base{};
+   {
+      auto doc = glz::lazy_json<kEndBounded>(json);
+      if (!doc) std::abort();
+      expected_base = scan_headers_skip_rows<kEndBounded>(*doc);
+   }
+
+   {
+      bencher::stage stage;
+      stage.min_execution_count = 1;
+      stage.max_execution_count = 1;
+      stage.warmup_duration_ms = 0;
+      stage.name = "Split-catalog header scan A/B (~1.2 GB fixture)";
+
+      stage.run("streaming off (default opts)", [&] {
+         auto result = glz::lazy_json<kEndBounded>(json);
+         if (!result) std::abort();
+         const auto sum = scan_headers_skip_rows<kEndBounded>(*result);
+         if (sum != expected_base) std::abort();
+         return json.size();
+      });
+
+#if defined(GLAZE_LAZY_LOAD_FORK)
+      stage.run("streaming on (enabled)", [&] {
+         auto result = glz::lazy_json<kStreaming>(json);
+         if (!result) std::abort();
+         const auto sum = scan_headers_skip_rows<kStreaming>(*result);
+         if (sum != expected_stream) std::abort();
+         return json.size();
+      });
+#endif
+
+      bencher::print_results(stage);
+   }
+
+   return 0;
+}

--- a/docs/lazy-json.md
+++ b/docs/lazy-json.md
@@ -725,6 +725,27 @@ See [Partial Read](./partial-read.md) for detailed documentation.
 
 *k = bytes to skip to reach field
 
+## Slim view (opt-in): `lazy_slim_view`
+
+`lazy_json_view` is 48 bytes on 64-bit: three pointers plus a per-value object key
+(`std::string_view`, only meaningful during object iteration) and an `error_code` (only set
+on views returned by fallible lookups). Setting `lazy_slim_view = true` on your `opts` drops
+both from the value, shrinking it to **24 bytes** (the three pointers). The object key then
+comes from the iterator (`lazy_iterator::key()` / `indexed_lazy_iterator::key()`) instead of
+the element view, and error state is signalled by a null value pointer
+(`has_error() == (data() == nullptr)`; the specific `error_code` is not retained). Default is
+the full 48-byte layout, so existing code is unaffected.
+
+Use it for consumers that store or copy the value handle per element (a smaller handle is
+cheaper to move); a pure transient read sees little difference.
+
+> **Known limitation — `lazy_slim_view` + streaming cursor on Windows/clang-cl.** With the
+> streaming cursor enabled, the slim view is a win on Apple clang (arm64, ~+8%) and neutral
+> on Linux clang (x86), but **clang-cl (MSVC-mode) on x86 regresses ~26%** on cell-access-bound
+> streaming ingest — a clang-cl-specific codegen artifact (L1 store-ordering stalls; not
+> reproduced by Linux clang on the same hardware, and not a struct-layout issue). If you
+> target clang-cl with the streaming cursor on a cell-heavy read path, keep the full layout.
+
 ## See Also
 
 - [Partial Read](./partial-read.md) - Compile-time partial reading with structs

--- a/docs/lazy-json.md
+++ b/docs/lazy-json.md
@@ -486,6 +486,89 @@ User user{};
 
 Both `glz::read_json(value, view)` and `view.read_into(value)` are **~49% faster** than the older pattern of `glz::read_json(value, view.raw_json())`. The `raw_json()` approach requires scanning the value twice: once to find its extent, and once to parse it.
 
+## Streaming Cursor (opt-in)
+
+`lazy_streaming_cursor` is a compile-time option (default **`lazy_streaming_cursor_policy::disabled`**) for workloads that combine **sequential container iteration** with **`read_into()`** on each element — for example nested arrays of table rows where every cell is parsed with `read_into`.
+
+```cpp
+struct load_opts : glz::opts {
+   bool null_terminated = false;
+   glz::lazy_streaming_cursor_policy lazy_streaming_cursor =
+      glz::lazy_streaming_cursor_policy::enabled;
+};
+constexpr load_opts load{};
+auto doc = glz::lazy_json<load>(buffer);
+```
+
+Legacy `bool lazy_streaming_cursor` is still accepted: `true` maps to `packed_with_fallback`, `false` to `disabled`.
+
+### Policy enum
+
+All active policies share one implementation: **`lazy_streaming_extent<OffsetT, WithFallback>`** — two `OffsetT` offsets (`end_off == 0` means invalid). Jump logic is identical; only storage width and overflow handling differ.
+
+| Policy | `OffsetT` (64-bit) | `OffsetT` (32-bit) | Overflow |
+|--------|-------------------|-------------------|----------|
+| `disabled` | — (empty slot) | — | — |
+| `enabled` | `size_t` | `size_t` | none |
+| `packed` | `uint32_t` | `size_t` *(same as enabled)* | assert if offset > `UINT32_MAX` |
+| `packed_with_fallback` | `uint32_t` | `size_t` *(same as enabled)* | skip recording if offset > `UINT32_MAX` |
+
+On 32-bit platforms `packed` / `packed_with_fallback` are no-ops relative to `enabled` — `size_t` is already 32-bit, so there is nothing to pack.
+
+### Spans larger than 4 GiB (`packed_with_fallback`)
+
+Offsets are stored as **`uint32_t` byte indices** from the document base pointer. When either `start - base` or `end - base` exceeds `UINT32_MAX` (~4 GiB − 1), **`packed_with_fallback` clears the slot and does not record** — parsing continues, but `operator++` falls back to ordinary `skip_value_lazy` for that step. There is no silent truncation.
+
+Use `enabled` (`size_t` offsets) when the JSON buffer can exceed 4 GiB. Use `packed_with_fallback` when the span is known to fit in 32-bit byte indices and you want a smaller `lazy_document` slot on 64-bit.
+
+With `packed` (no fallback), overflow is a programmer error: debug builds assert; release clears the slot after the failed assert path.
+
+Glaze can expose any subset of these to end users depending on how much configurability vs. simplicity is desired.
+
+### What it does
+
+When not `disabled`, `lazy_document` stores the byte extent **`[start, end)`** of the most recently fully consumed value (from `read_into`, or from an iterator finishing a container). The next `lazy_iterator::operator++` can **jump** to `end` instead of re-scanning with `skip_value_lazy`.
+
+**Why store both start and end?** `operator++` must confirm the element being skipped is the **same value** whose extent was recorded — it checks that the current position equals **start** before jumping to **end**. End alone is insufficient: a stale end from a prior read could wrongly jump when advancing over a different element. Nested containers record `[container_start, close)` for parent iterators; start anchors depth-correct matching.
+
+### Document-backed vs detached views
+
+The streaming cursor stores its extent slot on **`lazy_document`** (`consumed_`). Views and iterators therefore need a non-null `doc_` pointer to record or jump.
+
+| Source | `doc_` | Streaming cursor |
+|--------|--------|------------------|
+| `lazy_json(buffer)` and all views/iterators derived from it | always set | works |
+| Detached subview `lazy_json_view{nullptr, data}` (null-terminated buffer) | null | silently skipped — parse/iterate still work, no jump |
+| Error / end iterators | null | never reached on live paths |
+
+Compile-time `lazy_streaming_cursor_policy != disabled` does **not** imply `doc_ != nullptr`; the runtime `if (doc_)` guard covers detached subviews only. On the intended `lazy_json` ingest path, `doc_` is always non-null when the cursor can do useful work.
+
+### When to enable
+
+| Pattern | Benefit |
+|---------|---------|
+| `for (auto& row : rows) { row.read_into(cell); }` | **High** — avoids re-scanning each parsed row |
+| `get()` / `operator[]` only | **None** — extra stores on container finish |
+| Indexed random `read_into` | **Low** — recording cost, no following `++` |
+| `raw_json()` + `read_json()` | **None** — double-pass path ignores the cursor |
+
+### Tradeoffs
+
+**Pros**
+
+- Large win on sequential `read_into` + iterator loops on Rama-shaped multi‑MB fixtures (`lazy_load_benchmark`: streaming **on** vs **off** on ~32 MB `dimensions`/`variables` dump; `read_into` stage in `lazy_benchmark`: ~2× throughput vs upstream on the official fixture).
+- No change to default `glz::opts` behavior or `lazy_document` layout when disabled.
+- `packed` / `packed_with_fallback` use compact `uint32_t` offsets on 64-bit when the document span fits in 4 GiB (on 32-bit, equivalent to `enabled`).
+
+**Cons (when enabled)**
+
+- One predictable branch in `operator++` when no extent is recorded.
+- Stores after each successful `read_into` and when iterators finish containers.
+- Single slot per document — only the **most recently recorded** extent is eligible for a jump. Any other `operator++` (stale extent, interleaved iterators, no prior `read_into`) falls back to `skip_value_lazy`; correctness is unchanged, only the fast path is skipped.
+- `packed_with_fallback`: not recorded when offsets exceed 32 bits (graceful fallback to byte skip — see **Spans larger than 4 GiB** above). `packed`: overflow is a programmer error (assert).
+
+See `benchmarks/lazy_load_benchmark.cpp` (Rama-shaped ~32 MB ingest + flat smoke) and `benchmarks/lazy_benchmark.cpp` for micro-stages.
+
 ### The `raw_json()` Method
 
 Returns a `std::string_view` of the raw JSON bytes for any lazy view. Use this when you need the JSON text itself (for logging, forwarding, or storage):

--- a/docs/lazy-json.md
+++ b/docs/lazy-json.md
@@ -556,7 +556,7 @@ Compile-time `lazy_streaming_cursor_policy != disabled` does **not** imply `doc_
 
 **Pros**
 
-- Large win on sequential `read_into` + iterator loops on Rama-shaped multi‑MB fixtures (`lazy_load_benchmark`: streaming **on** vs **off** on ~32 MB `dimensions`/`variables` dump; `read_into` stage in `lazy_benchmark`: ~2× throughput vs upstream on the official fixture).
+- Large win on sequential `read_into` + iterator loops on warehouse-shaped multi‑MB fixtures (`lazy_load_benchmark`: streaming **on** vs **off** on a catalog-of-record-matrices dump; `read_into` stage in `lazy_benchmark`: ~2× throughput vs upstream on the official fixture).
 - No change to default `glz::opts` behavior or `lazy_document` layout when disabled.
 - `packed` / `packed_with_fallback` use compact `uint32_t` offsets on 64-bit when the document span fits in 4 GiB (on 32-bit, equivalent to `enabled`).
 
@@ -567,7 +567,7 @@ Compile-time `lazy_streaming_cursor_policy != disabled` does **not** imply `doc_
 - Single slot per document — only the **most recently recorded** extent is eligible for a jump. Any other `operator++` (stale extent, interleaved iterators, no prior `read_into`) falls back to `skip_value_lazy`; correctness is unchanged, only the fast path is skipped.
 - `packed_with_fallback`: not recorded when offsets exceed 32 bits (graceful fallback to byte skip — see **Spans larger than 4 GiB** above). `packed`: overflow is a programmer error (assert).
 
-See `benchmarks/lazy_load_benchmark.cpp` (Rama-shaped ~32 MB ingest + flat smoke) and `benchmarks/lazy_benchmark.cpp` for micro-stages.
+See `benchmarks/lazy_load_benchmark.cpp` (warehouse-shaped ingest + flat smoke) and `benchmarks/lazy_benchmark.cpp` for micro-stages.
 
 ### The `raw_json()` Method
 

--- a/include/glaze/core/lazy_streaming_cursor_policy.hpp
+++ b/include/glaze/core/lazy_streaming_cursor_policy.hpp
@@ -65,4 +65,20 @@ namespace glz
       }
       return true;
    }
+
+   // Opt-in slim lazy_json_view. When enabled, lazy_json_view drops its per-value
+   // object-key (a pure object-iteration artifact) and error-code members, shrinking
+   // the value from 48 to 24 bytes on 64-bit. In the slim layout the object key is
+   // obtained from the iterator (lazy_iterator::key() / indexed_lazy_iterator::key())
+   // rather than from the element view, and error state is signalled by a null value
+   // pointer (has_error() == (data() == nullptr)); the specific error_code is not
+   // retained. An absent field or `false` keeps the full (default) 48-byte value.
+   // Opt in by setting `lazy_slim_view = true` on your opts.
+   consteval bool lazy_slim_view_active(auto&& Opts)
+   {
+      if constexpr (requires { Opts.lazy_slim_view; }) {
+         return Opts.lazy_slim_view;
+      }
+      return false;
+   }
 } // namespace glz

--- a/include/glaze/core/lazy_streaming_cursor_policy.hpp
+++ b/include/glaze/core/lazy_streaming_cursor_policy.hpp
@@ -1,0 +1,55 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+namespace glz
+{
+   // ============================================================================
+   // Lazy JSON streaming cursor policy
+   // ============================================================================
+   //
+   // Controls whether lazy_iterator::operator++ can jump past a value extent
+   // recorded by read_into (or a finished container iterator), and how that
+   // extent is stored on lazy_document.
+   //
+   // - disabled: zero storage, zero runtime cost (default)
+   // - enabled: OffsetT = size_t (full span)
+   // - packed / packed_with_fallback: OffsetT = uint32_t on 64-bit (compact storage);
+   //   on 32-bit platforms packed policies are equivalent to enabled (size_t is already 32-bit)
+   //
+   // ============================================================================
+
+   inline constexpr bool lazy_streaming_packed_is_enabled = sizeof(std::size_t) <= sizeof(std::uint32_t);
+
+   enum struct lazy_streaming_cursor_policy : uint8_t {
+      disabled = 0,
+      enabled = 1,
+      packed = 2,
+      packed_with_fallback = 3
+   };
+
+   consteval lazy_streaming_cursor_policy get_lazy_streaming_cursor_policy(auto&& Opts)
+   {
+      if constexpr (requires { Opts.lazy_streaming_cursor; }) {
+         using T = std::remove_cvref_t<decltype(Opts.lazy_streaming_cursor)>;
+         if constexpr (std::same_as<T, lazy_streaming_cursor_policy>) {
+            return Opts.lazy_streaming_cursor;
+         }
+         else if constexpr (std::same_as<T, bool>) {
+            return Opts.lazy_streaming_cursor ? lazy_streaming_cursor_policy::packed_with_fallback
+                                              : lazy_streaming_cursor_policy::disabled;
+         }
+      }
+      return lazy_streaming_cursor_policy::disabled;
+   }
+
+   consteval bool lazy_streaming_cursor_active(auto&& Opts)
+   {
+      return get_lazy_streaming_cursor_policy(Opts) != lazy_streaming_cursor_policy::disabled;
+   }
+} // namespace glz

--- a/include/glaze/core/lazy_streaming_cursor_policy.hpp
+++ b/include/glaze/core/lazy_streaming_cursor_policy.hpp
@@ -52,4 +52,17 @@ namespace glz
    {
       return get_lazy_streaming_cursor_policy(Opts) != lazy_streaming_cursor_policy::disabled;
    }
+
+   // Opt-out SWAR pre-scan in the lazy skip loops (end-bounded, non-null-terminated
+   // buffers only). An absent field or `true` keeps the SWAR pre-scan enabled (the
+   // default). Set `lazy_swar_skip = false` on your opts to compile the plain scalar
+   // skip path instead — useful for A/B ablation and to reproduce the exact
+   // pre-SWAR (upstream-equivalent) skip behavior from the same headers.
+   consteval bool lazy_swar_skip_active(auto&& Opts)
+   {
+      if constexpr (requires { Opts.lazy_swar_skip; }) {
+         return Opts.lazy_swar_skip;
+      }
+      return true;
+   }
 } // namespace glz

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -7,6 +7,7 @@
 #include <type_traits>
 
 #include "glaze/core/context.hpp"
+#include "glaze/core/lazy_streaming_cursor_policy.hpp"
 #include "glaze/core/optimization_level.hpp"
 #include "glaze/core/traits.hpp"
 #include "glaze/forward.hpp"
@@ -184,6 +185,12 @@ namespace glz
    // bool skip_self_constraint = false;
    // Skip self_constraint validation during reading. Useful for performance when constraints are known to be valid
    // or when validation should be deferred.
+
+   // ---
+   // lazy_streaming_cursor_policy lazy_streaming_cursor = lazy_streaming_cursor_policy::disabled;
+   // When not disabled, lazy JSON records byte extents of fully consumed values (read_into and
+   // finished container iteration) so a subsequent lazy_iterator advance can jump past them.
+   // See lazy_streaming_cursor_policy and docs/lazy-json.md#streaming-cursor-opt-in.
 
    // ---
    // bool linear_search = false;
@@ -709,6 +716,11 @@ namespace glz
       else {
          return false;
       }
+   }
+
+   consteval bool check_lazy_streaming_cursor(auto&& Opts)
+   {
+      return lazy_streaming_cursor_active(Opts);
    }
 
    consteval bool check_linear_search(auto&& Opts)

--- a/include/glaze/json/lazy.hpp
+++ b/include/glaze/json/lazy.hpp
@@ -22,13 +22,13 @@
 namespace glz
 {
    // Forward declarations (needed for circular references)
-   template <opts Opts>
+   template <auto Opts>
    struct lazy_document;
-   template <opts Opts>
+   template <auto Opts>
    class lazy_iterator;
-   template <opts Opts>
+   template <auto Opts>
    struct indexed_lazy_view;
-   template <opts Opts>
+   template <auto Opts>
    class indexed_lazy_iterator;
 
    // ============================================================================
@@ -38,7 +38,7 @@ namespace glz
    namespace detail
    {
       // Skip string - returns position after closing quote
-      template <opts Opts>
+      template <auto Opts>
       GLZ_ALWAYS_INLINE const char* skip_string_fast(const char* p, const char* end) noexcept
       {
          const char* const start = p;
@@ -98,16 +98,16 @@ namespace glz
          return {p, end};
       }
 
-      template <opts Opts>
+      template <auto Opts>
       GLZ_ALWAYS_INLINE const char* skip_value_lazy(const char* p, const char* end) noexcept;
 
       // Skip from current position to depth zero (end of enclosing container)
-      template <opts Opts>
+      template <auto Opts>
       GLZ_ALWAYS_INLINE const char* skip_to_depth_zero(const char* p, const char* end, int depth) noexcept
       {
          using enum lazy_char_type;
          while (depth > 0) {
-            if constexpr (!Opts.null_terminated) {
+            if constexpr (!Opts.null_terminated && lazy_swar_skip_active(Opts)) {
                std::tie(p, end) = lazy_swar_advance_any_bracket<false>(p, end);
             }
 
@@ -148,7 +148,7 @@ namespace glz
       }
 
       // Skip any JSON value - upstream depth logic + SWAR pre-scan on end-bounded buffers
-      template <opts Opts>
+      template <auto Opts>
       GLZ_ALWAYS_INLINE const char* skip_value_lazy(const char* p, const char* end) noexcept
       {
          using enum lazy_char_type;
@@ -172,7 +172,7 @@ namespace glz
             ++p;
 
             while (depth > 0) {
-               if constexpr (!Opts.null_terminated) {
+               if constexpr (!Opts.null_terminated && lazy_swar_skip_active(Opts)) {
                   std::tie(p, end) = lazy_swar_advance_any_bracket<false>(p, end);
                }
 
@@ -311,27 +311,27 @@ namespace glz
          std::conditional_t<lazy_streaming_packed_is_enabled, lazy_streaming_extent_enabled,
                             lazy_streaming_extent<std::uint32_t, WithFallback>>;
 
-      template <opts Opts>
+      template <auto Opts>
       struct lazy_streaming_slot_for
       {
          using type = lazy_streaming_extent_disabled;
       };
 
-      template <opts Opts>
+      template <auto Opts>
          requires(get_lazy_streaming_cursor_policy(Opts) == lazy_streaming_cursor_policy::enabled)
       struct lazy_streaming_slot_for<Opts>
       {
          using type = lazy_streaming_extent_enabled;
       };
 
-      template <opts Opts>
+      template <auto Opts>
          requires(get_lazy_streaming_cursor_policy(Opts) == lazy_streaming_cursor_policy::packed)
       struct lazy_streaming_slot_for<Opts>
       {
          using type = lazy_streaming_extent_packed<false>;
       };
 
-      template <opts Opts>
+      template <auto Opts>
          requires(get_lazy_streaming_cursor_policy(Opts) == lazy_streaming_cursor_policy::packed_with_fallback)
       struct lazy_streaming_slot_for<Opts>
       {
@@ -339,7 +339,7 @@ namespace glz
       };
    } // namespace detail
 
-   template <opts Opts>
+   template <auto Opts>
    using lazy_streaming_slot = typename detail::lazy_streaming_slot_for<Opts>::type;
 
    // ============================================================================
@@ -366,7 +366,7 @@ namespace glz
     * - error_: error code (4 bytes)
     * - padding: 4/0 bytes
     */
-   template <opts Opts = opts{}>
+   template <auto Opts = opts{}>
    struct lazy_json_view
    {
      private:
@@ -511,7 +511,7 @@ namespace glz
    // lazy_document - Minimal container, no upfront processing
    // ============================================================================
 
-   template <opts Opts = opts{}>
+   template <auto Opts = opts{}>
    struct lazy_document
    {
      private:
@@ -527,7 +527,7 @@ namespace glz
       friend class lazy_iterator<Opts>;
 
       // Factory method for lazy_json
-      template <opts O, class Buffer>
+      template <auto O, class Buffer>
       friend expected<lazy_document<O>, error_ctx> lazy_json(Buffer&&);
 
       // Helper to initialize root_view_ with correct doc_ pointer
@@ -603,7 +603,7 @@ namespace glz
    // lazy_iterator - Forward iterator with lazy scanning
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    class lazy_iterator
    {
      private:
@@ -672,7 +672,7 @@ namespace glz
     *
     * Memory: Base view + 8 bytes per element (+ 16 bytes per element for objects with keys)
     */
-   template <opts Opts>
+   template <auto Opts>
    struct indexed_lazy_view
    {
      private:
@@ -765,7 +765,7 @@ namespace glz
    // indexed_lazy_iterator - O(1) advancement using pre-built index
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    class indexed_lazy_iterator
    {
      private:
@@ -872,13 +872,13 @@ namespace glz
    // Implementation: lazy_json_view methods (truly lazy - no structural index)
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    inline const char* lazy_json_view<Opts>::json_end() const noexcept
    {
       return doc_ ? doc_->json_ + doc_->len_ : nullptr;
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline std::string_view lazy_json_view<Opts>::parse_key(const char*& p, const char* end) noexcept
    {
       // A non-null-terminated buffer has no '\0' sentinel, so a scan loop can reach the next
@@ -918,7 +918,7 @@ namespace glz
       return std::string_view{key_start, static_cast<size_t>(p - key_start)};
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline lazy_json_view<Opts> lazy_json_view<Opts>::operator[](size_t index) const
    {
       if (has_error()) return *this;
@@ -952,7 +952,7 @@ namespace glz
       return {doc_, p};
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline lazy_json_view<Opts> lazy_json_view<Opts>::operator[](std::string_view key) const
    {
       if (has_error()) return *this;
@@ -1064,14 +1064,14 @@ namespace glz
       return make_error(error_code::key_not_found);
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline bool lazy_json_view<Opts>::contains(std::string_view key) const
    {
       auto result = (*this)[key];
       return !result.has_error();
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline size_t lazy_json_view<Opts>::size() const
    {
       if (has_error() || !data_) return 0;
@@ -1123,7 +1123,7 @@ namespace glz
       }
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline bool lazy_json_view<Opts>::empty() const noexcept
    {
       if (has_error() || !data_) return true;
@@ -1145,7 +1145,7 @@ namespace glz
    // lazy_iterator implementation (truly lazy)
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    inline lazy_iterator<Opts>::lazy_iterator(const lazy_document<Opts>* doc, const char* container_start,
                                              const char* end, bool is_object)
       : doc_(doc), json_end_(end), container_start_(container_start), is_object_(is_object), at_end_(false)
@@ -1183,7 +1183,7 @@ namespace glz
       advance_to_next_element(pos);
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline void lazy_iterator<Opts>::advance_to_next_element(const char*& pos)
    {
       std::string_view key{};
@@ -1213,7 +1213,7 @@ namespace glz
       current_view_ = lazy_json_view<Opts>{doc_, pos, key};
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline lazy_iterator<Opts>& lazy_iterator<Opts>::operator++()
    {
       if (at_end_) return *this;
@@ -1283,7 +1283,7 @@ namespace glz
       return *this;
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline lazy_iterator<Opts> lazy_json_view<Opts>::begin() const
    {
       if (has_error() || !data_) return end();
@@ -1291,7 +1291,7 @@ namespace glz
       return lazy_iterator<Opts>{doc_, data_, json_end(), is_object()};
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline lazy_iterator<Opts> lazy_json_view<Opts>::end() const
    {
       return lazy_iterator<Opts>{};
@@ -1301,13 +1301,13 @@ namespace glz
    // indexed_lazy_view implementation
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    inline indexed_lazy_iterator<Opts> indexed_lazy_view<Opts>::begin() const
    {
       return indexed_lazy_iterator<Opts>{this, 0};
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline indexed_lazy_iterator<Opts> indexed_lazy_view<Opts>::end() const
    {
       return indexed_lazy_iterator<Opts>{this, value_starts_.size()};
@@ -1317,7 +1317,7 @@ namespace glz
    // lazy_json_view::index() implementation
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    inline indexed_lazy_view<Opts> lazy_json_view<Opts>::index() const
    {
       // Return empty indexed view for non-containers or errors
@@ -1386,7 +1386,7 @@ namespace glz
    // lazy_json_view::get<T>() implementation
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    template <class T>
    [[nodiscard]] inline expected<T, error_ctx> lazy_json_view<Opts>::get() const
    {
@@ -1496,7 +1496,7 @@ namespace glz
    // JSON writer for lazy_json_view
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    struct to<JSON, lazy_json_view<Opts>>
    {
       template <auto WriteOpts, class B>
@@ -1550,7 +1550,7 @@ namespace glz
     * @param buffer The JSON text buffer (must remain valid for document lifetime)
     * @return lazy_document on success, error_ctx on failure
     */
-   template <opts Opts = opts{}, class Buffer>
+   template <auto Opts = opts{}, class Buffer>
    [[nodiscard]] inline expected<lazy_document<Opts>, error_ctx> lazy_json(Buffer&& buffer)
    {
       lazy_document<Opts> doc;

--- a/include/glaze/json/lazy.hpp
+++ b/include/glaze/json/lazy.hpp
@@ -82,6 +82,34 @@ namespace glz
          if constexpr (NullTerminated) {
             return {p, end};
          }
+#if defined(__clang__) || defined(__GNUC__)
+         // Wide portable SIMD via GCC/Clang vector extensions: the compiler lowers this
+         // to AVX2/SSE2 on x86 and NEON on ARM for the target arch, with no intrinsics.
+         // MSVC's cl.exe lacks vector extensions and falls through to the SWAR loop
+         // below (this project builds with clang-cl, which does support them).
+         if (!std::is_constant_evaluated()) {
+            using vbytes = unsigned char __attribute__((vector_size(32)));
+            while (p + 32 <= end) {
+               vbytes chunk;
+               std::memcpy(&chunk, p, sizeof(chunk));
+               const vbytes hits =
+                  (chunk == '"') | (chunk == '[') | (chunk == ']') | (chunk == '{') | (chunk == '}');
+               std::uint64_t words[4];
+               std::memcpy(words, &hits, sizeof(words));
+               for (int w = 0; w < 4; ++w) {
+                  std::uint64_t bits = words[w];
+                  if constexpr (std::endian::native == std::endian::big) {
+                     bits = std::byteswap(bits);
+                  }
+                  if (bits) {
+                     p += w * 8 + (glz::countr_zero(bits) >> 3);
+                     return {p, end};
+                  }
+               }
+               p += 32;
+            }
+         }
+#endif
          while (p + 8 <= end) {
             uint64_t chunk{};
             std::memcpy(&chunk, p, 8);

--- a/include/glaze/json/lazy.hpp
+++ b/include/glaze/json/lazy.hpp
@@ -3,12 +3,21 @@
 
 #pragma once
 
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <limits>
 #include <string_view>
+#include <type_traits>
+#include <utility>
 
+#include "glaze/core/lazy_streaming_cursor_policy.hpp"
 #include "glaze/json/read.hpp"
 #include "glaze/json/skip.hpp"
 #include "glaze/json/write.hpp"
+#include "glaze/util/bit.hpp"
 #include "glaze/util/expected.hpp"
+#include "glaze/tuplet/tuple.hpp"
 
 namespace glz
 {
@@ -59,19 +68,56 @@ namespace glz
          return p;
       }
 
+      // SWAR scan for the next quote or container bracket (end-bounded buffers only).
+      GLZ_GNU_CONST_LEAF inline uint64_t lazy_swar_any_bracket_mask(const uint64_t chunk) noexcept
+      {
+         return glz::has_quote(chunk) | glz::has_char<'['>(chunk) | glz::has_char<']'>(chunk) |
+                glz::has_char<'{'>(chunk) | glz::has_char<'}'>(chunk);
+      }
+
+      template <bool NullTerminated>
+      constexpr std::pair<const char*, const char*> lazy_swar_advance_any_bracket(const char* p,
+                                                                                   const char* end) noexcept
+      {
+         if constexpr (NullTerminated) {
+            return {p, end};
+         }
+         while (p + 8 <= end) {
+            uint64_t chunk{};
+            std::memcpy(&chunk, p, 8);
+            if constexpr (std::endian::native == std::endian::big) {
+               chunk = std::byteswap(chunk);
+            }
+            const uint64_t test = lazy_swar_any_bracket_mask(chunk);
+            if (test) {
+               p += (glz::countr_zero(test) >> 3);
+               return {p, end};
+            }
+            p += 8;
+         }
+         return {p, end};
+      }
+
+      template <opts Opts>
+      GLZ_ALWAYS_INLINE const char* skip_value_lazy(const char* p, const char* end) noexcept;
+
       // Skip from current position to depth zero (end of enclosing container)
-      // Used after partial scanning to find container end efficiently
       template <opts Opts>
       GLZ_ALWAYS_INLINE const char* skip_to_depth_zero(const char* p, const char* end, int depth) noexcept
       {
          using enum lazy_char_type;
          while (depth > 0) {
+            if constexpr (!Opts.null_terminated) {
+               std::tie(p, end) = lazy_swar_advance_any_bracket<false>(p, end);
+            }
+
             if constexpr (Opts.null_terminated) {
                if (*p == '\0') break;
             }
-            else {
-               if (p >= end) break;
+            else if (p >= end) {
+               break;
             }
+
             switch (lazy_char_class[uint8_t(*p)]) {
             case quote:
                p = skip_string_fast<Opts>(p, end);
@@ -101,8 +147,7 @@ namespace glz
          return p;
       }
 
-      // Skip any JSON value - optimized container skip
-      // Returns pointer after the value
+      // Skip any JSON value - upstream depth logic + SWAR pre-scan on end-bounded buffers
       template <opts Opts>
       GLZ_ALWAYS_INLINE const char* skip_value_lazy(const char* p, const char* end) noexcept
       {
@@ -127,12 +172,17 @@ namespace glz
             ++p;
 
             while (depth > 0) {
+               if constexpr (!Opts.null_terminated) {
+                  std::tie(p, end) = lazy_swar_advance_any_bracket<false>(p, end);
+               }
+
                if constexpr (Opts.null_terminated) {
                   if (*p == '\0') break;
                }
-               else {
-                  if (p >= end) break;
+               else if (p >= end) {
+                  break;
                }
+
                switch (lazy_char_class[uint8_t(*p)]) {
                case quote:
                   p = skip_string_fast<Opts>(p, end);
@@ -184,7 +234,113 @@ namespace glz
          }
          }
       }
+
+      // Opt-in streaming cursor storage (see lazy_streaming_cursor_policy).
+      struct lazy_streaming_extent_disabled
+      {
+         static constexpr void clear() noexcept {}
+         static constexpr void set(const char*, const char*, const char*) noexcept {}
+         [[nodiscard]] static constexpr bool try_jump(const char*, const char*, const char*&) noexcept
+         {
+            return false;
+         }
+      };
+
+      // Shared extent slot: two OffsetT offsets. end_off == 0 means invalid.
+      // enabled uses size_t;
+      // packed policies use uint32_t on 64-bit (noop alias of enabled on 32-bit).
+      template <typename OffsetT, bool WithFallback>
+      struct lazy_streaming_extent
+      {
+         static_assert(std::is_unsigned_v<OffsetT> && !std::is_same_v<OffsetT, bool>);
+
+         OffsetT start_off{};
+         OffsetT end_off{};
+
+         void clear() noexcept { end_off = 0; }
+
+         void set(const char* base, const char* start, const char* end) noexcept
+         {
+            if (!base || start < base || end < start) [[unlikely]] {
+               clear();
+               return;
+            }
+            const auto start_off_val = static_cast<std::size_t>(start - base);
+            const auto end_off_val = static_cast<std::size_t>(end - base);
+            if (end_off_val == 0) [[unlikely]] {
+               clear();
+               return;
+            }
+            if constexpr (sizeof(OffsetT) < sizeof(std::size_t)) {
+               static constexpr auto k_max_off = (std::numeric_limits<OffsetT>::max)();
+               if (start_off_val > k_max_off || end_off_val > k_max_off) [[unlikely]] {
+                  if constexpr (WithFallback) {
+                     clear();
+                     return;
+                  }
+                  else {
+                     assert(start_off_val <= k_max_off && end_off_val <= k_max_off);
+                     clear();
+                     return;
+                  }
+               }
+            }
+            start_off = static_cast<OffsetT>(start_off_val);
+            end_off = static_cast<OffsetT>(end_off_val);
+         }
+
+         [[nodiscard]] bool try_jump(const char* base, const char* pos, const char*& out) noexcept
+         {
+            if (end_off == 0 || !base) [[unlikely]] {
+               return false;
+            }
+            const char* const start = base + start_off;
+            if (pos != start) [[unlikely]] {
+               return false;
+            }
+            out = base + end_off;
+            clear();
+            return true;
+         }
+      };
+
+      using lazy_streaming_extent_enabled = lazy_streaming_extent<std::size_t, false>;
+
+      template <bool WithFallback>
+      using lazy_streaming_extent_packed =
+         std::conditional_t<lazy_streaming_packed_is_enabled, lazy_streaming_extent_enabled,
+                            lazy_streaming_extent<std::uint32_t, WithFallback>>;
+
+      template <opts Opts>
+      struct lazy_streaming_slot_for
+      {
+         using type = lazy_streaming_extent_disabled;
+      };
+
+      template <opts Opts>
+         requires(get_lazy_streaming_cursor_policy(Opts) == lazy_streaming_cursor_policy::enabled)
+      struct lazy_streaming_slot_for<Opts>
+      {
+         using type = lazy_streaming_extent_enabled;
+      };
+
+      template <opts Opts>
+         requires(get_lazy_streaming_cursor_policy(Opts) == lazy_streaming_cursor_policy::packed)
+      struct lazy_streaming_slot_for<Opts>
+      {
+         using type = lazy_streaming_extent_packed<false>;
+      };
+
+      template <opts Opts>
+         requires(get_lazy_streaming_cursor_policy(Opts) == lazy_streaming_cursor_policy::packed_with_fallback)
+      struct lazy_streaming_slot_for<Opts>
+      {
+         using type = lazy_streaming_extent_packed<true>;
+      };
    } // namespace detail
+
+   template <opts Opts>
+   using lazy_streaming_slot = typename detail::lazy_streaming_slot_for<Opts>::type;
 
    // ============================================================================
    // lazy_json_view - Truly lazy view with on-demand scanning
@@ -193,13 +349,17 @@ namespace glz
    /**
     * @brief A truly lazy view into JSON data.
     *
-    * No upfront processing - all navigation uses SWAR-accelerated scanning.
+    * No upfront processing - all navigation uses on-demand scanning.
     *
     * For objects, parse_pos_ tracks the current scan position to enable
     * efficient sequential key access (O(n) total instead of O(n²)).
     *
     * Memory layout (48 bytes on 64-bit, 24 bytes on 32-bit):
-    * - doc_: pointer to document (8/4 bytes)
+    * - doc_: pointer to owning lazy_document (8/4 bytes). Optional: may be null for
+    *   detached subviews constructed via lazy_json_view(nullptr, data) on null-terminated
+    *   buffers. Views from lazy_json() always set doc_ to the owning document.
+    *   The streaming cursor slot (consumed_) lives on lazy_document, so extent
+    *   record/jump is skipped when doc_ is null.
     * - data_: pointer to value start in JSON (8/4 bytes)
     * - parse_pos_: current scan position for progressive parsing (8/4 bytes)
     * - key_: stored key for iteration (16/8 bytes - string_view)
@@ -246,6 +406,12 @@ namespace glz
       [[nodiscard]] const char* data() const noexcept { return data_; }
       [[nodiscard]] const char* json_end() const noexcept;
 
+      // Progressive object-scan cursor accessors. Exposed so an external handle
+      // can persist/restore the in-order field-scan position across reconstructed
+      // views (keeps sequential key access O(n) total rather than O(n^2)).
+      [[nodiscard]] const char* parse_pos() const noexcept { return parse_pos_; }
+      void set_parse_pos(const char* p) const noexcept { parse_pos_ = p; }
+
       /// @brief Get the raw JSON bytes for this value
       /// @return string_view of the raw JSON, or empty if error
       /// @note Useful for passing to glz::read_json to deserialize into a struct
@@ -280,6 +446,15 @@ namespace glz
          finalize_read_context<Opts>(ctx);
          if (bool(ctx.error)) {
             return error_ctx{static_cast<size_t>(it - data_), ctx.error};
+         }
+         // Streaming cursor: the value spans [data_, it). Record it so a
+         // subsequent iterator advance over this element can jump instead of
+         // re-scanning. (parse<JSON>::op leaves `it` at the value end.)
+         if constexpr (lazy_streaming_cursor_active(Opts)) {
+            // doc_ is null only for detached subviews; lazy_json()-backed views always have doc_.
+            if (doc_) [[likely]] {
+               doc_->consumed_.set(doc_->json_data(), data_, it);
+            }
          }
          return {};
       }
@@ -345,6 +520,9 @@ namespace glz
       const char* root_data_{};
       mutable lazy_json_view<Opts> root_view_{}; // Cached root view with parse_pos_
 
+      // Opt-in streaming cursor (see lazy_streaming_cursor_policy). Default off → empty disabled type.
+      GLZ_NO_UNIQUE_ADDRESS mutable lazy_streaming_slot<Opts> consumed_{};
+
       friend struct lazy_json_view<Opts>;
       friend class lazy_iterator<Opts>;
 
@@ -359,7 +537,8 @@ namespace glz
       lazy_document() = default;
 
       // Copy constructor - fix doc_ pointer and preserve parse_pos_
-      lazy_document(const lazy_document& other) : json_(other.json_), len_(other.len_), root_data_(other.root_data_)
+      lazy_document(const lazy_document& other)
+         : json_(other.json_), len_(other.len_), root_data_(other.root_data_), consumed_(other.consumed_)
       {
          init_root_view();
          root_view_.parse_pos_ = other.root_view_.parse_pos_;
@@ -371,6 +550,7 @@ namespace glz
             json_ = other.json_;
             len_ = other.len_;
             root_data_ = other.root_data_;
+            consumed_ = other.consumed_;
             init_root_view();
             root_view_.parse_pos_ = other.root_view_.parse_pos_;
          }
@@ -378,7 +558,8 @@ namespace glz
       }
 
       // Move constructor - fix doc_ pointer and transfer parse_pos_
-      lazy_document(lazy_document&& other) noexcept : json_(other.json_), len_(other.len_), root_data_(other.root_data_)
+      lazy_document(lazy_document&& other) noexcept
+         : json_(other.json_), len_(other.len_), root_data_(other.root_data_), consumed_(other.consumed_)
       {
          init_root_view();
          root_view_.parse_pos_ = other.root_view_.parse_pos_;
@@ -390,6 +571,7 @@ namespace glz
             json_ = other.json_;
             len_ = other.len_;
             root_data_ = other.root_data_;
+            consumed_ = other.consumed_;
             init_root_view();
             root_view_.parse_pos_ = other.root_view_.parse_pos_;
          }
@@ -427,6 +609,7 @@ namespace glz
      private:
       const lazy_document<Opts>* doc_{};
       const char* json_end_{};
+      const char* container_start_{}; // '[' / '{' of the container being iterated
       char close_char_{};
       bool is_object_{};
       bool at_end_{true};
@@ -965,7 +1148,7 @@ namespace glz
    template <opts Opts>
    inline lazy_iterator<Opts>::lazy_iterator(const lazy_document<Opts>* doc, const char* container_start,
                                              const char* end, bool is_object)
-      : doc_(doc), json_end_(end), is_object_(is_object), at_end_(false)
+      : doc_(doc), json_end_(end), container_start_(container_start), is_object_(is_object), at_end_(false)
    {
       close_char_ = is_object ? '}' : ']';
       const char* pos = container_start + 1; // skip '[' or '{'
@@ -975,12 +1158,23 @@ namespace glz
       if constexpr (Opts.null_terminated) {
          if (*pos == close_char_) {
             at_end_ = true;
+            if constexpr (lazy_streaming_cursor_active(Opts)) {
+               if (doc_) [[likely]] {
+                  doc_->consumed_.set(doc_->json_data(), container_start_, pos + 1);
+               }
+            }
             return;
          }
       }
       else {
          if (pos >= json_end_ || *pos == close_char_) {
             at_end_ = true;
+            if constexpr (lazy_streaming_cursor_active(Opts)) {
+               if (doc_) [[likely]] {
+                  doc_->consumed_.set(doc_->json_data(), container_start_,
+                                      (pos < json_end_) ? pos + 1 : pos);
+               }
+            }
             return;
          }
       }
@@ -1026,33 +1220,53 @@ namespace glz
 
       const char* pos = current_view_.data();
 
-      // Optimization: if user accessed fields via operator[], parse_pos_ tells us how far we scanned
-      // We can skip from there instead of re-scanning the entire element
-      // Note: check current_view_.is_object(), not is_object_ (which is about the container)
-      if (current_view_.is_object() && current_view_.parse_pos_ && current_view_.parse_pos_ > pos) {
-         // Skip the last accessed value, then scan to end of object
-         pos = current_view_.parse_pos_;
-         pos = detail::skip_value_lazy<Opts>(pos, json_end_);
-         // Skip remaining content until we close this object (depth 1 -> 0)
-         pos = detail::skip_to_depth_zero<Opts>(pos, json_end_, 1);
+      bool jumped = false;
+      if constexpr (lazy_streaming_cursor_active(Opts)) {
+         if (doc_) [[likely]] {
+            jumped = doc_->consumed_.try_jump(doc_->json_data(), pos, pos);
+         }
       }
-      else {
-         // No optimization possible, skip entire value
-         pos = detail::skip_value_lazy<Opts>(pos, json_end_);
+      if (!jumped) {
+         // Optimization: if user accessed fields via operator[], parse_pos_ tells us how far we scanned
+         // We can skip from there instead of re-scanning the entire element
+         // Note: check current_view_.is_object(), not is_object_ (which is about the container)
+         if (current_view_.is_object() && current_view_.parse_pos_ && current_view_.parse_pos_ > pos) {
+            // Skip the last accessed value, then scan to end of object
+            pos = current_view_.parse_pos_;
+            pos = detail::skip_value_lazy<Opts>(pos, json_end_);
+            // Skip remaining content until we close this object (depth 1 -> 0)
+            pos = detail::skip_to_depth_zero<Opts>(pos, json_end_, 1);
+         }
+         else {
+            // No optimization possible, skip entire value
+            pos = detail::skip_value_lazy<Opts>(pos, json_end_);
+         }
       }
 
       skip_ws(pos);
 
-      // Check for end
+      // Check for end — and record this container's full extent so a parent
+      // iterator advancing over us can jump (self-composing streaming cursor).
       if constexpr (Opts.null_terminated) {
          if (*pos == close_char_) {
             at_end_ = true;
+            if constexpr (lazy_streaming_cursor_active(Opts)) {
+               if (doc_) [[likely]] {
+                  doc_->consumed_.set(doc_->json_data(), container_start_, pos + 1);
+               }
+            }
             return *this;
          }
       }
       else {
          if (pos >= json_end_ || *pos == close_char_) {
             at_end_ = true;
+            if constexpr (lazy_streaming_cursor_active(Opts)) {
+               if (doc_) [[likely]] {
+                  doc_->consumed_.set(doc_->json_data(), container_start_,
+                                      (pos < json_end_) ? pos + 1 : pos);
+               }
+            }
             return *this;
          }
       }

--- a/include/glaze/json/lazy.hpp
+++ b/include/glaze/json/lazy.hpp
@@ -365,6 +365,37 @@ namespace glz
       {
          using type = lazy_streaming_extent_packed<true>;
       };
+
+      // Pure storage (no behavior) for lazy_json_view's per-value key + error — the key is
+      // only meaningful while iterating an object, the error only tags views from fallible
+      // lookups. The full layout holds both; the slim policy (lazy_slim_view) drops them
+      // entirely: the key moves onto the iterator and error state is derived from a null
+      // value pointer. The empty slim specialization occupies no space via
+      // GLZ_NO_UNIQUE_ADDRESS. The view owns the accessor logic (key()/error()/has_error()),
+      // so neither specialization needs stub getters/setters.
+      template <bool Slim>
+      struct lazy_view_meta
+      {
+         std::string_view key{};
+         error_code error{error_code::none};
+      };
+
+      template <>
+      struct lazy_view_meta<true>
+      {};
+
+      // Iterator-side key storage: empty under the full layout (the key lives on the stored
+      // element view, GLZ_NO_UNIQUE_ADDRESS), a single string_view under the slim layout
+      // (the value carries no key, so the iterator retains it).
+      template <bool Slim>
+      struct lazy_iter_key
+      {};
+
+      template <>
+      struct lazy_iter_key<true>
+      {
+         std::string_view key{};
+      };
    } // namespace detail
 
    template <auto Opts>
@@ -382,7 +413,7 @@ namespace glz
     * For objects, parse_pos_ tracks the current scan position to enable
     * efficient sequential key access (O(n) total instead of O(n²)).
     *
-    * Memory layout (48 bytes on 64-bit, 24 bytes on 32-bit):
+    * Memory layout (full: 48 bytes on 64-bit, 24 bytes on 32-bit):
     * - doc_: pointer to owning lazy_document (8/4 bytes). Optional: may be null for
     *   detached subviews constructed via lazy_json_view(nullptr, data) on null-terminated
     *   buffers. Views from lazy_json() always set doc_ to the owning document.
@@ -390,21 +421,34 @@ namespace glz
     *   record/jump is skipped when doc_ is null.
     * - data_: pointer to value start in JSON (8/4 bytes)
     * - parse_pos_: current scan position for progressive parsing (8/4 bytes)
-    * - key_: stored key for iteration (16/8 bytes - string_view)
-    * - error_: error code (4 bytes)
-    * - padding: 4/0 bytes
+    * - meta_: key (16/8-byte string_view) + error_code + padding (see lazy_view_meta).
+    *
+    * Under the slim policy (lazy_slim_view = true on the opts) meta_ is empty and the
+    * value shrinks to 24/12 bytes (the three pointers): the object key moves onto the
+    * iterator and errors are signalled by a null data_. See lazy_slim_view_active.
     */
    template <auto Opts = opts{}>
    struct lazy_json_view
    {
      private:
+      static constexpr bool slim_ = lazy_slim_view_active(Opts);
+
       const lazy_document<Opts>* doc_{};
       const char* data_{};
       mutable const char* parse_pos_{}; // Current scan position (advances on key access)
-      std::string_view key_{};
-      error_code error_{error_code::none};
 
-      lazy_json_view(error_code ec) noexcept : error_(ec) {}
+      // Key + error channel. Full (default) layout carries both on the value; under the
+      // slim policy (lazy_slim_view) this is empty and the accessors below derive their
+      // answers instead — see lazy_view_meta.
+      GLZ_NO_UNIQUE_ADDRESS detail::lazy_view_meta<slim_> meta_{};
+
+      lazy_json_view(error_code ec) noexcept
+      {
+         // Slim: an error view is simply one with a null data_ (the default), nothing to store.
+         if constexpr (!slim_) {
+            meta_.error = ec;
+         }
+      }
 
      public:
       lazy_json_view() = default;
@@ -412,8 +456,24 @@ namespace glz
 
       [[nodiscard]] static lazy_json_view make_error(error_code ec) noexcept { return lazy_json_view{ec}; }
 
-      [[nodiscard]] bool has_error() const noexcept { return error_ != error_code::none; }
-      [[nodiscard]] error_code error() const noexcept { return error_; }
+      [[nodiscard]] bool has_error() const noexcept
+      {
+         if constexpr (slim_) {
+            return !data_;
+         }
+         else {
+            return meta_.error != error_code::none;
+         }
+      }
+      [[nodiscard]] error_code error() const noexcept
+      {
+         if constexpr (slim_) {
+            return data_ ? error_code::none : error_code::unexpected_end;
+         }
+         else {
+            return meta_.error;
+         }
+      }
 
       // Type checking - direct from JSON byte
       [[nodiscard]] bool is_null() const noexcept { return has_error() || !data_ || *data_ == 'n'; }
@@ -461,7 +521,7 @@ namespace glz
       [[nodiscard]] error_ctx read_into(T& value) const
       {
          if (has_error()) {
-            return error_ctx{0, error_};
+            return error_ctx{0, error()};
          }
          if (!data_) {
             return error_ctx{0, error_code::unexpected_end};
@@ -497,8 +557,17 @@ namespace glz
       [[nodiscard]] size_t size() const;
       [[nodiscard]] bool empty() const noexcept;
 
-      // Key access for object iteration
-      [[nodiscard]] std::string_view key() const noexcept { return key_; }
+      // Key access for object iteration. Under the slim policy the value does not carry
+      // its key (returns {}); use the iterator's key() during traversal instead.
+      [[nodiscard]] std::string_view key() const noexcept
+      {
+         if constexpr (slim_) {
+            return {};
+         }
+         else {
+            return meta_.key;
+         }
+      }
 
       [[nodiscard]] lazy_iterator<Opts> begin() const;
       [[nodiscard]] lazy_iterator<Opts> end() const;
@@ -513,10 +582,15 @@ namespace glz
       friend struct indexed_lazy_view<Opts>;
       friend class indexed_lazy_iterator<Opts>;
 
-      // Constructor with key for iteration
+      // Constructor with key for iteration. Under the slim policy the key is not stored on
+      // the value (it stays on the iterator).
       lazy_json_view(const lazy_document<Opts>* doc, const char* data, std::string_view key) noexcept
-         : doc_(doc), data_(data), key_(key)
-      {}
+         : doc_(doc), data_(data)
+      {
+         if constexpr (!slim_) {
+            meta_.key = key;
+         }
+      }
 
       // Skip whitespace helper
       // Note: The minified option is not used here because branch prediction
@@ -644,6 +718,10 @@ namespace glz
       bool at_end_{true};
       lazy_json_view<Opts> current_view_{}; // Stored view for parse_pos_ optimization
 
+      // Slim policy only: the value no longer carries its key, so the iterator retains
+      // the current element's key here. Empty (zero-size) under the full layout.
+      GLZ_NO_UNIQUE_ADDRESS detail::lazy_iter_key<lazy_slim_view_active(Opts)> iter_key_{};
+
      public:
       using iterator_category = std::forward_iterator_tag;
       using value_type = lazy_json_view<Opts>;
@@ -658,6 +736,18 @@ namespace glz
       // Return reference to stored view - allows parse_pos_ optimization when user uses auto&
       reference operator*() { return current_view_; }
       const lazy_json_view<Opts>& operator*() const { return current_view_; }
+
+      // Current element's object key (empty for arrays). Works under both value layouts:
+      // the full layout reads it back from the stored view, the slim layout from iter_key_.
+      [[nodiscard]] std::string_view key() const noexcept
+      {
+         if constexpr (lazy_slim_view_active(Opts)) {
+            return iter_key_.key;
+         }
+         else {
+            return current_view_.key();
+         }
+      }
 
       lazy_iterator& operator++();
 
@@ -823,6 +913,13 @@ namespace glz
       {
          operator*(); // Update current_view_
          return &current_view_;
+      }
+
+      // Current element's object key (empty for arrays). Read from the parent's key
+      // index, so it works under both value layouts (slim value carries no key).
+      [[nodiscard]] std::string_view key() const noexcept
+      {
+         return parent_->is_object_ ? parent_->keys_[index_] : std::string_view{};
       }
 
       indexed_lazy_iterator& operator++()
@@ -1238,8 +1335,11 @@ namespace glz
          at_end_ = true;
          return;
       }
-      // Store key in current_view_ (will be set properly after this call)
+      // Full layout stores the key on the view; slim layout keeps it on the iterator.
       current_view_ = lazy_json_view<Opts>{doc_, pos, key};
+      if constexpr (lazy_slim_view_active(Opts)) {
+         iter_key_.key = key;
+      }
    }
 
    template <auto Opts>
@@ -1420,7 +1520,7 @@ namespace glz
    [[nodiscard]] inline expected<T, error_ctx> lazy_json_view<Opts>::get() const
    {
       if (has_error()) {
-         return unexpected(error_ctx{0, error_});
+         return unexpected(error_ctx{0, error()});
       }
 
       const char* end = json_end();

--- a/include/glaze/json/lazy.hpp
+++ b/include/glaze/json/lazy.hpp
@@ -432,6 +432,7 @@ namespace glz
       explicit operator bool() const noexcept { return !has_error() && data_ && *data_ != 'n'; }
 
       [[nodiscard]] const char* data() const noexcept { return data_; }
+      [[nodiscard]] const lazy_document<Opts>* document() const noexcept { return doc_; }
       [[nodiscard]] const char* json_end() const noexcept;
 
       // Progressive object-scan cursor accessors. Exposed so an external handle

--- a/include/glaze/util/inline.hpp
+++ b/include/glaze/util/inline.hpp
@@ -53,3 +53,18 @@
 #define GLZ_NO_INLINE __declspec((noinline))
 #endif
 #endif
+
+#ifndef GLZ_NO_INLINE
+#define GLZ_NO_INLINE
+#endif
+
+// Pure leaf helpers: no globals, no side effects — lets the compiler hoist CSE across calls.
+#if defined(__clang__) || defined(__GNUC__)
+#ifndef GLZ_GNU_CONST_LEAF
+#define GLZ_GNU_CONST_LEAF [[gnu::const, gnu::leaf]]
+#endif
+#endif
+
+#ifndef GLZ_GNU_CONST_LEAF
+#define GLZ_GNU_CONST_LEAF
+#endif

--- a/tests/json_test/lazy_test.cpp
+++ b/tests/json_test/lazy_test.cpp
@@ -2,6 +2,7 @@
 // For the license information refer to glaze.hpp
 
 #include "glaze/json.hpp"
+#include "glaze/core/lazy_streaming_cursor_policy.hpp"
 #include "ut/ut.hpp"
 
 using namespace ut;
@@ -30,6 +31,38 @@ struct Item
    int id{};
    std::string value{};
 };
+
+struct LazyRow
+{
+   int a{};
+   int b{};
+};
+
+struct LazyItem
+{
+   int id{};
+   std::string name{};
+};
+
+struct lazy_streaming_enabled_opts : glz::opts
+{
+   glz::lazy_streaming_cursor_policy lazy_streaming_cursor = glz::lazy_streaming_cursor_policy::enabled;
+};
+
+struct lazy_streaming_disabled_opts : glz::opts
+{
+   glz::lazy_streaming_cursor_policy lazy_streaming_cursor = glz::lazy_streaming_cursor_policy::disabled;
+};
+
+struct lazy_streaming_packed_opts : glz::opts
+{
+   glz::lazy_streaming_cursor_policy lazy_streaming_cursor =
+      glz::lazy_streaming_cursor_policy::packed_with_fallback;
+};
+
+inline constexpr lazy_streaming_enabled_opts kLazyStreamingEnabled{};
+inline constexpr lazy_streaming_disabled_opts kLazyStreamingDisabled{};
+inline constexpr lazy_streaming_packed_opts kLazyStreamingPacked{};
 
 struct MinimalUser
 {
@@ -1580,6 +1613,46 @@ suite dynamic_key_custom_tests = [] {
       expect((*result).root().size() == 1u); // '@' scalar, then bounded by json_end_
       expect((*result).root().index().size() == 1u);
       expect((*result).root()[1].has_error()); // nothing past the lone scalar
+   };
+
+   "lazy_streaming_cursor_read_into_row_loop"_test = [] {
+      std::string buffer = R"({"rows":[{"a":1,"b":2},{"a":3,"b":4},{"a":5,"b":6}]})";
+      auto result = glz::lazy_json<kLazyStreamingEnabled>(buffer);
+      expect(result.has_value());
+
+      std::int64_t sum{};
+      for (auto& row : (*result)["rows"]) {
+         LazyRow parsed{};
+         expect(not row.read_into(parsed));
+         sum += parsed.a + parsed.b;
+      }
+      expect(sum == 21);
+   };
+
+   "lazy_streaming_cursor_disabled_matches_default"_test = [] {
+      std::string buffer = R"({"rows":[{"a":1},{"a":2}]})";
+      auto result = glz::lazy_json<kLazyStreamingDisabled>(buffer);
+      expect(result.has_value());
+
+      std::int64_t sum{};
+      for (auto& row : (*result)["rows"]) {
+         expect(row["a"].get<int64_t>().value() == ++sum);
+      }
+      expect(sum == 2);
+   };
+
+   "lazy_streaming_packed_with_fallback_policy"_test = [] {
+      std::string buffer = R"({"items":[{"id":1,"name":"alpha"},{"id":2,"name":"beta"}]})";
+      auto result = glz::lazy_json<kLazyStreamingPacked>(buffer);
+      expect(result.has_value());
+
+      std::int64_t checksum{};
+      for (auto& item : (*result)["items"]) {
+         LazyItem row{};
+         expect(not item.read_into(row));
+         checksum += row.id + static_cast<std::int64_t>(row.name.size());
+      }
+      expect(checksum == 13);
    };
 };
 

--- a/tests/json_test/lazy_test.cpp
+++ b/tests/json_test/lazy_test.cpp
@@ -60,9 +60,18 @@ struct lazy_streaming_packed_opts : glz::opts
       glz::lazy_streaming_cursor_policy::packed_with_fallback;
 };
 
+// End-bounded (non-null-terminated) buffer + streaming cursor enabled — mirrors a
+// downstream consumer that feeds bounded string_views and opts in the cursor.
+struct lazy_end_bounded_cursor_opts : glz::opts
+{
+   bool null_terminated = false;
+   glz::lazy_streaming_cursor_policy lazy_streaming_cursor = glz::lazy_streaming_cursor_policy::enabled;
+};
+
 inline constexpr lazy_streaming_enabled_opts kLazyStreamingEnabled{};
 inline constexpr lazy_streaming_disabled_opts kLazyStreamingDisabled{};
 inline constexpr lazy_streaming_packed_opts kLazyStreamingPacked{};
+inline constexpr lazy_end_bounded_cursor_opts kLazyEndBoundedCursor{};
 
 struct MinimalUser
 {
@@ -1652,7 +1661,33 @@ suite dynamic_key_custom_tests = [] {
          expect(not item.read_into(row));
          checksum += row.id + static_cast<std::int64_t>(row.name.size());
       }
-      expect(checksum == 13);
+      // (id 1 + "alpha" 5) + (id 2 + "beta" 4) = 12. This test previously never
+      // exercised the cursor (it was compiled out by opts NTTP slicing), so the
+      // stale expectation went unnoticed.
+      expect(checksum == 12);
+   };
+
+   "lazy_json_out_of_order_keys_end_bounded_cursor"_test = [] {
+      // Object field access must be order-independent (forward + wrap-around) and
+      // must never over-read a bounded (non-null-terminated) buffer regardless of
+      // the order keys are requested in. Exercises the end-bounded skip path with
+      // the streaming cursor enabled, and a trailing non-JSON tail after '}' to
+      // catch any read past json_end().
+      std::string backing = R"({"a":10,"b":20,"c":30,"d":40}TRAILING_NON_JSON_TAIL)";
+      const std::string_view json{backing.data(), backing.find('}') + 1};
+
+      auto result = glz::lazy_json<kLazyEndBoundedCursor>(json);
+      expect(result.has_value());
+      auto& doc = *result;
+
+      // Last field first forces the wrap-around pass; then earlier fields, a repeat,
+      // and an absent key.
+      expect(doc["d"].get<int64_t>().value() == 40);
+      expect(doc["a"].get<int64_t>().value() == 10);
+      expect(doc["c"].get<int64_t>().value() == 30);
+      expect(doc["b"].get<int64_t>().value() == 20);
+      expect(doc["a"].get<int64_t>().value() == 10); // repeat resolves the same value
+      expect(doc["missing_key"].has_error());        // absent key: reported, not a false hit
    };
 };
 


### PR DESCRIPTION
## Motivation

Large **nested tabular JSON** — a top-level catalog of entity arrays, each with a `rows`
matrix of scalar cells — is dominated by **sequential bulk ingest**: walk every row,
`read_into` every cell. This PR fixes a correctness bug that made a lazy optimization
silently inert, then adds two ingest optimizations on top.

### 1. Fix: custom `opts` are silently ignored by the lazy JSON API

The lazy-JSON types (`lazy_document`, `lazy_json_view`, `lazy_iterator`, `indexed_lazy_view`,
the streaming-slot selector, and the `skip_*` helpers) were declared `template <opts Opts>`
— a concrete, base-class NTTP. A user options struct that **derives from `glz::opts`** to
carry extra fields — the pattern the header comments recommend ("*Add these fields to a
custom options struct if you want to use them*") — is **sliced to `glz::opts`** at that
boundary, dropping every derived field. So any `if constexpr (requires { Opts.my_field; })`
inside the lazy code evaluated false. The rest of Glaze's read/write API already uses
`template <auto Opts>` (which preserves the exact type); this PR aligns the lazy surface
with that convention.

### 2. Opt-in streaming cursor

`lazy_streaming_cursor_policy` (default `disabled`): `read_into` and finished container
iterators record the consumed byte extent `[start, end)`; the next `operator++` jumps to
`end` instead of re-scanning with `skip_value_lazy`. Zero storage / no layout change when
disabled. **Because of the slicing bug above, the cursor never actually compiled in before
this fix** — every prior "cursor on/off" comparison was two identical builds.

### 3. SIMD structural skip (expanded from SWAR)

`skip_value_lazy` / `skip_to_depth_zero` locate the next JSON structural byte
(`" [ ] { }`) to advance past scalar runs. This started as an 8-byte SWAR pre-scan; it is
now a **32-byte portable SIMD scan built on GCC/Clang vector extensions**, which the
compiler lowers to **AVX2/SSE2 on x86 and NEON on ARM** with no intrinsics. The first
match is located via a memcpy to 4×`uint64` + `countr_zero`, so it stays portable across
clang and gcc (no target-specific `movemask`). MSVC's `cl.exe` (no vector extensions)
falls back to the SWAR loop; the scan is skipped during constant evaluation. Gated by an
opt-out `lazy_swar_skip` (default on) for A/B isolation.

### 4. Opt-in slim `lazy_json_view` (48 → 24 bytes)

`lazy_json_view` carries a per-value object key (`std::string_view`, 16 B) and an
`error_code`, even though the key is only meaningful while iterating an object and the
error only tags views returned by fallible lookups. On 64-bit this makes every value view
48 bytes; a consumer that copies the view per cell pays for those 24 bytes on every copy.

`lazy_slim_view` (default off) drops both from the value, shrinking it to 24 bytes (the
three pointers). The object key moves onto the iterator (`lazy_iterator::key()` /
`indexed_lazy_iterator::key()`), and error state is signalled by a null value pointer
(`has_error() == (data() == nullptr)`; the specific `error_code` is not retained in this
layout). The full 48-byte layout stays the default, so existing users and the whole test
suite are unaffected; the key/error storage is selected with the same
empty-specialization + `[[no_unique_address]]` pattern used for the streaming slot, so the
dropped members occupy zero space under the policy.

## Benchmarks

### Streaming cursor on vs off — `lazy_load_benchmark` (Release)

| Fixture | Windows (Core Ultra 7) | Mac (Apple M1) | Linux (Clang) |
|---------|----------------------:|---------------:|--------------:|
| Mixed-warehouse ~2.2 GB (rotating scalar/numeric/object rows) | **+10%** | **+6.5%** | **+10%** |
| Split-catalog scalar-cell load ~12 MB | **+18%** | **+39%** | **+22%** |
| Flat tables smoke ~3.8 MB | **+28%** | **+39%** | **+35%** |

Object records in the mixed fixture are consumed key-by-key via `operator[]` (which the
cursor does not accelerate), so the mixed number reflects only the row shapes that benefit.

### SIMD structural skip vs 8-byte SWAR (same fixtures, cursor on)

The vector scan lifts absolute throughput a further **~5–14%** over SWAR (e.g. scalar-cell
load 307→323 MB/s, flat 411→443 MB/s), and shaves **~3–4% CPU** off a downstream
multi-GB string-heavy import. Full lazy test suite: 70/70 at both AVX2 and SSE2 widths.

### Downstream: multi-GB import, cursor + SIMD vs an external parser (simdjson)

An analytics engine (Farseer/Rama) parsing multi-GB dumps into columnar storage. usr+krn
CPU, median of interleaved runs, Windows, Release; four builds from one tree:

| Import | simdjson | vanilla glaze | +cursor | +cursor +SIMD |
|--------|---------:|--------------:|--------:|--------------:|
| 325 MB mixed | 8390 | 8655 | 8405 | **7906** |
| 3.4 GB string-heavy | 32734 | 33985 | 32311 | **30296** |

Vanilla lazy trails simdjson (+3–9%); cursor + SIMD turn that into a **−6% / −7% win** on
the large imports that dominate load time. (Peak RSS is also ~halved vs simdjson,
though that's a property of lazy parsing generally, not this PR.)

### Slim view: measured throughput, and a clang-cl caveat

Benchmarked on the realistic `read_into`-per-cell ingest (GB-scale flat cell-heavy fixture),
full 48-byte vs slim 24-byte view **with the streaming cursor on**, interleaved
separate-process runs, pinned:

| toolchain / target | slim vs full (streaming on) |
|---|---|
| Apple clang, arm64 | **+8%** (slim faster) |
| Linux clang, x86-64 | ≈ neutral (+1.4%, noise) |
| Windows clang-cl, x86-64 | **−26%** (regression) |

Without the streaming cursor, slim and full are within noise on all three. So the slim view
is a modest win or neutral everywhere **except clang-cl + streaming cursor**, where it
regresses ~26% on cell-access-bound ingest. VTune attributes that to L1 store-ordering stalls
(elevated *Store Early Blk* / *L1 Latency Dependency*) — not DRAM/L3-bound, not a
store-forwarding violation, and **not a struct-layout issue** (padding `lazy_document` to keep
the streaming slot's offset fixed does not move it). Linux clang on the *same hardware* is
fine, so this is a **clang-cl-specific codegen artifact, not algorithmic**. It is documented
as a known limitation in `docs/lazy-json.md`, and the slim view stays **off by default**.

## Notes / test plan

- [x] Lazy JSON unit tests pass with the streaming cursor **actually enabled** (the
  `auto Opts` fix — previously these exercised the disabled path only); added an
  out-of-order-key regression test on an end-bounded + cursor opts.
- [x] SIMD skip verified at AVX2 and SSE2 widths (70/70); MSVC/constexpr fall back to SWAR.
- [x] Downstream import parity: force-reimport + recalc, 0 variables diverged vs reference.
- [x] Slim view: full lazy suite 70/70 (+ BEVE 57/57) on the default (full) layout; slim
  produces byte-identical `read_into` results (checksums match full across all fixtures);
  throughput measured on arm64 / Linux-x86 / clang-cl-x86 (see the slim-view caveat above).
- Default remains `lazy_streaming_cursor_policy::disabled`; the `auto Opts` change is
  source-compatible with existing `glz::opts{}` call sites.

