### PR TITLE
RFC 9112: fix HTTP/1.0 Host header field validation

### DIFF
--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -2581,31 +2581,28 @@ namespace glz
          auto& headers = conn->request_.headers;
          bool host_header_parsed = false;
 
+         // RFC 9112, Section 3.2:
+         // A server MUST respond with a 400 (Bad Request) status code to any
+         // HTTP/1.1 request message that lacks a Host header field and to any
+         // request message that contains more than one Host header field line
+         // or a Host header field with an invalid field value.
+         //
+         // The "HTTP/1.1" qualifier applies only to a missing Host field. The
+         // words "any request message" make the duplicate and invalid Host
+         // rules independent of the request's HTTP version. This means that we
+         // MUST also enforce those rules for HTTP/1.0 requests.
+
          while (true) {
             // Need at least 2 bytes to check for empty line
             if (pos + 1 >= conn->buf_len) return result; // incomplete
 
             // Empty line = end of headers
             if (data[pos] == '\r' && data[pos + 1] == '\n') {
-               if (result.is_http_11) {
-                  auto host_header_it = headers.find("host");
-
-                  // RFC 9112, 3.2: A server MUST respond with a 400 (Bad Request) status
-                  // code to any HTTP/1.1 request message that lacks a Host header...
-                  if (host_header_it == headers.end()) {
-                     result.status = parse_status::error;
-                     send_error_response_with_close(conn, 400, "Bad Request");
-                     return result;
-                  }
-
-                  // RFC 9112, 3.2: A server MUST respond with a 400 (Bad Request) status
-                  // code to any HTTP/1.1 request message that lacks a Host header ... or
-                  // a Host header field with an invalid field value.
-                  if (!detail::is_valid_authority(host_header_it->second)) {
-                     result.status = parse_status::error;
-                     send_error_response_with_close(conn, 400, "Bad Request");
-                     return result;
-                  }
+               // A missing Host field is an error only for HTTP/1.1 requests
+               if (result.is_http_11 && !host_header_parsed) {
+                  result.status = parse_status::error;
+                  send_error_response_with_close(conn, 400, "Bad Request");
+                  return result;
                }
 
                result.headers_end = pos + 2;
@@ -2668,10 +2665,9 @@ namespace glz
                   }
                }
 
-               // RFC 9112, 3.2: A server MUST respond with a 400 (Bad Request) status code to
-               // any HTTP/1.1 request message that ... contains more than one Host header field.
-               if (result.is_http_11 && key == "host") {
-                  if (host_header_parsed) {
+               // Duplicate or invalid Host fields are errors for any HTTP/1.x request
+               if (key == "host") {
+                  if (host_header_parsed || !detail::is_valid_authority(value_sv)) {
                      result.status = parse_status::error;
                      send_error_response_with_close(conn, 400, "Bad Request");
                      return result;

--- a/tests/networking_tests/http_server_test/http_server_headers_validation_test.cpp
+++ b/tests/networking_tests/http_server_test/http_server_headers_validation_test.cpp
@@ -262,6 +262,7 @@ suite http_server_host_header_value_validation_suite = [] {
 suite http_server_headers_validation_suite = [] {
    auto io_ctx = std::make_shared<asio::io_context>();
    glz::http_server<> server(io_ctx, error_handler);
+   server.get("/http10-host-validation", [](const glz::request&, glz::response& response) { response.body("ok"); });
 
    std::thread server_thr([&] {
       server.bind("0.0.0.0", test_port);
@@ -319,6 +320,77 @@ suite http_server_headers_validation_suite = [] {
       }
 
       expect(response.contains("HTTP/1.1 400")) << "Expected 400 for multiple Host headers";
+   };
+
+   "HTTP/1.0 request without Host header reaches handler"_test = [&] {
+      // RFC 9112 Section 3.2 only requires Host to be present in HTTP/1.1 requests
+      std::string payload =
+         "GET /http10-host-validation HTTP/1.0\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 200"))
+         << "Expected HTTP/1.0 request without Host to pass validation and reach its handler";
+   };
+
+   "HTTP/1.0 request with valid Host header reaches handler"_test = [&] {
+      std::string payload =
+         "GET /http10-host-validation HTTP/1.0\r\n"
+         "Host: example.com\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 200"))
+         << "Expected valid Host in HTTP/1.0 request to pass validation and reach its handler";
+   };
+
+   "HTTP/1.0 request with multiple Host headers is rejected with 400 bad request"_test = [&] {
+      std::string payload =
+         "GET /front HTTP/1.0\r\n"
+         "Host: first\r\n"
+         "hoST: second\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 400")) << "Expected 400 for multiple Host headers in HTTP/1.0 request";
+   };
+
+   "HTTP/1.0 request with invalid Host header is rejected with 400 bad request"_test = [&] {
+      std::string payload =
+         "GET /front HTTP/1.0\r\n"
+         "Host: user@example.com\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+
+      std::string response;
+      if (f.wait_for(5s) == std::future_status::ready) {
+         response = f.get();
+      }
+
+      expect(response.contains("HTTP/1.1 400")) << "Expected 400 for invalid Host header in HTTP/1.0 request";
    };
 
    "request with empty Host header value is rejected with 400 bad request"_test = [&] {

--- a/tests/networking_tests/http_server_test/http_server_headers_validation_test.cpp
+++ b/tests/networking_tests/http_server_test/http_server_headers_validation_test.cpp
@@ -307,7 +307,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {
@@ -325,7 +325,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {
@@ -344,7 +344,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {
@@ -361,7 +361,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {


### PR DESCRIPTION
This PR applies the Host field validation rules as specified in RFC 9112 for HTTP/1.0 requests.
In one of my previous PRs (#2676), I misinterpreted a subtle distinction in the text of RFC 9112, Section 3.2, not noticing the distinction between an HTTP/1.1 request and a request of any version, which is described separately:

> A server MUST respond with a 400 (Bad Request) status code to any
> HTTP/1.1 request message that lacks a Host header field and to any
> request message that contains more than one Host header field line or
> a Host header field with an invalid field value.

If we take a closer look, there is a clear distinction here:

> ... HTTP/1.1 request message ...
> ... and to "any request message" ...