### PR TITLE
guard lazy json scans against end of non-null-terminated input

### DIFF
--- a/include/glaze/json/lazy.hpp
+++ b/include/glaze/json/lazy.hpp
@@ -161,15 +161,27 @@ namespace glz
             }
             return p;
          }
-         default:
-            // Number
+         default: {
+            // Number, or an unrecognized byte.
+            const char* const start = p;
             if constexpr (Opts.null_terminated) {
                while (numeric_table[uint8_t(*p)]) ++p;
             }
             else {
                while (p < end && numeric_table[uint8_t(*p)]) ++p;
             }
+            // Guarantee forward progress. A byte that begins no valid value (not a string,
+            // literal, container, or number - impossible in well-formed JSON) leaves p unmoved,
+            // which would spin every caller that skips values in a loop (size(), index(),
+            // operator[], iteration) forever on malformed input. Treat it as a one-byte scalar so
+            // the scan always advances whenever p < end. Bounded by end because json_end_ is the
+            // authoritative message end: a byte within it is safe to step over, while at or past
+            // end we must not move (the caller's own p >= end guard then stops the loop). On
+            // valid input p is always a real value start, so this branch never fires - no
+            // behavior change.
+            if (p == start && p < end) ++p;
             return p;
+         }
          }
       }
    } // namespace detail
@@ -733,25 +745,16 @@ namespace glz
       const char* p = data_ + 1; // skip '['
       skip_ws(p, end);
 
-      // Check for empty array
-      if constexpr (Opts.null_terminated) {
-         if (*p == ']') return make_error(error_code::exceeded_static_array_size);
-      }
-      else {
-         if (p >= end || *p == ']') return make_error(error_code::exceeded_static_array_size);
-      }
+      // Check for empty array. json_end_ bounds the message in both modes: null_terminated does
+      // not guarantee the '\0' sits at json_end_, so fall back to the bound here too.
+      if (p >= end || *p == ']') return make_error(error_code::exceeded_static_array_size);
 
       // Skip 'index' elements using lazy scanning
       for (size_t i = 0; i < index; ++i) {
          p = detail::skip_value_lazy<Opts>(p, end);
          skip_ws(p, end);
 
-         if constexpr (Opts.null_terminated) {
-            if (*p == ']') return make_error(error_code::exceeded_static_array_size);
-         }
-         else {
-            if (p >= end || *p == ']') return make_error(error_code::exceeded_static_array_size);
-         }
+         if (p >= end || *p == ']') return make_error(error_code::exceeded_static_array_size);
 
          if (*p == ',') {
             ++p;
@@ -759,11 +762,10 @@ namespace glz
          }
       }
 
-      if constexpr (!Opts.null_terminated) {
-         // The requested index landed past end-of-input (e.g. a trailing comma with no
-         // following element); a view positioned at end would read past the buffer.
-         if (p >= end) return make_error(error_code::exceeded_static_array_size);
-      }
+      // The requested index landed at or past end-of-input (a trailing comma with no following
+      // element, or an unclosed array); a view positioned at end would read past the buffer, or,
+      // when null_terminated, off the message into trailing bytes.
+      if (p >= end) return make_error(error_code::exceeded_static_array_size);
       return {doc_, p};
    }
 
