### PR TITLE
guard structs_as_arrays beve object reader against end of input

### DIFF
--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -1903,6 +1903,9 @@ namespace glz
             constexpr auto N = detail::count_members<T>;
             if constexpr (N == 0) {
                // Handle empty structs by just reading and validating the generic_array header
+               if (invalid_end(ctx, it, end)) {
+                  return;
+               }
                const auto tag = uint8_t(*it);
                if (tag != tag::generic_array) [[unlikely]] {
                   ctx.error = error_code::syntax_error;
@@ -1924,6 +1927,9 @@ namespace glz
             }
          }
          else {
+            if (invalid_end(ctx, it, end)) {
+               return;
+            }
             const auto tag = uint8_t(*it);
             if (tag != tag::generic_array) [[unlikely]] {
                ctx.error = error_code::syntax_error;

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -2515,6 +2515,26 @@ suite example_reflection_test = [] {
    };
 };
 
+struct untagged_bounds_inner
+{
+   int x{};
+   struct glaze
+   {
+      using T = untagged_bounds_inner;
+      static constexpr auto value = glz::object("x", &T::x);
+   };
+};
+
+struct untagged_bounds_outer
+{
+   untagged_bounds_inner a{};
+   struct glaze
+   {
+      using T = untagged_bounds_outer;
+      static constexpr auto value = glz::object("a", &T::a);
+   };
+};
+
 suite example_reflection_without_keys_test = [] {
    "example_reflection_without_keys"_test = [] {
       std::string without_keys;
@@ -2569,6 +2589,23 @@ suite example_reflection_without_keys_test = [] {
       expect(decoded.i == 42);
       expect(decoded.d == 2.718);
       expect(decoded.hello == "world");
+   };
+
+   "read_beve_untagged truncated nested struct"_test = [] {
+      untagged_bounds_outer obj{};
+      obj.a.x = 7;
+      auto encoded = glz::write_beve_untagged(obj);
+      expect(encoded.has_value());
+
+      // Keep only the outer generic_array header (tag + compressed count) so the
+      // nested struct member begins exactly at end-of-input. Read through an
+      // exact-size, non-padded string_view so an over-read lands past the buffer.
+      std::vector<char> truncated(encoded->begin(), encoded->begin() + 2);
+      std::string_view buffer{truncated.data(), truncated.size()};
+
+      untagged_bounds_outer decoded{};
+      auto ec = glz::read_beve_untagged(decoded, buffer);
+      expect(bool(ec));
    };
 };
 


### PR DESCRIPTION
The untagged (structs_as_arrays) BEVE object reader reads the generic_array tag with uint8_t(*it) before any bounds check, at both the reflectable empty-struct branch and the glaze_object_t branch. Every sibling reader in this file (the keyed object overload, tuple, array, null, bitset) calls invalid_end first. When a nested struct member is reached with it == end over a non-padded buffer, for example a std::string_view handed to read_beve_untagged where read() adds no trailing padding, the tag read runs one byte past the buffer.

Add the same invalid_end guard the other readers already use, at both sites. Before: a truncated payload over a string_view faults on the stray read (ASAN reports a heap-buffer-overflow) instead of returning an error. After: it reports unexpected_end, matching the keyed path. The guard lives in the reader because it owns its own entry bounds, and the cost is one comparison per struct on the untagged path only. Added a beve_test regression that reads a truncated nested struct through an exact-size string_view.