### PR TITLE
fix signed overflow in jsonb_to_json int5 hex conversion

### DIFF
--- a/include/glaze/jsonb/jsonb_to_json.hpp
+++ b/include/glaze/jsonb/jsonb_to_json.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <string>
 #include <string_view>
 
@@ -130,9 +131,13 @@ namespace glz
             return;
          }
          case jsonb::type::int5: {
-            // Parse and re-emit as decimal so the output is strict JSON.
+            // Parse and re-emit as strict JSON. The magnitude is accumulated as an
+            // unsigned value so a negative literal whose magnitude has the sign bit
+            // set (e.g. "-0x8000000000000000") negates without the signed-overflow
+            // UB, and a positive literal above INT64_MAX ("0xFFFFFFFFFFFFFFFF") keeps
+            // its value instead of wrapping to a negative int. Mirrors the reader's
+            // parse_int_payload in jsonb/read.hpp.
             sv s{reinterpret_cast<const char*>(payload), static_cast<size_t>(sz)};
-            // Strip leading '+'.
             const char* p = s.data();
             const char* e = p + s.size();
             bool neg = false;
@@ -141,26 +146,26 @@ namespace glz
                neg = true;
                ++p;
             }
-            int64_t value = 0;
-            if (e - p >= 2 && p[0] == '0' && (p[1] == 'x' || p[1] == 'X')) {
-               uint64_t tmp = 0;
-               auto [ptr, ec] = std::from_chars(p + 2, e, tmp, 16);
-               if (ec != std::errc{} || ptr != e) {
+            const int base = (e - p >= 2 && p[0] == '0' && (p[1] == 'x' || p[1] == 'X')) ? 16 : 10;
+            const char* digits = (base == 16) ? p + 2 : p;
+            uint64_t mag = 0;
+            auto [ptr, ec] = std::from_chars(digits, e, mag, base);
+            if (ec != std::errc{} || ptr != e) {
+               ctx.error = error_code::parse_number_failure;
+               return;
+            }
+            if (neg) {
+               // |INT64_MIN| == INT64_MAX + 1, so that magnitude is still representable.
+               constexpr uint64_t max_neg_mag = static_cast<uint64_t>((std::numeric_limits<int64_t>::max)()) + 1u;
+               if (mag > max_neg_mag) {
                   ctx.error = error_code::parse_number_failure;
                   return;
                }
-               value = neg ? -static_cast<int64_t>(tmp) : static_cast<int64_t>(tmp);
+               to<JSON, int64_t>::template op<Opts>(static_cast<int64_t>(uint64_t{0} - mag), ctx, out, ix);
             }
             else {
-               int64_t tmp = 0;
-               auto [ptr, ec] = std::from_chars(p, e, tmp, 10);
-               if (ec != std::errc{} || ptr != e) {
-                  ctx.error = error_code::parse_number_failure;
-                  return;
-               }
-               value = neg ? -tmp : tmp;
+               to<JSON, uint64_t>::template op<Opts>(mag, ctx, out, ix);
             }
-            to<JSON, int64_t>::template op<Opts>(value, ctx, out, ix);
             return;
          }
          case jsonb::type::float5: {

--- a/tests/jsonb_test/jsonb_test.cpp
+++ b/tests/jsonb_test/jsonb_test.cpp
@@ -1130,6 +1130,33 @@ suite converter_tests = [] {
       expect(j.value() == "255");
    };
 
+   "jsonb_to_json INT5 hex sign-bit magnitudes"_test = [] {
+      auto convert = [](const std::string& payload) {
+         std::string buf;
+         buf.push_back(static_cast<char>((12u << 4) | 4u)); // INT5, u8_follows
+         buf.push_back(static_cast<char>(payload.size()));
+         buf += payload;
+         return glz::jsonb_to_json(buf);
+      };
+
+      // "-0x8000000000000000" is exactly int64 min; negating the signed magnitude was UB.
+      auto j = convert("-0x8000000000000000");
+      expect(j.has_value());
+      expect(j.value() == "-9223372036854775808");
+
+      // Positive magnitudes with the sign bit set used to wrap to a negative int.
+      j = convert("0x8000000000000000");
+      expect(j.has_value());
+      expect(j.value() == "9223372036854775808");
+
+      j = convert("0xFFFFFFFFFFFFFFFF");
+      expect(j.has_value());
+      expect(j.value() == "18446744073709551615");
+
+      // A negative magnitude past int64 min has no representation and is rejected.
+      expect(!convert("-0x8000000000000001").has_value());
+   };
+
    "jsonb_to_json maps NaN to null and infinities to 9e999"_test = [] {
       std::string buf;
       expect(not glz::write_jsonb(std::numeric_limits<double>::quiet_NaN(), buf));


### PR DESCRIPTION
jsonb_to_json's INT5 branch parses the JSON5 hex payload into a uint64 magnitude, then applies the sign with `neg ? -static_cast<int64_t>(tmp) : static_cast<int64_t>(tmp)`. On "-0x8000000000000000" that negation is `-INT64_MIN`, signed-overflow UB that UBSan aborts on, and a positive payload with the top bit set such as "0xFFFFFFFFFFFFFFFF" casts to a negative int64, so a positive value comes out negative. jsonb_to_json takes untrusted blobs, so both reach it from a crafted document.

Before, the magnitude was cast to signed before the sign was applied. After, it stays unsigned: a negative magnitude is range-checked against the absolute value of int64 min and negated in unsigned space, and a positive magnitude above INT64_MAX is written through the uint64 path instead of wrapping. This mirrors parse_int_payload in jsonb/read.hpp, which already reads the same payloads that way. The tradeoff is one branch on the sign and a wider positive range; anything that fits int64 renders the same.