@@ -797,13 +799,10 @@ namespace glz
 
       // Forward pass: search from current position to end of object
       while (true) {
-         // Check for end of object
-         if constexpr (Opts.null_terminated) {
-            if (*p == '}') break;
-         }
-         else {
-            if (p >= end || *p == '}') break;
-         }
+         // Check for end of object. json_end_ bounds the message in both modes (null_terminated
+         // does not guarantee the '\0' sits at json_end_); this is also the loop's backstop
+         // against an unclosed object spinning forever on a key parse that never advances.
+         if (p >= end || *p == '}') break;
 
          // Parse key
          auto k = parse_key(p, end);
@@ -817,12 +816,12 @@ namespace glz
 
          // Check if key matches
          if (k == key) {
+            // A matched key whose value begins at or past json_end_ is truncated; a view
+            // positioned at end would read past the buffer (or, when null_terminated, off the
+            // message into trailing bytes). Return the error before storing parse_pos_ so a
+            // truncated match leaves no state.
+            if (p >= end) return make_error(error_code::unexpected_end);
             parse_pos_ = p; // Store value position (lazy - don't skip yet)
-            if constexpr (!Opts.null_terminated) {
-               // A matched key whose value begins at end-of-input is truncated; a view
-               // positioned at end would read past the buffer on its first access.
-               if (p >= end) return make_error(error_code::unexpected_end);
-            }
             return {doc_, p};
          }
 
@@ -843,13 +842,8 @@ namespace glz
          skip_ws(p, end);
 
          while (p < search_start) {
-            // Check for end of object
-            if constexpr (Opts.null_terminated) {
-               if (*p == '}') break;
-            }
-            else {
-               if (p >= end || *p == '}') break;
-            }
+            // Check for end of object (see forward pass).
+            if (p >= end || *p == '}') break;
 
             // Parse key
             auto k = parse_key(p, end);
@@ -863,12 +857,12 @@ namespace glz
 
             // Check if key matches
             if (k == key) {
+               // A matched key whose value begins at or past json_end_ is truncated; a view
+               // positioned at end would read past the buffer (or, when null_terminated, off the
+               // message into trailing bytes). Return the error before storing parse_pos_ so a
+               // truncated match leaves no state.
+               if (p >= end) return make_error(error_code::unexpected_end);
                parse_pos_ = p; // Store value position (lazy - don't skip yet)
-               if constexpr (!Opts.null_terminated) {
-                  // A matched key whose value begins at end-of-input is truncated; a view
-                  // positioned at end would read past the buffer on its first access.
-                  if (p >= end) return make_error(error_code::unexpected_end);
-               }
                return {doc_, p};
             }
 
@@ -906,17 +900,19 @@ namespace glz
 
       const char close_char = is_array() ? ']' : '}';
 
-      if constexpr (Opts.null_terminated) {
-         if (*p == close_char) return 0;
-      }
-      else {
-         if (p >= end || *p == close_char) return 0;
-      }
+      // json_end_ bounds the message in both modes: null_terminated does not guarantee the '\0'
+      // sits at json_end_, so fall back to the bound here and throughout the loop below.
+      if (p >= end || *p == close_char) return 0;
 
       size_t count = 0;
       const bool is_obj = is_object();
 
       while (true) {
+         // Stop before scanning a key/value at or past end. This keeps skip_string_fast and
+         // skip_value_lazy from dereferencing off the buffer, and is the loop's backstop against
+         // an unclosed container running off the end.
+         if (p >= end) return count;
+
          if (is_obj) {
             // Skip key
             p = detail::skip_string_fast<Opts>(p, end);
@@ -925,6 +921,9 @@ namespace glz
                ++p;
                skip_ws(p, end);
             }
+            // The value begins at or past end (truncated pair); don't count it, so size() agrees
+            // with index() and iteration.
+            if (p >= end) return count;
          }
 
          // Skip value
@@ -932,12 +931,7 @@ namespace glz
          ++count;
          skip_ws(p, end);
 
-         if constexpr (Opts.null_terminated) {
-            if (*p == close_char) return count;
-         }
-         else {
-            if (p >= end || *p == close_char) return count;
-         }
+         if (p >= end || *p == close_char) return count;
 
          if (*p == ',') {
             ++p;
@@ -958,12 +952,10 @@ namespace glz
       skip_ws(p, end);
 
       const char close_char = is_array() ? ']' : '}';
-      if constexpr (Opts.null_terminated) {
-         return *p == close_char;
-      }
-      else {
-         return p >= end || *p == close_char;
-      }
+      // json_end_ bounds the message in both modes (null_terminated does not guarantee the '\0'
+      // sits at json_end_); a container with nothing before end is empty. This keeps empty()
+      // consistent with size()/index()/iteration reporting 0 on a bare, unclosed container.
+      return p >= end || *p == close_char;
    }
 
    // ============================================================================
@@ -1012,8 +1004,13 @@ namespace glz
             skip_ws(pos);
          }
       }
