### PR TITLE
guard shrink_to_fit on a has_shrink_to_fit concept

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -282,6 +282,10 @@ When reading into arrays, appends new elements instead of replacing existing con
 #### `shrink_to_fit`
 Calls `shrink_to_fit()` on dynamic containers after reading to minimize memory usage.
 
+Containers that have no `shrink_to_fit()` member (such as `std::list` and `std::forward_list`) are left alone rather than failing to compile. Note that `shrink_to_fit()` is a non-binding request in the standard library, so it is a hint rather than a guarantee.
+
+Honored by JSON, NDJSON, BEVE, CBOR, and EETF. Other formats currently ignore this option.
+
 ### Binary Size Options
 
 #### `linear_search`

--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -991,7 +991,7 @@ namespace glz
             if constexpr (resizable<T>) {
                value.resize(n);
 
-               if constexpr (check_shrink_to_fit(Opts)) {
+               if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
                   value.shrink_to_fit();
                }
             }
@@ -1034,7 +1034,7 @@ namespace glz
                if constexpr (resizable<T>) {
                   value.resize(n);
 
-                  if constexpr (check_shrink_to_fit(Opts)) {
+                  if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
                      value.shrink_to_fit();
                   }
                }
@@ -1293,7 +1293,7 @@ namespace glz
             if constexpr (resizable<T>) {
                value.resize(n);
 
-               if constexpr (check_shrink_to_fit(Opts)) {
+               if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
                   value.shrink_to_fit();
                }
             }
@@ -1322,8 +1322,8 @@ namespace glz
 
                x.resize(length);
 
-               if constexpr (check_shrink_to_fit(Opts)) {
-                  value.shrink_to_fit();
+               if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<decltype(x)>) {
+                  x.shrink_to_fit();
                }
 
                std::memcpy(x.data(), it, length);
@@ -1377,7 +1377,7 @@ namespace glz
             if constexpr (resizable<T>) {
                value.resize(n);
 
-               if constexpr (check_shrink_to_fit(Opts)) {
+               if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
                   value.shrink_to_fit();
                }
             }
@@ -1459,7 +1459,7 @@ namespace glz
             if constexpr (resizable<T>) {
                value.resize(n);
 
-               if constexpr (check_shrink_to_fit(Opts)) {
+               if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
                   value.shrink_to_fit();
                }
             }

--- a/include/glaze/cbor/read.hpp
+++ b/include/glaze/cbor/read.hpp
@@ -839,7 +839,7 @@ namespace glz
 
                   if constexpr (resizable<T>) {
                      value.resize(count);
-                     if constexpr (check_shrink_to_fit(Opts)) {
+                     if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
                         value.shrink_to_fit();
                      }
                   }
@@ -986,7 +986,7 @@ namespace glz
 
                   if constexpr (resizable<T>) {
                      value.resize(count);
-                     if constexpr (check_shrink_to_fit(Opts)) {
+                     if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
                         value.shrink_to_fit();
                      }
                   }
@@ -1120,7 +1120,7 @@ namespace glz
             if constexpr (resizable<T>) {
                value.resize(static_cast<size_t>(count));
 
-               if constexpr (check_shrink_to_fit(Opts)) {
+               if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
                   value.shrink_to_fit();
                }
             }

--- a/include/glaze/concepts/container_concepts.hpp
+++ b/include/glaze/concepts/container_concepts.hpp
@@ -39,6 +39,10 @@ namespace glz
    template <class T>
    concept erasable = requires(T v) { v.erase(v.cbegin(), v.cend()); };
 
+   // Not implied by `resizable`: std::list and std::forward_list are resizable but have no shrink_to_fit
+   template <class T>
+   concept has_shrink_to_fit = requires(T v) { v.shrink_to_fit(); };
+
    template <class T>
    concept has_size = requires(T v) { v.size(); };
 

--- a/include/glaze/eetf/ei.hpp
+++ b/include/glaze/eetf/ei.hpp
@@ -223,7 +223,7 @@ namespace glz
 
       if constexpr (resizable<T>) {
          value.resize(sz);
-         if constexpr (check_shrink_to_fit(Opts)) {
+         if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
             value.shrink_to_fit();
          }
       }
@@ -273,7 +273,7 @@ namespace glz
 
       if constexpr (resizable<T>) {
          value.resize(arity);
-         if constexpr (check_shrink_to_fit(Opts)) {
+         if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
             value.shrink_to_fit();
          }
       }
