### PR TITLE
Use ephemeral ports for test servers

### DIFF
--- a/tests/networking_tests/asio_repe/asio_repe.cpp
+++ b/tests/networking_tests/asio_repe/asio_repe.cpp
@@ -22,9 +22,8 @@ struct notify_api
 
 void notify_test()
 {
-   static constexpr int16_t port = 8431;
    std::latch ready{1};
-   glz::asio_server server{.port = port, .concurrency = 4};
+   glz::asio_server server{.port = 0, .concurrency = 4};
    server.reuse_address = true;
    server.on_listen = [&] { ready.count_down(); };
 
@@ -40,6 +39,7 @@ void notify_test()
    });
 
    ready.wait();
+   const uint16_t port = server.port;
 
    try {
       glz::asio_client client{"localhost", std::to_string(port)};
@@ -75,10 +75,9 @@ struct my_data
 
 void async_clients_test()
 {
-   static constexpr int16_t port = 8431;
    std::latch ready{1};
 
-   glz::asio_server server{.port = port, .concurrency = 4};
+   glz::asio_server server{.port = 0, .concurrency = 4};
    server.reuse_address = true;
    server.on_listen = [&] { ready.count_down(); };
 
@@ -94,6 +93,7 @@ void async_clients_test()
    });
 
    ready.wait();
+   const uint16_t port = server.port;
 
    try {
       glz::asio_client client{"localhost", std::to_string(port)};
@@ -138,10 +138,9 @@ struct api
 
 void asio_client_test()
 {
-   static constexpr int16_t port = 8431;
    std::latch ready{1};
 
-   glz::asio_server server{.port = port, .concurrency = 4};
+   glz::asio_server server{.port = 0, .concurrency = 4};
    server.reuse_address = true;
    server.on_listen = [&] { ready.count_down(); };
 
@@ -161,6 +160,7 @@ void asio_client_test()
    });
 
    ready.wait();
+   const uint16_t port = server.port;
 
    try {
       constexpr auto N = 100;
@@ -241,10 +241,9 @@ struct api2
 
 void async_calls()
 {
-   static constexpr int16_t port = 8765;
    std::latch ready{1};
 
-   glz::asio_server server{.port = port, .concurrency = 2};
+   glz::asio_server server{.port = 0, .concurrency = 2};
    server.reuse_address = true;
    server.on_listen = [&] { ready.count_down(); };
 
@@ -255,6 +254,7 @@ void async_calls()
    });
 
    ready.wait();
+   const uint16_t port = server.port;
 
    try {
       glz::asio_client client{"localhost", std::to_string(port)};
@@ -295,10 +295,9 @@ struct raw_json_api
 
 void raw_json_tests()
 {
-   static constexpr int16_t port = 8765;
    std::latch ready{1};
 
-   glz::asio_server server{.port = port, .concurrency = 2};
+   glz::asio_server server{.port = 0, .concurrency = 2};
    server.reuse_address = true;
    server.on_listen = [&] { ready.count_down(); };
 
@@ -310,6 +309,7 @@ void raw_json_tests()
    });
 
    ready.wait();
+   const uint16_t port = server.port;
 
    glz::raw_json results{};
 
