### PR TITLE
Add HTTP headers API

### DIFF
--- a/include/glaze/net/http_headers.hpp
+++ b/include/glaze/net/http_headers.hpp
@@ -1,0 +1,324 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include <algorithm>
+#include <optional>
+#include <ranges>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "glaze/util/attributes.hpp"
+#include "glaze/util/compare.hpp"
+
+namespace glz
+{
+   namespace detail
+   {
+      [[nodiscard]] inline std::string_view trim_optional_whitespace(std::string_view text)
+      {
+         size_t first_non_whitespace = text.find_first_not_of(" \t");
+         if (first_non_whitespace == std::string_view::npos) {
+            return {};
+         }
+         size_t last_non_whitespace = text.find_last_not_of(" \t");
+         return text.substr(first_non_whitespace, last_non_whitespace - first_non_whitespace + 1);
+      }
+   } // namespace detail
+
+   struct http_header
+   {
+      std::string name;
+      std::string value;
+
+      [[nodiscard]] bool contains_token(std::string_view token) const&
+      {
+         if (token.empty()) {
+            return false;
+         }
+
+         for (auto&& split_value : value | std::views::split(',')) {
+            std::string_view candidate{split_value};
+
+            if (glz::striequal(detail::trim_optional_whitespace(candidate), token)) {
+               return true;
+            }
+         }
+
+         return false;
+      }
+   };
+
+   class http_headers
+   {
+     public:
+      using value_type = glz::http_header;
+      using iterator = std::vector<value_type>::iterator;
+      using const_iterator = std::vector<value_type>::const_iterator;
+      using size_type = std::vector<value_type>::size_type;
+
+     private:
+      template <bool IsConst>
+      class matching_iterator
+      {
+         using owner_type = std::conditional_t<IsConst, const http_headers*, http_headers*>;
+
+        public:
+         using iterator_concept = std::forward_iterator_tag;
+         using iterator_category = std::forward_iterator_tag;
+         using difference_type = ptrdiff_t;
+         using value_type = http_headers::value_type;
+         using reference = std::conditional_t<IsConst, const value_type&, value_type&>;
+         using pointer = std::conditional_t<IsConst, const value_type*, value_type*>;
+
+         matching_iterator() = default;
+         matching_iterator(const matching_iterator&) = default;
+         matching_iterator(matching_iterator&&) = default;
+         matching_iterator& operator=(const matching_iterator&) = default;
+         matching_iterator& operator=(matching_iterator&&) = default;
+         ~matching_iterator() = default;
+
+         matching_iterator(owner_type owner, size_t start_index, std::string_view key)
+            : owner_(owner), index_(start_index), key_(key)
+         {
+            seek_forward();
+         }
+
+         [[nodiscard]] reference operator*() const noexcept { return owner_->headers_[index_]; }
+         [[nodiscard]] pointer operator->() const noexcept { return std::addressof(owner_->headers_[index_]); }
+
+         matching_iterator& operator++() noexcept
+         {
+            if (index_ < owner_->headers_.size()) {
+               ++index_;
+               seek_forward();
+            }
+            return *this;
+         }
+
+         matching_iterator operator++(int) noexcept
+         {
+            auto copy = *this;
+            ++(*this);
+            return copy;
+         }
+
+         [[nodiscard]] friend bool operator==(const matching_iterator& left, const matching_iterator& right) noexcept
+         {
+            return left.owner_ == right.owner_ && left.index_ == right.index_ && glz::striequal(left.key_, right.key_);
+         }
+
+        private:
+         void seek_forward() noexcept
+         {
+            while (index_ < owner_->headers_.size()) {
+               const auto& current = owner_->headers_[index_].name;
+               if (glz::striequal(current, key_)) {
+                  return;
+               }
+               ++index_;
+            }
+         }
+
+         owner_type owner_{};
+         size_t index_{0};
+         std::string_view key_;
+      };
+
+     public:
+      using range_iterator = matching_iterator<false>;
+      using const_range_iterator = matching_iterator<true>;
+
+      http_headers() = default;
+      http_headers(std::initializer_list<http_header> fields) : headers_(fields) {}
+
+      [[nodiscard]] bool empty() const noexcept { return headers_.empty(); }
+      [[nodiscard]] size_type size() const noexcept { return headers_.size(); }
+      [[nodiscard]] size_type capacity() const noexcept { return headers_.capacity(); }
+      [[nodiscard]] iterator begin() & noexcept { return headers_.begin(); }
+      [[nodiscard]] iterator end() & noexcept { return headers_.end(); }
+      [[nodiscard]] const_iterator begin() const& noexcept { return headers_.begin(); }
+      [[nodiscard]] const_iterator end() const& noexcept { return headers_.end(); }
+      [[nodiscard]] const_iterator cbegin() const& noexcept { return headers_.cbegin(); }
+      [[nodiscard]] const_iterator cend() const& noexcept { return headers_.cend(); }
+      [[nodiscard]] http_header& front() & noexcept { return headers_.front(); }
+      [[nodiscard]] const http_header& front() const& noexcept { return headers_.front(); }
+      [[nodiscard]] http_header& back() & noexcept { return headers_.back(); }
+      [[nodiscard]] const http_header& back() const& noexcept { return headers_.back(); }
+
+      void reserve(size_type count) { headers_.reserve(count); }
+      void clear() noexcept { headers_.clear(); }
+
+      [[nodiscard]] iterator find(std::string_view name) & noexcept
+      {
+         return std::ranges::find_if(
+            headers_, [&](const http_header& field) noexcept { return glz::striequal(field.name, name); });
+      }
+
+      [[nodiscard]] const_iterator find(std::string_view name) const& noexcept
+      {
+         return std::ranges::find_if(
+            headers_, [&](const http_header& field) noexcept { return glz::striequal(field.name, name); });
+      }
+
+      [[nodiscard]] auto fields(std::string_view name GLZ_LIFETIMEBOUND) &
+      {
+         auto first = range_iterator{this, 0, name};
+         auto last = range_iterator{this, headers_.size(), name};
+         return std::ranges::subrange{first, last};
+      }
+
+      [[nodiscard]] auto fields(std::string_view name GLZ_LIFETIMEBOUND) const&
+      {
+         auto first = const_range_iterator{this, 0, name};
+         auto last = const_range_iterator{this, headers_.size(), name};
+         return std::ranges::subrange{first, last};
+      }
+
+      [[nodiscard]] auto names() const&
+      {
+         return headers_ |
+                std::views::transform([](const http_header& field) noexcept -> std::string_view { return field.name; });
+      }
+
+      [[nodiscard]] auto values() const&
+      {
+         return headers_ | std::views::transform(
+                              [](const http_header& field) noexcept -> std::string_view { return field.value; });
+      }
+
+      [[nodiscard]] auto values(std::string_view name GLZ_LIFETIMEBOUND) const&
+      {
+         return fields(name) | std::views::transform(
+                                  [](const http_header& field) noexcept -> std::string_view { return field.value; });
+      }
+
+      [[nodiscard]] size_t count(std::string_view name) const& noexcept
+      {
+         return std::ranges::count_if(
+            headers_, [name](const http_header& field) noexcept { return glz::striequal(field.name, name); });
+      }
+
+      [[nodiscard]] std::optional<std::string_view> first_value(std::string_view name) const& noexcept
+      {
+         auto iterator = find(name);
+         if (iterator == end()) {
+            return std::nullopt;
+         }
+         return std::string_view{iterator->value};
+      }
+
+      [[nodiscard]] bool contains(std::string_view name) const noexcept { return find(name) != end(); }
+
+      [[nodiscard]] bool contains_token(std::string_view name, std::string_view token) const
+      {
+         return std::ranges::any_of(fields(name),
+                                    [token](const http_header& field) { return field.contains_token(token); });
+      }
+
+      [[nodiscard]] std::string serialize() const
+      {
+         if (headers_.empty()) {
+            return "\r\n";
+         }
+
+         static constexpr std::string_view value_separator = ": ";
+         static constexpr std::string_view crlf = "\r\n";
+
+         // A single range loop on the headers to reserve space, and a second
+         // one for appending, will be much faster than potentially frequent
+         // reallocations within a single append-loop
+         size_t expected_length{};
+         for (const auto& [name, value] : headers_) {
+            expected_length += name.length() + value.length() + value_separator.length() + crlf.length();
+         }
+
+         std::string result;
+         result.reserve(expected_length + crlf.length());
+
+         for (const auto& [name, value] : headers_) {
+            result.append(name).append(value_separator).append(value).append(crlf);
+         }
+
+         return result.append(crlf);
+      }
+
+      iterator set(std::string name, std::string value) &
+      {
+         auto target = find(name);
+         if (target == end()) {
+            return add(std::move(name), std::move(value));
+         }
+
+         target->name = std::move(name);
+         target->value = std::move(value);
+
+         auto duplicates = std::ranges::remove_if(
+            std::next(target), headers_.end(),
+            [&](const http_header& field) noexcept { return glz::striequal(field.name, target->name); });
+         headers_.erase(duplicates.begin(), duplicates.end());
+
+         return target;
+      }
+
+      iterator add(std::string name, std::string value) &
+      {
+         headers_.emplace_back(std::move(name), std::move(value));
+         return std::prev(headers_.end());
+      }
+
+      void append(const http_headers& other)
+      {
+         if (std::addressof(other) == this || other.empty()) {
+            return;
+         }
+         headers_.reserve(headers_.size() + other.headers_.size());
+         std::ranges::copy(other.headers_, std::back_inserter(headers_));
+      }
+
+      void append(http_headers&& other)
+      {
+         if (std::addressof(other) == this || other.empty()) {
+            return;
+         }
+         headers_.reserve(headers_.size() + other.headers_.size());
+         std::ranges::move(other.headers_, std::back_inserter(headers_));
+         other.clear();
+      }
+
+      void erase(std::string_view name)
+      {
+         auto to_remove = std::ranges::remove_if(
+            headers_, [&](const http_header& field) noexcept { return glz::striequal(field.name, name); });
+         headers_.erase(to_remove.begin(), to_remove.end());
+      }
+
+      // Disallow use on temporary objects
+      iterator begin() && = delete;
+      iterator end() && = delete;
+      const_iterator begin() const&& = delete;
+      const_iterator end() const&& = delete;
+      const_iterator cbegin() const&& = delete;
+      const_iterator cend() const&& = delete;
+      http_header& front() && = delete;
+      const http_header& front() const&& = delete;
+      http_header& back() && = delete;
+      const http_header& back() const&& = delete;
+      iterator find(std::string_view name) && = delete;
+      const_iterator find(std::string_view name) const&& = delete;
+      auto fields(std::string_view name) && = delete;
+      auto fields(std::string_view name) const&& = delete;
+      auto names() const&& = delete;
+      auto values() const&& = delete;
+      auto values(std::string_view name) const&& = delete;
+      std::optional<std::string_view> first_value(std::string_view name) const&& = delete;
+      iterator add(std::string name, std::string value) && = delete;
+      iterator set(std::string name, std::string value) && = delete;
+
+     private:
+      std::vector<value_type> headers_;
+   };
+
+}

