### PR TITLE
Add YAML support for system_clock time points and year_month_day

### DIFF
--- a/docs/chrono.md
+++ b/docs/chrono.md
@@ -145,7 +145,7 @@ glz::read_json(parsed, json);
 | libc++ (Clang), MSVC STL | `steady_clock` | numeric count, supported by every format |
 | libstdc++ (GCC) | `system_clock` | ISO 8601 string, only in the formats that support `system_clock::time_point` |
 
-Because the alias makes the two types *identical*, Glaze cannot give them different behavior. The practical consequence is that a type containing an `hrc::time_point` can compile on one platform and fail on another: under libstdc++ it is a `system_clock::time_point`, which BEVE, YAML, CSV, and JSONB do not support (see [Format Support](#format-support)).
+Because the alias makes the two types *identical*, Glaze cannot give them different behavior. The practical consequence is that a type containing an `hrc::time_point` can compile on one platform and fail on another: under libstdc++ it is a `system_clock::time_point`, which BEVE, CSV, and JSONB do not support (see [Format Support](#format-support)).
 
 Prefer naming the clock you actually mean:
 
@@ -370,9 +370,9 @@ Durations and count-based time points use one representation shared by every for
 |------|:----:|:----:|:----:|:-------:|:----:|:----:|:----:|:---:|:-----:|
 | `std::chrono::duration<Rep, Period>` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `steady_clock::time_point` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `system_clock::time_point` | ✅ | — | ✅ | ✅ | ✅ | ✅ | — | — | — |
-| `sys_days` (`sys_time<days>`) | ✅ | — | ✅ | — | — | ✅ | — | — | — |
-| `year_month_day` | ✅ | — | — | — | — | ✅ | — | — | — |
+| `system_clock::time_point` | ✅ | — | ✅ | ✅ | ✅ | ✅ | ✅ | — | — |
+| `sys_days` (`sys_time<days>`) | ✅ | — | ✅ | — | — | ✅ | ✅ | — | — |
+| `year_month_day` | ✅ | — | — | — | — | ✅ | ✅ | — | — |
 | `glz::epoch_time<D>` | ✅ | — | ✅ | — | — | — | — | — | — |
 
 `high_resolution_clock::time_point` is not listed because it is an alias: it follows the `steady_clock` row under libc++ and MSVC, and the `system_clock` row under libstdc++. See [High Resolution Clock Time Points](#high-resolution-clock-time-points).

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -274,6 +274,50 @@ YAML support leverages the same type system as JSON. All types that work with `g
 - `std::tuple`
 - User-defined types with `glz::meta` or pure reflection
 - Enums (as integers or strings with `glz::meta`)
+- `std::chrono` durations and time points (see below)
+
+## std::chrono Types
+
+Durations serialize as their bare numeric count, the same representation every Glaze format uses:
+
+```cpp
+std::chrono::milliseconds took{1500};  // took: 1500
+```
+
+Calendar types serialize as **plain (unquoted) ISO 8601 scalars**, which is the idiomatic YAML form and matches how Glaze's TOML writer emits a native datetime:
+
+```cpp
+struct event
+{
+   std::string name{};
+   std::chrono::sys_time<std::chrono::seconds> at{};
+   std::chrono::sys_days day{};
+   std::chrono::milliseconds took{};
+};
+```
+
+```yaml
+name: build
+at: 2024-12-13T15:30:45Z
+day: 2024-12-13
+took: 1500
+```
+
+Emitting these unquoted is safe: ISO 8601 uses only digits, `-`, `:`, `T` and `Z`, so it contains no character that requires quoting, none of the flow indicators (`,` `[` `]` `{` `}`), and no `: ` or ` #` sequence that would terminate a plain scalar. Every `:` is followed by a digit, which keeps it a scalar rather than a mapping separator in both block and flow context.
+
+Reading accepts any scalar style, so YAML from other generators (which commonly quote timestamps) parses without special handling:
+
+```yaml
+at: 2024-12-13T15:30:45Z      # plain
+at: '2024-12-13T15:30:45Z'    # single-quoted
+at: "2024-12-13T15:30:45Z"    # double-quoted
+```
+
+Timezone offsets are applied on read and normalized to UTC; `2024-12-13T10:30:45-05:00` and `2024-12-13T15:30:45Z` parse to the same instant. Fractional-second precision on write follows the time point's own duration, and a `sys_days` (days precision) is written date-only as `2024-12-13`.
+
+RFC 3339 has no representation for a year outside `[0000, 9999]`, so writing one fails with `constraint_violated` rather than emitting wrapped digits.
+
+See [std::chrono Support](./chrono.md) for the full cross-format behavior.
 
 ## Tag Validation
 

--- a/include/glaze/core/chrono.hpp
+++ b/include/glaze/core/chrono.hpp
@@ -295,6 +295,142 @@ namespace glz
          ix += N;
       }
 
+      // ============================================
+      // Shared ISO 8601 / RFC 3339 writers
+      // ============================================
+      //
+      // The digit layout of an ISO 8601 date or timestamp is identical in every text
+      // format; the only thing that varies is whether the scalar is wrapped in quotes.
+      // JSON emits a quoted string (unless the caller opted out via `unquoted`), while
+      // YAML emits a plain scalar, so the writers below take `Quote` as a parameter and
+      // are shared rather than duplicated per format.
+      //
+      // Like write_digits, these do not grow the buffer: the caller reserves capacity
+      // using the iso_*_max_size constants below and the writers then dump unchecked.
+
+      // Fractional-second digits implied by a time point's period. Anything finer than
+      // nanoseconds is still rendered at nanosecond precision, matching RFC 3339's
+      // practical limit.
+      template <class Period>
+      inline constexpr size_t iso_frac_digits = [] {
+         if constexpr (std::ratio_greater_equal_v<Period, std::ratio<1>>) {
+            return 0; // seconds or coarser
+         }
+         else if constexpr (std::ratio_greater_equal_v<Period, std::milli>) {
+            return 3;
+         }
+         else if constexpr (std::ratio_greater_equal_v<Period, std::micro>) {
+            return 6;
+         }
+         else {
+            return 9;
+         }
+      }();
+
+      // "YYYY-MM-DD" plus both quotes.
+      inline constexpr size_t iso_date_max_size = 12;
+
+      // "YYYY-MM-DDTHH:MM:SSZ" (20) plus both quotes, plus '.' and the fraction.
+      template <class Period>
+      inline constexpr size_t iso_time_point_max_size =
+         22 + (iso_frac_digits<Period> > 0 ? 1 + iso_frac_digits<Period> : 0);
+
+      // Write "YYYY-MM-DD". RFC 3339 requires a 4-digit year, and the fixed-width parsers
+      // on the read side cannot represent anything else, so a year outside [0000, 9999] is
+      // rejected rather than silently emitted as wrapped digits.
+      template <bool Quote, class B>
+      inline void write_iso_date(int yr, unsigned mo, unsigned dy, is_context auto&& ctx, B&& b, auto& ix) noexcept
+      {
+         if (yr < 0 || yr > 9999) [[unlikely]] {
+            ctx.error = error_code::constraint_violated;
+            return;
+         }
+
+         if constexpr (Quote) {
+            b[ix++] = '"';
+         }
+         write_digits<4>(b, ix, static_cast<uint64_t>(yr));
+         b[ix++] = '-';
+         write_digits<2>(b, ix, mo);
+         b[ix++] = '-';
+         write_digits<2>(b, ix, dy);
+         if constexpr (Quote) {
+            b[ix++] = '"';
+         }
+      }
+
+      // Write a system_clock time point as ISO 8601 in UTC.
+      //
+      // Time points whose period is exactly `days` (e.g. std::chrono::sys_days) are written
+      // as a date-only "YYYY-MM-DD": the time of day is always zero at that precision and
+      // the calendar date is the meaningful payload. Coarser periods (weeks, months, years)
+      // fall through to the full timestamp path, which avoids silently truncating an
+      // arbitrary date to a multi-day boundary on read.
+      template <bool Quote, class TP, class B>
+      inline void write_iso_time_point(const TP& value, is_context auto&& ctx, B&& b, auto& ix) noexcept
+      {
+         using namespace std::chrono;
+         using Duration = typename std::remove_cvref_t<TP>::duration;
+         using Period = typename Duration::period;
+
+         const auto dp = floor<days>(value);
+         const year_month_day ymd{dp};
+         const int yr = static_cast<int>(ymd.year());
+         const auto mo = static_cast<unsigned>(ymd.month());
+         const auto dy = static_cast<unsigned>(ymd.day());
+
+         if constexpr (std::ratio_equal_v<Period, std::ratio<86400>>) {
+            write_iso_date<Quote>(yr, mo, dy, ctx, b, ix);
+            return;
+         }
+         else {
+            if (yr < 0 || yr > 9999) [[unlikely]] {
+               ctx.error = error_code::constraint_violated;
+               return;
+            }
+
+            const hh_mm_ss tod{floor<Duration>(value - dp)};
+            const auto hr = static_cast<unsigned>(tod.hours().count());
+            const auto mi = static_cast<unsigned>(tod.minutes().count());
+            const auto sc = static_cast<unsigned>(tod.seconds().count());
+
+            if constexpr (Quote) {
+               b[ix++] = '"';
+            }
+            write_digits<4>(b, ix, static_cast<uint64_t>(yr));
+            b[ix++] = '-';
+            write_digits<2>(b, ix, mo);
+            b[ix++] = '-';
+            write_digits<2>(b, ix, dy);
+            b[ix++] = 'T';
+            write_digits<2>(b, ix, hr);
+            b[ix++] = ':';
+            write_digits<2>(b, ix, mi);
+            b[ix++] = ':';
+            write_digits<2>(b, ix, sc);
+
+            constexpr size_t frac_digits = iso_frac_digits<Period>;
+            if constexpr (frac_digits > 0) {
+               b[ix++] = '.';
+               const auto subsec = tod.subseconds();
+               if constexpr (frac_digits == 3) {
+                  write_digits<3>(b, ix, static_cast<uint64_t>(duration_cast<milliseconds>(subsec).count()));
+               }
+               else if constexpr (frac_digits == 6) {
+                  write_digits<6>(b, ix, static_cast<uint64_t>(duration_cast<microseconds>(subsec).count()));
+               }
+               else {
+                  write_digits<9>(b, ix, static_cast<uint64_t>(duration_cast<nanoseconds>(subsec).count()));
+               }
+            }
+
+            b[ix++] = 'Z';
+            if constexpr (Quote) {
+               b[ix++] = '"';
+            }
+         }
+      }
+
       // Parse exactly "YYYY-MM-DD" (10 chars) into a year_month_day.
       // On failure, sets ec to parse_error and leaves ymd unchanged.
       // The 10-char length check implicitly caps the year at 9999, which keeps the

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -2440,12 +2440,9 @@ namespace glz
    // to<uint32_t Format, is_duration T> specialization in core/chrono.hpp.
 
    // system_clock::time_point: serialize as ISO 8601 string.
-   // Zero-allocation implementation writing directly to buffer.
-   // Time points whose Duration period is exactly `days` (e.g. std::chrono::sys_days)
-   // are written as date-only "YYYY-MM-DD" since the time-of-day is always zero at that
-   // precision and the calendar date is the meaningful payload. Coarser periods (weeks,
-   // months, years) fall through to the full ISO 8601 path; this avoids silently
-   // truncating an arbitrary date to a multi-day boundary on read.
+   // Zero-allocation implementation writing directly to buffer. The layout is shared with
+   // every other text format via chrono_detail::write_iso_time_point; JSON supplies the
+   // quoting (a JSON scalar is a quoted string unless the caller opted out via `unquoted`).
    template <is_system_time_point T>
       requires(not custom_write<T>)
    struct to<JSON, T>
@@ -2453,111 +2450,11 @@ namespace glz
       template <auto Opts, class B>
       static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix) noexcept
       {
-         using namespace std::chrono;
-         using TP = std::remove_cvref_t<T>;
-         using Duration = typename TP::duration;
-         using Period = typename Duration::period;
-
-         constexpr bool date_only = std::ratio_equal_v<Period, std::ratio<86400>>;
-
-         const auto dp = floor<days>(value);
-         const year_month_day ymd{dp};
-         const int yr = static_cast<int>(ymd.year());
-         const unsigned mo = static_cast<unsigned>(ymd.month());
-         const unsigned dy = static_cast<unsigned>(ymd.day());
-
-         // RFC 3339 requires a 4-digit year in [0000, 9999]. Reject anything else rather
-         // than silently corrupting the output via uint64_t wrap of a negative year.
-         if (yr < 0 || yr > 9999) [[unlikely]] {
-            ctx.error = error_code::constraint_violated;
+         using Period = typename std::remove_cvref_t<T>::duration::period;
+         if (!ensure_space(ctx, b, ix + chrono_detail::iso_time_point_max_size<Period>)) [[unlikely]] {
             return;
          }
-
-         if constexpr (date_only) {
-            // "YYYY-MM-DD" = 10 chars + optional quotes
-            constexpr size_t max_size = 12;
-            if (!ensure_space(ctx, b, ix + max_size)) [[unlikely]] {
-               return;
-            }
-
-            if constexpr (not check_unquoted(Opts)) {
-               b[ix++] = '"';
-            }
-            chrono_detail::write_digits<4>(b, ix, static_cast<uint64_t>(yr));
-            b[ix++] = '-';
-            chrono_detail::write_digits<2>(b, ix, mo);
-            b[ix++] = '-';
-            chrono_detail::write_digits<2>(b, ix, dy);
-            if constexpr (not check_unquoted(Opts)) {
-               b[ix++] = '"';
-            }
-         }
-         else {
-            const hh_mm_ss tod{floor<Duration>(value - dp)};
-            const auto hr = static_cast<unsigned>(tod.hours().count());
-            const auto mi = static_cast<unsigned>(tod.minutes().count());
-            const auto sc = static_cast<unsigned>(tod.seconds().count());
-
-            // Calculate fractional digits based on duration precision
-            constexpr size_t frac_digits = []() constexpr {
-               if constexpr (std::ratio_greater_equal_v<Period, std::ratio<1>>) {
-                  return 0; // seconds or coarser
-               }
-               else if constexpr (std::ratio_greater_equal_v<Period, std::milli>) {
-                  return 3; // milliseconds
-               }
-               else if constexpr (std::ratio_greater_equal_v<Period, std::micro>) {
-                  return 6; // microseconds
-               }
-               else {
-                  return 9; // nanoseconds or finer
-               }
-            }();
-
-            // Max size: "YYYY-MM-DDTHH:MM:SS.nnnnnnnnnZ" = 30 + quotes = 32
-            constexpr size_t max_size = 22 + (frac_digits > 0 ? 1 + frac_digits : 0);
-            if (!ensure_space(ctx, b, ix + max_size)) [[unlikely]] {
-               return;
-            }
-
-            if constexpr (not check_unquoted(Opts)) {
-               b[ix++] = '"';
-            }
-            chrono_detail::write_digits<4>(b, ix, static_cast<uint64_t>(yr));
-            b[ix++] = '-';
-            chrono_detail::write_digits<2>(b, ix, mo);
-            b[ix++] = '-';
-            chrono_detail::write_digits<2>(b, ix, dy);
-            b[ix++] = 'T';
-            chrono_detail::write_digits<2>(b, ix, hr);
-            b[ix++] = ':';
-            chrono_detail::write_digits<2>(b, ix, mi);
-            b[ix++] = ':';
-            chrono_detail::write_digits<2>(b, ix, sc);
-
-            // Write fractional seconds if duration is finer than seconds
-            if constexpr (frac_digits > 0) {
-               b[ix++] = '.';
-               const auto subsec = tod.subseconds();
-               if constexpr (frac_digits == 3) {
-                  chrono_detail::write_digits<3>(b, ix,
-                                                 static_cast<uint64_t>(duration_cast<milliseconds>(subsec).count()));
-               }
-               else if constexpr (frac_digits == 6) {
-                  chrono_detail::write_digits<6>(b, ix,
-                                                 static_cast<uint64_t>(duration_cast<microseconds>(subsec).count()));
-               }
-               else {
-                  chrono_detail::write_digits<9>(b, ix,
-                                                 static_cast<uint64_t>(duration_cast<nanoseconds>(subsec).count()));
-               }
-            }
-
-            b[ix++] = 'Z';
-            if constexpr (not check_unquoted(Opts)) {
-               b[ix++] = '"';
-            }
-         }
+         chrono_detail::write_iso_time_point<not check_unquoted(Opts)>(value, ctx, b, ix);
       }
    };
 
@@ -2569,34 +2466,15 @@ namespace glz
       template <auto Opts, class B>
       static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix) noexcept
       {
-         const int yr = static_cast<int>(value.year());
-         const unsigned mo = static_cast<unsigned>(value.month());
-         const unsigned dy = static_cast<unsigned>(value.day());
-
-         // std::chrono::year is a signed 16-bit-ish range, so users can construct dates
-         // outside [0000, 9999]. Reject those rather than emitting wrap-around digits.
-         if (yr < 0 || yr > 9999) [[unlikely]] {
-            ctx.error = error_code::constraint_violated;
+         if (!ensure_space(ctx, b, ix + chrono_detail::iso_date_max_size)) [[unlikely]] {
             return;
          }
-
-         // "YYYY-MM-DD" = 10 chars + optional quotes
-         constexpr size_t max_size = 12;
-         if (!ensure_space(ctx, b, ix + max_size)) [[unlikely]] {
-            return;
-         }
-
-         if constexpr (not check_unquoted(Opts)) {
-            b[ix++] = '"';
-         }
-         chrono_detail::write_digits<4>(b, ix, static_cast<uint64_t>(yr));
-         b[ix++] = '-';
-         chrono_detail::write_digits<2>(b, ix, mo);
-         b[ix++] = '-';
-         chrono_detail::write_digits<2>(b, ix, dy);
-         if constexpr (not check_unquoted(Opts)) {
-            b[ix++] = '"';
-         }
+         // std::chrono::year spans a signed 16-bit range, so users can construct dates
+         // outside [0000, 9999]; write_iso_date rejects those rather than emitting
+         // wrap-around digits.
+         chrono_detail::write_iso_date<not check_unquoted(Opts)>(static_cast<int>(value.year()),
+                                                                 static_cast<unsigned>(value.month()),
+                                                                 static_cast<unsigned>(value.day()), ctx, b, ix);
       }
    };
 

--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -1764,6 +1764,68 @@ namespace glz
       }
    };
 
