### PR TITLE
reject ".." traversal (/ and \) in route param and wildcard captures

### DIFF
--- a/include/glaze/net/http_router.hpp
+++ b/include/glaze/net/http_router.hpp
@@ -349,25 +349,32 @@ namespace glz
       /**
        * @brief Detect a ".." path-traversal component in a decoded capture.
        *
-       * Returns true when `path` contains a ".." segment delimited by '/' or a
-       * string boundary. Percent-decoding happens after the target is split on
-       * literal '/', so a "%2e%2e%2f" sequence only becomes a "../" here; a
-       * capture carrying such a segment can climb out of a base directory once
-       * a handler resolves it as a filesystem path.
+       * Returns true when `path` contains a ".." segment delimited by a
+       * separator or a string boundary. Percent-decoding happens after the
+       * target is split on literal '/', so a "%2e%2e%2f" sequence only becomes
+       * a "../" here; a capture carrying such a segment can climb out of a base
+       * directory once a handler resolves it as a filesystem path.
+       *
+       * Both '/' and '\\' are treated as separators: on Windows the backslash
+       * is a path separator too, so a "%2e%2e%5c" ("..\") capture traverses the
+       * same way and an encoded backslash would otherwise slip past a '/'-only
+       * check. A backslash is a legal byte in a POSIX filename, but a capture
+       * bound for a filesystem join is exactly the case guarded here, so the
+       * traversal reading wins over the rare literal-backslash name.
        */
       static bool has_dot_dot_segment(std::string_view path) noexcept
       {
          size_t start = 0;
          while (true) {
-            const size_t slash = path.find('/', start);
-            const size_t seg_len = (slash == std::string_view::npos ? path.size() : slash) - start;
+            const size_t sep = path.find_first_of("/\\", start);
+            const size_t seg_len = (sep == std::string_view::npos ? path.size() : sep) - start;
             if (seg_len == 2 && path[start] == '.' && path[start + 1] == '.') {
                return true;
             }
-            if (slash == std::string_view::npos) {
+            if (sep == std::string_view::npos) {
                return false;
             }
-            start = slash + 1;
+            start = sep + 1;
          }
       }
 

--- a/include/glaze/net/http_router.hpp
+++ b/include/glaze/net/http_router.hpp
@@ -347,6 +347,31 @@ namespace glz
       }
 
       /**
+       * @brief Detect a ".." path-traversal component in a decoded capture.
+       *
+       * Returns true when `path` contains a ".." segment delimited by '/' or a
+       * string boundary. Percent-decoding happens after the target is split on
+       * literal '/', so a "%2e%2e%2f" sequence only becomes a "../" here; a
+       * capture carrying such a segment can climb out of a base directory once
+       * a handler resolves it as a filesystem path.
+       */
+      static bool has_dot_dot_segment(std::string_view path) noexcept
+      {
+         size_t start = 0;
+         while (true) {
+            const size_t slash = path.find('/', start);
+            const size_t seg_len = (slash == std::string_view::npos ? path.size() : slash) - start;
+            if (seg_len == 2 && path[start] == '.' && path[start + 1] == '.') {
+               return true;
+            }
+            if (slash == std::string_view::npos) {
+               return false;
+            }
+            start = slash + 1;
+         }
+      }
+
+      /**
        * @brief Register a route in the table.
        *
        * @param method The HTTP method (GET, POST, etc.)
@@ -538,14 +563,21 @@ namespace glz
          }
 
          if (node->parameter_child) {
-            std::string param_name = node->parameter_child->parameter_name;
-            params[param_name] = url_decode(segment);
+            std::string decoded = url_decode(segment);
 
-            if (match_node(node->parameter_child.get(), segments, index + 1, method, params, result)) {
-               return true;
+            // A ":param" captures a single segment; refuse a decoded ".."
+            // component so the value cannot escape a base directory when a
+            // handler treats it as a path.
+            if (!has_dot_dot_segment(decoded)) {
+               std::string param_name = node->parameter_child->parameter_name;
+               params[param_name] = std::move(decoded);
+
+               if (match_node(node->parameter_child.get(), segments, index + 1, method, params, result)) {
+                  return true;
+               }
+
+               params.erase(param_name);
             }
-
-            params.erase(param_name);
          }
 
          if (node->wildcard_child) {
@@ -553,6 +585,13 @@ namespace glz
             for (size_t i = index; i < segments.size(); i++) {
                if (i > index) full_capture += "/";
                full_capture += url_decode(segments[i]);
+            }
+
+            // The capture is joined from decoded segments, so a "%2e%2e%2f" in
+            // the request only resolves to a ".." here; refuse it so a mount
+            // like "/files/*path" cannot be walked outside its base directory.
+            if (has_dot_dot_segment(full_capture)) {
+               return false;
             }
 
             const auto& wildcard_name = node->wildcard_child->parameter_name;

--- a/tests/networking_tests/http_router_test/http_router_test.cpp
+++ b/tests/networking_tests/http_router_test/http_router_test.cpp
@@ -433,6 +433,46 @@ suite path_param_decoding_tests = [] {
    };
 };
 
+// Route captures must not resolve to a ".." traversal component. The target is
+// split on literal '/' before percent-decoding, so a "%2e%2e%2f" reaches the
+// capture as "../" only here; leaving it in place lets a handler that resolves
+// the capture as a path escape its base directory.
+suite path_traversal_tests = [] {
+   "wildcard_rejects_encoded_traversal"_test = [] {
+      glz::http_router router;
+      router.get("/files/*path", [](const glz::request&, glz::response&) {});
+
+      auto [handler, params] = router.match(glz::http_method::GET, "/files/..%2f..%2f..%2fetc%2fpasswd");
+      expect(handler == nullptr);
+   };
+
+   "wildcard_rejects_plain_traversal"_test = [] {
+      glz::http_router router;
+      router.get("/files/*path", [](const glz::request&, glz::response&) {});
+
+      auto [handler, params] = router.match(glz::http_method::GET, "/files/../../etc/passwd");
+      expect(handler == nullptr);
+   };
+
+   "param_rejects_encoded_traversal"_test = [] {
+      glz::http_router router;
+      router.get("/download/:file", [](const glz::request&, glz::response&) {});
+
+      auto [handler, params] = router.match(glz::http_method::GET, "/download/..%2f..%2fsecret");
+      expect(handler == nullptr);
+   };
+
+   "wildcard_allows_dotdot_within_segment"_test = [] {
+      glz::http_router router;
+      router.get("/files/*path", [](const glz::request&, glz::response&) {});
+
+      // ".." only escapes when it is a whole segment; "a..b" is an ordinary name.
+      auto [handler, params] = router.match(glz::http_method::GET, "/files/a..b/report.pdf");
+      expect(handler != nullptr);
+      expect(params["path"] == "a..b/report.pdf");
+   };
+};
+
 // Service composition test types (GitHub issue #2401)
 
 struct Task

--- a/tests/networking_tests/http_router_test/http_router_test.cpp
+++ b/tests/networking_tests/http_router_test/http_router_test.cpp
@@ -471,6 +471,35 @@ suite path_traversal_tests = [] {
       expect(handler != nullptr);
       expect(params["path"] == "a..b/report.pdf");
    };
+
+   "wildcard_rejects_encoded_backslash_traversal"_test = [] {
+      glz::http_router router;
+      router.get("/files/*path", [](const glz::request&, glz::response&) {});
+
+      // '\' is a path separator on Windows, so "..%5c" decodes to a "..\"
+      // traversal segment that must be refused alongside "../".
+      auto [handler, params] = router.match(glz::http_method::GET, "/files/..%5c..%5cwindows%5cwin.ini");
+      expect(handler == nullptr);
+   };
+
+   "param_rejects_encoded_backslash_traversal"_test = [] {
+      glz::http_router router;
+      router.get("/download/:file", [](const glz::request&, glz::response&) {});
+
+      auto [handler, params] = router.match(glz::http_method::GET, "/download/..%5c..%5csecret");
+      expect(handler == nullptr);
+   };
+
+   "wildcard_allows_backslash_within_segment"_test = [] {
+      glz::http_router router;
+      router.get("/files/*path", [](const glz::request&, glz::response&) {});
+
+      // A backslash that does not delimit a lone ".." is left intact; only the
+      // ".." segment triggers a refusal.
+      auto [handler, params] = router.match(glz::http_method::GET, "/files/a..b%5creport.pdf");
+      expect(handler != nullptr);
+      expect(params["path"] == "a..b\\report.pdf");
+   };
 };
 
 // Service composition test types (GitHub issue #2401)


### PR DESCRIPTION
Against a "*wildcard" mount the router returns a capture it decoded past the path structure:

    router.get("/files/*path", ...);
    GET /files/..%2f..%2f..%2fetc%2fpasswd  ->  params["path"] == "../../../etc/passwd"

The request target is split on literal '/' first and each segment is url_decoded afterward, so a "%2e%2e%2f" resolves to "../" only once it lands in the capture. A front proxy sees the opaque encoded form and cannot normalize it, so the ".." first exists here; a handler that joins the capture onto a base directory then reads outside it (CWE-22). ":param" captures decode the same way (GET /download/..%2f..%2fsecret gives "../../secret").

An encoded backslash decodes the same way: "%5c" becomes "\", a path separator on Windows, so GET /files/..%5c..%5cwindows%5cwin.ini reaches the capture as "..\..\windows\win.ini" and climbs out of the base directory just as "../" does.

Before: param and wildcard captures were returned verbatim after decoding, ".." segments included.
After: a capture whose decoded value has a ".." segment delimited by '/' or '\' (or a string boundary) yields no match and the handler is not called. "a..b" and encoded separators inside a single segment stay valid, and the url-decode behavior for ordinary captures is unchanged.

Tradeoff: a route that deliberately wanted a ".." segment now gets a miss; at the routing layer that case is indistinguishable from traversal, so it is refused rather than forwarded. A literal backslash is a legal POSIX filename byte, but a capture bound for a filesystem join is exactly the guarded case, so it is treated as a separator too.
