### PR TITLE
fix exponent overflow in unsigned atoi

### DIFF
--- a/include/glaze/util/atoi.hpp
+++ b/include/glaze/util/atoi.hpp
@@ -382,7 +382,10 @@ namespace glz
             return false;
          }
          ++c;
-         uint8_t exp = c[-1] - '0';
+         // exp accumulates up to three digits, so it must be wider than uint8_t: a byte wraps
+         // mod 256, aliasing an out-of-range exponent onto an accepted one (e.g. "1e256" -> 0,
+         // decoded as 1 instead of being rejected as out of range).
+         uint32_t exp = c[-1] - '0';
          if (is_digit(*c)) {
             exp = exp * 10 + (*c - '0');
             ++c;

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -992,6 +992,32 @@ suite basic_types = [] {
       expect(glz::read_json(num, "0045") == glz::error_code::parse_number_failure);
    };
 
+   "unsigned exponent out of range"_test = [] {
+      // A three-digit exponent must be rejected as out of range, not wrapped into an accepted
+      // value. "1e256" denotes 10^256; the exponent accumulator used to overflow a uint8_t
+      // (256 & 0xFF == 0) and decode it as 1.
+      uint64_t u64{};
+      expect(glz::read_json(u64, "1e256") == glz::error_code::parse_number_failure);
+      expect(glz::read_json(u64, "5e256") == glz::error_code::parse_number_failure);
+      expect(glz::read_json(u64, "1e260") == glz::error_code::parse_number_failure);
+      expect(glz::read_json(u64, "1e275") == glz::error_code::parse_number_failure);
+      expect(glz::read_json(u64, "1e512") == glz::error_code::parse_number_failure);
+      expect(glz::read_json(u64, "1e100") == glz::error_code::parse_number_failure);
+
+      uint32_t u32{};
+      expect(glz::read_json(u32, "1e256") == glz::error_code::parse_number_failure);
+      uint16_t u16{};
+      expect(glz::read_json(u16, "7e256") == glz::error_code::parse_number_failure);
+      uint8_t u8{};
+      expect(glz::read_json(u8, "9e256") == glz::error_code::parse_number_failure);
+
+      // In-range exponents still parse correctly, including leading zeros in the exponent.
+      expect(glz::read_json(u64, "1e19") == glz::error_code::none);
+      expect(u64 == 10000000000000000000ull);
+      expect(glz::read_json(u64, "1e007") == glz::error_code::none);
+      expect(u64 == 10000000ull);
+   };
+
    "bool write"_test = [] {
       std::string buffer{};
       expect(not glz::write_json(true, buffer));


### PR DESCRIPTION
The unsigned `atoi` overload reads up to three exponent digits into a `uint8_t`, while the signed overload reads only two. A three-digit exponent overflows the byte and wraps mod 256, so the `exp > 19` range check that follows sees the wrapped value. Reading an unsigned integer such as `1e256` through `read_json` or `read_csv` returns success with the value 1 rather than a parse error; `5e256` decodes to 5, `1e260` to 10000, and the pattern repeats across every unsigned width.

Widen the accumulator to `uint32_t` so three digits can no longer wrap, which lets the existing guard reject every out-of-range exponent. Before, an out-of-range magnitude could alias onto a small accepted value; after, `1e256` and the rest fail the same way `1e20` already does. Valid exponents (including ones written with leading zeros) and the two-digit signed path are untouched, and keeping the check inside `atoi` means callers that receive only a bool don't each need to re-detect the overflow.
