### PR TITLE
bound lazy beve object key length to remaining input

### DIFF
--- a/include/glaze/beve/lazy.hpp
+++ b/include/glaze/beve/lazy.hpp
@@ -738,6 +738,9 @@ namespace glz
          const char* counter = p;
          while (counter < search_start && start_index < n_keys) {
             const auto key_len = detail::read_compressed_int(counter, end);
+            if (static_cast<size_t>(end - counter) < key_len) [[unlikely]] {
+               break;
+            }
             counter += key_len;
             counter = detail::skip_value_beve_lazy<Opts>(counter, end);
             ++start_index;
@@ -748,6 +751,9 @@ namespace glz
       const char* iter = search_start;
       for (size_t i = start_index; i < n_keys; ++i) {
          const auto key_len = detail::read_compressed_int(iter, end);
+         if (static_cast<size_t>(end - iter) < key_len) [[unlikely]] {
+            return make_error(error_code::unexpected_end);
+         }
          std::string_view current_key{iter, key_len};
          iter += key_len;
 
@@ -764,6 +770,9 @@ namespace glz
          iter = p;
          for (size_t i = 0; i < start_index; ++i) {
             const auto key_len = detail::read_compressed_int(iter, end);
+            if (static_cast<size_t>(end - iter) < key_len) [[unlikely]] {
+               return make_error(error_code::unexpected_end);
+            }
             std::string_view current_key{iter, key_len};
             iter += key_len;
 
@@ -884,6 +893,13 @@ namespace glz
          if (has_string_keys_) {
             // String key: length prefix + string data
             const auto key_len = detail::read_compressed_int(current_pos_, beve_end_);
+            if (static_cast<size_t>(beve_end_ - current_pos_) < key_len) [[unlikely]] {
+               // Declared key length runs past the buffer; stop rather than
+               // handing back a view over out-of-bounds memory.
+               at_end_ = true;
+               current_view_ = lazy_beve_view<Opts>::make_error(error_code::unexpected_end);
+               return;
+            }
             key = std::string_view{current_pos_, key_len};
             current_pos_ += key_len;
          }
@@ -981,6 +997,11 @@ namespace glz
             // Object with string keys
             for (size_t i = 0; i < count; ++i) {
                const auto key_len = detail::read_compressed_int(p, end);
+               if (static_cast<size_t>(end - p) < key_len) [[unlikely]] {
+                  // Truncated key; stop indexing instead of storing an
+                  // out-of-bounds key view.
+                  break;
+               }
                std::string_view key{p, key_len};
                p += key_len;
 

--- a/tests/beve_test/lazy_beve_test.cpp
+++ b/tests/beve_test/lazy_beve_test.cpp
@@ -1018,6 +1018,27 @@ suite lazy_beve_tests = [] {
       expect(missing.error() == glz::error_code::key_not_found);
    };
 
+   "lazy_beve_object_key_length_past_end"_test = [] {
+      // Object with string keys (0x03), one key (compressed count 0x04), a key
+      // length prefix of 60 (0xF0), and no key bytes: the declared key length
+      // runs past the end of the buffer. The scanner must not build a key view
+      // over the missing bytes.
+      std::vector<std::byte> buffer{std::byte{0x03}, std::byte{0x04}, std::byte{0xF0}};
+
+      auto result = glz::lazy_beve(buffer);
+      expect(result.has_value());
+      auto& doc = result.value();
+
+      for (auto v : doc.root()) {
+         expect(v.key().size() <= buffer.size());
+      }
+
+      expect(doc.root().index().size() == 0);
+
+      auto looked_up = doc.root()["anything"];
+      expect(looked_up.has_error());
+   };
+
    // ============================================================================
    // Unsigned integer array tests
    // ============================================================================


### PR DESCRIPTION
The lazy BEVE navigator scans object keys on demand: it reads each key's compressed length prefix and then builds a std::string_view of that length without checking it against the bytes left in the buffer. lazy_beve accepts an unpadded buffer and validates only the first byte, so an object whose key-length prefix is larger than the remaining input makes a range-for over the document (advance_to_current_element) and index() return a key view spanning past the end. Reading that key is an out-of-bounds read of attacker-controlled length; operator[] compares the same over-long view.

Before, only get<std::string>/get<std::string_view> and skip_string_content bounded the length with end - p < len; the key-scan sites had no check at all. After, each key-scan site applies the same bound and either stops the scan (index, the operator[] counter pass) or returns unexpected_end (the operator[] search, the iterator) rather than viewing past the buffer. The bound sits in the scanner because that is where the key view is produced and handed back; the trade is that a truncated key now ends iteration instead of yielding a bogus key, matching what the value readers in this file already do. Added a lazy_beve_test case that fails under ASan before the change.