### PR TITLE
Fix dangling std::string_view when reading YAML scalars

### DIFF
--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -266,7 +266,7 @@ auto ec = glz::write<glz::yaml::yaml_opts{.flow_style = true}>(cfg, yaml);
 YAML support leverages the same type system as JSON. All types that work with `glz::read_json`/`glz::write_json` also work with YAML:
 
 - Arithmetic types (integers, floating-point)
-- `std::string`, `std::string_view`
+- `std::string` (read and write), `std::string_view` (write only, see below)
 - `std::vector`, `std::array`, `std::deque`, `std::list`
 - `std::map`, `std::unordered_map`
 - `std::optional`, `std::unique_ptr`, `std::shared_ptr`
@@ -319,6 +319,24 @@ RFC 3339 has no representation for a year outside `[0000, 9999]`, so writing one
 
 See [std::chrono Support](./chrono.md) for the full cross-format behavior.
 
+### Reading strings requires an owning target
+
+Unlike JSON, YAML cannot hand you a view into the input buffer. A double-quoted scalar may carry escape sequences, a plain scalar may fold across multiple lines, and a block scalar joins lines together, so the decoded value often does not appear contiguously in the source. The reader therefore decodes into an owning buffer and gives that buffer to your type.
+
+Read targets must be able to take ownership, so use `std::string` (or another owning string type) rather than `std::string_view`:
+
+```cpp
+struct config
+{
+   std::string name{};       // reads and writes
+   std::string_view label{}; // writes only
+};
+```
+
+A non-owning read target is rejected at compile time, and `glz::read_supported<std::string_view, glz::YAML>` is `false`. Writing is unaffected, since a view is a perfectly good source: `glz::write_supported<std::string_view, glz::YAML>` remains `true`. `std::array<char, N>` is likewise write-only for the same reason.
+
+This is a YAML-specific restriction. JSON views the input buffer directly and keeps zero-copy `std::string_view` reads.
+
 ## Tag Validation
 
 Glaze supports YAML Core Schema tags and validates them against the C++ types being parsed. This catches type mismatches at parse time.
@@ -327,7 +345,7 @@ Glaze supports YAML Core Schema tags and validates them against the C++ types be
 
 | Tag | Verbatim Form | Valid C++ Types |
 |-----|---------------|-----------------|
-| `!!str` | `!<tag:yaml.org,2002:str>` | `std::string`, `std::string_view` |
+| `!!str` | `!<tag:yaml.org,2002:str>` | `std::string` (`std::string_view` on write only) |
 | `!!int` | `!<tag:yaml.org,2002:int>` | `int`, `int64_t`, `uint32_t`, etc. |
 | `!!float` | `!<tag:yaml.org,2002:float>` | `float`, `double` |
 | `!!bool` | `!<tag:yaml.org,2002:bool>` | `bool` |

--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -5,6 +5,8 @@
 
 #include <cctype>
 #include <charconv>
+#include <concepts>
+#include <string>
 
 #include "glaze/core/chrono.hpp"
 #include "glaze/core/common.hpp"
@@ -1704,10 +1706,27 @@ namespace glz
          return true;
       }
 
+      // A YAML scalar cannot generally be viewed in place in the input buffer: a
+      // double-quoted scalar may carry escapes, a plain scalar may fold across lines, and a
+      // block scalar joins them. The reader therefore decodes into an owning buffer and
+      // hands that buffer to the target, so the target must be able to take ownership of it.
+      //
+      // This is deliberately narrower than str_t. A std::string_view is assignable from the
+      // decoded buffer, so without this constraint it compiled and then pointed at freed
+      // memory once the buffer died. A std::array<char, N> is not assignable at all, so it
+      // reported as supported and then failed to compile deep inside the reader. Both are
+      // now reported unsupported by read_supported<T, YAML>, which is the honest answer.
+      //
+      // Writing is unaffected: a non-owning string is a perfectly good source, so
+      // write_supported<std::string_view, YAML> remains true.
+      template <class T>
+      concept owning_scalar_target = not string_view_t<T> && std::assignable_from<std::decay_t<T>&, std::string&&>;
+
    } // namespace yaml
 
    // String types
    template <str_t T>
+      requires(yaml::owning_scalar_target<T>)
    struct from<YAML, T>
    {
       template <auto Opts, class It>

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -10569,4 +10569,67 @@ suite yaml_chrono_calendar_tests = [] {
    };
 };
 
