### PR TITLE
fix out-of-bounds read in repe zero-copy read_params

### DIFF
--- a/include/glaze/rpc/repe/repe.hpp
+++ b/include/glaze/rpc/repe/repe.hpp
@@ -554,7 +554,17 @@ namespace glz::repe
       }
       auto start = b;
 
-      glz::parse<Opts.format>::template op<Opts>(std::forward<Value>(value), ctx, b, e);
+      // The body is a view into the request span, so nothing is guaranteed to follow it.
+      // A null_terminated read drops its end checks and scans for the '\0' sentinel that
+      // only a std::string body would supply, so read the view as unterminated input and
+      // clear the end_reached a value finishing at the span end reports, matching what
+      // finalize_read_context does for glz::read.
+      static constexpr auto BodyOpts = opt_false<Opts, &opts::null_terminated>;
+
+      glz::parse<Opts.format>::template op<BodyOpts>(std::forward<Value>(value), ctx, b, e);
+      if (ctx.error == error_code::end_reached && ctx.depth == 0) {
+         ctx.error = error_code::none;
+      }
 
       if (bool(ctx.error)) {
          error_ctx ec{size_t(b - start), ctx.error, ctx.custom_error_message};

--- a/tests/networking_tests/registry_view_test/registry_view_test.cpp
+++ b/tests/networking_tests/registry_view_test/registry_view_test.cpp
@@ -3,6 +3,7 @@
 
 #include <cstring>
 #include <string>
+#include <vector>
 
 #include "glaze/rpc/registry.hpp"
 #include "ut/ut.hpp"
@@ -286,6 +287,55 @@ suite registry_span_call_tests = [] {
 
       auto result = glz::repe::parse_request({response_buf.data(), response_buf.size()});
       expect(result.request.id() == 12345) << "Response ID should match request ID";
+   };
+};
+
+struct vec2
+{
+   int x{};
+   int y{};
+};
+
+struct object_api
+{
+   vec2 position{};
+};
+
+suite span_call_unterminated_buffer_tests = [] {
+   // make_request hands back a std::string, whose data()[size()] is a '\0' the reader
+   // can stop on. Off the wire the body ends where the buffer ends, so copy the message
+   // into an exactly sized vector to reproduce that.
+   auto exact_buffer = [](std::string_view message) { return std::vector<char>(message.begin(), message.end()); };
+
+   "scalar_body_ending_at_buffer_end"_test = [&] {
+      glz::registry<> registry;
+      test_api api{};
+      registry.on(api);
+
+      const auto request = exact_buffer(make_request("/value", "7"));
+      std::string response_buf;
+      registry.call(std::span<const char>{request.data(), request.size()}, response_buf);
+
+      expect(api.value == 7) << "Scalar body should be applied";
+      auto result = glz::repe::parse_request({response_buf.data(), response_buf.size()});
+      expect(bool(result)) << "Response should be parseable";
+      expect(result.request.error() == glz::error_code::none) << "No error expected";
+   };
+
+   "object_body_ending_at_buffer_end"_test = [&] {
+      glz::registry<> registry;
+      object_api api{};
+      registry.on(api);
+
+      const auto request = exact_buffer(make_request("/position", R"({"x":3,"y":4})"));
+      std::string response_buf;
+      registry.call(std::span<const char>{request.data(), request.size()}, response_buf);
+
+      expect(api.position.x == 3) << "Object body should be applied";
+      expect(api.position.y == 4) << "Object body should be applied";
+      auto result = glz::repe::parse_request({response_buf.data(), response_buf.size()});
+      expect(bool(result)) << "Response should be parseable";
+      expect(result.request.error() == glz::error_code::none) << "No error expected";
    };
 };
 


### PR DESCRIPTION
`registry::call(std::span<const char>, std::string&)` parses the request in place, so `state.in.body` views the caller's span with nothing guaranteed after it, yet the `state_view` overload of `read_params` reads that view with the registry's `Opts`, whose `null_terminated` is on by default. That is the mode in which the JSON reader drops its end checks and scans for a `'\0'` sentinel. Before: a 51 byte buffer holding a well formed message whose body is `1` gives an ASAN heap-buffer-overflow read of size 1, zero bytes past the allocation; after: the scan stops at the end of the span.

The `message` overload beside it is unaffected because its body is a `std::string`, which does supply that sentinel, so the view overload is where the buffer shape is known and where the bound belongs rather than in the callers that own the span. Reading the body as unterminated input trades the sentinel scan for per-byte end checks. It also moves one edge case: a whitespace-only body now reads as an empty value instead of a number failure, which is what `glz::read` already returns for the same bytes with `null_terminated` off.