-      // A value that begins at end-of-input is a truncated element; stop iterating instead
-      // of handing back a view whose data pointer sits at end (every view op reads *data_).
+      // A value that begins at or past json_end_ is a truncated element; stop iterating instead
+      // of handing back a view whose data pointer sits at end (every view op reads *data_, an
+      // out-of-bounds read for a non-null-terminated buffer). This bound is unconditional on
+      // purpose: json_end_ is the authoritative end of the message, whereas null_terminated only
+      // promises a '\0' sentinel exists, not that it sits at json_end_ (it may be trailing buffer
+      // content further on), so '\0' cannot substitute here. It is also the iterator's only
+      // backstop against spinning forever on unclosed null-terminated input.
       if (pos >= json_end_) {
          at_end_ = true;
          return;
@@ -1123,16 +1120,17 @@ namespace glz
       const char close_char = is_array() ? ']' : '}';
       const bool is_obj = is_object();
 
-      // Check for empty container
-      if constexpr (Opts.null_terminated) {
-         if (*p == close_char) return result;
-      }
-      else {
-         if (p >= end || *p == close_char) return result;
-      }
+      // Check for empty container. json_end_ bounds the message in both modes: null_terminated
+      // does not guarantee the '\0' sits at json_end_, so fall back to the bound throughout.
+      if (p >= end || *p == close_char) return result;
 
       // Scan and record all element positions
       while (true) {
+         // Stop before parsing a key/value at or past end: this keeps the scans from reading off
+         // the buffer and is the loop's backstop against an unclosed container looping forever
+         // (repeatedly recording an element positioned at end).
+         if (p >= end) break;
+
          std::string_view key{};
          if (is_obj) {
             // Parse and record key
@@ -1146,11 +1144,9 @@ namespace glz
             }
          }
 
-         // A truncated element whose value begins at end-of-input must not be recorded:
+         // A truncated element whose value begins at or past json_end_ must not be recorded:
          // an indexed view would later hand back a view positioned at end.
-         if constexpr (!Opts.null_terminated) {
-            if (p >= end) break;
-         }
+         if (p >= end) break;
 
          // Record element start position
          result.add_element(p, key);
@@ -1160,12 +1156,7 @@ namespace glz
          skip_ws(p, end);
 
          // Check for end of container
-         if constexpr (Opts.null_terminated) {
-            if (*p == close_char) break;
-         }
-         else {
-            if (p >= end || *p == close_char) break;
-         }
+         if (p >= end || *p == close_char) break;
 
          // Skip comma
          if (*p == ',') {

--- a/include/glaze/json/lazy.hpp
+++ b/include/glaze/json/lazy.hpp
@@ -107,15 +107,20 @@ namespace glz
       GLZ_ALWAYS_INLINE const char* skip_value_lazy(const char* p, const char* end) noexcept
       {
          using enum lazy_char_type;
+         if constexpr (!Opts.null_terminated) {
+            // Non-null-terminated buffers have no '\0' sentinel, so a caller can reach here
+            // with p == end (e.g. a key whose value is missing). Guard the tag dereference.
+            if (p >= end) return p;
+         }
          switch (*p) {
          case '"':
             return skip_string_fast<Opts>(p, end);
          case 't':
-            return p + 4;
+            return p + 4 <= end ? p + 4 : end;
          case 'f':
-            return p + 5;
+            return p + 5 <= end ? p + 5 : end;
          case 'n':
-            return p + 4;
+            return p + 4 <= end ? p + 4 : end;
          case '[':
          case '{': {
             int depth = 1;
@@ -681,6 +686,11 @@ namespace glz
    template <opts Opts>
    inline std::string_view lazy_json_view<Opts>::parse_key(const char*& p, const char* end) noexcept
    {
+      // A non-null-terminated buffer has no '\0' sentinel, so a scan loop can reach the next
+      // key position with p == end (e.g. after a trailing comma). Guard the opening dereference.
+      if constexpr (!Opts.null_terminated) {
+         if (p >= end) return {};
+      }
       if (*p != '"') return {};
       const char* const start = p;
       ++p; // skip opening quote
@@ -749,6 +759,11 @@ namespace glz
          }
       }
 
+      if constexpr (!Opts.null_terminated) {
+         // The requested index landed past end-of-input (e.g. a trailing comma with no
+         // following element); a view positioned at end would read past the buffer.
+         if (p >= end) return make_error(error_code::exceeded_static_array_size);
+      }
       return {doc_, p};
    }
 
@@ -770,7 +785,7 @@ namespace glz
          const char* p = parse_pos_;
          p = detail::skip_value_lazy<Opts>(p, end);
          skip_ws(p, end);
-         if (*p == ',') {
+         if (p < end && *p == ',') {
             ++p;
             skip_ws(p, end);
          }
@@ -795,7 +810,7 @@ namespace glz
          skip_ws(p, end);
 
          // Skip ':'
-         if (*p == ':') {
+         if (p < end && *p == ':') {
             ++p;
             skip_ws(p, end);
          }
@@ -803,6 +818,11 @@ namespace glz
          // Check if key matches
          if (k == key) {
             parse_pos_ = p; // Store value position (lazy - don't skip yet)
+            if constexpr (!Opts.null_terminated) {
+               // A matched key whose value begins at end-of-input is truncated; a view
+               // positioned at end would read past the buffer on its first access.
+               if (p >= end) return make_error(error_code::unexpected_end);
+            }
             return {doc_, p};
          }
 
@@ -811,7 +831,7 @@ namespace glz
          skip_ws(p, end);
 
          // Skip comma
-         if (*p == ',') {
+         if (p < end && *p == ',') {
             ++p;
             skip_ws(p, end);
          }
@@ -836,7 +856,7 @@ namespace glz
             skip_ws(p, end);
 
             // Skip ':'
-            if (*p == ':') {
+            if (p < end && *p == ':') {
                ++p;
                skip_ws(p, end);
             }
@@ -844,6 +864,11 @@ namespace glz
             // Check if key matches
             if (k == key) {
                parse_pos_ = p; // Store value position (lazy - don't skip yet)
+               if constexpr (!Opts.null_terminated) {
+                  // A matched key whose value begins at end-of-input is truncated; a view
+                  // positioned at end would read past the buffer on its first access.
+                  if (p >= end) return make_error(error_code::unexpected_end);
+               }
                return {doc_, p};
             }
 
@@ -852,7 +877,7 @@ namespace glz
             skip_ws(p, end);
 
             // Skip comma
-            if (*p == ',') {
+            if (p < end && *p == ',') {
                ++p;
                skip_ws(p, end);
             }
@@ -896,7 +921,7 @@ namespace glz
             // Skip key
             p = detail::skip_string_fast<Opts>(p, end);
             skip_ws(p, end);
-            if (*p == ':') {
+            if (p < end && *p == ':') {
                ++p;
                skip_ws(p, end);
             }
@@ -982,10 +1007,16 @@ namespace glz
          skip_ws(pos);
 
          // Skip ':'
-         if (*pos == ':') {
+         if (pos < json_end_ && *pos == ':') {
             ++pos;
             skip_ws(pos);
          }
+      }
+      // A value that begins at end-of-input is a truncated element; stop iterating instead
+      // of handing back a view whose data pointer sits at end (every view op reads *data_).
+      if (pos >= json_end_) {
+         at_end_ = true;
+         return;
       }
       // Store key in current_view_ (will be set properly after this call)
       current_view_ = lazy_json_view<Opts>{doc_, pos, key};
@@ -1109,10 +1140,16 @@ namespace glz
             skip_ws(p, end);
 
             // Skip ':'
-            if (*p == ':') {
+            if (p < end && *p == ':') {
                ++p;
                skip_ws(p, end);
             }
+         }
+
+         // A truncated element whose value begins at end-of-input must not be recorded:
+         // an indexed view would later hand back a view positioned at end.
+         if constexpr (!Opts.null_terminated) {
+            if (p >= end) break;
          }
 
          // Record element start position

--- a/tests/json_test/lazy_test.cpp
+++ b/tests/json_test/lazy_test.cpp
@@ -1348,6 +1348,239 @@ suite dynamic_key_custom_tests = [] {
       }
       expect(count == 0u); // the truncated element is not yielded
    };
+
+   // size(), index().size(), and iteration must agree on a truncated object. size() used to
+   // count the incomplete "a": pair (returning 1) while index() and iteration reported 0.
+   "lazy_json_truncated_size_consistency"_test = [] {
+      const std::vector<char> buf{'{', '"', 'a', '"', ':'};
+      const std::string_view sv{buf.data(), buf.size()};
+      auto result = glz::lazy_json<glz::opts{.null_terminated = false}>(sv);
+      expect(result.has_value());
+      auto& root = (*result).root();
+      const size_t by_size = root.size();
+      const size_t by_index = root.index().size();
+      size_t by_iter = 0;
+      for (auto element : root) {
+         (void)element;
+         ++by_iter;
+      }
+      expect(by_size == 0u);
+      expect(by_index == 0u);
+      expect(by_iter == 0u);
+      expect(by_size == by_index);
+      expect(by_size == by_iter);
+   };
+
+   // Iterating a malformed null-terminated document (an unclosed container, valid to feed with
+   // the default null_terminated option since std::string supplies the '\0') must terminate via
+   // json_end_ rather than spinning forever on the end position.
+   "lazy_json_unterminated_iterate_null_terminated"_test = [] {
+      const std::string json = R"({"a":1)"; // no closing brace
+      auto result = glz::lazy_json<glz::opts{}>(json);
+      expect(result.has_value());
+      size_t count = 0;
+      for (auto element : (*result).root()) {
+         (void)element;
+         if (++count > 1000) break; // guard: a regression here would loop forever
+      }
+      expect(count == 1u); // only the complete "a" element is yielded, then iteration stops
+   };
+
+   // null_terminated only promises a '\0' sentinel exists somewhere the parser may rely on, not
+   // that it sits at json_end_. Here the message is the first 7 bytes ("{\"a\":1,"), but the
+   // backing storage continues with more JSON and the '\0' is far past json_end_. Iteration must
+   // stop at json_end_ (yielding only the complete "a" element), not run on into the trailing
+   // bytes toward the distant '\0'.
+   "lazy_json_null_terminated_end_before_sentinel"_test = [] {
+      const char storage[] = R"({"a":1,"b":2})"; // '\0' at storage[13], well past the view below
+      const std::string_view sv{storage, 7}; // "{\"a\":1,"
+      auto result = glz::lazy_json<glz::opts{}>(sv); // null_terminated = true (default)
+      expect(result.has_value());
+      size_t count = 0;
+      std::string_view last_key{};
+      for (auto element : (*result).root()) {
+         last_key = element.key();
+         if (++count > 10) break; // guard: a '\0'-based stop would iterate into "b" and beyond
+      }
+      expect(count == 1u); // "b" lies past json_end_, so it must not be yielded
+      expect(last_key == "a");
+   };
+
+   // A successful lookup primes parse_pos_, so a following lookup runs the progressive-scan branch.
+   // If that second lookup matches a key whose value is truncated at end-of-input, it must report
+   // the error and still leave the view usable: a later lookup of an earlier key must recover.
+   "lazy_json_truncated_match_recovers_after_progressive_scan"_test = [] {
+      // "a" has a complete value; "b" is matched but its value begins exactly at end-of-input.
+      const std::vector<char> buf{'{', '"', 'a', '"', ':', '1', ',', '"', 'b', '"', ':'};
+      const std::string_view sv{buf.data(), buf.size()};
+      auto result = glz::lazy_json<glz::opts{.null_terminated = false}>(sv);
+      expect(result.has_value());
+      auto& doc = *result;
+
+      auto a1 = doc["a"]; // primes parse_pos_ to the value of "a"
+      expect(!a1.has_error());
+      expect(a1.template get<int64_t>().value() == 1);
+
+      expect(doc["b"].has_error()); // progressive scan matches "b"; its value is truncated
+
+      auto a2 = doc["a"]; // must still resolve after the truncated match
+      expect(!a2.has_error());
+      expect(a2.template get<int64_t>().value() == 1);
+   };
+
+   // Malformed *null-terminated* input (an unclosed container) must stay bounded by json_end_ in
+   // the accessors too, not just iteration. Each backing store below is a heap std::vector holding
+   // the message bytes followed by a single '\0' at json_end_, with the view sized to exclude the
+   // '\0'; any read past that sentinel lands outside the allocation and aborts under the sanitizer
+   // CI builds. Before the fix, size() walked skip_string_fast past the sentinel (OOB read),
+   // index() recorded elements at end forever (OOM), operator[](key) spun forever, and
+   // operator[](index) handed back a view positioned at end.
+   "lazy_json_null_terminated_unclosed_object_size"_test = [] {
+      std::vector<char> storage{'{', '"', 'a', '"', ':', '1', '\0'}; // '\0' at index 6 == json_end_
+      const std::string_view sv{storage.data(), 6}; // "{\"a\":1"
+      auto result = glz::lazy_json<glz::opts{}>(sv); // null_terminated = true
+      expect(result.has_value());
+      expect((*result).root().size() == 1u); // one complete member, then bounded by json_end_
+   };
+
+   "lazy_json_null_terminated_unclosed_object_index"_test = [] {
+      std::vector<char> storage{'{', '"', 'a', '"', ':', '1', '\0'};
+      const std::string_view sv{storage.data(), 6};
+      auto result = glz::lazy_json<glz::opts{}>(sv);
+      expect(result.has_value());
+      auto idx = (*result).root().index();
+      expect(idx.size() == 1u); // loop stops at json_end_ instead of recording end forever
+      expect(idx["a"].template get<int64_t>().value() == 1);
+   };
+
+   "lazy_json_null_terminated_unclosed_object_lookup"_test = [] {
+      std::vector<char> storage{'{', '"', 'a', '"', ':', '1', '\0'};
+      const std::string_view sv{storage.data(), 6};
+      auto result = glz::lazy_json<glz::opts{}>(sv);
+      expect(result.has_value());
+      auto& root = (*result).root();
+      expect(!root["a"].has_error()); // present key resolves
+      expect(root["a"].template get<int64_t>().value() == 1);
+      expect(root["missing"].has_error()); // absent key on an unclosed object: not_found, no spin
+   };
+
+   "lazy_json_null_terminated_unclosed_array_index"_test = [] {
+      std::vector<char> storage{'[', '1', ',', '2', '\0'}; // "[1,2" then '\0' at json_end_
+      const std::string_view sv{storage.data(), 4};
+      auto result = glz::lazy_json<glz::opts{}>(sv);
+      expect(result.has_value());
+      auto& root = (*result).root();
+      expect(root[0].template get<int64_t>().value() == 1);
+      expect(root[1].template get<int64_t>().value() == 2);
+      expect(root[2].has_error()); // past the end: an error, not a bogus view positioned at end
+   };
+
+   // operator[](key) runs its value-truncation guard in null-terminated mode too. Without it, a
+   // matched key whose value begins at json_end_ hands back a bogus non-error view positioned at
+   // end; for a std::string that view's data_ points at the '\0', so ASan would NOT catch the
+   // regression. This test pins the behavior via has_error() instead.
+   "lazy_json_null_terminated_truncated_match_lookup"_test = [] {
+      // {"a":1,"b":  -- "a" is complete, "b" is matched but its value begins at json_end_.
+      std::vector<char> storage{'{', '"', 'a', '"', ':', '1', ',', '"', 'b', '"', ':', '\0'};
+      const std::string_view sv{storage.data(), 11}; // excludes the trailing '\0'
+      auto result = glz::lazy_json<glz::opts{}>(sv); // null_terminated = true
+      expect(result.has_value());
+      auto& root = *result;
+      expect(root["a"].template get<int64_t>().value() == 1); // complete member resolves
+      expect(root["b"].has_error()); // matched, value truncated at end: error, not a view at end
+   };
+
+   // empty() must agree with size()==0 for a clearly-empty (bare, unclosed) null-terminated
+   // container. Previously it inspected only the first byte after the brace and reported non-empty.
+   "lazy_json_null_terminated_unclosed_empty"_test = [] {
+      std::vector<char> obj{'{', '\0'};
+      std::vector<char> arr{'[', '\0'};
+      auto o = glz::lazy_json<glz::opts{}>(std::string_view{obj.data(), 1});
+      auto a = glz::lazy_json<glz::opts{}>(std::string_view{arr.data(), 1});
+      expect(o.has_value());
+      expect(a.has_value());
+      expect((*o).root().empty()); // '{' with nothing inside is empty
+      expect((*o).root().size() == 0u);
+      expect((*a).root().empty()); // '[' with nothing inside is empty
+      expect((*a).root().size() == 0u);
+   };
+
+   // An unrecognized byte in value position (not a string, literal, container, or number - e.g.
+   // '@') makes skip_value_lazy's number branch consume nothing. Before the fix that left the scan
+   // position unmoved, so every value-skipping loop (size/index/operator[]/iteration) spun forever
+   // on this malformed input. skip_value_lazy now guarantees forward progress by treating the byte
+   // as a one-byte scalar, so the accessors terminate. The backing stores below are heap vectors
+   // sized to exclude any '\0', so the sanitizer CI builds abort on any read past json_end_ - the
+   // force-advance must never step over the end.
+   "lazy_json_invalid_value_byte_array"_test = [] {
+      const std::vector<char> closed{'[', '@', ']'}; // garbage element, closed
+      const std::vector<char> open{'[', '@'}; // garbage element, unclosed
+      const std::string_view sv_closed{closed.data(), closed.size()};
+      const std::string_view sv_open{open.data(), open.size()};
+
+      auto rc = glz::lazy_json<glz::opts{.null_terminated = false}>(sv_closed);
+      auto ro = glz::lazy_json<glz::opts{.null_terminated = false}>(sv_open);
+      expect(rc.has_value());
+      expect(ro.has_value());
+
+      // Each of these calls spun forever before the fix; reaching the assertions proves termination.
+      expect((*rc).root().size() == 1u); // '@' counted as a lone scalar, then ']'
+      expect((*rc).root().index().size() == 1u);
+      expect((*rc).root()[1].has_error()); // only index 0 exists; index 1 is past the end
+
+      expect((*ro).root().size() == 1u); // unclosed: bounded by json_end_ after the one scalar
+      expect((*ro).root().index().size() == 1u);
+   };
+
+   // operator[](key) is the case the report called out: an invalid byte in value position hung the
+   // key search. {"a":@} matches "a" (its value is the garbage byte) and must resolve an absent key
+   // to not_found instead of spinning. {"a":1@ (a complete value followed by trailing garbage and
+   // no close) must likewise terminate. Non-null-terminated exact-sized stores catch any OOB.
+   "lazy_json_invalid_value_byte_object_lookup"_test = [] {
+      const std::vector<char> garbage_val{'{', '"', 'a', '"', ':', '@', '}'}; // {"a":@}
+      const std::vector<char> trailing{'{', '"', 'a', '"', ':', '1', '@'}; // {"a":1@  (unclosed)
+      const std::string_view sv_g{garbage_val.data(), garbage_val.size()};
+      const std::string_view sv_t{trailing.data(), trailing.size()};
+
+      auto rg = glz::lazy_json<glz::opts{.null_terminated = false}>(sv_g);
+      auto rt = glz::lazy_json<glz::opts{.null_terminated = false}>(sv_t);
+      expect(rg.has_value());
+      expect(rt.has_value());
+
+      expect(!(*rg).root()["a"].has_error()); // "a" matches (value is the garbage byte)
+      expect((*rg).root()["missing"].has_error()); // absent key: not_found, no spin
+
+      expect((*rt).root()["a"].template get<int64_t>().value() == 1); // "a" resolves to 1
+      expect((*rt).root()["missing"].has_error()); // scan past trailing garbage terminates
+   };
+
+   // Iteration must also terminate across an invalid value byte. A counter guard converts a
+   // regression from a true hang into a visible wrong count.
+   "lazy_json_invalid_value_byte_iteration"_test = [] {
+      const std::vector<char> arr{'[', '1', ',', '@', ',', '2', ']'}; // [1,@,2]
+      const std::string_view sv{arr.data(), arr.size()};
+      auto result = glz::lazy_json<glz::opts{.null_terminated = false}>(sv);
+      expect(result.has_value());
+      size_t count = 0;
+      for (auto element : (*result).root()) {
+         (void)element;
+         if (++count > 100) break; // guard: a regression here would loop forever
+      }
+      expect(count == 3u); // 1, the '@' scalar, and 2
+   };
+
+   // The same invalid-byte guarantee under the default null_terminated option: the garbage byte
+   // sits strictly before the '\0', which lands at json_end_. The scan must advance across the
+   // garbage and stop at json_end_, not spin and not walk past the sentinel.
+   "lazy_json_invalid_value_byte_null_terminated"_test = [] {
+      std::vector<char> storage{'[', '@', '\0'}; // '\0' at index 2 == json_end_
+      const std::string_view sv{storage.data(), 2}; // "[@"
+      auto result = glz::lazy_json<glz::opts{}>(sv); // null_terminated = true
+      expect(result.has_value());
+      expect((*result).root().size() == 1u); // '@' scalar, then bounded by json_end_
+      expect((*result).root().index().size() == 1u);
+      expect((*result).root()[1].has_error()); // nothing past the lone scalar
+   };
 };
 
 int main() { return 0; }

--- a/tests/json_test/lazy_test.cpp
+++ b/tests/json_test/lazy_test.cpp
@@ -1278,6 +1278,76 @@ suite dynamic_key_custom_tests = [] {
       expect(top.b.val == 2);
       expect(top.c.val == 3);
    };
+
+   // Truncated, non-null-terminated input must not read past the buffer. Each buffer below is
+   // sized exactly to its bytes (a std::vector<char>, no trailing '\0'), so any read at
+   // data() + size() lands in unallocated memory and aborts under the sanitizer CI builds. The
+   // lazy scanner previously walked one byte past end whenever a value/element/key began at
+   // end-of-input (a value missing after ':', a truncated literal, an unclosed key, or a
+   // trailing comma), and it also handed back views positioned at end.
+   "lazy_json_truncated_missing_value"_test = [] {
+      const std::vector<char> buf{'{', '"', 'a', '"', ':'};
+      const std::string_view sv{buf.data(), buf.size()};
+      auto result = glz::lazy_json<glz::opts{.null_terminated = false}>(sv);
+      expect(result.has_value());
+      auto& doc = *result;
+      expect(doc["x"].has_error()); // non-matching key drives skip_value_lazy at end
+      expect(doc["a"].has_error()); // matching key whose value is truncated
+   };
+
+   "lazy_json_truncated_literal"_test = [] {
+      const std::vector<char> buf{'{', '"', 'a', '"', ':', 't'};
+      const std::string_view sv{buf.data(), buf.size()};
+      auto result = glz::lazy_json<glz::opts{.null_terminated = false}>(sv);
+      expect(result.has_value());
+      expect((*result)["x"].has_error()); // skip over a truncated 'true' literal
+
+      const std::vector<char> lit{'t'};
+      const std::string_view lit_sv{lit.data(), lit.size()};
+      auto lit_doc = glz::lazy_json<glz::opts{.null_terminated = false}>(lit_sv);
+      expect(lit_doc.has_value());
+      expect((*lit_doc).root().raw_json().size() == lit.size()); // span clamped to the buffer
+   };
+
+   "lazy_json_truncated_unclosed_key"_test = [] {
+      const std::vector<char> buf{'{', '"', 'a'};
+      const std::string_view sv{buf.data(), buf.size()};
+      auto result = glz::lazy_json<glz::opts{.null_terminated = false}>(sv);
+      expect(result.has_value());
+      auto& doc = *result;
+      expect(doc["a"].has_error());
+      (void)doc.root().index(); // index() scans the key at end
+      (void)doc.root().size();
+   };
+
+   "lazy_json_truncated_trailing_comma"_test = [] {
+      const std::vector<char> buf{'{', '"', 'a', '"', ':', '1', ','};
+      const std::string_view sv{buf.data(), buf.size()};
+      auto result = glz::lazy_json<glz::opts{.null_terminated = false}>(sv);
+      expect(result.has_value());
+      auto& doc = *result;
+      expect(doc["z"].has_error());
+      (void)doc.root().index(); // the next key parse begins at end after the comma
+      size_t count = 0;
+      for (auto element : doc.root()) {
+         (void)element;
+         ++count;
+      }
+      expect(count == 1u); // only the "a" element is complete
+   };
+
+   "lazy_json_truncated_iterate"_test = [] {
+      const std::vector<char> buf{'{', '"', 'a', '"', ':'};
+      const std::string_view sv{buf.data(), buf.size()};
+      auto result = glz::lazy_json<glz::opts{.null_terminated = false}>(sv);
+      expect(result.has_value());
+      size_t count = 0;
+      for (auto element : (*result).root()) {
+         (void)element;
+         ++count;
+      }
+      expect(count == 0u); // the truncated element is not yielded
+   };
 };
 
 int main() { return 0; }


### PR DESCRIPTION
The lazy JSON parser in json/lazy.hpp scans values on demand, and several of its helpers dereference the cursor without checking it against end. On a non-null-terminated buffer (a std::string_view or std::span, where the reader appends no NUL sentinel) a value or key that begins at end-of-input reads one byte past the buffer: skip_value_lazy reads the tag and returns data+4 past end for a truncated true/false/null, parse_key reads the opening quote, and the object scans read the ":" and "," separators. operator[], size(), index(), and range iteration reach these on a truncated document.

The fix bounds every scan dereference against the remaining input, clamps the literal skips to end, and stops the object, index, and iterator scans from returning a view whose data pointer sits at end, since each view operation reads *data_. The scanner is the only layer that sees end; a caller holding a string_view cannot make a truncated value complete. Null-terminated input keeps its sentinel fast path, so valid documents behave exactly as before.