### PR TITLE
Bound every registry read to its buffer rather than a null terminator

### DIFF
--- a/include/glaze/core/read.hpp
+++ b/include/glaze/core/read.hpp
@@ -52,35 +52,26 @@ namespace glz
 
    // Settle what a read that ran to the end of the buffer means, then finalize the context.
    //
-   // Without a '\0' sentinel the reader reports end_reached both when a value ended with the buffer
-   // and when it ran out of input still looking for one. The first is a completed read, which
-   // finalize_read_context clears; the second is not, and the two are told apart by what was
-   // consumed. A span holding only whitespace and comments held no value, and has to be rejected
-   // the way an empty buffer is. skip_ws answers that exactly, comments included, so the question
-   // is put to the same code that produced the end_reached rather than to a second opinion about
-   // which bytes count as whitespace. Because it == end here, replaying it over the consumed span
-   // is an exact re-run of the parse's own leading skip_ws over the same bytes under the same
-   // options, not a truncated variant of it, so it cannot manufacture an answer the parse did not
-   // already reach.
+   // Without a '\0' sentinel, end_reached means either "the value ended with the buffer" (a
+   // completed read, which finalize_read_context clears) or "ran out of input looking for a value"
+   // (not one). What was consumed tells them apart: a span of only whitespace and comments held no
+   // value and is rejected the way an empty buffer is. Replaying skip_ws answers that exactly
+   // instead of second-guessing which bytes count as whitespace, and because it == end the replay
+   // covers the same bytes under the same options as the parse's own leading skip_ws.
    //
-   // The it == end guard is load-bearing: a variant alternative resolved by shape rewinds its
-   // iterator once it settles, so a completed read can end with end_reached, depth 0, and a
-   // consumed span that is nothing but the whitespace ahead of the value it did apply.
-   //
-   // This runs after the parse rather than before it so that readers which take the buffer verbatim
-   // (glz::text, glz::raw_json) still see every byte the caller passed: they complete without
-   // error, so they never reach this. Only JSON produces end_reached, and only a read without a
-   // terminator can reach the end with no sentinel to stop on; every other configuration compiles
-   // this away.
+   // Two conditions are load-bearing rather than defensive:
+   //   - it == end, because a variant alternative resolved by shape rewinds its iterator, so a
+   //     completed read can end with end_reached, depth 0, and a span of only leading whitespace.
+   //   - running after the parse, because readers that take the buffer verbatim (glz::text,
+   //     glz::raw_json) must see every byte; they complete without error and never reach this.
    template <auto Opts>
    GLZ_ALWAYS_INLINE void finalize_top_level_read(is_context auto&& ctx, const char* start, const char* it,
                                                   const char* end) noexcept
    {
       if constexpr (Opts.format == JSON && !check_null_terminated(Opts)) {
-         // Not unlikely: a scalar or object body that ends with the buffer lands here on every
+         // Deliberately not [[unlikely]]: a body that ends with the buffer lands here on every
          // successful read, which is the ordinary case for a registry parsing a wire span.
-         // The span must be non-empty and must run forwards. A streaming read hands in a window
-         // origin that consumed its value in an earlier window, or that overshoots on an error
+         // start < it, not !=, because a streaming origin can be empty or overshoot on an error
          // path; neither is an absent value.
          if (ctx.error == error_code::end_reached && ctx.depth == 0 && it == end && start < it) {
             context ws_ctx{}; // only written to when skip_ws parses a comment; the result is unused

--- a/include/glaze/core/read.hpp
+++ b/include/glaze/core/read.hpp
@@ -31,6 +31,25 @@ namespace glz
       return std::pair{it, end};
    }
 
+   // Whitespace ahead of a value is not a value. Without a '\0' sentinel the reader reports
+   // end_reached when it runs out of input looking for one, and that is indistinguishable from a
+   // value that ended with the buffer unless we look at what was actually consumed.
+   [[nodiscard]] GLZ_ALWAYS_INLINE bool consumed_only_whitespace(const char* start, const char* it) noexcept
+   {
+      for (; start < it; ++start) {
+         switch (*start) {
+         case ' ':
+         case '\t':
+         case '\n':
+         case '\r':
+            break;
+         default:
+            return false;
+         }
+      }
+      return true;
+   }
+
    template <auto Opts, is_context Ctx>
    GLZ_ALWAYS_INLINE void finalize_read_context(Ctx&& ctx) noexcept
    {
@@ -114,6 +133,15 @@ namespace glz
       }
 
    finish:
+      if constexpr (Opts.format != NDJSON) {
+         // NDJSON treats an empty document as valid; every other format needs a value.
+         // `it == end` distinguishes "ran off the end looking for a value" from a reader that
+         // rewound its iterator after resolving a value (variant alternatives do this).
+         if (ctx.error == error_code::end_reached && ctx.depth == 0 && it == end && consumed_only_whitespace(start, it))
+            [[unlikely]] {
+            ctx.error = error_code::no_read_input;
+         }
+      }
       finalize_read_context<Opts>(ctx);
 
       if constexpr (use_padded) {

--- a/include/glaze/core/read.hpp
+++ b/include/glaze/core/read.hpp
@@ -31,25 +31,6 @@ namespace glz
       return std::pair{it, end};
    }
 
-   // Whitespace ahead of a value is not a value. Without a '\0' sentinel the reader reports
-   // end_reached when it runs out of input looking for one, and that is indistinguishable from a
-   // value that ended with the buffer unless we look at what was actually consumed.
-   [[nodiscard]] GLZ_ALWAYS_INLINE bool consumed_only_whitespace(const char* start, const char* it) noexcept
-   {
-      for (; start < it; ++start) {
-         switch (*start) {
-         case ' ':
-         case '\t':
-         case '\n':
-         case '\r':
-            break;
-         default:
-            return false;
-         }
-      }
-      return true;
-   }
-
    template <auto Opts, is_context Ctx>
    GLZ_ALWAYS_INLINE void finalize_read_context(Ctx&& ctx) noexcept
    {
@@ -67,6 +48,47 @@ namespace glz
             ctx.error = error_code::none;
          }
       }
+   }
+
+   // Settle what a read that ran to the end of the buffer means, then finalize the context.
+   //
+   // Without a '\0' sentinel the reader reports end_reached both when a value ended with the buffer
+   // and when it ran out of input still looking for one. The first is a completed read, which
+   // finalize_read_context clears; the second is not, and the two are told apart by what was
+   // consumed. A span holding only whitespace and comments held no value, and has to be rejected
+   // the way an empty buffer is. skip_ws answers that exactly, comments included, so the question
+   // is put to the same code that produced the end_reached rather than to a second opinion about
+   // which bytes count as whitespace. Because it == end here, replaying it over the consumed span
+   // is an exact re-run of the parse's own leading skip_ws over the same bytes under the same
+   // options, not a truncated variant of it, so it cannot manufacture an answer the parse did not
+   // already reach.
+   //
+   // The it == end guard is load-bearing: a variant alternative resolved by shape rewinds its
+   // iterator once it settles, so a completed read can end with end_reached, depth 0, and a
+   // consumed span that is nothing but the whitespace ahead of the value it did apply.
+   //
+   // This runs after the parse rather than before it so that readers which take the buffer verbatim
+   // (glz::text, glz::raw_json) still see every byte the caller passed: they complete without
+   // error, so they never reach this. Only JSON produces end_reached, and only a read without a
+   // terminator can reach the end with no sentinel to stop on; every other configuration compiles
+   // this away.
+   template <auto Opts>
+   GLZ_ALWAYS_INLINE void finalize_top_level_read(is_context auto&& ctx, const char* start, const char* it,
+                                                  const char* end) noexcept
+   {
+      if constexpr (Opts.format == JSON && !check_null_terminated(Opts)) {
+         // Not unlikely: a scalar or object body that ends with the buffer lands here on every
+         // successful read, which is the ordinary case for a registry parsing a wire span.
+         if (ctx.error == error_code::end_reached && ctx.depth == 0 && it == end) {
+            context ws_ctx{}; // only written to when skip_ws parses a comment; the result is unused
+            const char* consumed = start;
+            skip_ws<Opts>(ws_ctx, consumed, it);
+            if (consumed == it) {
+               ctx.error = error_code::no_read_input;
+            }
+         }
+      }
+      finalize_read_context<Opts>(ctx);
    }
 
    template <auto Opts, class T>
