### PR TITLE
reject truncated bitset payload in msgpack reader

### DIFF
--- a/include/glaze/msgpack/read.hpp
+++ b/include/glaze/msgpack/read.hpp
@@ -369,7 +369,12 @@ namespace glz
             return;
          }
 
-         for (size_t byte_i{}, i{}; byte_i < num_bytes && it < end; ++byte_i, ++it) {
+         if (static_cast<size_t>(end - it) < num_bytes) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return;
+         }
+
+         for (size_t byte_i{}, i{}; byte_i < num_bytes; ++byte_i, ++it) {
             uint8_t byte = static_cast<uint8_t>(*it);
             for (size_t bit_i = 0; bit_i < 8 && i < value.size(); ++bit_i, ++i) {
                value[i] = (byte >> bit_i) & uint8_t(1);

--- a/tests/msgpack_test/msgpack_test.cpp
+++ b/tests/msgpack_test/msgpack_test.cpp
@@ -944,6 +944,24 @@ int main()
       expect_roundtrip_equal(mask);
    };
 
+   "msgpack bitset rejects truncated payload"_test = [] {
+      // The bin header declares num_bytes of packed bits, but the buffer is cut
+      // short so fewer payload bytes are present. The reader must report
+      // unexpected_end rather than silently leaving the missing bits at zero.
+      std::bitset<16> mask{0b10101010'01010101};
+      std::string buffer;
+      expect(!glz::write_msgpack(mask, buffer));
+
+      std::bitset<16> out{};
+      const auto ec = glz::read_msgpack(out, std::string_view{buffer}.substr(0, buffer.size() - 1));
+      expect(ec.ec == glz::error_code::unexpected_end)
+         << "expected unexpected_end on truncated bitset payload, got: " << glz::format_error(ec, buffer);
+
+      std::bitset<16> out2{};
+      const auto ec2 = glz::read_msgpack(out2, std::string_view{buffer}.substr(0, buffer.size() - 2));
+      expect(ec2.ec == glz::error_code::unexpected_end) << "expected unexpected_end on missing bitset payload";
+   };
+
    "msgpack ext container roundtrip"_test = [] {
       std::vector<glz::msgpack::ext> payloads{
          glz::msgpack::ext{1, {std::byte{0x01}, std::byte{0x02}}},


### PR DESCRIPTION
Reading a std::bitset from a truncated MessagePack buffer:

    // bin header declares 2 payload bytes, buffer supplies 1
    c4 02 55   ->   read_msgpack returns success, bits = 0000000001010101

`from<MSGPACK, is_bitset>::op` checks the bin length against `num_bytes = (value.size()+7)/8`, but the unpack loop was bounded by `it < end`, so a short buffer just stops the loop early and leaves the missing high bits at their default.

Before: a truncated payload is accepted and the absent bytes read as zero.
After: `end - it < num_bytes` returns unexpected_end before the loop, matching the CBOR bitset reader (cbor/read.hpp) and the BEVE bitset/bool readers, which already bound the packed payload against end. Valid input is unchanged; the cost is one compare before the loop.