--- a/include/glaze/net/http_headers.hpp
+++ b/include/glaze/net/http_headers.hpp
@@ -33,7 +33,7 @@ namespace glz
       std::string name;
       std::string value;
 
-      [[nodiscard]] bool contains_token(std::string_view token) const&
+      [[nodiscard]] bool contains_token(std::string_view token) const
       {
          if (token.empty()) {
             return false;

--- a/include/glaze/net/http_headers.hpp
+++ b/include/glaze/net/http_headers.hpp
@@ -321,4 +321,7 @@ namespace glz
       std::vector<value_type> headers_;
    };
 
+   static_assert(std::ranges::forward_range<decltype(std::declval<http_headers&>().fields(""))>);
+   static_assert(std::ranges::forward_range<decltype(std::declval<http_headers&>().names())>);
+   static_assert(std::ranges::forward_range<decltype(std::declval<http_headers&>().values(""))>);
 }

--- a/include/glaze/net/http_headers.hpp
+++ b/include/glaze/net/http_headers.hpp
@@ -51,9 +51,8 @@ namespace glz
       }
    };
 
-   class http_headers
+   struct http_headers
    {
-     public:
       using value_type = glz::http_header;
       using iterator = std::vector<value_type>::iterator;
       using const_iterator = std::vector<value_type>::const_iterator;

--- a/include/glaze/util/attributes.hpp
+++ b/include/glaze/util/attributes.hpp
@@ -1,0 +1,14 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#ifndef __has_cpp_attribute
+#define GLZ_LIFETIMEBOUND
+#elif __has_cpp_attribute(msvc::lifetimebound)
+#define GLZ_LIFETIMEBOUND [[msvc::lifetimebound]]
+#elif __has_cpp_attribute(clang::lifetimebound)
+#define GLZ_LIFETIMEBOUND [[clang::lifetimebound]]
+#else
+#define GLZ_LIFETIMEBOUND
+#endif

--- a/tests/networking_tests/CMakeLists.txt
+++ b/tests/networking_tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_subdirectory(http_server_post_test)
 add_subdirectory(http_server_test)
 add_subdirectory(http_smuggling_test)
 add_subdirectory(http_header_strictness_test)
+add_subdirectory(http_headers_test)
 add_subdirectory(http_response_splitting_test)
 
 # Networking Tests

--- a/tests/networking_tests/http_headers_test/CMakeLists.txt
+++ b/tests/networking_tests/http_headers_test/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.21)
+project(http_headers_test)
+
+add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)
+target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+    glz_test_exceptions
+)
+
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/tests/networking_tests/http_headers_test/http_headers_test.cpp
+++ b/tests/networking_tests/http_headers_test/http_headers_test.cpp
@@ -1,0 +1,847 @@
+#include "glaze/net/http_headers.hpp"
+
+#include <ranges>
+#include <string>
+#include <string_view>
+#include <ut/ut.hpp>
+#include <vector>
+
+using namespace ut;
+using namespace std::string_view_literals;
+
+std::vector<std::string> values_of(const glz::http_headers& fields, std::string_view name)
+{
+   std::vector<std::string> values{};
+   for (std::string_view value : fields.values(name)) {
+      values.emplace_back(value);
+   }
+   return values;
+}
+
+bool contains_value(const glz::http_headers& fields, std::string_view name, std::string_view expected_value)
+{
+   auto values = fields.values(name);
+   return std::ranges::find(values, expected_value) != values.end();
+}
+
+// The checks are templated because 'requires' reports invalid
+// expressions only during template substitution
+template <class T = glz::http_headers>
+consteval bool rvalue_overloads_are_deleted()
+{
+   static_assert(not requires(T fields) { std::move(fields).begin(); });
+   static_assert(not requires(T fields) { std::move(fields).end(); });
+   static_assert(not requires(T fields) { std::move(fields).cbegin(); });
+   static_assert(not requires(T fields) { std::move(fields).cend(); });
+   static_assert(not requires(T fields) { std::move(fields).front(); });
+   static_assert(not requires(T fields) { std::move(fields).back(); });
+   static_assert(not requires(T fields) { std::move(fields).find("A"); });
+   static_assert(not requires(T fields) { std::move(fields).fields("A"); });
+   static_assert(not requires(T fields) { std::move(fields).names(); });
+   static_assert(not requires(T fields) { std::move(fields).values(); });
+   static_assert(not requires(T fields) { std::move(fields).values("A"); });
+   static_assert(not requires(T fields) { std::move(fields).first_value("A"); });
+   static_assert(not requires(T fields) { std::move(fields).add("A", "1"); });
+   static_assert(not requires(T fields) { std::move(fields).set("A", "1"); });
+
+   static_assert(not requires(const T fields) { std::move(fields).begin(); });
+   static_assert(not requires(const T fields) { std::move(fields).end(); });
+   static_assert(not requires(const T fields) { std::move(fields).front(); });
+   static_assert(not requires(const T fields) { std::move(fields).back(); });
+   static_assert(not requires(const T fields) { std::move(fields).find("A"); });
+   static_assert(not requires(const T fields) { std::move(fields).fields("A"); });
+
+   return true;
+}
+static_assert(rvalue_overloads_are_deleted());
+
+suite http_headers = [] {
+   "default constructed headers are empty"_test = [] {
+      glz::http_headers fields{};
+
+      expect(fields.empty());
+      expect(fields.size() == 0);
+      expect(fields.begin() == fields.end());
+   };
+
+   "clear removes all fields"_test = [] {
+      glz::http_headers fields{{"A", "1"}, {"B", "2"}};
+
+      fields.clear();
+
+      expect(fields.empty());
+      expect(fields.size() == 0U);
+      expect(fields.begin() == fields.end());
+      expect(fields.cbegin() == fields.cend());
+   };
+
+   "front and back return the first and last fields"_test = [] {
+      glz::http_headers fields{{"A", "1"}, {"B", "2"}, {"C", "3"}};
+
+      expect(fields.front().name == "A");
+      expect(fields.front().value == "1");
+      expect(fields.back().name == "C");
+      expect(fields.back().value == "3");
+
+      const auto& const_fields = fields;
+      expect(const_fields.front().name == "A");
+      expect(const_fields.back().name == "C");
+   };
+
+   "initializer list preserves insertion order and duplicates"_test = [] {
+      glz::http_headers fields{{"A", "1"}, {"B", "2"}, {"C", "3"}, {"D", "4"}, {"A", "11"}};
+      auto repeated_record_values = values_of(fields, "A");
+
+      expect(fields.size() == 5U);
+
+      expect(repeated_record_values.size() == 2U);
+      if (repeated_record_values.size() == 2U) {
+         expect(repeated_record_values[0] == "1");
+         expect(repeated_record_values[1] == "11");
+      }
+
+      expect(fields.first_value("B") == "2");
+      expect(fields.first_value("C") == "3");
+      expect(fields.first_value("D") == "4");
+   };
+
+   "adding a field preserves insertion order for iteration"_test = [] {
+      glz::http_headers fields{};
+      fields.add("A", "1");
+      fields.add("B", "2");
+      fields.add("C", "3");
+
+      std::vector<glz::http_headers::value_type> all_fields(fields.begin(), fields.end());
+
+      expect(all_fields.size() == 3U);
+      if (all_fields.size() == 3U) {
+         expect(all_fields[0].name == "A");
+         expect(all_fields[0].value == "1");
+         expect(all_fields[1].name == "B");
+         expect(all_fields[1].value == "2");
+         expect(all_fields[2].name == "C");
+         expect(all_fields[2].value == "3");
+      }
+   };
+
+   "contains and find are case-insensitive"_test = [] {
+      glz::http_headers fields{};
+
+      fields.add("Content-Length", "123");
+
+      expect(fields.contains("content-length"));
+      expect(fields.contains("CONTENT-LENGTH"));
+      expect(not fields.contains("Connection"));
+
+      const auto it = fields.find("CONTENT-length");
+      expect(it != fields.end());
+      if (it != fields.end()) {
+         expect(it->value == "123");
+      }
+   };
+
+   "contains_token matches a single token case-insensitively"_test = [] {
+      glz::http_headers fields{{"Connection", "UpGrAde"}};
+
+      expect(fields.contains_token("Connection", "upgrade"));
+      expect(fields.contains_token("CONNECTION", "UPGRADE"));
+      expect(not fields.contains_token("Connection", "close"));
+   };
+
+   "contains_token finds tokens anywhere in a comma-separated list"_test = [] {
+      glz::http_headers fields{
+         {"Accept-Encoding", "gzip, deflate, br, zstd"},
+      };
+
+      expect(fields.contains_token("Accept-Encoding", "gzip"));
+      expect(fields.contains_token("Accept-Encoding", "deflate"));
+      expect(fields.contains_token("Accept-Encoding", "zstd"));
+      expect(not fields.contains_token("Accept-Encoding", "identity"));
+   };
+
+   "contains_token ignores optional whitespace around tokens"_test = [] {
+      glz::http_headers fields{{"Connection", "  keep-alive  ,\tupgrade\t"}};
+
+      expect(fields.contains_token("Connection", "keep-alive"));
+      expect(fields.contains_token("Connection", "upgrade"));
+   };
+
+   "contains_token does not match a substring of a token"_test = [] {
+      glz::http_headers fields{
+         {"Accept-Encoding", "gzipped, deflated"},
+      };
+
+      expect(not fields.contains_token("Accept-Encoding", "gzip"));
+      expect(not fields.contains_token("Accept-Encoding", "deflate"));
+      expect(fields.contains_token("Accept-Encoding", "gzipped"));
+   };
+
+   "contains_token returns false for an empty token"_test = [] {
+      glz::http_headers fields{
+         {"Connection", "keep-alive"},
+      };
+
+      expect(not fields.contains_token("Connection", ""));
+   };
+
+   "contains_token returns false when the field is missing"_test = [] {
+      glz::http_headers fields{
+         {"Connection", "keep-alive"},
+      };
+
+      expect(not fields.contains_token("Upgrade", "websocket"));
+   };
+
+   "contains_token searches every occurrence of a repeated field"_test = [] {
+      glz::http_headers fields{};
+
+      fields.add("Connection", "keep-alive");
+      fields.add("X", "x");
+      fields.add("connection", "upgrade");
+
+      expect(fields.contains_token("Connection", "keep-alive"));
+      expect(fields.contains_token("Connection", "upgrade"));
+      expect(not fields.contains_token("Connection", "close"));
+   };
+
+   "contains_token skips empty list elements"_test = [] {
+      glz::http_headers fields{
+         {"Accept-Encoding", "gzip,,br,"},
+      };
+
+      expect(fields.contains_token("Accept-Encoding", "gzip"));
+      expect(fields.contains_token("Accept-Encoding", "br"));
+   };
+
+   "contains_token returns false on an empty field value"_test = [] {
+      glz::http_headers fields{
+         {"Connection", ""},
+      };
+
+      expect(not fields.contains_token("Connection", "keep-alive"));
+   };
+
+   "header contains_token matches tokens in its own value"_test = [] {
+      const glz::http_header field{"Accept-Encoding", "gzip, br"};
+
+      expect(field.contains_token("gzip"));
+      expect(field.contains_token("BR"));
+      expect(not field.contains_token("zstd"));
+      expect(not field.contains_token(""));
+   };
+
+   "erasing a field removes all matching occurrences"_test = [] {
+      glz::http_headers fields{};
+
+      fields.add("Set-Cookie", "a=1");
+      fields.add("Set-Cookie", "b=2");
+      fields.add("X", "x");
+
+      auto cookies = values_of(fields, "SET-COOKIE");
+
+      expect(fields.contains("set-cookie"));
+      expect(cookies.size() == 2U);
+
+      fields.erase("set-cookie");
+
+      expect(not fields.contains("Set-Cookie"));
+      expect(fields.contains("X"));
+      expect(fields.size() == 1U);
+   };
+
+   "erasing a missing field leaves headers unchanged"_test = [] {
+      glz::http_headers fields{{"A", "1"}, {"B", "2"}};
+
+      fields.erase("Missing");
+
+      expect(fields.size() == 2U);
+      expect(fields.first_value("A") == "1");
+      expect(fields.first_value("B") == "2");
+   };
+
+   "fields view iterates matching pairs in insertion order"_test = [] {
+      glz::http_headers fields{};
+      fields.add("Set-Cookie", "a=1");
+      fields.add("X", "x");
+      fields.add("set-cookie", "b=2");
+      fields.add("Y", "y");
+      fields.add("SET-COOKIE", "c=3");
+
+      auto range = fields.fields("set-cookie");
+
+      std::vector<std::string> collected_names;
+      std::vector<std::string> collected_values;
+
+      for (auto&& [name, value] : range) {
+         collected_names.emplace_back(name);
+         collected_values.emplace_back(value);
+      }
+
+      expect(collected_values.size() == 3U);
+      if (collected_values.size() == 3U) {
+         expect(collected_values[0] == "a=1");
+         expect(collected_values[1] == "b=2");
+         expect(collected_values[2] == "c=3");
+      }
+
+      expect(collected_names.size() == 3U);
+      if (collected_names.size() == 3U) {
+         expect(collected_names[0] == "Set-Cookie");
+         expect(collected_names[1] == "set-cookie");
+         expect(collected_names[2] == "SET-COOKIE");
+      }
+   };
+
+   "fields view on const works and is case-insensitive"_test = [] {
+      glz::http_headers mutable_fields{};
+      mutable_fields.add("Set-Cookie", "a=1");
+      mutable_fields.add("set-cookie", "b=2");
+      mutable_fields.add("X", "x");
+
+      const auto& fields = mutable_fields;
+      auto range = fields.fields("SET-COOKIE");
+
+      std::vector<std::string> collected_values;
+      for (auto&& field : range) {
+         collected_values.emplace_back(field.value);
+      }
+
+      expect(collected_values.size() == 2U);
+      if (collected_values.size() == 2U) {
+         expect(collected_values[0] == "a=1");
+         expect(collected_values[1] == "b=2");
+      }
+   };
+
+   "fields view is empty when key does not exist"_test = [] {
+      glz::http_headers fields{};
+      fields.add("A", "1");
+      fields.add("B", "2");
+
+      auto range = fields.fields("Missing");
+
+      expect(std::ranges::empty(range));
+      expect(std::ranges::distance(range) == 0);
+   };
+
+   "names view returns every name in insertion order"_test = [] {
+      glz::http_headers fields{{"A", "1"}, {"b", "2"}, {"A", "3"}};
+
+      std::vector<std::string> names{};
+      for (std::string_view name : fields.names()) {
+         names.emplace_back(name);
+      }
+
+      expect(names.size() == 3U);
+      if (names.size() == 3U) {
+         expect(names[0] == "A");
+         expect(names[1] == "b");
+         expect(names[2] == "A");
+      }
+   };
+
+   "values view without a name returns every value in insertion order"_test = [] {
+      glz::http_headers fields{{"A", "1"}, {"B", "2"}, {"A", "3"}};
+
+      std::vector<std::string> values{};
+      for (std::string_view value : fields.values()) {
+         values.emplace_back(value);
+      }
+
+      expect(values.size() == 3U);
+      if (values.size() == 3U) {
+         expect(values[0] == "1");
+         expect(values[1] == "2");
+         expect(values[2] == "3");
+      }
+   };
+
+   "values view returns only values in insertion order"_test = [] {
+      glz::http_headers fields{};
+      fields.add("Set-Cookie", "a=1");
+      fields.add("X", "x");
+      fields.add("set-cookie", "b=2");
+      fields.add("SET-COOKIE", "c=3");
+
+      auto cookies = values_of(fields, "set-cookie");
+
+      expect(cookies.size() == 3U);
+      if (cookies.size() == 3U) {
+         expect(cookies[0] == "a=1");
+         expect(cookies[1] == "b=2");
+         expect(cookies[2] == "c=3");
+      }
+   };
+
+   "values view on const returns only values"_test = [] {
+      glz::http_headers mutable_fields{};
+      mutable_fields.add("Set-Cookie", "a=1");
+      mutable_fields.add("set-cookie", "b=2");
+      mutable_fields.add("X", "x");
+
+      const auto& fields = mutable_fields;
+      auto cookies = values_of(fields, "SET-COOKIE");
+
+      expect(cookies.size() == 2U);
+      if (cookies.size() == 2U) {
+         expect(cookies[0] == "a=1");
+         expect(cookies[1] == "b=2");
+      }
+   };
+
+   "value views on const are compatible with ranges algorithms"_test = [] {
+      glz::http_headers mutable_fields{};
+      mutable_fields.add("Set-Cookie", "a=1");
+      mutable_fields.add("set-cookie", "b=22");
+      mutable_fields.add("SET-COOKIE", "ccc");
+      mutable_fields.add("X", "x");
+
+      const auto& fields = mutable_fields;
+      auto value_views = fields.values("set-cookie");
+
+      expect(not std::ranges::empty(value_views));
+      expect(std::ranges::distance(value_views) == 3);
+   };
+
+   "serializes headers separated with crlf"_test = [] {
+      glz::http_headers fields{
+         {"Set-Cookie", "a=1"},
+         {"A", "a"},
+         {"B", "b"},
+         {"C", "c"},
+      };
+
+      glz::http_headers growing_fields{};
+
+      for (const auto& [header_name, header_value] : fields) {
+         growing_fields.add(header_name, header_value);
+
+         auto fields_str = growing_fields.serialize();
+
+         std::string_view clean_str = fields_str;
+         clean_str.remove_suffix("\r\n\r\n"sv.size());
+
+         auto split_headers = std::views::split(clean_str, "\r\n"sv);
+         auto str_headers_count = std::ranges::distance(split_headers);
+
+         expect(growing_fields.size() == static_cast<glz::http_headers::size_type>(str_headers_count));
+      }
+   };
+
+   "serializes empty headers as a lone crlf terminator"_test = [] {
+      glz::http_headers fields{};
+      expect(fields.serialize() == "\r\n");
+   };
+
+   "serializes multiple fields"_test = [] {
+      glz::http_headers fields{
+         {"Set-Cookie", "a=1"},
+         {"A", "a"},
+         {"B", "b"},
+         {"c", "c"},
+      };
+
+      expect(fields.serialize() == "Set-Cookie: a=1\r\nA: a\r\nB: b\r\nc: c\r\n\r\n");
+   };
+
+   "serializes repeated fields as separate lines"_test = [] {
+      glz::http_headers fields{
+         {"Set-Cookie", "a=1"},
+         {"set-cookie", "b=1"},
+      };
+
+      expect(fields.serialize() == "Set-Cookie: a=1\r\nset-cookie: b=1\r\n\r\n");
+   };
+
+   "serializes repeated fields in insertion order"_test = [] {
+      glz::http_headers fields{
+         {"Set-Cookie", "a=1"},
+         {"Set-Cookie", "b=22"},
+         {"Set-Cookie", "ccc"},
+      };
+
+      expect(fields.serialize() == "Set-Cookie: a=1\r\nSet-Cookie: b=22\r\nSet-Cookie: ccc\r\n\r\n");
+   };
+
+   "serializes fields with empty names as-is"_test = [] {
+      glz::http_headers fields{
+         {"", "ghost"},
+         {"A", "1"},
+      };
+
+      expect(fields.serialize() == ": ghost\r\nA: 1\r\n\r\n");
+   };
+
+   "serializes a field with an empty value"_test = [] {
+      // Empty field values are valid under RFC 9112
+      glz::http_headers fields{
+         {"X-Empty", ""},
+      };
+
+      expect(fields.serialize() == "X-Empty: \r\n\r\n");
+   };
+
+   "set replaces the value of an existing field in place"_test = [] {
+      glz::http_headers fields{
+         {"A", "1"},
+         {"Set-Cookie", "a=1"},
+         {"B", "2"},
+      };
+
+      auto it = fields.set("Set-Cookie", "c=3");
+
+      expect(fields.count("Set-Cookie") == 1U);
+      expect(fields.first_value("Set-Cookie") == "c=3");
+      expect(it == std::next(fields.begin()));
+
+      std::vector<glz::http_headers::value_type> all_fields(fields.begin(), fields.end());
+
+      expect(all_fields.size() == 3U);
+      if (all_fields.size() == 3U) {
+         expect(all_fields[0].name == "A");
+         expect(all_fields[1].name == "Set-Cookie");
+         expect(all_fields[1].value == "c=3");
+         expect(all_fields[2].name == "B");
+      }
+   };
+
+   "set replaces the stored name casing"_test = [] {
+      glz::http_headers fields{
+         {"Set-Cookie", "a=1"},
+      };
+
+      fields.set("SET-COOKIE", "c=3");
+
+      expect(fields.count("set-cookie") == 1U);
+      expect(fields.front().name == "SET-COOKIE");
+      expect(fields.serialize() == "SET-COOKIE: c=3\r\n\r\n");
+   };
+
+   "set adds the field at the end when it does not exist"_test = [] {
+      glz::http_headers fields{{"A", "1"}};
+
+      auto it = fields.set("Set-Cookie", "a=1");
+
+      expect(fields.size() == 2U);
+      expect(fields.first_value("Set-Cookie") == "a=1");
+      expect(fields.back().name == "Set-Cookie");
+      expect(it == std::prev(fields.end()));
+   };
+
+   "set collapses duplicates into the first occurrence"_test = [] {
+      glz::http_headers fields{
+         {"Set-Cookie", "a"},
+         {"X", "x"},
+         {"Set-Cookie", "b=2"},
+      };
+
+      expect(fields.count("Set-Cookie") == 2U);
+
+      fields.set("Set-Cookie", "c=3");
+
+      expect(fields.count("Set-Cookie") == 1U);
+      expect(fields.first_value("Set-Cookie") == "c=3");
+
+      std::vector<glz::http_headers::value_type> all_fields(fields.begin(), fields.end());
+
+      expect(all_fields.size() == 2U);
+      if (all_fields.size() == 2U) {
+         expect(all_fields[0].name == "Set-Cookie");
+         expect(all_fields[0].value == "c=3");
+         expect(all_fields[1].name == "X");
+      }
+   };
+
+   "set matches case-insensitively and stores the new spelling"_test = [] {
+      glz::http_headers fields{
+         {"Set-Cookie", "a=1"},
+         {"SET-COOKIE", "b=2"},
+      };
+
+      fields.set("set-cookie", "c=3");
+
+      expect(fields.count("Set-Cookie") == 1U);
+      expect(fields.size() == 1U);
+      expect(fields.front().name == "set-cookie");
+      expect(fields.front().value == "c=3");
+   };
+
+   "contains is case-insensitive and fields enumerates all occurrences"_test = [] {
+      glz::http_headers fields{};
+
+      fields.add("Upgrade", "websocket");
+      fields.add("upgrade", "h2c");
+
+      expect(fields.contains("UPGRADE"));
+      expect(fields.count("UpGrAdE") == 2U);
+
+      std::vector<std::string> values{};
+      for (const auto& value : fields.values("UPGRADE")) {
+         values.emplace_back(value);
+      }
+
+      expect(values.size() == 2U);
+      if (values.size() == 2U) {
+         expect(values[0] == "websocket");
+         expect(values[1] == "h2c");
+      }
+   };
+
+   "first_value returns the field value"_test = [] {
+      glz::http_headers fields{
+         {"Content-Length", "123123"},
+      };
+
+      expect(fields.first_value("Content-Length") == "123123");
+   };
+
+   "first_value returns nullopt when the field is missing"_test = [] {
+      glz::http_headers fields{};
+
+      auto content_length = fields.first_value("Content-Length");
+      expect(not content_length.has_value());
+   };
+
+   "append copies and returns size of both objects"_test = [] {
+      glz::http_headers fields{
+         {"Host", "example.com"},
+      };
+
+      glz::http_headers other_fields{
+         {"Hello-World", "aero"},
+      };
+
+      fields.append(other_fields);
+
+      expect(contains_value(fields, "Host", "example.com"));
+      expect(contains_value(fields, "Hello-World", "aero"));
+      expect(fields.size() == 2U);
+
+      expect(contains_value(other_fields, "Hello-World", "aero"));
+   };
+
+   "append moves fields and clears source"_test = [] {
+      glz::http_headers fields{
+         {"Host", "example.com"},
+      };
+
+      glz::http_headers other_fields{
+         {"Hello-World", "aero"},
+      };
+
+      fields.append(std::move(other_fields));
+
+      expect(contains_value(fields, "Host", "example.com"));
+      expect(contains_value(fields, "Hello-World", "aero"));
+      expect(fields.size() == 2U);
+
+      expect(other_fields.empty());
+      expect(other_fields.begin() == other_fields.end());
+   };
+
+   "append copies nothing from empty object"_test = [] {
+      glz::http_headers fields{
+         {"Host", "example.com"},
+      };
+
+      glz::http_headers other_fields{};
+
+      auto fields_size_before_append = fields.size();
+      fields.append(other_fields);
+
+      expect(contains_value(fields, "Host", "example.com"));
+      expect(fields_size_before_append == fields.size());
+   };
+
+   "append copies initialized object to empty"_test = [] {
+      glz::http_headers fields{
+         {"Host", "example.com"},
+      };
+
+      glz::http_headers other_fields{};
+
+      auto fields_size_before_append = fields.size();
+      other_fields.append(fields);
+
+      expect(contains_value(other_fields, "Host", "example.com"));
+      expect(other_fields.size() == fields_size_before_append);
+   };
+
+   "append moves initialized object to empty"_test = [] {
+      glz::http_headers fields{};
+
+      glz::http_headers other_fields{
+         {"Host", "example.com"},
+         {"Hello-World", "aero"},
+      };
+
+      auto other_fields_size_before_append = other_fields.size();
+      fields.append(std::move(other_fields));
+
+      expect(contains_value(fields, "Host", "example.com"));
+      expect(contains_value(fields, "Hello-World", "aero"));
+      expect(fields.size() == other_fields_size_before_append);
+
+      expect(other_fields.empty());
+   };
+
+   "append copies nothing when both objects empty"_test = [] {
+      glz::http_headers fields{};
+      glz::http_headers other_fields{};
+
+      fields.append(other_fields);
+
+      expect(fields.empty());
+      expect(other_fields.empty());
+   };
+
+   "append preserves duplicate header values on copy"_test = [] {
+      glz::http_headers fields{
+         {"Set-Cookie", "a=1"},
+      };
+
+      glz::http_headers other_fields{
+         {"Set-Cookie", "b=2"},
+      };
+
+      fields.append(other_fields);
+
+      expect(contains_value(fields, "Set-Cookie", "a=1"));
+      expect(contains_value(fields, "Set-Cookie", "b=2"));
+      expect(fields.size() == 2U);
+
+      auto cookies = values_of(fields, "Set-Cookie");
+
+      expect(cookies.size() == 2U);
+      if (cookies.size() == 2U) {
+         expect(cookies[0] == "a=1");
+         expect(cookies[1] == "b=2");
+      }
+
+      expect(contains_value(other_fields, "Set-Cookie", "b=2"));
+      expect(other_fields.size() == 1U);
+   };
+
+   "append preserves duplicate header values on move"_test = [] {
+      glz::http_headers fields{
+         {"Set-Cookie", "a=1"},
+      };
+
+      glz::http_headers other_fields{
+         {"Set-Cookie", "b=2"},
+      };
+
+      fields.append(std::move(other_fields));
+
+      expect(contains_value(fields, "Set-Cookie", "a=1"));
+      expect(contains_value(fields, "Set-Cookie", "b=2"));
+      expect(fields.size() == 2U);
+
+      auto cookies = values_of(fields, "Set-Cookie");
+
+      expect(cookies.size() == 2U);
+      if (cookies.size() == 2U) {
+         expect(cookies[0] == "a=1");
+         expect(cookies[1] == "b=2");
+      }
+
+      expect(other_fields.empty());
+   };
+
+   "append finds merged values case-insensitively"_test = [] {
+      glz::http_headers fields{
+         {"host", "example.com"},
+      };
+
+      glz::http_headers other_fields{
+         {"Host", "example.org"},
+      };
+
+      fields.append(other_fields);
+
+      expect(contains_value(fields, "Host", "example.com"));
+      expect(contains_value(fields, "HOST", "example.org"));
+
+      auto host_values = values_of(fields, "HOST");
+
+      expect(host_values.size() == 2U);
+      if (host_values.size() == 2U) {
+         expect(host_values[0] == "example.com");
+         expect(host_values[1] == "example.org");
+      }
+   };
+
+   "append keeps first value from existing fields when appending"_test = [] {
+      glz::http_headers fields{
+         {"X-Test", "first"},
+      };
+
+      glz::http_headers other_fields{
+         {"X-Test", "second"},
+      };
+
+      fields.append(other_fields);
+
+      expect(fields.first_value("X-Test") == "first");
+      expect(contains_value(fields, "X-Test", "first"));
+      expect(contains_value(fields, "X-Test", "second"));
+   };
+
+   "append preserves insertion order when appending"_test = [] {
+      glz::http_headers fields{
+         {"A", "1"},
+         {"B", "2"},
+      };
+
+      glz::http_headers other_fields{
+         {"C", "3"},
+         {"D", "4"},
+      };
+
+      fields.append(other_fields);
+
+      std::vector<glz::http_headers::value_type> all_fields(fields.begin(), fields.end());
+
+      expect(all_fields.size() == 4U);
+      if (all_fields.size() == 4U) {
+         expect(all_fields[0].name == "A");
+         expect(all_fields[0].value == "1");
+         expect(all_fields[1].name == "B");
+         expect(all_fields[1].value == "2");
+         expect(all_fields[2].name == "C");
+         expect(all_fields[2].value == "3");
+         expect(all_fields[3].name == "D");
+         expect(all_fields[3].value == "4");
+      }
+   };
+
+   "self append does nothing on copy"_test = [] {
+      glz::http_headers fields{
+         {"Host", "example.com"},
+         {"Hello-World", "aero"},
+      };
+
+      auto fields_size_before_append = fields.size();
+      fields.append(fields);
+
+      expect(fields.size() == fields_size_before_append);
+      expect(contains_value(fields, "Host", "example.com"));
+      expect(contains_value(fields, "Hello-World", "aero"));
+   };
+
+   "self append does nothing on move"_test = [] {
+      glz::http_headers fields{
+         {"Host", "example.com"},
+         {"Hello-World", "aero"},
+      };
+
+      auto fields_size_before_append = fields.size();
+      fields.append(std::move(fields));
+
+      expect(fields.size() == fields_size_before_append);
+      expect(contains_value(fields, "Host", "example.com"));
+      expect(contains_value(fields, "Hello-World", "aero"));
+   };
+};
+
+int main() {}