@@ -133,16 +155,7 @@ namespace glz
       }
 
    finish:
-      if constexpr (Opts.format != NDJSON) {
-         // NDJSON treats an empty document as valid; every other format needs a value.
-         // `it == end` distinguishes "ran off the end looking for a value" from a reader that
-         // rewound its iterator after resolving a value (variant alternatives do this).
-         if (ctx.error == error_code::end_reached && ctx.depth == 0 && it == end && consumed_only_whitespace(start, it))
-            [[unlikely]] {
-            ctx.error = error_code::no_read_input;
-         }
-      }
-      finalize_read_context<Opts>(ctx);
+      finalize_top_level_read<Opts>(ctx, start, it, end);
 
       if constexpr (use_padded) {
          // Restore the original buffer state
@@ -227,6 +240,12 @@ namespace glz
       const size_t final_consumed = static_cast<size_t>(it - ctx.stream.data());
       consume_buffer(buffer, final_consumed);
 
+      // Not finalize_top_level_read: StreamingOpts forces null_terminated off, so a stream holding
+      // nothing but whitespace ends in the same end_reached this clears to success, but the span it
+      // would have to inspect is not this buffer. Refills relocate and consume it, so the bytes the
+      // parse walked are no longer addressable as [start, it) by the time we get here. Bounding
+      // this case needs the streaming state to carry the answer out of the parse; until it does,
+      // read_streaming keeps the behavior it has always had.
       finalize_read_context<StreamingOpts>(ctx);
 
       if (bool(ctx.error)) {

--- a/include/glaze/core/read.hpp
+++ b/include/glaze/core/read.hpp
@@ -79,7 +79,10 @@ namespace glz
       if constexpr (Opts.format == JSON && !check_null_terminated(Opts)) {
          // Not unlikely: a scalar or object body that ends with the buffer lands here on every
          // successful read, which is the ordinary case for a registry parsing a wire span.
-         if (ctx.error == error_code::end_reached && ctx.depth == 0 && it == end) {
+         // The span must be non-empty and must run forwards. A streaming read hands in a window
+         // origin that consumed its value in an earlier window, or that overshoots on an error
+         // path; neither is an absent value.
+         if (ctx.error == error_code::end_reached && ctx.depth == 0 && it == end && start < it) {
             context ws_ctx{}; // only written to when skip_ws parses a comment; the result is unused
             const char* consumed = start;
             skip_ws<Opts>(ws_ctx, consumed, it);
@@ -237,16 +240,31 @@ namespace glz
       // Calculate final consumed bytes
       // Note: During streaming, the buffer may have been refilled multiple times,
       // so we use bytes_consumed() which tracks total consumption
-      const size_t final_consumed = static_cast<size_t>(it - ctx.stream.data());
+      const char* const window = ctx.stream.data();
+      const size_t final_consumed = static_cast<size_t>(it - window);
       consume_buffer(buffer, final_consumed);
 
-      // Not finalize_top_level_read: StreamingOpts forces null_terminated off, so a stream holding
-      // nothing but whitespace ends in the same end_reached this clears to success, but the span it
-      // would have to inspect is not this buffer. Refills relocate and consume it, so the bytes the
-      // parse walked are no longer addressable as [start, it) by the time we get here. Bounding
-      // this case needs the streaming state to carry the answer out of the parse; until it does,
-      // read_streaming keeps the behavior it has always had.
-      finalize_read_context<StreamingOpts>(ctx);
+      // Settle end_reached the same way a buffered read does. StreamingOpts forces null_terminated
+      // off, so a stream that held no value ends in the same end_reached a value ending with the
+      // buffer does, and telling them apart means looking at what the parse walked.
+      //
+      // Only an exhausted stream can be said to have held no value, which is why this waits until
+      // after consume_buffer: at_eof also requires the window to be drained. A stream that still
+      // has data instead ran out of window -- nothing refills while the top level skips leading
+      // whitespace, so whitespace wider than the window stops the parse short of a value that is
+      // really there. That is a separate limitation of streaming, and it keeps the behavior it has
+      // always had rather than being reported as an absent value.
+      //
+      // `window` still addresses the bytes the parse walked: consume only advances the buffer's
+      // read position, it does not move or release them. It is taken from the streaming state
+      // rather than from an iterator captured before the parse because a refill relocates the
+      // buffer, and it can overshoot `it` on an error path, which is why the helper compares.
+      if (ctx.stream.at_eof()) {
+         finalize_top_level_read<StreamingOpts>(ctx, window, it, end);
+      }
+      else {
+         finalize_read_context<StreamingOpts>(ctx);
+      }
 
       if (bool(ctx.error)) {
          return {buffer.bytes_consumed(), ctx.error, ctx.custom_error_message};

--- a/include/glaze/json/json_ptr.hpp
+++ b/include/glaze/json/json_ptr.hpp
@@ -207,9 +207,14 @@ namespace glz
    template <class T, string_literal Str, auto Opts = opts{}>
    [[nodiscard]] inline expected<T, error_ctx> get_as_json(contiguous auto&& buffer)
    {
-      const auto str = glz::get_view_json<Str>(buffer);
+      const auto str = glz::get_view_json<Str, Opts>(buffer);
       if (str) {
-         return glz::read_json<T>(*str);
+         T value{};
+         context ctx{};
+         if (const auto ec = glz::read<Opts>(value, *str, ctx); ec) {
+            return unexpected(ec);
+         }
+         return value;
       }
       return unexpected(str.error());
    }
@@ -217,7 +222,7 @@ namespace glz
    template <string_literal Str, auto Opts = opts{}>
    [[nodiscard]] inline expected<sv, error_ctx> get_sv_json(contiguous auto&& buffer)
    {
-      const auto s = glz::get_view_json<Str>(buffer);
+      const auto s = glz::get_view_json<Str, Opts>(buffer);
       if (s) {
          return sv{reinterpret_cast<const char*>(s->data()), s->size()};
       }

--- a/include/glaze/rpc/registry.hpp
+++ b/include/glaze/rpc/registry.hpp
@@ -126,6 +126,16 @@ namespace glz
       return o;
    }();
 
+   // The syntax check that decides between a parse error and an invalid request has to run under
+   // the same rules as the read that failed, so it extends the registry's options rather than
+   // falling back to the defaults glz::validate_json is fixed to.
+   template <auto Opts>
+   struct registry_validate_opts : std::decay_t<decltype(Opts)>
+   {
+      bool validate_skipped = true;
+      bool validate_trailing_whitespace = true;
+   };
+
    // This registry does not support adding methods from RPC calls or adding methods once RPC calls can be made.
    template <auto Opts = opts{}, uint32_t Proto = REPE>
    struct registry
@@ -134,6 +144,11 @@ namespace glz
       using procedure = std::function<void(repe::state_view&)>; // RPC method
 
       static constexpr auto read_opts = registry_read_opts<Opts>;
+      static_assert(!check_null_terminated(read_opts),
+                    "The registry parses buffers it does not own and cannot assume a '\\0' follows "
+                    "them, so its options must allow null_terminated to be turned off. An options "
+                    "struct that fixes it (static constexpr bool null_terminated = true) would "
+                    "leave the registry reading past the caller's buffer.");
 
       static constexpr auto protocol = Proto;
 
@@ -508,7 +523,7 @@ namespace glz
          rpc::generic_request_t request{};
          if (const auto read_ec = glz::read<read_opts>(request, json_request); read_ec) {
             // Check if it's a JSON syntax error vs schema error
-            static constexpr opts_validate validate_opts{{opts{.null_terminated = false}}};
+            static constexpr registry_validate_opts<read_opts> validate_opts{{read_opts}};
             glz::skip skip_value{};
             context validate_ctx{};
             if (glz::read<validate_opts>(skip_value, json_request, validate_ctx)) {

--- a/include/glaze/rpc/registry.hpp
+++ b/include/glaze/rpc/registry.hpp
@@ -112,12 +112,28 @@ namespace glz
 
 namespace glz
 {
+   // Every buffer the registry parses comes from a caller: a wire span, an FFI pointer, or a view
+   // into the caller's string. None of them can be assumed to carry the '\0' sentinel a
+   // null_terminated read relies on when it drops its end checks, so the registry reads with that
+   // option off no matter what the user asked for. The bound belongs here, where the buffer shape
+   // is known, rather than in every caller that hands the registry bytes it does not own.
+   template <auto Opts>
+   inline constexpr auto registry_read_opts = [] {
+      auto o = Opts;
+      if constexpr (requires { o.null_terminated = false; }) {
+         o.null_terminated = false;
+      }
+      return o;
+   }();
+
    // This registry does not support adding methods from RPC calls or adding methods once RPC calls can be made.
    template <auto Opts = opts{}, uint32_t Proto = REPE>
    struct registry
    {
       // procedure for REPE protocol (zero-copy state_view)
       using procedure = std::function<void(repe::state_view&)>; // RPC method
+
+      static constexpr auto read_opts = registry_read_opts<Opts>;
 
       static constexpr auto protocol = Proto;
 
@@ -143,7 +159,7 @@ namespace glz
             }
          }();
 
-         using impl = registry_impl<Opts, Proto>;
+         using impl = registry_impl<read_opts, Proto>;
 
          for_each<N>([&]<auto I>() {
             decltype(auto) func = [&]() -> decltype(auto) {
@@ -262,7 +278,7 @@ namespace glz
          requires(glaze_object_t<T> || reflectable<T>)
       void on(T& value)
       {
-         using impl = registry_impl<Opts, Proto>;
+         using impl = registry_impl<read_opts, Proto>;
 
          if constexpr (parent == root && (glaze_object_t<T> || reflectable<T>)) {
             impl::register_endpoint(root, value, *this);
@@ -276,7 +292,7 @@ namespace glz
          requires(sizeof...(Ts) > 0 && (... && (glaze_object_t<Ts> || reflectable<Ts>)))
       void on(glz::merge<Ts...>& merged)
       {
-         using impl = registry_impl<Opts, Proto>;
+         using impl = registry_impl<read_opts, Proto>;
 
          // Register root endpoint with the merged object - this handles ""
          impl::register_merge_endpoint(root, merged, *this);
@@ -468,16 +484,15 @@ namespace glz
 
          if (it != json_request.end() && *it == '[') {
             // Batch request
-            auto batch_requests = glz::read_json<std::vector<glz::raw_json_view>>(json_request);
-            if (!batch_requests) {
+            std::vector<glz::raw_json_view> batch_requests{};
+            if (const auto ec = glz::read<read_opts>(batch_requests, json_request); ec) {
                return R"({"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error","data":)" +
-                      write_json(format_error(batch_requests.error(), json_request)).value_or("null") +
-                      R"(},"id":null})";
+                      write_json(format_error(ec, json_request)).value_or("null") + R"(},"id":null})";
             }
-            if (batch_requests->empty()) {
+            if (batch_requests.empty()) {
                return R"({"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid Request","data":"Empty batch"},"id":null})";
             }
-            return process_batch(*batch_requests);
+            return process_batch(batch_requests);
          }
 
          // Single request
@@ -490,23 +505,25 @@ namespace glz
       std::optional<std::string> process_single_request(std::string_view json_request)
          requires(Proto == JSONRPC)
       {
-         auto request = glz::read_json<rpc::generic_request_t>(json_request);
-         if (!request.has_value()) {
+         rpc::generic_request_t request{};
+         if (const auto read_ec = glz::read<read_opts>(request, json_request); read_ec) {
             // Check if it's a JSON syntax error vs schema error
-            if (glz::validate_json(json_request)) {
+            static constexpr opts_validate validate_opts{{opts{.null_terminated = false}}};
+            glz::skip skip_value{};
+            context validate_ctx{};
+            if (glz::read<validate_opts>(skip_value, json_request, validate_ctx)) {
                // JSON is syntactically invalid - return Parse error (-32700)
                return R"({"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error","data":)" +
-                      write_json(format_error(request.error(), json_request)).value_or("null") + R"(},"id":null})";
+                      write_json(format_error(read_ec, json_request)).value_or("null") + R"(},"id":null})";
             }
             // Valid JSON but invalid request structure - return Invalid Request (-32600)
-            auto id = glz::get_as_json<rpc::id_t, "/id">(json_request);
+            auto id = glz::get_as_json<rpc::id_t, "/id", read_opts>(json_request);
             std::string id_json = id.has_value() ? glz::write_json(id.value()).value_or("null") : "null";
             return R"({"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid Request","data":)" +
-                   write_json(format_error(request.error(), json_request)).value_or("null") + R"(},"id":)" + id_json +
-                   "}";
+                   write_json(format_error(read_ec, json_request)).value_or("null") + R"(},"id":)" + id_json + "}";
          }
 
-         auto& req = request.value();
+         auto& req = request;
 
          // Validate version
          if (req.version != rpc::supported_version) {

--- a/include/glaze/rpc/repe/repe.hpp
+++ b/include/glaze/rpc/repe/repe.hpp
@@ -109,9 +109,11 @@ namespace glz::repe
       }
    }
 
-   // returns 0 on error
+   // Returns false on error. The byte count the reader reports cannot stand in for success here:
+   // without a null terminator a variant alternative that resolves at the end of the buffer rewinds
+   // its iterator, so a completed read can report zero bytes consumed.
    template <auto Opts, class Value>
-   size_t read_params(Value&& value, auto&& state)
+   bool read_params(Value&& value, auto&& state)
    {
       glz::context ctx{};
       auto [b, e] = read_iterators<Opts>(state.in.body);
@@ -119,11 +121,18 @@ namespace glz::repe
          ctx.error = error_code::no_read_input;
       }
       if (bool(ctx.error)) [[unlikely]] {
-         return 0;
+         return false;
       }
       auto start = b;
 
       glz::parse<Opts.format>::template op<Opts>(std::forward<Value>(value), ctx, b, e);
+      // These parse calls bypass glz::read, so the end-of-buffer bookkeeping it performs has to be
+      // done here: a value that finishes exactly at the end of the body reports end_reached, which
+      // is a completed read rather than an error, while a body that held no value at all is not.
+      if (ctx.error == error_code::end_reached && ctx.depth == 0 && b == e && consumed_only_whitespace(start, b)) {
+         ctx.error = error_code::no_read_input;
+      }
+      finalize_read_context<Opts>(ctx);
 
       if (bool(ctx.error)) {
          state.out.header.ec = ctx.error;
@@ -138,10 +147,10 @@ namespace glz::repe
          out.body = error_message;
 
          write_response<Opts>(state);
-         return 0;
+         return false;
       }
 
-      return size_t(b - start);
+      return true;
    }
 
    namespace detail
@@ -537,9 +546,10 @@ namespace glz::repe
    concept is_state_view = std::same_as<std::decay_t<T>, state_view>;
 
    /// Read parameters from state_view (zero-copy from input buffer)
-   /// Returns number of bytes read, or 0 on error (error set in state.out)
+   /// Returns false on error (error set in state.out); see the note on the overload above for why
+   /// this is not a byte count.
    template <auto Opts, class Value>
-   size_t read_params(Value&& value, state_view& state)
+   bool read_params(Value&& value, state_view& state)
    {
       glz::context ctx{};
       auto body = state.in.body;
@@ -550,21 +560,27 @@ namespace glz::repe
          ctx.error = error_code::no_read_input;
       }
       if (bool(ctx.error)) [[unlikely]] {
-         return 0;
+         return false;
       }
       auto start = b;
 
       glz::parse<Opts.format>::template op<Opts>(std::forward<Value>(value), ctx, b, e);
+      // See the note in the message overload above: end_reached at the top level means the value
+      // ended with the body, not that the read failed.
+      if (ctx.error == error_code::end_reached && ctx.depth == 0 && b == e && consumed_only_whitespace(start, b)) {
+         ctx.error = error_code::no_read_input;
+      }
+      finalize_read_context<Opts>(ctx);
 
       if (bool(ctx.error)) {
          error_ctx ec{size_t(b - start), ctx.error, ctx.custom_error_message};
          std::string error_message = format_error(ec, body);
          state.out.reset(state.in);
          state.out.set_error(ctx.error, error_message);
-         return 0;
+         return false;
       }
 
-      return size_t(b - start);
+      return true;
    }
 
    /// Write response with a value (zero-copy to output buffer)

--- a/include/glaze/rpc/repe/repe.hpp
+++ b/include/glaze/rpc/repe/repe.hpp
@@ -125,14 +125,12 @@ namespace glz::repe
       }
       auto start = b;
 
-      glz::parse<Opts.format>::template op<Opts>(std::forward<Value>(value), ctx, b, e);
-      // These parse calls bypass glz::read, so the end-of-buffer bookkeeping it performs has to be
-      // done here: a value that finishes exactly at the end of the body reports end_reached, which
-      // is a completed read rather than an error, while a body that held no value at all is not.
-      if (ctx.error == error_code::end_reached && ctx.depth == 0 && b == e && consumed_only_whitespace(start, b)) {
-         ctx.error = error_code::no_read_input;
-      }
-      finalize_read_context<Opts>(ctx);
+      glz::parse<Opts.format>::template op<is_padded_off<Opts>()>(std::forward<Value>(value), ctx, b, e);
+      // This bypasses glz::read, so the bookkeeping glz::read performs after the parse has to be
+      // repeated here: a value that finishes exactly at the end of the body reports end_reached,
+      // which is a completed read rather than an error, while a body that held no value at all is
+      // not. finalize_top_level_read draws that line.
+      finalize_top_level_read<Opts>(ctx, start, b, e);
 
       if (bool(ctx.error)) {
          state.out.header.ec = ctx.error;
@@ -564,13 +562,9 @@ namespace glz::repe
       }
       auto start = b;
 
-      glz::parse<Opts.format>::template op<Opts>(std::forward<Value>(value), ctx, b, e);
-      // See the note in the message overload above: end_reached at the top level means the value
-      // ended with the body, not that the read failed.
-      if (ctx.error == error_code::end_reached && ctx.depth == 0 && b == e && consumed_only_whitespace(start, b)) {
-         ctx.error = error_code::no_read_input;
-      }
-      finalize_read_context<Opts>(ctx);
+      glz::parse<Opts.format>::template op<is_padded_off<Opts>()>(std::forward<Value>(value), ctx, b, e);
+      // See the note in the message overload above for why glz::read's bookkeeping is repeated.
+      finalize_top_level_read<Opts>(ctx, start, b, e);
 
       if (bool(ctx.error)) {
          error_ctx ec{size_t(b - start), ctx.error, ctx.custom_error_message};

--- a/include/glaze/rpc/repe/repe_registry_impl.hpp
+++ b/include/glaze/rpc/repe/repe_registry_impl.hpp
@@ -27,7 +27,7 @@ namespace glz
       {
          reg.endpoints[path] = [&value](repe::state_view& state) mutable {
             if (state.has_body()) {
-               if (read_params<Opts>(value, state) == 0) {
+               if (!read_params<Opts>(value, state)) {
                   return;
                }
             }
@@ -74,7 +74,7 @@ namespace glz
          reg.endpoints[path] = [&func](repe::state_view& state) mutable {
             static thread_local std::decay_t<Params> params{};
             params = {}; // reset to avoid stale optional/variant fields across calls
-            if (read_params<Opts>(params, state) == 0) {
+            if (!read_params<Opts>(params, state)) {
                return;
             }
 
@@ -105,7 +105,7 @@ namespace glz
       {
          reg.endpoints[path] = [&obj](repe::state_view& state) mutable {
             if (state.has_body()) {
-               if (read_params<Opts>(obj, state) == 0) {
+               if (!read_params<Opts>(obj, state)) {
                   return;
                }
             }
@@ -128,7 +128,7 @@ namespace glz
       {
          reg.endpoints[path] = [value](repe::state_view& state) mutable {
             if (state.has_body()) {
-               if (read_params<Opts>(value, state) == 0) {
+               if (!read_params<Opts>(value, state)) {
                   return;
                }
             }
@@ -151,7 +151,7 @@ namespace glz
       {
          reg.endpoints[path] = [&var](repe::state_view& state) mutable {
             if (state.has_body()) {
-               if (read_params<Opts>(var, state) == 0) {
+               if (!read_params<Opts>(var, state)) {
                   return;
                }
             }
@@ -200,7 +200,7 @@ namespace glz
             static thread_local Input input{};
             input = {}; // reset to avoid stale optional/variant fields across calls
             if (state.has_body()) {
-               if (read_params<Opts>(input, state) == 0) {
+               if (!read_params<Opts>(input, state)) {
                   return;
                }
             }

--- a/tests/istream_buffer_test/istream_buffer_test.cpp
+++ b/tests/istream_buffer_test/istream_buffer_test.cpp
@@ -4079,6 +4079,69 @@ suite additional_edge_cases = [] {
       expect(r.id == 42);
       expect(r.name == "test");
    };
+
+   // A stream is read without a terminator, so running out of input while looking for a value
+   // reports the same end_reached a value ending with the buffer does. A stream that never held a
+   // value has to be rejected the way an empty one is, rather than reporting success over an
+   // untouched destination.
+   "stream holding no value"_test = [] {
+      for (std::string_view blank : {" ", "   ", "\t\n\r "}) {
+         std::istringstream iss{std::string{blank}};
+         glz::istream_buffer<> buffer(iss);
+
+         int i{42};
+         expect(glz::read_json(i, buffer) == glz::error_code::no_read_input) << blank;
+         expect(i == 42) << "destination must be left alone";
+      }
+
+      // read_streaming directly: read_jsonc has no streaming overload, so it would take the
+      // buffered path and never reach the code under test.
+      for (std::string_view commented : {"// hi\n", " /* block */ "}) {
+         std::istringstream iss{std::string{commented}};
+         glz::istream_buffer<> buffer(iss);
+
+         int i{42};
+         expect(glz::read_streaming<glz::opts{.comments = true}>(i, buffer) == glz::error_code::no_read_input)
+            << commented;
+         expect(i == 42) << "destination must be left alone";
+      }
+   };
+
+   // Nothing refills while the top level skips leading whitespace, so whitespace wider than the
+   // window stops the parse short of a value that is really there. Only an exhausted stream can be
+   // said to have held no value, so this case must not be reported as one. The read is left as it
+   // has always been -- the destination is untouched and no error is raised -- which is a known
+   // limitation of streaming rather than something this test endorses. It is pinned so that a
+   // change to either half is deliberate.
+   "leading whitespace wider than the window is not an absent value"_test = [] {
+      std::istringstream iss{std::string(600, ' ') + "7"};
+      glz::basic_istream_buffer<std::istringstream, 512> buffer(iss);
+
+      int i{42};
+      expect(glz::read_streaming<glz::opts{}>(i, buffer) != glz::error_code::no_read_input)
+         << "the stream has input; it is the window that ran out";
+      expect(i == 42) << "the value is past the window and is not reached";
+   };
+
+   // The absent-value check looks at the window the parse ended in. A read that refilled consumed
+   // its value in an earlier window, so the check must not mistake a short final span for one.
+   "value read across refills is not mistaken for an absent value"_test = [] {
+      std::string json = "[";
+      for (int i = 0; i < 400; ++i) {
+         if (i) json += ',';
+         json += std::to_string(i);
+      }
+      json += "]";
+      json += std::string(600, ' '); // trailing whitespace outlasting the window
+
+      std::istringstream iss{json};
+      glz::basic_istream_buffer<std::istringstream, 512> buffer(iss); // forces many refills
+
+      std::vector<int> v{};
+      expect(!glz::read_json(v, buffer));
+      expect(v.size() == 400u);
+      expect(v[399] == 399);
+   };
 };
 
 int main() { return 0; }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -1111,6 +1111,29 @@ suite basic_types = [] {
       }
    };
 
+   "whitespace only input holds no value"_test = [] {
+      // Without a terminator the reader runs out of input looking for a value and reports
+      // end_reached, which at the top level otherwise means "the value ended with the buffer".
+      // A buffer that never held a value must be rejected the way an empty one is, rather than
+      // leaving the destination untouched and reporting success.
+      // Both options are spelled out because this file is also built with GLZ_NULL_TERMINATED=false.
+      static constexpr glz::opts options{.null_terminated = false};
+      for (std::string_view blank : {" ", "   ", "\t\n\r "}) {
+         const std::vector<char> buf{blank.begin(), blank.end()};
+         const std::string_view input{buf.data(), buf.size()};
+
+         int i{42};
+         expect(glz::read<options>(i, input) == glz::error_code::no_read_input) << blank;
+         expect(i == 42) << "destination must be left alone";
+
+         std::vector<int> v{};
+         expect(glz::read<options>(v, input) == glz::error_code::no_read_input) << blank;
+
+         std::map<std::string, int> m{};
+         expect(glz::read<options>(m, input) == glz::error_code::no_read_input) << blank;
+      }
+   };
+
    "truncated number is rejected, not valued"_test = [] {
       // A number longer than the scratch buffer is copied in as a prefix, and the prefix can parse
       // cleanly on its own: "1e" followed by enough zeros reads as 1 once the copy cuts off the

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -1134,6 +1134,46 @@ suite basic_types = [] {
       }
    };
 
+   "comment only input holds no value"_test = [] {
+      // A comment is no more a value than whitespace is. With comments enabled the reader consumes
+      // one and then runs out of input the same way, so it has to reach the same answer.
+      static constexpr glz::opts options{.null_terminated = false, .comments = true};
+      for (std::string_view commented : {"// hi\n", " //x\n", "/* block */", "\t/*a*/ // b\n "}) {
+         const std::vector<char> buf{commented.begin(), commented.end()};
+         const std::string_view input{buf.data(), buf.size()};
+
+         int i{42};
+         expect(glz::read<options>(i, input) == glz::error_code::no_read_input) << commented;
+         expect(i == 42) << "destination must be left alone";
+
+         std::vector<int> v{};
+         expect(glz::read<options>(v, input) == glz::error_code::no_read_input) << commented;
+      }
+
+      // An unterminated block comment runs to the end of the buffer without skip_comment flagging
+      // it, so it arrives here as an input that held no value. That is the same answer as an empty
+      // buffer, which is a coarse diagnosis but a true one.
+      {
+         const std::string_view unterminated{"/* never closed"};
+         const std::vector<char> buf{unterminated.begin(), unterminated.end()};
+         const std::string_view input{buf.data(), buf.size()};
+         int i{42};
+         expect(glz::read<options>(i, input) == glz::error_code::no_read_input);
+         expect(i == 42) << "destination must be left alone";
+      }
+
+      // A comment malformed in a way skip_comment does detect keeps its own error, rather than
+      // being flattened into the absent-value answer.
+      for (std::string_view malformed : {"/", "/x"}) {
+         const std::vector<char> buf{malformed.begin(), malformed.end()};
+         int i{42};
+         const auto ec = glz::read<options>(i, std::string_view{buf.data(), buf.size()});
+         expect(ec != glz::error_code::none) << malformed;
+         expect(ec != glz::error_code::no_read_input) << malformed;
+         expect(i == 42) << "destination must be left alone";
+      }
+   };
+
    "truncated number is rejected, not valued"_test = [] {
       // A number longer than the scratch buffer is copied in as a prefix, and the prefix can parse
       // cleanly on its own: "1e" followed by enough zeros reads as 1 once the copy cuts off the

--- a/tests/networking_tests/jsonrpc_registry_test/jsonrpc_registry_test.cpp
+++ b/tests/networking_tests/jsonrpc_registry_test/jsonrpc_registry_test.cpp
@@ -1,6 +1,9 @@
 // Glaze Library
 // For the license information refer to glaze.hpp
 
+#include <string_view>
+#include <vector>
+
 #include "glaze/glaze.hpp"
 #include "glaze/rpc/registry.hpp"
 #include "ut/ut.hpp"
@@ -494,6 +497,58 @@ suite jsonrpc_function_pointer_tests = [] {
       // Test function with int param returning int
       response = server.call(R"({"jsonrpc":"2.0","method":"add","params":5,"id":3})");
       expect(response.find(R"("result":15)") != std::string::npos) << response;
+   };
+};
+
+// A request read off a socket ends where the buffer ends. The registry parses the caller's bytes in
+// place, so every parse it performs has to stop at that end rather than scan for a '\0' terminator.
+// Exactly sized copies reproduce the wire shape; run under a sanitizer these fail loudly otherwise.
+struct scalar_api
+{
+   int value{};
+};
+
+suite unterminated_request_tests = [] {
+   auto call_exact = [](auto& server, std::string_view request) {
+      const std::vector<char> exact{request.begin(), request.end()};
+      return server.call(std::string_view{exact.data(), exact.size()});
+   };
+
+   "valid_request_ending_at_buffer_end"_test = [&] {
+      glz::registry<glz::opts{}, glz::JSONRPC> server{};
+      scalar_api api{};
+      server.on(api);
+
+      const auto response = call_exact(server, R"({"jsonrpc":"2.0","method":"/value","params":7,"id":1})");
+      expect(api.value == 7) << "Params should be applied";
+      expect(response.find(R"("result":null)") != std::string::npos) << response;
+   };
+
+   "truncated_batch_ending_at_buffer_end"_test = [&] {
+      glz::registry<glz::opts{}, glz::JSONRPC> server{};
+      scalar_api api{};
+      server.on(api);
+
+      const auto response = call_exact(server, "[7");
+      expect(response.find(R"("code":-32700)") != std::string::npos) << response;
+   };
+
+   "truncated_object_ending_at_buffer_end"_test = [&] {
+      glz::registry<glz::opts{}, glz::JSONRPC> server{};
+      scalar_api api{};
+      server.on(api);
+
+      const auto response = call_exact(server, R"({"jsonrpc":"2.0","method":"/value","id":1,"params":7)");
+      expect(response.find(R"("error")") != std::string::npos) << response;
+   };
+
+   "bare_scalar_ending_at_buffer_end"_test = [&] {
+      glz::registry<glz::opts{}, glz::JSONRPC> server{};
+      scalar_api api{};
+      server.on(api);
+
+      const auto response = call_exact(server, "7");
+      expect(response.find(R"("code":-32600)") != std::string::npos) << response;
    };
 };
 

--- a/tests/networking_tests/registry_view_test/registry_view_test.cpp
+++ b/tests/networking_tests/registry_view_test/registry_view_test.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "glaze/rpc/registry.hpp"
+#include "glaze/rpc/repe/plugin_helper.hpp"
 #include "ut/ut.hpp"
 
 using namespace ut;
@@ -403,6 +404,40 @@ suite unterminated_buffer_tests = [] {
       expect(api.measure.index() == 1) << "Deduced alternative should be applied";
       expect(std::get<amount>(api.measure).value == 42.5);
       auto result = glz::repe::parse_request({response_buf.data(), response_buf.size()});
+      expect(result.request.error() == glz::error_code::none) << "No error expected";
+   };
+
+   // A registry that accepts comments must reject a body that holds nothing but one, for the same
+   // reason it rejects a body that holds nothing but whitespace.
+   "comment_only_body_is_an_error"_test = [] {
+      glz::registry<glz::opts{.comments = true}> registry;
+      unterminated_api api{};
+      api.value = 99;
+      registry.on(api);
+
+      const auto request = exact_buffer(make_request("/value", "// nothing here\n"));
+      std::string response_buf;
+      registry.call(std::span<const char>{request.data(), request.size()}, response_buf);
+
+      expect(api.value == 99) << "A body holding no value must not be applied";
+      auto result = glz::repe::parse_request({response_buf.data(), response_buf.size()});
+      expect(result.request.error() == glz::error_code::no_read_input) << "Expected no_read_input";
+   };
+
+   // plugin_call hands the registry a raw pointer and length across an FFI boundary, so its bytes
+   // carry no terminator either.
+   "plugin_call_body_ending_at_buffer_end"_test = [] {
+      glz::registry<> registry;
+      unterminated_api api{};
+      registry.on(api);
+
+      const auto request = exact_buffer(make_request("/position", R"({"x":5,"y":6})"));
+      const auto response = glz::repe::plugin_call(registry, request.data(), request.size());
+
+      expect(api.position.x == 5) << "Object body should be applied";
+      expect(api.position.y == 6) << "Object body should be applied";
+      expect(response.size > 0) << "A non-notify request must always get a response";
+      auto result = glz::repe::parse_request({response.data, response.size});
       expect(result.request.error() == glz::error_code::none) << "No error expected";
    };
 

--- a/tests/networking_tests/registry_view_test/registry_view_test.cpp
+++ b/tests/networking_tests/registry_view_test/registry_view_test.cpp
@@ -3,6 +3,8 @@
 
 #include <cstring>
 #include <string>
+#include <variant>
+#include <vector>
 
 #include "glaze/rpc/registry.hpp"
 #include "ut/ut.hpp"
@@ -286,6 +288,136 @@ suite registry_span_call_tests = [] {
 
       auto result = glz::repe::parse_request({response_buf.data(), response_buf.size()});
       expect(result.request.id() == 12345) << "Response ID should match request ID";
+   };
+};
+
+// Requests arriving off the wire end where the buffer ends: there is no '\0' after the body for a
+// reader to stop on. make_request returns a std::string, whose data()[size()] is a terminator, so
+// these tests copy the message into an exactly sized vector to reproduce the wire shape.
+namespace
+{
+   std::vector<char> exact_buffer(std::string_view message) { return {message.begin(), message.end()}; }
+}
+
+struct vec2
+{
+   int x{};
+   int y{};
+};
+
+struct unterminated_api
+{
+   int value{};
+   vec2 position{};
+   std::variant<double, std::string> choice{};
+};
+
+// A type deduced by shape rather than by a tag: resolving it walks to the end of the buffer.
+struct amount
+{
+   double value{};
+};
+
+template <>
+struct glz::meta<amount>
+{
+   static constexpr auto value = &amount::value;
+};
+
+struct inferred_api
+{
+   std::variant<std::string, amount> measure{};
+};
+
+suite unterminated_buffer_tests = [] {
+   "scalar_body_ending_at_buffer_end"_test = [] {
+      glz::registry<> registry;
+      unterminated_api api{};
+      registry.on(api);
+
+      const auto request = exact_buffer(make_request("/value", "7"));
+      std::string response_buf;
+      registry.call(std::span<const char>{request.data(), request.size()}, response_buf);
+
+      expect(api.value == 7) << "Scalar body should be applied";
+      auto result = glz::repe::parse_request({response_buf.data(), response_buf.size()});
+      expect(bool(result)) << "Response should be parseable";
+      expect(result.request.error() == glz::error_code::none) << "No error expected";
+   };
+
+   "object_body_ending_at_buffer_end"_test = [] {
+      glz::registry<> registry;
+      unterminated_api api{};
+      registry.on(api);
+
+      const auto request = exact_buffer(make_request("/position", R"({"x":3,"y":4})"));
+      std::string response_buf;
+      registry.call(std::span<const char>{request.data(), request.size()}, response_buf);
+
+      expect(api.position.x == 3) << "Object body should be applied";
+      expect(api.position.y == 4) << "Object body should be applied";
+      auto result = glz::repe::parse_request({response_buf.data(), response_buf.size()});
+      expect(result.request.error() == glz::error_code::none) << "No error expected";
+   };
+
+   "truncated_body_is_an_error"_test = [] {
+      glz::registry<> registry;
+      unterminated_api api{};
+      registry.on(api);
+
+      const auto request = exact_buffer(make_request("/position", R"({"x":3,"y":4)"));
+      std::string response_buf;
+      registry.call(std::span<const char>{request.data(), request.size()}, response_buf);
+
+      auto result = glz::repe::parse_request({response_buf.data(), response_buf.size()});
+      expect(result.request.error() != glz::error_code::none) << "Truncated body should not report success";
+   };
+
+   "whitespace_only_body_is_an_error"_test = [] {
+      glz::registry<> registry;
+      unterminated_api api{};
+      api.value = 99;
+      registry.on(api);
+
+      const auto request = exact_buffer(make_request("/value", "   "));
+      std::string response_buf;
+      registry.call(std::span<const char>{request.data(), request.size()}, response_buf);
+
+      expect(api.value == 99) << "A body holding no value must not be applied";
+      auto result = glz::repe::parse_request({response_buf.data(), response_buf.size()});
+      expect(result.request.error() == glz::error_code::no_read_input) << "Expected no_read_input";
+   };
+
+   // A variant alternative that resolves at the end of the buffer rewinds its iterator, so the
+   // read completes having reported zero bytes consumed. read_params must report that as success.
+   "variant_body_ending_at_buffer_end_gets_a_response"_test = [] {
+      glz::registry<> registry;
+      inferred_api api{};
+      registry.on(api);
+
+      const auto request = exact_buffer(make_request("/measure", "42.5"));
+      std::string response_buf;
+      registry.call(std::span<const char>{request.data(), request.size()}, response_buf);
+
+      expect(!response_buf.empty()) << "A non-notify request must always get a response";
+      expect(api.measure.index() == 1) << "Deduced alternative should be applied";
+      expect(std::get<amount>(api.measure).value == 42.5);
+      auto result = glz::repe::parse_request({response_buf.data(), response_buf.size()});
+      expect(result.request.error() == glz::error_code::none) << "No error expected";
+   };
+
+   "tagless_variant_body_ending_at_buffer_end"_test = [] {
+      glz::registry<> registry;
+      unterminated_api api{};
+      registry.on(api);
+
+      const auto request = exact_buffer(make_request("/choice", "42.5"));
+      std::string response_buf;
+      registry.call(std::span<const char>{request.data(), request.size()}, response_buf);
+
+      expect(!response_buf.empty()) << "A non-notify request must always get a response";
+      expect(api.choice.index() == 0);
+      expect(std::get<double>(api.choice) == 42.5);
    };
 };
 


### PR DESCRIPTION
Supersedes #2729, whose diagnosis and REPE test this builds on (thanks @uwezkhan).

The registry parses bytes it does not own — a wire span given to `registry::call(std::span<const char>, std::string&)`, a raw pointer and length given to `repe::plugin_call` across an FFI boundary, a `std::string_view` given to the JSON RPC `call`. None of them carry the `'\0'` a `null_terminated` read relies on when it drops its end checks, and no caller can reach the option to turn it off. Three reads over the caller's buffer ran past its end, each on a well formed request:

| entry point | input | ASAN |
| --- | --- | --- |
| `registry::call(span, string&)` | body `7`, buffer ends there | READ of size 1, 0 bytes after a 55 byte region (`repe.hpp` `read_params`) |
| `registry<opts{}, JSONRPC>::call(sv)` | `[7` | READ of size 1, 0 bytes after a 52 byte region (`registry.hpp:471`, batch `read_json`) |
| `registry<opts{}, JSONRPC>::call(sv)` | truncated object | READ of size 1, 0 bytes after a 52 byte region (`registry.hpp:496`, `validate_json`) |

#2729 bounds the first. This bounds all three by making it a property of the registry rather than of one call site: the registry reads with `null_terminated` off regardless of the user's options. Two of those reads went through `glz::read_json` / `glz::validate_json`, which hardcode default options, so they move onto the registry's options. `get_as_json` / `get_sv_json` took an `Opts` parameter and then discarded it in favor of defaults; fixed here too.

Because that bound is what keeps the registry inside the caller's buffer, an options struct that fixes `null_terminated` (`static constexpr bool null_terminated = true`, the shape `opts_csv` uses and the "create your own options struct" note invites) must not quietly opt out of it. The requires-expression that turns the option off simply fails for such a type, so a `static_assert` turns that into a compile error rather than a silent out of bounds read.

### Two defects the change surfaced

**A completed read could report zero bytes consumed.** `repe::read_params` returned bytes consumed and all six callers read `0` as failure. Without a terminator, a variant alternative that resolves at the end of the buffer rewinds its iterator, so the read finishes with the value applied and nothing consumed. The registry took that for an error and returned without writing anything — a non-notify request got **no response at all**:

```cpp
struct api { std::variant<std::string, amount> measure{}; };  // amount deduced by shape
// REPE body "42.5", buffer ends there  ->  response buffer empty, value applied
```

`read_params` returns `bool` now; the count had no other use. This bites any fix that turns `null_terminated` off, including #2729 as written.

**Input holding no value read as a completed value.** The reader runs out of input looking for a value and reports `end_reached`, which at the top level otherwise means "the value ended with the buffer", so `glz::read` cleared it and returned success with the destination untouched — `glz::read<{.null_terminated = false}>(v, "   ")` does this on `main`, and so does `glz::read<{.null_terminated = false, .comments = true}>(v, "// hi\n")`. Through the registry that would answer a malformed request with a success response, and would have turned a REST `PUT` with a blank body from 400 into 204. A buffer holding nothing but whitespace and comments is now `no_read_input`, the code an empty buffer already reports.

`finalize_top_level_read` draws that line, in one place for `glz::read` and both `read_params` overloads. It answers "did this hold a value?" by replaying `skip_ws` over the consumed span rather than by holding a second opinion about which bytes count as whitespace — and since the span ends where the buffer ends, that replay is an exact re-run of the parse's own leading `skip_ws` under the same options. Two constraints shape where it sits:

- It runs **after** the parse, not before. Readers that take the buffer verbatim (`glz::text`, `glz::text_view`, `glz::raw_json`) capture bytes straight off the iterator, so nothing may consume input ahead of them; they complete without error and never reach the check.
- It keeps the `it == end` guard. A variant alternative resolved by shape rewinds its iterator once it settles, so a *successful* read can end with `end_reached`, depth 0, and a consumed span that is nothing but the whitespace ahead of the value it applied. Without the guard that read would be rejected.

`read_streaming` is bounded too, so every top-level entry point is. It forces `null_terminated` off, so it had the same defect. Refills looked like an obstacle — they relocate the buffer — but `consume_and_refill` is only ever reached inside array and object element loops, so nothing refills while the top level skips leading whitespace and a stream that held no value never leaves its first window. The span origin comes from the streaming state rather than from an iterator captured before the parse.

That last property cuts both ways, so the streaming check is narrower than the buffered one: it runs behind `at_eof`, because only an exhausted stream can be said to have held no value. Leading whitespace wider than the window also stops the parse short — of a value that is really there — and that case keeps the behavior it has always had rather than being reported as an absent value. Both halves are pinned by tests.

### Cost

Measured, `-O2 -DNDEBUG`, interleaved runs:

| | before | after |
| --- | --- | --- |
| `registry::call` span, 120 byte object body | 201 ns | 219 ns (+8.7%) |
| `registry::call` span, int body | 72 ns | 76 ns (+5%) |
| `glz::read` into a `std::string` body, parse only | 136 ns | 161 ns (+18%) |

The REPE figures match #2729 — the extra coverage is free there. The REST path is the one that pays for a bound it does not strictly need today, since `request::body` is a `std::string`. I would not exempt it: "which registry buffers happen to be `std::string`" is exactly the invariant that rotted here, since `state_view`'s body used to be one and is now a wire span.

Nothing outside a non-null-terminated JSON read pays anything. The whole check is behind `if constexpr (Opts.format == JSON && !check_null_terminated(Opts))`, so the default read path compiles it away entirely.

### Tests

New tests in `registry_view_test` (REPE spans over exactly sized buffers: scalar, object, truncated, whitespace-only, comment-only, both variant shapes, and the `plugin_call` FFI entry point), `jsonrpc_registry_test` (exactly sized requests: valid, truncated batch, truncated object, bare scalar), `json_test` (whitespace-only, comment-only and malformed-comment input under `null_terminated = false`, which also runs in the `GLZ_NULL_TERMINATED=false` build of that file), and `istream_buffer_test` (streams holding no value, a value read across refills, and leading whitespace wider than the window). Both networking test files trip ASAN against `main` as written and pass here. Full suite is 108/108 under `-fsanitize=address,undefined -fno-sanitize-recover=all`.

### Follow-up, not in this PR

- There is no REPE or JSON RPC fuzz target. A harness feeding `registry.call` from exactly sized buffers would have found all three of these and would cover the whole wire-facing surface.
- **`read_jsonc` on a streaming buffer reads out of bounds.** It has no `is_input_streaming` overload, unlike `read_json`, so it binds to the buffered `glz::read` with `null_terminated = true` over a window that carries no terminator and cannot be padded (`istream_buffer` is not resizable). ASAN reports a heap-buffer-overflow one byte past the window. This is the same defect class as this PR reached through a different door, and the missing-overload shape applies to the other per-format helpers as well, so it wants a systematic fix rather than a one-off. Left out of this PR to keep the change focused, but it is more severe than anything fixed here.
- `read_streaming` ignores `validate_trailing_whitespace`; that block lives only in `glz::read`.
- Leading whitespace wider than the streaming window stops the parse short of a value that is really there. Bounding it needs a refill during the top-level whitespace skip, which no parser does today.
- An unterminated block comment reports `no_read_input`. `skip_comment` runs off the end without flagging it, so that is the honest answer available here, and it beats the silent success `main` returns. A real fix belongs in `skip_comment` and would change the null-terminated path too.