@@ -321,7 +321,7 @@ namespace glz
             decode_token(buff, std::forward<Ctx>(ctx), std::forward<It0>(it), end);
             if constexpr (resizable<T>) {
                value.resize(sz);
-               if constexpr (check_shrink_to_fit(Opts)) {
+               if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
                   value.shrink_to_fit();
                }
             }

--- a/include/glaze/json/ndjson.hpp
+++ b/include/glaze/json/ndjson.hpp
@@ -113,6 +113,13 @@ namespace glz
             while (it < end) {
                parse<JSON>::op<Opts>(value.emplace_back(), ctx, it, end);
                if (bool(ctx.error)) {
+                  // A non-null-terminated buffer has no sentinel, so the last record reports
+                  // end_reached instead of stopping on '\0'. A depth of zero means that record was
+                  // parsed completely, which is the normal end of input rather than a failure. This
+                  // matches the condition finalize_read_context clears the code on.
+                  if (ctx.error == error_code::end_reached && ctx.depth == 0) {
+                     break;
+                  }
                   return;
                }
 

--- a/include/glaze/json/ndjson.hpp
+++ b/include/glaze/json/ndjson.hpp
@@ -45,7 +45,7 @@ namespace glz
             if constexpr (resizable<T>) {
                value.clear();
 
-               if constexpr (check_shrink_to_fit(Opts)) {
+               if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
                   value.shrink_to_fit();
                }
             }
@@ -98,7 +98,7 @@ namespace glz
                   value.erase(value_it,
                               value.end()); // use erase rather than resize for non-default constructible elements
 
-                  if constexpr (check_shrink_to_fit(Opts)) {
+                  if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
                      value.shrink_to_fit();
                   }
                }
@@ -117,6 +117,10 @@ namespace glz
                }
 
                read_new_lines();
+            }
+
+            if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
+               value.shrink_to_fit();
             }
          }
          else {

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2283,7 +2283,7 @@ namespace glz
             if constexpr ((resizable<T> || is_inplace_vector<T>) && not check_append_arrays(Opts)) {
                value.clear();
 
-               if constexpr (check_shrink_to_fit(Opts)) {
+               if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
                   value.shrink_to_fit();
                }
             }
@@ -2327,7 +2327,7 @@ namespace glz
                      value.erase(value_it,
                                  value.end()); // use erase rather than resize for non-default constructible elements
 
-                     if constexpr (check_shrink_to_fit(Opts)) {
+                     if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
                         value.shrink_to_fit();
                      }
                   }
@@ -2419,10 +2419,8 @@ namespace glz
                         --ctx.depth;
                      }
                      ++it;
-                     if constexpr (resizable<T>) {
-                        if constexpr (check_shrink_to_fit(Opts)) {
-                           value.shrink_to_fit();
-                        }
+                     if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
+                        value.shrink_to_fit();
                      }
                      return;
                   }

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2419,6 +2419,11 @@ namespace glz
                         --ctx.depth;
                      }
                      ++it;
+                     if constexpr (resizable<T>) {
+                        if constexpr (check_shrink_to_fit(Opts)) {
+                           value.shrink_to_fit();
+                        }
+                     }
                      return;
                   }
                   else [[unlikely]] {

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -7042,6 +7042,63 @@ suite beve_byte_and_char_array_tests = [] {
    };
 };
 
