### PR TITLE
Reject truncated JSON arrays in null-terminated reads

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2426,6 +2426,17 @@ namespace glz
                      return;
                   }
                }
+
+               // A valid array always returns from inside the loop upon reaching ']'.
+               // For a null-terminated buffer the loop can only exit here by falling
+               // through when `it` reaches the terminator without a closing bracket,
+               // which means the input was truncated (e.g. "[", "[1," or "[1,2,").
+               // Non-null-terminated buffers surface this through skip_ws/depth
+               // tracking (or the streaming refill break), so this guard is limited
+               // to the null-terminated case.
+               if constexpr (Opts.null_terminated) {
+                  ctx.error = error_code::unexpected_end;
+               }
             }
             else {
                ctx.error = error_code::exceeded_static_array_size;

--- a/tests/json_conformance/json_conformance.cpp
+++ b/tests/json_conformance/json_conformance.cpp
@@ -52,6 +52,36 @@ inline void should_fail()
       }
    };
 
+   // A trailing comma with no following element, or a bare '[', must be rejected rather than
+   // silently accepted as a complete array.
+   "truncated array"_test = [] {
+      for (const sv s : {sv{"["}, sv{"[ "}, sv{"[1,"}, sv{"[1, "}, sv{"[1,2,"}}) {
+         {
+            std::vector<int> v;
+            expect(glz::read_json(v, s)) << s;
+         }
+         {
+            std::deque<int> v;
+            expect(glz::read_json(v, s)) << s;
+         }
+         {
+            std::list<int> v;
+            expect(glz::read_json(v, s)) << s;
+         }
+         {
+            glz::generic obj{};
+            expect(glz::read_json(obj, s)) << s;
+         }
+      }
+   };
+
+   "truncated nested array"_test = [] {
+      for (const sv s : {sv{"[["}, sv{"[[1,"}, sv{"[[1],"}}) {
+         std::vector<std::vector<int>> v;
+         expect(glz::read_json(v, s)) << s;
+      }
+   };
+
    "unquoted_key"_test = [] {
       constexpr sv s = R"({unquoted_key: "keys must be quoted"})";
       {


### PR DESCRIPTION
## Problem

With `null_terminated = true` (the default), Glaze silently accepts truncated JSON arrays. For example:

```cpp
std::vector<int> v{};
const auto error = glz::read_json(v, std::string{"[1,"}); // truncated JSON
// error.ec == none, v == {1}  -- the truncated array is accepted
```

Inputs like `[1,`, `[1,2,`, and a bare `[` all parse as "successful" complete arrays. Setting `validate_skipped`, `validate_trailing_whitespace`, or `error_on_missing_array_elements` does not help, since none of them gate the affected code path.

## Root cause

The *growing* array reader (used for `std::vector`, `std::deque`, `std::list`, `inplace_vector`, `glz::generic`, etc.) looped with `while (it < end)`. In null-terminated mode a trailing comma advances `it` to the terminating sentinel (or a bare `[` leaves the growing loop empty), so the loop condition becomes false and the loop **falls through without setting an error**.

This only affected the growing path. Fixed-size arrays (`std::array`), `std::set` (which pre-counts via `number_of_array_elements`, with an explicit `case '\0'`), and pre-sized containers with enough slots already rejected truncation because they parse the next value directly and fail on the sentinel. Object/map readers use `while (true)` and were never affected.

## Fix

A valid array always returns from inside the loop upon reaching `]`, so in null-terminated mode a fall-through can only mean the input was truncated. Report `unexpected_end` there:

```cpp
if constexpr (Opts.null_terminated) {
   ctx.error = error_code::unexpected_end;
}
```

The guard is limited to the null-terminated case because non-null-terminated / streaming buffers already surface truncation through `skip_ws`/depth tracking (`end_reached`) or the streaming refill break, and those must keep their existing behavior. The check sits outside the loop and only runs on the fall-through path, so there is **no overhead on well-formed input**.

## Tests

Added `truncated array` and `truncated nested array` cases to `json_conformance.cpp`, covering `std::vector`, `std::deque`, `std::list`, and `glz::generic`. They run under all three `should_fail<Opts>()` configurations.

Verified locally:
- The reported repro now returns `unexpected_end` instead of `none`.
- `json_conformance`: 99 tests / 252 asserts pass.
- `json_test`: 688 tests / 60,433 asserts pass (no regressions).
- `istream_buffer_test` (streaming / non-null-terminated), `inplace_vector_test`, `int_parsing`, `json_reflection_test`, `ostream_buffer_test`, `mock_json_test` all pass.