+struct yaml_sv_writable
+{
+   std::string_view a{};
+};
+
+struct yaml_string_holder
+{
+   std::string a{};
+};
+
+// A YAML scalar is decoded into an owning buffer before it reaches the target, so a
+// non-owning target cannot be supported: it would be left pointing at that buffer after it
+// died. These pin the contract, because the failure mode this replaced was silent (a
+// std::string_view target compiled and then read freed memory) rather than diagnosed.
+static_assert(not glz::read_supported<std::string_view, glz::YAML>,
+              "reading a YAML scalar into a non-owning view would dangle");
+static_assert(not glz::read_supported<std::u8string_view, glz::YAML>);
+
+// std::array<char, N> cannot take ownership of the buffer either. It previously reported as
+// supported and then failed to compile inside the reader.
+static_assert(not glz::read_supported<std::array<char, 16>, glz::YAML>);
+
+// Writing is unaffected: a non-owning string is a perfectly good source.
+static_assert(glz::write_supported<std::string_view, glz::YAML>);
+static_assert(glz::write_supported<std::u8string_view, glz::YAML>);
+
+// Owning targets are unaffected.
+static_assert(glz::read_supported<std::string, glz::YAML>);
+static_assert(glz::write_supported<std::string, glz::YAML>);
+
+// The restriction is YAML-specific. JSON views into the input buffer directly, so it keeps
+// zero-copy string_view reads.
+static_assert(glz::read_supported<std::string_view, glz::JSON>);
+
+suite yaml_string_target_tests = [] {
+   // Regression guard for the owning path the constraint now scopes: every scalar style must
+   // still decode correctly into a std::string.
+   "owning string targets read every scalar style"_test = [] {
+      const auto read_a = [](const std::string& yaml) {
+         yaml_string_holder v{};
+         const auto ec = glz::read_yaml(v, yaml);
+         expect(not ec) << glz::format_error(ec, yaml);
+         return v.a;
+      };
+      expect(read_a("a: hello") == "hello");
+      expect(read_a("a: 'hello'") == "hello");
+      expect(read_a("a: \"hello\"") == "hello");
+      expect(read_a("a: \"tab\\there\"") == "tab\there"); // escapes are decoded
+      expect(read_a("a: 'it''s'") == "it's"); // '' unescapes to '
+      expect(read_a("a: |\n  line1\n  line2\n") == "line1\nline2\n"); // literal block
+      expect(read_a("a: >\n  folded\n  onto one\n") == "folded onto one\n"); // folded block
+   };
+
+   // Writing a view remains supported, which is what makes the read-side restriction
+   // asymmetric rather than a blanket ban on std::string_view.
+   "string_view still writes"_test = [] {
+      yaml_sv_writable v{"hello"};
+      std::string out{};
+      expect(not glz::write_yaml(v, out));
+      expect(out == "a: hello\n") << out;
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
Found while implementing #2715.

## The bug

Reading a YAML scalar into a `std::string_view` produced a view over **freed memory**.

`yaml/read.hpp`'s `str_t` reader decodes into a local `std::string str` and ends with `value = std::move(str)`. A `std::string_view` is assignable from that local, so the code compiled and then pointed at the buffer after it died.

The failure was silent — correct length, no error code, just a read of freed memory:

```cpp
const std::string buf = "a: hello\n";
struct h { std::string_view a{}; };
h v{};
glz::read_yaml(v, buf);   // ec == 0
                          // v.a.size() == 5   (looks right)
                          // v.a.data() points outside buf entirely
```

`docs/yaml.md` listed `std::string_view` as a supported YAML type, so this was reachable straight from documented usage.

**Same root cause, second face:** `std::array<char, N>` is not assignable from `std::string` at all, so `read_supported` reported it as supported and any actual use failed to compile with `no viable overloaded '='` pointing into the reader instead of at the user's type.

| Target | `read_supported` claimed | Actual behavior |
|---|:---:|---|
| `std::string_view` | ✅ | compiled, **dangled silently** |
| `std::u8string_view` | ✅ | compiled, **dangled silently** |
| `std::array<char, N>` | ✅ | hard compile error inside the reader |

## The fix

Constrain the reader to targets that can take ownership of the decoded buffer, which is what the code already required. `read_supported<T, YAML>` now answers honestly for both cases instead of over-promising.

## Why not make views work instead

A YAML scalar generally **cannot** be viewed in place. A double-quoted scalar may carry escapes, a plain scalar may fold across lines, and a block scalar joins them, so the decoded value often does not appear contiguously in the source.

Supporting views would mean either data-dependent runtime failures (works on `a: hello`, fails on `a: "a\nb"`) or threading a "did I transform this?" signal through all five scalar parsers — for an optimization nobody has asked for. If it is wanted later, it can be added without breaking anything here.

JSON is unaffected and keeps its zero-copy `string_view` reads, since it views the raw bytes between quotes.

## Scope

Read-side only. Writing a view is perfectly sound, so `write_supported<std::string_view, glz::YAML>` stays `true` and the asymmetry is documented.

**Compatibility:** code that reads YAML into a `std::string_view` stops compiling. That code is currently reading freed memory, so this converts silent UB into a compile error. The fix is to use `std::string`.

## Testing

Three `static_assert`s pin the contract. They **fail against the unfixed header and pass with the fix**, so they pin the change rather than restate it — worth stating explicitly, because the behavior being locked down is the absence of a silent memory error.

Regression coverage added for the owning path the constraint scopes: plain, single-quoted, double-quoted with escapes, `''` unescaping, and literal and folded block scalars all still decode into `std::string`.

Full build clean, 106/106 ctest suites pass locally (`yaml_test`: 698 tests / 2512 asserts). Nothing in the library or tests depended on YAML view reads; the only instantiation sites were ordinary struct-member paths.
