### PR TITLE
reject foreign column headers in colwise csv struct readers

### DIFF
--- a/include/glaze/csv/read.hpp
+++ b/include/glaze/csv/read.hpp
@@ -1097,7 +1097,10 @@ namespace glz
                   const auto member_idx = decode_hash_with_size<CSV, U, HashInfo, HashInfo.type>::op(
                      key.data(), key.data() + key.size(), key.size());
 
-                  if (member_idx >= N) [[unlikely]] {
+                  // Confirm the decoded index actually matches the header string. The hash can
+                  // return an in-range index for a non-member key that happens to collide, so a
+                  // bare index check would silently route a foreign column onto a real member.
+                  if (member_idx >= N || reflect<U>::keys[member_idx] != key) [[unlikely]] {
                      ctx.error = error_code::unknown_key;
                      return;
                   }
@@ -1460,7 +1463,7 @@ namespace glz
                      const auto index = decode_hash_with_size<CSV, T, HashInfo, HashInfo.type>::op(
                         key.data(), key.data() + key.size(), key.size());
 
-                     if (index < N) [[likely]] {
+                     if (index < N && reflect<T>::keys[index] == key) [[likely]] {
                         visit<N>(
                            [&]<size_t I>() {
                               decltype(auto) member = [&]() -> decltype(auto) {

--- a/tests/csv_test/csv_test.cpp
+++ b/tests/csv_test/csv_test.cpp
@@ -118,6 +118,14 @@ struct glz::meta<enum_column_struct>
    static constexpr auto value = glz::object("colors", &T::colors);
 };
 
+struct four_int_columns
+{
+   int alpha{};
+   int bravo{};
+   int charlie{};
+   int delta{};
+};
+
 suite csv_tests = [] {
    "read/write column wise"_test = [] {
       std::string input_col =
@@ -216,6 +224,35 @@ suite csv_tests = [] {
 )");
 
       expect(!glz::write_file_csv<glz::colwise>(obj, "csv_test_colwise.csv", std::string{}));
+   };
+
+   "column wise rejects colliding foreign header"_test = [] {
+      // "uJXtL" is not a member of four_int_columns, but the key hash decodes it to the
+      // same index as "alpha". The rowwise and enum readers already reject a decoded index
+      // whose key text does not match; the colwise readers must reject it too instead of
+      // silently routing the foreign column onto alpha.
+      {
+         four_int_columns obj{};
+         std::string input = "uJXtL\n77\n";
+         auto ec = glz::read_csv<glz::colwise>(obj, input);
+         expect(ec.ec == glz::error_code::unknown_key);
+         expect(obj.alpha == 0);
+      }
+      {
+         std::vector<four_int_columns> obj{};
+         std::string input = "uJXtL\n77\n";
+         auto ec = glz::read_csv<glz::colwise>(obj, input);
+         expect(ec.ec == glz::error_code::unknown_key);
+         expect(obj.empty());
+      }
+      // A legitimate header on the same struct still parses.
+      {
+         four_int_columns obj{};
+         std::string input = "alpha\n77\n";
+         auto ec = glz::read_csv<glz::colwise>(obj, input);
+         expect(!ec);
+         expect(obj.alpha == 77);
+      }
    };
 
    "signed minimum integers"_test = [] {


### PR DESCRIPTION
Repro: read a headed colwise CSV whose column name is not a field but whose key hash collides onto one (e.g. a struct {alpha,bravo,charlie,delta} read with the header "uJXtL").

Cause: the two colwise readers route each header through decode_hash_with_size and check only index < N. The hash returns an in-range index for non-member keys that collide, so the foreign column is accepted and its value lands in an unrelated field.

Fix: compare reflect<T>::keys[index] against the header text before accepting, the same guard the rowwise object reader and the enum reader already apply.

Before: "uJXtL\n77\n" colwise returns success and sets alpha = 77.
After: the same input returns unknown_key, matching the rowwise path. Legitimate headers, including array-element headers like v3s[0], are unchanged.

Tradeoff: one extra string compare per column at parse time. Regression test added under the csv suite.