+   // ============================================
+   // std::chrono calendar types
+   // ============================================
+   //
+   // Parsed from an ISO 8601 scalar using the shared chrono_detail parsers. Reading goes
+   // through the str_t reader above, so every YAML scalar style is accepted regardless of
+   // which one the writer emits: plain (what Glaze writes), single-quoted, double-quoted
+   // and block. That keeps hand-written and third-party YAML readable, since many
+   // generators quote timestamps.
+   //
+   // std::string rather than std::string_view is deliberate: YAML scalars can require
+   // unescaping and line folding, so the reader materializes them into an owning buffer.
+
+   // system_clock::time_point: parse from ISO 8601.
+   // Time points whose period is exactly `days` (e.g. std::chrono::sys_days) also accept
+   // the bare "YYYY-MM-DD" form; full datetimes remain accepted and are floored to days.
+   // Coarser periods fall through to the full parser so dates are not silently snapped to
+   // a multi-day boundary.
+   template <is_system_time_point T>
+      requires(not custom_read<T>)
+   struct from<YAML, T>
+   {
+      template <auto Opts, class It>
+      static void op(auto&& value, is_context auto&& ctx, It&& it, auto end) noexcept
+      {
+         std::string str;
+         from<YAML, std::string>::template op<Opts>(str, ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+
+         using Duration = typename std::remove_cvref_t<T>::duration;
+         using Period = typename Duration::period;
+         if constexpr (std::ratio_equal_v<Period, std::ratio<86400>>) {
+            if (str.size() == 10) {
+               std::chrono::year_month_day ymd{};
+               chrono_detail::parse_ymd(str, ymd, ctx.error);
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
+               value = std::chrono::time_point_cast<Duration>(std::chrono::sys_days{ymd});
+               return;
+            }
+         }
+         chrono_detail::parse_iso8601(str, value, ctx.error);
+      }
+   };
+
+   // year_month_day: parse from "YYYY-MM-DD"
+   template <is_year_month_day T>
+      requires(not custom_read<T>)
+   struct from<YAML, T>
+   {
+      template <auto Opts, class It>
+      static void op(auto&& value, is_context auto&& ctx, It&& it, auto end) noexcept
+      {
+         std::string str;
+         from<YAML, std::string>::template op<Opts>(str, ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+         chrono_detail::parse_ymd(str, value, ctx.error);
+      }
+   };
+
    // Boolean types
    template <bool_t T>
    struct from<YAML, T>

--- a/include/glaze/yaml/write.hpp
+++ b/include/glaze/yaml/write.hpp
@@ -376,6 +376,55 @@ namespace glz
       }
    };
 
