### PR TITLE
remove unreachable object-member branch from jmespath array access

### DIFF
--- a/include/glaze/json/jmespath.hpp
+++ b/include/glaze/json/jmespath.hpp
@@ -852,125 +852,50 @@ namespace glz
             static_assert(not decomposed_key.error, "invalid JMESPath expression");
 
             if constexpr (decomposed_key.is_array_access) {
-               // If we have a key, that means we're looking into an object like: key[0:5]
-               if constexpr (key.empty()) {
-                  if (skip_ws<Opts>(ctx, it, end)) {
-                     return;
-                  }
-                  // We expect the JSON at this level to be an array
-                  if (match_invalid_end<'[', Opts>(ctx, it, end)) {
-                     return;
-                  }
+               // `finalize_tokens` splits every token at '[' and pushes any key prefix out as its
+               // own token, so a bracketed token always begins with '['. An array-access token
+               // therefore always has an empty key: "a[0]" tokenizes as "a" then "[0]", and the
+               // object-member step is handled by the preceding key token. The `key[...]` form is
+               // consequently unreachable, so there is no branch for it here. If tokenization ever
+               // stops splitting, this fires rather than silently taking an unexercised path.
+               static_assert(key.empty(), "array-access token carries a key; jmespath tokenization changed");
 
-                  // If this is a slice (colon_count > 0)
-                  if constexpr (decomposed_key.colon_count > 0) {
-                     detail::handle_slice<Opts>(decomposed_key, value, ctx, it, end);
-                  }
-                  else {
-                     // SINGLE INDEX SCENARIO (no slice, just an index)
-                     if constexpr (decomposed_key.start.has_value()) {
-                        constexpr auto n = decomposed_key.start.value();
-
-                        // Position `it` at element n (negative indices count from the back).
-                        detail::seek_array_index<Opts>(int32_t(n), ctx, it, end);
-                        if (bool(ctx.error)) [[unlikely]]
-                           return;
-
-                        // For the final token read the element into value; otherwise leave `it`
-                        // positioned so the next token can continue indexing into it.
-                        if constexpr (I == (N - 1)) {
-                           parse<Opts.format>::template op<Opts>(value, ctx, it, end);
-                        }
-                     }
-                     else {
-                        ctx.error = error_code::array_element_not_found;
-                        return;
-                     }
-                  }
-
-                  // After handling the array access, we're done for this token
+               if (skip_ws<Opts>(ctx, it, end)) {
                   return;
                }
+               // We expect the JSON at this level to be an array
+               if (match_invalid_end<'[', Opts>(ctx, it, end)) {
+                  return;
+               }
+
+               // If this is a slice (colon_count > 0)
+               if constexpr (decomposed_key.colon_count > 0) {
+                  detail::handle_slice<Opts>(decomposed_key, value, ctx, it, end);
+               }
                else {
-                  // Object scenario with a key, like: key[0:5]
-                  if (match_invalid_end<'{', Opts>(ctx, it, end)) {
-                     return;
-                  }
+                  // SINGLE INDEX SCENARIO (no slice, just an index)
+                  if constexpr (decomposed_key.start.has_value()) {
+                     constexpr auto n = decomposed_key.start.value();
 
-                  while (true) {
-                     if (skip_ws<Opts>(ctx, it, end)) {
-                        return;
-                     }
-                     if (match<'"'>(ctx, it)) {
-                        return;
-                     }
-
-                     auto* start = it;
-                     skip_string_view(ctx, it, end);
+                     // Position `it` at element n (negative indices count from the back).
+                     detail::seek_array_index<Opts>(int32_t(n), ctx, it, end);
                      if (bool(ctx.error)) [[unlikely]]
                         return;
-                     const sv k = {start, size_t(it - start)};
-                     ++it;
 
-                     if (key.size() == k.size() && comparitor<key>(k.data())) {
-                        if (skip_ws<Opts>(ctx, it, end)) {
-                           return;
-                        }
-                        if (match_invalid_end<':', Opts>(ctx, it, end)) {
-                           return;
-                        }
-                        if (skip_ws<Opts>(ctx, it, end)) {
-                           return;
-                        }
-                        if (match_invalid_end<'[', Opts>(ctx, it, end)) {
-                           return;
-                        }
-
-                        // Distinguish single index vs slice using colon_count
-                        if constexpr (decomposed_key.colon_count > 0) {
-                           detail::handle_slice<Opts, decomposed_key>(value, ctx, it, end);
-                        }
-                        else {
-                           // SINGLE INDEX SCENARIO (colon_count == 0)
-                           if constexpr (decomposed_key.start.has_value()) {
-                              constexpr auto n = decomposed_key.start.value();
-
-                              // Position `it` at element n (negative indices count from the back).
-                              detail::seek_array_index<Opts>(int32_t(n), ctx, it, end);
-                              if (bool(ctx.error)) [[unlikely]]
-                                 return;
-
-                              if (skip_ws<Opts>(ctx, it, end)) {
-                                 return;
-                              }
-
-                              if constexpr (I == (N - 1)) {
-                                 parse<Opts.format>::template op<Opts>(value, ctx, it, end);
-                              }
-                              return;
-                           }
-                           else {
-                              ctx.error = error_code::array_element_not_found;
-                              return;
-                           }
-                        }
-                     }
-                     else {
-                        skip_value<JSON>::op<Opts>(ctx, it, end);
-                        if (bool(ctx.error)) [[unlikely]] {
-                           return;
-                        }
-                        if (skip_ws<Opts>(ctx, it, end)) {
-                           return;
-                        }
-                        if (*it != ',') {
-                           ctx.error = error_code::key_not_found;
-                           return;
-                        }
-                        ++it;
+                     // For the final token read the element into value; otherwise leave `it`
+                     // positioned so the next token can continue indexing into it.
+                     if constexpr (I == (N - 1)) {
+                        parse<Opts.format>::template op<Opts>(value, ctx, it, end);
                      }
                   }
+                  else {
+                     ctx.error = error_code::array_element_not_found;
+                     return;
+                  }
                }
+
+               // After handling the array access, we're done for this token
+               return;
             }
             else {
                // If it's not array access, we are dealing with an object key
@@ -1111,123 +1036,48 @@ namespace glz
                }
 
                if (decomposed_key.is_array_access) {
-                  if (key.empty()) {
-                     // Top-level array scenario
-                     if (skip_ws<Opts>(ctx, it, end)) {
-                        return;
-                     }
-                     if (match_invalid_end<'[', Opts>(ctx, it, end)) {
-                        return;
-                     }
+                  // Unreachable by construction: `finalize_tokens` splits every token at '[', so an
+                  // array-access token always has an empty key (see the static_assert on the
+                  // compile-time path). Guard rather than silently mis-parse if that ever changes.
+                  if (not key.empty()) [[unlikely]] {
+                     ctx.error = error_code::syntax_error;
+                     return;
+                  }
 
-                     if (decomposed_key.colon_count > 0) {
-                        // Slice scenario
-                        detail::handle_slice<Opts>(decomposed_key, value, ctx, it, end);
-                        return;
-                     }
-                     else {
-                        // Single index scenario
-                        if (decomposed_key.start.has_value()) {
-                           const int32_t n = decomposed_key.start.value();
+                  // Top-level array scenario
+                  if (skip_ws<Opts>(ctx, it, end)) {
+                     return;
+                  }
+                  if (match_invalid_end<'[', Opts>(ctx, it, end)) {
+                     return;
+                  }
 
-                           // Position `it` at element n (negative indices count from the back).
-                           detail::seek_array_index<Opts>(n, ctx, it, end);
-                           if (bool(ctx.error)) [[unlikely]]
-                              return;
-
-                           // For the final token read the element into value; otherwise leave `it`
-                           // positioned so the next token can continue indexing into it.
-                           if (I == (N - 1)) {
-                              parse<Opts.format>::template op<Opts>(value, ctx, it, end);
-                           }
-                        }
-                        else {
-                           ctx.error = error_code::array_element_not_found;
-                           return;
-                        }
-                        return;
-                     }
+                  if (decomposed_key.colon_count > 0) {
+                     // Slice scenario
+                     detail::handle_slice<Opts>(decomposed_key, value, ctx, it, end);
+                     return;
                   }
                   else {
-                     // Object scenario: key[...]
-                     if (match_invalid_end<'{', Opts>(ctx, it, end)) {
-                        return;
-                     }
+                     // Single index scenario
+                     if (decomposed_key.start.has_value()) {
+                        const int32_t n = decomposed_key.start.value();
 
-                     while (true) {
-                        if (skip_ws<Opts>(ctx, it, end)) {
-                           return;
-                        }
-                        if (match<'"'>(ctx, it)) {
-                           return;
-                        }
-
-                        auto* start_pos = it;
-                        skip_string_view(ctx, it, end);
+                        // Position `it` at element n (negative indices count from the back).
+                        detail::seek_array_index<Opts>(n, ctx, it, end);
                         if (bool(ctx.error)) [[unlikely]]
                            return;
-                        const sv k = {start_pos, size_t(it - start_pos)};
-                        ++it;
 
-                        if (key.size() == k.size() && memcmp(key.data(), k.data(), key.size()) == 0) {
-                           if (skip_ws<Opts>(ctx, it, end)) {
-                              return;
-                           }
-                           if (match_invalid_end<':', Opts>(ctx, it, end)) {
-                              return;
-                           }
-                           if (skip_ws<Opts>(ctx, it, end)) {
-                              return;
-                           }
-                           if (match_invalid_end<'[', Opts>(ctx, it, end)) {
-                              return;
-                           }
-
-                           if (decomposed_key.colon_count > 0) {
-                              // Slice scenario
-                              detail::handle_slice<Opts>(decomposed_key, value, ctx, it, end);
-                              return;
-                           }
-                           else {
-                              // Single index scenario
-                              if (decomposed_key.start.has_value()) {
-                                 const int32_t n = decomposed_key.start.value();
-
-                                 // Position `it` at element n (negative indices count from the back).
-                                 detail::seek_array_index<Opts>(n, ctx, it, end);
-                                 if (bool(ctx.error)) [[unlikely]]
-                                    return;
-
-                                 if (skip_ws<Opts>(ctx, it, end)) {
-                                    return;
-                                 }
-
-                                 if (I == (N - 1)) {
-                                    parse<Opts.format>::template op<Opts>(value, ctx, it, end);
-                                 }
-                                 return;
-                              }
-                              else {
-                                 ctx.error = error_code::array_element_not_found;
-                                 return;
-                              }
-                           }
-                        }
-                        else {
-                           skip_value<JSON>::op<Opts>(ctx, it, end);
-                           if (bool(ctx.error)) [[unlikely]] {
-                              return;
-                           }
-                           if (skip_ws<Opts>(ctx, it, end)) {
-                              return;
-                           }
-                           if (*it != ',') {
-                              ctx.error = error_code::key_not_found;
-                              return;
-                           }
-                           ++it;
+                        // For the final token read the element into value; otherwise leave `it`
+                        // positioned so the next token can continue indexing into it.
+                        if (I == (N - 1)) {
+                           parse<Opts.format>::template op<Opts>(value, ctx, it, end);
                         }
                      }
+                     else {
+                        ctx.error = error_code::array_element_not_found;
+                        return;
+                     }
+                     return;
                   }
                }
                else {

--- a/tests/jmespath/jmespath.cpp
+++ b/tests/jmespath/jmespath.cpp
@@ -557,4 +557,63 @@ suite non_null_terminated_slice_bounds = [] {
    };
 };
 
+// A "key[...]" expression is tokenized as the key and the bracket separately ("a[1:3]" -> "a",
+// "[1:3]"), so the array-access token always has an empty key and object-member navigation is
+// handled by the preceding key token. The read paths rely on that invariant and carry no
+// "key[...]" branch. These cases pin the behavior that invariant produces, on both the
+// compile-time and runtime overloads.
+suite key_prefixed_array_access = [] {
+   "key-prefixed slice"_test = [] {
+      std::string buffer = R"({"a":[10,20,30,40,50],"b":[1,2]})";
+
+      std::vector<int> slice{};
+      expect(not glz::read_jmespath<"a[1:3]">(slice, buffer));
+      expect(slice == (std::vector<int>{20, 30}));
+
+      slice.clear();
+      expect(not glz::read_jmespath(glz::jmespath_expression{"a[1:3]"}, slice, buffer));
+      expect(slice == (std::vector<int>{20, 30}));
+
+      // Reverse slice behind a key.
+      std::vector<int> rev{};
+      expect(not glz::read_jmespath<"a[::-1]">(rev, buffer));
+      expect(rev == (std::vector<int>{50, 40, 30, 20, 10}));
+
+      // A later key is unaffected by the earlier one.
+      std::vector<int> b{};
+      expect(not glz::read_jmespath<"b[0:2]">(b, buffer));
+      expect(b == (std::vector<int>{1, 2}));
+   };
+
+   "key-prefixed index and nesting"_test = [] {
+      std::string buffer = R"({"a":{"b":{"c":[1,2,3,4]}},"list":[{"n":1},{"n":2},{"n":3}]})";
+
+      int n{};
+      expect(not glz::read_jmespath<"a.b.c[2]">(n, buffer));
+      expect(n == 3);
+      expect(not glz::read_jmespath(glz::jmespath_expression{"a.b.c[2]"}, n, buffer));
+      expect(n == 3);
+
+      std::vector<int> slice{};
+      expect(not glz::read_jmespath<"a.b.c[1:3]">(slice, buffer));
+      expect(slice == (std::vector<int>{2, 3}));
+
+      // Index into an array of objects, then navigate a key.
+      expect(not glz::read_jmespath<"list[1].n">(n, buffer));
+      expect(n == 2);
+      expect(not glz::read_jmespath(glz::jmespath_expression{"list[2].n"}, n, buffer));
+      expect(n == 3);
+   };
+
+   "key-prefixed access on missing key errors"_test = [] {
+      std::string buffer = R"({"a":[10,20,30]})";
+      std::vector<int> slice{};
+      expect(glz::read_jmespath<"missing[0:2]">(slice, buffer));
+      expect(glz::read_jmespath(glz::jmespath_expression{"missing[0:2]"}, slice, buffer));
+
+      int n{};
+      expect(glz::read_jmespath<"missing[0]">(n, buffer));
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
Fixes the pre-existing issue flagged in #2713: the compile-time object-member slice branch is uninstantiable.

## The defect

Both `read_jmespath` overloads branched on whether an array-access token carried a key, with the `key[...]` side handling object-member navigation. The compile-time half of that branch does not compile:

```cpp
detail::handle_slice<Opts, decomposed_key>(value, ctx, it, end);  // 4 args
```

All three `handle_slice` overloads take **five** parameters, and `decomposed_key` is a value passed where `class T` is expected. It builds today only because the branch is never instantiated. Making it reachable is a hard compile error.

## Why it is unreachable

`finalize_tokens` splits every token at `[` and pushes any key prefix out as its own token, so a bracketed token always begins with `[`. Since `parse_jmespath_token` derives the key as `token.substr(0, find('['))`, an array-access token always has an empty key.

`a[1:3]` tokenizes as `a` then `[1:3]`; the object-member step is handled by the preceding key token, and the bracket token takes the `key.empty()` path. Both overloads share this tokenizer (`jmespath_expression` calls the same `tokenize_full_jmespath`), so the invariant holds for each. The runtime twin is instantiated but likewise never executed.

## The change

Drop both dead branches. In their place:

- **compile-time**: `static_assert(key.empty(), ...)`, so a tokenizer change fails loudly instead of falling into an unexercised path.
- **runtime**: cannot `static_assert`, so it guards and errors.

Most of the diff is re-indentation from removing a nesting level. `git diff -w` shows the real change: **166 deletions against 75 insertions**.

## Verification

- **Invariant proof**: generated 5284 expressions (keys, brackets, slices, `.`/`|` separators, chained and nested forms, quoted keys) yielding 10604 array-access tokens. Zero had a non-empty key.
- **The static_assert is load-bearing**: inverting it fails 38 instantiations, confirming it is evaluated for every array-access token rather than vacuous.
- **Differential**: a dump of 58 (expression, JSON) results across the compile-time, runtime and non-null-terminated paths is byte-identical before and after the change.
- **New tests** cover `key[...]` slices, indices and nesting on both overloads. Nothing exercised that shape before, despite it being what the removed branch nominally handled. They pass unchanged against the pre-change header, confirming they pin existing behavior rather than new behavior.
- Suite passes under ASan: 32 tests, 276 asserts (was 29 / 255).

## Note on ordering

This is independent of #2713 and does not conflict with it, but #2713 touches nearby declarations, so whichever lands second may want a trivial rebase.