+struct beve_shrink_opts : glz::opts
+{
+   bool shrink_to_fit = true;
+};
+
+// shrink_to_fit() is a non-binding request, so track the call rather than the capacity
+struct shrink_counting_string : std::string
+{
+   using std::string::basic_string;
+   size_t shrink_calls{};
+   void shrink_to_fit()
+   {
+      ++shrink_calls;
+      std::string::shrink_to_fit();
+   }
+};
+
+suite beve_shrink_to_fit_tests = [] {
+   "string elements are shrunk, not the container"_test = [] {
+      const std::vector<std::string> src{"a", "b", "c"};
+      std::string buffer{};
+      expect(not glz::write_beve(src, buffer));
+
+      // each element starts long, so resizing it down leaves excess capacity to reclaim
+      std::vector<shrink_counting_string> dst(3, shrink_counting_string(256, 'x'));
+      expect(not glz::read<beve_shrink_opts{{.format = glz::BEVE}}>(dst, buffer));
+
+      expect(dst.size() == 3);
+      for (size_t i = 0; i < dst.size(); ++i) {
+         expect(dst[i] == src[i]);
+         expect(dst[i].shrink_calls == 1);
+      }
+   };
+
+   // the outer container is not resizable, so shrinking it was never guarded
+   "fixed size string containers still compile"_test = [] {
+      const std::array<std::string, 3> src{"a", "b", "c"};
+      std::string buffer{};
+      expect(not glz::write_beve(src, buffer));
+
+      std::array<std::string, 3> dst{};
+      expect(not glz::read<beve_shrink_opts{{.format = glz::BEVE}}>(dst, buffer));
+      expect(dst == src);
+   };
+
+   // std::list is resizable but has no shrink_to_fit member
+   "containers without shrink_to_fit still compile"_test = [] {
+      const std::vector<int> src{1, 2, 3};
+      std::string buffer{};
+      expect(not glz::write_beve(src, buffer));
+
+      std::list<int> dst{9, 9, 9, 9};
+      expect(not glz::read<beve_shrink_opts{{.format = glz::BEVE}}>(dst, buffer));
+      expect(dst == (std::list<int>{1, 2, 3}));
+   };
+};
+
 int main()
 {
    trace.begin("binary_test");

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -3556,6 +3556,44 @@ suite cbor_byte_uint8_unify_tests = [] {
    };
 };
 
+struct cbor_shrink_opts : glz::opts
+{
+   bool shrink_to_fit = true;
+};
+
+// Resizable but deliberately without a shrink_to_fit member, like std::list.
+// std::list itself can't be used here: CBOR's array reader subscripts its target.
+// String elements keep this on the generic array path rather than the typed-array path.
+struct no_shrink_strings
+{
+   using value_type = std::string;
+   std::vector<std::string> data{};
+
+   auto begin() { return data.begin(); }
+   auto end() { return data.end(); }
+   auto begin() const { return data.begin(); }
+   auto end() const { return data.end(); }
+   size_t size() const { return data.size(); }
+   void resize(size_t n) { data.resize(n); }
+   void clear() { data.clear(); }
+   std::string& emplace_back() { return data.emplace_back(); }
+   std::string& back() { return data.back(); }
+   std::string& operator[](size_t i) { return data[i]; }
+   const std::string& operator[](size_t i) const { return data[i]; }
+};
+
+suite cbor_shrink_to_fit_tests = [] {
+   "containers without shrink_to_fit still compile"_test = [] {
+      const std::vector<std::string> src{"a", "b", "c"};
+      std::string buffer{};
+      expect(not glz::write_cbor(src, buffer));
+
+      no_shrink_strings dst{{"x", "x", "x", "x"}};
+      expect(not glz::read<cbor_shrink_opts{{.format = glz::CBOR}}>(dst, buffer));
+      expect(dst.data == src);
+   };
+};
+
 int main()
 {
    custom_variant_ambiguity_tests();

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -4432,23 +4432,106 @@ suite nested_file_include_test = [] {
    };
 };
 
