### PR TITLE
error on truncated content-length body in async http_client

### DIFF
--- a/include/glaze/net/http_client.hpp
+++ b/include/glaze/net/http_client.hpp
@@ -2738,16 +2738,21 @@ namespace glz
                      [this, socket_var, buffer, url, use_https, content_length,
                       status_code = parsed_status->status_code, response_headers = std::move(response_headers),
                       handler = std::forward<CompletionHandler>(handler)](asio::error_code ec, std::size_t) mutable {
-                        // EOF is expected if the server closes the connection.
-                        if (ec && ec != asio::error::eof) {
+                        // transfer_exactly only completes without error once the full
+                        // Content-Length has been read, so any error here - including EOF - means
+                        // the peer closed before delivering the declared body. That is an
+                        // incomplete message (RFC 7230 §3.3.3), not a short success: close the
+                        // connection (with graceful SSL shutdown if configured; never pool a socket
+                        // the peer just closed) and surface the error. Matches the synchronous path.
+                        if (ec) {
+                           detail::close_socket(*socket_var, connection_pool->graceful_ssl_shutdown());
                            handler(std::unexpected(ec));
                            return;
                         }
 
-                        // Frame the body by Content-Length. A server can deliver more than
-                        // content_length octets in the same segment (a pipelined next response or
-                        // trailing junk); clamp so those bytes never leak into response_body. Matches
-                        // the synchronous path.
+                        // Full body received. A server can deliver more than content_length octets
+                        // in the same segment (a pipelined next response or trailing junk); clamp
+                        // so those bytes never leak into response_body. Matches the synchronous path.
                         std::string body(static_cast<const char*>(buffer->data().data()),
                                          (std::min)(content_length, buffer->size()));
 
@@ -2756,10 +2761,16 @@ namespace glz
                         resp.response_headers = std::move(response_headers);
                         resp.response_body = std::move(body);
 
-                        // Return connection to pool if it's still usable
+                        // Pool the connection unless the server asked to close it. A truncated or
+                        // peer-closed connection already returned above, so anything reaching here
+                        // is a complete response on a still-open socket.
                         auto connection_header = resp.response_headers.find("connection");
-                        if (connection_header == resp.response_headers.end() ||
-                            connection_header->second.find("close") == std::string::npos) {
+                        const bool server_wants_close = connection_header != resp.response_headers.end() &&
+                                                        connection_header->second.find("close") != std::string::npos;
+                        if (server_wants_close) {
+                           detail::close_socket(*socket_var, connection_pool->graceful_ssl_shutdown());
+                        }
+                        else {
                            connection_pool->return_connection(url.host, url.port, use_https, std::move(*socket_var));
                         }
 

--- a/tests/networking_tests/http_content_length_test/http_content_length_test.cpp
+++ b/tests/networking_tests/http_content_length_test/http_content_length_test.cpp
@@ -1,13 +1,22 @@
-// Tests that glz::http_client frames a non-chunked response body strictly by
-// Content-Length. A server may deliver more than Content-Length octets in the
-// same segment (a pipelined next response, or trailing junk); those bytes must
-// not leak into response_body. Covers both the synchronous and asynchronous
-// client paths.
+// Tests for how glz::http_client frames and finalizes a non-chunked, Content-Length
+// response:
+//   1. The body is framed strictly by Content-Length. A server may deliver more than
+//      Content-Length octets in the same segment (a pipelined next response, or
+//      trailing junk); those bytes must not leak into response_body. Covers both the
+//      synchronous and asynchronous client paths.
+//   2. A body truncated by the peer closing the connection before the declared
+//      Content-Length arrives is an incomplete message (RFC 7230 §3.3.3) and is reported
+//      as an error, not a short body. Covers both client paths.
+//   3. A connection whose body read ends with the peer closing the socket (EOF) is not
+//      returned to the pool. Pooling an EOF'd (half-closed) socket would hand the next
+//      request a dead connection.
 
+#include <atomic>
 #include <chrono>
 #include <memory>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include "glaze/net/http_client.hpp"
 #include "ut/ut.hpp"
@@ -64,6 +73,16 @@ static const std::string overrun_response =
    "\r\n"
    "ABCHTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nHELLO";
 
+// A response that declares 10 body octets but delivers only 3 before the peer closes
+// the connection. Per RFC 7230 §3.3.3 this is an incomplete message and must surface as
+// an error rather than a silently truncated body.
+static const std::string truncated_response =
+   "HTTP/1.1 200 OK\r\n"
+   "Content-Length: 10\r\n"
+   "Connection: keep-alive\r\n"
+   "\r\n"
+   "ABC";
+
 suite content_length_framing = [] {
    "async_body_clamped_to_content_length"_test = [] {
       uint16_t port = 0;
@@ -97,6 +116,114 @@ suite content_length_framing = [] {
          expect(result->response_body == "ABC")
             << "sync body must stop at Content-Length, got: " << result->response_body;
       }
+   };
+
+   // A Content-Length response truncated by connection close is an incomplete message and
+   // must be reported as an error, not a short-but-successful body. Both client paths agree.
+   "async_truncated_body_is_error"_test = [] {
+      uint16_t port = 0;
+      auto server = start_raw_server(port, truncated_response);
+
+      glz::http_client client;
+      auto result = client.get_async("http://127.0.0.1:" + std::to_string(port) + "/", {}).get();
+
+      server.join();
+
+      expect(!result.has_value())
+         << "async: a truncated Content-Length response must be an error, not a short body";
+   };
+
+   "sync_truncated_body_is_error"_test = [] {
+      uint16_t port = 0;
+      auto server = start_raw_server(port, truncated_response);
+
+      glz::http_client client;
+      auto result = client.get("http://127.0.0.1:" + std::to_string(port) + "/");
+
+      server.join();
+
+      expect(!result.has_value())
+         << "sync: a truncated Content-Length response must be an error, not a short body";
+   };
+};
+
+// Serve a fixed sequence of raw responses, one per accepted connection, closing each
+// connection after writing so the client observes EOF at the end of the body. The
+// acceptor polls with a deadline instead of blocking, so the server never hangs waiting
+// for a connection that a buggy client won't make: if the EOF'd connection is wrongly
+// pooled, the follow-up request reuses that dead socket and connection 2 never arrives.
+static std::thread serve_sequence(std::shared_ptr<asio::io_context> listener,
+                                  std::shared_ptr<asio::ip::tcp::acceptor> acceptor,
+                                  std::vector<std::string> responses,
+                                  std::shared_ptr<std::atomic<int>> accept_count)
+{
+   return std::thread([listener, acceptor, responses = std::move(responses), accept_count] {
+      asio::error_code ec;
+      acceptor->non_blocking(true, ec);
+      const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+      while (accept_count->load() < static_cast<int>(responses.size()) &&
+             std::chrono::steady_clock::now() < deadline) {
+         asio::ip::tcp::socket socket(*listener);
+         acceptor->accept(socket, ec);
+         if (ec == asio::error::would_block || ec == asio::error::try_again) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            continue;
+         }
+         if (ec) break;
+         const size_t n = static_cast<size_t>(accept_count->fetch_add(1));
+         socket.non_blocking(false, ec); // the accepted socket may inherit non-blocking mode
+         asio::streambuf req_buf;
+         asio::read_until(socket, req_buf, "\r\n\r\n", ec);
+         asio::write(socket, asio::buffer(responses[n]), ec);
+         socket.shutdown(asio::ip::tcp::socket::shutdown_both, ec);
+         socket.close(ec);
+      }
+   });
+}
+
+suite content_length_connection_reuse = [] {
+   // A Content-Length response whose body is truncated by the peer closing the connection
+   // (declares 10 octets, delivers 3 then EOF) must not leave the socket in the pool. The
+   // follow-up request has to open a fresh connection rather than reuse a dead one. POST is
+   // used so the transparent-retry path (idempotent methods only) can't mask a wrongly
+   // pooled socket, and the acquire-time liveness peek is disabled so a pooled dead socket
+   // would actually be handed back out.
+   "eof_truncated_response_not_pooled"_test = [] {
+      auto listener = std::make_shared<asio::io_context>();
+      auto acceptor = std::make_shared<asio::ip::tcp::acceptor>(*listener);
+      asio::ip::tcp::endpoint ep(asio::ip::make_address("127.0.0.1"), 0);
+      acceptor->open(ep.protocol());
+      acceptor->set_option(asio::socket_base::reuse_address(true));
+      acceptor->bind(ep);
+      acceptor->listen(2);
+      const uint16_t port = acceptor->local_endpoint().port();
+
+      auto accept_count = std::make_shared<std::atomic<int>>(0);
+      std::vector<std::string> responses = {
+         "HTTP/1.1 200 OK\r\nContent-Length: 10\r\nConnection: keep-alive\r\n\r\nABC",
+         "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: keep-alive\r\n\r\nHELLO",
+      };
+      auto server = serve_sequence(listener, acceptor, responses, accept_count);
+
+      glz::http_client client;
+      // Force a pooled dead socket to be reused rather than culled by the acquire-time peek.
+      client.set_pool_active_liveness_check(false);
+
+      const std::string base = "http://127.0.0.1:" + std::to_string(port) + "/";
+      client.post_async(base, "one").get(); // truncated response; peer closes connection 1
+      auto second = client.post_async(base, "two").get(); // must land on a fresh connection 2
+
+      server.join();
+
+      expect(second.has_value())
+         << "after an EOF-truncated response the connection must not be pooled; the follow-up "
+            "request must open a fresh connection instead of reusing a dead socket";
+      if (second) {
+         expect(second->status_code == 200);
+         expect(second->response_body == "HELLO");
+      }
+      expect(accept_count->load() == 2)
+         << "expected two server connections (dead socket not reused), got: " << accept_count->load();
    };
 };
 


### PR DESCRIPTION
## Problem

The async Content-Length reader in `parse_and_read_body` treated an EOF during the body read as success. `asio::async_read(..., transfer_exactly(remaining))` only completes without error once the full Content-Length has been read, so an EOF there means the peer closed **before** delivering the declared body, a truncated/incomplete message (RFC 7230 §3.3.3). The old code instead:

1. returned that short body to the caller as a successful `200`, and
2. returned the half-closed, peer-closed socket to the connection pool.

Both are wrong. A caller seeing `has_value() && status_code == 200` reasonably assumes the body is complete, so a silent truncation leads to partial JSON parsed as whole, partial file writes, etc. And pooling a socket the peer just closed hands the next request a dead connection (rediscovered only via the acquire-time peek, idle-timeout eviction, or a doomed request + retry).

The synchronous reader one function over already treats this as an error (`std::unexpected(read_ec)` and closes the socket), so the two paths disagreed.

## Change

Fold the EOF case into the error path. On any read error (including EOF) the async reader now closes the connection (with graceful SSL shutdown if configured) and surfaces the error, matching the sync path. A complete response still frames strictly by Content-Length (the `std::min(content_length, buffer->size())` clamp from #2684 is retained to drop trailing/pipelined junk) and is pooled unless the server sent `Connection: close`.

This also fixes a smaller pre-existing issue: the non-EOF error branch previously returned the error without closing the socket, leaking it to the `shared_ptr` destructor without a graceful SSL shutdown. It now closes it explicitly.

**Behavior change:** a truncated Content-Length response on the async path now returns an error instead of a short body. This aligns async with sync and with the broader ecosystem (curl `CURLE_PARTIAL_FILE`, urllib3 `IncompleteRead`, Go `io.ErrUnexpectedEOF`). Complete responses, including complete responses followed by trailing junk in the same segment, are unaffected.

## Tests

Added to `http_content_length_test`:

- `async_truncated_body_is_error` / `sync_truncated_body_is_error`: a response declaring 10 octets but delivering 3 before close must be an error, not a short body. (The async case is the new behavior; sync already did this.)
- `eof_truncated_response_not_pooled`: after an EOF-truncated response, a follow-up request must open a fresh connection rather than reuse the dead pooled socket. Uses POST (async never retries non-idempotent methods) with the acquire-time liveness peek disabled, so a wrongly-pooled dead socket is actually handed back out and observable.

Each new test was confirmed to fail against the old lenient behavior and pass with this change. Full networking suite locally: `http_content_length_test` 5/5 (6/6 repeated runs, no flakiness), `http_client_test` 33/33, `http_client_pool_test` 14/14, `http_chunked_test` 59/59.
