### PR TITLE
Replace the HTTP header maps with glz::http_headers

### DIFF
--- a/docs/networking/advanced-networking.md
+++ b/docs/networking/advanced-networking.md
@@ -74,7 +74,7 @@ server.use(custom_cors);
 server.get("/test-cors", [](const glz::request& req, glz::response& res) {
     res.json({
         {"message", "CORS test endpoint"},
-        {"origin", req.headers.count("Origin") ? req.headers.at("Origin") : "none"},
+        {"origin", std::string{req.headers.first_value("Origin").value_or("none")}},
         {"method", glz::to_string(req.method)},
         {"timestamp", std::time(nullptr)}
     });
@@ -207,12 +207,12 @@ secure_ws->on_validate([](const glz::request& req) -> bool {
         return false;
     }
     
-    return validate_jwt_token(auth_header->second);
+    return validate_jwt_token(auth_header->value);
 });
 
 secure_ws->on_open([](auto conn, const glz::request& req) {
     // Store user info from validated token
-    auto user_data = extract_user_from_token(req.headers.at("Authorization"));
+    auto user_data = extract_user_from_token(*req.headers.first_value("Authorization"));
     conn->set_user_data(std::make_shared<UserData>(user_data));
     
     conn->send_text("Authenticated successfully");
@@ -384,7 +384,7 @@ User new_user{0, "John Doe", "john@example.com"};
 auto create_response = client.post_json("https://api.example.com/users", new_user);
 
 // POST with custom headers
-std::unordered_map<std::string, std::string> headers = {
+glz::http_headers headers = {
     {"Authorization", "Bearer " + token},
     {"Content-Type", "application/json"}
 };
@@ -444,7 +444,7 @@ auto timing_middleware = [](const glz::request& req, glz::response& res) {
 auto response_time_middleware = [](const glz::request& req, glz::response& res) {
     auto start_header = res.response_headers.find("X-Request-Start");
     if (start_header != res.response_headers.end()) {
-        auto start_ms = std::stoll(start_header->second);
+        auto start_ms = std::stoll(start_header->value);
         auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::high_resolution_clock::now().time_since_epoch()).count();
         

--- a/docs/networking/advanced-networking.md
+++ b/docs/networking/advanced-networking.md
@@ -202,12 +202,12 @@ auto secure_ws = std::make_shared<glz::websocket_server>();
 
 // Validate connections before upgrade
 secure_ws->on_validate([](const glz::request& req) -> bool {
-    auto auth_header = req.headers.find("Authorization");
-    if (auth_header == req.headers.end()) {
+    auto auth_header = req.headers.first_value("Authorization");
+    if (!auth_header) {
         return false;
     }
     
-    return validate_jwt_token(auth_header->value);
+    return validate_jwt_token(*auth_header);
 });
 
 secure_ws->on_open([](auto conn, const glz::request& req) {
@@ -442,9 +442,10 @@ auto timing_middleware = [](const glz::request& req, glz::response& res) {
 
 // Response time middleware (would need to be applied after handler)
 auto response_time_middleware = [](const glz::request& req, glz::response& res) {
-    auto start_header = res.response_headers.find("X-Request-Start");
-    if (start_header != res.response_headers.end()) {
-        auto start_ms = std::stoll(start_header->value);
+    auto start_header = res.response_headers.first_value("X-Request-Start");
+    if (start_header) {
+        long long start_ms{};
+        std::from_chars(start_header->data(), start_header->data() + start_header->size(), start_ms);
         auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::high_resolution_clock::now().time_since_epoch()).count();
         

--- a/docs/networking/http-client.md
+++ b/docs/networking/http-client.md
@@ -84,7 +84,7 @@ Notes:
 ```cpp
 std::expected<response, std::error_code> get(
     std::string_view url,
-    const std::unordered_map<std::string, std::string>& headers = {}
+    const glz::http_headers& headers = {}
 );
 ```
 
@@ -93,7 +93,7 @@ std::expected<response, std::error_code> get(
 std::expected<response, std::error_code> post(
     std::string_view url, 
     std::string_view body,
-    const std::unordered_map<std::string, std::string>& headers = {}
+    const glz::http_headers& headers = {}
 );
 ```
 
@@ -103,7 +103,7 @@ template<class T>
 std::expected<response, std::error_code> post_json(
     std::string_view url, 
     const T& data,
-    const std::unordered_map<std::string, std::string>& headers = {}
+    const glz::http_headers& headers = {}
 );
 ```
 
@@ -120,7 +120,7 @@ All asynchronous methods come in two variants:
 ```cpp
 std::future<std::expected<response, std::error_code>> get_async(
     std::string_view url,
-    const std::unordered_map<std::string, std::string>& headers = {}
+    const glz::http_headers& headers = {}
 );
 ```
 
@@ -129,7 +129,7 @@ std::future<std::expected<response, std::error_code>> get_async(
 template<typename CompletionHandler>
 void get_async(
     std::string_view url,
-    const std::unordered_map<std::string, std::string>& headers,
+    const glz::http_headers& headers,
     CompletionHandler&& handler
 );
 ```
@@ -141,7 +141,7 @@ void get_async(
 std::future<std::expected<response, std::error_code>> post_async(
     std::string_view url, 
     std::string_view body,
-    const std::unordered_map<std::string, std::string>& headers = {}
+    const glz::http_headers& headers = {}
 );
 ```
 
@@ -151,7 +151,7 @@ template<typename CompletionHandler>
 void post_async(
     std::string_view url, 
     std::string_view body,
-    const std::unordered_map<std::string, std::string>& headers,
+    const glz::http_headers& headers,
     CompletionHandler&& handler
 );
 ```
@@ -164,7 +164,7 @@ template<class T>
 std::future<std::expected<response, std::error_code>> post_json_async(
     std::string_view url, 
     const T& data,
-    const std::unordered_map<std::string, std::string>& headers = {}
+    const glz::http_headers& headers = {}
 );
 ```
 
@@ -174,7 +174,7 @@ template<class T, typename CompletionHandler>
 void post_json_async(
     std::string_view url, 
     const T& data,
-    const std::unordered_map<std::string, std::string>& headers,
+    const glz::http_headers& headers,
     CompletionHandler&& handler
 );
 ```
@@ -197,7 +197,7 @@ struct stream_request_params_v2 {
     stream_read_strategy strategy{stream_read_strategy::bulk_transfer};
     size_t max_buffer_size{1024 * 1024};
     std::string body;
-    std::unordered_map<std::string, std::string> headers;
+    glz::http_headers headers;
     http_connect_handler on_connect;
     http_disconnect_handler on_disconnect;
     http_data_handler on_data;
@@ -257,7 +257,7 @@ The `response` object contains:
 ```cpp
 struct response {
     uint16_t status_code;                                      // HTTP status code
-    std::unordered_map<std::string, std::string> response_headers; // Response headers
+    glz::http_headers response_headers; // Response headers
     std::string response_body;                                 // Response body
 };
 ```
@@ -294,7 +294,7 @@ int main() {
 
     if (response) {
         std::cout << "Status: " << response->status_code << std::endl;
-        std::cout << "Content-Type: " << response->response_headers["Content-Type"] << std::endl;
+        std::cout << "Content-Type: " << response->response_headers.first_value("Content-Type").value_or("") << std::endl;
         std::cout << "Body: " << response->response_body << std::endl;
     } else {
         std::cerr << "Error: " << response.error().message() << std::endl;
@@ -312,7 +312,7 @@ int main() {
 int main() {
     glz::http_client client;
 
-    std::unordered_map<std::string, std::string> headers = {
+    glz::http_headers headers = {
         {"Content-Type", "text/plain"},
         {"Authorization", "Bearer your-token"}
     };

--- a/docs/networking/http-examples.md
+++ b/docs/networking/http-examples.md
@@ -590,9 +590,8 @@ int main() {
         std::string username = "User" + std::to_string(std::rand() % 1000);
         
         // In a real app, you'd extract this from authentication
-        auto auth_header = req.headers.find("x-username");
-        if (auth_header != req.headers.end()) {
-            username = auth_header->second;
+        if (auto name = req.headers.first_value("x-username")) {
+            username = *name;
         }
         
         std::cout << "WebSocket connection from " << conn->remote_address() << " (username: " << username << ")" << std::endl;
@@ -815,7 +814,7 @@ auto create_simple_auth_middleware(SimpleAuthService& auth_service) {
             return;
         }
         
-        std::string auth_value = auth_header->second;
+        std::string auth_value{auth_header->value};
         if (!auth_value.starts_with("Bearer ")) {
             res.status(401).json({{"error", "Bearer token required"}});
             return;
@@ -871,8 +870,8 @@ int main() {
     // Protected endpoints
     server.get("/api/profile", [](const glz::request& req, glz::response& res) {
         // User info is available from auth middleware
-        std::string username = res.response_headers["X-Username"];
-        std::string role = res.response_headers["X-User-Role"];
+        std::string username{res.response_headers.first_value("X-Username").value_or("")};
+        std::string role{res.response_headers.first_value("X-User-Role").value_or("")};
         
         res.json({
             {"username", username},
@@ -882,7 +881,7 @@ int main() {
     });
     
     server.get("/api/admin", [](const glz::request& req, glz::response& res) {
-        std::string role = res.response_headers["X-User-Role"];
+        std::string role{res.response_headers.first_value("X-User-Role").value_or("")};
         
         if (role != "admin") {
             res.status(403).json({{"error", "Admin access required"}});

--- a/docs/networking/http-examples.md
+++ b/docs/networking/http-examples.md
@@ -808,19 +808,18 @@ auto create_simple_auth_middleware(SimpleAuthService& auth_service) {
             return;
         }
         
-        auto auth_header = req.headers.find("authorization");
-        if (auth_header == req.headers.end()) {
+        auto auth_value = req.headers.first_value("authorization");
+        if (!auth_value) {
             res.status(401).json({{"error", "Authorization header required"}});
             return;
         }
         
-        std::string auth_value{auth_header->value};
-        if (!auth_value.starts_with("Bearer ")) {
+        if (!auth_value->starts_with("Bearer ")) {
             res.status(401).json({{"error", "Bearer token required"}});
             return;
         }
         
-        std::string token = auth_value.substr(7); // Remove "Bearer "
+        std::string token{auth_value->substr(7)}; // Remove "Bearer "
         auto user = auth_service.validate_token(token);
         
         if (!user) {

--- a/docs/networking/http-rest-support.md
+++ b/docs/networking/http-rest-support.md
@@ -107,7 +107,7 @@ struct request {
     http_method method;                                    // GET, POST, etc.
     std::string target;                                    // "/users/123"
     std::unordered_map<std::string, std::string> params;   // Route parameters
-    std::unordered_map<std::string, std::string> headers;  // HTTP headers
+    glz::http_headers headers;                             // HTTP headers
     std::string body;                                      // Request body
     std::string remote_ip;                                 // Client IP
     uint16_t remote_port;                                  // Client port
@@ -119,12 +119,13 @@ struct request {
 ```cpp
 struct response {
     int status_code = 200;
-    std::unordered_map<std::string, std::string> response_headers;
+    glz::http_headers response_headers;
     std::string response_body;
     
     // Fluent interface
     response& status(int code);
-    response& header(std::string_view name, std::string_view value);
+    response& header(std::string_view name, std::string_view value);     // replaces any existing field
+    response& add_header(std::string_view name, std::string_view value); // appends, for Set-Cookie and friends
     response& body(std::string_view content);
     response& content_type(std::string_view type);
   

--- a/docs/networking/http-rest-support.md
+++ b/docs/networking/http-rest-support.md
@@ -140,6 +140,27 @@ struct response {
 `glz::generic` is the dynamic JSON-compatible type (formerly `glz::json_t`) and remains the default payload for
 helpers like `response::json` when you need flexible data that can be serialized to JSON or equivalent formats.
 
+### Field Name Casing
+
+Field names keep the case they were written with. `request::headers` holds the names exactly as the client sent them,
+and `response::header` serializes fields exactly in the case the handler passed them in.
+
+Lookups are case-insensitive: `find`, `contains`, `first_value`, `values`, `count`, `contains_token`, `set` and `erase`
+all match regardless of case, so `req.headers.find("content-type")` finds a field the client sent as `Content-Type`.
+
+Code that iterates the container and compares names on its own has to do the same:
+
+```cpp
+for (const auto& field : req.headers) {
+    if (field.name == "content-type") {                // misses "Content-Type"
+    }
+    if (glz::striequal(field.name, "content-type")) {  // matches any casing
+    }
+}
+```
+
+Both forms compile, so the first one fails silently.
+
 ## HTTP Methods
 
 Glaze supports all standard HTTP methods:

--- a/docs/networking/http-rest-support.md
+++ b/docs/networking/http-rest-support.md
@@ -161,6 +161,45 @@ for (const auto& field : req.headers) {
 
 Both forms compile, so the first one fails silently.
 
+### The `glz::http_headers` Container
+
+`request::headers` and `response::response_headers` are both `glz::http_headers`: `{name, value}` fields held in arrival order, where a name is allowed to repeat. Names match case-insensitively throughout, as described above.
+
+Reading:
+
+| Call | Result |
+| --- | --- |
+| `contains(name)` | whether any field carries that name |
+| `count(name)` | how many fields carry it |
+| `first_value(name)` | `std::optional<std::string_view>` of the first match |
+| `values(name)` | range over the value of every match |
+| `fields(name)` | range over every matching `http_header`, name included |
+| `contains_token(name, token)` | whether any match lists `token` in its comma-separated value |
+| `find(name)` | iterator to the first match, or `end()` |
+| `names()`, `values()` | range over every field in the container |
+
+Writing:
+
+| Call | Effect |
+| --- | --- |
+| `add(name, value)` | appends a field, always, even when the name is already present |
+| `set(name, value)` | leaves the name present exactly once (see below) |
+| `erase(name)` | removes every field with that name, returns `void` |
+| `append(other)` | appends every field of another container, without merging names |
+| `clear()` | removes every field |
+
+`set` is not an overwrite of the first match. It replaces the first field with that name and erases every other one:
+
+```cpp
+headers.add("Set-Cookie", "session=abc");
+headers.add("Set-Cookie", "theme=dark");
+headers.set("Set-Cookie", "session=xyz"); // both earlier cookies are gone
+```
+
+That is what a single-valued field like `Content-Type` wants and the opposite of what a repeatable field wants, where `add` is the correct call. `set` also adopts the casing of the name handed to it, so `set("content-type", v)` makes a field the client sent as `Content-Type` serialize lowercase.
+
+`first_value`, `values`, `fields`, and `names` all borrow from the container, so copy into a `std::string` before adding to, setting, erasing from, or destroying it.
+
 ### Migrating from `std::unordered_map`
 
 `request::headers` and `response::response_headers` were `std::unordered_map<std::string, std::string>`. `glz::http_headers` keeps fields in arrival order and lets a name repeat, so the map operations that assumed one value per key are gone. Every replacement below is case-insensitive on the name.

--- a/docs/networking/http-rest-support.md
+++ b/docs/networking/http-rest-support.md
@@ -161,6 +161,65 @@ for (const auto& field : req.headers) {
 
 Both forms compile, so the first one fails silently.
 
+### Migrating from `std::unordered_map`
+
+`request::headers` and `response::response_headers` were `std::unordered_map<std::string, std::string>`. `glz::http_headers` keeps fields in arrival order and lets a name repeat, so the map operations that assumed one value per key are gone. Every replacement below is case-insensitive on the name.
+
+| Was | Now |
+| --- | --- |
+| `headers["Accept"]` (read) | `headers.first_value("Accept").value_or("")` |
+| `headers.at("Accept")` | `headers.first_value("Accept").value()` |
+| `headers["Accept"] = v` (on a response) | `res.header("Accept", v)` |
+| `headers.count("Accept")` as a presence test | `headers.contains("Accept")` |
+| `headers.count("Accept")` as a tally | `headers.count("Accept")` (same call, now counts repeats) |
+| `it->first` / `it->second` | `it->name` / `it->value` |
+| `headers.erase("Accept")` | `headers.erase("Accept")` (removes every match, but returns `void`) |
+
+Use `.value()` rather than `operator*` when replacing `at()`: `at()` threw `std::out_of_range` on a missing key, `.value()` throws `std::bad_optional_access`, but `operator*` on a missing field is undefined behavior.
+
+`first_value` returns `std::optional<std::string_view>` that borrows from the container, so copy into a `std::string` before the container is modified, moved, or goes out of scope.
+
+Reading every value of a repeated field:
+
+```cpp
+for (std::string_view cookie : req.headers.values("Cookie")) {
+    // ...
+}
+```
+
+Testing one item of a comma-separated list, rather than substring-matching the whole value:
+
+```cpp
+if (req.headers.contains_token("Connection", "upgrade")) {  // also matches "keep-alive, Upgrade"
+}
+```
+
+On a response, `header()` replaces any existing field of that name and `add_header()` appends one, which is what
+`Set-Cookie` and other repeatable fields need:
+
+```cpp
+res.add_header("Set-Cookie", "session=abc; Path=/; HttpOnly")
+   .add_header("Set-Cookie", "theme=dark; Path=/");
+```
+
+`Content-Length` and `Transfer-Encoding` are replaced even by `add_header`: a second, disagreeing copy would leave the
+body length ambiguous (RFC 9112 §6.3). That guard lives in `header()` and `add_header()`, so writing straight to the
+`response_headers` container with `.add()` bypasses it and can still put two conflicting fields on the wire.
+
+### Body Framing on Client Requests
+
+`http_client` owns the framing of the requests it sends. It writes the `Content-Length` matching the body it is about to
+send, and drops any `Content-Length` or `Transfer-Encoding` supplied in the caller's headers, which could only
+contradict it (RFC 9112 §6.3). Requests whose method anticipates content (`POST`, `PUT`, `PATCH`) always carry a
+`Content-Length`, including `Content-Length: 0` for an empty body.
+
+The client also rejects a *response* it cannot frame to a single body length: `Content-Length` fields that disagree, or
+a value that is not a bare decimal, fail the request with `glz::http_client_error::unframed_response` rather than
+guessing a boundary. Fields repeated with the same length are accepted.
+
+A chunked response is exempt. `Transfer-Encoding` overrides `Content-Length` (RFC 9112 §6.3), so the body comes from the
+chunk sizes and any `Content-Length` alongside it is never read — including one that would otherwise be rejected.
+
 ## HTTP Methods
 
 Glaze supports all standard HTTP methods:

--- a/docs/networking/http-router.md
+++ b/docs/networking/http-router.md
@@ -355,7 +355,7 @@ router.use([](const glz::request& req, glz::response& res) {
             return;
         }
         
-        if (!validate_token(auth_header->second)) {
+        if (!validate_token(auth_header->value)) {
             res.status(403).json({{"error", "Invalid token"}});
             return;
         }

--- a/docs/networking/http-router.md
+++ b/docs/networking/http-router.md
@@ -349,13 +349,13 @@ router.use([](const glz::request& req, glz::response& res) {
 // Authentication middleware
 router.use([](const glz::request& req, glz::response& res) {
     if (requires_auth(req.target)) {
-        auto auth_header = req.headers.find("Authorization");
-        if (auth_header == req.headers.end()) {
+        auto auth_header = req.headers.first_value("Authorization");
+        if (!auth_header) {
             res.status(401).json({{"error", "Authentication required"}});
             return;
         }
         
-        if (!validate_token(auth_header->value)) {
+        if (!validate_token(*auth_header)) {
             res.status(403).json({{"error", "Invalid token"}});
             return;
         }

--- a/docs/networking/http-server.md
+++ b/docs/networking/http-server.md
@@ -338,7 +338,7 @@ server.use([](const glz::request& req, glz::response& res) {
 // Authentication middleware
 server.use([](const glz::request& req, glz::response& res) {
     // Note: Header names are case-insensitive (RFC 7230)
-    if (req.headers.find("authorization") == req.headers.end()) {
+    if (!req.headers.contains("authorization")) {
         res.status(401).json({{"error", "Authorization required"}});
         return;
     }

--- a/docs/networking/url.md
+++ b/docs/networking/url.md
@@ -247,9 +247,9 @@ For `application/x-www-form-urlencoded` POST requests, use `parse_urlencoded` on
 ```cpp
 server.post("/login", [](const glz::request& req, glz::response& res) {
     // Check content type
-    auto ct = req.headers.find("content-type");
-    if (ct == req.headers.end() ||
-        ct->second.find("application/x-www-form-urlencoded") == std::string::npos) {
+    // A media type can carry parameters like "; charset=utf-8", so match on the prefix.
+    auto ct = req.headers.first_value("content-type");
+    if (!ct || !ct->starts_with("application/x-www-form-urlencoded")) {
         res.status(415).json({{"error", "Unsupported content type"}});
         return;
     }

--- a/include/glaze/net/cors.hpp
+++ b/include/glaze/net/cors.hpp
@@ -144,7 +144,7 @@ namespace glz
          std::string origin;
          auto origin_it = req.headers.find("origin");
          if (origin_it != req.headers.end()) {
-            origin = origin_it->second;
+            origin = origin_it->value;
          }
 
          // Check if this is a preflight request (OPTIONS method with specific headers)
@@ -189,7 +189,7 @@ namespace glz
                }
                else if (auto requested_headers = req.headers.find("access-control-request-headers");
                         requested_headers != req.headers.end()) {
-                  res.header("Access-Control-Allow-Headers", requested_headers->second);
+                  res.header("Access-Control-Allow-Headers", requested_headers->value);
                }
 
                // Add max age

--- a/include/glaze/net/http.hpp
+++ b/include/glaze/net/http.hpp
@@ -11,6 +11,8 @@
 #include <string_view>
 #include <system_error>
 
+#include "glaze/util/compare.hpp"
+
 // To deconflict Windows.h
 #ifdef DELETE
 #undef DELETE
@@ -248,6 +250,17 @@ namespace glz
    {
       return name.find_first_of("\r\n") != std::string_view::npos ||
              value.find_first_of("\r\n") != std::string_view::npos;
+   }
+
+   // RFC 9112 6.3: Content-Length and Transfer-Encoding are the only fields that
+   // tell a recipient where a message body ends. Two of either, disagreeing, let
+   // an intermediary and an endpoint split the same byte stream at different
+   // offsets, so bytes one of them reads as the next message are chosen by
+   // whoever supplied the second field (request/response smuggling). Every other
+   // field name may repeat freely, so the serializers single out just these two.
+   [[nodiscard]] inline bool header_field_frames_body(std::string_view name) noexcept
+   {
+      return striequal(name, "content-length") || striequal(name, "transfer-encoding");
    }
 
    // RFC 7230 3.2.6: a header field-name is one or more token characters (tchar).

--- a/include/glaze/net/http_client.hpp
+++ b/include/glaze/net/http_client.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "glaze/ext/glaze_asio.hpp"
+#include "glaze/net/http_headers.hpp"
 #include "glaze/net/http_router.hpp"
 #include "glaze/util/env.hpp"
 #include "glaze/util/itoa.hpp"
@@ -260,8 +261,7 @@ namespace glz
       // body or re-iterating the headers map. For large idempotent PUT bodies this is
       // the difference between O(1) and O(N) body copies per request through the chain.
       inline std::string build_http_request_bytes(const std::string& method, const url_parts& url, bool use_https,
-                                                  const std::string& body,
-                                                  const std::unordered_map<std::string, std::string>& headers)
+                                                  const std::string& body, const glz::http_headers& headers)
       {
          const bool is_default_port = (!use_https && url.port == 80) || (use_https && url.port == 443);
 
@@ -937,7 +937,7 @@ namespace glz
       http_error_handler on_error;
       std::string method{"GET"};
       std::string body{};
-      std::unordered_map<std::string, std::string> headers{};
+      glz::http_headers headers{};
       http_connect_handler on_connect{};
       http_disconnect_handler on_disconnect{};
       std::chrono::seconds timeout{std::chrono::seconds{30}};
@@ -955,7 +955,7 @@ namespace glz
       stream_read_strategy strategy{stream_read_strategy::bulk_transfer};
       size_t max_buffer_size{1024 * 1024};
       std::string body;
-      std::unordered_map<std::string, std::string> headers;
+      glz::http_headers headers;
       http_connect_handler on_connect;
       http_disconnect_handler on_disconnect;
       http_data_handler on_data;
@@ -1097,8 +1097,7 @@ namespace glz
       void clear_connection_pool() { connection_pool->clear(); }
 
       // Synchronous GET request - truly synchronous, no promises/futures
-      std::expected<response, std::error_code> get(std::string_view url,
-                                                   const std::unordered_map<std::string, std::string>& headers = {})
+      std::expected<response, std::error_code> get(std::string_view url, const glz::http_headers& headers = {})
       {
          auto url_result = parse_url(url);
          if (!url_result) {
@@ -1110,7 +1109,7 @@ namespace glz
 
       // Synchronous POST request - truly synchronous, no promises/futures
       std::expected<response, std::error_code> post(std::string_view url, const std::string& body,
-                                                    const std::unordered_map<std::string, std::string>& headers = {})
+                                                    const glz::http_headers& headers = {})
       {
          auto url_result = parse_url(url);
          if (!url_result) {
@@ -1122,7 +1121,7 @@ namespace glz
 
       // Synchronous PUT request - truly synchronous, no promises/futures
       std::expected<response, std::error_code> put(std::string_view url, const std::string& body,
-                                                   const std::unordered_map<std::string, std::string>& headers = {})
+                                                   const glz::http_headers& headers = {})
       {
          auto url_result = parse_url(url);
          if (!url_result) {
@@ -1134,8 +1133,8 @@ namespace glz
 
       // Synchronous JSON POST request
       template <class T>
-      std::expected<response, std::error_code> post_json(
-         std::string_view url, const T& data, const std::unordered_map<std::string, std::string>& headers = {})
+      std::expected<response, std::error_code> post_json(std::string_view url, const T& data,
+                                                         const glz::http_headers& headers = {})
       {
          std::string json_str;
          auto ec = glz::write_json(data, json_str);
@@ -1144,15 +1143,15 @@ namespace glz
          }
 
          auto merged_headers = headers;
-         merged_headers["content-type"] = "application/json";
+         merged_headers.set("Content-Type", "application/json");
 
          return post(url, json_str, merged_headers);
       }
 
       // Synchronous JSON PUT request
       template <class T>
-      std::expected<response, std::error_code> put_json(
-         std::string_view url, const T& data, const std::unordered_map<std::string, std::string>& headers = {})
+      std::expected<response, std::error_code> put_json(std::string_view url, const T& data,
+                                                        const glz::http_headers& headers = {})
       {
          std::string json_str;
          auto ec = glz::write_json(data, json_str);
@@ -1161,7 +1160,7 @@ namespace glz
          }
 
          auto merged_headers = headers;
-         merged_headers["content-type"] = "application/json";
+         merged_headers.set("Content-Type", "application/json");
 
          return put(url, json_str, merged_headers);
       }
@@ -1195,8 +1194,7 @@ namespace glz
 
       // Asynchronous GET request
       template <typename CompletionHandler>
-      void get_async(std::string_view url, const std::unordered_map<std::string, std::string>& headers,
-                     CompletionHandler&& handler)
+      void get_async(std::string_view url, const glz::http_headers& headers, CompletionHandler&& handler)
       {
          auto url_result = parse_url(url);
          if (!url_result) {
@@ -1209,8 +1207,8 @@ namespace glz
       }
 
       // Overload for get_async without completion handler (returns future)
-      std::future<std::expected<response, std::error_code>> get_async(
-         std::string_view url, const std::unordered_map<std::string, std::string>& headers = {})
+      std::future<std::expected<response, std::error_code>> get_async(std::string_view url,
+                                                                      const glz::http_headers& headers = {})
       {
          std::promise<std::expected<response, std::error_code>> promise;
          auto future = promise.get_future();
@@ -1225,8 +1223,8 @@ namespace glz
 
       // Asynchronous POST request
       template <typename CompletionHandler>
-      void post_async(std::string_view url, const std::string& body,
-                      const std::unordered_map<std::string, std::string>& headers, CompletionHandler&& handler)
+      void post_async(std::string_view url, const std::string& body, const glz::http_headers& headers,
+                      CompletionHandler&& handler)
       {
          auto url_result = parse_url(url);
          if (!url_result) {
@@ -1239,9 +1237,8 @@ namespace glz
       }
 
       // Overload for post_async without completion handler (returns future)
-      std::future<std::expected<response, std::error_code>> post_async(
-         std::string_view url, const std::string& body,
-         const std::unordered_map<std::string, std::string>& headers = {})
+      std::future<std::expected<response, std::error_code>> post_async(std::string_view url, const std::string& body,
+                                                                       const glz::http_headers& headers = {})
       {
          std::promise<std::expected<response, std::error_code>> promise;
          auto future = promise.get_future();
@@ -1256,8 +1253,8 @@ namespace glz
 
       // Async JSON POST request
       template <class T, typename CompletionHandler>
-      void post_json_async(std::string_view url, const T& data,
-                           const std::unordered_map<std::string, std::string>& headers, CompletionHandler&& handler)
+      void post_json_async(std::string_view url, const T& data, const glz::http_headers& headers,
+                           CompletionHandler&& handler)
       {
          std::string json_str;
          auto ec = glz::write_json(data, json_str);
@@ -1269,15 +1266,15 @@ namespace glz
          }
 
          auto merged_headers = headers;
-         merged_headers["content-type"] = "application/json";
+         merged_headers.set("Content-Type", "application/json");
 
          post_async(url, json_str, merged_headers, std::forward<CompletionHandler>(handler));
       }
 
       // Overload for post_json_async without completion handler (returns future)
       template <class T>
-      std::future<std::expected<response, std::error_code>> post_json_async(
-         std::string_view url, const T& data, const std::unordered_map<std::string, std::string>& headers = {})
+      std::future<std::expected<response, std::error_code>> post_json_async(std::string_view url, const T& data,
+                                                                            const glz::http_headers& headers = {})
       {
          std::promise<std::expected<response, std::error_code>> promise;
          auto future = promise.get_future();
@@ -1354,9 +1351,9 @@ namespace glz
 
       std::shared_ptr<http_stream_connection> perform_stream_request(
          const std::string& method, const url_parts& url, const std::string& body, size_t max_buffer_size,
-         const std::unordered_map<std::string, std::string>& headers, std::chrono::seconds timeout,
-         stream_read_strategy strategy, std::function<bool(int)> status_is_error, http_data_handler on_data,
-         http_error_handler on_error, http_connect_handler on_connect, http_disconnect_handler on_disconnect)
+         const glz::http_headers& headers, std::chrono::seconds timeout, stream_read_strategy strategy,
+         std::function<bool(int)> status_is_error, http_data_handler on_data, http_error_handler on_error,
+         http_connect_handler on_connect, http_disconnect_handler on_disconnect)
       {
          const bool use_https = (url.protocol == "https");
 
@@ -1477,7 +1474,7 @@ namespace glz
 
 #ifdef GLZ_ENABLE_SSL
       void perform_stream_ssl_handshake(const url_parts& url, const std::string& method, const std::string& body,
-                                        const std::unordered_map<std::string, std::string>& headers,
+                                        const glz::http_headers& headers,
                                         std::shared_ptr<http_stream_connection> connection, http_data_handler on_data,
                                         http_error_handler on_error, http_connect_handler on_connect,
                                         http_disconnect_handler on_disconnect)
@@ -1509,9 +1506,8 @@ namespace glz
 
       // Needs to take the wrapped disconnect handler and use keep-alive
       void send_stream_request(const url_parts& url, const std::string& method, const std::string& body,
-                               const std::unordered_map<std::string, std::string>& headers,
-                               std::shared_ptr<http_stream_connection> connection, http_data_handler on_data,
-                               http_error_handler on_error, http_connect_handler on_connect,
+                               const glz::http_headers& headers, std::shared_ptr<http_stream_connection> connection,
+                               http_data_handler on_data, http_error_handler on_error, http_connect_handler on_connect,
                                http_disconnect_handler on_disconnect)
       {
          const bool use_https = url.protocol == "https";
@@ -1600,8 +1596,7 @@ namespace glz
                            std::string_view value =
                               (value_start != std::string::npos) ? header_line.substr(value_start) : "";
 
-                           // Convert header name to lowercase for case-insensitive lookups (RFC 7230)
-                           response_headers.response_headers[to_lower_case(name)] = std::string(value);
+                           response_headers.response_headers.add(std::string(name), std::string(value));
                         }
                      }
 
@@ -1626,15 +1621,7 @@ namespace glz
                         return;
                      }
 
-                     bool is_chunked = false;
-                     auto it = response_headers.response_headers.find("transfer-encoding");
-                     if (it != response_headers.response_headers.end()) {
-                        if (it->second.find("chunked") != std::string::npos) {
-                           is_chunked = true;
-                        }
-                     }
-
-                     if (is_chunked) {
+                     if (response_headers.response_headers.contains_token("transfer-encoding", "chunked")) {
                         start_chunked_reading(connection, std::move(on_data), std::move(on_error),
                                               std::move(on_disconnect));
                      }
@@ -1865,9 +1852,9 @@ namespace glz
             *connection->socket);
       }
 
-      std::expected<response, std::error_code> perform_sync_request(
-         const std::string& method, const url_parts& url, const std::string& body,
-         const std::unordered_map<std::string, std::string>& headers)
+      std::expected<response, std::error_code> perform_sync_request(const std::string& method, const url_parts& url,
+                                                                    const std::string& body,
+                                                                    const glz::http_headers& headers)
       {
          const bool use_https = (url.protocol == "https");
 
@@ -1987,11 +1974,7 @@ namespace glz
             }
 
             // Parse headers from the view
-            std::unordered_map<std::string, std::string> response_headers;
-            size_t content_length = 0;
-            bool has_content_length = false;
-            bool connection_close = false;
-            bool is_chunked = false;
+            glz::http_headers response_headers;
 
             while (!header_data.starts_with("\r\n")) {
                line_end = header_data.find("\r\n");
@@ -2008,25 +1991,19 @@ namespace glz
                   size_t value_start = header_line.find_first_not_of(" \t", colon_pos + 1);
                   std::string_view value = (value_start != std::string::npos) ? header_line.substr(value_start) : "";
 
-                  if (name.length() == 14 && glz::strncasecmp(name.data(), "Content-Length", 14) == 0) {
-                     std::from_chars(value.data(), value.data() + value.size(), content_length);
-                     has_content_length = true;
-                  }
-                  else if (name.length() == 17 && glz::strncasecmp(name.data(), "Transfer-Encoding", 17) == 0) {
-                     if (value.find("chunked") != std::string_view::npos) {
-                        is_chunked = true;
-                     }
-                  }
-                  else if (name.length() == 10 && glz::strncasecmp(name.data(), "Connection", 10) == 0) {
-                     if (value.find("close") != std::string_view::npos) {
-                        connection_close = true;
-                     }
-                  }
-
-                  // Convert header name to lowercase for case-insensitive lookups (RFC 7230)
-                  response_headers.emplace(to_lower_case(name), value);
+                  response_headers.add(std::string(name), std::string(value));
                }
             }
+
+            size_t content_length = 0;
+            const auto content_length_value = response_headers.first_value("Content-Length");
+            const bool has_content_length = content_length_value.has_value();
+            if (has_content_length) {
+               std::from_chars(content_length_value->data(),
+                               content_length_value->data() + content_length_value->size(), content_length);
+            }
+            const bool is_chunked = response_headers.contains_token("Transfer-Encoding", "chunked");
+            bool connection_close = response_headers.contains_token("Connection", "close");
 
             // Consume header data, leaving only the over-read body part.
             response_buffer.consume(header_bytes);
@@ -2212,8 +2189,7 @@ namespace glz
 
       template <typename CompletionHandler>
       void perform_request_async(const std::string& method, const url_parts& url, const std::string& body,
-                                 const std::unordered_map<std::string, std::string>& headers,
-                                 CompletionHandler&& handler)
+                                 const glz::http_headers& headers, CompletionHandler&& handler)
       {
          const bool use_https = (url.protocol == "https");
 
@@ -2424,8 +2400,7 @@ namespace glz
       template <typename CompletionHandler>
       void async_consume_trailers(std::shared_ptr<socket_variant> socket_var, std::shared_ptr<asio::streambuf> buffer,
                                   std::shared_ptr<std::string> body, const url_parts& url, bool use_https,
-                                  int status_code, std::unordered_map<std::string, std::string> response_headers,
-                                  CompletionHandler&& handler)
+                                  int status_code, glz::http_headers response_headers, CompletionHandler&& handler)
       {
          std::visit(
             [&, this](auto& sock) {
@@ -2454,9 +2429,7 @@ namespace glz
                         resp.response_headers = std::move(response_headers);
                         resp.response_body = std::move(*body);
 
-                        auto connection_header = resp.response_headers.find("connection");
-                        if (connection_header == resp.response_headers.end() ||
-                            connection_header->second.find("close") == std::string::npos) {
+                        if (!resp.response_headers.contains_token("connection", "close")) {
                            connection_pool->return_connection(url.host, url.port, use_https, std::move(*socket_var));
                         }
 
@@ -2476,8 +2449,7 @@ namespace glz
       template <typename CompletionHandler>
       void async_read_chunked_body(std::shared_ptr<socket_variant> socket_var, std::shared_ptr<asio::streambuf> buffer,
                                    std::shared_ptr<std::string> body, const url_parts& url, bool use_https,
-                                   int status_code, std::unordered_map<std::string, std::string> response_headers,
-                                   CompletionHandler&& handler)
+                                   int status_code, glz::http_headers response_headers, CompletionHandler&& handler)
       {
          // Read until we have the chunk size line
          std::visit(
@@ -2532,8 +2504,7 @@ namespace glz
       template <typename CompletionHandler>
       void async_read_chunk_data(std::shared_ptr<socket_variant> socket_var, std::shared_ptr<asio::streambuf> buffer,
                                  std::shared_ptr<std::string> body, size_t chunk_size, const url_parts& url,
-                                 bool use_https, int status_code,
-                                 std::unordered_map<std::string, std::string> response_headers,
+                                 bool use_https, int status_code, glz::http_headers response_headers,
                                  CompletionHandler&& handler)
       {
          // Check accumulated body size against limit before reading chunk data
@@ -2595,8 +2566,7 @@ namespace glz
       template <typename CompletionHandler>
       void async_read_eof_body(std::shared_ptr<socket_variant> socket_var, std::shared_ptr<asio::streambuf> buffer,
                                const url_parts& url, bool use_https, int status_code,
-                               std::unordered_map<std::string, std::string> response_headers,
-                               CompletionHandler&& handler)
+                               glz::http_headers response_headers, CompletionHandler&& handler)
       {
          std::visit(
             [&, this](auto& sock) {
@@ -2659,11 +2629,7 @@ namespace glz
          }
 
          // Parse all header fields from the view.
-         std::unordered_map<std::string, std::string> response_headers;
-         size_t content_length = 0;
-         bool has_content_length = false;
-         bool connection_close = false;
-         bool is_chunked = false;
+         glz::http_headers response_headers;
          // The header section ends with an empty line ("\r\n"), which means our view will start with it.
          while (!header_section.starts_with("\r\n")) {
             line_end = header_section.find("\r\n");
@@ -2681,28 +2647,19 @@ namespace glz
                size_t value_start = header_line.find_first_not_of(" \t", colon_pos + 1);
                std::string_view value = (value_start != std::string::npos) ? header_line.substr(value_start) : "";
 
-               // A case-insensitive comparison is more robust for header names.
-               if (name.size() == 14 && (name[0] == 'C' || name[0] == 'c') &&
-                   glz::strncasecmp(name.data(), "Content-Length", 14) == 0) {
-                  std::from_chars(value.data(), value.data() + value.size(), content_length);
-                  has_content_length = true;
-               }
-               else if (name.size() == 17 && (name[0] == 'T' || name[0] == 't') &&
-                        glz::strncasecmp(name.data(), "Transfer-Encoding", 17) == 0) {
-                  if (value.find("chunked") != std::string_view::npos) {
-                     is_chunked = true;
-                  }
-               }
-               else if (name.size() == 10 && (name[0] == 'C' || name[0] == 'c') &&
-                        glz::strncasecmp(name.data(), "Connection", 10) == 0) {
-                  if (value.find("close") != std::string_view::npos) {
-                     connection_close = true;
-                  }
-               }
-               // Convert header name to lowercase for case-insensitive lookups (RFC 7230)
-               response_headers.emplace(to_lower_case(name), value);
+               response_headers.add(std::string(name), std::string(value));
             }
          }
+
+         size_t content_length = 0;
+         const auto content_length_value = response_headers.first_value("Content-Length");
+         const bool has_content_length = content_length_value.has_value();
+         if (has_content_length) {
+            std::from_chars(content_length_value->data(), content_length_value->data() + content_length_value->size(),
+                            content_length);
+         }
+         const bool is_chunked = response_headers.contains_token("Transfer-Encoding", "chunked");
+         const bool connection_close = response_headers.contains_token("Connection", "close");
 
          // Consume the entire header block from the streambuf.
          // This efficiently discards the header data we've just parsed, leaving only body data.
@@ -2764,10 +2721,7 @@ namespace glz
                         // Pool the connection unless the server asked to close it. A truncated or
                         // peer-closed connection already returned above, so anything reaching here
                         // is a complete response on a still-open socket.
-                        auto connection_header = resp.response_headers.find("connection");
-                        const bool server_wants_close = connection_header != resp.response_headers.end() &&
-                                                        connection_header->second.find("close") != std::string::npos;
-                        if (server_wants_close) {
+                        if (resp.response_headers.contains_token("connection", "close")) {
                            detail::close_socket(*socket_var, connection_pool->graceful_ssl_shutdown());
                         }
                         else {

--- a/include/glaze/net/http_client.hpp
+++ b/include/glaze/net/http_client.hpp
@@ -133,6 +133,7 @@ namespace glz
    enum class http_client_error {
       success = 0,
       response_too_large, // Response body exceeds max_response_body_size
+      unframed_response, // Response Content-Length is malformed or repeats with conflicting values
    };
 
    // HTTP client error category for std::error_code integration
@@ -148,6 +149,8 @@ namespace glz
             return "Success";
          case http_client_error::response_too_large:
             return "Response body size exceeds configured maximum";
+         case http_client_error::unframed_response:
+            return "Response Content-Length is malformed or repeats with conflicting values";
          default:
             return "Unknown HTTP client error";
          }
@@ -282,13 +285,33 @@ namespace glz
          }
          request_str.append("\r\n");
          request_str.append("Connection: keep-alive\r\n");
-         if (!body.empty()) {
+         // RFC 9110 8.6: a user agent SHOULD send Content-Length when the method
+         // anticipates content, even for an empty body - origin servers and proxies
+         // commonly answer a bodyless POST with 411 Length Required. Since a caller's
+         // own Content-Length is dropped below, omitting it here would leave them no
+         // way to frame an empty POST at all. For a method that anticipates no
+         // content, no field is the unambiguous encoding of an empty body
+         // (RFC 9112 6), so adding one would only invite a body where none belongs.
+         const bool anticipates_content = method == "POST" || method == "PUT" || method == "PATCH";
+         if (!body.empty() || anticipates_content) {
             request_str.append("Content-Length: ");
             request_str.append(std::to_string(body.size()));
             request_str.append("\r\n");
          }
          for (const auto& [name, value] : headers) {
             if (header_field_has_crlf(name, value)) [[unlikely]] {
+               continue;
+            }
+            // This builder owns the body framing: it has already written the
+            // Content-Length that matches the body it is about to append. A
+            // caller-supplied Content-Length or Transfer-Encoding would ride
+            // alongside it as a second, contradicting frame - and unlike the
+            // response side there is no correct value to keep, because the body
+            // length is whatever this function writes. Drop them rather than
+            // emit a request no two recipients would parse the same way
+            // (RFC 9112 6.3, request smuggling). glz::http_headers keeps
+            // repeats, so a single lookup would not have caught the second one.
+            if (header_field_frames_body(name)) [[unlikely]] {
                continue;
             }
             request_str.append(name);
@@ -299,6 +322,70 @@ namespace glz
          request_str.append("\r\n");
          request_str.append(body);
          return request_str;
+      }
+
+      // Outcome of reading the Content-Length of a response. `absent` and
+      // `unframed` are distinct because they lead to different reads: no
+      // Content-Length at all is a legitimate response whose body runs to the end
+      // of the connection, whereas one we cannot resolve to a single length has to
+      // fail the request.
+      enum struct content_length_state { absent, present, unframed };
+
+      struct parsed_content_length
+      {
+         content_length_state state{content_length_state::absent};
+         size_t value{};
+      };
+
+      // RFC 9112 6.3: a response whose Content-Length fields disagree has no
+      // recoverable body length. Picking one - first or last - lets a proxy that
+      // picked the other resume framing at a different offset, so the bytes this
+      // client reads as the start of the next response are chosen by whoever
+      // supplied the second field (response smuggling). Repeats that resolve to the
+      // same length are unambiguous and tolerated, in the same spirit as the
+      // server's rule for a request - though the server compares the raw field
+      // text, so it rejects the "3" and "03" pair this accepts. Both readings frame
+      // the body identically; only the strictness differs.
+      //
+      // A value that is not a bare decimal is rejected for the same reason: it
+      // resolves to no length at all, and defaulting it to zero would leave a real
+      // body sitting in the socket to be read as the next response.
+      [[nodiscard]] inline parsed_content_length read_content_length(const glz::http_headers& headers)
+      {
+         // RFC 9112 6.3: Transfer-Encoding overrides Content-Length, so a chunked
+         // response is framed by the chunk sizes and its Content-Length is never
+         // consulted. A field this client will not use must not be able to fail the
+         // request either - the framing is already unambiguous without it. Reporting
+         // `absent` says exactly that: there is no Content-Length framing to apply,
+         // whether or not such a field was sent.
+         //
+         // This also keeps the two framings from ever being weighed against each
+         // other. Whether a Content-Length parses cannot change how a chunked body
+         // is read, so the order these are evaluated in stops mattering.
+         if (headers.contains_token("Transfer-Encoding", "chunked")) {
+            return {content_length_state::absent, 0};
+         }
+
+         parsed_content_length result{};
+
+         for (const auto field_value : headers.values("Content-Length")) {
+            size_t length{};
+            const char* const first = field_value.data();
+            const char* const last = first + field_value.size();
+            const auto [stopped_at, ec] = std::from_chars(first, last, length);
+            if (ec != std::errc{} || stopped_at != last) {
+               return {content_length_state::unframed, 0};
+            }
+
+            if (result.state == content_length_state::absent) {
+               result = {content_length_state::present, length};
+            }
+            else if (result.value != length) {
+               return {content_length_state::unframed, 0};
+            }
+         }
+
+         return result;
       }
 
       // Sets the Content-Type header to application/json if the Content-Type
@@ -1592,10 +1679,9 @@ namespace glz
                         auto colon_pos = header_line.find(':');
                         if (colon_pos != std::string::npos) {
                            std::string_view name = header_line.substr(0, colon_pos);
-                           // Skip past ':' and any whitespace
-                           size_t value_start = header_line.find_first_not_of(" \t", colon_pos + 1);
-                           std::string_view value =
-                              (value_start != std::string::npos) ? header_line.substr(value_start) : "";
+                           // RFC 9110 5.5 / RFC 9112 5: strip both leading and trailing OWS,
+                           // so a value reaches the caller as the field value proper.
+                           std::string_view value = detail::trim_optional_whitespace(header_line.substr(colon_pos + 1));
 
                            response_headers.response_headers.add(std::string(name), std::string(value));
                         }
@@ -1989,20 +2075,27 @@ namespace glz
                auto colon_pos = header_line.find(':');
                if (colon_pos != std::string::npos) {
                   std::string_view name = header_line.substr(0, colon_pos);
-                  size_t value_start = header_line.find_first_not_of(" \t", colon_pos + 1);
-                  std::string_view value = (value_start != std::string::npos) ? header_line.substr(value_start) : "";
+                  // RFC 9110 5.5 / RFC 9112 5: a field value excludes both leading and
+                  // trailing OWS, and a recipient MUST strip them before evaluating it.
+                  // "Content-Length: 3 " is legal, so keeping the trailing space would
+                  // leave a value no strict parse of the field can accept.
+                  std::string_view value = detail::trim_optional_whitespace(header_line.substr(colon_pos + 1));
 
                   response_headers.add(std::string(name), std::string(value));
                }
             }
 
-            size_t content_length = 0;
-            const auto content_length_value = response_headers.first_value("Content-Length");
-            const bool has_content_length = content_length_value.has_value();
-            if (has_content_length) {
-               std::from_chars(content_length_value->data(),
-                               content_length_value->data() + content_length_value->size(), content_length);
+            const auto content_length_field = detail::read_content_length(response_headers);
+            if (content_length_field.state == detail::content_length_state::unframed) [[unlikely]] {
+               // The body boundary is unknowable, so the socket cannot be handed
+               // back to the pool: whatever is left on it would be read as the
+               // head of an unrelated response.
+               detail::close_socket(socket_var, connection_pool->graceful_ssl_shutdown());
+               r.outcome = std::unexpected(make_error_code(http_client_error::unframed_response));
+               return r;
             }
+            const size_t content_length = content_length_field.value;
+            const bool has_content_length = content_length_field.state == detail::content_length_state::present;
             const bool is_chunked = response_headers.contains_token("Transfer-Encoding", "chunked");
             bool connection_close = response_headers.contains_token("Connection", "close");
 
@@ -2644,21 +2737,27 @@ namespace glz
             auto colon_pos = header_line.find(':');
             if (colon_pos != std::string::npos) {
                std::string_view name = header_line.substr(0, colon_pos);
-               // Skip past ':' and any leading whitespace on the value.
-               size_t value_start = header_line.find_first_not_of(" \t", colon_pos + 1);
-               std::string_view value = (value_start != std::string::npos) ? header_line.substr(value_start) : "";
+               // RFC 9110 5.5 / RFC 9112 5: a field value excludes both leading and
+               // trailing OWS, and a recipient MUST strip them before evaluating it.
+               // "Content-Length: 3 " is legal, so keeping the trailing space would
+               // leave a value no strict parse of the field can accept.
+               std::string_view value = detail::trim_optional_whitespace(header_line.substr(colon_pos + 1));
 
                response_headers.add(std::string(name), std::string(value));
             }
          }
 
-         size_t content_length = 0;
-         const auto content_length_value = response_headers.first_value("Content-Length");
-         const bool has_content_length = content_length_value.has_value();
-         if (has_content_length) {
-            std::from_chars(content_length_value->data(), content_length_value->data() + content_length_value->size(),
-                            content_length);
+         const auto content_length_field = detail::read_content_length(response_headers);
+         if (content_length_field.state == detail::content_length_state::unframed) [[unlikely]] {
+            // The body boundary is unknowable, so the socket cannot be handed back
+            // to the pool: whatever is left on it would be read as the head of an
+            // unrelated response.
+            detail::close_socket(*socket_var, connection_pool->graceful_ssl_shutdown());
+            handler(std::unexpected(make_error_code(http_client_error::unframed_response)));
+            return;
          }
+         const size_t content_length = content_length_field.value;
+         const bool has_content_length = content_length_field.state == detail::content_length_state::present;
          const bool is_chunked = response_headers.contains_token("Transfer-Encoding", "chunked");
          const bool connection_close = response_headers.contains_token("Connection", "close");
 

--- a/include/glaze/net/http_client.hpp
+++ b/include/glaze/net/http_client.hpp
@@ -301,6 +301,16 @@ namespace glz
          return request_str;
       }
 
+      // Sets the Content-Type header to application/json if the Content-Type
+      // header is not already set.
+      inline glz::http_headers with_json_content_type(glz::http_headers headers)
+      {
+         if (!headers.contains("Content-Type")) {
+            headers.add("Content-Type", "application/json");
+         }
+         return headers;
+      }
+
 #ifdef GLZ_ENABLE_SSL
       // Configure SNI and hostname verification for client TLS connections.
       inline bool configure_ssl_client_hostname(ssl_socket& sock, const std::string& host)
@@ -1142,10 +1152,7 @@ namespace glz
             return std::unexpected(std::make_error_code(std::errc::invalid_argument));
          }
 
-         auto merged_headers = headers;
-         merged_headers.set("Content-Type", "application/json");
-
-         return post(url, json_str, merged_headers);
+         return post(url, json_str, detail::with_json_content_type(headers));
       }
 
       // Synchronous JSON PUT request
@@ -1159,10 +1166,7 @@ namespace glz
             return std::unexpected(std::make_error_code(std::errc::invalid_argument));
          }
 
-         auto merged_headers = headers;
-         merged_headers.set("Content-Type", "application/json");
-
-         return put(url, json_str, merged_headers);
+         return put(url, json_str, detail::with_json_content_type(headers));
       }
 
       [[deprecated("use stream_request_v2 instead")]]
@@ -1265,10 +1269,7 @@ namespace glz
             return;
          }
 
-         auto merged_headers = headers;
-         merged_headers.set("Content-Type", "application/json");
-
-         post_async(url, json_str, merged_headers, std::forward<CompletionHandler>(handler));
+         post_async(url, json_str, detail::with_json_content_type(headers), std::forward<CompletionHandler>(handler));
       }
 
       // Overload for post_json_async without completion handler (returns future)

--- a/include/glaze/net/http_router.hpp
+++ b/include/glaze/net/http_router.hpp
@@ -86,31 +86,32 @@ namespace glz
          return *this;
       }
 
+      // Replaces any existing field with this name.
       inline response& header(std::string_view name, std::string_view value)
       {
-         // RFC 7230 3.2: a field-name or field-value carrying CR or LF would
-         // terminate the field on the wire, letting attacker-influenced data
-         // inject extra headers or a body (CWE-113). Reject such a field where it
-         // is set so it never enters the map and, crucially, the default-header
-         // bookkeeping below is skipped: otherwise a dropped Content-Length or
-         // Connection would still suppress its auto-generated counterpart and
-         // leave the message unframed. The wire serializers keep an independent
-         // drop as a backstop for headers that bypass this setter.
-         if (header_field_has_crlf(name, value)) [[unlikely]] {
+         if (reject_unwritable_field(name, value)) [[unlikely]] {
             return *this;
          }
 
-         // Track which default headers the user has set
-         if (glz::striequal(name, "content-length"))
-            user_headers_set |= has_content_length;
-         else if (glz::striequal(name, "date"))
-            user_headers_set |= has_date;
-         else if (glz::striequal(name, "server"))
-            user_headers_set |= has_server;
-         else if (glz::striequal(name, "connection"))
-            user_headers_set |= has_connection;
-
          response_headers.set(std::string(name), std::string(value));
+         return *this;
+      }
+
+      // Appends instead of replacing, for names that can repeat like Set-Cookie.
+      // Content-Length and Transfer-Encoding are replaced regardless: a second one leaves
+      // the body length ambiguous and opens response smuggling (RFC 9112 6.3).
+      inline response& add_header(std::string_view name, std::string_view value)
+      {
+         if (reject_unwritable_field(name, value)) [[unlikely]] {
+            return *this;
+         }
+
+         if (frames_the_body(name)) [[unlikely]] {
+            response_headers.set(std::string(name), std::string(value));
+         }
+         else {
+            response_headers.add(std::string(name), std::string(value));
+         }
          return *this;
       }
 
@@ -177,6 +178,38 @@ namespace glz
             response_body = R"({"error":"glz::write_json error"})"; // rare that this would ever happen
          }
          return *this;
+      }
+
+     private:
+      [[nodiscard]] static bool frames_the_body(std::string_view name) noexcept
+      {
+         return glz::striequal(name, "content-length") || glz::striequal(name, "transfer-encoding");
+      }
+
+      // RFC 7230 3.2: a field-name or field-value carrying CR or LF would
+      // terminate the field on the wire, letting attacker-influenced data
+      // inject extra headers or a body (CWE-113). Reject such a field where it
+      // is set so it never enters the container and, crucially, the default-header
+      // bookkeeping is skipped: otherwise a dropped Content-Length or
+      // Connection would still suppress its auto-generated counterpart and
+      // leave the message unframed. The wire serializers keep an independent
+      // drop as a backstop for headers that bypass these setters.
+      [[nodiscard]] bool reject_unwritable_field(std::string_view name, std::string_view value) noexcept
+      {
+         if (header_field_has_crlf(name, value)) {
+            return true;
+         }
+
+         if (glz::striequal(name, "content-length"))
+            user_headers_set |= has_content_length;
+         else if (glz::striequal(name, "date"))
+            user_headers_set |= has_date;
+         else if (glz::striequal(name, "server"))
+            user_headers_set |= has_server;
+         else if (glz::striequal(name, "connection"))
+            user_headers_set |= has_connection;
+
+         return false;
       }
    };
 

--- a/include/glaze/net/http_router.hpp
+++ b/include/glaze/net/http_router.hpp
@@ -17,6 +17,7 @@
 
 #include "glaze/json/generic.hpp"
 #include "glaze/net/http.hpp"
+#include "glaze/net/http_headers.hpp"
 #include "glaze/net/url.hpp"
 #include "glaze/util/key_transformers.hpp"
 
@@ -48,7 +49,7 @@ namespace glz
       std::string path{}; // Path component only (without query string)
       std::unordered_map<std::string, std::string> params{}; // Path parameters (e.g., :id)
       std::unordered_map<std::string, std::string> query{}; // Query parameters (e.g., ?limit=10)
-      std::unordered_map<std::string, std::string> headers{};
+      glz::http_headers headers{};
       std::string body{};
       std::string remote_ip{};
       uint16_t remote_port{};

--- a/include/glaze/net/http_router.hpp
+++ b/include/glaze/net/http_router.hpp
@@ -76,7 +76,7 @@ namespace glz
       };
 
       int status_code = 200;
-      std::unordered_map<std::string, std::string> response_headers{};
+      glz::http_headers response_headers{};
       std::string response_body{};
       uint8_t user_headers_set{};
 
@@ -100,21 +100,17 @@ namespace glz
             return *this;
          }
 
-         // Convert header name to lowercase for case-insensitive lookups (RFC 7230)
-         std::string key(name);
-         for (auto& c : key) c = ascii_tolower(c);
-
          // Track which default headers the user has set
-         if (key == "content-length")
+         if (glz::striequal(name, "content-length"))
             user_headers_set |= has_content_length;
-         else if (key == "date")
+         else if (glz::striequal(name, "date"))
             user_headers_set |= has_date;
-         else if (key == "server")
+         else if (glz::striequal(name, "server"))
             user_headers_set |= has_server;
-         else if (key == "connection")
+         else if (glz::striequal(name, "connection"))
             user_headers_set |= has_connection;
 
-         response_headers[std::move(key)] = std::string(value);
+         response_headers.set(std::string(name), std::string(value));
          return *this;
       }
 
@@ -169,7 +165,7 @@ namespace glz
          user_headers_set = 0;
       }
 
-      inline response& content_type(std::string_view type) { return header("content-type", type); }
+      inline response& content_type(std::string_view type) { return header("Content-Type", type); }
 
       // JSON response helper using Glaze
       template <class T = glz::generic>

--- a/include/glaze/net/http_router.hpp
+++ b/include/glaze/net/http_router.hpp
@@ -89,10 +89,11 @@ namespace glz
       // Replaces any existing field with this name.
       inline response& header(std::string_view name, std::string_view value)
       {
-         if (reject_unwritable_field(name, value)) [[unlikely]] {
+         if (header_field_has_crlf(name, value)) [[unlikely]] {
             return *this;
          }
 
+         mark_user_supplied(name);
          response_headers.set(std::string(name), std::string(value));
          return *this;
       }
@@ -102,9 +103,11 @@ namespace glz
       // the body length ambiguous and opens response smuggling (RFC 9112 6.3).
       inline response& add_header(std::string_view name, std::string_view value)
       {
-         if (reject_unwritable_field(name, value)) [[unlikely]] {
+         if (header_field_has_crlf(name, value)) [[unlikely]] {
             return *this;
          }
+
+         mark_user_supplied(name);
 
          if (frames_the_body(name)) [[unlikely]] {
             response_headers.set(std::string(name), std::string(value));
@@ -186,20 +189,8 @@ namespace glz
          return glz::striequal(name, "content-length") || glz::striequal(name, "transfer-encoding");
       }
 
-      // RFC 7230 3.2: a field-name or field-value carrying CR or LF would
-      // terminate the field on the wire, letting attacker-influenced data
-      // inject extra headers or a body (CWE-113). Reject such a field where it
-      // is set so it never enters the container and, crucially, the default-header
-      // bookkeeping is skipped: otherwise a dropped Content-Length or
-      // Connection would still suppress its auto-generated counterpart and
-      // leave the message unframed. The wire serializers keep an independent
-      // drop as a backstop for headers that bypass these setters.
-      [[nodiscard]] bool reject_unwritable_field(std::string_view name, std::string_view value) noexcept
+      void mark_user_supplied(std::string_view name) noexcept
       {
-         if (header_field_has_crlf(name, value)) {
-            return true;
-         }
-
          if (glz::striequal(name, "content-length"))
             user_headers_set |= has_content_length;
          else if (glz::striequal(name, "date"))
@@ -208,8 +199,6 @@ namespace glz
             user_headers_set |= has_server;
          else if (glz::striequal(name, "connection"))
             user_headers_set |= has_connection;
-
-         return false;
       }
    };
 

--- a/include/glaze/net/http_router.hpp
+++ b/include/glaze/net/http_router.hpp
@@ -87,6 +87,14 @@ namespace glz
       }
 
       // Replaces any existing field with this name.
+      //
+      // A field-name or field-value carrying CR or LF would terminate the field on
+      // the wire, letting attacker-influenced data inject extra headers or a body
+      // (CWE-113); header_field_has_crlf carries the full rationale. Rejecting it
+      // here keeps it out of the container and, crucially, skips the
+      // mark_user_supplied bookkeeping below - see that function for why the order
+      // of these two lines is load-bearing. The wire serializers keep an
+      // independent drop as a backstop for fields that bypass this setter.
       inline response& header(std::string_view name, std::string_view value)
       {
          if (header_field_has_crlf(name, value)) [[unlikely]] {
@@ -109,7 +117,7 @@ namespace glz
 
          mark_user_supplied(name);
 
-         if (frames_the_body(name)) [[unlikely]] {
+         if (header_field_frames_body(name)) [[unlikely]] {
             response_headers.set(std::string(name), std::string(value));
          }
          else {
@@ -184,11 +192,11 @@ namespace glz
       }
 
      private:
-      [[nodiscard]] static bool frames_the_body(std::string_view name) noexcept
-      {
-         return glz::striequal(name, "content-length") || glz::striequal(name, "transfer-encoding");
-      }
-
+      // Records that the handler supplied one of the headers the wire serializer
+      // would otherwise generate, so the serializer leaves it alone. Only reached
+      // once the field has passed the CR/LF check: a field dropped there must not
+      // set its flag, or a rejected Content-Length or Connection would suppress
+      // the auto-generated counterpart and leave the response unframed.
       void mark_user_supplied(std::string_view name) noexcept
       {
          if (glz::striequal(name, "content-length"))

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -951,7 +951,7 @@ namespace glz
       virtual ~streaming_connection_interface() = default;
 
       // Send initial headers for streaming response
-      virtual void send_headers(int status_code, const std::unordered_map<std::string, std::string>& headers = {},
+      virtual void send_headers(int status_code, const glz::http_headers& headers = {},
                                 data_sent_handler handler = {}) = 0;
 
       // Send a chunk of data
@@ -1009,8 +1009,7 @@ namespace glz
       {}
 
       // Send initial headers for streaming response
-      void send_headers(int status_code, const std::unordered_map<std::string, std::string>& headers = {},
-                        data_sent_handler handler = {}) override
+      void send_headers(int status_code, const glz::http_headers& headers = {}, data_sent_handler handler = {}) override
       {
          if (is_headers_sent_) return;
          is_headers_sent_ = true;
@@ -1040,9 +1039,10 @@ namespace glz
          // dropped Transfer-Encoding/Connection would otherwise leave the stream
          // unframed (no chunked framing, no keep-alive signal). Treat a
          // present-but-invalid header as absent, matching what was written.
-         const auto present_and_valid = [&](const char* key) {
-            const auto it = headers.find(key);
-            return it != headers.end() && !header_field_has_crlf(it->first, it->second);
+         const auto present_and_valid = [&](std::string_view key) {
+            return std::ranges::any_of(headers.fields(key), [](const http_header& field) {
+               return !header_field_has_crlf(field.name, field.value);
+            });
          };
 
          if (!present_and_valid("transfer-encoding")) {
@@ -1284,8 +1284,7 @@ namespace glz
       streaming_response(std::shared_ptr<streaming_connection_interface> conn) : stream(std::move(conn)) {}
 
       // Send headers and start streaming
-      streaming_response& start_stream(int status_code = 200,
-                                       const std::unordered_map<std::string, std::string>& headers = {})
+      streaming_response& start_stream(int status_code = 200, const glz::http_headers& headers = {})
       {
          if (stream) {
             stream->send_headers(status_code, headers);

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -26,6 +26,7 @@
 #include "glaze/ext/glaze_asio.hpp"
 #include "glaze/net/cors.hpp"
 #include "glaze/net/http.hpp"
+#include "glaze/net/http_headers.hpp"
 #include "glaze/net/http_router.hpp"
 #include "glaze/net/openapi.hpp"
 #include "glaze/net/websocket_connection.hpp"
@@ -2555,7 +2556,7 @@ namespace glz
          std::string_view data(conn->read_buf.data(), conn->buf_len);
          parse_result result;
 
-         // Clear headers for re-parse safety (preserves bucket allocation)
+         // Clear headers for re-parse safety (preserves capacity)
          conn->request_.headers.clear();
 
          // --- Parse request line ---
@@ -2650,15 +2651,13 @@ namespace glz
                if (const auto last = value_sv.find_last_not_of(" \t"); last != std::string_view::npos) {
                   value_sv.remove_suffix(value_sv.size() - (last + 1));
                }
-               std::string key(name_sv);
-               for (auto& c : key) c = ascii_tolower(c);
                // RFC 7230 3.3.2: multiple Content-Length fields with differing values make the
-               // body framing unrecoverable. The header map keeps last-wins, so a second
-               // Content-Length would silently override the first; a proxy that frames the body
-               // by the first value then desyncs from this server (CL.CL request smuggling).
+               // body framing unrecoverable. Lookups resolve to the first field, so a second
+               // Content-Length carrying another length would leave a proxy that frames the body
+               // by the later value desynced from this server (CL.CL request smuggling).
                // Reject with 400 and close. Identical repeats are tolerated.
-               if (key == "content-length") {
-                  if (auto existing = headers.find(key); existing != headers.end() && existing->second != value_sv) {
+               if (glz::striequal(name_sv, "content-length")) {
+                  if (auto existing = headers.find(name_sv); existing != headers.end() && existing->value != value_sv) {
                      result.status = parse_status::error;
                      send_error_response_with_close(conn, 400, "Bad Request");
                      return result;
@@ -2666,7 +2665,7 @@ namespace glz
                }
 
                // Duplicate or invalid Host fields are errors for any HTTP/1.x request
-               if (key == "host") {
+               if (glz::striequal(name_sv, "host")) {
                   if (host_header_parsed || !detail::is_valid_authority(value_sv)) {
                      result.status = parse_status::error;
                      send_error_response_with_close(conn, 400, "Bad Request");
@@ -2675,7 +2674,7 @@ namespace glz
                   host_header_parsed = true;
                }
 
-               headers[std::move(key)] = std::string(value_sv);
+               headers.add(std::string(name_sv), std::string(value_sv));
             }
 
             pos = line_end + 2;
@@ -2703,14 +2702,14 @@ namespace glz
          // keep-alive loop parses it as a second, smuggled request (TE/CL desync).
          // RFC 7230 3.3.1 requires answering an undecodable Transfer-Encoding with
          // 501 and closing the connection.
-         if (headers.find("transfer-encoding") != headers.end()) {
+         if (headers.contains("transfer-encoding")) {
             send_error_response_with_close(conn, 501, "Not Implemented");
             return;
          }
 
          std::size_t content_length = 0;
          if (auto it = headers.find("content-length"); it != headers.end()) {
-            const auto& cl = it->second;
+            const auto& cl = it->value;
             auto [ptr, ec] = std::from_chars(cl.data(), cl.data() + cl.size(), content_length);
             if (ec != std::errc{} || ptr != cl.data() + cl.size()) {
                send_error_response_with_close(conn, 400, "Bad Request");
@@ -2770,7 +2769,7 @@ namespace glz
          return false;
       }
 
-      inline bool determine_keep_alive(const std::unordered_map<std::string, std::string>& headers, bool is_http_11,
+      inline bool determine_keep_alive(const glz::http_headers& headers, bool is_http_11,
                                        std::shared_ptr<connection_state> conn)
       {
          // If server has keep-alive disabled, always close
@@ -2785,12 +2784,12 @@ namespace glz
          }
 
          // Check client's Connection header (case-insensitive)
-         auto conn_header_it = headers.find("connection");
+         const auto conn_header_it = headers.find("connection");
          if (conn_header_it != headers.end()) {
-            if (ci_contains(conn_header_it->second, "close")) {
+            if (conn_header_it->contains_token("close")) {
                return false;
             }
-            if (ci_contains(conn_header_it->second, "keep-alive")) {
+            if (conn_header_it->contains_token("keep-alive")) {
                return true;
             }
          }
@@ -2891,7 +2890,7 @@ namespace glz
                   if (auto request_method_it = request.headers.find("access-control-request-method");
                       request_method_it != request.headers.end()) {
                      has_request_method_header = true;
-                     std::string method_token{request_method_it->second};
+                     std::string method_token{request_method_it->value};
                      auto trim_pos = method_token.find_last_not_of(" \t\r\n");
                      if (trim_pos != std::string::npos) {
                         method_token.erase(trim_pos + 1);
@@ -3173,7 +3172,7 @@ namespace glz
          send_error_response_with_conn(conn, status_code, message);
       }
 
-      inline bool is_websocket_upgrade(const std::unordered_map<std::string, std::string>& headers)
+      inline bool is_websocket_upgrade(const glz::http_headers& headers)
       {
          auto upgrade_it = headers.find("upgrade");
          if (upgrade_it == headers.end()) return false;
@@ -3181,8 +3180,8 @@ namespace glz
          auto connection_it = headers.find("connection");
          if (connection_it == headers.end()) return false;
 
-         if (!ci_contains(upgrade_it->second, "websocket")) return false;
-         return ci_contains(connection_it->second, "upgrade");
+         if (!upgrade_it->contains_token("websocket")) return false;
+         return connection_it->contains_token("upgrade");
       }
 
       inline void handle_websocket_upgrade_with_conn(std::shared_ptr<connection_state> conn)

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -2756,18 +2756,6 @@ namespace glz
          }
       }
 
-      // Case-insensitive substring search
-      static bool ci_contains(std::string_view haystack, std::string_view needle)
-      {
-         if (needle.size() > haystack.size()) return false;
-         for (size_t i = 0; i <= haystack.size() - needle.size(); ++i) {
-            if (glz::striequal(haystack.substr(i, needle.size()), needle)) {
-               return true;
-            }
-         }
-         return false;
-      }
-
       inline bool determine_keep_alive(const glz::http_headers& headers, bool is_http_11,
                                        std::shared_ptr<connection_state> conn)
       {

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -2782,15 +2782,11 @@ namespace glz
             return false;
          }
 
-         // Check client's Connection header (case-insensitive)
-         const auto conn_header_it = headers.find("connection");
-         if (conn_header_it != headers.end()) {
-            if (conn_header_it->contains_token("close")) {
-               return false;
-            }
-            if (conn_header_it->contains_token("keep-alive")) {
-               return true;
-            }
+         if (headers.contains_token("connection", "close")) {
+            return false;
+         }
+         if (headers.contains_token("connection", "keep-alive")) {
+            return true;
          }
 
          // Default behavior based on HTTP version
@@ -3173,14 +3169,7 @@ namespace glz
 
       inline bool is_websocket_upgrade(const glz::http_headers& headers)
       {
-         auto upgrade_it = headers.find("upgrade");
-         if (upgrade_it == headers.end()) return false;
-
-         auto connection_it = headers.find("connection");
-         if (connection_it == headers.end()) return false;
-
-         if (!upgrade_it->contains_token("websocket")) return false;
-         return connection_it->contains_token("upgrade");
+         return headers.contains_token("upgrade", "websocket") && headers.contains_token("connection", "upgrade");
       }
 
       inline void handle_websocket_upgrade_with_conn(std::shared_ptr<connection_state> conn)

--- a/include/glaze/net/websocket_client.hpp
+++ b/include/glaze/net/websocket_client.hpp
@@ -14,6 +14,7 @@
 #include "glaze/net/http_client.hpp"
 #include "glaze/net/http_headers.hpp"
 #include "glaze/net/websocket_connection.hpp"
+#include "glaze/util/compare.hpp"
 #include "glaze/util/itoa.hpp"
 
 namespace glz
@@ -74,26 +75,16 @@ namespace glz
 
          explicit impl(std::shared_ptr<asio::io_context> context) : ctx(std::move(context)) {}
 
-         static bool header_name_equal(std::string_view lhs, std::string_view rhs)
-         {
-            if (lhs.size() != rhs.size()) return false;
-            return std::equal(lhs.begin(), lhs.end(), rhs.begin(), [](char a, char b) {
-               return std::tolower(static_cast<unsigned char>(a)) == std::tolower(static_cast<unsigned char>(b));
-            });
-         }
-
          static bool header_name_starts_with(std::string_view value, std::string_view prefix)
          {
             if (value.size() < prefix.size()) return false;
-            return std::equal(prefix.begin(), prefix.end(), value.begin(), [](char a, char b) {
-               return std::tolower(static_cast<unsigned char>(a)) == std::tolower(static_cast<unsigned char>(b));
-            });
+            return glz::striequal(value.substr(0, prefix.size()), prefix);
          }
 
          static bool is_reserved_handshake_header(std::string_view name)
          {
-            return header_name_equal(name, "Host") || header_name_equal(name, "Upgrade") ||
-                   header_name_equal(name, "Connection") || header_name_starts_with(name, "Sec-WebSocket-");
+            return glz::striequal(name, "Host") || glz::striequal(name, "Upgrade") ||
+                   glz::striequal(name, "Connection") || header_name_starts_with(name, "Sec-WebSocket-");
          }
 
          // Field-name and field-value validity (tchar names, no CR/LF/CTL/DEL

--- a/include/glaze/net/websocket_client.hpp
+++ b/include/glaze/net/websocket_client.hpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "glaze/net/http_client.hpp"
+#include "glaze/net/http_headers.hpp"
 #include "glaze/net/websocket_connection.hpp"
 #include "glaze/util/itoa.hpp"
 
@@ -63,7 +64,7 @@ namespace glz
          std::shared_ptr<ssl_socket> ssl_socket_;
 #endif
          mutable std::mutex request_headers_mutex_;
-         std::vector<std::pair<std::string, std::string>> request_headers_;
+         glz::http_headers request_headers_;
          std::atomic<header_validation_error> last_header_validation_error_{header_validation_error::none};
 
          size_t max_message_size{1024 * 1024 * 16}; // 16 MB limit
@@ -127,7 +128,7 @@ namespace glz
             return true;
          }
 
-         std::vector<std::pair<std::string, std::string>> request_headers_snapshot() const
+         glz::http_headers request_headers_snapshot() const
          {
             std::lock_guard<std::mutex> lock(request_headers_mutex_);
             return request_headers_;
@@ -142,14 +143,7 @@ namespace glz
             }
 
             std::lock_guard<std::mutex> lock(request_headers_mutex_);
-            for (auto& [existing_name, existing_value] : request_headers_) {
-               if (header_name_equal(existing_name, name)) {
-                  existing_value = std::string(value);
-                  last_header_validation_error_.store(header_validation_error::none, std::memory_order_relaxed);
-                  return true;
-               }
-            }
-            request_headers_.emplace_back(std::string(name), std::string(value));
+            request_headers_.set(std::string(name), std::string(value));
             last_header_validation_error_.store(header_validation_error::none, std::memory_order_relaxed);
             return true;
          }
@@ -363,95 +357,86 @@ namespace glz
             auto response_buf = std::make_shared<asio::streambuf>(max_handshake_size);
             std::weak_ptr<impl> weak_self = weak_from_this();
 
-            asio::async_read_until(*socket, *response_buf, "\r\n\r\n",
-                                   [weak_self, socket, response_buf, expected_key](std::error_code ec, std::size_t) {
-                                      auto self = weak_self.lock();
-                                      if (!self) return; // Client was destroyed
+            asio::async_read_until(
+               *socket, *response_buf, "\r\n\r\n",
+               [weak_self, socket, response_buf, expected_key](std::error_code ec, std::size_t) {
+                  auto self = weak_self.lock();
+                  if (!self) return; // Client was destroyed
 
-                                      if (ec) {
-                                         if (self->on_error && *self->on_error) (*self->on_error)(ec);
-                                         return;
-                                      }
+                  if (ec) {
+                     if (self->on_error && *self->on_error) (*self->on_error)(ec);
+                     return;
+                  }
 
-                                      std::istream response_stream(response_buf.get());
-                                      std::string http_version;
-                                      unsigned int status_code;
-                                      std::string status_message;
+                  std::istream response_stream(response_buf.get());
+                  std::string http_version;
+                  unsigned int status_code;
+                  std::string status_message;
 
-                                      response_stream >> http_version >> status_code;
-                                      std::getline(response_stream, status_message);
+                  response_stream >> http_version >> status_code;
+                  std::getline(response_stream, status_message);
 
-                                      if (!response_stream || status_code != 101) {
-                                         if (self->on_error && *self->on_error)
-                                            (*self->on_error)(std::make_error_code(std::errc::protocol_error));
-                                         return;
-                                      }
+                  if (!response_stream || status_code != 101) {
+                     if (self->on_error && *self->on_error)
+                        (*self->on_error)(std::make_error_code(std::errc::protocol_error));
+                     return;
+                  }
 
-                                      // Parse headers to verify upgrade and accept key
-                                      std::string header;
-                                      bool upgrade_websocket = false;
-                                      bool connection_upgrade = false;
-                                      bool accept_key_valid = false;
+                  // Parse headers to verify upgrade and accept key
+                  std::string header;
+                  glz::http_headers response_headers;
 
-                                      std::string expected_accept = ws_util::generate_accept_key(expected_key);
+                  std::string expected_accept = ws_util::generate_accept_key(expected_key);
 
-                                      while (std::getline(response_stream, header) && header != "\r") {
-                                         if (!header.empty() && header.back() == '\r') header.pop_back();
+                  while (std::getline(response_stream, header) && header != "\r") {
+                     if (!header.empty() && header.back() == '\r') header.pop_back();
 
-                                         auto colon = header.find(':');
-                                         if (colon != std::string::npos) {
-                                            std::string name = header.substr(0, colon);
-                                            std::string value = header.substr(colon + 1);
+                     auto colon = header.find(':');
+                     if (colon != std::string::npos) {
+                        std::string name = header.substr(0, colon);
+                        std::string value = header.substr(colon + 1);
 
-                                            while (!value.empty() && (value.front() == ' ' || value.front() == '\t'))
-                                               value.erase(0, 1);
-                                            while (!value.empty() && (value.back() == ' ' || value.back() == '\t'))
-                                               value.pop_back();
+                        while (!value.empty() && (value.front() == ' ' || value.front() == '\t')) value.erase(0, 1);
+                        while (!value.empty() && (value.back() == ' ' || value.back() == '\t')) value.pop_back();
 
-                                            if (strncasecmp(name.c_str(), "Upgrade", 7) == 0 &&
-                                                ws_util::header_contains(value, "websocket")) {
-                                               upgrade_websocket = true;
-                                            }
-                                            else if (strncasecmp(name.c_str(), "Connection", 10) == 0 &&
-                                                     ws_util::header_contains(value, "upgrade")) {
-                                               connection_upgrade = true;
-                                            }
-                                            else if (strncasecmp(name.c_str(), "Sec-WebSocket-Accept", 20) == 0) {
-                                               if (value == expected_accept) accept_key_valid = true;
-                                            }
-                                         }
-                                      }
+                        response_headers.add(std::move(name), std::move(value));
+                     }
+                  }
 
-                                      if (!upgrade_websocket || !connection_upgrade || !accept_key_valid) {
-                                         if (self->on_error && *self->on_error)
-                                            (*self->on_error)(std::make_error_code(std::errc::protocol_error));
-                                         return;
-                                      }
+                  const bool upgrade_websocket = response_headers.contains_token("Upgrade", "websocket");
+                  const bool connection_upgrade = response_headers.contains_token("Connection", "upgrade");
+                  const bool accept_key_valid = response_headers.first_value("Sec-WebSocket-Accept") == expected_accept;
 
-                                      // Handshake successful. Transfer socket to websocket_connection.
-                                      auto ws_conn = std::make_shared<websocket_connection<SocketType>>(socket);
-                                      ws_conn->set_client_mode(true);
-                                      ws_conn->set_max_message_size(self->max_message_size);
+                  if (!upgrade_websocket || !connection_upgrade || !accept_key_valid) {
+                     if (self->on_error && *self->on_error)
+                        (*self->on_error)(std::make_error_code(std::errc::protocol_error));
+                     return;
+                  }
 
-                                      if (self->on_message && *self->on_message) ws_conn->on_message(*self->on_message);
-                                      if (self->on_close && *self->on_close) ws_conn->on_close(*self->on_close);
-                                      if (self->on_error && *self->on_error) ws_conn->on_error(*self->on_error);
+                  // Handshake successful. Transfer socket to websocket_connection.
+                  auto ws_conn = std::make_shared<websocket_connection<SocketType>>(socket);
+                  ws_conn->set_client_mode(true);
+                  ws_conn->set_max_message_size(self->max_message_size);
 
-                                      {
-                                         std::lock_guard<std::mutex> lock(self->connection_mutex);
-                                         self->connection = ws_conn;
-                                      }
+                  if (self->on_message && *self->on_message) ws_conn->on_message(*self->on_message);
+                  if (self->on_close && *self->on_close) ws_conn->on_close(*self->on_close);
+                  if (self->on_error && *self->on_error) ws_conn->on_error(*self->on_error);
 
-                                      if (self->on_open && *self->on_open) (*self->on_open)();
+                  {
+                     std::lock_guard<std::mutex> lock(self->connection_mutex);
+                     self->connection = ws_conn;
+                  }
 
-                                      if (response_buf->size() > 0) {
-                                         std::vector<uint8_t> initial_data(response_buf->size());
-                                         asio::buffer_copy(asio::buffer(initial_data), response_buf->data());
-                                         ws_conn->set_initial_data(std::move(initial_data));
-                                      }
+                  if (self->on_open && *self->on_open) (*self->on_open)();
 
-                                      ws_conn->start_read();
-                                   });
+                  if (response_buf->size() > 0) {
+                     std::vector<uint8_t> initial_data(response_buf->size());
+                     asio::buffer_copy(asio::buffer(initial_data), response_buf->data());
+                     ws_conn->set_initial_data(std::move(initial_data));
+                  }
+
+                  ws_conn->start_read();
+               });
          }
 
          void send_text(std::string_view msg)

--- a/include/glaze/net/websocket_connection.hpp
+++ b/include/glaze/net/websocket_connection.hpp
@@ -252,40 +252,6 @@ namespace glz
          return glz::write_base64(std::string_view{reinterpret_cast<char*>(hash), sizeof(hash)});
       }
 
-      // Check if a string contains a value (case-insensitive, comma-separated)
-      inline bool header_contains(std::string_view header, std::string_view value)
-      {
-         while (!header.empty()) {
-            // Skip whitespace
-            while (!header.empty() && (header.front() == ' ' || header.front() == '\t')) {
-               header.remove_prefix(1);
-            }
-
-            if (header.empty()) break;
-
-            // Find the end of this token
-            auto comma_pos = header.find(',');
-            std::string_view token = header.substr(0, comma_pos);
-
-            // Remove trailing whitespace from token
-            while (!token.empty() && (token.back() == ' ' || token.back() == '\t')) {
-               token.remove_suffix(1);
-            }
-
-            // Case-insensitive comparison
-            if (token.size() == value.size() &&
-                std::equal(token.begin(), token.end(), value.begin(), value.end(), [](char a, char b) {
-                   return std::tolower(static_cast<unsigned char>(a)) == std::tolower(static_cast<unsigned char>(b));
-                })) {
-               return true;
-            }
-
-            if (comma_pos == std::string_view::npos) break;
-            header.remove_prefix(comma_pos + 1);
-         }
-
-         return false;
-      }
    }
 
    // Forward declarations

--- a/include/glaze/net/websocket_connection.hpp
+++ b/include/glaze/net/websocket_connection.hpp
@@ -580,19 +580,17 @@ namespace glz
       inline void perform_handshake(const request& req)
       {
          // Validate WebSocket upgrade request
-         auto it = req.headers.find("upgrade");
-         if (it == req.headers.end() || !glz::striequal(it->value, "websocket")) {
+         if (!req.headers.contains_token("upgrade", "websocket")) {
             do_close();
             return;
          }
 
-         it = req.headers.find("connection");
-         if (it == req.headers.end() || !it->contains_token("upgrade")) {
+         if (!req.headers.contains_token("connection", "upgrade")) {
             do_close();
             return;
          }
 
-         it = req.headers.find("sec-websocket-version");
+         auto it = req.headers.find("sec-websocket-version");
          if (it == req.headers.end() || it->value != "13") {
             do_close();
             return;

--- a/include/glaze/net/websocket_connection.hpp
+++ b/include/glaze/net/websocket_connection.hpp
@@ -18,6 +18,8 @@
 #include <utility>
 #include <vector>
 
+#include "glaze/util/compare.hpp"
+
 // Optional OpenSSL support - detected at compile time
 #if defined(GLZ_ENABLE_OPENSSL) && __has_include(<openssl/sha.h>)
 #include <openssl/sha.h>
@@ -613,24 +615,19 @@ namespace glz
       {
          // Validate WebSocket upgrade request
          auto it = req.headers.find("upgrade");
-         constexpr std::string_view websocket_str = "websocket";
-         if (it == req.headers.end() || !std::equal(it->second.begin(), it->second.end(), websocket_str.begin(),
-                                                    websocket_str.end(), [](char a, char b) {
-                                                       return std::tolower(static_cast<unsigned char>(a)) ==
-                                                              std::tolower(static_cast<unsigned char>(b));
-                                                    })) {
+         if (it == req.headers.end() || !glz::striequal(it->value, "websocket")) {
             do_close();
             return;
          }
 
          it = req.headers.find("connection");
-         if (it == req.headers.end() || !ws_util::header_contains(it->second, "upgrade")) {
+         if (it == req.headers.end() || !it->contains_token("upgrade")) {
             do_close();
             return;
          }
 
          it = req.headers.find("sec-websocket-version");
-         if (it == req.headers.end() || it->second != "13") {
+         if (it == req.headers.end() || it->value != "13") {
             do_close();
             return;
          }
@@ -649,8 +646,9 @@ namespace glz
             }
          }
 
-         // Generate accept key
-         std::string accept_key = ws_util::generate_accept_key(it->second);
+         std::string_view sec_websocket_key = it->value;
+
+         std::string accept_key = ws_util::generate_accept_key(sec_websocket_key);
 
          // Send handshake response
          std::string response_str =

--- a/include/glaze/util/compare.hpp
+++ b/include/glaze/util/compare.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <array>
 #include <bit>
 #include <cstdint>
 #include <cstring>

--- a/tests/networking_tests/cors_test/cors_test.cpp
+++ b/tests/networking_tests/cors_test/cors_test.cpp
@@ -30,8 +30,8 @@ suite cors_origin_tests = [] {
       expect(glz::is_origin_allowed(config, "https://evil.example"));
 
       auto res = run_cors(config, "https://evil.example");
-      expect(res.response_headers["access-control-allow-origin"] == "*");
-      expect(res.response_headers.count("access-control-allow-credentials") == 0);
+      expect(res.response_headers.first_value("access-control-allow-origin") == "*");
+      expect(!res.response_headers.contains("access-control-allow-credentials"));
    };
 
    "wildcard_with_credentials_rejects_unlisted_origin"_test = [] {
@@ -41,8 +41,8 @@ suite cors_origin_tests = [] {
       expect(not glz::is_origin_allowed(config, "https://evil.example"));
 
       auto res = run_cors(config, "https://evil.example");
-      expect(res.response_headers.count("access-control-allow-origin") == 0);
-      expect(res.response_headers.count("access-control-allow-credentials") == 0);
+      expect(!res.response_headers.contains("access-control-allow-origin"));
+      expect(!res.response_headers.contains("access-control-allow-credentials"));
    };
 
    "credentials_allow_exact_listed_origin"_test = [] {
@@ -53,8 +53,8 @@ suite cors_origin_tests = [] {
       expect(not glz::is_origin_allowed(config, "https://evil.example"));
 
       auto res = run_cors(config, "https://app.example");
-      expect(res.response_headers["access-control-allow-origin"] == "https://app.example");
-      expect(res.response_headers["access-control-allow-credentials"] == "true");
+      expect(res.response_headers.first_value("access-control-allow-origin") == "https://app.example");
+      expect(res.response_headers.first_value("access-control-allow-credentials") == "true");
    };
 
    "empty_origins_with_credentials_rejects"_test = [] {

--- a/tests/networking_tests/cors_test/cors_test.cpp
+++ b/tests/networking_tests/cors_test/cors_test.cpp
@@ -3,6 +3,7 @@
 
 #include "glaze/net/cors.hpp"
 
+#include "glaze/net/http_headers.hpp"
 #include "ut/ut.hpp"
 
 using namespace ut;
@@ -14,7 +15,7 @@ namespace
       auto middleware = glz::create_cors_middleware(config);
       glz::request req{};
       req.method = glz::http_method::GET;
-      req.headers["origin"] = std::string(origin);
+      req.headers.set("origin", std::string(origin));
       glz::response res{};
       middleware(req, res);
       return res;

--- a/tests/networking_tests/http_chunked_test/http_chunked_test.cpp
+++ b/tests/networking_tests/http_chunked_test/http_chunked_test.cpp
@@ -379,13 +379,13 @@ suite chunked_sync_tests = [] {
          auto custom = result->response_headers.find("x-custom-header");
          expect(custom != result->response_headers.end()) << "Custom header should be present";
          if (custom != result->response_headers.end()) {
-            expect(custom->second == "custom-value") << "Custom header value should match";
+            expect(custom->value == "custom-value") << "Custom header value should match";
          }
 
          auto te = result->response_headers.find("transfer-encoding");
          expect(te != result->response_headers.end()) << "Transfer-Encoding header should be present";
          if (te != result->response_headers.end()) {
-            expect(te->second.find("chunked") != std::string::npos) << "Transfer-Encoding should be chunked";
+            expect(te->value.find("chunked") != std::string::npos) << "Transfer-Encoding should be chunked";
          }
       }
 

--- a/tests/networking_tests/http_client_ssl_test/http_client_ssl_test.cpp
+++ b/tests/networking_tests/http_client_ssl_test/http_client_ssl_test.cpp
@@ -448,9 +448,9 @@ suite https_client_tests = [] {
       glz::http_client client;
       client.set_ssl_verify_mode(asio::ssl::verify_none);
 
-      std::unordered_map<std::string, std::string> headers;
-      headers["X-Custom-Header"] = "CustomValue";
-      headers["Authorization"] = "Bearer test-token";
+      glz::http_headers headers;
+      headers.set("X-Custom-Header", "CustomValue");
+      headers.set("Authorization", "Bearer test-token");
 
       auto result = client.get(g_server.base_url() + "/headers", headers);
       expect(result.has_value()) << "HTTPS with custom headers should succeed";

--- a/tests/networking_tests/http_client_ssl_test/http_client_ssl_test.cpp
+++ b/tests/networking_tests/http_client_ssl_test/http_client_ssl_test.cpp
@@ -456,7 +456,7 @@ suite https_client_tests = [] {
       expect(result.has_value()) << "HTTPS with custom headers should succeed";
       if (result.has_value()) {
          expect(result->status_code == 200);
-         expect(result->response_body.find("x-custom-header") != std::string::npos);
+         expect(result->response_body.find("X-Custom-Header") != std::string::npos);
       }
    };
 

--- a/tests/networking_tests/http_client_test/http_client_test.cpp
+++ b/tests/networking_tests/http_client_test/http_client_test.cpp
@@ -326,7 +326,7 @@ class simple_test_client
    }
 
    std::expected<response, std::error_code> options(
-      const std::string& url, const std::vector<std::pair<std::string, std::string>>& extra_headers)
+      const std::string& url, const glz::http_headers& extra_headers)
    {
       auto url_parts = parse_url(url);
       if (!url_parts) {
@@ -342,7 +342,7 @@ class simple_test_client
 
    std::expected<response, std::error_code> perform_request(
       const std::string& method, const url_parts& url, const std::string& body,
-      std::vector<std::pair<std::string, std::string>> extra_headers = {})
+      glz::http_headers extra_headers = {})
    {
       std::promise<std::expected<response, std::error_code>> promise;
       auto future = promise.get_future();
@@ -413,8 +413,7 @@ class simple_test_client
                   std::find_if(value.rbegin(), value.rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(),
                   value.end());
 
-               auto lower_name = glz::to_lower_case(name);
-               resp.response_headers[lower_name] = value;
+               resp.response_headers.add(std::move(name), std::move(value));
             }
 
             // Read body
@@ -482,7 +481,7 @@ suite working_http_tests = [] {
       expect(server.start()) << "Server should start\n";
 
       simple_test_client client;
-      std::vector<std::pair<std::string, std::string>> headers = {
+      glz::http_headers headers = {
          {"Origin", "http://localhost"},
          {"Access-Control-Request-Method", "GET"},
          {"Access-Control-Request-Headers", "X-Test-Header"},
@@ -512,7 +511,7 @@ suite working_http_tests = [] {
       expect(server.start()) << "Server should start\n";
 
       simple_test_client client;
-      std::vector<std::pair<std::string, std::string>> headers = {
+      glz::http_headers headers = {
          {"Origin", "http://app.allowed.local"},
          {"Access-Control-Request-Method", "GET"},
       };
@@ -523,19 +522,19 @@ suite working_http_tests = [] {
          auto origin_header = allowed->response_headers.find("access-control-allow-origin");
          expect(origin_header != allowed->response_headers.end()) << "Allow-Origin header should be present\n";
          if (origin_header != allowed->response_headers.end()) {
-            expect(origin_header->second == "http://app.allowed.local")
+            expect(origin_header->value == "http://app.allowed.local")
                << "Origin should be echoed for allowed pattern\n";
          }
       }
 
-      headers[0].second = "http://special.local";
+      headers.set("Origin", "http://special.local");
       auto allowed_callback = client.options(server.base_url() + "/hello", headers);
       expect(allowed_callback.has_value()) << "Dynamic callback origin should succeed\n";
       if (allowed_callback.has_value()) {
          expect(allowed_callback->status_code == 204);
       }
 
-      headers[0].second = "http://denied.local";
+      headers.set("Origin", "http://denied.local");
       auto denied = client.options(server.base_url() + "/hello", headers);
       expect(denied.has_value()) << "Request should return a response even when denied\n";
       if (denied.has_value()) {
@@ -571,19 +570,19 @@ suite working_http_tests = [] {
          auto methods_it = result->response_headers.find("access-control-allow-methods");
          expect(methods_it != result->response_headers.end()) << "Allow-Methods header missing\n";
          if (methods_it != result->response_headers.end()) {
-            expect(methods_it->second == "GET, HEAD, POST, PUT, DELETE, PATCH");
+            expect(methods_it->value == "GET, HEAD, POST, PUT, DELETE, PATCH");
          }
 
          auto headers_it = result->response_headers.find("access-control-allow-headers");
          expect(headers_it != result->response_headers.end());
          if (headers_it != result->response_headers.end()) {
-            expect(headers_it->second == "X-Test-Header");
+            expect(headers_it->value == "X-Test-Header");
          }
 
          auto max_age_it = result->response_headers.find("access-control-max-age");
          expect(max_age_it != result->response_headers.end());
          if (max_age_it != result->response_headers.end()) {
-            expect(max_age_it->second == "123");
+            expect(max_age_it->value == "123");
          }
       }
 
@@ -611,7 +610,7 @@ suite working_http_tests = [] {
          auto headers_it = result->response_headers.find("access-control-allow-headers");
          expect(headers_it != result->response_headers.end());
          if (headers_it != result->response_headers.end()) {
-            expect(headers_it->second == "*") << "Expected * but got " << headers_it->second << "\n";
+            expect(headers_it->value == "*") << "Expected * but got " << headers_it->value << "\n";
          }
       }
 
@@ -636,7 +635,7 @@ suite working_http_tests = [] {
          auto allow_it = result->response_headers.find("allow");
          expect(allow_it != result->response_headers.end()) << "Allow header must be present\n";
          if (allow_it != result->response_headers.end()) {
-            expect(allow_it->second.find("GET") != std::string::npos)
+            expect(allow_it->value.find("GET") != std::string::npos)
                << "Allow header should list the implemented method\n";
          }
       }
@@ -724,7 +723,7 @@ suite working_http_tests = [] {
          auto allow_it = put_result->response_headers.find("allow");
          expect(allow_it != put_result->response_headers.end()) << "Allow header should be present\n";
          if (allow_it != put_result->response_headers.end()) {
-            expect(allow_it->second.find("PUT") != std::string::npos) << "Allow should advertise PUT\n";
+            expect(allow_it->value.find("PUT") != std::string::npos) << "Allow should advertise PUT\n";
          }
       }
 
@@ -782,26 +781,26 @@ suite working_http_tests = [] {
          auto origin_it = result->response_headers.find("access-control-allow-origin");
          expect(origin_it != result->response_headers.end()) << "Allow-Origin header missing\n";
          if (origin_it != result->response_headers.end()) {
-            expect(origin_it->second == "https://app.local")
+            expect(origin_it->value == "https://app.local")
                << "Allow-Origin should echo the specific origin, not '*', when credentials are allowed\n";
          }
 
          auto credentials_it = result->response_headers.find("access-control-allow-credentials");
          expect(credentials_it != result->response_headers.end()) << "Allow-Credentials should be present\n";
          if (credentials_it != result->response_headers.end()) {
-            expect(credentials_it->second == "true");
+            expect(credentials_it->value == "true");
          }
 
          auto methods_it = result->response_headers.find("access-control-allow-methods");
          expect(methods_it != result->response_headers.end()) << "Allow-Methods should be present\n";
          if (methods_it != result->response_headers.end()) {
-            expect(methods_it->second == "GET, POST");
+            expect(methods_it->value == "GET, POST");
          }
 
          auto max_age_it = result->response_headers.find("access-control-max-age");
          expect(max_age_it != result->response_headers.end()) << "Max-Age should be present\n";
          if (max_age_it != result->response_headers.end()) {
-            expect(max_age_it->second == "7200");
+            expect(max_age_it->value == "7200");
          }
       }
 
@@ -973,7 +972,7 @@ suite glz_http_client_tests = [] {
 
       glz::http_client client;
 
-      std::unordered_map<std::string, std::string> headers{{"x-test-header", "header-value"}};
+      glz::http_headers headers{{"x-test-header", "header-value"}};
       auto result = client.put(server.base_url() + "/update", "payload", headers);
 
       expect(result.has_value()) << "PUT request should succeed";
@@ -997,7 +996,7 @@ suite glz_http_client_tests = [] {
       auto ec = glz::write_json(payload, expected_json);
       expect(!ec) << "Serializing payload should succeed";
 
-      std::unordered_map<std::string, std::string> extra_headers{{"x-extra", "value"}};
+      glz::http_headers extra_headers{{"x-extra", "value"}};
       auto result = client.put_json(server.base_url() + "/json", payload, extra_headers);
 
       expect(result.has_value()) << "PUT JSON request should succeed";

--- a/tests/networking_tests/http_client_test/http_client_test.cpp
+++ b/tests/networking_tests/http_client_test/http_client_test.cpp
@@ -161,7 +161,7 @@ class working_test_server
          response_body.append(req.body);
          if (auto it = req.headers.find("x-test-header"); it != req.headers.end()) {
             response_body.append(":");
-            response_body.append(it->second);
+            response_body.append(it->value);
          }
          res.status(200).content_type("text/plain").body(response_body);
       });
@@ -174,7 +174,7 @@ class working_test_server
          }
 
          std::string response_body = "CT=";
-         response_body.append(content_type->second);
+         response_body.append(content_type->value);
          response_body.append(";BODY=");
          response_body.append(req.body);
          res.status(200).content_type("text/plain").body(response_body);

--- a/tests/networking_tests/http_client_test/http_client_test.cpp
+++ b/tests/networking_tests/http_client_test/http_client_test.cpp
@@ -1015,7 +1015,7 @@ suite glz_http_client_tests = [] {
       server.stop();
    };
 
-   "put_json_keeps_a_caller_supplied_content_type"_test = [] {
+   "put_json_keeps_caller_content_type"_test = [] {
       working_test_server server;
       expect(server.start());
 
@@ -1037,7 +1037,7 @@ suite glz_http_client_tests = [] {
       server.stop();
    };
 
-   "put_json_matches_a_lowercase_caller_content_type"_test = [] {
+   "put_json_matches_lowercase_content_type"_test = [] {
       working_test_server server;
       expect(server.start());
 
@@ -1613,7 +1613,7 @@ suite host_header_tests = [] {
 };
 
 suite with_json_content_type_tests = [] {
-   "absent_content_type_gets_the_json_default"_test = [] {
+   "with_json_content_type_sets_default"_test = [] {
       auto headers = glz::detail::with_json_content_type(glz::http_headers{{"X-Extra", "value"}});
 
       expect(headers.count("Content-Type") == 1);
@@ -1621,7 +1621,7 @@ suite with_json_content_type_tests = [] {
       expect(headers.first_value("X-Extra") == "value") << "Caller headers should be carried through";
    };
 
-   "a_caller_content_type_is_left_alone"_test = [] {
+   "with_json_content_type_keeps_caller_value"_test = [] {
       auto headers =
          glz::detail::with_json_content_type(glz::http_headers{{"Content-Type", "application/vnd.api+json"}});
 
@@ -1629,14 +1629,14 @@ suite with_json_content_type_tests = [] {
       expect(headers.first_value("Content-Type") == "application/vnd.api+json");
    };
 
-   "the_lookup_ignores_field_name_case"_test = [] {
+   "with_json_content_type_ignores_name_case"_test = [] {
       auto headers = glz::detail::with_json_content_type(glz::http_headers{{"content-type", "text/plain"}});
 
       expect(headers.count("Content-Type") == 1) << "A lowercase name must not yield a second field";
       expect(headers.first_value("Content-Type") == "text/plain");
    };
 
-   "the_caller_headers_are_not_mutated"_test = [] {
+   "with_json_content_type_copies_caller_headers"_test = [] {
       glz::http_headers original{{"X-Extra", "value"}};
       auto headers = glz::detail::with_json_content_type(original);
 

--- a/tests/networking_tests/http_client_test/http_client_test.cpp
+++ b/tests/networking_tests/http_client_test/http_client_test.cpp
@@ -167,14 +167,16 @@ class working_test_server
       });
 
       server_.put("/json", [](const request& req, response& res) {
-         auto content_type = req.headers.find("content-type");
-         if (content_type == req.headers.end()) {
+         auto content_type = req.headers.first_value("content-type");
+         if (!content_type) {
             res.status(415).body("missing content-type");
             return;
          }
 
          std::string response_body = "CT=";
-         response_body.append(content_type->value);
+         response_body.append(*content_type);
+         response_body.append(";CT_COUNT=");
+         response_body.append(std::to_string(req.headers.count("content-type")));
          response_body.append(";BODY=");
          response_body.append(req.body);
          res.status(200).content_type("text/plain").body(response_body);
@@ -1004,8 +1006,54 @@ suite glz_http_client_tests = [] {
          expect(result->status_code == 200) << "PUT JSON status should be 200";
          expect(result->response_body.find("CT=application/json") != std::string::npos)
             << "Content-Type header should be forwarded";
+         expect(result->response_body.find("CT_COUNT=1") != std::string::npos)
+            << "Content-Type should reach the wire exactly once";
          expect(result->response_body.find("BODY=" + expected_json) != std::string::npos)
             << "JSON body should be forwarded";
+      }
+
+      server.stop();
+   };
+
+   "put_json_keeps_a_caller_supplied_content_type"_test = [] {
+      working_test_server server;
+      expect(server.start());
+
+      glz::http_client client;
+
+      test_http_client::put_payload payload{.value = 7, .message = "vendor"};
+
+      glz::http_headers vendor_headers{{"Content-Type", "application/vnd.api+json"}};
+      auto result = client.put_json(server.base_url() + "/json", payload, vendor_headers);
+
+      expect(result.has_value()) << "PUT JSON request should succeed";
+      if (result.has_value()) {
+         expect(result->response_body.find("CT=application/vnd.api+json") != std::string::npos)
+            << "A caller-supplied Content-Type must not be replaced by application/json";
+         expect(result->response_body.find("CT_COUNT=1") != std::string::npos)
+            << "The default must not be appended alongside the caller's field";
+      }
+
+      server.stop();
+   };
+
+   "put_json_matches_a_lowercase_caller_content_type"_test = [] {
+      working_test_server server;
+      expect(server.start());
+
+      glz::http_client client;
+
+      test_http_client::put_payload payload{.value = 9, .message = "charset"};
+
+      glz::http_headers lowercase_headers{{"content-type", "application/json; charset=utf-8"}};
+      auto result = client.put_json(server.base_url() + "/json", payload, lowercase_headers);
+
+      expect(result.has_value()) << "PUT JSON request should succeed";
+      if (result.has_value()) {
+         expect(result->response_body.find("CT=application/json; charset=utf-8") != std::string::npos)
+            << "The charset parameter must survive";
+         expect(result->response_body.find("CT_COUNT=1") != std::string::npos)
+            << "A lowercase field name must be recognized as already present";
       }
 
       server.stop();
@@ -1561,6 +1609,39 @@ suite host_header_tests = [] {
 
       const std::string expected_host = "127.0.0.1:" + std::to_string(server.port());
       expect(server.host_header() == expected_host) << "Host header should include authority port";
+   };
+};
+
+suite with_json_content_type_tests = [] {
+   "absent_content_type_gets_the_json_default"_test = [] {
+      auto headers = glz::detail::with_json_content_type(glz::http_headers{{"X-Extra", "value"}});
+
+      expect(headers.count("Content-Type") == 1);
+      expect(headers.first_value("Content-Type") == "application/json");
+      expect(headers.first_value("X-Extra") == "value") << "Caller headers should be carried through";
+   };
+
+   "a_caller_content_type_is_left_alone"_test = [] {
+      auto headers =
+         glz::detail::with_json_content_type(glz::http_headers{{"Content-Type", "application/vnd.api+json"}});
+
+      expect(headers.count("Content-Type") == 1);
+      expect(headers.first_value("Content-Type") == "application/vnd.api+json");
+   };
+
+   "the_lookup_ignores_field_name_case"_test = [] {
+      auto headers = glz::detail::with_json_content_type(glz::http_headers{{"content-type", "text/plain"}});
+
+      expect(headers.count("Content-Type") == 1) << "A lowercase name must not yield a second field";
+      expect(headers.first_value("Content-Type") == "text/plain");
+   };
+
+   "the_caller_headers_are_not_mutated"_test = [] {
+      glz::http_headers original{{"X-Extra", "value"}};
+      auto headers = glz::detail::with_json_content_type(original);
+
+      expect(!original.contains("Content-Type")) << "The caller's container is taken by value";
+      expect(headers.contains("Content-Type"));
    };
 };
 

--- a/tests/networking_tests/http_content_length_test/http_content_length_test.cpp
+++ b/tests/networking_tests/http_content_length_test/http_content_length_test.cpp
@@ -83,6 +83,62 @@ static const std::string truncated_response =
    "\r\n"
    "ABC";
 
+// Two Content-Length fields that disagree. Framing by either one leaves the
+// remainder of the segment on the socket for the next read to pick up as a
+// response the server never sent - here a 200 carrying "INJECTED". RFC 9112 §6.3
+// leaves no correct choice between them, so the message has to be rejected.
+static const std::string conflicting_content_length_response =
+   "HTTP/1.1 200 OK\r\n"
+   "Content-Length: 3\r\n"
+   "Content-Length: 47\r\n"
+   "Connection: keep-alive\r\n"
+   "\r\n"
+   "ABCHTTP/1.1 200 OK\r\nContent-Length: 8\r\n\r\nINJECTED";
+
+// Repeated but identical, which resolves to one unambiguous length. RFC 9112 §6.3
+// permits collapsing these, and the server does the same for a request, so the
+// client must not reject the response.
+static const std::string agreeing_content_length_response =
+   "HTTP/1.1 200 OK\r\n"
+   "Content-Length: 3\r\n"
+   "Content-Length: 3\r\n"
+   "Connection: keep-alive\r\n"
+   "\r\n"
+   "ABC";
+
+// A Content-Length that is not a bare decimal resolves to no length at all.
+// Defaulting it to zero would leave the body on the socket to be read as the head
+// of the next response.
+static const std::string malformed_content_length_response =
+   "HTTP/1.1 200 OK\r\n"
+   "Content-Length: 3, 3\r\n"
+   "Connection: keep-alive\r\n"
+   "\r\n"
+   "ABC";
+
+// Chunked framing plus a Content-Length that would be rejected on its own. RFC 9112
+// 6.3 has Transfer-Encoding override Content-Length, so the body comes from the chunk
+// sizes and the unusable field is simply never read.
+static const std::string chunked_with_malformed_content_length_response =
+   "HTTP/1.1 200 OK\r\n"
+   "Transfer-Encoding: chunked\r\n"
+   "Content-Length: abc\r\n"
+   "Connection: keep-alive\r\n"
+   "\r\n"
+   "3\r\nABC\r\n0\r\n\r\n";
+
+// RFC 9112 5 admits OWS on both sides of a field value, and RFC 9110 5.5 requires a
+// recipient to strip it. These fields are conformant, so a client that frames the
+// body by a strict parse of Content-Length has to trim before parsing rather than
+// reject the response.
+static const std::string padded_content_length_response =
+   "HTTP/1.1 200 OK\r\n"
+   "Content-Length: 3 \r\n"
+   "X-Padded: \tspaced out\t \r\n"
+   "Connection: keep-alive\r\n"
+   "\r\n"
+   "ABC";
+
 suite content_length_framing = [] {
    "async_body_clamped_to_content_length"_test = [] {
       uint16_t port = 0;
@@ -142,6 +198,269 @@ suite content_length_framing = [] {
       server.join();
 
       expect(!result.has_value()) << "sync: a truncated Content-Length response must be an error, not a short body";
+   };
+};
+
+// A response the client cannot frame to a single body length must fail the request
+// outright. Accepting one of two disagreeing lengths is the client half of the
+// smuggling desync the server already rejects on a request (CL.CL, 400 + close).
+suite conflicting_content_length = [] {
+   "async_conflicting_content_length_is_error"_test = [] {
+      uint16_t port = 0;
+      auto server = start_raw_server(port, conflicting_content_length_response);
+
+      glz::http_client client;
+      auto result = client.get_async("http://127.0.0.1:" + std::to_string(port) + "/", {}).get();
+
+      server.join();
+
+      expect(!result.has_value()) << "async: disagreeing Content-Length fields must fail the request";
+      if (!result.has_value()) {
+         expect(result.error() == glz::make_error_code(glz::http_client_error::unframed_response));
+      }
+      else {
+         expect(result->response_body.find("INJECTED") == std::string::npos)
+            << "a smuggled response must never surface as body data";
+      }
+   };
+
+   "sync_conflicting_content_length_is_error"_test = [] {
+      uint16_t port = 0;
+      auto server = start_raw_server(port, conflicting_content_length_response);
+
+      glz::http_client client;
+      auto result = client.get("http://127.0.0.1:" + std::to_string(port) + "/");
+
+      server.join();
+
+      expect(!result.has_value()) << "sync: disagreeing Content-Length fields must fail the request";
+      if (!result.has_value()) {
+         expect(result.error() == glz::make_error_code(glz::http_client_error::unframed_response));
+      }
+      else {
+         expect(result->response_body.find("INJECTED") == std::string::npos)
+            << "a smuggled response must never surface as body data";
+      }
+   };
+
+   "async_repeated_agreeing_content_length_is_accepted"_test = [] {
+      uint16_t port = 0;
+      auto server = start_raw_server(port, agreeing_content_length_response);
+
+      glz::http_client client;
+      auto result = client.get_async("http://127.0.0.1:" + std::to_string(port) + "/", {}).get();
+
+      server.join();
+
+      expect(result.has_value()) << "async: identical repeats resolve to one length and must be accepted";
+      if (result) {
+         expect(result->response_body == "ABC");
+      }
+   };
+
+   "sync_repeated_agreeing_content_length_is_accepted"_test = [] {
+      uint16_t port = 0;
+      auto server = start_raw_server(port, agreeing_content_length_response);
+
+      glz::http_client client;
+      auto result = client.get("http://127.0.0.1:" + std::to_string(port) + "/");
+
+      server.join();
+
+      expect(result.has_value()) << "sync: identical repeats resolve to one length and must be accepted";
+      if (result) {
+         expect(result->response_body == "ABC");
+      }
+   };
+
+   "sync_malformed_content_length_is_error"_test = [] {
+      uint16_t port = 0;
+      auto server = start_raw_server(port, malformed_content_length_response);
+
+      glz::http_client client;
+      auto result = client.get("http://127.0.0.1:" + std::to_string(port) + "/");
+
+      server.join();
+
+      expect(!result.has_value()) << "sync: a Content-Length that is not a bare decimal must fail the request";
+      if (!result.has_value()) {
+         expect(result.error() == glz::make_error_code(glz::http_client_error::unframed_response));
+      }
+   };
+
+   "async_malformed_content_length_is_error"_test = [] {
+      uint16_t port = 0;
+      auto server = start_raw_server(port, malformed_content_length_response);
+
+      glz::http_client client;
+      auto result = client.get_async("http://127.0.0.1:" + std::to_string(port) + "/", {}).get();
+
+      server.join();
+
+      expect(!result.has_value()) << "async: a Content-Length that is not a bare decimal must fail the request";
+      if (!result.has_value()) {
+         expect(result.error() == glz::make_error_code(glz::http_client_error::unframed_response));
+      }
+   };
+};
+
+// Trailing OWS is legal and must be stripped before the value is evaluated, not
+// treated as part of it. The server already does this; the client parsers must
+// agree, or a conformant response fails the strict Content-Length parse.
+suite optional_whitespace_around_field_values = [] {
+   "sync_trailing_whitespace_is_stripped"_test = [] {
+      uint16_t port = 0;
+      auto server = start_raw_server(port, padded_content_length_response);
+
+      glz::http_client client;
+      auto result = client.get("http://127.0.0.1:" + std::to_string(port) + "/");
+
+      server.join();
+
+      expect(result.has_value()) << "sync: 'Content-Length: 3 ' is conformant and must not fail the request";
+      if (result) {
+         expect(result->response_body == "ABC");
+         expect(result->response_headers.first_value("Content-Length") == "3") << "trailing OWS must not be stored";
+         expect(result->response_headers.first_value("X-Padded") == "spaced out")
+            << "OWS must be stripped from both ends of every field, not just Content-Length";
+      }
+   };
+
+   "async_trailing_whitespace_is_stripped"_test = [] {
+      uint16_t port = 0;
+      auto server = start_raw_server(port, padded_content_length_response);
+
+      glz::http_client client;
+      auto result = client.get_async("http://127.0.0.1:" + std::to_string(port) + "/", {}).get();
+
+      server.join();
+
+      expect(result.has_value()) << "async: 'Content-Length: 3 ' is conformant and must not fail the request";
+      if (result) {
+         expect(result->response_body == "ABC");
+         expect(result->response_headers.first_value("Content-Length") == "3") << "trailing OWS must not be stored";
+         expect(result->response_headers.first_value("X-Padded") == "spaced out")
+            << "OWS must be stripped from both ends of every field, not just Content-Length";
+      }
+   };
+};
+
+// A chunked response is framed by its chunk sizes, so a Content-Length the client
+// never consults must not decide whether the request succeeds.
+suite chunked_overrides_content_length = [] {
+   "sync_chunked_ignores_an_unusable_content_length"_test = [] {
+      uint16_t port = 0;
+      auto server = start_raw_server(port, chunked_with_malformed_content_length_response);
+
+      glz::http_client client;
+      auto result = client.get("http://127.0.0.1:" + std::to_string(port) + "/");
+
+      server.join();
+
+      expect(result.has_value()) << "sync: chunked framing must win over an unusable Content-Length";
+      if (result) {
+         expect(result->response_body == "ABC") << "body must come from the chunk sizes";
+      }
+   };
+
+   "async_chunked_ignores_an_unusable_content_length"_test = [] {
+      uint16_t port = 0;
+      auto server = start_raw_server(port, chunked_with_malformed_content_length_response);
+
+      glz::http_client client;
+      auto result = client.get_async("http://127.0.0.1:" + std::to_string(port) + "/", {}).get();
+
+      server.join();
+
+      expect(result.has_value()) << "async: chunked framing must win over an unusable Content-Length";
+      if (result) {
+         expect(result->response_body == "ABC") << "body must come from the chunk sizes";
+      }
+   };
+};
+
+// read_content_length is the single decision point both client paths share, so pin
+// its behavior directly rather than only through the socket harness.
+suite read_content_length_unit = [] {
+   "absent_when_no_field"_test = [] {
+      const auto parsed = glz::detail::read_content_length(glz::http_headers{{"Connection", "keep-alive"}});
+      expect(parsed.state == glz::detail::content_length_state::absent);
+   };
+
+   "present_for_a_single_decimal"_test = [] {
+      const auto parsed = glz::detail::read_content_length(glz::http_headers{{"Content-Length", "42"}});
+      expect(parsed.state == glz::detail::content_length_state::present);
+      expect(parsed.value == 42u);
+   };
+
+   "name_case_is_ignored"_test = [] {
+      const auto parsed = glz::detail::read_content_length(glz::http_headers{{"content-length", "7"}});
+      expect(parsed.state == glz::detail::content_length_state::present);
+      expect(parsed.value == 7u);
+   };
+
+   "identical_repeats_collapse"_test = [] {
+      const auto parsed =
+         glz::detail::read_content_length(glz::http_headers{{"Content-Length", "3"}, {"Content-Length", "3"}});
+      expect(parsed.state == glz::detail::content_length_state::present);
+      expect(parsed.value == 3u);
+   };
+
+   "disagreeing_repeats_are_unframed"_test = [] {
+      const auto parsed =
+         glz::detail::read_content_length(glz::http_headers{{"Content-Length", "3"}, {"Content-Length", "47"}});
+      expect(parsed.state == glz::detail::content_length_state::unframed);
+   };
+
+   "a_trailing_list_is_unframed"_test = [] {
+      const auto parsed = glz::detail::read_content_length(glz::http_headers{{"Content-Length", "3, 3"}});
+      expect(parsed.state == glz::detail::content_length_state::unframed);
+   };
+
+   "non_digits_are_unframed"_test = [] {
+      expect(glz::detail::read_content_length(glz::http_headers{{"Content-Length", "abc"}}).state ==
+             glz::detail::content_length_state::unframed);
+      expect(glz::detail::read_content_length(glz::http_headers{{"Content-Length", ""}}).state ==
+             glz::detail::content_length_state::unframed);
+      expect(glz::detail::read_content_length(glz::http_headers{{"Content-Length", "-1"}}).state ==
+             glz::detail::content_length_state::unframed);
+      expect(glz::detail::read_content_length(glz::http_headers{{"Content-Length", "+1"}}).state ==
+             glz::detail::content_length_state::unframed);
+   };
+
+   // Transfer-Encoding overrides Content-Length (RFC 9112 6.3), so a chunked
+   // response reports no Content-Length framing to apply and a field that would
+   // otherwise be rejected cannot fail the request. Without this the outcome would
+   // hinge on whether a value we never read happens to parse.
+   "chunked_ignores_content_length_entirely"_test = [] {
+      const auto well_formed =
+         glz::detail::read_content_length(glz::http_headers{{"Transfer-Encoding", "chunked"}, {"Content-Length", "5"}});
+      expect(well_formed.state == glz::detail::content_length_state::absent);
+
+      const auto malformed = glz::detail::read_content_length(
+         glz::http_headers{{"Transfer-Encoding", "chunked"}, {"Content-Length", "abc"}});
+      expect(malformed.state == glz::detail::content_length_state::absent)
+         << "a Content-Length that is never consulted must not fail the request";
+
+      const auto conflicting = glz::detail::read_content_length(
+         glz::http_headers{{"Transfer-Encoding", "chunked"}, {"Content-Length", "3"}, {"Content-Length", "47"}});
+      expect(conflicting.state == glz::detail::content_length_state::absent)
+         << "chunked framing resolves the ambiguity the two lengths would otherwise create";
+
+      // The override only applies to chunked. Another transfer coding leaves the
+      // Content-Length as the body framing.
+      const auto gzip_only =
+         glz::detail::read_content_length(glz::http_headers{{"Transfer-Encoding", "gzip"}, {"Content-Length", "3"}});
+      expect(gzip_only.state == glz::detail::content_length_state::present);
+      expect(gzip_only.value == 3u);
+   };
+
+   "an_overflowing_length_is_unframed"_test = [] {
+      // Silently truncating this to a small number would frame the body short and
+      // leave the remainder to be read as the next response.
+      const auto parsed =
+         glz::detail::read_content_length(glz::http_headers{{"Content-Length", "99999999999999999999999"}});
+      expect(parsed.state == glz::detail::content_length_state::unframed);
    };
 };
 

--- a/tests/networking_tests/http_response_splitting_test/http_response_splitting_test.cpp
+++ b/tests/networking_tests/http_response_splitting_test/http_response_splitting_test.cpp
@@ -124,7 +124,7 @@ suite client_request_serializer_crlf = [] {
       url.port = 80;
       url.path = "/";
 
-      const std::unordered_map<std::string, std::string> headers{
+      const glz::http_headers headers{
          {"X-Evil", "a\r\nSmuggled-Header: 1"},
          {"X-Safe", "kept"},
       };
@@ -210,8 +210,7 @@ suite http_response_splitting_suite = [] {
 
       const std::string response = send_raw_timed(port, payload);
       expect(response.find("200") != std::string::npos) << "Request should be served";
-      // response::header() lowercases the field-name (RFC 7230 case-insensitive).
-      expect(response.find("x-echo: harmless-value") != std::string::npos) << "Benign header should round-trip";
+      expect(response.find("X-Echo: harmless-value") != std::string::npos) << "Benign header should round-trip";
    };
 
    "dropping a reflected Content-Length still frames the response"_test = [&] {

--- a/tests/networking_tests/http_response_splitting_test/http_response_splitting_test.cpp
+++ b/tests/networking_tests/http_response_splitting_test/http_response_splitting_test.cpp
@@ -133,6 +133,86 @@ suite client_request_serializer_crlf = [] {
       expect(request.find("Smuggled-Header") == std::string::npos) << "CRLF-bearing header must be dropped";
       expect(request.find("X-Safe: kept") != std::string::npos) << "Benign header must still be written";
    };
+
+   // The request writer computes Content-Length from the body it is about to append,
+   // so a caller-supplied one can only contradict it. glz::http_headers keeps
+   // repeats, which makes a conflicting pair expressible in a single call - two
+   // lengths on the wire let a proxy and the origin split the stream at different
+   // offsets (RFC 9112 6.3, request smuggling).
+   "build_http_request_bytes drops caller-supplied body framing headers"_test = [] {
+      glz::url_parts url;
+      url.protocol = "http";
+      url.host = "example.com";
+      url.port = 80;
+      url.path = "/";
+
+      const glz::http_headers headers{
+         {"Content-Length", "0"},
+         {"Content-Length", "999"},
+         {"Transfer-Encoding", "chunked"},
+         {"X-Safe", "kept"},
+      };
+
+      const std::string request = glz::detail::build_http_request_bytes("POST", url, false, "BODY", headers);
+
+      expect(request.find("Transfer-Encoding") == std::string::npos)
+         << "A caller Transfer-Encoding must not frame a body the writer does not chunk";
+      expect(request.find("Content-Length: 999") == std::string::npos) << "A contradicting length must be dropped";
+      expect(request.find("Content-Length: 0\r\n") == std::string::npos) << "A contradicting length must be dropped";
+      expect(request.find("Content-Length: 4\r\n") != std::string::npos)
+         << "The writer's own length, matching the body it appends, must survive";
+      expect(request.find("X-Safe: kept") != std::string::npos) << "Unrelated headers must still be written";
+
+      // Exactly one Content-Length reaches the wire.
+      size_t count = 0;
+      for (size_t at = request.find("Content-Length"); at != std::string::npos;
+           at = request.find("Content-Length", at + 1)) {
+         ++count;
+      }
+      expect(count == 1) << "Exactly one Content-Length must be written, found " << count;
+
+      expect(request.ends_with("\r\n\r\nBODY")) << "The body must follow the header block unchanged";
+   };
+
+   // Dropping the caller's Content-Length has to be lossless. A method that
+   // anticipates content carries a Content-Length even when the body is empty
+   // (RFC 9110 8.6), or a caller who used to send "Content-Length: 0" by hand for
+   // an empty POST would be left with a request many origin servers answer 411.
+   "build_http_request_bytes frames an empty body for methods that anticipate content"_test = [] {
+      glz::url_parts url;
+      url.protocol = "http";
+      url.host = "example.com";
+      url.port = 80;
+      url.path = "/";
+
+      for (const auto* method : {"POST", "PUT", "PATCH"}) {
+         const std::string request = glz::detail::build_http_request_bytes(method, url, false, "", {});
+         expect(request.find("Content-Length: 0\r\n") != std::string::npos)
+            << method << " with an empty body must still frame it";
+      }
+
+      // A caller-supplied length is still dropped in favor of the writer's own.
+      const glz::http_headers headers{{"Content-Length", "999"}};
+      const std::string overridden = glz::detail::build_http_request_bytes("POST", url, false, "", headers);
+      expect(overridden.find("Content-Length: 0\r\n") != std::string::npos);
+      expect(overridden.find("999") == std::string::npos) << "The caller's contradicting length must not survive";
+   };
+
+   // A method that anticipates no content frames an empty body by carrying no field
+   // at all; inventing one would invite a body where none belongs.
+   "build_http_request_bytes omits Content-Length for a bodyless GET"_test = [] {
+      glz::url_parts url;
+      url.protocol = "http";
+      url.host = "example.com";
+      url.port = 80;
+      url.path = "/";
+
+      for (const auto* method : {"GET", "HEAD", "DELETE", "OPTIONS"}) {
+         const std::string request = glz::detail::build_http_request_bytes(method, url, false, "", {});
+         expect(request.find("Content-Length") == std::string::npos)
+            << method << " with no body must not carry a Content-Length";
+      }
+   };
 };
 
 suite http_response_splitting_suite = [] {

--- a/tests/networking_tests/http_server_api_tests/http_server_api_tests.cpp
+++ b/tests/networking_tests/http_server_api_tests/http_server_api_tests.cpp
@@ -1153,7 +1153,7 @@ struct raw_http_client
    struct http_response
    {
       int status_code = 0;
-      std::unordered_map<std::string, std::string> headers;
+      glz::http_headers headers;
       std::string body;
    };
 
@@ -1218,11 +1218,10 @@ struct raw_http_client
             value.erase(0, value.find_first_not_of(" \t"));
             value.erase(value.find_last_not_of(" \t") + 1);
 
-            // Convert name to lowercase for easier lookup
-            std::transform(name.begin(), name.end(), name.begin(), [](unsigned char c) { return std::tolower(c); });
-            resp.headers[name] = value;
+            const bool is_content_length = glz::striequal(name, "content-length");
+            resp.headers.add(std::move(name), value);
 
-            if (name == "content-length") {
+            if (is_content_length) {
                content_length = std::stoul(value);
             }
          }
@@ -1322,7 +1321,7 @@ struct keepalive_test_server
       server_.get("/echo-connection", [](const glz::request& req, glz::response& res) {
          auto conn_it = req.headers.find("connection");
          if (conn_it != req.headers.end()) {
-            res.body("Connection: " + conn_it->second);
+            res.body("Connection: " + conn_it->value);
          }
          else {
             res.body("Connection: (none)");
@@ -1377,13 +1376,13 @@ suite keepalive_behavior_tests = [] {
          auto conn_header = resp->headers.find("connection");
          expect(conn_header != resp->headers.end()) << "Connection header should be present\n";
          if (conn_header != resp->headers.end()) {
-            expect(conn_header->second == "keep-alive") << "Connection should be keep-alive\n";
+            expect(conn_header->value == "keep-alive") << "Connection should be keep-alive\n";
          }
 
          auto ka_header = resp->headers.find("keep-alive");
          expect(ka_header != resp->headers.end()) << "Keep-Alive header should be present\n";
          if (ka_header != resp->headers.end()) {
-            expect(ka_header->second.find("timeout=30") != std::string::npos) << "Should contain timeout value\n";
+            expect(ka_header->value.find("timeout=30") != std::string::npos) << "Should contain timeout value\n";
          }
       }
 
@@ -1406,7 +1405,7 @@ suite keepalive_behavior_tests = [] {
          auto conn_header = resp->headers.find("connection");
          expect(conn_header != resp->headers.end()) << "Connection header should be present\n";
          if (conn_header != resp->headers.end()) {
-            expect(conn_header->second == "close") << "Connection should be close\n";
+            expect(conn_header->value == "close") << "Connection should be close\n";
          }
       }
 
@@ -1431,7 +1430,7 @@ suite keepalive_behavior_tests = [] {
          auto conn_header = resp->headers.find("connection");
          expect(conn_header != resp->headers.end()) << "Connection header should be present\n";
          if (conn_header != resp->headers.end()) {
-            expect(conn_header->second == "close") << "Server should respect client's close request\n";
+            expect(conn_header->value == "close") << "Server should respect client's close request\n";
          }
       }
 
@@ -1477,7 +1476,7 @@ suite keepalive_behavior_tests = [] {
       if (resp1.has_value()) {
          auto conn_header = resp1->headers.find("connection");
          if (conn_header != resp1->headers.end()) {
-            expect(conn_header->second == "keep-alive") << "First request should keep alive\n";
+            expect(conn_header->value == "keep-alive") << "First request should keep alive\n";
          }
       }
 
@@ -1487,7 +1486,7 @@ suite keepalive_behavior_tests = [] {
       if (resp2.has_value()) {
          auto conn_header = resp2->headers.find("connection");
          if (conn_header != resp2->headers.end()) {
-            expect(conn_header->second == "close") << "Second request should close (at limit)\n";
+            expect(conn_header->value == "close") << "Second request should close (at limit)\n";
          }
       }
 
@@ -1510,8 +1509,8 @@ suite keepalive_behavior_tests = [] {
          auto ka_header = resp->headers.find("keep-alive");
          expect(ka_header != resp->headers.end()) << "Keep-Alive header should be present\n";
          if (ka_header != resp->headers.end()) {
-            expect(ka_header->second.find("timeout=45") != std::string::npos) << "Should contain timeout\n";
-            expect(ka_header->second.find("max=100") != std::string::npos) << "Should contain max\n";
+            expect(ka_header->value.find("timeout=45") != std::string::npos) << "Should contain timeout\n";
+            expect(ka_header->value.find("max=100") != std::string::npos) << "Should contain max\n";
          }
       }
 

--- a/tests/networking_tests/http_server_api_tests/http_server_api_tests.cpp
+++ b/tests/networking_tests/http_server_api_tests/http_server_api_tests.cpp
@@ -735,8 +735,8 @@ suite response_building_tests = [] {
 
       expect(&chained_res == &res) << "Response methods should return reference for chaining\n";
       expect(res.status_code == 201) << "Status should be set correctly\n";
-      expect(res.response_headers.at("x-custom") == "value") << "Custom header should be set\n";
-      expect(res.response_headers.at("content-type") == "application/json") << "Content-Type should be set\n";
+      expect(res.response_headers.first_value("x-custom") == "value") << "Custom header should be set\n";
+      expect(res.response_headers.first_value("content-type") == "application/json") << "Content-Type should be set\n";
       expect(res.response_body == "test body") << "Body should be set correctly\n";
    };
 
@@ -747,7 +747,7 @@ suite response_building_tests = [] {
       res.json(data);
 
       expect(!res.response_body.empty()) << "JSON serialization should produce content\n";
-      expect(res.response_headers.at("content-type") == "application/json") << "Should set JSON content type\n";
+      expect(res.response_headers.first_value("content-type") == "application/json") << "Should set JSON content type\n";
 
       // Verify serialization worked
       TestData deserialized;
@@ -882,7 +882,7 @@ suite response_middleware_tests = [] {
       auto response_hook = [&captured_content_type](const glz::request&, const glz::response& res) {
          auto it = res.response_headers.find("content-type");
          if (it != res.response_headers.end()) {
-            captured_content_type = it->second;
+            captured_content_type = it->value;
          }
       };
 

--- a/tests/networking_tests/http_server_api_tests/http_server_api_tests.cpp
+++ b/tests/networking_tests/http_server_api_tests/http_server_api_tests.cpp
@@ -1527,7 +1527,7 @@ suite keepalive_behavior_tests = [] {
 };
 
 suite repeated_response_header_tests = [] {
-   "repeated_set_cookie_fields_reach_the_wire"_test = [] {
+   "server_sends_repeated_set_cookie_fields"_test = [] {
       keepalive_test_server server;
       expect(server.start()) << "Server should start\n";
 

--- a/tests/networking_tests/http_server_api_tests/http_server_api_tests.cpp
+++ b/tests/networking_tests/http_server_api_tests/http_server_api_tests.cpp
@@ -747,7 +747,8 @@ suite response_building_tests = [] {
       res.json(data);
 
       expect(!res.response_body.empty()) << "JSON serialization should produce content\n";
-      expect(res.response_headers.first_value("content-type") == "application/json") << "Should set JSON content type\n";
+      expect(res.response_headers.first_value("content-type") == "application/json")
+         << "Should set JSON content type\n";
 
       // Verify serialization worked
       TestData deserialized;
@@ -1327,6 +1328,12 @@ struct keepalive_test_server
             res.body("Connection: (none)");
          }
       });
+
+      server_.get("/set-cookies", [](const glz::request&, glz::response& res) {
+         res.add_header("Set-Cookie", "session=abc; Path=/; HttpOnly")
+            .add_header("Set-Cookie", "theme=dark; Path=/")
+            .body("OK");
+      });
    }
 };
 
@@ -1511,6 +1518,38 @@ suite keepalive_behavior_tests = [] {
          if (ka_header != resp->headers.end()) {
             expect(ka_header->value.find("timeout=45") != std::string::npos) << "Should contain timeout\n";
             expect(ka_header->value.find("max=100") != std::string::npos) << "Should contain max\n";
+         }
+      }
+
+      client.close();
+      server.stop();
+   };
+};
+
+suite repeated_response_header_tests = [] {
+   "repeated_set_cookie_fields_reach_the_wire"_test = [] {
+      keepalive_test_server server;
+      expect(server.start()) << "Server should start\n";
+
+      raw_http_client client;
+      expect(client.connect("127.0.0.1", server.port())) << "Client should connect\n";
+
+      auto resp = client.send_request("GET", "/set-cookies", "127.0.0.1:" + std::to_string(server.port()));
+      expect(resp.has_value()) << "Should receive response\n";
+
+      if (resp.has_value()) {
+         expect(resp->status_code == 200) << "Status should be 200\n";
+         expect(resp->headers.count("Set-Cookie") == 2) << "Both Set-Cookie fields should reach the wire\n";
+
+         std::vector<std::string> cookies;
+         for (auto value : resp->headers.values("Set-Cookie")) {
+            cookies.emplace_back(value);
+         }
+
+         expect(cookies.size() == 2);
+         if (cookies.size() == 2) {
+            expect(cookies[0] == "session=abc; Path=/; HttpOnly") << "First cookie should keep its position\n";
+            expect(cookies[1] == "theme=dark; Path=/") << "Second cookie should keep its position\n";
          }
       }
 

--- a/tests/networking_tests/rest_test/rest_server/rest_server.cpp
+++ b/tests/networking_tests/rest_test/rest_server/rest_server.cpp
@@ -277,7 +277,7 @@ int main()
    server.get("/test-cors", [](const glz::request& req, glz::response& res) {
       // The CORS middleware will automatically add the appropriate headers
       res.json({{"message", "CORS test endpoint"},
-                {"origin", req.headers.count("origin") ? req.headers.at("origin") : "none"},
+                {"origin", std::string{req.headers.first_value("origin").value_or("none")}},
                 {"method", glz::to_string(req.method)}});
    });
 

--- a/tests/networking_tests/websocket_test/websocket_client_test.cpp
+++ b/tests/networking_tests/websocket_test/websocket_client_test.cpp
@@ -223,9 +223,13 @@ void run_counting_server(std::atomic<bool>& server_ready, std::atomic<bool>& sho
    }
 }
 
-// Helper to run a server that returns a load-balancer-style connection header
-void run_lb_header_handshake_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_stop,
-                                    std::atomic<uint16_t>& selected_port, std::string* host_header = nullptr)
+constexpr std::string_view lb_upgrade_fields =
+   "Upgrade: websocket\r\n"
+   "Connection: keep-alive, Upgrade\r\n";
+
+void run_handshake_response_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_stop,
+                                   std::atomic<uint16_t>& selected_port, std::string_view upgrade_fields,
+                                   std::string* host_header = nullptr)
 {
    try {
       asio::io_context io_ctx;
@@ -269,12 +273,8 @@ void run_lb_header_handshake_server(std::atomic<bool>& server_ready, std::atomic
       if (websocket_key.empty()) return;
 
       const std::string accept_key = ws_util::generate_accept_key(websocket_key);
-      const std::string response =
-         "HTTP/1.1 101 Switching Protocols\r\n"
-         "Upgrade: websocket\r\n"
-         "Connection: keep-alive, Upgrade\r\n"
-         "Sec-WebSocket-Accept: " +
-         accept_key + "\r\n\r\n";
+      const std::string response = "HTTP/1.1 101 Switching Protocols\r\n" + std::string(upgrade_fields) +
+                                   "Sec-WebSocket-Accept: " + accept_key + "\r\n\r\n";
 
       asio::write(socket, asio::buffer(response), ec);
       if (ec) return;
@@ -285,7 +285,7 @@ void run_lb_header_handshake_server(std::atomic<bool>& server_ready, std::atomic
       }
    }
    catch (const std::exception& e) {
-      std::cerr << "[lb_header_server] Exception: " << e.what() << "\n";
+      std::cerr << "[handshake_response_server] Exception: " << e.what() << "\n";
       server_ready = true;
    }
 }
@@ -516,9 +516,8 @@ void run_auth_websocket_server(std::atomic<bool>& server_ready, std::atomic<bool
    http_server server;
    auto ws_server = std::make_shared<websocket_server>();
 
-   ws_server->on_validate([expected_auth](const request& req) {
-      return req.headers.first_value("authorization") == expected_auth;
-   });
+   ws_server->on_validate(
+      [expected_auth](const request& req) { return req.headers.first_value("authorization") == expected_auth; });
 
    ws_server->on_open([](auto /*conn*/, const request&) {});
    ws_server->on_message([](auto conn, std::string_view message, ws_opcode opcode) {
@@ -1361,8 +1360,8 @@ suite websocket_client_tests = [] {
       std::atomic<bool> stop_server{false};
       std::atomic<uint16_t> port{0};
 
-      std::thread server_thread(run_lb_header_handshake_server, std::ref(server_ready), std::ref(stop_server),
-                                std::ref(port), nullptr);
+      std::thread server_thread(run_handshake_response_server, std::ref(server_ready), std::ref(stop_server),
+                                std::ref(port), lb_upgrade_fields, nullptr);
 
       expect(wait_for_condition([&] { return server_ready.load() && port.load() != 0; })) << "Server failed to start";
 
@@ -1395,6 +1394,59 @@ suite websocket_client_tests = [] {
          << "Handshake did not complete";
       expect(open_called.load()) << "Client should accept load-balancer-style Connection header";
       expect(!protocol_error.load()) << "Handshake should not fail with protocol_error";
+
+      if (!client.context()->stopped()) {
+         client.context()->stop();
+      }
+      if (client_thread.joinable()) {
+         client_thread.join();
+      }
+
+      stop_server = true;
+      server_thread.join();
+   };
+
+   "handshake_upgrade_field_name_must_match_in_full_test"_test = [] {
+      std::atomic<bool> server_ready{false};
+      std::atomic<bool> stop_server{false};
+      std::atomic<uint16_t> port{0};
+
+      std::thread server_thread(run_handshake_response_server, std::ref(server_ready), std::ref(stop_server),
+                                std::ref(port),
+                                std::string_view{"Upgrade-Extra: websocket\r\n"
+                                                 "Connection: Upgrade\r\n"},
+                                nullptr);
+
+      expect(wait_for_condition([&] { return server_ready.load() && port.load() != 0; })) << "Server failed to start";
+
+      websocket_client client;
+      std::atomic<bool> open_called{false};
+      std::atomic<bool> protocol_error{false};
+
+      client.on_open([&]() {
+         open_called = true;
+         client.context()->stop();
+      });
+
+      client.on_message([](std::string_view, ws_opcode) {});
+
+      client.on_close([](ws_close_code, std::string_view) {});
+
+      client.on_error([&](std::error_code ec) {
+         if (ec == std::make_error_code(std::errc::protocol_error)) {
+            protocol_error = true;
+         }
+         client.context()->stop();
+      });
+
+      client.connect("ws://127.0.0.1:" + std::to_string(port.load()) + "/ws");
+
+      std::thread client_thread([&client]() { client.context()->run(); });
+
+      expect(wait_for_condition([&] { return open_called.load() || protocol_error.load(); }))
+         << "Handshake neither completed nor failed";
+      expect(!open_called.load()) << "Upgrade-Extra must not satisfy the Upgrade check\n";
+      expect(protocol_error.load()) << "A response without a real Upgrade field must fail the handshake\n";
 
       if (!client.context()->stopped()) {
          client.context()->stop();
@@ -1445,8 +1497,8 @@ suite websocket_client_tests = [] {
       std::atomic<uint16_t> port{0};
       std::string host_header;
 
-      std::thread server_thread(run_lb_header_handshake_server, std::ref(server_ready), std::ref(stop_server),
-                                std::ref(port), &host_header);
+      std::thread server_thread(run_handshake_response_server, std::ref(server_ready), std::ref(stop_server),
+                                std::ref(port), lb_upgrade_fields, &host_header);
 
       expect(wait_for_condition([&] { return server_ready.load() && port.load() != 0; })) << "Server failed to start";
 

--- a/tests/networking_tests/websocket_test/websocket_client_test.cpp
+++ b/tests/networking_tests/websocket_test/websocket_client_test.cpp
@@ -496,8 +496,7 @@ void run_auth_websocket_server(std::atomic<bool>& server_ready, std::atomic<bool
    auto ws_server = std::make_shared<websocket_server>();
 
    ws_server->on_validate([expected_auth](const request& req) {
-      auto it = req.headers.find("authorization");
-      return it != req.headers.end() && it->second == expected_auth;
+      return req.headers.first_value("authorization") == expected_auth;
    });
 
    ws_server->on_open([](auto /*conn*/, const request&) {});

--- a/tests/networking_tests/websocket_test/websocket_client_test.cpp
+++ b/tests/networking_tests/websocket_test/websocket_client_test.cpp
@@ -290,6 +290,27 @@ void run_lb_header_handshake_server(std::atomic<bool>& server_ready, std::atomic
    }
 }
 
+std::string send_raw_upgrade_request(uint16_t port, const std::string& request)
+{
+   try {
+      asio::io_context io_ctx;
+      asio::ip::tcp::socket socket(io_ctx);
+      asio::error_code ec;
+      socket.connect(asio::ip::tcp::endpoint(asio::ip::make_address("127.0.0.1"), port), ec);
+      if (ec) return "";
+
+      asio::write(socket, asio::buffer(request), ec);
+      if (ec) return "";
+
+      asio::streambuf response_buf;
+      asio::read_until(socket, response_buf, "\r\n\r\n", ec);
+      return {asio::buffers_begin(response_buf.data()), asio::buffers_end(response_buf.data())};
+   }
+   catch (const std::exception&) {
+      return "";
+   }
+}
+
 // Helper to run a server that sends WebSocket frames in the same TCP segment
 // as the handshake response
 void run_initial_data_handshake_server(std::atomic<bool>& server_ready, std::atomic<bool>& should_stop,
@@ -1381,6 +1402,38 @@ suite websocket_client_tests = [] {
       if (client_thread.joinable()) {
          client_thread.join();
       }
+
+      stop_server = true;
+      server_thread.join();
+   };
+
+   "upgrade_accepted_with_connection_split_over_two_fields_test"_test = [] {
+      std::atomic<bool> server_ready{false};
+      std::atomic<bool> stop_server{false};
+      std::atomic<uint16_t> port{0};
+
+      std::thread server_thread(run_echo_server, std::ref(server_ready), std::ref(stop_server), std::ref(port));
+
+      expect(wait_for_condition([&] { return server_ready.load() && port.load() != 0; })) << "Server failed to start";
+
+      const std::string request =
+         "GET /ws HTTP/1.1\r\n"
+         "Host: 127.0.0.1:" +
+         std::to_string(port.load()) +
+         "\r\n"
+         "Upgrade: websocket\r\n"
+         "Connection: keep-alive\r\n"
+         "Connection: Upgrade\r\n"
+         "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+         "Sec-WebSocket-Version: 13\r\n"
+         "\r\n";
+
+      const std::string response = send_raw_upgrade_request(port.load(), request);
+
+      expect(response.find("101") != std::string::npos)
+         << "Split Connection options must still be recognized as an upgrade, got: " << response << "\n";
+      expect(response.find("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=") != std::string::npos)
+         << "The RFC 6455 accept key for the sample nonce should come back\n";
 
       stop_server = true;
       server_thread.join();


### PR DESCRIPTION
Ports the net stack to glz::http_headers (#2709).

Rewriting the header lookups for the new container resulted in fixing two WebSocket bugs. `glz::http_headers` keeps repeated field names instead of overwriting them, and its `.contains_token()` replaced the hand-rolled substring and prefix comparisons, so every lookup had to be revisited, and both were found there.

## WebSocket implementation bugs
1 - the handshake response check never compared a full field name. The code used a comparison like this: 
`strncasecmp(name.c_str(), "Upgrade", 7)` for the headers "Upgrade", "Connection" and "Sec-WebSocket-Accept" comparing the first N bytes using `strncasecmp`, where N is the length of the expected header name. The problem is that this approach would accept headers such as "Connection-Something" as valid because the name starts with "Connection", and so on with other headers listed previously.

Example - the old client accepted this response even though the server never sent an `Upgrade` field:
```
HTTP/1.1 101 Switching Protocols\r\n
Upgrade-Extra: websocket\r\n
Connection: Upgrade\r\n
Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n
```

---

2 - the client is allowed to send a list-based field not as a comma-separated list, but as separate header fields separated by CRLF. The previous issue was that `std::unordered_map` used a "last-wins" approach, thereby discarding one of the values for that header. In such cases, user could only hope that the last header received contained the required token (`"Connection: Upgrade"`) as the header-field value.

Example - the old server refused this valid request because `keep-alive` arrived last:
```
GET /ws HTTP/1.1\r\n
Host: 127.0.0.1:8080\r\n
Upgrade: websocket\r\n
Connection: Upgrade\r\n
Connection: keep-alive\r\n
Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n
Sec-WebSocket-Version: 13\r\n\r\n
```