### PR TITLE
reject out-of-range integers instead of wrapping them

### DIFF
--- a/include/glaze/util/atoi.hpp
+++ b/include/glaze/util/atoi.hpp
@@ -373,12 +373,15 @@ namespace glz
       }
 
       if (is_digit(*c)) {
-         v = v * 10 + (*c - '0');
-         constexpr auto split = (std::numeric_limits<T>::max)() / 10 - 10;
-         if (v < split) [[unlikely]] {
-            // due to overflow
+         // Test before multiplying. The previous guard multiplied first and then compared the
+         // already-wrapped value against max/10 - 10, which only caught wraps that happened to land
+         // below that threshold: "300" wraps to 44 for uint8_t and sailed through, as did most
+         // out-of-range values. would_overflow_positive is the same branch-free check the signed
+         // path above already uses, so the two paths now reject on the same rule.
+         if (would_overflow_positive<T>(v, *c)) [[unlikely]] {
             return {};
          }
+         v = v * 10 + (*c - '0');
          ++c;
          if (is_digit(*c)) [[unlikely]] {
             return {};
@@ -750,22 +753,19 @@ namespace glz
          }
 
          utype i = utype((utype(v) ^ -sign) + sign);
-         if constexpr (sizeof(T) == 1) {
-            static constexpr std::array<utype, 3> powers_of_ten{1, 10, 100};
-            i *= powers_of_ten[exp];
-            v = T((utype(i) ^ -sign) + sign);
-            return (i - sign) <= static_cast<utype>((std::numeric_limits<T>::max)());
-         }
-         else if constexpr (sizeof(T) == 2) {
-            static constexpr std::array<utype, 5> powers_of_ten{1, 10, 100, 1000, 10000};
-            i *= powers_of_ten[exp];
-            v = T((utype(i) ^ -sign) + sign);
-            return (i - sign) <= static_cast<utype>((std::numeric_limits<T>::max)());
-         }
-         else if constexpr (sizeof(T) == 4) {
-            i *= powers_of_ten_int[exp];
-            v = T((utype(i) ^ -sign) + sign);
-            return (i - sign) <= static_cast<utype>((std::numeric_limits<T>::max)());
+         if constexpr (sizeof(T) < 8) {
+            // Scale in a width the product cannot wrap, then range check before narrowing. Scaling
+            // inside `utype` truncated first and checked afterwards, so an out-of-range magnitude
+            // aliased onto an accepted one: "13e2" read as 20 for int8_t and "5e9" as 705032704 for
+            // int32_t. The widest case here is a 4-byte magnitude scaled by 10^9, which stays well
+            // inside uint64_t. The unsigned path already widens the same way.
+            const uint64_t scaled = uint64_t(i) * powers_of_ten_int[exp];
+            v = T((utype(scaled) ^ -sign) + sign);
+            // Bound the magnitude directly rather than subtracting the sign from it: a negative
+            // zero makes `scaled - sign` underflow, and the old narrow expression only survived
+            // that because it promoted to int. A negative value may reach one past the positive
+            // limit, which is exactly INT_MIN's magnitude.
+            return scaled <= uint64_t((std::numeric_limits<T>::max)()) + sign;
          }
          else {
             // Scale the sign-stripped magnitude `i`, not the two's-complement bit pattern of `v`:

--- a/include/glaze/util/atoi.hpp
+++ b/include/glaze/util/atoi.hpp
@@ -413,24 +413,28 @@ namespace glz
             return false;
          }
          const uint32_t exp = parse_exponent(c);
+         // An exponent past the width's limit overflows any non-zero magnitude, but zero stays zero
+         // however far it is scaled, so "0e19" is in range for every width. Testing the magnitude
+         // here rather than ahead of the dispatch keeps it off the hot path: it only runs once the
+         // exponent has already failed the range check.
          if constexpr (sizeof(T) == 1) {
             if (exp > 2) [[unlikely]] {
-               return false;
+               return v == 0;
             }
          }
          else if constexpr (sizeof(T) == 2) {
             if (exp > 4) [[unlikely]] {
-               return false;
+               return v == 0;
             }
          }
          else if constexpr (sizeof(T) == 4) {
             if (exp > 9) [[unlikely]] {
-               return false;
+               return v == 0;
             }
          }
          else {
             if (exp > 19) [[unlikely]] {
-               return false;
+               return v == 0;
             }
          }
 
@@ -731,24 +735,27 @@ namespace glz
             return false;
          }
          const uint32_t exp = parse_exponent(c);
+         // As in the unsigned overload: only a non-zero magnitude can overflow, so "0e19" and
+         // "-0e19" are in range for every width. `v` is already the signed mantissa, and negative
+         // zero compares equal to zero, so both spellings land here with the value they should keep.
          if constexpr (sizeof(T) == 1) {
             if (exp > 2) [[unlikely]] {
-               return false;
+               return v == 0;
             }
          }
          else if constexpr (sizeof(T) == 2) {
             if (exp > 4) [[unlikely]] {
-               return false;
+               return v == 0;
             }
          }
          else if constexpr (sizeof(T) == 4) {
             if (exp > 9) [[unlikely]] {
-               return false;
+               return v == 0;
             }
          }
          else {
             if (exp > 18) [[unlikely]] {
-               return false;
+               return v == 0;
             }
          }
 

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -1254,6 +1254,14 @@ namespace glz
       ctx.error = error_code::unexpected_end;
    }
 
+   // Parses a JSON unsigned integer, returning nullopt if `s` does not start with one or if the
+   // value is out of range for uint64_t. Trailing content is ignored: "12abc" reads as 12.
+   //
+   // `s` must be null terminated. Scanning stops on the first non-digit rather than at s.size(), so
+   // without a terminator there is nothing to halt it inside the view: a std::string_view over a
+   // bare character array reads past its end, and a view of the first few digits of a longer run
+   // consumes the rest of them. String literals and std::string satisfy this; a subview of a larger
+   // buffer does not, unless the character just past it is a non-digit.
    inline constexpr std::optional<uint64_t> stoui(const std::string_view s) noexcept
    {
       if (s.empty()) {

--- a/tests/int_parsing/int_parsing.cpp
+++ b/tests/int_parsing/int_parsing.cpp
@@ -774,4 +774,80 @@ suite u8_test = [] {
    "i64 array minified"_test = [] { test_struct_with_array_minified<int64_t>(); };
 };
 
+// An out-of-range integer must be rejected, never wrapped into an accepted value. Reading through a
+// vector forces the whole number to be consumed, since a top-level read ignores trailing content.
+template <class T>
+[[nodiscard]] bool rejects(const std::string& number)
+{
+   std::vector<T> v{};
+   return bool(glz::read_json(v, "[" + number + "]"));
+}
+
+template <class T>
+[[nodiscard]] bool reads_as(const std::string& number, T expected)
+{
+   std::vector<T> v{};
+   return !glz::read_json(v, "[" + number + "]") && v.size() == 1 && v[0] == expected;
+}
+
+suite overflow_rejection = [] {
+   // The unsigned guard used to multiply first and compare the already-wrapped value against
+   // max/10 - 10, so it only caught wraps that landed below that threshold. "300" wrapped to 44 for
+   // uint8_t and was accepted; so were 699 of the 744 out-of-range values below.
+   "unsigned plain integer overflow exhaustive"_test = [] {
+      size_t accepted = 0;
+      for (int i = 256; i <= 999; ++i) {
+         if (!rejects<uint8_t>(std::to_string(i))) ++accepted;
+      }
+      expect(accepted == 0) << accepted << " out-of-range uint8_t values were accepted";
+
+      for (long i = 65536; i <= 66600; ++i) {
+         if (!rejects<uint16_t>(std::to_string(i))) {
+            expect(false) << "uint16_t accepted " << i;
+            break;
+         }
+      }
+      // Every width, just past the limit and at a value that previously wrapped into range.
+      expect(rejects<uint8_t>("271") && rejects<uint8_t>("300") && rejects<uint8_t>("999"));
+      expect(rejects<uint16_t>("72079") && rejects<uint16_t>("75495"));
+      expect(rejects<uint32_t>("4294967296") && rejects<uint32_t>("5000000000"));
+      expect(rejects<uint64_t>("18446744073709551616") && rejects<uint64_t>("99999999999999999999"));
+
+      // The limit itself and the value below it still read correctly.
+      expect(reads_as<uint8_t>("255", 255) && reads_as<uint8_t>("254", 254));
+      expect(reads_as<uint16_t>("65535", 65535));
+      expect(reads_as<uint32_t>("4294967295", 4294967295u));
+      expect(reads_as<uint64_t>("18446744073709551615", 18446744073709551615ull));
+   };
+
+   // The signed exponent path scaled inside the narrow unsigned type, truncating the product before
+   // the range check, so an out-of-range magnitude aliased onto an accepted one.
+   "signed exponent overflow"_test = [] {
+      expect(rejects<int8_t>("13e2")); // was 20
+      expect(rejects<int8_t>("3e2")); // was 44
+      expect(rejects<int16_t>("9e4")); // was 24464
+      expect(rejects<int16_t>("7e4")); // was 4464
+      expect(rejects<int32_t>("5e9")); // was 705032704
+      expect(rejects<int32_t>("13e9")); // was 115098112
+      expect(rejects<int8_t>("-13e2") && rejects<int16_t>("-9e4") && rejects<int32_t>("-5e9"));
+
+      // In-range scaling is unchanged, at the limit and either side of zero.
+      expect(reads_as<int8_t>("12e1", int8_t(120)) && reads_as<int8_t>("-12e1", int8_t(-120)));
+      expect(reads_as<int16_t>("3e4", int16_t(30000)) && reads_as<int16_t>("-3e4", int16_t(-30000)));
+      expect(reads_as<int32_t>("2e9", 2000000000) && reads_as<int32_t>("-2e9", -2000000000));
+      expect(reads_as<int64_t>("9e18", 9000000000000000000ll));
+   };
+
+   // Negative zero is zero, and it must be accepted uniformly. Previously the range check subtracted
+   // the sign from the magnitude, which underflowed; the narrow widths only survived because they
+   // promoted to int, so int16_t accepted "-0e0" while int32_t rejected it.
+   "negative zero with exponent"_test = [] {
+      expect(reads_as<int8_t>("-0e0", int8_t(0)) && reads_as<int8_t>("-0e2", int8_t(0)));
+      expect(reads_as<int16_t>("-0e0", int16_t(0)) && reads_as<int16_t>("-0e4", int16_t(0)));
+      expect(reads_as<int32_t>("-0e0", 0) && reads_as<int32_t>("-0e9", 0));
+      expect(reads_as<int64_t>("-0e0", 0ll) && reads_as<int64_t>("-0e18", 0ll));
+      expect(reads_as<int8_t>("-0", int8_t(0)) && reads_as<int32_t>("-0", 0));
+   };
+};
+
 int main() { return 0; }

--- a/tests/int_parsing/int_parsing.cpp
+++ b/tests/int_parsing/int_parsing.cpp
@@ -848,6 +848,26 @@ suite overflow_rejection = [] {
       expect(reads_as<int64_t>("-0e0", 0ll) && reads_as<int64_t>("-0e18", 0ll));
       expect(reads_as<int8_t>("-0", int8_t(0)) && reads_as<int32_t>("-0", 0));
    };
+
+   // Zero stays zero however far it is scaled, so a zero mantissa is in range whatever the exponent.
+   // The width limits reject on the exponent alone, which turned these valid inputs into errors.
+   "zero mantissa with out of range exponent"_test = [] {
+      expect(reads_as<uint8_t>("0e3", uint8_t(0)) && reads_as<uint8_t>("0e19", uint8_t(0)));
+      expect(reads_as<uint16_t>("0e5", uint16_t(0)) && reads_as<uint16_t>("0e19", uint16_t(0)));
+      expect(reads_as<uint32_t>("0e10", 0u) && reads_as<uint32_t>("0e19", 0u));
+      expect(reads_as<uint64_t>("0e20", 0ull) && reads_as<uint64_t>("0e999999", 0ull));
+
+      expect(reads_as<int8_t>("0e3", int8_t(0)) && reads_as<int8_t>("-0e3", int8_t(0)));
+      expect(reads_as<int16_t>("0e5", int16_t(0)) && reads_as<int16_t>("-0e5", int16_t(0)));
+      expect(reads_as<int32_t>("0e10", 0) && reads_as<int32_t>("-0e10", 0));
+      expect(reads_as<int64_t>("0e19", 0ll) && reads_as<int64_t>("-0e19", 0ll));
+      expect(reads_as<int64_t>("0e999999", 0ll) && reads_as<int64_t>("-0e999999", 0ll));
+
+      // A non-zero mantissa with the same exponent is still out of range, and the mantissa still
+      // has to be well formed: JSON forbids a leading zero in the integer part.
+      expect(rejects<uint8_t>("1e19") && rejects<int64_t>("1e19") && rejects<uint64_t>("1e20"));
+      expect(rejects<uint8_t>("00e19") && rejects<int32_t>("-00e19"));
+   };
 };
 
 int main() { return 0; }


### PR DESCRIPTION
Stacked on #2721 — that branch is the base, so review this diff on its own and merge it after. Found while chasing a review comment on #2721.

Two range checks ran *after* the operation that destroyed the value they were checking. Same shape as #2719, #2721 and #2722, but this one reaches ordinary JSON integers with no exponent involved. Two narrower defects came out of the differential harness built to check the first two, and are fixed here as well.

### 1. Most out-of-range unsigned integers were accepted with a wrapped value

The unsigned digit guard multiplied first, then compared the already-wrapped value against `max/10 - 10`. That only catches wraps that happen to land below the threshold, so most out-of-range input sailed through:

```cpp
glz::read_json(std::vector<uint8_t>{},  "[300]")    // was: 44    now: error
glz::read_json(std::vector<uint8_t>{},  "[999]")    // was: 231   now: error
glz::read_json(std::vector<uint8_t>{},  "[271]")    // was: 15    now: error
glz::read_json(std::vector<uint16_t>{}, "[75495]")  // was: 9959  now: error
```

**699 of the 744 values in [256, 999] were accepted as `uint8_t`.** No exponent, no unusual spelling — plain integer parsing returning a plausible wrong number for out-of-range input.

The fix tests before multiplying, using `would_overflow_positive`, which already exists in this file and which the *signed* path has been using all along. Only the unsigned path carried the older heuristic, so this removes a divergence rather than adding machinery.

### 2. The signed exponent path truncated the product before checking it

The 1/2/4-byte signed branches scaled the magnitude inside the narrow unsigned type, wrapping it before the range check:

```cpp
glz::read_json(std::vector<int8_t>{},  "[13e2]")  // was: 20         now: error
glz::read_json(std::vector<int16_t>{}, "[9e4]")   // was: 24464      now: error
glz::read_json(std::vector<int32_t>{}, "[5e9]")   // was: 705032704  now: error
```

Now scaled in `uint64_t` and checked before narrowing, matching what the unsigned branches already do. The widest case is a 4-byte magnitude scaled by 10^9, which stays well inside `uint64_t`.

### 3. Negative zero was accepted or rejected depending on width

Bounding via `(magnitude - sign) <= max` underflows when the magnitude is zero and the value is negative. It only worked at all for the narrow widths because they integer-promote to `int`; `uint32_t` does not, so `int16_t` accepted `-0e0` while `int32_t` rejected it. Bounding against `max + sign` instead removes the subtraction, and every width now accepts it. This surfaced as a regression in my own first attempt at fix 2 — the differential harness caught it.

### 4. A zero mantissa was rejected when the exponent exceeded the width's limit

A zero-mantissa form such as `0e19` is equal to 0 and in range for every width, but the range check looks only at the exponent, so it errored. These were the last wrong rejections the harness below still reported.

```cpp
glz::read_json(std::vector<int64_t>{},  "[0e19]")   // was: error  now: {0}
glz::read_json(std::vector<uint8_t>{},  "[0e19]")   // was: error  now: {0}
glz::read_json(std::vector<int32_t>{},  "[-0e10]")  // was: error  now: {0}
```

Zero stays zero however far it is scaled, so only a non-zero magnitude can overflow: the guard returns whether the mantissa is zero instead of a flat `false`. This costs nothing on the hot path, which is why it is here rather than left as a follow-up — the test runs inside the branch that has already failed the exponent range check, the `[[unlikely]]` one. A non-zero mantissa with the same exponent is still rejected, and the mantissa still has to be well formed, so `00e19` stays an error.

With this, the harness reports no disagreement with the reference in either direction, at any width.

### Measurement

103,135 inputs (boundary sweeps around every width's limit, mantissa × exponent grids, 60k random) checked against a `__int128` reference for both accept/reject and value:

| | base (#2721) | this PR |
|---|---|---|
| accepted with a **wrong value** | 17714 | **0** |
| wrongly rejected | 150 | **0** |

Per width, accepted-with-wrong-value goes to zero everywhere: `int8` 231→0, `uint8` 699→0, `int16` 195→0, `uint16` 2→0, `int32` 16587→0.

### Testing

- New tests in `int_parsing`, including an exhaustive sweep asserting every value in [256, 999] is rejected as `uint8_t`. Against the pre-fix header it reports `699 out-of-range uint8_t values were accepted`.
- Zero-mantissa coverage across every width and both signs, including the clamped `0e999999`, alongside the non-zero and malformed cases that must stay rejected.
- Full suite green: 107/107 via ctest.
- `int_parsing` (45 tests) and `json_test` (706 tests) clean under ASAN and UBSAN with `-fno-sanitize-recover=all`.

### Performance

No measurable change, which was a design constraint here rather than an afterthought. The overflow test is one comparison either way, just moved before the multiply, and a 64-bit multiply costs the same as a narrow one on 64-bit targets. Interleaved runs:

- plain integers: 1738–1763 MB/s base vs 1752–1787 MB/s with the fix
- exponent-heavy: 1168–1179 MB/s base vs 1170–1192 MB/s with the fix

Fix 4 adds nothing measurable for the same reason it is cheap by construction: it sits inside a branch that has already been taken only when the exponent is out of range.

### Note on `glz::stoui`

While reviewing #2721 it came up that `glz::stoui` scans for a non-digit with no end pointer, so a non-null-terminated `std::string_view` over-reads. That is pre-existing on main for the mantissa scan. Adding per-character bounds checks would cost throughput on a path that does not need it, since the function's contract is null-terminated input and every in-tree caller is a compile-time constant expression over a string literal.

So the contract is now written down at the declaration rather than guarded at runtime: what the function returns, that trailing content is ignored, and which argument types actually satisfy null termination — string literals and `std::string` do, a subview of a larger buffer does not unless the character just past it is a non-digit, which is the case a caller is most likely to get wrong.