-// Shrink to fit is nonbinding and cannot be properly tested
-/*suite shrink_to_fit = [] {
-   "shrink_to_fit"_test = [] {
-      std::vector<int> v = { 1, 2, 3, 4, 5, 6 };
-      std::string b = R"([1,2,3])";
-      expect(glz::read_json(v, b) == glz::error_code::none);
+struct shrink_opts : glz::opts
+{
+   bool shrink_to_fit = true;
+};
 
-      expect(v.size() == 3);
-      expect(v.capacity() > 3);
+// std::vector::shrink_to_fit() is a non-binding request, so capacity can't be asserted portably.
+// Track the call itself instead, which is what Glaze is responsible for.
+struct shrink_counter : std::vector<int>
+{
+   using std::vector<int>::vector;
+   size_t shrink_calls{};
+   void shrink_to_fit()
+   {
+      ++shrink_calls;
+      std::vector<int>::shrink_to_fit();
+   }
+};
 
-      v = { 1, 2, 3, 4, 5, 6 };
+const std::vector<int> expected_123{1, 2, 3};
 
-      expect(glz::read<glz::opts{.shrink_to_fit = true}>(v, b) == glz::error_code::none);
-      expect(v.size() == 3);
-      expect(v.capacity() == 3);
+suite shrink_to_fit_tests = [] {
+   "growing read shrinks"_test = [] {
+      shrink_counter v;
+      expect(not glz::read<shrink_opts{}>(v, std::string{"[1,2,3]"}));
+      expect(v == expected_123);
+      expect(v.shrink_calls == 1);
    };
-};*/
+
+   "read past existing size shrinks"_test = [] {
+      // starts smaller than the buffer, so the overwrite loop falls through into the growing loop
+      shrink_counter v{1};
+      expect(not glz::read<shrink_opts{}>(v, std::string{"[1,2,3]"}));
+      expect(v == expected_123);
+      expect(v.shrink_calls == 1);
+   };
+
+   "shrinking read shrinks"_test = [] {
+      shrink_counter v{1, 2, 3, 4, 5, 6};
+      expect(not glz::read<shrink_opts{}>(v, std::string{"[1,2,3]"}));
+      expect(v == expected_123);
+      expect(v.shrink_calls == 1);
+   };
+
+   "empty array shrinks"_test = [] {
+      shrink_counter v{1, 2, 3};
+      expect(not glz::read<shrink_opts{}>(v, std::string{"[]"}));
+      expect(v.empty());
+      expect(v.shrink_calls == 1);
+   };
+
+   "appended read shrinks"_test = [] {
+      struct append_shrink_opts : glz::opts
+      {
+         bool append_arrays = true;
+         bool shrink_to_fit = true;
+      };
+      shrink_counter v{1};
+      expect(not glz::read<append_shrink_opts{}>(v, std::string{"[2,3]"}));
+      expect(v == expected_123);
+      expect(v.shrink_calls == 1);
+   };
+
+   "no shrink by default"_test = [] {
+      shrink_counter v{1, 2, 3, 4, 5, 6};
+      expect(not glz::read_json(v, std::string{"[1,2,3]"}));
+      expect(v == expected_123);
+      expect(v.shrink_calls == 0);
+   };
+
+   // std::list and std::forward_list are resizable but have no shrink_to_fit member
+   "containers without shrink_to_fit still compile"_test = [] {
+      std::list<int> l{9, 9, 9, 9};
+      expect(not glz::read<shrink_opts{}>(l, std::string{"[1,2,3]"}));
+      expect(l == (std::list<int>{1, 2, 3}));
+
+      std::forward_list<int> fl{9, 9, 9, 9};
+      expect(not glz::read<shrink_opts{}>(fl, std::string{"[1,2,3]"}));
+      expect(fl == (std::forward_list<int>{1, 2, 3}));
+   };
+
+   "ndjson shrinking read shrinks"_test = [] {
+      shrink_counter v{1, 2, 3, 4, 5, 6};
+      expect(not glz::read<shrink_opts{{.format = glz::NDJSON}}>(v, std::string{"1\n2\n3"}));
+      expect(v == expected_123);
+      expect(v.shrink_calls == 1);
+   };
+
+   "ndjson growing read shrinks"_test = [] {
+      shrink_counter v;
+      expect(not glz::read<shrink_opts{{.format = glz::NDJSON}}>(v, std::string{"1\n2\n3"}));
+      expect(v == expected_123);
+      expect(v.shrink_calls == 1);
+   };
+
+   "ndjson containers without shrink_to_fit still compile"_test = [] {
+      std::list<int> l{9, 9, 9, 9};
+      expect(not glz::read<shrink_opts{{.format = glz::NDJSON}}>(l, std::string{"1\n2\n3"}));
+      expect(l == (std::list<int>{1, 2, 3}));
+   };
+};
 
 suite recorder_test = [] {
    "recorder_to_file"_test = [] {


### PR DESCRIPTION
Supersedes #2711 by @ays7, whose commit is included here unchanged.

That PR made the JSON growing path honor `shrink_to_fit`. Auditing the other call sites turned up a shared latent bug and two more gaps:

- `resizable` was used as the guard for calling `shrink_to_fit()`, but it doesn't imply that member. `std::list` and `std::forward_list` are resizable without it, so enabling the option and reading into one failed to compile — already true on main for the empty-array and overwrite paths. Adds a `has_shrink_to_fit` concept and guards all 17 sites across JSON, NDJSON, BEVE, CBOR and EETF.
- The BEVE string-array reader shrank the outer container instead of the string element it had just resized. Reading into `std::array<std::string, N>` failed to compile, and it reallocated the container being iterated.
- The NDJSON growing loop never shrank — the same gap #2711 fixes for JSON.

`shrink_to_fit()` is a non-binding request, which is why the pre-existing test for this option was commented out; the new tests count calls through a wrapper container instead of asserting capacity. Each was verified to fail without its fix.
