### PR TITLE
Support free function pointers in glz::custom

### DIFF
--- a/docs/wrappers.md
+++ b/docs/wrappers.md
@@ -30,7 +30,7 @@ glz::write_float64<&T::x> // Writes out numbers with a maximum precision of floa
 glz::write_float_full<&T::x> // Writes out numbers with full precision (turns off higher level float precision wrappers)
 glz::float_format<&T::x, "{:.2f}"> // Format floats using std::format syntax (C++23)
 
-glz::custom<&T::read, &T::write> // Calls custom read and write std::functions, lambdas, or member functions
+glz::custom<&T::read, &T::write> // Calls custom read and write std::functions, lambdas, member functions, or free functions
 glz::manage<&T::x, &T::read_x, &T::write_x> // Calls read_x() after reading x and calls write_x() before writing x
 glz::as_array<&T::member> // Treat a reflected/member-annotated type as a positional array for read and write
 glz::flatten_map<&T::member> // Flatten map-like containers into a JSON array [key..., value, ...]
@@ -1016,7 +1016,7 @@ float_precision float_max_write_precision{};
 
 ## custom
 
-Calls custom read and write std::functions, lambdas, or member functions.
+Calls custom read and write std::functions, lambdas, member functions, or free functions.
 
 ```c++
 struct custom_encoding
@@ -1105,6 +1105,41 @@ expect(obj.str == "Hello!");
 > [!NOTE]
 >
 > With read lambdas like `[](custom_buffer_input& s, const std::string& input)`, both types must be concrete (cannot use `auto`), otherwise you'll get a compilation error noting this. The reason is that Glaze must be able to determine what type to decode into before passing the decoded value to `input`.
+
+### Free functions
+
+Free functions (as non-member function pointers) follow the same conventions as lambdas: the object is the first argument, the decoded input is the second, and an optional `glz::context&` third argument enables custom error handling. A free function with a non-void return acts as a getter, so reading decodes into the returned reference and writing serializes the returned value.
+
+```c++
+struct free_func_counter
+{
+   int count{};
+};
+
+void counter_read(free_func_counter& obj, int val) { obj.count = val; }
+int counter_write(const free_func_counter& obj) { return obj.count; }
+
+template <>
+struct glz::meta<free_func_counter>
+{
+   static constexpr auto value = object("count", custom<counter_read, counter_write>);
+};
+```
+
+With a `glz::context&` parameter for custom errors:
+
+```c++
+void counter_read_checked(free_func_counter& obj, int val, glz::context& ctx)
+{
+   if (val < 0) {
+      ctx.error = glz::error_code::constraint_violated;
+      ctx.custom_error_message = "count cannot be negative";
+   }
+   else {
+      obj.count = val;
+   }
+}
+```
 
 ## manage
 

--- a/include/glaze/core/custom.hpp
+++ b/include/glaze/core/custom.hpp
@@ -100,13 +100,15 @@ namespace glz
             }
          }
          else {
-            if constexpr (is_invocable_concrete<From>) {
+            // Concrete callables: lambdas/function objects with concrete arguments and
+            // free function pointers (e.g. void (*)(T&, int))
+            if constexpr (is_invocable_concrete<From> || is_function_ptr_invocable<From>) {
                using Ret = invocable_result_t<From>;
                if constexpr (std::is_void_v<Ret>) {
                   using Tuple = invocable_args_t<From>;
                   constexpr auto N = glz::tuple_size_v<Tuple>;
                   if constexpr (N == 0) {
-                     static_assert(false_v<T>, "lambda must take in the class as the first argument");
+                     static_assert(false_v<T>, "callable must take in the class as the first argument");
                   }
                   else if constexpr (N == 1) {
                      skip_array<Opts>(ctx, it, end);
@@ -134,8 +136,19 @@ namespace glz
                      }
                   }
                }
+               else if constexpr (std::invocable<From, decltype(value.val)>) {
+                  // A non-void return acts as a getter: read into the returned reference
+                  decltype(auto) ref = value.from(value.val);
+                  glz::from<Format, std::decay_t<decltype(ref)>>::template op<Opts>(ref, ctx, it, end);
+               }
+               else if constexpr (std::invocable<From, decltype(value.val), context&>) {
+                  decltype(auto) ref = value.from(value.val, ctx);
+                  glz::from<Format, std::decay_t<decltype(ref)>>::template op<Opts>(ref, ctx, it, end);
+               }
                else {
-                  static_assert(false_v<T>, "lambda must have void return");
+                  static_assert(false_v<T>,
+                                "a callable with a non-void return must return a reference to read into and take "
+                                "only the class (and optionally glz::context&) as arguments");
                }
             }
             else if constexpr (std::invocable<From, decltype(value.val)>) {

--- a/include/glaze/core/custom_meta.hpp
+++ b/include/glaze/core/custom_meta.hpp
@@ -49,10 +49,12 @@ namespace glz
       template <class T>
       struct custom_read_input_type<
          T,
-         std::enable_if_t<has_custom_meta_v<T> &&
-                          is_invocable_concrete<typename decltype(glz::meta<T>::value(std::declval<T&>()))::from_t> &&
-                          (glz::tuple_size_v<invocable_args_t<typename decltype(glz::meta<T>::value(
-                              std::declval<T&>()))::from_t>> >= 2)>>
+         std::enable_if_t<
+            has_custom_meta_v<T> &&
+            (is_invocable_concrete<typename decltype(glz::meta<T>::value(std::declval<T&>()))::from_t> ||
+             is_function_ptr_invocable<typename decltype(glz::meta<T>::value(std::declval<T&>()))::from_t>) &&
+            (glz::tuple_size_v<invocable_args_t<typename decltype(glz::meta<T>::value(std::declval<T&>()))::from_t>> >=
+             2)>>
       {
          static constexpr bool has_custom = true;
          using CustomT = decltype(glz::meta<T>::value(std::declval<T&>()));

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -686,7 +686,7 @@ namespace glz
          }
       }
       else {
-         if constexpr (is_invocable_concrete<From>) {
+         if constexpr (is_invocable_concrete<From> || is_function_ptr_invocable<From>) {
             using Ret = invocable_result_t<From>;
             if constexpr (std::is_void_v<Ret>) {
                using Tuple = invocable_args_t<From>;

--- a/include/glaze/util/type_traits.hpp
+++ b/include/glaze/util/type_traits.hpp
@@ -369,11 +369,30 @@ namespace glz
       using arguments = std::tuple<Args...>;
    };
 
+   // Selects invocable_traits for a concrete callable: function objects (including lambdas)
+   // dispatch through decltype(&T::operator()), while free function pointers match
+   // invocable_traits directly. The primary template is intentionally empty (rather than a
+   // hard error) so that invocable_args_t/invocable_result_t remain SFINAE-friendly for other
+   // types, such as member pointers inspected inside std::enable_if_t conditions.
    template <class T>
-   using invocable_args_t = typename invocable_traits<decltype(&T::operator())>::arguments;
+   struct invocable_traits_for
+   {};
 
    template <class T>
-   using invocable_result_t = typename invocable_traits<decltype(&T::operator())>::result_type;
+      requires requires { &T::operator(); }
+   struct invocable_traits_for<T> : invocable_traits<decltype(&T::operator())>
+   {};
+
+   template <class T>
+      requires(std::is_pointer_v<T> && std::is_function_v<std::remove_pointer_t<T>>)
+   struct invocable_traits_for<T> : invocable_traits<T>
+   {};
+
+   template <class T>
+   using invocable_args_t = typename invocable_traits_for<T>::arguments;
+
+   template <class T>
+   using invocable_result_t = typename invocable_traits_for<T>::result_type;
 
    // checks if type is a lambda with all known arguments
    template <class T>

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -8958,6 +8958,216 @@ suite noexcept_mem_func_tests = [] {
    };
 };
 
+// Free function pointers (non-member) used with glz::custom
+// https://github.com/stephenberry/glaze/issues/2639
+// Free function parameters must match the exact struct type.
+
+struct ff_counter
+{
+   int count{};
+   std::string name{};
+};
+
+void ff_counter_read(ff_counter& obj, int val) { obj.count = val; }
+int ff_counter_write(const ff_counter& obj) { return obj.count; }
+
+template <>
+struct glz::meta<ff_counter>
+{
+   using T = ff_counter;
+   static constexpr auto value = object("count", custom<ff_counter_read, ff_counter_write>, "name", &T::name);
+};
+
+// Free function read with glz::context for custom error handling
+struct ff_safe
+{
+   int count{};
+   std::string name{};
+};
+
+void ff_safe_read(ff_safe& obj, int val, glz::context& ctx)
+{
+   if (val < 0) {
+      ctx.error = glz::error_code::constraint_violated;
+      ctx.custom_error_message = "count cannot be negative";
+   }
+   else {
+      obj.count = val;
+   }
+}
+
+int ff_safe_write(const ff_safe& obj) { return obj.count; }
+
+template <>
+struct glz::meta<ff_safe>
+{
+   using T = ff_safe;
+   static constexpr auto value = object("count", custom<ff_safe_read, ff_safe_write>, "name", &T::name);
+};
+
+// Free function read paired with a member pointer write
+struct ff_mixed
+{
+   int count{};
+   std::string name{};
+};
+
+void ff_mixed_read(ff_mixed& obj, int val) { obj.count = val; }
+
+template <>
+struct glz::meta<ff_mixed>
+{
+   using T = ff_mixed;
+   static constexpr auto value = object("count", custom<ff_mixed_read, &T::count>, "name", &T::name);
+};
+
+// Free function read + free function getter taking glz::context
+struct ff_ctx_getter
+{
+   int count{};
+   std::string name{};
+};
+
+void ff_ctx_getter_read(ff_ctx_getter& obj, int val) { obj.count = val; }
+int ff_ctx_getter_write(const ff_ctx_getter& obj, glz::context&) { return obj.count; }
+
+template <>
+struct glz::meta<ff_ctx_getter>
+{
+   using T = ff_ctx_getter;
+   static constexpr auto value = object("count", custom<ff_ctx_getter_read, ff_ctx_getter_write>, "name", &T::name);
+};
+
+// Free function setter with a string input and a const reference getter
+struct string_wrapper
+{
+   std::string data{};
+};
+
+void string_wrapper_read(string_wrapper& self, const std::string& input) { self.data = input; }
+const std::string& string_wrapper_write(const string_wrapper& self) { return self.data; }
+
+template <>
+struct glz::meta<string_wrapper>
+{
+   static constexpr auto value = object("d", custom<string_wrapper_read, string_wrapper_write>);
+};
+
+// Reference-returning free function: reading writes through the returned reference
+struct string_ref_holder
+{
+   std::string data{};
+};
+
+std::string& string_ref_access(string_ref_holder& self) { return self.data; }
+const std::string& string_ref_view(const string_ref_holder& self) { return self.data; }
+
+template <>
+struct glz::meta<string_ref_holder>
+{
+   static constexpr auto value = object("d", custom<string_ref_access, string_ref_view>);
+};
+
+suite free_function_custom_tests = [] {
+   // Free function read + free function write
+   "free_func_basic"_test = [] {
+      ff_counter obj{};
+      std::string s = R"({"count":42,"name":"hello"})";
+      expect(!glz::read_json(obj, s));
+      expect(obj.count == 42);
+      expect(obj.name == "hello");
+
+      s.clear();
+      expect(not glz::write_json(obj, s));
+      expect(s == R"({"count":42,"name":"hello"})");
+   };
+
+   // Free function read with context: valid value
+   "free_func_ctx_valid"_test = [] {
+      ff_safe obj{};
+      std::string s = R"({"count":10,"name":"test"})";
+      expect(!glz::read_json(obj, s));
+      expect(obj.count == 10);
+      expect(obj.name == "test");
+
+      s.clear();
+      expect(not glz::write_json(obj, s));
+      expect(s == R"({"count":10,"name":"test"})");
+   };
+
+   // Free function read with context: invalid value
+   "free_func_ctx_invalid"_test = [] {
+      ff_safe obj{};
+      std::string s = R"({"count":-5,"name":"test"})";
+      auto ec = glz::read_json(obj, s);
+      expect(bool(ec));
+      expect(obj.count == 0); // should not have been set
+      auto msg = glz::format_error(ec, s);
+      expect(msg.find("count cannot be negative") != std::string::npos);
+   };
+
+   // Mixed: free function read + member pointer write
+   "free_func_mixed"_test = [] {
+      ff_mixed obj{};
+      std::string s = R"({"count":7,"name":"mixed"})";
+      expect(!glz::read_json(obj, s));
+      expect(obj.count == 7);
+      expect(obj.name == "mixed");
+
+      s.clear();
+      expect(not glz::write_json(obj, s));
+      expect(s == R"({"count":7,"name":"mixed"})");
+   };
+
+   // Free function getter with context
+   "free_func_ctx_getter"_test = [] {
+      ff_ctx_getter obj{};
+      obj.count = 100;
+      std::string s;
+      expect(not glz::write_json(obj, s));
+      expect(s == R"({"count":100,"name":""})");
+
+      // Reading should still work
+      s = R"({"count":99,"name":"c"})";
+      obj = ff_ctx_getter{};
+      expect(!glz::read_json(obj, s));
+      expect(obj.count == 99);
+   };
+
+   // Free function read with a string input, including escape handling
+   "free_func_string_input"_test = [] {
+      string_wrapper obj{};
+      std::string json = R"({"d":"hello world"})";
+      expect(!glz::read_json(obj, json));
+      expect(obj.data == "hello world");
+
+      json.clear();
+      expect(not glz::write_json(obj, json));
+      expect(json == R"({"d":"hello world"})");
+
+      // escaped input must be unescaped on read and re-escaped on write
+      json = R"({"d":"line1\nline2"})";
+      expect(!glz::read_json(obj, json));
+      expect(obj.data == "line1\nline2");
+
+      json.clear();
+      expect(not glz::write_json(obj, json));
+      expect(json == R"({"d":"line1\nline2"})");
+   };
+
+   // A reference-returning free function reads into the returned reference
+   "free_func_ref_getter"_test = [] {
+      string_ref_holder obj{};
+      std::string json = R"({"d":"ref test"})";
+      expect(!glz::read_json(obj, json));
+      expect(obj.data == "ref test");
+
+      json.clear();
+      expect(not glz::write_json(obj, json));
+      expect(json == R"({"d":"ref test"})");
+   };
+};
+
 struct constrained_object
 {
    int age{};


### PR DESCRIPTION
Resolves #2639

Free functions can now be used with `glz::custom`, following the same conventions as lambdas: the object is the first argument, the decoded input is the second, and an optional `glz::context&` third argument enables custom error handling. A free function with a non-void return acts as a getter, so reading decodes into the returned reference and writing serializes the returned value.

```c++
struct free_func_counter
{
   int count{};
};