+   // ============================================
+   // std::chrono calendar types
+   // ============================================
+   //
+   // Written as plain (unquoted) ISO 8601 scalars, sharing the digit layout with JSON via
+   // chrono_detail. Plain is the idiomatic YAML form and matches how Glaze's TOML writer
+   // emits a native datetime. It is also unambiguously safe: ISO 8601 uses only digits,
+   // '-', ':', 'T' and 'Z', so it contains no character that requires quoting, none of the
+   // flow indicators (',' '[' ']' '{' '}'), and no ": " or " #" sequence that would end a
+   // plain scalar. Every ':' is followed by a digit, which keeps it a scalar rather than a
+   // mapping separator in both block and flow context.
+   //
+   // Durations and steady_clock / high_resolution_clock time points are numeric and are
+   // handled generically in core/chrono.hpp; only the calendar types need a format-specific
+   // representation.
+
+   // system_clock::time_point: plain ISO 8601 scalar (date-only for `days` precision)
+   template <is_system_time_point T>
+      requires(not custom_write<T>)
+   struct to<YAML, T>
+   {
+      template <auto Opts, class B>
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix) noexcept
+      {
+         using Period = typename std::remove_cvref_t<T>::duration::period;
+         constexpr size_t max_size = chrono_detail::iso_time_point_max_size<Period> + write_padding_bytes;
+         if (!ensure_space(ctx, b, ix + max_size)) [[unlikely]] {
+            return;
+         }
+         chrono_detail::write_iso_time_point<false>(value, ctx, b, ix);
+      }
+   };
+
+   // year_month_day: plain "YYYY-MM-DD" scalar
+   template <is_year_month_day T>
+      requires(not custom_write<T>)
+   struct to<YAML, T>
+   {
+      template <auto Opts, class B>
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix) noexcept
+      {
+         if (!ensure_space(ctx, b, ix + chrono_detail::iso_date_max_size + write_padding_bytes)) [[unlikely]] {
+            return;
+         }
+         chrono_detail::write_iso_date<false>(static_cast<int>(value.year()), static_cast<unsigned>(value.month()),
+                                              static_cast<unsigned>(value.day()), ctx, b, ix);
+      }
+   };
+
    // Enum with glz::meta - writes string representation
    template <class T>
       requires((glaze_enum_t<T> || (meta_keys<T> && std::is_enum_v<std::decay_t<T>>)) && not custom_write<T>)

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -4,6 +4,7 @@
 #include "glaze/yaml.hpp"
 
 #include <array>