### PR DESCRIPTION
A more refined version which supersedes #2402.

## Motivation
Main issues with using `std::unordered_map` to store header fields are:
1. **Data loss for repeated fields**. [RFC 9110, Section 5.3](https://datatracker.ietf.org/doc/html/rfc9110#section-5.3) specifies that header fields do not necessarily have to be concatenated before being sent over the wire. Therefore, a header section where multiple header-fields separated by CRLF have the same name is valid, and the implementation must handle such cases. Current behavior: `response_headers[...] = ...` - last wins.
2. **Names are stored in lowercase**. If the original case is important to the user during iteration, they won't be able to retrieve it. This would make sense if Glaze implemented HTTP/2 or HTTP/3, but it doesn't at this time. The issues this might cause are mostly cosmetic (e.g. logging/debugging), but it's still a problem. This can be fixed using a custom comparator, but that won't resolve the issue above.
3. **Parsing becomes more complicated when correcting data loss**. Even if we solve the problem with the comparator for `std::unordered_map`, a problem arises with concatenating header fields to avoid "last-wins" scenarios. When we receive multiple headers with the same name, , we need to concatenate their values, separating them with a comma (", "), which complicates the parser's behavior and makes storage less straightforward.
4. **Loss of the original field order**. `std::unordered_map` is unordered, so this behavior will cause problems during logging and/or debugging.

## Proposed solution
The class I propose is a low-level storage for header fields with a modern interface that satisfies the `std::ranges::forward_range` concept, allowing Glaze users to easily use this class into a wide variety of algorithms and scenarios in just a few lines of code.

The entire class iteration is a simple view idiom, no copies are created during iterations, and the entire immutable API is built on std::string_view.

### Short code example
```cpp
glz::http_headers headers{
   {"Content-Type", "application/json"},
   {"X-Request-ID", "7d42"},
   {"X-Rate-Limit", "100"},
   {"Cache-Control", "no-cache, no-store"},
   {"Set-Cookie", "theme=dark"},
};

headers.add("Set-Cookie", "session=7d42");
headers.set("Content-Type", "application/json; charset=utf-8");

if (auto first_cookie = headers.first_value("Set-Cookie")) {
   std::println("First cookie: {}", *first_cookie);
}

auto custom = headers | std::views::filter([](const glz::http_header& header) {
                 return header.name.starts_with("X-");
              });

for (const glz::http_header& header : custom) {
   std::println("{}: {}", header.name, header.value);
}

for (const auto& [name, value] : headers.fields("Set-Cookie")) {
   std::println("{}: {}", name, value);
}

if (headers.contains_token("Cache-Control", "no-store")) {
   std::println("response must not be stored");
}

std::print("{}", headers.serialize());
```

### API
```cpp
struct http_header
{
  std::string name;
  std::string value;

  [[nodiscard]] bool contains_token(std::string_view token) const;
};

class http_headers
{
 public:
  using value_type = glz::http_header;
  using iterator = std::vector<value_type>::iterator;
  using const_iterator = std::vector<value_type>::const_iterator;
  using size_type = std::vector<value_type>::size_type;

  private:
  template <bool IsConst>
  class matching_iterator
  {
      // std::forward_iterator_tag
  };

  public:
  using range_iterator = matching_iterator<false>;
  using const_range_iterator = matching_iterator<true>;

  http_headers() = default;
  http_headers(std::initializer_list<http_header> fields);

  [[nodiscard]] bool empty() const noexcept;
  [[nodiscard]] size_type size() const noexcept;
  [[nodiscard]] size_type capacity() const noexcept;
  [[nodiscard]] iterator begin() & noexcept;
  [[nodiscard]] iterator end() & noexcept;
  [[nodiscard]] const_iterator begin() const& noexcept;
  [[nodiscard]] const_iterator end() const& noexcept;
  [[nodiscard]] const_iterator cbegin() const& noexcept;
  [[nodiscard]] const_iterator cend() const& noexcept;
  [[nodiscard]] http_header& front() & noexcept;
  [[nodiscard]] const http_header& front() const& noexcept;
  [[nodiscard]] http_header& back() & noexcept;
  [[nodiscard]] const http_header& back() const& noexcept;

  void reserve(size_type count);
  void clear() noexcept;

  [[nodiscard]] iterator find(std::string_view name) & noexcept;
  [[nodiscard]] const_iterator find(std::string_view name) const& noexcept;
  [[nodiscard]] auto fields(std::string_view name GLZ_LIFETIMEBOUND) &;
  [[nodiscard]] auto fields(std::string_view name GLZ_LIFETIMEBOUND) const&;
  [[nodiscard]] auto names() const&;
  [[nodiscard]] auto values() const&;
  [[nodiscard]] auto values(std::string_view name GLZ_LIFETIMEBOUND) const&;
  [[nodiscard]] size_t count(std::string_view name) const& noexcept;
  [[nodiscard]] std::optional<std::string_view> first_value(std::string_view name) const& noexcept;
  [[nodiscard]] bool contains(std::string_view name) const noexcept;
  [[nodiscard]] bool contains_token(std::string_view name, std::string_view token) const;

  [[nodiscard]] std::string serialize() const;

  iterator set(std::string name, std::string value) &;
  iterator add(std::string name, std::string value) &;
  void append(const http_headers& other);
  void append(http_headers&& other);
  void erase(std::string_view name);

  // Disallow use on temporary objects
  iterator begin() && = delete;
  iterator end() && = delete;
  const_iterator begin() const&& = delete;
  const_iterator end() const&& = delete;
  const_iterator cbegin() const&& = delete;
  const_iterator cend() const&& = delete;
  http_header& front() && = delete;
  const http_header& front() const&& = delete;
  http_header& back() && = delete;
  const http_header& back() const&& = delete;
  iterator find(std::string_view name) && = delete;
  const_iterator find(std::string_view name) const&& = delete;
  auto fields(std::string_view name) && = delete;
  auto fields(std::string_view name) const&& = delete;
  auto names() const&& = delete;
  auto values() const&& = delete;
  auto values(std::string_view name) const&& = delete;
  std::optional<std::string_view> first_value(std::string_view name) const&& = delete;
  iterator add(std::string name, std::string value) && = delete;
  iterator set(std::string name, std::string value) && = delete;

 private:
  std::vector<value_type> headers_;
};
```

### Key design idea
Current `glz::http_headers` is intended to store header fields without the parser formatting their values. In other words, if the parser receives a header section containing multiple fields with the same name, the parser places all of these fields into `glz::http_headers` after validation, without concatenating their values.

The main API point is that by implementing the std::range interface, all non-trivial operations not covered by the current shortcut API can be easily implemented using C++2x ranges. This is one of the key advantages of the current design, because code that uses this API will look really idiomatic alongside modern heavy-std code.

Here are a few methods for understanding the design of this class:
| Method | What it solves |
|---|---|
| `fields(name)` | Returns every header with the given name as a range. Useful for headers that can appear more than once, e.g. `Set-Cookie`. |
| `names()` | Returns a lazy view over all header names. |
| `values()` | Returns a lazy view over all header values. The `values(name)` overload limits the view to header fields whose names match the passed one. |
| `serialize()` | Serializes header fields into HTTP wire format, including the final CRLF to finish the header section. |
| `contains_token(name, token)` | Checks for a comma-separated token in header fields whose names match the passed one. Token matching is case-insensitive and ignores optional whitespace. Useful for list-based headers, such as `Connection`, `Cache-Control`, etc. |
| `first_value(name)` | Returns the value of the first matching header, or `std::nullopt` if the header is not present. Provides a convenient layer for callers that only need a single value. |
| `set(name, value)` | Sets a header field to exactly one value. If the header already exists, its first occurrence is updated and all duplicates are removed. |
| `add(name, value)` | Appends a new header without replacing existing ones. Useful when repeated header lines are meaningful or required. |

### Pros
1. **Preserving the order of header fields** due to the use of `std::vector`, as well as manually preserving the insertion order when using `.set()`. Instead of simply using `.erase()` followed by `.add()`, implementation performs an in-place insertion while removing duplicates using the `erase-remove` idiom.
2. **Preservation of name case**. The container does not modify any values inserted by the user, searches are performed using the SWAR-optimized `glz::striequal` and have linear complexity.
3. **The parser stays straightforward and simple**. Concatenating the values of header fields with the same name is not required due to the current class design.
5. A clean and intuitive API for anyone who has ever worked with HTTP header fields.

### Cons
One potential issue that may arise and which the design takes into account - is temporary objects. Personally, I don't consider this a problem, but I understand that such cases can occur. It's more of a trade-off you have to accept when working with `std::ranges` and `std::views`, and this class simply follows that idiom.

Here's the example:
```cpp
// 1. Save range that was built from a temporary string to use it later
auto fields = h.fields(build_name()); // build_name() returns an std::string
for (auto& field : fields) { ... } // UB, std::string_view inside the "fields" iterator is pointing to a dead buffer

// 2. Return lazy range from function, in which the header name is a local string
auto cookie_values(const headers& h, std::string name) {
    return h.values(name); // name will get destroyed on return, UB
}

// 3. Rare, but still: header name was changed while range is alive
std::string name = "set-cookie";
auto r = h.fields(name);
name = "access-control-request-headers";
// Best case - iterators are now searching for other name
// Worst case - UB if new string assignment resulted in reallocation
```

### Tackling the downsides
- With C++23 support, we have a clear advantage that we can leverage, this is [P2718R0](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2718r0.html), which solves the problem of the lifetimes of temporary objects inside a range-loop.
Such code stays valid: `for (const auto& f : h.fields(std::string{prefix} + "-id")) { ... }`.
- Using the `[[compiler::lifetimebound]]` attribute practically eliminates the risk of errors when passing a temporary string to the `.fields()` and `.values()` methods. This attribute causes the compiler to warn the user when temporary `std::string` objects are used as arguments.
Unfortunately, GCC does not support this attribute, so users will only see warnings when using Clang or MSVC.

### Afterword
If I forgot to go into detail about any aspect of the design, I apologize. I'll be happy to answer any follow-up questions you may have regarding the decisions made.
It's also worth mentioning that I'm not finalizing the proposed API design. I'm simply presenting an initial version that's already ready for practical use.

As soon as we finalize the API - if that's okay with you - I'll start replacing the current code in the `net/` directory that uses `std::unordered_map`, and then I'll write the documentation for `glz::http_headers`.