### PR TITLE
guard yaml anchor alias check against end of input

### DIFF
--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -5645,7 +5645,7 @@ namespace glz
 
                // Anchor on alias (&anchor *alias) is invalid per YAML spec.
                // But alias-as-key (&anchor *alias : value) is valid.
-               if (*it == '*' && !yaml::alias_token_is_mapping_key(it, end)) {
+               if (it != end && *it == '*' && !yaml::alias_token_is_mapping_key(it, end)) {
                   ctx.error = error_code::syntax_error;
                   return;
                }

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -4276,6 +4276,31 @@ ship-to: *id001)";
          R"({"bill-to":{"given":"Chris","family":"Dumars"},"ship-to":{"given":"Chris","family":"Dumars"}})";
       expect(json == expected) << json;
    };
+
+   "anchor_trailing_blank_line_stays_in_bounds"_test = [] {
+      static constexpr glz::opts options{.format = glz::YAML, .null_terminated = false};
+      // An anchor whose value is on the next line, where that line holds only whitespace the
+      // indent scan does not measure (a tab), leaves the cursor at the end of the buffer.
+      // A non-null-terminated buffer has no sentinel there, so the anchor scan must stop
+      // rather than read the byte past the end.
+      for (const std::string_view s : {"&a\n\t", "&a\n\t\t", "&a\n \t", "&a\n\t \t"}) {
+         std::vector<char> buf{s.begin(), s.end()};
+         const std::string_view view{buf.data(), buf.data() + buf.size()};
+         glz::generic parsed{};
+         const auto ec = glz::read<options>(parsed, view);
+         expect(ec.ec == glz::error_code::unexpected_end) << s;
+         expect(ec.count <= view.size()) << s;
+      }
+
+      // An anchor with real content on the next line still parses.
+      const std::string_view valid = "&a\n  x";
+      std::vector<char> buf{valid.begin(), valid.end()};
+      const std::string_view view{buf.data(), buf.data() + buf.size()};
+      glz::generic parsed{};
+      const auto ec = glz::read<options>(parsed, view);
+      expect(!ec) << glz::format_error(ec, view);
+      expect(glz::write_json(parsed).value_or("WRITE_ERR") == R"("x")");
+   };
 };
 
 // ============================================================


### PR DESCRIPTION
The anchor branch of the YAML variant reader advances the cursor past the line break to the anchored value, then tests for the invalid anchor-on-alias form with `*it == '*'`. When the next line holds only whitespace that `skip_inline_ws` consumes but the indent scan does not measure, that advance lands on `end`. Before: `glz::read<opts{.format = glz::YAML, .null_terminated = false}>` of the four byte document `&a\n\t` into `glz::generic` reads the byte past the buffer, which ASAN reports as a heap-buffer-overflow at `yaml/read.hpp:5648`.

After: the scan stops and the read reports `unexpected_end`, which is what the null terminated path already returns for that input, so both modes now agree. The bound belongs on this test rather than earlier in the advance because the tag branch of the same switch handles its end case that way, and the next statement in this branch already guards its own `&` test identically. The tradeoff is one comparison on a path that runs once per anchor; documents with content after the anchor are unaffected.