+#include <chrono>
 #include <cmath>
 #include <cstdio>
 #include <deque>
@@ -10401,6 +10402,170 @@ suite recursion_depth_tests = [] {
       skip_depth_probe value{};
       auto ec = glz::read_yaml<glz::opts{.error_on_unknown_keys = false}>(value, yaml);
       expect(ec.ec == glz::error_code::exceeded_max_recursive_depth);
+   };
+};
+
+struct yaml_event
+{
+   std::string name{};
+   std::chrono::sys_time<std::chrono::seconds> at{};
+   std::chrono::sys_days day{};
+   std::chrono::year_month_day ymd{};
+   std::chrono::milliseconds took{};
+   bool operator==(const yaml_event&) const = default;
+};
+
+struct yaml_tp_holder
+{
+   std::chrono::sys_time<std::chrono::seconds> at{};
+};
+
+struct yaml_ymd_holder
+{
+   std::chrono::year_month_day d{};
+};
+
+suite yaml_chrono_calendar_tests = [] {
+   using namespace std::chrono;
+
+   static constexpr auto expected = sys_days{2024y / 12 / 13} + 15h + 30min + 45s;
+
+   // Glaze writes a plain (unquoted) ISO 8601 scalar, matching the TOML writer's native
+   // datetime and the idiomatic YAML form.
+   "time_point writes a plain ISO 8601 scalar"_test = [] {
+      yaml_tp_holder v{time_point_cast<seconds>(expected)};
+      std::string out{};
+      expect(not glz::write_yaml(v, out));
+      expect(out == "at: 2024-12-13T15:30:45Z\n") << out;
+   };
+
+   "struct round-trip with mixed chrono members"_test = [] {
+      yaml_event e{"build", time_point_cast<seconds>(expected), sys_days{2024y / 12 / 13}, 2024y / 12 / 13,
+                   milliseconds{1500}};
+      std::string out{};
+      expect(not glz::write_yaml(e, out));
+      yaml_event decoded{};
+      const auto ec = glz::read_yaml(decoded, out);
+      expect(not ec) << glz::format_error(ec, out);
+      expect(decoded == e);
+   };
+
+   // The writer emits plain scalars, but hand-written and third-party YAML routinely quotes
+   // timestamps, so every scalar style must read back.
+   "reads every scalar style"_test = [] {
+      const auto check = [](const std::string& yaml) {
+         yaml_tp_holder v{};
+         const auto ec = glz::read_yaml(v, yaml);
+         expect(not ec) << glz::format_error(ec, yaml);
+         expect(v.at == time_point_cast<seconds>(expected));
+      };
+      check("at: 2024-12-13T15:30:45Z");
+      check("at: '2024-12-13T15:30:45Z'");
+      check("at: \"2024-12-13T15:30:45Z\"");
+   };
+
+   // A plain scalar must survive flow context, where ',' '}' ']' would terminate it. ISO 8601
+   // contains none of them, and every ':' is followed by a digit so it cannot be mistaken for
+   // a mapping separator.
+   "plain scalar survives flow context"_test = [] {
+      const std::string yaml = "{at: 2024-12-13T15:30:45Z}";
+      yaml_tp_holder v{};
+      const auto ec = glz::read_yaml(v, yaml);
+      expect(not ec) << glz::format_error(ec, yaml);
+      expect(v.at == time_point_cast<seconds>(expected));
+   };
+
+   "timezone offsets are applied"_test = [] {
+      const auto check = [](const std::string& yaml) {
+         yaml_tp_holder v{};
+         const auto ec = glz::read_yaml(v, yaml);
+         expect(not ec) << glz::format_error(ec, yaml);
+         expect(v.at == time_point_cast<seconds>(expected));
+      };
+      check("at: 2024-12-13T15:30:45+00:00");
+      check("at: 2024-12-13T10:30:45-05:00");
+      check("at: 2024-12-13T21:00:45+05:30");
+   };
+
+   "fractional precision matches the time point"_test = [] {
+      const auto written = [](auto tp) {
+         std::string out{};
+         expect(not glz::write_yaml(tp, out));
+         return out;
+      };
+      expect(written(time_point_cast<seconds>(expected)) == "2024-12-13T15:30:45Z");
+      expect(written(time_point_cast<milliseconds>(expected + 123ms)) == "2024-12-13T15:30:45.123Z");
+      expect(written(time_point_cast<microseconds>(expected + 123456us)) == "2024-12-13T15:30:45.123456Z");
+      expect(written(time_point_cast<nanoseconds>(expected + 123456789ns)) == "2024-12-13T15:30:45.123456789Z");
+   };
+
+   // `days` precision carries no time of day, so it is written (and accepted) date-only.
+   "sys_days is date-only"_test = [] {
+      std::string out{};
+      expect(not glz::write_yaml(sys_days{2024y / 12 / 13}, out));
+      expect(out == "2024-12-13") << out;
+
+      sys_days decoded{};
+      expect(not glz::read_yaml(decoded, out));
+      expect(decoded == sys_days{2024y / 12 / 13});
+
+      // A full datetime is still accepted at days precision and floored.
+      sys_days floored{};
+      const std::string full = "2024-12-13T15:30:45Z";
+      expect(not glz::read_yaml(floored, full));
+      expect(floored == sys_days{2024y / 12 / 13});
+   };
+
+   "year_month_day round-trip"_test = [] {
+      yaml_ymd_holder v{2024y / 12 / 13};
+      std::string out{};
+      expect(not glz::write_yaml(v, out));
+      expect(out == "d: 2024-12-13\n") << out;
+      yaml_ymd_holder decoded{};
+      expect(not glz::read_yaml(decoded, out));
+      expect(decoded.d == v.d);
+   };
+
+   "sequences of time points"_test = [] {
+      std::vector<sys_time<seconds>> v{time_point_cast<seconds>(expected), time_point_cast<seconds>(expected + 1h)};
+      std::string out{};
+      expect(not glz::write_yaml(v, out));
+      std::vector<sys_time<seconds>> decoded{};
+      const auto ec = glz::read_yaml(decoded, out);
+      expect(not ec) << glz::format_error(ec, out);
+      expect(decoded == v);
+   };
+
+   "malformed input is rejected"_test = [] {
+      const auto rejects = [](const std::string& yaml) {
+         yaml_tp_holder v{};
+         return bool(glz::read_yaml(v, yaml));
+      };
+      expect(rejects("at: not-a-date"));
+      expect(rejects("at: 2024-13-45T99:99:99Z"));
+      expect(rejects("at: 2024-02-30T00:00:00Z")); // Feb 30 is not a real date
+      expect(rejects("at: 2024-12-13")); // date-only is not valid at seconds precision
+      expect(rejects("at: 2024-12-13T15:30:45Z trailing"));
+   };
+
+   // RFC 3339 has no representation for a year outside [0000, 9999], and the fixed-width
+   // parsers cannot read one back, so writing must fail rather than emit wrapped digits.
+   "years outside [0000, 9999] are rejected on write"_test = [] {
+      std::string out{};
+      expect(bool(glz::write_yaml(sys_days{year{10000} / 1 / 1}, out)));
+      out.clear();
+      expect(bool(glz::write_yaml(year_month_day{year{-1} / 1 / 1}, out)));
+   };
+
+   // Durations and steady_clock time points stay numeric; the calendar types above are the
+   // only ones with a YAML-specific representation.
+   "durations remain numeric"_test = [] {
+      std::string out{};
+      expect(not glz::write_yaml(milliseconds{1500}, out));
+      expect(out == "1500") << out;
+      milliseconds decoded{};
+      expect(not glz::read_yaml(decoded, out));
+      expect(decoded == milliseconds{1500});
    };
 };
 


