### PR TITLE
Document the JSON body precondition on repe to_jsonrpc conversion

### DIFF
--- a/include/glaze/rpc/repe/repe_to_jsonrpc.hpp
+++ b/include/glaze/rpc/repe/repe_to_jsonrpc.hpp
@@ -53,6 +53,16 @@ namespace glz::repe
    // Convert REPE message to JSON-RPC request
    // The query should be a method name (with or without leading slash)
    // The body should be JSON formatted params
+   //
+   // Precondition: msg.body must be a single, complete JSON value. It is spliced
+   // in verbatim as the "params" value; it is NOT validated or re-serialized (by
+   // design, to avoid a redundant parse). A body that is a valid JSON value
+   // followed by trailing bytes (e.g. `[1,2,3],"method":"other"`) injects sibling
+   // members into the emitted object. This is not caught downstream: duplicate
+   // keys are valid JSON, so the reader accepts the request and the injected
+   // members silently override the caller's (last-wins). Callers converting
+   // untrusted, wire-sourced messages must validate the body (e.g. with
+   // glz::validate_json) at their trust boundary before calling this.
    inline std::string to_jsonrpc_request(const message& msg)
    {
       if (msg.header.body_format != body_format::JSON) {
@@ -94,6 +104,16 @@ namespace glz::repe
    }
 
    // Convert REPE message to JSON-RPC response
+   //
+   // Precondition: for a success response (msg.header.ec == none), msg.body must
+   // be a single, complete JSON value. It is spliced in verbatim as the "result"
+   // value; it is NOT validated or re-serialized (by design, to avoid a redundant
+   // parse). A body that is a valid JSON value followed by trailing bytes injects
+   // sibling members into the emitted object, which the downstream reader accepts
+   // as valid JSON rather than rejects. Callers converting untrusted, wire-sourced
+   // messages must validate the body (e.g. with glz::validate_json) at their trust
+   // boundary before calling this. (Error responses carry msg.body as the error
+   // "data" string and are escaped, so this does not apply to them.)
    inline std::string to_jsonrpc_response(const message& msg)
    {
       if (msg.header.body_format != body_format::JSON && msg.header.body_format != body_format::UTF8) {


### PR DESCRIPTION
Follow-up to #2699, which escaped the `method`. Reviewing that fix surfaced that `to_jsonrpc_request` (params) and the success path of `to_jsonrpc_response` (result) splice `msg.body` in verbatim as a JSON value.

Rather than add a runtime validation pass (a redundant parse the downstream reader repeats, and inconsistent with glaze's trust-the-writer model), this just makes the precondition explicit on both functions.

## Why it's worth documenting

The failure mode is unusual. The REPE decoder doesn't validate the body against its `body_format` flag — it slices `body_length` bytes into a view (`repe.hpp:295`) — and this converter splices those bytes in as-is. A body that is a valid JSON value followed by trailing bytes injects sibling members:

```
msg.body = R"([1,2,3],"method":"admin_delete_all")"   // body_format = JSON
// -> {"jsonrpc":"2.0","method":"add","params":[1,2,3],"method":"admin_delete_all","id":42}
```

Crucially this is **not** caught downstream: duplicate keys are valid JSON (RFC 8259), so the reader accepts the request and — last-wins — dispatches `admin_delete_all`. Unlike a malformed body, an injected-but-valid body never triggers a parse error, so a caller can't rely on "the reader will reject bad input."

## The change

Documents on both functions that `msg.body` is spliced verbatim and must be a single, complete JSON value, and that callers converting untrusted, wire-sourced messages must validate it (e.g. `glz::validate_json`) at their trust boundary. Docs-only, no runtime cost.