### PR TITLE
fix exponent digit handling in integer parsing

### DIFF
--- a/docs/JSON/json-integer-parsing.md
+++ b/docs/JSON/json-integer-parsing.md
@@ -10,7 +10,10 @@ Valid examples for a `uint8_t`:
 255
 1e1
 1e+2
+1e002
 ```
+
+An exponent may carry leading zeros. JSON forbids them in the integer part but permits any run of digits in the exponent, so `1e002` is simply another spelling of `1e2`.
 
 Invalid examples for a `uint8_t`:
 

--- a/include/glaze/util/atoi.hpp
+++ b/include/glaze/util/atoi.hpp
@@ -102,6 +102,34 @@ namespace glz
 
    GLZ_ALWAYS_INLINE constexpr bool is_digit(const uint8_t c) noexcept { return c <= '9' && c >= '0'; }
 
+   // Exponents at or beyond this magnitude are out of range for every integer width, so the exponent
+   // accumulators clamp here rather than growing without bound. Sits far above the largest accepted
+   // exponent (19, for uint64_t) and low enough that a clamped value cannot overflow uint32_t.
+   inline constexpr uint32_t exponent_clamp = 1000;
+
+   // Consumes the run of exponent digits starting at `c` and returns its value, clamped at
+   // exponent_clamp. Clamping is what keeps the result meaningful: a narrow accumulator wraps mod its
+   // width, which aliases an out-of-range exponent onto an accepted one. Every digit is consumed so
+   // that leading zeros reach their true value -- JSON forbids a leading zero in the integer part but
+   // permits any run of digits in the exponent, making "1e007" a valid spelling of 10^7 -- and so the
+   // caller resumes past the whole exponent rather than mid-number.
+   //
+   // Requires *c to be a digit and the buffer to be terminated by a non-digit (the null terminator
+   // counts); this scan is bounded by the input, not by a digit count.
+   template <class Char>
+   GLZ_ALWAYS_INLINE constexpr uint32_t parse_exponent(Char*& c) noexcept
+   {
+      uint32_t exp = uint32_t(*c - '0');
+      ++c;
+      while (is_digit(*c)) {
+         // Written as a select rather than a branch: the clamp only ever engages on absurdly long
+         // exponents, so a branch here would be a mispredict risk on the path that matters.
+         exp = exp < exponent_clamp ? exp * 10 + uint32_t(*c - '0') : exp;
+         ++c;
+      }
+      return exp;
+   }
+
    // Computed overflow checks - used instead of lookup tables to save 4KB+ of binary size
    // Uses adjusted threshold for branch-free single comparison (7-12% faster than bitwise approach)
    template <class T>
@@ -381,19 +409,7 @@ namespace glz
          if (not is_digit(*c)) [[unlikely]] {
             return false;
          }
-         ++c;
-         // exp accumulates up to three digits, so it must be wider than uint8_t: a byte wraps
-         // mod 256, aliasing an out-of-range exponent onto an accepted one (e.g. "1e256" -> 0,
-         // decoded as 1 instead of being rejected as out of range).
-         uint32_t exp = c[-1] - '0';
-         if (is_digit(*c)) {
-            exp = exp * 10 + (*c - '0');
-            ++c;
-         }
-         if (is_digit(*c)) {
-            exp = exp * 10 + (*c - '0');
-            ++c;
-         }
+         const uint32_t exp = parse_exponent(c);
          if constexpr (sizeof(T) == 1) {
             if (exp > 2) [[unlikely]] {
                return false;
@@ -711,12 +727,7 @@ namespace glz
          if (not is_digit(*c)) [[unlikely]] {
             return false;
          }
-         ++c;
-         uint8_t exp = c[-1] - '0';
-         if (is_digit(*c)) {
-            exp = exp * 10 + (*c - '0');
-            ++c;
-         }
+         const uint32_t exp = parse_exponent(c);
          if constexpr (sizeof(T) == 1) {
             if (exp > 2) [[unlikely]] {
                return false;
@@ -757,12 +768,18 @@ namespace glz
             return (i - sign) <= static_cast<utype>((std::numeric_limits<T>::max)());
          }
          else {
+            // Scale the sign-stripped magnitude `i`, not the two's-complement bit pattern of `v`:
+            // for a negative value that pattern is a huge unsigned number, so every negative
+            // 64-bit integer written with an exponent ("-1e2") overflowed and was rejected. The
+            // narrower branches above already scale `i`.
 #if defined(__SIZEOF_INT128__)
-            const __uint128_t res = __uint128_t(std::bit_cast<utype>(v)) * powers_of_ten_int[exp];
+            const __uint128_t res = __uint128_t(i) * powers_of_ten_int[exp];
             v = T((uint64_t(res) ^ -sign) + sign);
-            return uint64_t(res) <= (9223372036854775807ull + sign);
+            // Compare the full 128-bit product. Narrowing it to 64 bits first would let an
+            // out-of-range magnitude alias onto an accepted one, e.g. 9e36 truncating into range.
+            return res <= __uint128_t(9223372036854775807ull + sign);
 #else
-            const auto res = full_multiplication(std::bit_cast<utype>(v), powers_of_ten_int[exp]);
+            const auto res = full_multiplication(i, powers_of_ten_int[exp]);
             v = T((uint64_t(res.low) ^ -sign) + sign);
             return res.high == 0 && (uint64_t(res.low) <= (9223372036854775807ull + sign));
 #endif
@@ -779,16 +796,15 @@ namespace glz
    {
       // The number of characters needed at most for each type, rounded to nearest 8 bytes
       constexpr auto buffer_length = int_buffer_lengths[std::bit_width(sizeof(T)) - 1];
-      // We copy the rest of the buffer or 64 bytes into a null terminated buffer
-      std::array<char, buffer_length> data{};
+      // We copy the rest of the buffer, or buffer_length bytes, into a null terminated buffer. The
+      // trailing byte is never written by the copy, so the null-terminated atoi below always halts
+      // inside the array even when the input fills it: the exponent scan stops at a non-digit rather
+      // than after a fixed digit count, and a value-initialized array alone would not terminate a
+      // copy that covers every byte.
+      std::array<char, buffer_length + 1> data{};
       const auto n = size_t(end - it);
       if (n > 0) [[likely]] {
-         if (n < buffer_length) {
-            std::memcpy(data.data(), it, n);
-         }
-         else {
-            std::memcpy(data.data(), it, buffer_length);
-         }
+         std::memcpy(data.data(), it, n < buffer_length ? n : buffer_length);
 
          const auto start = data.data();
          const auto* c = start;
@@ -868,9 +884,15 @@ namespace glz::detail
             negative = (*c == '-');
             ++c;
          }
-         uint8_t exp = 0;
-         while (digit_table[uint8_t(*c)] && exp < 128) {
-            exp = 10 * exp + (*c - '0');
+         // Clamp instead of wrapping: a uint8_t accumulator turns "1e256" into exponent 0, which
+         // aliases an out-of-range magnitude onto an accepted one ("1e256" decoding as 1). The old
+         // `exp < 128` guard could not catch that, since the wrap happened before the test, and it
+         // also left `c` parked mid-number once it did trip.
+         int32_t exp = 0;
+         while (digit_table[uint8_t(*c)]) {
+            if (exp < int32_t(exponent_clamp)) {
+               exp = 10 * exp + (*c - '0');
+            }
             ++c;
          }
          n += negative ? -exp : exp;

--- a/include/glaze/util/atoi.hpp
+++ b/include/glaze/util/atoi.hpp
@@ -804,13 +804,20 @@ namespace glz
       std::array<char, buffer_length + 1> data{};
       const auto n = size_t(end - it);
       if (n > 0) [[likely]] {
-         std::memcpy(data.data(), it, n < buffer_length ? n : buffer_length);
+         const auto truncated = n > buffer_length;
+         std::memcpy(data.data(), it, truncated ? buffer_length : n);
 
          const auto start = data.data();
          const auto* c = start;
          const auto valid = glz::atoi(v, c);
-         it += size_t(c - start);
-         return valid;
+         const auto consumed = size_t(c - start);
+         it += consumed;
+         // Reaching the end of a truncated copy means the number was cut off: parsing halted on the
+         // terminator this buffer supplies rather than on a character of the input, so what parsed is
+         // a prefix and its value is not the number's. Only zero padding can stretch a number this
+         // far -- no in-range integer needs buffer_length characters -- but a caller that ignores
+         // trailing content would otherwise take the prefix's value as the answer.
+         return valid && not(truncated && consumed == buffer_length);
       }
       else [[unlikely]] {
          return false;

--- a/tests/int_parsing/int_parsing.cpp
+++ b/tests/int_parsing/int_parsing.cpp
@@ -561,6 +561,9 @@ suite u8_test = [] {
       expect(not glz::read_json(value, "[-32767, -32768]"));
       expect(value == std::array<V, 2>{-32767, -32768});
 
+      expect(not glz::read_json(value, "[-1e2, -3e4]"));
+      expect(value == std::array<V, 2>{-100, -30000});
+
       expect(not glz::read_json(value, "[1e3, 1e3]"));
       expect(value == std::array<V, 2>{1000, 1000});
 
@@ -632,6 +635,9 @@ suite u8_test = [] {
 
       expect(not glz::read_json(value, "[-2147483647, -2147483648]"));
       expect(value == std::array<V, 2>{-2147483647, -2147483648});
+
+      expect(not glz::read_json(value, "[-1e2, -21e8]"));
+      expect(value == std::array<V, 2>{-100, -2100000000});
 
       expect(not glz::read_json(value, "[1e7, 12e7]"));
       expect(value == std::array<V, 2>{10000000, 120000000});
@@ -725,6 +731,20 @@ suite u8_test = [] {
 
       expect(not glz::read_json(value, "[-5594732989048119398, -5594732989048119398]"));
       expect(value == std::array<V, 2>{-5594732989048119398, -5594732989048119398});
+
+      // The existing negative-with-exponent case above is -9223372036854775808e0, which passes
+      // even when the exponent scales the two's-complement bit pattern instead of the magnitude:
+      // INT64_MIN is the one negative value whose bit pattern equals its own magnitude, and e0
+      // makes the multiply an identity. Every other negative value exercises the scaling.
+      expect(not glz::read_json(value, "[-1e2, -1e18]"));
+      expect(value == std::array<V, 2>{-100, -1000000000000000000});
+
+      expect(not glz::read_json(value, "[-9e18, -9223372036854775807e0]"));
+      expect(value == std::array<V, 2>{-9000000000000000000, -9223372036854775807});
+
+      // Out of range once scaled, including from INT64_MIN, whose magnitude is already the limit.
+      expect(glz::read_json(value, "[-9223372036854775808e1]"));
+      expect(glz::read_json(value, "[-1e19]"));
 
       expect(not glz::read<glz::opts{.minified = true}>(value, "[337184269,337184283]"));
       expect(not glz::read<glz::opts{.minified = true}>(value, "[-5637358391044507426,-4563386007050245647]"));

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -1018,6 +1018,99 @@ suite basic_types = [] {
       expect(u64 == 10000000ull);
    };
 
+   "exponent leading zeros"_test = [] {
+      // JSON forbids a leading zero in the integer part but allows any run of digits in the
+      // exponent, so "1e007" is a valid spelling of 10^7. Reading the exponent with a fixed digit
+      // count stopped mid-number, leaving the trailing digits to be rejected as trailing content.
+      // These are read inside arrays because a top-level read ignores trailing content.
+      std::vector<int64_t> i64s{};
+      expect(glz::read_json(i64s, "[1e007,2]") == glz::error_code::none);
+      expect(i64s == std::vector<int64_t>{10000000, 2});
+
+      std::vector<uint64_t> u64s{};
+      expect(glz::read_json(u64s, "[1e0007,2]") == glz::error_code::none);
+      expect(u64s == std::vector<uint64_t>{10000000, 2});
+
+      expect(glz::read_json(u64s, "[1e00000000000007,2]") == glz::error_code::none);
+      expect(u64s == std::vector<uint64_t>{10000000, 2});
+
+      std::vector<int32_t> i32s{};
+      expect(glz::read_json(i32s, "[3e0004,7]") == glz::error_code::none);
+      expect(i32s == std::vector<int32_t>{30000, 7});
+
+      // A padded exponent that is still out of range must stay rejected.
+      expect(glz::read_json(u64s, "[1e0020]") == glz::error_code::parse_number_failure);
+      expect(glz::read_json(i64s, "[1e0019]") == glz::error_code::parse_number_failure);
+      // As must an exponent long enough to overrun any fixed-width accumulator.
+      expect(glz::read_json(u64s, "[1e999999]") == glz::error_code::parse_number_failure);
+   };
+
+   "signed exponent negative values"_test = [] {
+      // The 64-bit signed path scaled the two's-complement bit pattern instead of the magnitude,
+      // so every negative 64-bit integer written with an exponent overflowed and was rejected.
+      int64_t i64{};
+      expect(glz::read_json(i64, "-1e2") == glz::error_code::none);
+      expect(i64 == -100);
+      expect(glz::read_json(i64, "-5e7") == glz::error_code::none);
+      expect(i64 == -50000000);
+      expect(glz::read_json(i64, "-1e18") == glz::error_code::none);
+      expect(i64 == -1000000000000000000ll);
+      expect(glz::read_json(i64, "-9e18") == glz::error_code::none);
+      expect(i64 == -9000000000000000000ll);
+      expect(glz::read_json(i64, "-5e0007") == glz::error_code::none);
+      expect(i64 == -50000000);
+
+      expect(glz::read_json(i64, "9e18") == glz::error_code::none);
+      expect(i64 == 9000000000000000000ll);
+      expect(glz::read_json(i64, "-1e19") == glz::error_code::parse_number_failure);
+
+      // The 128-bit product must be range checked at full width; narrowing it to 64 bits first
+      // let an out-of-range magnitude alias onto an accepted value (9e36 truncated into range).
+      expect(glz::read_json(i64, "9000000000000000000e18") == glz::error_code::parse_number_failure);
+      expect(glz::read_json(i64, "-9000000000000000000e18") == glz::error_code::parse_number_failure);
+      expect(glz::read_json(i64, "1000000000000000000e17") == glz::error_code::parse_number_failure);
+      expect(glz::read_json(i64, "5000000000000000000e10") == glz::error_code::parse_number_failure);
+   };
+
+   "stoui exponent out of range"_test = [] {
+      // Same wrap as the atoi path: a uint8_t accumulator turned "1e256" into exponent 0.
+      expect(glz::stoui("1e256") == std::nullopt);
+      expect(glz::stoui("5e256") == std::nullopt);
+      expect(glz::stoui("1e260") == std::nullopt);
+      expect(glz::stoui("1e20") == std::nullopt);
+      expect(glz::stoui("1e999999") == std::nullopt);
+
+      // A magnitude below one truncates to zero rather than aliasing onto the significand.
+      expect(glz::stoui("1e-256") == std::optional<uint64_t>{0});
+
+      expect(glz::stoui("1e19") == std::optional<uint64_t>{10000000000000000000ull});
+      expect(glz::stoui("1e007") == std::optional<uint64_t>{10000000ull});
+      expect(glz::stoui("1e0000000007") == std::optional<uint64_t>{10000000ull});
+      expect(glz::stoui("123") == std::optional<uint64_t>{123});
+   };
+
+   "exponent scan stays in bounds"_test = [] {
+      // The exponent scan stops at a non-digit rather than after a fixed digit count, so the
+      // scratch buffer that the non-null-terminated overload copies into must be terminated even
+      // when the input fills it. Each input gets its own exact-size heap buffer so ASAN flags any
+      // read past the end. Values this long exceed the scratch buffer and so must error, but they
+      // must error rather than over-read.
+      static constexpr glz::opts options{.null_terminated = false};
+      for (std::string_view number : {"1e00000000000000000000000000000000000007",
+                                      "1e99999999999999999999999999999999999999",
+                                      "12345678901234567890123456789012345678901234567890",
+                                      "-1e00000000000000000000000000000000000007"}) {
+         const std::string complete = "[" + std::string{number} + "]";
+         std::vector<char> buf{complete.begin(), complete.end()};
+
+         std::vector<uint64_t> u64s{};
+         expect(bool(glz::read<options>(u64s, std::string_view{buf.data(), buf.size()}))) << number;
+
+         std::vector<int64_t> i64s{};
+         expect(bool(glz::read<options>(i64s, std::string_view{buf.data(), buf.size()}))) << number;
+      }
+   };
+
    "bool write"_test = [] {
       std::string buffer{};
       expect(not glz::write_json(true, buffer));

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -1096,10 +1096,9 @@ suite basic_types = [] {
       // read past the end. Values this long exceed the scratch buffer and so must error, but they
       // must error rather than over-read.
       static constexpr glz::opts options{.null_terminated = false};
-      for (std::string_view number : {"1e00000000000000000000000000000000000007",
-                                      "1e99999999999999999999999999999999999999",
-                                      "12345678901234567890123456789012345678901234567890",
-                                      "-1e00000000000000000000000000000000000007"}) {
+      for (std::string_view number :
+           {"1e00000000000000000000000000000000000007", "1e99999999999999999999999999999999999999",
+            "12345678901234567890123456789012345678901234567890", "-1e00000000000000000000000000000000000007"}) {
          const std::string complete = "[" + std::string{number} + "]";
          std::vector<char> buf{complete.begin(), complete.end()};
 
@@ -1108,6 +1107,46 @@ suite basic_types = [] {
 
          std::vector<int64_t> i64s{};
          expect(bool(glz::read<options>(i64s, std::string_view{buf.data(), buf.size()}))) << number;
+      }
+   };
+
+   "truncated number is rejected, not valued"_test = [] {
+      // A number longer than the scratch buffer is copied in as a prefix, and the prefix can parse
+      // cleanly on its own: "1e" followed by enough zeros reads as 1 once the copy cuts off the
+      // final digit. A caller that ignores trailing content -- a top level scalar read does, the
+      // same way "17abc" reads as 17 -- would then take that prefix's value as the answer. The
+      // number must be rejected instead. Padding is the only way to stretch a number this far,
+      // since no in-range integer needs that many characters.
+      // Both options are spelled out because this file is also built with GLZ_NULL_TERMINATED=false,
+      // which flips what the default would mean.
+      static constexpr glz::opts options{.null_terminated = false};
+      static constexpr glz::opts terminated{.null_terminated = true};
+      for (size_t zeros : {size_t(30), size_t(40), size_t(64)}) {
+         // 1e<zeros>5 is 100000 however long the padding is
+         const std::string number = "1e" + std::string(zeros, '0') + "5";
+         std::vector<char> buf{number.begin(), number.end()};
+         const std::string_view input{buf.data(), buf.size()};
+
+         uint64_t u64{};
+         expect(bool(glz::read<options>(u64, input))) << number;
+
+         int64_t i64{};
+         expect(bool(glz::read<options>(i64, input))) << number;
+
+         // Null terminated input has the whole number available and reads it exactly. std::string
+         // supplies the terminator this path relies on.
+         expect(glz::read<terminated>(u64, number) == glz::error_code::none) << number;
+         expect(u64 == 100000ull) << number;
+      }
+
+      // A number that fits is still read from a non-null-terminated buffer, padding and all. The
+      // second of these fills the scratch buffer exactly, which is not a truncation: every
+      // character of the input made it in.
+      for (std::string_view fits : {"1e0000000005", "1e000000000000000000000000000005"}) {
+         std::vector<char> buf{fits.begin(), fits.end()};
+         uint64_t u64{};
+         expect(glz::read<options>(u64, std::string_view{buf.data(), buf.size()}) == glz::error_code::none) << fits;
+         expect(u64 == 100000ull) << fits;
       }
    };
 


### PR DESCRIPTION
Follow-up to #2719. That PR fixed the `uint8_t` exponent wrap in the unsigned `atoi` path; reviewing the surrounding code turned up three more defects with the same origin — reading the exponent with a fixed digit count and a narrow accumulator — plus one wrong operand in the 64-bit signed branch, and one more in the scratch buffer that unbounding the exponent scan brought into view.

### 1. `glz::stoui` wrapped the same way

`detail::stoui64` still accumulated the exponent into a `uint8_t`, so `"1e256"` became exponent 0 and the magnitude aliased onto the significand. The `exp < 128` guard could not catch it: the wrap happened before the test. It also left the cursor parked mid-number once it did trip.

```cpp
glz::stoui("1e256")   // was: 1        now: nullopt
glz::stoui("1e-256")  // was: 1        now: 0
glz::stoui("1e20")    // nullopt, unchanged
```

### 2. Leading zeros in the exponent rejected valid JSON

JSON forbids a leading zero in the integer part but permits any run of digits in the exponent, so `1e007` is a valid spelling of 10^7 — `integer` is `onenine digits`, while `exponent` is `'e' sign digits`. The signed path read two exponent digits and the unsigned path three, then stopped mid-number, leaving the remaining digits to be rejected as trailing content.

```cpp
glz::read_json(std::vector<int64_t>{},  "[1e007,2]")    // was: error  now: {10000000, 2}
glz::read_json(std::vector<uint64_t>{}, "[1e0007,2]")   // was: error  now: {10000000, 2}
```

Exponent digits are now consumed to the end and the accumulator clamps, so padding reaches its true value while `1e999999` stays rejected. At the top level these previously truncated silently (`1e007` → 1) rather than erroring, since a top-level read ignores trailing content the same way `"17abc"` reads as 17.

### 3. Negative 64-bit integers with an exponent were always rejected

The `sizeof(T) == 8` signed branch scaled `std::bit_cast<utype>(v)` — the two's-complement bit pattern — instead of the sign-stripped magnitude `i` computed just above it. For a negative value that pattern is a huge unsigned number, so the multiply overflowed. The 1/2/4-byte branches already used `i`, which is why only 64-bit was affected.

```cpp
glz::read_json(int64_t{}, "-1e2")    // was: error  now: -100
glz::read_json(int64_t{}, "-1e18")   // was: error  now: -1000000000000000000
glz::read_json(int32_t{}, "-1e2")    // -100, unchanged
```

### 4. The 128-bit product was range checked at 64 bits

The same branch compared only `uint64_t(res)`, so an out-of-range magnitude could truncate into range — the exact failure mode #2719 fixed for unsigned:

```cpp
glz::read_json(int64_t{}, "9000000000000000000e18")  // was: 5595889181738926080  now: error
```

The comparison is now full width, matching the `full_multiplication` fallback, which already checked the high word.

### Buffer termination

Consuming exponent digits to the end makes the scan bounded by the input rather than by a digit count. The scratch buffer in the `(it, end)` overload was fully overwritten by its `memcpy` when the input filled it, leaving no terminator to stop on, so it gets one guaranteed spare byte. Without this, fix 2 would be a stack over-read on non-null-terminated input. `parse_int` is fully unrolled and was never affected.

### 5. A number too long for the scratch buffer was valued from its prefix

Terminating the buffer stops the over-read but not the truncation behind it. The `(it, end)` overload copies a bounded prefix of the input, and that prefix can parse cleanly on its own: `1e` followed by enough zeros reads as 1 once the copy cuts off the final digit. Inside an array the leftover digits are caught as trailing content, but a top-level scalar read ignores trailing content the same way `"17abc"` reads as 17, so the prefix's value became the answer.

```cpp
// "1e" + N zeros + "5" is 100000 for any N, read with .null_terminated = false
//                        null terminated    before    after
// 30 characters               100000        100000    100000
// 32 characters               100000        100000    100000   // fills the buffer exactly
// 33 characters               100000             1    error
// 43 characters               100000             1    error
```

If the copy was truncated and parsing ran to the end of it, the scan halted on the terminator the buffer supplies rather than on a character of the input, so the parse is rejected. Nothing valid is lost: no in-range integer needs `buffer_length` characters, so only zero padding stretches a number that far, and input that fills the buffer exactly is not a truncation and still reads. This was wrong on main too, in both the null-terminated and non-null-terminated cases; fix 2 repairs the former and this repairs the latter.

### Docs

`docs/JSON/json-integer-parsing.md` gains `1e002` as a valid example, since leading zeros in the exponent are now accepted. It already listed `256` as out of range for a `uint8_t`, which the parser did not actually enforce — #2723 makes that true.

### Testing

- Full suite green: 107/107 via ctest, `json_test` at 706 tests / 60544 asserts.
- New tests cover each fix, out-of-range exponents at and around the clamp, padded-but-still-out-of-range exponents, and a non-null-terminated sweep over exact-size heap buffers so ASAN flags any over-read.
- The truncation test spells out both `null_terminated` settings rather than relying on the default, since `json_test` is also built with `GLZ_NULL_TERMINATED=false` as `json_test_non_null`, which flips what the default means. It covers the boundary in both directions: padding that overruns the buffer must error, padding that fills it exactly must still read.
- `json_test` and the targeted cases run clean under ASAN and UBSAN.
- Both `__int128` and `full_multiplication` branches verified, the latter by forcing the fallback.

### Performance

No measurable change on integer-heavy JSON without exponents (1782–1785 MB/s before and after). On a deliberately exponent-saturated corpus — 40% of values carrying an exponent, far above real JSON — parsing is ~1.5% slower, from replacing the unrolled digit reads with a clamped loop. An unrolled fast path was tried and measured worse (~6%), apparently from the added code size, so the simpler loop is what is here.