### PR DESCRIPTION
Follow-up to #2678.

## Motivation

YAML was the only text format that could not serialize a wall-clock time point. JSON, CBOR and TOML all support `system_clock::time_point`; YAML's implementation is independent of JSON's and simply never grew an `is_system_time_point` specialization. This surfaced while reviewing #2678, which generalized durations across every format and made the remaining unevenness visible.

It also made an existing portability trap worse. Under libstdc++, `high_resolution_clock` is an alias for `system_clock`, so a type holding an `hrc::time_point` compiled under libc++/MSVC but failed under GCC for YAML. That is now fixed for YAML (BEVE, CSV and JSONB remain).

## What changed

**YAML calendar types.** `system_clock::time_point`, `sys_days` and `year_month_day` now serialize as **plain, unquoted ISO 8601 scalars**, matching how Glaze's TOML writer emits a native datetime and the idiomatic YAML form:

```yaml
name: build
at: 2024-12-13T15:30:45Z
day: 2024-12-13
took: 1500
```

Emitting them unquoted is safe: ISO 8601 uses only digits, `-`, `:`, `T` and `Z`, so it contains no character that requires quoting, none of the flow indicators (`,` `[` `]` `{` `}`), and no `: ` or ` #` sequence that would terminate a plain scalar. Every `:` is followed by a digit, which keeps it a scalar rather than a mapping separator in both block and flow context. There is a test pinning flow context specifically.

