### PR TITLE
fix signed overflow in the %YAML directive version parser

### DIFF
--- a/include/glaze/yaml/common.hpp
+++ b/include/glaze/yaml/common.hpp
@@ -830,12 +830,16 @@ namespace glz::yaml
                ctx.error = error_code::syntax_error;
                return;
             }
-            // Clamp rather than accumulate without bound. The version is only ever compared
-            // against a small threshold below, while an int accumulator overflows on a long digit
-            // run -- undefined behavior, and in practice a wrap that carries a huge version back
-            // into the accepted range, so "%YAML 4294967296.0" was read as major version 0. The
-            // clamp sits above any threshold worth distinguishing, so a clamped value always
-            // compares greater.
+            // Clamp rather than accumulate without bound. An int accumulator overflows on a long
+            // digit run -- undefined behavior, and in practice a wrap that carries a huge version
+            // back into the accepted range, so "%YAML 4294967296.0" was read as major version 0.
+            //
+            // Clamping is safe because the accumulator only grows: it stops updating once it has
+            // already reached max_tracked_version, so a clamped value is always at least that
+            // large, and the clamp is far above the threshold checked below. A version big enough
+            // to freeze the accumulator therefore still compares greater and is still rejected.
+            // The bound is deliberately independent of that threshold, so raising the threshold
+            // later cannot quietly reintroduce the wrap. Peak value is 999, well inside int.
             constexpr int max_tracked_version = 100;
             int major_version = 0;
             while (it != end && *it >= '0' && *it <= '9') {

--- a/include/glaze/yaml/common.hpp
+++ b/include/glaze/yaml/common.hpp
@@ -830,9 +830,18 @@ namespace glz::yaml
                ctx.error = error_code::syntax_error;
                return;
             }
+            // Clamp rather than accumulate without bound. The version is only ever compared
+            // against a small threshold below, while an int accumulator overflows on a long digit
+            // run -- undefined behavior, and in practice a wrap that carries a huge version back
+            // into the accepted range, so "%YAML 4294967296.0" was read as major version 0. The
+            // clamp sits above any threshold worth distinguishing, so a clamped value always
+            // compares greater.
+            constexpr int max_tracked_version = 100;
             int major_version = 0;
             while (it != end && *it >= '0' && *it <= '9') {
-               major_version = major_version * 10 + (*it - '0');
+               if (major_version < max_tracked_version) {
+                  major_version = major_version * 10 + (*it - '0');
+               }
                ++it;
             }
             if (it == end || *it != '.') {

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -3600,6 +3600,42 @@ name: test)";
       expect(bool(ec)) << "%YAML 3.0 should be rejected";
    };
 
+   // A long version number must not wrap past the major version check. The accumulator used to be
+   // an unbounded int, so a value congruent to 0 or 1 mod 2^32 overflowed -- undefined behavior --
+   // and came back inside the accepted range: "%YAML 4294967296.0" was read as major version 0.
+   "yaml_directive_major_version_overflow_error"_test = [] {
+      for (std::string_view version : {"4294967296", // 2^32, wrapped to 0
+                                       "4294967297", // 2^32 + 1, wrapped to 1
+                                       "8589934592", // 2^33, wrapped to 0
+                                       "2147483648", // 2^31
+                                       "99999999999999999999"}) {
+         const std::string yaml = "%YAML " + std::string{version} + ".0\n---\nx: 42\ny: 3.14\nname: test";
+         simple_struct obj{};
+         auto ec = glz::read_yaml(obj, yaml);
+         expect(bool(ec)) << "%YAML " << version << ".0 should be rejected";
+      }
+   };
+
+   // Clamping the accumulator must not disturb versions that are in range, including the zero
+   // padding the grammar allows (the version is digits '.' digits, with no leading-zero rule).
+   "yaml_directive_major_version_padded"_test = [] {
+      for (std::string_view version : {"01.2", "001.2", "00000000000000000001.2"}) {
+         const std::string yaml = "%YAML " + std::string{version} + "\n---\nx: 42\ny: 3.14\nname: test";
+         simple_struct obj{};
+         auto ec = glz::read_yaml(obj, yaml);
+         expect(!ec) << glz::format_error(ec, yaml);
+         expect(obj.x == 42);
+      }
+
+      // Multi-digit majors are still out of range, on both sides of the clamp.
+      for (std::string_view version : {"10.0", "11.0", "99.0", "100.0", "101.0"}) {
+         const std::string yaml = "%YAML " + std::string{version} + "\n---\nx: 42\ny: 3.14\nname: test";
+         simple_struct obj{};
+         auto ec = glz::read_yaml(obj, yaml);
+         expect(bool(ec)) << "%YAML " << version << " should be rejected";
+      }
+   };
+
    // Unknown directives should be silently ignored (per spec)
    "yaml_directive_unknown_ignored"_test = [] {
       std::string yaml = R"(%FOOBAR some params here

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -3608,6 +3608,8 @@ name: test)";
                                        "4294967297", // 2^32 + 1, wrapped to 1
                                        "8589934592", // 2^33, wrapped to 0
                                        "2147483648", // 2^31
