### PR TITLE
escape method in repe to_jsonrpc_request

### DIFF
--- a/include/glaze/rpc/repe/repe_to_jsonrpc.hpp
+++ b/include/glaze/rpc/repe/repe_to_jsonrpc.hpp
@@ -65,10 +65,12 @@ namespace glz::repe
          method = method.substr(1);
       }
 
-      // Build JSON-RPC request
-      std::string result = R"({"jsonrpc":"2.0","method":")";
-      result += method;
-      result += R"(","params":)";
+      // Build JSON-RPC request. The method comes from the REPE query, which is
+      // attacker-controlled on the wire, so write it as a JSON string (quoted
+      // and escaped) instead of splicing it in between raw quotes.
+      std::string result = R"({"jsonrpc":"2.0","method":)";
+      result += glz::write_json(method).value_or(R"("")");
+      result += R"(,"params":)";
 
       // Add params from body (or empty object if no body)
       if (!msg.body.empty()) {

--- a/tests/networking_tests/repe_to_jsonrpc_test/repe_to_jsonrpc_test.cpp
+++ b/tests/networking_tests/repe_to_jsonrpc_test/repe_to_jsonrpc_test.cpp
@@ -74,6 +74,32 @@ suite repe_to_jsonrpc_request_tests = [] {
       expect(jsonrpc_str.find("Invalid request") != std::string::npos) << jsonrpc_str;
       expect(jsonrpc_str.find("REPE body must be JSON format") != std::string::npos) << jsonrpc_str;
    };
+
+   "method_with_quote_cannot_inject_members"_test = [] {
+      // The method comes verbatim from the untrusted REPE query. A method that
+      // contains a quote must stay inside the JSON string rather than break out
+      // and add sibling members to the emitted request.
+      repe::message msg{};
+      msg.query = R"(add","id":1337,"params":["INJECTED"],"x":")";
+      msg.body = R"([1,2,3])";
+      msg.header.id = 42;
+      msg.header.body_format = repe::body_format::JSON;
+      msg.header.notify = false;
+
+      auto jsonrpc_str = repe::to_jsonrpc_request(msg);
+      expect(
+         jsonrpc_str ==
+         R"({"jsonrpc":"2.0","method":"add\",\"id\":1337,\"params\":[\"INJECTED\"],\"x\":\"","params":[1,2,3],"id":42})")
+         << jsonrpc_str;
+
+      auto parsed = glz::read_json<glz::generic>(jsonrpc_str);
+      expect(parsed.has_value()) << jsonrpc_str;
+      if (parsed) {
+         auto& obj = parsed->get_object();
+         expect(obj.at("method").get<std::string>() == msg.query) << jsonrpc_str;
+         expect(not obj.contains("x")) << jsonrpc_str;
+      }
+   };
 };
 
 suite repe_to_jsonrpc_response_tests = [] {


### PR DESCRIPTION
to_jsonrpc_request pastes the method between two literal quotes without escaping it. The method is msg.query, the REPE query read straight off the wire, so a method that contains a double quote closes the "method" string early and the trailing bytes are parsed as sibling members. A query like `add","id":1337,"params":["INJECTED"],"x":"` makes the function emit a JSON-RPC request carrying an attacker-chosen id and params rather than the caller's.

Writing the method through write_json emits it as a quoted, escaped JSON string, the way registry.hpp already builds its method field and to_jsonrpc_response already escapes its body. This belongs in the callee because the function owns the REPE to JSON-RPC boundary and the caller only holds the raw query. Before, a quote in the method broke out and injected sibling members; after, the method round-trips as one string value, and a method with no special characters serializes to the same bytes as before.