### PR TITLE
require explicit Opts on jmespath slice/index helpers

### DIFF
--- a/include/glaze/json/jmespath.hpp
+++ b/include/glaze/json/jmespath.hpp
@@ -429,7 +429,13 @@ namespace glz
 
    namespace detail
    {
-      template <auto Opts = opts{}, class T>
+      // The slice/index helpers below intentionally do not default `Opts`. They must inherit the
+      // caller's parse options, and a defaulted `Opts` makes a call site that forgets `<Opts>`
+      // compile silently against `opts{}`, resetting every option. That is how #2710 read past the
+      // end of a non-null-terminated buffer: `null_terminated` reverted to true, so the end guards
+      // in `handle_slice` compiled out while the caller was parsing a buffer with no '\0' sentinel.
+      // Requiring an explicit `Opts` turns that mistake into a compile error.
+      template <auto Opts, class T>
          requires(Opts.format == JSON && not readable_array_t<T> &&
                   not(tuple_t<std::decay_t<T>> || is_std_tuple<std::decay_t<T>>))
       inline void handle_slice(const jmespath::ArrayParseResult&, T&&, context& ctx, auto&&, auto&&)
@@ -437,7 +443,7 @@ namespace glz
          ctx.error = error_code::syntax_error;
       }
 
-      template <auto Opts = opts{}, class T>
+      template <auto Opts, class T>
          requires(Opts.format == JSON && (tuple_t<std::decay_t<T>> || is_std_tuple<std::decay_t<T>>))
       inline void handle_slice(const jmespath::ArrayParseResult& decomposed_key, T&& value, context& ctx, auto&& it,
                                auto end)
@@ -558,7 +564,7 @@ namespace glz
       // against the array length per JMESPath (e.g. [-1] is the last element). On entry `it`
       // must point at the first element (just past '['), or at ']' for an empty array. On
       // success `it` is positioned at element `n`; otherwise ctx.error is set.
-      template <auto Opts = opts{}>
+      template <auto Opts>
       inline void seek_array_index(int32_t n, context& ctx, auto&& it, auto end)
       {
          const auto at_end = [&]() -> bool {
@@ -618,7 +624,7 @@ namespace glz
          }
       }
 
-      template <auto Opts = opts{}, class T>
+      template <auto Opts, class T>
          requires(Opts.format == JSON && readable_array_t<T>)
       inline void handle_slice(const jmespath::ArrayParseResult& decomposed_key, T&& value, context& ctx, auto&& it,
                                auto end)


### PR DESCRIPTION
Follow-up to #2710, which fixed the two runtime `read_jmespath` slice call sites that dropped `<Opts>`. This removes the defaulted `Opts` that made that mistake possible in the first place.

## Why

`detail::handle_slice` (3 overloads) and `detail::seek_array_index` declared `template <auto Opts = opts{}, ...>`. On an internal helper that default is a footgun: a call site that forgets `<Opts>` still compiles, silently binding `opts{}` and resetting every option.

In #2710 that meant `null_terminated` reverted to `true`, so the end guards inside `handle_slice` compiled out and the structural `]` / `,` scans ran past the end of a non-null-terminated buffer. Guarded and unguarded builds diverged only for non-null-terminated input, so nothing caught it at compile time.

Worth noting the lost option was never just `null_terminated`. Binding `opts{}` resets the whole option set for everything inside the helper, including the nested `parse<Opts.format>::op<Opts>` that reads the sliced elements, so runtime slices silently ignored caller options in general. The buffer overrun was the acute symptom; dropping the options was the defect.

## What

Drop the defaults so `Opts` must be passed explicitly, plus a comment recording why the default is absent so it does not get restored later.

All seven call sites already pass `<Opts>`, so this is a no-op at runtime. But omitting it at any of them is now a compile error instead of a silent option reset:

```
error: no matching function for call to 'handle_slice'
```

## Verification

- Reintroduced the omission at each of the seven call sites in turn (lines 873, 881, 945, 1131, 1140, 1194, 1203); every one fails to compile.
- jmespath suite passes unchanged under ASan: 29 tests, 255 asserts.
- `jmespath.hpp` is not included by `glaze.hpp` and `tests/jmespath` is its only consumer, so the change is fully contained.

## Unrelated pre-existing issue spotted nearby

Not addressed here, flagging for the record. The compile-time object-member slice branch at `jmespath.hpp:931` is uninstantiable:

```cpp
detail::handle_slice<Opts, decomposed_key>(value, ctx, it, end);  // 4 args
```

All three `handle_slice` overloads take 5 parameters, and `decomposed_key` is a value passed where `class T` is expected. It compiles today only because the branch is never instantiated: the tokenizer splits `a[1:3]` into `a` and `[1:3]`, so an array-access token always has an empty key and the `key.empty()` branch above always wins. Its runtime twin at line 1194 is instantiated but likewise never executed, for the same tokenization reason. If anyone makes that branch reachable it is a hard compile error.