Reading routes through the existing `str_t` reader, so plain, single-quoted, double-quoted and block styles are all accepted regardless of what Glaze writes. That keeps third-party YAML readable, since many generators quote timestamps.

**Shared ISO 8601 writer.** The formatter was inline in `to<JSON, T>`, but nothing in it was JSON-specific except the quoting. It moves to `chrono_detail` in `core/chrono.hpp` parameterized on a `Quote` flag, and JSON and YAML now share it. This removes 139 lines of duplicated digit layout from `json/write.hpp` — the same deduplication pattern #2678 applied to durations.

## Behavior

| Type | YAML representation |
|------|---------------------|
| `system_clock::time_point` | plain ISO 8601, UTC, precision follows the time point's duration |
| `sys_days` (`sys_time<days>`) | plain `YYYY-MM-DD` (full datetimes still accepted on read, floored) |
| `year_month_day` | plain `YYYY-MM-DD` |
| `duration`, `steady_clock::time_point` | unchanged — numeric, handled generically |

Timezone offsets are applied on read and normalized to UTC. Years outside `[0000, 9999]` are rejected on write with `constraint_violated` rather than emitting wrapped digits, matching JSON.

## Note on `std::string_view`

The reader materializes the scalar into a `std::string` rather than a `std::string_view` as the JSON reader does, because YAML scalars can require unescaping and line folding and so cannot generally be viewed in place.

Separately: `from<YAML, std::string_view>` currently compiles but yields a **dangling view** — `yaml/read.hpp` parses into a local `std::string` and assigns it out, so the view points at freed memory. `docs/yaml.md` lists `std::string_view` as supported. That is a pre-existing bug outside this PR's scope and is deliberately not worked around here; it deserves its own fix.

## Testing

`yaml_test` gains coverage for every scalar style, flow context, timezone offset normalization, fractional precision (seconds through nanoseconds), date-only `sys_days`, sequences of time points, malformed input rejection, and the `[0000, 9999]` year constraint.

The JSON writer refactor was verified to produce **byte-identical output** before and after across all precisions, `sys_days`, `year_month_day`, the epoch, and both out-of-range year rejections.

Full build clean, 106/106 ctest suites pass locally (`yaml_test`: 708 tests / 2547 asserts). The support matrix in `docs/chrono.md` is measured via `write_supported`/`read_supported` rather than hand-maintained.