void counter_read(free_func_counter& obj, int val) { obj.count = val; }
int counter_write(const free_func_counter& obj) { return obj.count; }

template <>
struct glz::meta<free_func_counter>
{
   static constexpr auto value = object("count", custom<counter_read, counter_write>);
};
```

### Implementation notes

- `invocable_args_t`/`invocable_result_t` now dispatch through a new `invocable_traits_for` selector that handles function objects via `decltype(&T::operator())` and free function pointers directly. Its primary template is intentionally empty so the aliases remain SFINAE-friendly for other types (e.g. `std::function` member pointers inspected inside `std::enable_if_t` conditions), matching the previous alias behavior.
- `is_invocable_concrete` is deliberately unchanged (it still means "callable with a concrete `operator()`"), so the dispatch chains in `registry.hpp`, `cli_menu.hpp`, and `constraint.hpp` are unaffected. The places that support free functions (`custom.hpp`, `custom_meta.hpp`, `reflect.hpp`) opt in explicitly with `is_function_ptr_invocable`.
- The custom read dispatch routes non-void concrete callables to the reference-read path instead of a blanket `static_assert`, so reference-returning free functions (and now concrete lambdas) work as read-side getters.
- `custom_read_input_type` recognizes free function setters, enabling variant type deduction and JSON schema generation for them, on par with lambdas.

### Tests

New `free_function_custom_tests` suite in `json_test` covering: basic free read/write, the `glz::context&` read and write forms with custom error messages, mixing a free function with a member pointer, string inputs including escape round-tripping, and a reference-returning free function. Also verified compile-compatibility for registry member-function endpoints, registry function-pointer endpoints, whole-value `custom` over `std::function` members inside variants and schema generation, and `cli_menu` structs with multi-argument function pointer members.