### PR TITLE
Call shrink_to_fit after growing JSON array reads when requested

### DIFF
--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2419,6 +2419,11 @@ namespace glz
                         --ctx.depth;
                      }
                      ++it;
+                     if constexpr (resizable<T>) {
+                        if constexpr (check_shrink_to_fit(Opts)) {
+                           value.shrink_to_fit();
+                        }
+                     }
                      return;
                   }
                   else [[unlikely]] {


### PR DESCRIPTION
When `opts.shrink_to_fit` is enabled, JSON array reads now call `shrink_to_fit()`
on the emplace_back growing path after the closing `]`.
That option was already honored for empty arrays and for the fixed-size overwrite
path, but not when the container grew element-by-element via `emplace_back`.
Streaming reads benefit most, since they use geometric growth and can leave excess
capacity.