### PR TITLE
File I/O correctness fixes: binary write, non-throwing directory read, TOCTOU-safe read

### DIFF
--- a/include/glaze/core/write.hpp
+++ b/include/glaze/core/write.hpp
@@ -114,13 +114,22 @@ namespace glz
    }
 
    // requires file_name to be null terminated
+   //
+   // Writes the buffer verbatim in binary mode (symmetric with the "rb" read in
+   // file_to_buffer) so binary formats are not corrupted by newline translation on
+   // Windows, and reports a write/flush failure instead of silently succeeding.
    [[nodiscard]] inline error_code buffer_to_file(auto&& buffer, const sv file_name)
    {
-      auto file = std::ofstream(file_name.data(), std::ios::out);
+      std::ofstream file(file_name.data(), std::ios::out | std::ios::binary);
       if (!file) {
          return error_code::file_open_failure;
       }
       file.write(buffer.data(), buffer.size());
+      file.close();
+      if (!file) {
+         // A failed write or flush surfaces on close; do not report success silently.
+         return error_code::file_close_failure;
+      }
       return {};
    }
 }

--- a/include/glaze/file/file_ops.hpp
+++ b/include/glaze/file/file_ops.hpp
@@ -32,9 +32,19 @@ namespace glz
       }
       buffer.resize(n);
 