@@ -332,14 +332,13 @@ struct async_api
 
 void async_server_test()
 {
-   static constexpr int16_t port = 8765;
-
-   glz::asio_server server{.port = port, .concurrency = 1, .reuse_address = true};
+   glz::asio_server server{.port = 0, .concurrency = 1, .reuse_address = true};
 
    async_api api{};
    server.on(api);
 
    server.run_async();
+   const uint16_t port = server.port;
 
    glz::asio_client client{"localhost", std::to_string(port)};
    (void)client.init();
@@ -359,15 +358,14 @@ struct error_api
 
 void server_error_test()
 {
-   static constexpr int16_t port = 8765;
-
-   glz::asio_server server{.port = port, .concurrency = 1, .reuse_address = true};
+   glz::asio_server server{.port = 0, .concurrency = 1, .reuse_address = true};
    server.error_handler = [](const std::string& error) { expect(error == "func error"); };
 
    error_api api{};
    server.on(api);
 
    server.run_async();
+   const uint16_t port = server.port;
 
    glz::asio_client client{"localhost", std::to_string(port)};
    (void)client.init();
@@ -388,14 +386,13 @@ struct some_object_t
 
 suite send_receive_api_tests = [] {
    "send"_test = [] {
-      static constexpr int16_t port = 8765;
-
-      glz::asio_server server{.port = port, .concurrency = 1, .reuse_address = true};
+      glz::asio_server server{.port = 0, .concurrency = 1, .reuse_address = true};
 
       some_object_t obj{};
       server.on(obj);
 
       server.run_async();
+      const uint16_t port = server.port;
 
       glz::asio_client client{"localhost", std::to_string(port)};
       (void)client.init();
@@ -440,9 +437,7 @@ struct keep_alive_api
 
 void server_keep_alive_test()
 {
-   static constexpr int16_t port = 8766;
-
-   glz::asio_server server{.port = port, .concurrency = 1};
+   glz::asio_server server{.port = 0, .concurrency = 1};
    server.error_handler = [](const std::string& error) {
       if (error != "broken" && error != "unknown error") {
          expect(false) << "Unexpected error: " << error;
@@ -453,6 +448,7 @@ void server_keep_alive_test()
    server.on(api);
 
    server.run_async();
+   const uint16_t port = server.port;
 
    glz::asio_client client{"localhost", std::to_string(port)};
    (void)client.init();
@@ -486,14 +482,13 @@ void server_keep_alive_test()
 
 void client_exception_test()
 {
-   static constexpr int16_t port = 8767;
-
-   glz::asio_server server{.port = port, .concurrency = 1};
+   glz::asio_server server{.port = 0, .concurrency = 1};
 
    keep_alive_api api{};
    server.on(api);
 
    server.run_async();
+   const uint16_t port = server.port;
 
    glz::asio_client client{"localhost", std::to_string(port)};
    (void)client.init();
@@ -524,9 +519,7 @@ struct custom_call_api
 
 void custom_call_handler_test()
 {
-   static constexpr int16_t port = 8768;
-
-   glz::asio_server server{.port = port, .concurrency = 1};
+   glz::asio_server server{.port = 0, .concurrency = 1};
 
    custom_call_api api{};
    server.on(api);
@@ -558,6 +551,7 @@ void custom_call_handler_test()
    };
 
    server.run_async();
+   const uint16_t port = server.port;
 
    glz::asio_client client{"localhost", std::to_string(port)};
    (void)client.init();
@@ -581,9 +575,7 @@ void custom_call_handler_test()
 
 void custom_call_middleware_test()
 {
-   static constexpr int16_t port = 8769;
-
-   glz::asio_server server{.port = port, .concurrency = 1};
+   glz::asio_server server{.port = 0, .concurrency = 1};
 
    custom_call_api api{};
    server.on(api);
@@ -615,6 +607,7 @@ void custom_call_middleware_test()
    };
 
    server.run_async();
+   const uint16_t port = server.port;
 
    glz::asio_client client{"localhost", std::to_string(port)};
    (void)client.init();
@@ -635,9 +628,7 @@ void custom_call_middleware_test()
 
 void custom_call_error_handling_test()
 {
-   static constexpr int16_t port = 8770;
-
-   glz::asio_server server{.port = port, .concurrency = 1};
+   glz::asio_server server{.port = 0, .concurrency = 1};
 
    // Custom handler that returns an error for certain paths using zero-copy API
    server.call = [](std::span<const char> request, std::string& response_buffer) {
@@ -662,6 +653,7 @@ void custom_call_error_handling_test()
    };
 
    server.run_async();
+   const uint16_t port = server.port;
 
    glz::asio_client client{"localhost", std::to_string(port)};
    (void)client.init();
@@ -689,13 +681,12 @@ suite connection_state_tests = [] {
    };
 
    "connected_after_init"_test = [] {
-      static constexpr int16_t port = 8771;
-
-      glz::asio_server server{.port = port, .concurrency = 1};
+      glz::asio_server server{.port = 0, .concurrency = 1};
 
       some_object_t obj{};
       server.on(obj);
       server.run_async();
+      const uint16_t port = server.port;
 
       glz::asio_client client{"localhost", std::to_string(port)};
       expect(not client.connected()) << "Client should not be connected before init()";
@@ -708,15 +699,14 @@ suite connection_state_tests = [] {
    };
 
    "connected_false_after_server_shutdown"_test = [] {
-      static constexpr int16_t port = 8772;
-
       auto server = std::make_unique<glz::asio_server<>>();
-      server->port = port;
+      server->port = 0;
       server->concurrency = 1;
 
       some_object_t obj{};
       server->on(obj);
       server->run_async();
+      const uint16_t port = server->port;
 
       glz::asio_client client{"localhost", std::to_string(port)};
       (void)client.init();
@@ -806,17 +796,16 @@ suite connection_state_tests = [] {
    };
 
    "reconnect_after_server_restart"_test = [] {
-      static constexpr int16_t port = 8773;
-
       // Start server
       auto server = std::make_unique<glz::asio_server<>>();
-      server->port = port;
+      server->port = 0;
       server->concurrency = 1;
       server->reuse_address = true;
 
       some_object_t obj{.age = 25};
       server->on(obj);
       server->run_async();
+      const uint16_t port = server->port;
 
       glz::asio_client client{"localhost", std::to_string(port)};
       (void)client.init();

--- a/tests/networking_tests/http_chunked_test/http_chunked_test.cpp
+++ b/tests/networking_tests/http_chunked_test/http_chunked_test.cpp
@@ -39,17 +39,8 @@ struct chunked_test_server
       setup_routes();
 
       try {
-         for (uint16_t p = 19100; p < 19300; ++p) {
-            try {
-               server_.bind("127.0.0.1", p);
-               port_ = p;
-               break;
-            }
-            catch (...) {
-               continue;
-            }
-         }
-         if (port_ == 0) return false;
+         server_.bind("127.0.0.1", 0);
+         port_ = server_.port();
 
          running_ = true;
          server_thread_ = std::thread([this] {
@@ -650,18 +641,8 @@ suite chunked_sync_tests = [] {
          res.close();
       });
 
-      uint16_t port = 0;
-      for (uint16_t p = 19500; p < 19700; ++p) {
-         try {
-            server.bind("127.0.0.1", p);
-            port = p;
-            break;
-         }
-         catch (...) {
-            continue;
-         }
-      }
-      expect(port != 0) << "Server should bind";
+      server.bind("127.0.0.1", 0);
+      const uint16_t port = server.port();
 
       std::thread server_thread([&] { server.start(1); });
       expect(wait_until_listening(port)) << "Server should accept connections";
@@ -695,18 +676,8 @@ suite chunked_sync_tests = [] {
       glz::http_server<> server;
       server.mount("/api", router);
 
-      uint16_t port = 0;
-      for (uint16_t p = 19700; p < 19900; ++p) {
-         try {
-            server.bind("127.0.0.1", p);
-            port = p;
-            break;
-         }
-         catch (...) {
-            continue;
-         }
-      }
-      expect(port != 0) << "Server should bind";
+      server.bind("127.0.0.1", 0);
+      const uint16_t port = server.port();
 
       std::thread server_thread([&] { server.start(1); });
       expect(wait_until_listening(port)) << "Server should accept connections";
@@ -744,18 +715,8 @@ suite chunked_sync_tests = [] {
       glz::http_server<> server;
       server.mount("/", router);
 
-      uint16_t port = 0;
-      for (uint16_t p = 19900; p < 20100; ++p) {
-         try {
-            server.bind("127.0.0.1", p);
-            port = p;
-            break;
-         }
-         catch (...) {
-            continue;
-         }
-      }
-      expect(port != 0) << "Server should bind";
+      server.bind("127.0.0.1", 0);
+      const uint16_t port = server.port();
 
       std::thread server_thread([&] { server.start(1); });
       expect(wait_until_listening(port)) << "Server should accept connections";
@@ -790,18 +751,8 @@ suite chunked_sync_tests = [] {
       glz::http_server<> server;
       server.mount("/", router);
 
-      uint16_t port = 0;
-      for (uint16_t p = 20100; p < 20300; ++p) {
-         try {
-            server.bind("127.0.0.1", p);
-            port = p;
-            break;
-         }
-         catch (...) {
-            continue;
-         }
-      }
-      expect(port != 0) << "Server should bind";
+      server.bind("127.0.0.1", 0);
+      const uint16_t port = server.port();
 
       std::thread server_thread([&] { server.start(1); });
       expect(wait_until_listening(port)) << "Server should accept connections";
@@ -836,18 +787,8 @@ suite chunked_sync_tests = [] {
          res.close();
       });
 
-      uint16_t port = 0;
-      for (uint16_t p = 20300; p < 20500; ++p) {
-         try {
-            server.bind("127.0.0.1", p);
-            port = p;
-            break;
-         }
-         catch (...) {
-            continue;
-         }
-      }
-      expect(port != 0) << "Server should bind";
+      server.bind("127.0.0.1", 0);
+      const uint16_t port = server.port();
 
       std::thread server_thread([&] { server.start(1); });
       expect(wait_until_listening(port)) << "Server should accept connections";
@@ -879,18 +820,8 @@ suite chunked_sync_tests = [] {
          res.close();
       });
 
-      uint16_t port = 0;
-      for (uint16_t p = 20500; p < 20700; ++p) {
-         try {
-            server.bind("127.0.0.1", p);
-            port = p;
-            break;
-         }
-         catch (...) {
-            continue;
-         }
-      }
-      expect(port != 0) << "Server should bind";
+      server.bind("127.0.0.1", 0);
+      const uint16_t port = server.port();
 
       std::thread server_thread([&] { server.start(1); });
       expect(wait_until_listening(port)) << "Server should accept connections";
@@ -936,18 +867,8 @@ suite chunked_sync_tests = [] {
          },
          spec);
 
-      uint16_t port = 0;
-      for (uint16_t p = 20700; p < 20900; ++p) {
-         try {
-            server.bind("127.0.0.1", p);
-            port = p;
-            break;
-         }
-         catch (...) {
-            continue;
-         }
-      }
-      expect(port != 0) << "Server should bind";
+      server.bind("127.0.0.1", 0);
+      const uint16_t port = server.port();
 
       std::thread server_thread([&] { server.start(1); });
       expect(wait_until_listening(port)) << "Server should accept connections";

--- a/tests/networking_tests/http_client_ssl_test/http_client_ssl_test.cpp
+++ b/tests/networking_tests/http_client_ssl_test/http_client_ssl_test.cpp
@@ -259,11 +259,11 @@ class TestHTTPSServer
    glz::https_server server_;
    std::future<void> server_future_;
    std::atomic<bool> running_{false};
-   uint16_t port_;
+   uint16_t port_{};
    bool initialized_{false};
 
   public:
-   TestHTTPSServer(uint16_t port = 9443) : port_(port)
+   TestHTTPSServer()
    {
       // Always regenerate certificates so test expectations stay deterministic.
       if (!CertificateGenerator::generate_certificates()) {
@@ -282,7 +282,8 @@ class TestHTTPSServer
          server_.load_certificate("client_test_cert.pem", "client_test_key.pem");
          server_.set_ssl_verify_mode(0);
          server_.enable_cors();
-         server_.bind("127.0.0.1", port_);
+         server_.bind("127.0.0.1", 0);
+         port_ = server_.port();
 
          running_ = true;
          server_future_ = std::async(std::launch::async, [this]() { server_.start(2); });
@@ -367,7 +368,7 @@ class TestHTTPSServer
 };
 
 // Global test server - initialized before tests run
-static TestHTTPSServer g_server{9443};
+static TestHTTPSServer g_server;
 
 // Test suite
 suite https_client_tests = [] {

--- a/tests/networking_tests/http_client_test/http_client_test.cpp
+++ b/tests/networking_tests/http_client_test/http_client_test.cpp
@@ -56,22 +56,8 @@ class working_test_server
       setup_routes();
 
       try {
-         // Try to find a free port
-         for (uint16_t test_port = 18080; test_port < 18200; ++test_port) {
-            try {
-               server_.bind("127.0.0.1", test_port);
-               port_ = test_port;
-               break;
-            }
-            catch (...) {
-               continue;
-            }
-         }
-
-         if (port_ == 0) {
-            std::cerr << "Could not find free port for test server\n";
-            return false;
-         }
+         server_.bind("127.0.0.1", 0);
+         port_ = server_.port();
 
          running_ = true;
 

--- a/tests/networking_tests/http_server_api_tests/http_server_api_tests.cpp
+++ b/tests/networking_tests/http_server_api_tests/http_server_api_tests.cpp
@@ -1266,20 +1266,8 @@ struct keepalive_test_server
       setup_routes();
 
       try {
-         for (uint16_t test_port = 19080; test_port < 19200; ++test_port) {
-            try {
-               server_.bind("127.0.0.1", test_port);
-               port_ = test_port;
-               break;
-            }
-            catch (...) {
-               continue;
-            }
-         }
-
-         if (port_ == 0) {
-            return false;
-         }
+         server_.bind("127.0.0.1", 0);
+         port_ = server_.port();
 
          running_ = true;
 

--- a/tests/networking_tests/http_server_post_test/http_server_post_test.cpp
+++ b/tests/networking_tests/http_server_post_test/http_server_post_test.cpp
@@ -20,7 +20,6 @@ namespace
 {
    using namespace ut;
 
-   constexpr int test_port = 8888;
    constexpr char test_host[] = "127.0.0.1";
    constexpr char test_route[] = "/post_test";
 
@@ -37,28 +36,8 @@ namespace
   "property1": "aeboomeLoo9eYohaeshue4Aesheimoal9EC9Ohquarepei8ut0aethue"
 })";
 
-   void wait_for_server_ready(int port, int max_tries = 50)
-   {
-      for (int tries = 0; tries < max_tries; ++tries) {
-         try {
-            asio::io_context io_ctx;
-            asio::ip::tcp::socket sock(io_ctx);
-            asio::ip::tcp::endpoint endpoint(asio::ip::make_address(test_host), uint16_t(port));
-            asio::error_code ec;
-            sock.connect(endpoint, ec);
-            if (ec != asio::error::connection_refused) {
-               return;
-            }
-         }
-         catch (...) {
-         }
-         std::this_thread::sleep_for(std::chrono::milliseconds(40));
-      }
-      throw std::runtime_error("Server did not start in time");
-   }
-
    // Build HTTP headers with many custom headers to simulate the original bug scenario
-   std::string build_headers(size_t content_length)
+   std::string build_headers(uint16_t port, size_t content_length)
    {
       std::ostringstream req;
       req << "POST " << test_route << " HTTP/1.1\r\n"
@@ -66,7 +45,7 @@ namespace
           << "User-Agent: glaze-test/1.0\r\n"
           << "Content-Length: " << content_length << "\r\n"
           << "Accept-Encoding: gzip, compress, deflate, br\r\n"
-          << "Host: " << test_host << ":" << test_port << "\r\n"
+          << "Host: " << test_host << ":" << port << "\r\n"
           << "Connection: close\r\n"
           // Many additional headers to fill the initial buffer read
           << "X-Testheader-1: zie3ethahf4oomouHohPhi5HuhahvuL8jeilohqua0Ohdaivahqueido\r\n"
@@ -96,19 +75,18 @@ namespace
    }
 
    // Send headers and body in a single write (tests the case where body is already buffered)
-   std::string post_single_write(const std::string& body)
+   std::string post_single_write(uint16_t port, const std::string& body)
    {
-      wait_for_server_ready(test_port);
       asio::io_context io_ctx;
       asio::ip::tcp::socket socket(io_ctx);
-      asio::ip::tcp::endpoint endpoint(asio::ip::make_address(test_host), uint16_t(test_port));
+      asio::ip::tcp::endpoint endpoint(asio::ip::make_address(test_host), port);
       asio::error_code ec;
       socket.connect(endpoint, ec);
       if (ec) {
          return "";
       }
 
-      std::string headers = build_headers(body.size());
+      std::string headers = build_headers(port, body.size());
       std::string request = headers + body;
       asio::write(socket, asio::buffer(request.data(), request.size()));
 
@@ -117,19 +95,18 @@ namespace
 
    // Send headers first, then body separately to exercise the async_read path
    // This simulates the scenario where the body hasn't arrived when headers are parsed
-   std::string post_chunked_write(const std::string& body)
+   std::string post_chunked_write(uint16_t port, const std::string& body)
    {
-      wait_for_server_ready(test_port);
       asio::io_context io_ctx;
       asio::ip::tcp::socket socket(io_ctx);
-      asio::ip::tcp::endpoint endpoint(asio::ip::make_address(test_host), uint16_t(test_port));
+      asio::ip::tcp::endpoint endpoint(asio::ip::make_address(test_host), port);
       asio::error_code ec;
       socket.connect(endpoint, ec);
       if (ec) {
          return "";
       }
 
-      std::string headers = build_headers(body.size());
+      std::string headers = build_headers(port, body.size());
 
       // Send headers first
       asio::write(socket, asio::buffer(headers.data(), headers.size()));
@@ -158,25 +135,24 @@ suite http_server_post_suite = [] {
    std::mutex body_mutex;
    std::string received_body;
 
-   std::thread server_thr([&] {
-      server.post(test_route, [&](const glz::request& req, glz::response& res) {
-         {
-            std::lock_guard<std::mutex> lock(body_mutex);
-            received_body = req.body;
-         }
-         res.status(200);
-         res.content_type("text/plain");
-         res.body("OK:" + std::to_string(req.body.size()));
-      });
-
-      server.bind("0.0.0.0", test_port);
-      server.start(0);
-      io_ctx->run();
+   server.post(test_route, [&](const glz::request& req, glz::response& res) {
+      {
+         std::lock_guard<std::mutex> lock(body_mutex);
+         received_body = req.body;
+      }
+      res.status(200);
+      res.content_type("text/plain");
+      res.body("OK:" + std::to_string(req.body.size()));
    });
+   server.bind(test_host, 0);
+   const uint16_t test_port = server.port();
+   server.start(0);
+
+   std::thread server_thr([&] { io_ctx->run(); });
 
    "POST with body sent in single write"_test = [&] {
       std::string body(post_body);
-      std::future<std::string> f = std::async(std::launch::async, [&] { return post_single_write(body); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return post_single_write(test_port, body); });
 
       auto future_timeout = std::chrono::system_clock::now() + std::chrono::seconds(5);
       std::string response;
@@ -195,7 +171,7 @@ suite http_server_post_suite = [] {
 
    "POST with headers and body sent separately (exercises async_read)"_test = [&] {
       std::string body(post_body);
-      std::future<std::string> f = std::async(std::launch::async, [&] { return post_chunked_write(body); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return post_chunked_write(test_port, body); });
 
       auto future_timeout = std::chrono::system_clock::now() + std::chrono::seconds(5);
       std::string response;
@@ -224,7 +200,8 @@ suite http_server_post_suite = [] {
       binary_body.push_back('\0');
       binary_body += "more data";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return post_chunked_write(binary_body); });
+      std::future<std::string> f =
+         std::async(std::launch::async, [&] { return post_chunked_write(test_port, binary_body); });
 
       auto future_timeout = std::chrono::system_clock::now() + std::chrono::seconds(5);
       std::string response;

--- a/tests/networking_tests/http_server_test/http_server_headers_validation_test.cpp
+++ b/tests/networking_tests/http_server_test/http_server_headers_validation_test.cpp
@@ -19,28 +19,7 @@ using namespace ut;
 using namespace std::chrono_literals;
 using glz::detail::is_valid_authority;
 
-constexpr int test_port = 8899;
 constexpr char test_host[] = "127.0.0.1";
-
-void wait_for_server_ready(int port, int max_tries = 50)
-{
-   for (int tries = 0; tries < max_tries; ++tries) {
-      try {
-         asio::io_context io_ctx;
-         asio::ip::tcp::socket sock(io_ctx);
-         asio::ip::tcp::endpoint endpoint(asio::ip::make_address(test_host), uint16_t(port));
-         asio::error_code ec;
-         sock.connect(endpoint, ec);
-         if (ec != asio::error::connection_refused) {
-            return;
-         }
-      }
-      catch (...) {
-      }
-      std::this_thread::sleep_for(40ms);
-   }
-   throw std::runtime_error("Server did not start in time");
-}
 
 std::string read_response(asio::ip::tcp::socket& socket)
 {
@@ -55,12 +34,11 @@ std::string read_response(asio::ip::tcp::socket& socket)
    return resp;
 }
 
-std::string send_raw(const std::string& request)
+std::string send_raw(uint16_t port, const std::string& request)
 {
-   wait_for_server_ready(test_port);
    asio::io_context io_ctx;
    asio::ip::tcp::socket socket(io_ctx);
-   asio::ip::tcp::endpoint endpoint(asio::ip::make_address(test_host), uint16_t(test_port));
+   asio::ip::tcp::endpoint endpoint(asio::ip::make_address(test_host), port);
    asio::error_code ec;
    socket.connect(endpoint, ec);
    if (ec) {
@@ -263,11 +241,11 @@ suite http_server_headers_validation_suite = [] {
    auto io_ctx = std::make_shared<asio::io_context>();
    glz::http_server<> server(io_ctx, error_handler);
 
-   std::thread server_thr([&] {
-      server.bind("0.0.0.0", test_port);
-      server.start(0);
-      io_ctx->run();
-   });
+   server.bind(test_host, 0);
+   const uint16_t test_port = server.port();
+   server.start(0);
+
+   std::thread server_thr([&] { io_ctx->run(); });
 
    "request with missing Host header is rejected with 400 bad request"_test = [&] {
       std::string payload =
@@ -275,7 +253,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {
@@ -293,7 +271,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {
@@ -311,7 +289,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {
@@ -328,7 +306,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {
@@ -345,7 +323,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {
@@ -362,7 +340,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {
@@ -379,7 +357,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {
@@ -396,7 +374,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {
@@ -413,7 +391,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {
@@ -430,7 +408,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {
@@ -447,7 +425,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {
@@ -470,7 +448,7 @@ suite http_server_headers_validation_suite = [] {
       for (const std::string& host_line : {"Host: example.com \r\n", "Host: example.com\t\r\n"}) {
          std::string payload = "GET /front HTTP/1.1\r\n" + host_line + "Connection: close\r\n\r\n";
 
-         std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+         std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
          std::string response;
          if (f.wait_for(5s) == std::future_status::ready) {
@@ -492,7 +470,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {
@@ -509,7 +487,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {
@@ -526,7 +504,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {
@@ -543,7 +521,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {
@@ -560,7 +538,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {
@@ -577,7 +555,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {
@@ -594,7 +572,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {
@@ -611,7 +589,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {
@@ -628,7 +606,7 @@ suite http_server_headers_validation_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       std::string response;
       if (f.wait_for(5s) == std::future_status::ready) {

--- a/tests/networking_tests/http_smuggling_test/http_smuggling_test.cpp
+++ b/tests/networking_tests/http_smuggling_test/http_smuggling_test.cpp
@@ -19,28 +19,7 @@ namespace
 {
    using namespace ut;
 
-   constexpr int test_port = 8899;
    constexpr char test_host[] = "127.0.0.1";
-
-   void wait_for_server_ready(int port, int max_tries = 50)
-   {
-      for (int tries = 0; tries < max_tries; ++tries) {
-         try {
-            asio::io_context io_ctx;
-            asio::ip::tcp::socket sock(io_ctx);
-            asio::ip::tcp::endpoint endpoint(asio::ip::make_address(test_host), uint16_t(port));
-            asio::error_code ec;
-            sock.connect(endpoint, ec);
-            if (ec != asio::error::connection_refused) {
-               return;
-            }
-         }
-         catch (...) {
-         }
-         std::this_thread::sleep_for(std::chrono::milliseconds(40));
-      }
-      throw std::runtime_error("Server did not start in time");
-   }
 
    std::string read_response(asio::ip::tcp::socket& socket)
    {
@@ -55,12 +34,11 @@ namespace
       return resp;
    }
 
-   std::string send_raw(const std::string& request)
+   std::string send_raw(uint16_t port, const std::string& request)
    {
-      wait_for_server_ready(test_port);
       asio::io_context io_ctx;
       asio::ip::tcp::socket socket(io_ctx);
-      asio::ip::tcp::endpoint endpoint(asio::ip::make_address(test_host), uint16_t(test_port));
+      asio::ip::tcp::endpoint endpoint(asio::ip::make_address(test_host), port);
       asio::error_code ec;
       socket.connect(endpoint, ec);
       if (ec) {
@@ -80,21 +58,20 @@ suite http_smuggling_suite = [] {
 
    std::atomic<int> smuggled_hits{0};
 
-   std::thread server_thr([&] {
-      server.post("/front", [&](const glz::request&, glz::response& res) {
-         res.status(200);
-         res.body("front");
-      });
-      server.get("/smuggled", [&](const glz::request&, glz::response& res) {
-         smuggled_hits.fetch_add(1, std::memory_order_relaxed);
-         res.status(200);
-         res.body("smuggled");
-      });
-
-      server.bind("0.0.0.0", test_port);
-      server.start(0);
-      io_ctx->run();
+   server.post("/front", [&](const glz::request&, glz::response& res) {
+      res.status(200);
+      res.body("front");
    });
+   server.get("/smuggled", [&](const glz::request&, glz::response& res) {
+      smuggled_hits.fetch_add(1, std::memory_order_relaxed);
+      res.status(200);
+      res.body("smuggled");
+   });
+   server.bind(test_host, 0);
+   const uint16_t test_port = server.port();
+   server.start(0);
+
+   std::thread server_thr([&] { io_ctx->run(); });
 
    "Transfer-Encoding request is refused, not desynced"_test = [&] {
       // The bytes after the blank line are a complete second request. With a
@@ -112,7 +89,7 @@ suite http_smuggling_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       auto future_timeout = std::chrono::system_clock::now() + std::chrono::seconds(5);
       std::string response;
@@ -144,7 +121,7 @@ suite http_smuggling_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       auto future_timeout = std::chrono::system_clock::now() + std::chrono::seconds(5);
       std::string response;
@@ -174,7 +151,7 @@ suite http_smuggling_suite = [] {
          "\r\n"
          "HELLO";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       auto future_timeout = std::chrono::system_clock::now() + std::chrono::seconds(5);
       std::string response;
@@ -204,7 +181,7 @@ suite http_smuggling_suite = [] {
          "Connection: close\r\n"
          "\r\n";
 
-      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(payload); });
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
 
       auto future_timeout = std::chrono::system_clock::now() + std::chrono::seconds(5);
       std::string response;

--- a/tests/networking_tests/https_test/https_test.cpp
+++ b/tests/networking_tests/https_test/https_test.cpp
@@ -336,6 +336,7 @@ class HTTPSTestServer
    std::future<void> server_future_;
    std::chrono::steady_clock::time_point start_time_;
    std::atomic<bool> running_{false};
+   uint16_t port_{};
    std::vector<TestUser> users_;
    int next_user_id_;
 
@@ -361,13 +362,14 @@ class HTTPSTestServer
 
    ~HTTPSTestServer() { stop(); }
 
-   bool start(uint16_t port = 8443)
+   bool start()
    {
       try {
          server_.load_certificate("test_cert.pem", "test_key.pem");
          server_.set_ssl_verify_mode(0);
          server_.enable_cors();
-         server_.bind("127.0.0.1", port);
+         server_.bind("127.0.0.1", 0);
+         port_ = server_.port();
 
          running_ = true;
          server_future_ = std::async(std::launch::async, [this]() { server_.start(2); });
@@ -380,6 +382,8 @@ class HTTPSTestServer
          return false;
       }
    }
+
+   uint16_t port() const { return port_; }
 
    void stop()
    {
@@ -532,16 +536,6 @@ bool file_exists(const std::string& filename)
 
 bool certificates_exist() { return file_exists("test_cert.pem") && file_exists("test_key.pem"); }
 
-void wait_for_port_free(int port, int max_attempts = 20)
-{
-   for (int i = 0; i < max_attempts; ++i) {
-      if (system(("lsof -ti:" + std::to_string(port) + " >/dev/null 2>&1").c_str()) != 0) {
-         return; // Port is free
-      }
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
-   }
-}
-
 // Test suites (unchanged)
 suite certificate_tests = [] {
    "certificate_generation"_test = [] {
@@ -584,10 +578,8 @@ suite server_lifecycle_tests = [] {
          CertificateGenerator::generate_test_certificates();
       }
 
-      wait_for_port_free(8444);
-
       HTTPSTestServer test_server;
-      expect(test_server.start(8444)) << "HTTPS server should start successfully\n";
+      expect(test_server.start()) << "HTTPS server should start successfully\n";
 
       std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
@@ -609,27 +601,26 @@ class ExternalIOContextServer
       if (!certificates_exist()) {
          CertificateGenerator::generate_test_certificates();
       }
-
-      wait_for_port_free(8443);
    }
 
    ~ExternalIOContextServer() { stop_io_thread(); }
 
    void start_io_thread()
    {
-      io_thread = std::thread([this]() {
-         setup_routes();
-         server_.load_certificate("test_cert.pem", "test_key.pem");
-         server_.set_ssl_verify_mode(0);
-         server_.enable_cors();
-         server_.bind("127.0.0.1", 8443);
-         // Start the server accepting connections without creating worker threads (0)
-         // We'll run the io_context manually in this thread
-         server_.start(0);
-         // Run the io_context event loop in this thread
-         io_context->run();
-      });
+      setup_routes();
+      server_.load_certificate("test_cert.pem", "test_key.pem");
+      server_.set_ssl_verify_mode(0);
+      server_.enable_cors();
+      server_.bind("127.0.0.1", 0);
+      port_ = server_.port();
+      // Start the server accepting connections without creating worker threads (0)
+      // We'll run the io_context manually in this thread
+      server_.start(0);
+      // Run the io_context event loop in a separate thread
+      io_thread = std::thread([this]() { io_context->run(); });
    }
+
+   uint16_t port() const { return port_; }
 
    void stop_io_thread()
    {
@@ -650,6 +641,7 @@ class ExternalIOContextServer
   private:
    std::shared_ptr<asio::io_context> io_context;
    glz::https_server server_;
+   uint16_t port_{};
    std::thread io_thread;
    asio::executor_work_guard<asio::io_context::executor_type> work_guard;
 };
@@ -679,6 +671,7 @@ suite server_lifecycle_external_context_tests = [] {
       ExternalIOContextServer server;
       std::cout << "Starting HTTPS server with external io_context thread...\n";
       server.start_io_thread();
+      const uint16_t port = server.port();
 
       // Wait for server to be ready
       std::this_thread::sleep_for(std::chrono::milliseconds(500));
@@ -688,7 +681,7 @@ suite server_lifecycle_external_context_tests = [] {
       try {
          asio::io_context client_io;
          asio::ip::tcp::socket socket(client_io);
-         asio::ip::tcp::endpoint endpoint(asio::ip::make_address("127.0.0.1"), 8443);
+         asio::ip::tcp::endpoint endpoint(asio::ip::make_address("127.0.0.1"), port);
 
          asio::error_code ec;
          socket.connect(endpoint, ec);
@@ -715,7 +708,7 @@ suite server_lifecycle_external_context_tests = [] {
       try {
          asio::io_context client_io;
          asio::ip::tcp::socket socket(client_io);
-         asio::ip::tcp::endpoint endpoint(asio::ip::make_address("127.0.0.1"), 8443);
+         asio::ip::tcp::endpoint endpoint(asio::ip::make_address("127.0.0.1"), port);
 
          asio::error_code ec;
          socket.connect(endpoint, ec);
@@ -739,23 +732,21 @@ suite api_functionality_tests = [] {
          CertificateGenerator::generate_test_certificates();
       }
 
-      wait_for_port_free(8445);
-
       HTTPSTestServer test_server;
-      if (!test_server.start(8445)) {
+      if (!test_server.start()) {
          std::cout << "❌ Failed to start server for API test\n";
          return;
       }
 
       std::this_thread::sleep_for(std::chrono::milliseconds(300));
 
-      std::cout << "HTTPS server started on port 8445 with API endpoints:\n";
+      std::cout << "HTTPS server started on port " << test_server.port() << " with API endpoints:\n";
       std::cout << "  /health - Health check\n";
       std::cout << "  /status - Server status\n";
       std::cout << "  /echo - JSON echo service\n";
       std::cout << "  /users - User management API\n";
       std::cout << "  /large - Large response test\n";
-      std::cout << "Manual test: curl -k https://localhost:8445/health\n";
+      std::cout << "Manual test: curl -k https://localhost:" << test_server.port() << "/health\n";
 
       test_server.stop();
       expect(true) << "API endpoints configured successfully\n";
@@ -769,16 +760,14 @@ suite concurrent_tests = [] {
          CertificateGenerator::generate_test_certificates();
       }
 
-      wait_for_port_free(8446);
-      wait_for_port_free(8447);
-
       HTTPSTestServer server1;
       HTTPSTestServer server2;
 
-      expect(server1.start(8446)) << "First server should start successfully\n";
+      expect(server1.start()) << "First server should start successfully\n";
       std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
-      expect(server2.start(8447)) << "Second server should start on different port\n";
+      expect(server2.start()) << "Second server should start on different port\n";
+      expect(server1.port() != server2.port()) << "Concurrent servers should use different ephemeral ports\n";
       std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
       server1.stop();
@@ -793,11 +782,9 @@ suite concurrent_tests = [] {
          CertificateGenerator::generate_test_certificates();
       }
 
-      wait_for_port_free(8448);
-
       for (int i = 0; i < 3; ++i) {
          HTTPSTestServer server;
-         expect(server.start(8448)) << "Server " << i << " should start\n";
+         expect(server.start()) << "Server " << i << " should start\n";
          std::this_thread::sleep_for(std::chrono::milliseconds(100));
          server.stop();
          std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -814,12 +801,10 @@ suite performance_tests = [] {
          CertificateGenerator::generate_test_certificates();
       }
 
-      wait_for_port_free(8449);
-
       auto start_time = std::chrono::high_resolution_clock::now();
 
       HTTPSTestServer server;
-      bool started = server.start(8449);
+      bool started = server.start();
 
       auto end_time = std::chrono::high_resolution_clock::now();
       auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
@@ -901,12 +886,7 @@ int main()
 
    // Tests run automatically through the ut library
 
-   std::cout << "\n🔍 Manual Testing Commands:\n";
-   std::cout << "  curl -k https://localhost:8443/health\n";
-   std::cout << "  curl -k https://localhost:8443/status\n";
-   std::cout << "  curl -k -X POST https://localhost:8443/echo -H 'Content-Type: application/json' -d "
-                "'{\"message\":\"test\",\"echo_count\":3}'\n";
-   std::cout << "  openssl s_client -connect localhost:8443 -servername localhost\n\n";
+   std::cout << "\nHTTPS integration servers used ephemeral ports and have been stopped.\n\n";
 
    return 0;
 }

--- a/tests/networking_tests/openapi_test/openapi_test.cpp
+++ b/tests/networking_tests/openapi_test/openapi_test.cpp
@@ -159,11 +159,11 @@ int main()
          }
       }
 
+      server.bind("127.0.0.1", 0);
+      const uint16_t port = server.port();
+
       // Start the server in a separate thread
-      std::thread server_thread([&]() {
-         server.bind("127.0.0.1", 8080);
-         server.start();
-      });
+      std::thread server_thread([&]() { server.start(); });
 
       // Give the server time to start
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -171,7 +171,7 @@ int main()
       // Make HTTP request to get OpenAPI spec
       try {
          glz::http_client client{};
-         auto response_result = client.get("http://127.0.0.1:8080/openapi.json");
+         auto response_result = client.get("http://127.0.0.1:" + std::to_string(port) + "/openapi.json");
 
          if (response_result.has_value()) {
             const auto& response = response_result.value();

--- a/tests/networking_tests/websocket_test/websocket_client_test.cpp
+++ b/tests/networking_tests/websocket_test/websocket_client_test.cpp
@@ -43,7 +43,8 @@ bool wait_for_condition(Predicate pred, std::chrono::milliseconds timeout = std:
 }
 
 // Helper to run a basic echo server
-void run_echo_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_stop, uint16_t port)
+void run_echo_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_stop,
+                     std::atomic<uint16_t>& selected_port)
 {
    http_server server;
    auto ws_server = std::make_shared<websocket_server>();
@@ -80,7 +81,8 @@ void run_echo_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_
    server.websocket("/ws", ws_server);
 
    try {
-      server.bind(port);
+      server.bind("127.0.0.1", 0);
+      selected_port = server.port();
       server.start();
       server_ready = true;
 
@@ -108,8 +110,8 @@ struct ws_upgrade_capture
 // Helper to run a server that records the request seen by on_open.
 // Used to verify that query parameters on the WebSocket upgrade URL are parsed
 // and that the upgrade matches the path-only handler (regression for issue #2549).
-void run_capture_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_stop, uint16_t port,
-                        std::shared_ptr<ws_upgrade_capture> capture)
+void run_capture_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_stop,
+                        std::atomic<uint16_t>& selected_port, std::shared_ptr<ws_upgrade_capture> capture)
 {
    http_server server;
    auto ws_server = std::make_shared<websocket_server>();
@@ -131,7 +133,8 @@ void run_capture_server(std::atomic<bool>& server_ready, std::atomic<bool>& shou
    server.websocket("/ws", ws_server);
 
    try {
-      server.bind(port);
+      server.bind("127.0.0.1", 0);
+      selected_port = server.port();
       server.start();
       server_ready = true;
       while (!should_stop) {
@@ -146,7 +149,8 @@ void run_capture_server(std::atomic<bool>& server_ready, std::atomic<bool>& shou
 }
 
 // Helper to run a server that closes connections after first message
-void run_close_after_message_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_stop, uint16_t port)
+void run_close_after_message_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_stop,
+                                    std::atomic<uint16_t>& selected_port)
 {
    http_server server;
    auto ws_server = std::make_shared<websocket_server>();
@@ -164,7 +168,8 @@ void run_close_after_message_server(std::atomic<bool>& server_ready, std::atomic
    server.websocket("/ws", ws_server);
 
    try {
-      server.bind(port);
+      server.bind("127.0.0.1", 0);
+      selected_port = server.port();
       server.start();
       server_ready = true;
 
@@ -180,8 +185,8 @@ void run_close_after_message_server(std::atomic<bool>& server_ready, std::atomic
 }
 
 // Helper to run a server that counts messages
-void run_counting_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_stop, uint16_t port,
-                         std::atomic<int>& message_count)
+void run_counting_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_stop,
+                         std::atomic<uint16_t>& selected_port, std::atomic<int>& message_count)
 {
    http_server server;
    auto ws_server = std::make_shared<websocket_server>();
@@ -202,7 +207,8 @@ void run_counting_server(std::atomic<bool>& server_ready, std::atomic<bool>& sho
    server.websocket("/ws", ws_server);
 
    try {
-      server.bind(port);
+      server.bind("127.0.0.1", 0);
+      selected_port = server.port();
       server.start();
       server_ready = true;
 
@@ -624,11 +630,11 @@ void run_invalid_frame_case(std::string_view name, std::vector<uint8_t> frame_pa
 
 suite websocket_client_tests = [] {
    "basic_echo_test"_test = [] {
-      uint16_t port = 8091;
+      std::atomic<uint16_t> port{0};
       std::atomic<bool> server_ready{false};
       std::atomic<bool> stop_server{false};
 
-      std::thread server_thread(run_echo_server, std::ref(server_ready), std::ref(stop_server), port);
+      std::thread server_thread(run_echo_server, std::ref(server_ready), std::ref(stop_server), std::ref(port));
 
       expect(wait_for_condition([&] { return server_ready.load(); })) << "Server failed to start";
 
@@ -655,7 +661,7 @@ suite websocket_client_tests = [] {
          client.context()->stop();
       });
 
-      std::string client_url = "ws://localhost:" + std::to_string(port) + "/ws";
+      std::string client_url = "ws://localhost:" + std::to_string(port.load()) + "/ws";
       client.connect(client_url);
 
       std::thread client_thread([&client]() { client.context()->run(); });
@@ -676,12 +682,12 @@ suite websocket_client_tests = [] {
    };
 
    "multiple_messages_test"_test = [] {
-      uint16_t port = 8092;
+      std::atomic<uint16_t> port{0};
       std::atomic<bool> server_ready{false};
       std::atomic<bool> stop_server{false};
       std::atomic<int> server_message_count{0};
 
-      std::thread server_thread(run_counting_server, std::ref(server_ready), std::ref(stop_server), port,
+      std::thread server_thread(run_counting_server, std::ref(server_ready), std::ref(stop_server), std::ref(port),
                                 std::ref(server_message_count));
 
       expect(wait_for_condition([&] { return server_ready.load(); })) << "Server failed to start";
@@ -710,7 +716,7 @@ suite websocket_client_tests = [] {
 
       client.on_close([&](ws_close_code, std::string_view) { client.context()->stop(); });
 
-      std::string client_url = "ws://localhost:" + std::to_string(port) + "/ws";
+      std::string client_url = "ws://localhost:" + std::to_string(port.load()) + "/ws";
       client.connect(client_url);
 
       std::thread client_thread([&client]() { client.context()->run(); });
@@ -733,11 +739,11 @@ suite websocket_client_tests = [] {
    };
 
    "binary_message_test"_test = [] {
-      uint16_t port = 8093;
+      std::atomic<uint16_t> port{0};
       std::atomic<bool> server_ready{false};
       std::atomic<bool> stop_server{false};
 
-      std::thread server_thread(run_echo_server, std::ref(server_ready), std::ref(stop_server), port);
+      std::thread server_thread(run_echo_server, std::ref(server_ready), std::ref(stop_server), std::ref(port));
 
       expect(wait_for_condition([&] { return server_ready.load(); })) << "Server failed to start";
 
@@ -764,7 +770,7 @@ suite websocket_client_tests = [] {
 
       client.on_close([&](ws_close_code, std::string_view) { client.context()->stop(); });
 
-      std::string client_url = "ws://localhost:" + std::to_string(port) + "/ws";
+      std::string client_url = "ws://localhost:" + std::to_string(port.load()) + "/ws";
       client.connect(client_url);
 
       std::thread client_thread([&client]() { client.context()->run(); });
@@ -784,11 +790,11 @@ suite websocket_client_tests = [] {
    };
 
    "large_message_test"_test = [] {
-      uint16_t port = 8094;
+      std::atomic<uint16_t> port{0};
       std::atomic<bool> server_ready{false};
       std::atomic<bool> stop_server{false};
 
-      std::thread server_thread(run_echo_server, std::ref(server_ready), std::ref(stop_server), port);
+      std::thread server_thread(run_echo_server, std::ref(server_ready), std::ref(stop_server), std::ref(port));
 
       expect(wait_for_condition([&] { return server_ready.load(); })) << "Server failed to start";
 
@@ -827,7 +833,7 @@ suite websocket_client_tests = [] {
 
       client.on_close([&](ws_close_code, std::string_view) { client.context()->stop(); });
 
-      std::string client_url = "ws://localhost:" + std::to_string(port) + "/ws";
+      std::string client_url = "ws://localhost:" + std::to_string(port.load()) + "/ws";
       client.connect(client_url);
 
       std::thread client_thread([&client]() { client.context()->run(); });
@@ -910,11 +916,12 @@ suite websocket_client_tests = [] {
    };
 
    "server_initiated_close_test"_test = [] {
-      uint16_t port = 8095;
+      std::atomic<uint16_t> port{0};
       std::atomic<bool> server_ready{false};
       std::atomic<bool> stop_server{false};
 
-      std::thread server_thread(run_close_after_message_server, std::ref(server_ready), std::ref(stop_server), port);
+      std::thread server_thread(run_close_after_message_server, std::ref(server_ready), std::ref(stop_server),
+                                std::ref(port));
 
       expect(wait_for_condition([&] { return server_ready.load(); })) << "Server failed to start";
 
@@ -937,7 +944,7 @@ suite websocket_client_tests = [] {
 
       client.on_error([](std::error_code ec) { std::cerr << "Client Error: " << ec.message() << "\n"; });
 
-      std::string client_url = "ws://localhost:" + std::to_string(port) + "/ws";
+      std::string client_url = "ws://localhost:" + std::to_string(port.load()) + "/ws";
       client.connect(client_url);
 
       std::thread client_thread([&client]() { client.context()->run(); });
@@ -987,11 +994,11 @@ suite websocket_client_tests = [] {
    };
 
    "multiple_clients_shared_context_test"_test = [] {
-      uint16_t port = 8096;
+      std::atomic<uint16_t> port{0};
       std::atomic<bool> server_ready{false};
       std::atomic<bool> stop_server{false};
 
-      std::thread server_thread(run_echo_server, std::ref(server_ready), std::ref(stop_server), port);
+      std::thread server_thread(run_echo_server, std::ref(server_ready), std::ref(stop_server), std::ref(port));
 
       expect(wait_for_condition([&] { return server_ready.load(); })) << "Server failed to start";
 
@@ -1030,7 +1037,7 @@ suite websocket_client_tests = [] {
          client_ptr->on_close(
             [&clients_closed, client_id](ws_close_code, std::string_view) { clients_closed[client_id] = true; });
 
-         std::string client_url = "ws://localhost:" + std::to_string(port) + "/ws";
+         std::string client_url = "ws://localhost:" + std::to_string(port.load()) + "/ws";
          client_ptr->connect(client_url);
       }
 
@@ -1070,12 +1077,12 @@ suite websocket_client_tests = [] {
    };
 
    "thread_safety_test"_test = [] {
-      uint16_t port = 8097;
+      std::atomic<uint16_t> port{0};
       std::atomic<bool> server_ready{false};
       std::atomic<bool> stop_server{false};
       std::atomic<int> server_message_count{0};
 
-      std::thread server_thread(run_counting_server, std::ref(server_ready), std::ref(stop_server), port,
+      std::thread server_thread(run_counting_server, std::ref(server_ready), std::ref(stop_server), std::ref(port),
                                 std::ref(server_message_count));
 
       expect(wait_for_condition([&] { return server_ready.load(); })) << "Server failed to start";
@@ -1100,7 +1107,7 @@ suite websocket_client_tests = [] {
 
       client.on_close([&](ws_close_code, std::string_view) { client.context()->stop(); });
 
-      std::string client_url = "ws://localhost:" + std::to_string(port) + "/ws";
+      std::string client_url = "ws://localhost:" + std::to_string(port.load()) + "/ws";
       client.connect(client_url);
 
       std::thread client_thread([&client]() { client.context()->run(); });
@@ -1141,7 +1148,7 @@ suite websocket_client_tests = [] {
    };
 
    "json_message_exchange_test"_test = [] {
-      uint16_t port = 8098;
+      std::atomic<uint16_t> port{0};
       std::atomic<bool> server_ready{false};
       std::atomic<bool> stop_server{false};
 
@@ -1172,7 +1179,8 @@ suite websocket_client_tests = [] {
 
       std::thread server_thread([&]() {
          try {
-            server.bind(port);
+            server.bind("127.0.0.1", 0);
+            port = server.port();
             server.start();
             server_ready = true;
 
@@ -1215,7 +1223,7 @@ suite websocket_client_tests = [] {
 
       client.on_close([&](ws_close_code, std::string_view) { client.context()->stop(); });
 
-      std::string client_url = "ws://localhost:" + std::to_string(port) + "/ws";
+      std::string client_url = "ws://localhost:" + std::to_string(port.load()) + "/ws";
       client.connect(client_url);
 
       std::thread client_thread([&client]() { client.context()->run(); });
@@ -1235,11 +1243,11 @@ suite websocket_client_tests = [] {
    };
 
    "empty_message_test"_test = [] {
-      uint16_t port = 8099;
+      std::atomic<uint16_t> port{0};
       std::atomic<bool> server_ready{false};
       std::atomic<bool> stop_server{false};
 
-      std::thread server_thread(run_echo_server, std::ref(server_ready), std::ref(stop_server), port);
+      std::thread server_thread(run_echo_server, std::ref(server_ready), std::ref(stop_server), std::ref(port));
 
       expect(wait_for_condition([&] { return server_ready.load(); })) << "Server failed to start";
 
@@ -1259,7 +1267,7 @@ suite websocket_client_tests = [] {
 
       client.on_close([&](ws_close_code, std::string_view) { client.context()->stop(); });
 
-      std::string client_url = "ws://localhost:" + std::to_string(port) + "/ws";
+      std::string client_url = "ws://localhost:" + std::to_string(port.load()) + "/ws";
       client.connect(client_url);
 
       std::thread client_thread([&client]() { client.context()->run(); });
@@ -1279,11 +1287,11 @@ suite websocket_client_tests = [] {
    };
 
    "max_message_size_test"_test = [] {
-      uint16_t port = 8100;
+      std::atomic<uint16_t> port{0};
       std::atomic<bool> server_ready{false};
       std::atomic<bool> stop_server{false};
 
-      std::thread server_thread(run_echo_server, std::ref(server_ready), std::ref(stop_server), port);
+      std::thread server_thread(run_echo_server, std::ref(server_ready), std::ref(stop_server), std::ref(port));
 
       expect(wait_for_condition([&] { return server_ready.load(); })) << "Server failed to start";
 
@@ -1308,7 +1316,7 @@ suite websocket_client_tests = [] {
 
       client.on_close([&](ws_close_code, std::string_view) { client.context()->stop(); });
 
-      std::string client_url = "ws://localhost:" + std::to_string(port) + "/ws";
+      std::string client_url = "ws://localhost:" + std::to_string(port.load()) + "/ws";
       client.connect(client_url);
 
       std::thread client_thread([&client]() { client.context()->run(); });
@@ -1967,12 +1975,13 @@ suite websocket_client_tests = [] {
    // Regression for issue #2549: WebSocket upgrade lookup must strip the query string
    // and the on_open handler must see the parsed path/query like a regular handler.
    "websocket_upgrade_with_query_parameters_test"_test = [] {
-      uint16_t port = 8131;
+      std::atomic<uint16_t> port{0};
       std::atomic<bool> server_ready{false};
       std::atomic<bool> stop_server{false};
       auto capture = std::make_shared<ws_upgrade_capture>();
 
-      std::thread server_thread(run_capture_server, std::ref(server_ready), std::ref(stop_server), port, capture);
+      std::thread server_thread(run_capture_server, std::ref(server_ready), std::ref(stop_server), std::ref(port),
+                                capture);
       expect(wait_for_condition([&] { return server_ready.load(); })) << "Server failed to start";
 
       websocket_client client;
@@ -1990,7 +1999,7 @@ suite websocket_client_tests = [] {
       client.on_close([&](ws_close_code, std::string_view) { client.context()->stop(); });
 
       // Connect with a query string. Without the fix this 404s before the upgrade.
-      std::string client_url = "ws://localhost:" + std::to_string(port) + "/ws?token=abc&user=alice";
+      std::string client_url = "ws://localhost:" + std::to_string(port.load()) + "/ws?token=abc&user=alice";
       client.connect(client_url);
 
       std::thread client_thread([&client]() { client.context()->run(); });
@@ -2023,7 +2032,7 @@ suite websocket_client_tests = [] {
    // WebSocket routes registered with ":param" path segments must populate
    // request.params with the captured value, just like normal and streaming routes.
    "websocket_upgrade_with_path_parameter_test"_test = [] {
-      uint16_t port = 8132;
+      std::atomic<uint16_t> port{0};
       std::atomic<bool> server_ready{false};
       std::atomic<bool> stop_server{false};
       auto capture = std::make_shared<ws_upgrade_capture>();
@@ -2055,7 +2064,8 @@ suite websocket_client_tests = [] {
          server.websocket("/rooms/:room/ws", ws_server);
 
          try {
-            server.bind(port);
+            server.bind("127.0.0.1", 0);
+            port = server.port();
             server.start();
             server_ready = true;
             while (!stop_server) {
@@ -2084,7 +2094,7 @@ suite websocket_client_tests = [] {
       client.on_error([&](std::error_code) { connect_error = true; });
       client.on_close([&](ws_close_code, std::string_view) { client.context()->stop(); });
 
-      std::string client_url = "ws://localhost:" + std::to_string(port) + "/rooms/lobby/ws";
+      std::string client_url = "ws://localhost:" + std::to_string(port.load()) + "/rooms/lobby/ws";
       client.connect(client_url);
       std::thread client_thread([&client]() { client.context()->run(); });
 
@@ -2109,7 +2119,7 @@ suite websocket_client_tests = [] {
    // WebSocket routes registered through http_router and mounted via server.mount()
    // must also support ":param" segments and propagate captured params to on_open.
    "websocket_router_mount_with_path_parameter_test"_test = [] {
-      uint16_t port = 8133;
+      std::atomic<uint16_t> port{0};
       std::atomic<bool> server_ready{false};
       std::atomic<bool> stop_server{false};
       auto capture = std::make_shared<ws_upgrade_capture>();
@@ -2144,7 +2154,8 @@ suite websocket_client_tests = [] {
          server.mount("/api", router);
 
          try {
-            server.bind(port);
+            server.bind("127.0.0.1", 0);
+            port = server.port();
             server.start();
             server_ready = true;
             while (!stop_server) {
@@ -2173,7 +2184,7 @@ suite websocket_client_tests = [] {
       client.on_error([&](std::error_code) { connect_error = true; });
       client.on_close([&](ws_close_code, std::string_view) { client.context()->stop(); });
 
-      std::string client_url = "ws://localhost:" + std::to_string(port) + "/api/users/42/ws";
+      std::string client_url = "ws://localhost:" + std::to_string(port.load()) + "/api/users/42/ws";
       client.connect(client_url);
       std::thread client_thread([&client]() { client.context()->run(); });
 
@@ -2197,7 +2208,7 @@ suite websocket_client_tests = [] {
    // WebSocket routes with a wildcard segment ("*name") should capture the entire
    // remaining path (including embedded slashes), like normal and streaming routes.
    "websocket_with_wildcard_path_test"_test = [] {
-      uint16_t port = 8134;
+      std::atomic<uint16_t> port{0};
       std::atomic<bool> server_ready{false};
       std::atomic<bool> stop_server{false};
       auto capture = std::make_shared<ws_upgrade_capture>();
@@ -2228,7 +2239,8 @@ suite websocket_client_tests = [] {
          server.websocket("/files/*rest", ws_server);
 
          try {
-            server.bind(port);
+            server.bind("127.0.0.1", 0);
+            port = server.port();
             server.start();
             server_ready = true;
             while (!stop_server) {
@@ -2257,7 +2269,7 @@ suite websocket_client_tests = [] {
       client.on_error([&](std::error_code) { connect_error = true; });
       client.on_close([&](ws_close_code, std::string_view) { client.context()->stop(); });
 
-      std::string client_url = "ws://localhost:" + std::to_string(port) + "/files/a/b/c.txt";
+      std::string client_url = "ws://localhost:" + std::to_string(port.load()) + "/files/a/b/c.txt";
       client.connect(client_url);
       std::thread client_thread([&client]() { client.context()->run(); });
 
@@ -2284,7 +2296,7 @@ suite websocket_client_tests = [] {
    // handler with its own captured params, confirming the three radix tables in
    // basic_http_router are independent.
    "router_normal_streaming_websocket_coexist_test"_test = [] {
-      uint16_t port = 8135;
+      std::atomic<uint16_t> port{0};
       std::atomic<bool> server_ready{false};
       std::atomic<bool> stop_server{false};
 
@@ -2327,7 +2339,8 @@ suite websocket_client_tests = [] {
          server.mount("/api", router);
 
          try {
-            server.bind(port);
+            server.bind("127.0.0.1", 0);
+            port = server.port();
             server.start();
             server_ready = true;
             while (!stop_server) {
@@ -2344,12 +2357,12 @@ suite websocket_client_tests = [] {
 
       // Hit the normal route via http_client.
       glz::http_client http;
-      auto normal = http.get("http://127.0.0.1:" + std::to_string(port) + "/api/normal/1");
+      auto normal = http.get("http://127.0.0.1:" + std::to_string(port.load()) + "/api/normal/1");
       expect(normal.has_value() && normal->status_code == 200);
       if (normal) expect(normal->response_body == "normal-id=1") << normal->response_body;
 
       // Hit the streaming route via http_client.
-      auto stream = http.get("http://127.0.0.1:" + std::to_string(port) + "/api/stream/2");
+      auto stream = http.get("http://127.0.0.1:" + std::to_string(port.load()) + "/api/stream/2");
       expect(stream.has_value() && stream->status_code == 200);
       if (stream) expect(stream->response_body == "stream-id=2") << stream->response_body;
 
@@ -2368,7 +2381,7 @@ suite websocket_client_tests = [] {
       client.on_error([&](std::error_code) { connect_error = true; });
       client.on_close([&](ws_close_code, std::string_view) { client.context()->stop(); });
 
-      client.connect("ws://localhost:" + std::to_string(port) + "/api/ws/3");
+      client.connect("ws://localhost:" + std::to_string(port.load()) + "/api/ws/3");
       std::thread client_thread([&client]() { client.context()->run(); });
 
       expect(wait_for_condition([&] { return ws_opened.load(); })) << "WebSocket sibling route did not open";
@@ -2395,8 +2408,9 @@ suite websocket_client_tests = [] {
 // =============================================================================
 
 // Helper server that validates message integrity and echoes with sequence number
-void run_integrity_check_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_stop, uint16_t port,
-                                std::atomic<int>& valid_messages, std::atomic<int>& invalid_messages)
+void run_integrity_check_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_stop,
+                                std::atomic<uint16_t>& selected_port, std::atomic<int>& valid_messages,
+                                std::atomic<int>& invalid_messages)
 {
    http_server server;
    auto ws_server = std::make_shared<websocket_server>();
@@ -2444,7 +2458,8 @@ void run_integrity_check_server(std::atomic<bool>& server_ready, std::atomic<boo
    server.websocket("/ws", ws_server);
 
    try {
-      server.bind(port);
+      server.bind("127.0.0.1", 0);
+      selected_port = server.port();
       server.start();
       server_ready = true;
 
@@ -2460,8 +2475,8 @@ void run_integrity_check_server(std::atomic<bool>& server_ready, std::atomic<boo
 }
 
 // Helper server that broadcasts messages rapidly to all connected clients
-void run_broadcast_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_stop, uint16_t port,
-                          std::atomic<bool>& start_broadcast, int broadcast_count)
+void run_broadcast_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_stop,
+                          std::atomic<uint16_t>& selected_port, std::atomic<bool>& start_broadcast, int broadcast_count)
 {
    http_server server;
    auto ws_server = std::make_shared<websocket_server>();
@@ -2491,7 +2506,8 @@ void run_broadcast_server(std::atomic<bool>& server_ready, std::atomic<bool>& sh
    server.websocket("/ws", ws_server);
 
    try {
-      server.bind(port);
+      server.bind("127.0.0.1", 0);
+      selected_port = server.port();
       server.start();
       server_ready = true;
 
@@ -2526,14 +2542,14 @@ void run_broadcast_server(std::atomic<bool>& server_ready, std::atomic<bool>& sh
 suite websocket_write_queue_tests = [] {
    // Test: Rapid fire messages from a single thread (no delays)
    "rapid_fire_single_thread_test"_test = [] {
-      uint16_t port = 8110;
+      std::atomic<uint16_t> port{0};
       std::atomic<bool> server_ready{false};
       std::atomic<bool> stop_server{false};
       std::atomic<int> valid_messages{0};
       std::atomic<int> invalid_messages{0};
 
-      std::thread server_thread(run_integrity_check_server, std::ref(server_ready), std::ref(stop_server), port,
-                                std::ref(valid_messages), std::ref(invalid_messages));
+      std::thread server_thread(run_integrity_check_server, std::ref(server_ready), std::ref(stop_server),
+                                std::ref(port), std::ref(valid_messages), std::ref(invalid_messages));
 
       expect(wait_for_condition([&] { return server_ready.load(); })) << "Server failed to start";
 
@@ -2564,7 +2580,7 @@ suite websocket_write_queue_tests = [] {
 
       client.on_close([&](ws_close_code, std::string_view) { client.context()->stop(); });
 
-      std::string client_url = "ws://localhost:" + std::to_string(port) + "/ws";
+      std::string client_url = "ws://localhost:" + std::to_string(port.load()) + "/ws";
       client.connect(client_url);
 
       std::thread client_thread([&client]() { client.context()->run(); });
@@ -2591,14 +2607,14 @@ suite websocket_write_queue_tests = [] {
 
    // Test: Concurrent message sending from multiple threads (the key race condition test)
    "concurrent_multi_thread_send_test"_test = [] {
-      uint16_t port = 8111;
+      std::atomic<uint16_t> port{0};
       std::atomic<bool> server_ready{false};
       std::atomic<bool> stop_server{false};
       std::atomic<int> valid_messages{0};
       std::atomic<int> invalid_messages{0};
 
-      std::thread server_thread(run_integrity_check_server, std::ref(server_ready), std::ref(stop_server), port,
-                                std::ref(valid_messages), std::ref(invalid_messages));
+      std::thread server_thread(run_integrity_check_server, std::ref(server_ready), std::ref(stop_server),
+                                std::ref(port), std::ref(valid_messages), std::ref(invalid_messages));
 
       expect(wait_for_condition([&] { return server_ready.load(); })) << "Server failed to start";
 
@@ -2625,7 +2641,7 @@ suite websocket_write_queue_tests = [] {
 
       client.on_close([&](ws_close_code, std::string_view) { client.context()->stop(); });
 
-      std::string client_url = "ws://localhost:" + std::to_string(port) + "/ws";
+      std::string client_url = "ws://localhost:" + std::to_string(port.load()) + "/ws";
       client.connect(client_url);
 
       std::thread client_thread([&client]() { client.context()->run(); });
@@ -2685,13 +2701,13 @@ suite websocket_write_queue_tests = [] {
 
    // Test: Server-side rapid broadcasting (tests server write queue)
    "server_broadcast_stress_test"_test = [] {
-      uint16_t port = 8112;
+      std::atomic<uint16_t> port{0};
       std::atomic<bool> server_ready{false};
       std::atomic<bool> stop_server{false};
       std::atomic<bool> start_broadcast{false};
       const int broadcast_count = 100;
 
-      std::thread server_thread(run_broadcast_server, std::ref(server_ready), std::ref(stop_server), port,
+      std::thread server_thread(run_broadcast_server, std::ref(server_ready), std::ref(stop_server), std::ref(port),
                                 std::ref(start_broadcast), broadcast_count);
 
       expect(wait_for_condition([&] { return server_ready.load(); })) << "Server failed to start";
@@ -2743,7 +2759,7 @@ suite websocket_write_queue_tests = [] {
 
       client.on_close([&](ws_close_code, std::string_view) { client.context()->stop(); });
 
-      std::string client_url = "ws://localhost:" + std::to_string(port) + "/ws";
+      std::string client_url = "ws://localhost:" + std::to_string(port.load()) + "/ws";
       client.connect(client_url);
 
       std::thread client_thread([&client]() { client.context()->run(); });
@@ -2773,14 +2789,14 @@ suite websocket_write_queue_tests = [] {
 
    // Test: Mixed message sizes with concurrent sends
    "mixed_size_concurrent_test"_test = [] {
-      uint16_t port = 8113;
+      std::atomic<uint16_t> port{0};
       std::atomic<bool> server_ready{false};
       std::atomic<bool> stop_server{false};
       std::atomic<int> valid_messages{0};
       std::atomic<int> invalid_messages{0};
 
-      std::thread server_thread(run_integrity_check_server, std::ref(server_ready), std::ref(stop_server), port,
-                                std::ref(valid_messages), std::ref(invalid_messages));
+      std::thread server_thread(run_integrity_check_server, std::ref(server_ready), std::ref(stop_server),
+                                std::ref(port), std::ref(valid_messages), std::ref(invalid_messages));
 
       expect(wait_for_condition([&] { return server_ready.load(); })) << "Server failed to start";
 
@@ -2807,7 +2823,7 @@ suite websocket_write_queue_tests = [] {
 
       client.on_close([&](ws_close_code, std::string_view) { client.context()->stop(); });
 
-      std::string client_url = "ws://localhost:" + std::to_string(port) + "/ws";
+      std::string client_url = "ws://localhost:" + std::to_string(port.load()) + "/ws";
       client.connect(client_url);
 
       std::thread client_thread([&client]() { client.context()->run(); });
@@ -2864,14 +2880,14 @@ suite websocket_write_queue_tests = [] {
 
    // Test: Concurrent send and close - exercises close_after_write_ race condition fix
    "concurrent_send_and_close_test"_test = [] {
-      uint16_t port = 8115;
+      std::atomic<uint16_t> port{0};
       std::atomic<bool> server_ready{false};
       std::atomic<bool> stop_server{false};
       std::atomic<int> valid_messages{0};
       std::atomic<int> invalid_messages{0};
 
-      std::thread server_thread(run_integrity_check_server, std::ref(server_ready), std::ref(stop_server), port,
-                                std::ref(valid_messages), std::ref(invalid_messages));
+      std::thread server_thread(run_integrity_check_server, std::ref(server_ready), std::ref(stop_server),
+                                std::ref(port), std::ref(valid_messages), std::ref(invalid_messages));
 
       expect(wait_for_condition([&] { return server_ready.load(); })) << "Server failed to start";
 
@@ -2897,7 +2913,7 @@ suite websocket_write_queue_tests = [] {
          client.context()->stop();
       });
 
-      std::string client_url = "ws://localhost:" + std::to_string(port) + "/ws";
+      std::string client_url = "ws://localhost:" + std::to_string(port.load()) + "/ws";
       client.connect(client_url);
 
       std::thread client_thread([&client]() { client.context()->run(); });
@@ -2963,14 +2979,14 @@ suite websocket_write_queue_tests = [] {
 
    // Test: Stress test with many messages to ensure queue doesn't leak/corrupt under load
    "high_volume_stress_test"_test = [] {
-      uint16_t port = 8114;
+      std::atomic<uint16_t> port{0};
       std::atomic<bool> server_ready{false};
       std::atomic<bool> stop_server{false};
       std::atomic<int> valid_messages{0};
       std::atomic<int> invalid_messages{0};
 
-      std::thread server_thread(run_integrity_check_server, std::ref(server_ready), std::ref(stop_server), port,
-                                std::ref(valid_messages), std::ref(invalid_messages));
+      std::thread server_thread(run_integrity_check_server, std::ref(server_ready), std::ref(stop_server),
+                                std::ref(port), std::ref(valid_messages), std::ref(invalid_messages));
 
       expect(wait_for_condition([&] { return server_ready.load(); })) << "Server failed to start";
 
@@ -2994,7 +3010,7 @@ suite websocket_write_queue_tests = [] {
 
       client.on_close([&](ws_close_code, std::string_view) { client.context()->stop(); });
 
-      std::string client_url = "ws://localhost:" + std::to_string(port) + "/ws";
+      std::string client_url = "ws://localhost:" + std::to_string(port.load()) + "/ws";
       client.connect(client_url);
 
       std::thread client_thread([&client]() { client.context()->run(); });

--- a/tests/networking_tests/websocket_test/websocket_close_test.cpp
+++ b/tests/networking_tests/websocket_test/websocket_close_test.cpp
@@ -280,7 +280,6 @@ uint16_t close_code_from_frame(const websocket_frame& frame)
 
 suite websocket_close_frame_tests = [] {
    "coalesced_close_response_is_processed"_test = [] {
-      constexpr uint16_t port = 18088;
       std::atomic<bool> server_ready{false};
       std::atomic<bool> server_closed{false};
       std::atomic<int> message_count{0};
@@ -294,9 +293,10 @@ suite websocket_close_frame_tests = [] {
 
       http_server server;
       server.websocket("/ws", ws_server);
+      server.bind("127.0.0.1", 0);
+      const uint16_t port = server.port();
 
       std::thread server_thread([&]() {
-         server.bind(port);
          server_ready = true;
          server.start();
       });
@@ -357,9 +357,10 @@ suite websocket_close_frame_tests = [] {
       // Create HTTP server
       http_server server;
       server.websocket("/ws", ws_server);
+      server.bind("127.0.0.1", 0);
+      const uint16_t port = server.port();
 
       std::thread server_thread([&]() {
-         server.bind(18081);
          server_ready = true;
          server.start();
       });
@@ -372,14 +373,16 @@ suite websocket_close_frame_tests = [] {
       asio::io_context io_context;
       asio::ip::tcp::socket socket(io_context);
       asio::ip::tcp::resolver resolver(io_context);
-      auto endpoints = resolver.resolve("127.0.0.1", "18081");
+      auto endpoints = resolver.resolve("127.0.0.1", std::to_string(port));
 
       asio::connect(socket, endpoints);
 
       // Send WebSocket handshake
       std::string handshake =
          "GET /ws HTTP/1.1\r\n"
-         "Host: localhost:18081\r\n"
+         "Host: localhost:" +
+         std::to_string(port) +
+         "\r\n"
          "Upgrade: websocket\r\n"
          "Connection: Upgrade\r\n"
          "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
@@ -431,9 +434,10 @@ suite websocket_close_frame_tests = [] {
       // Create HTTP server
       http_server server;
       server.websocket("/ws", ws_server);
+      server.bind("127.0.0.1", 0);
+      const uint16_t port = server.port();
 
       std::thread server_thread([&]() {
-         server.bind(18082);
          server_ready = true;
          server.start();
       });
@@ -446,14 +450,16 @@ suite websocket_close_frame_tests = [] {
       asio::io_context io_context;
       asio::ip::tcp::socket socket(io_context);
       asio::ip::tcp::resolver resolver(io_context);
-      auto endpoints = resolver.resolve("127.0.0.1", "18082");
+      auto endpoints = resolver.resolve("127.0.0.1", std::to_string(port));
 
       asio::connect(socket, endpoints);
 
       // Send WebSocket handshake
       std::string handshake =
          "GET /ws HTTP/1.1\r\n"
-         "Host: localhost:18082\r\n"
+         "Host: localhost:" +
+         std::to_string(port) +
+         "\r\n"
          "Upgrade: websocket\r\n"
          "Connection: Upgrade\r\n"
          "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
@@ -522,9 +528,10 @@ suite websocket_error_handling_tests = [] {
       // Create HTTP server
       http_server server;
       server.websocket("/ws", ws_server);
+      server.bind("127.0.0.1", 0);
+      const uint16_t port = server.port();
 
       std::thread server_thread([&]() {
-         server.bind(18083);
          server_ready = true;
          server.start();
       });
@@ -537,14 +544,16 @@ suite websocket_error_handling_tests = [] {
       asio::io_context io_context;
       asio::ip::tcp::socket socket(io_context);
       asio::ip::tcp::resolver resolver(io_context);
-      auto endpoints = resolver.resolve("127.0.0.1", "18083");
+      auto endpoints = resolver.resolve("127.0.0.1", std::to_string(port));
 
       asio::connect(socket, endpoints);
 
       // Send WebSocket handshake
       std::string handshake =
          "GET /ws HTTP/1.1\r\n"
-         "Host: localhost:18083\r\n"
+         "Host: localhost:" +
+         std::to_string(port) +
+         "\r\n"
          "Upgrade: websocket\r\n"
          "Connection: Upgrade\r\n"
          "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
@@ -592,9 +601,10 @@ suite websocket_error_handling_tests = [] {
       // Create HTTP server
       http_server server;
       server.websocket("/ws", ws_server);
+      server.bind("127.0.0.1", 0);
+      const uint16_t port = server.port();
 
       std::thread server_thread([&]() {
-         server.bind(18084);
          server_ready = true;
          server.start();
       });
@@ -607,14 +617,16 @@ suite websocket_error_handling_tests = [] {
       asio::io_context io_context;
       asio::ip::tcp::socket socket(io_context);
       asio::ip::tcp::resolver resolver(io_context);
-      auto endpoints = resolver.resolve("127.0.0.1", "18084");
+      auto endpoints = resolver.resolve("127.0.0.1", std::to_string(port));
 
       asio::connect(socket, endpoints);
 
       // Send WebSocket handshake
       std::string handshake =
          "GET /ws HTTP/1.1\r\n"
-         "Host: localhost:18084\r\n"
+         "Host: localhost:" +
+         std::to_string(port) +
+         "\r\n"
          "Upgrade: websocket\r\n"
          "Connection: Upgrade\r\n"
          "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
@@ -657,9 +669,10 @@ suite websocket_error_handling_tests = [] {
       // Create HTTP server
       http_server server;
       server.websocket("/ws", ws_server);
+      server.bind("127.0.0.1", 0);
+      const uint16_t port = server.port();
 
       std::thread server_thread([&]() {
-         server.bind(18085);
          server_ready = true;
          server.start();
       });
@@ -672,14 +685,16 @@ suite websocket_error_handling_tests = [] {
       asio::io_context io_context;
       asio::ip::tcp::socket socket(io_context);
       asio::ip::tcp::resolver resolver(io_context);
-      auto endpoints = resolver.resolve("127.0.0.1", "18085");
+      auto endpoints = resolver.resolve("127.0.0.1", std::to_string(port));
 
       asio::connect(socket, endpoints);
 
       // Send WebSocket handshake
       std::string handshake =
          "GET /ws HTTP/1.1\r\n"
-         "Host: localhost:18085\r\n"
+         "Host: localhost:" +
+         std::to_string(port) +
+         "\r\n"
          "Upgrade: websocket\r\n"
          "Connection: Upgrade\r\n"
          "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
@@ -725,7 +740,6 @@ suite websocket_error_handling_tests = [] {
 
 suite websocket_utf8_fail_fast_tests = [] {
    "invalid_utf8_in_incomplete_text_frame_fails_fast"_test = [] {
-      constexpr uint16_t port = 18086;
       std::atomic<bool> server_ready{false};
       std::atomic<bool> server_closed{false};
       std::atomic<int> message_count{0};
@@ -740,9 +754,10 @@ suite websocket_utf8_fail_fast_tests = [] {
 
       http_server server;
       server.websocket("/ws", ws_server);
+      server.bind("127.0.0.1", 0);
+      const uint16_t port = server.port();
 
       std::thread server_thread([&]() {
-         server.bind(port);
          server_ready = true;
          server.start();
       });
@@ -785,7 +800,6 @@ suite websocket_utf8_fail_fast_tests = [] {
    };
 
    "split_masked_text_frame_preserves_utf8_payload"_test = [] {
-      constexpr uint16_t port = 18087;
       std::atomic<bool> server_ready{false};
       std::atomic<int> message_count{0};
       std::mutex received_mutex;
@@ -803,9 +817,10 @@ suite websocket_utf8_fail_fast_tests = [] {
 
       http_server server;
       server.websocket("/ws", ws_server);
+      server.bind("127.0.0.1", 0);
+      const uint16_t port = server.port();
 
       std::thread server_thread([&]() {
-         server.bind(port);
          server_ready = true;
          server.start();
       });
@@ -857,7 +872,6 @@ suite websocket_utf8_fail_fast_tests = [] {
 
 suite websocket_masking_tests = [] {
    "unmasked_client_frame_fails_with_protocol_error"_test = [] {
-      constexpr uint16_t port = 18089;
       std::atomic<bool> server_ready{false};
       std::atomic<bool> server_closed{false};
       std::atomic<int> message_count{0};
@@ -872,9 +886,10 @@ suite websocket_masking_tests = [] {
 
       http_server server;
       server.websocket("/ws", ws_server);
+      server.bind("127.0.0.1", 0);
+      const uint16_t port = server.port();
 
       std::thread server_thread([&]() {
-         server.bind(port);
          server_ready = true;
          server.start();
       });


### PR DESCRIPTION
This will fix the flaky CI runs that have recently started occurring quite frequently ([1](https://github.com/stephenberry/glaze/actions/runs/29376184736/job/87230024448), [2](https://github.com/stephenberry/glaze/actions/runs/29157147577/job/86556016016), [3](https://github.com/stephenberry/glaze/actions/runs/29157147577/job/86556016016)).

The most stable solution is to use ephemeral-ports, by binding port 0, the OS will assign a random, unoccupied port, after which we simply need to read the local endpoint and use the port from it. I've already [encountered this problem before](https://github.com/blazeauth/aero/pull/26/changes/797693013a4560c85be302bf475a2fd78a98c7f9) and this has proven to be a reliable fix.

I'd like to note that, specifically for this PR, I used an AI to scan and perform this boilerplate task. I couldn't find anything regarding Glaze's policy on AI use, but I've reviewed the final diff and it's LGTM.