+                                       "18446744073709551616", // 2^64, 20 digits, wrapped to 0
+                                       "18446744073709551617", // 2^64 + 1, wrapped to 1
                                        "99999999999999999999"}) {
          const std::string yaml = "%YAML " + std::string{version} + ".0\n---\nx: 42\ny: 3.14\nname: test";
          simple_struct obj{};
@@ -3627,12 +3629,40 @@ name: test)";
          expect(obj.x == 42);
       }
 
+      // Padding far longer than the clamp bound: the two are unrelated, since leading zeros never
+      // advance the accumulator. The matching out-of-range case must still be rejected.
+      {
+         const std::string yaml = "%YAML " + std::string(200, '0') + "1.2\n---\nx: 42\ny: 3.14\nname: test";
+         simple_struct obj{};
+         auto ec = glz::read_yaml(obj, yaml);
+         expect(!ec) << glz::format_error(ec, yaml);
+         expect(obj.x == 42);
+      }
+      {
+         const std::string yaml = "%YAML " + std::string(200, '0') + "2.0\n---\nx: 42\ny: 3.14\nname: test";
+         simple_struct obj{};
+         expect(bool(glz::read_yaml(obj, yaml))) << "padded major 2 should be rejected";
+      }
+
       // Multi-digit majors are still out of range, on both sides of the clamp.
       for (std::string_view version : {"10.0", "11.0", "99.0", "100.0", "101.0"}) {
          const std::string yaml = "%YAML " + std::string{version} + "\n---\nx: 42\ny: 3.14\nname: test";
          simple_struct obj{};
          auto ec = glz::read_yaml(obj, yaml);
          expect(bool(ec)) << "%YAML " << version << " should be rejected";
+      }
+   };
+
+   // Major version 0 is accepted: the spec only requires rejecting a version this parser is too
+   // old to understand, and 0 is not that. Pinned here because the all-zeros digit run is the one
+   // accepted input that reaches the clamped accumulator, so a change to the clamp would show up.
+   "yaml_directive_major_version_zero"_test = [] {
+      for (std::string_view version : {"0.1", "0.0", "00.1", "000.2"}) {
+         const std::string yaml = "%YAML " + std::string{version} + "\n---\nx: 42\ny: 3.14\nname: test";
+         simple_struct obj{};
+         auto ec = glz::read_yaml(obj, yaml);
+         expect(!ec) << glz::format_error(ec, yaml);
+         expect(obj.x == 42);
       }
    };
 


### PR DESCRIPTION
Found while auditing for the defect class behind #2719 and #2721: a range check placed after the operation that can destroy the value it is checking.

### The bug

`%YAML` directive parsing accumulated the major version from an unbounded run of digits into an `int`, and the check that rejects a major version above 1 ran only after the loop:

```cpp
int major_version = 0;
while (it != end && *it >= '0' && *it <= '9') {
   major_version = major_version * 10 + (*it - '0');   // overflows
   ++it;
}
...
if (major_version > 1) { ctx.error = error_code::syntax_error; return; }
```

A long version number overflows the accumulator and wraps a large value back into the accepted range:

```
%YAML 2.0            -> rejected    (correct)
%YAML 4294967296.0   -> accepted    2^32,   wrapped to 0
%YAML 4294967297.0   -> accepted    2^32+1, wrapped to 1
%YAML 8589934592.0   -> accepted    2^33,   wrapped to 0
```

Unlike the unsigned wraps in #2719 and #2721, this one is undefined behavior rather than merely a wrong answer — UBSAN aborts on the parse:

```
include/glaze/yaml/common.hpp:835:46: runtime error: signed integer overflow:
429496729 * 10 cannot be represented in type 'int'
```

Functional impact is small: it accepts a malformed directive rather than corrupting data. The UB is the reason to close it, since a compiler may assume signed overflow cannot happen.

### The fix

Clamp the accumulator. The clamp sits above any threshold worth distinguishing, so a clamped value always compares greater than the limit and the existing check rejects it. The clamp is deliberately not tied to the `> 1` threshold, so changing that threshold later cannot silently reintroduce the wrap.

Versions in range are unaffected, including the zero padding the grammar allows — the version is `digits '.' digits` with no leading-zero rule, so `%YAML 001.2` is a valid spelling of 1.2.

### Testing

- New tests cover the wrapping values, multi-digit majors on both sides of the clamp, and zero-padded versions. Four of the five overflow cases fail against the unfixed parser; the padded cases are there to pin the behavior the clamp must not disturb.
- Full suite green: 107/107 via ctest.
- `yaml_test` (712 tests) and `yaml_conformance` (402 tests) run clean under ASAN and UBSAN with `-fno-sanitize-recover=all`. The same UBSAN build aborts on the unfixed parser.

### Scope

Independent of #2721 and based on main, so the two can merge in either order. The rest of the audit came back clean: `fast_float.hpp` and `glaze_fast_float.hpp` clamp before the multiply, `simple_float.hpp` clamps, `toml/read.hpp` and `core/chrono.hpp` bound their digit counts, and `zmij.hpp` is a write path over a bounded significand. This was the only other site where a narrow accumulator feeds a range check.