-      if (n != std::fread(static_cast<void*>(buffer.data()), 1, n, file)) {
-         std::fclose(file);
-         return error_code::file_open_failure;
+      // file_size() and the read below observe the file at two different moments,
+      // so the file may have changed size in between (e.g. a concurrent atomic
+      // replace). Trust the bytes actually read from the open handle, not the stat:
+      // a short read that is not a stream error simply means the file was smaller
+      // than reported, so keep exactly what was read instead of failing. This keeps
+      // the common case a single fread with no added cost.
+      const auto read = std::fread(static_cast<void*>(buffer.data()), 1, n, file);
+      if (read != n) {
+         if (std::ferror(file)) {
+            std::fclose(file);
+            return error_code::file_open_failure;
+         }
+         buffer.resize(read);
       }
 
       if (std::fclose(file)) {

--- a/include/glaze/file/read_directory.hpp
+++ b/include/glaze/file/read_directory.hpp
@@ -27,11 +27,32 @@ namespace glz
    [[nodiscard]] inline error_ctx directory_to_buffers(auto& files, const sv directory_path,
                                                        const sv target_extension = ".json")
    {
-      for (const auto& entry : std::filesystem::directory_iterator(directory_path)) {
-         if (entry.is_regular_file() && (target_extension.empty() || (entry.path().extension() == target_extension))) {
+      namespace fs = std::filesystem;
+
+      // Use the non-throwing overloads throughout: a concurrent modification of the
+      // directory must be reported through error_ctx, not by throwing a
+      // std::filesystem_error out of a function whose contract is to return one.
+      std::error_code fs_ec{};
+      fs::directory_iterator it(fs::path(directory_path), fs_ec);
+      if (fs_ec) {
+         return {0, error_code::file_open_failure};
+      }
+
+      const fs::directory_iterator end{};
+      while (it != end) {
+         const auto& entry = *it;
+         std::error_code stat_ec{};
+         const bool regular = entry.is_regular_file(stat_ec);
+         // Skip entries we cannot stat (e.g. removed mid-iteration) rather than
+         // failing the whole read.
+         if (!stat_ec && regular && (target_extension.empty() || entry.path().extension() == target_extension)) {
             if (auto ec = file_to_buffer(files[entry.path()], entry.path().string()); bool(ec)) {
                return {0, ec};
             }
+         }
+         it.increment(fs_ec);
+         if (fs_ec) {
+            return {0, error_code::file_open_failure};
          }
       }
       return {};

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -13018,6 +13018,41 @@ suite directory_tests = [] {
       expect(input.contains("./dir/beta.json"));
       expect(input["./dir/beta.json"].i == 0);
    };
+
+   // read_directory must report a missing directory through its error_ctx rather
+   // than throwing a std::filesystem_error out of directory_to_buffers.
+   "read_directory nonexistent"_test = [] {
+      std::map<std::filesystem::path, my_struct> input{};
+      const auto ec = glz::read_directory(input, "./directory_that_does_not_exist_9f3a");
+      expect(bool(ec));
+      expect(input.empty());
+   };
+};
+
+suite buffer_to_file_tests = [] {
+   // buffer_to_file must write bytes verbatim: text-mode newline translation would
+   // corrupt binary formats on Windows (0x0A -> 0x0D 0x0A) and break byte-exact
+   // round-trips. On POSIX this passes regardless; it guards the Windows path.
+   "buffer_to_file byte-exact round trip"_test = [] {
+      const std::string path = "./verbatim_roundtrip.bin";
+      std::string payload{};
+      for (int rep = 0; rep < 4; ++rep) {
+         for (int b = 0; b < 256; ++b) {
+            payload.push_back(static_cast<char>(b)); // includes 0x0A and 0x0D
+         }
+      }
+      payload += "a\nb\r\nc\r"; // explicit newline combinations
+
+      expect(glz::buffer_to_file(payload, path) == glz::error_code::none);
+
+      std::string readback{};
+      expect(glz::file_to_buffer(readback, path) == glz::error_code::none);
+      expect(readback.size() == payload.size());
+      expect(readback == payload);
+
+      std::error_code fs_ec{};
+      std::filesystem::remove(path, fs_ec);
+   };
 };
 
 struct WorkshopModConfig


### PR DESCRIPTION
Three zero-cost correctness fixes in the file I/O helpers. These surfaced while diagnosing intermittent CI failures in the filesystem-based tests, but they apply to any user of `write_file_*` / `read_directory`.

## 1. `buffer_to_file` — binary write + no silent failures (`core/write.hpp`)

- Opens with `std::ios::out | std::ios::binary` so the buffer's bytes are written verbatim. The write side previously used text mode while the read side (`file_to_buffer`) uses `"rb"`; on Windows that asymmetry translated `\n`→`\r\n` on write, corrupting **binary** formats (BEVE/msgpack/CBOR/BSON) whose payloads can contain `0x0A` and breaking byte-exact round-trips. No effect on POSIX, where the modes are identical.
- Checks the stream state after write/close and returns `file_close_failure` instead of silently reporting success on a failed write.

## 2. `directory_to_buffers` — non-throwing (`file/read_directory.hpp`)

`read_directory` is contracted to return an `error_ctx`, but it used the throwing `directory_iterator` constructor and `is_regular_file()`, so a missing or concurrently modified directory threw `std::filesystem_error` out of the function. Switched to the `std::error_code` overloads throughout; entries that can't be stat'd mid-iteration are skipped rather than failing the whole read.

## 3. `file_to_buffer` — TOCTOU-safe read (`file/file_ops.hpp`)

It called `std::filesystem::file_size(path)` then `fread` exactly that many bytes, returning `file_open_failure` if fewer bytes were read — which can happen when the file shrinks between the two calls (e.g. a concurrent replace). Now a short read that isn't a stream error is treated as success, keeping the bytes actually read. The common path is still a single `fread` with no added cost.

## On atomicity

An atomic temp-file-plus-rename for `buffer_to_file` was evaluated (it would prevent a concurrent reader from ever seeing a torn/empty file) but **not included**: benchmarking showed it adds ~2-3x to small-file writes on APFS (fresh inode per write + rename churn), too costly to make the default. If concurrent-read safety is wanted later, it fits better as an opt-in mode than a default.

## Tests

- Byte-exact round trip over all 256 byte values plus explicit CR/LF combinations, guarding the Windows binary-mode path.
- `read_directory` on a missing directory now returns an error instead of throwing.

Verified locally: `json_test` / `json_test_non_null` plus the beve, bson, jsonb, csv, msgpack, yaml, mock_json and exceptions suites all pass.