### PR TITLE
Report truncated non-null-terminated input as unexpected_end

### DIFF
--- a/include/glaze/core/context.hpp
+++ b/include/glaze/core/context.hpp
@@ -29,8 +29,15 @@ namespace glz
       // Other errors
       // Internal to a non-null-terminated read: "the buffer ran out here", which is a completed
       // read or a truncated one depending on the nesting depth. settle_end_reached decides which
-      // at the top level and replaces it with none or unexpected_end, so a read never returns it.
-      // json_stream_reader is the exception: it raises this itself to signal end of stream.
+      // and replaces it with none or unexpected_end, so every entry point that finalizes its
+      // context -- glz::read, read_streaming, repe::read_params -- has stopped returning it.
+      //
+      // Two paths still hand it back. json_stream_reader raises it deliberately, to signal end of
+      // stream. read_jmespath and get_view_json return ctx.error without finalizing at all; they
+      // navigate by matching braces rather than by entering depth, so ctx.depth stays zero
+      // throughout and settle_end_reached cannot be dropped in as-is -- it would settle their
+      // truncated reads to none, which is worse than leaking. Those need their own truncation
+      // accounting before they can join.
       end_reached,
       partial_read_complete, // A non-error code for short circuiting partial reads
       no_read_input, //

--- a/include/glaze/core/context.hpp
+++ b/include/glaze/core/context.hpp
@@ -27,7 +27,11 @@ namespace glz
       send_error,
       connection_failure,
       // Other errors
-      end_reached, // A non-error code for non-null terminated input buffers
+      // Internal to a non-null-terminated read: "the buffer ran out here", which is a completed
+      // read or a truncated one depending on the nesting depth. settle_end_reached decides which
+      // at the top level and replaces it with none or unexpected_end, so a read never returns it.
+      // json_stream_reader is the exception: it raises this itself to signal end of stream.
+      end_reached,
       partial_read_complete, // A non-error code for short circuiting partial reads
       no_read_input, //
       data_must_be_null_terminated, //

--- a/include/glaze/core/read.hpp
+++ b/include/glaze/core/read.hpp
@@ -52,10 +52,21 @@ namespace glz
    template <auto Opts, is_context Ctx>
    GLZ_ALWAYS_INLINE void finalize_read_context(Ctx&& ctx) noexcept
    {
-      // We don't do depth validation for partial reading
+      // A partial read stops as soon as it has the fields it was asked for, so it unwinds through
+      // its enclosing containers on an error code rather than through their closing braces, and
+      // none of them decrement depth on the way out. Depth is left standing at whatever nesting the
+      // last field sat at.
+      //
+      // That has to be cleared here rather than left for the next read to trip over. This is the
+      // one path that reports success with depth still raised, and depth is what settle_end_reached
+      // reads to tell a completed parse from a truncated one -- so a context reused after a partial
+      // read would see a later well-formed buffer settle to unexpected_end. Reads that end any
+      // other way either return depth to zero themselves or carry an error, and a context holding
+      // an error short-circuits the next read before it parses anything.
       if constexpr (check_partial_read(Opts)) {
          if (ctx.error == error_code::partial_read_complete) [[likely]] {
             ctx.error = error_code::none;
+            ctx.depth = 0;
             return;
          }
       }

--- a/include/glaze/core/read.hpp
+++ b/include/glaze/core/read.hpp
@@ -31,6 +31,24 @@ namespace glz
       return std::pair{it, end};
    }
 
+   // Only a non-null-terminated read produces end_reached, and only ever to say "the buffer ran
+   // out here"; whether that is an outcome or a failure is settled at the top level and nowhere
+   // else. ctx.depth carries the answer: a value that closed cleanly leaves it at zero, so the
+   // buffer ended exactly where the value did and the read succeeded. Any other depth means the
+   // buffer ran out with containers still open, which is truncated input.
+   //
+   // Both halves have to be handled here. end_reached is documented as a non-error code and
+   // callers are entitled to read it that way, so letting it escape hands them a truncated parse
+   // labeled as a success that happened to stop early. It reached the wire that way: since #2732
+   // every registry read runs non-null-terminated, so a truncated REPE body answered its client
+   // with end_reached in the response header.
+   GLZ_ALWAYS_INLINE void settle_end_reached(is_context auto&& ctx) noexcept
+   {
+      if (ctx.error == error_code::end_reached) {
+         ctx.error = (ctx.depth == 0) ? error_code::none : error_code::unexpected_end;
+      }
+   }
+
    template <auto Opts, is_context Ctx>
    GLZ_ALWAYS_INLINE void finalize_read_context(Ctx&& ctx) noexcept
    {
@@ -38,16 +56,10 @@ namespace glz
       if constexpr (check_partial_read(Opts)) {
          if (ctx.error == error_code::partial_read_complete) [[likely]] {
             ctx.error = error_code::none;
-         }
-         else if (ctx.error == error_code::end_reached && ctx.depth == 0) {
-            ctx.error = error_code::none;
+            return;
          }
       }
-      else {
-         if (ctx.error == error_code::end_reached && ctx.depth == 0) {
-            ctx.error = error_code::none;
-         }
-      }
+      settle_end_reached(ctx);
    }
 
    // Settle what a read that ran to the end of the buffer means, then finalize the context.

--- a/tests/istream_buffer_test/istream_buffer_test.cpp
+++ b/tests/istream_buffer_test/istream_buffer_test.cpp
@@ -4142,6 +4142,41 @@ suite additional_edge_cases = [] {
       expect(v.size() == 400u);
       expect(v[399] == 399);
    };
+
+   // A stream that ends with containers still open is truncated input. end_reached is documented as
+   // a non-error code, so surfacing it here would tell the caller the read succeeded and merely
+   // stopped early -- exactly the wrong reading of a stream that was cut off.
+   "a truncated stream reports unexpected_end"_test = [] {
+      for (std::string_view truncated : {"[1,2", "[[1,2],[3", "{\"a\":1", "[{\"a\":1}"}) {
+         std::istringstream iss{std::string{truncated}};
+         glz::istream_buffer<> buffer(iss);
+
+         glz::generic j{};
+         const auto ec = glz::read_json(j, buffer);
+         expect(ec == glz::error_code::unexpected_end) << truncated;
+         expect(ec != glz::error_code::end_reached) << truncated;
+      }
+   };
+
+   // The same input, but long enough that the reader refills its way through several windows before
+   // the source runs dry. The truncation is then many windows away from where the parse started,
+   // which is the case a check written against the first window would miss.
+   "a truncation found after refills reports unexpected_end"_test = [] {
+      std::string json = "[";
+      for (int i = 0; i < 400; ++i) {
+         if (i) json += ',';
+         json += std::to_string(i);
+      }
+      // no closing bracket
+
+      std::istringstream iss{json};
+      glz::basic_istream_buffer<std::istringstream, 512> buffer(iss);
+
+      std::vector<int> v{};
+      const auto ec = glz::read_json(v, buffer);
+      expect(ec == glz::error_code::unexpected_end);
+      expect(ec != glz::error_code::end_reached);
+   };
 };
 
 // A streaming buffer satisfies `contiguous`, so before these entry points routed to read_streaming

--- a/tests/istream_buffer_test/istream_buffer_test.cpp
+++ b/tests/istream_buffer_test/istream_buffer_test.cpp
@@ -699,6 +699,43 @@ suite json_stream_reader_tests = [] {
       expect(records.size() == 3u);
    };
 
+   // A stream whose last record is cut off used to come back as a success holding only the records
+   // that survived. read_json_stream stops on end_reached and treats it as end of stream, so a tail
+   // that ran out mid-record was indistinguishable from a stream that ended between records, and
+   // the caller was handed a short vector with nothing to say it was short.
+   "a truncated final record is reported, not dropped"_test = [] {
+      for (std::string_view tail : {R"({"id":2)", R"({"id":2,"name":"b")", R"({"id":2,"name":)"}) {
+         std::istringstream iss{R"({"id":1,"name":"a"})"
+                                "\n" +
+                                std::string{tail}};
+
+         std::vector<Record> records;
+         const auto ec = glz::read_json_stream(records, iss);
+
+         expect(ec.ec == glz::error_code::unexpected_end) << tail;
+         expect(ec.ec != glz::error_code::end_reached) << tail;
+         expect(records.size() == 1u) << tail;
+      }
+   };
+
+   "a stream ending between records still succeeds"_test = [] {
+      for (std::string_view text : {R"({"id":1,"name":"a"})"
+                                    "\n"
+                                    R"({"id":2,"name":"b"})",
+                                    R"({"id":1,"name":"a"})"
+                                    "\n"
+                                    R"({"id":2,"name":"b"})"
+                                    "\n"}) {
+         std::istringstream iss{std::string{text}};
+
+         std::vector<Record> records;
+         const auto ec = glz::read_json_stream(records, iss);
+
+         expect(!ec) << text;
+         expect(records.size() == 2u) << text;
+      }
+   };
+
    "json_stream_reader error handling"_test = [] {
       std::istringstream iss(R"({"id":1,"name":"valid"}
 {"id":invalid})");

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -1214,6 +1214,31 @@ suite basic_types = [] {
       }
    };
 
+   "truncated input reports unexpected_end"_test = [] {
+      // A non-null-terminated buffer that runs out with containers still open is truncated input.
+      // end_reached is how the reader says "the buffer ran out here" and is documented as a
+      // non-error code, so it must not be what the caller sees: read that way it labels a partial
+      // parse a success that stopped early.
+      static constexpr glz::opts options{.null_terminated = false};
+      for (std::string_view truncated : {"[1,2", "[[1,2],[3", "[1,2,", "{\"a\":1", "[{\"a\":1}", "[ "}) {
+         const std::vector<char> buf{truncated.begin(), truncated.end()};
+         const std::string_view input{buf.data(), buf.size()};
+
+         glz::generic j{};
+         const auto ec = glz::read<options>(j, input);
+         expect(ec == glz::error_code::unexpected_end) << truncated;
+         expect(ec != glz::error_code::end_reached) << truncated;
+      }
+
+      // The other half of the same condition: a value whose last byte is the buffer's last byte
+      // also ends in end_reached, and there it means the read completed.
+      for (std::string_view complete : {"[1,2,3]", "[[1,2],[3]]", "{\"a\":1}", "42", "\"abc\"", "null"}) {
+         const std::vector<char> buf{complete.begin(), complete.end()};
+         glz::generic j{};
+         expect(glz::read<options>(j, std::string_view{buf.data(), buf.size()}) == glz::error_code::none) << complete;
+      }
+   };
+
    "bool write"_test = [] {
       std::string buffer{};
       expect(not glz::write_json(true, buffer));

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -833,6 +833,21 @@ bool equal(T x, T y)
    return x == y;
 }
 
+// Reflection needs external linkage, so these cannot be declared inside the test that uses them.
+struct partial_reuse_inner_t
+{
+   int a{};
+};
+struct partial_reuse_outer_t
+{
+   partial_reuse_inner_t inner{};
+};
+struct partial_reuse_pair_t
+{
+   int a{};
+   int b{};
+};
+
 suite basic_types = [] {
    using namespace ut;
 
@@ -1237,6 +1252,32 @@ suite basic_types = [] {
          glz::generic j{};
          expect(glz::read<options>(j, std::string_view{buf.data(), buf.size()}) == glz::error_code::none) << complete;
       }
+   };
+
+   // Depth is what tells a completed non-null-terminated read from a truncated one, so a read that
+   // reports success has to leave it at zero. A partial read is the one that would not: it stops as
+   // soon as it has the fields it wants and unwinds on an error code, so its enclosing containers
+   // never decrement. A context reused after one would then see the next well-formed buffer settle
+   // to unexpected_end.
+   "a context reused after a partial read still reads"_test = [] {
+      static constexpr glz::opts options{.null_terminated = false};
+      static constexpr glz::opts partial{.null_terminated = false, .partial_read = true};
+
+      glz::context ctx{};
+
+      const std::string first = R"({"inner":{"a":1}})";
+      const std::vector<char> buf1{first.begin(), first.end()};
+      partial_reuse_outer_t o{};
+      expect(glz::read<partial>(o, std::string_view{buf1.data(), buf1.size()}, ctx) == glz::error_code::none);
+      expect(o.inner.a == 1);
+      expect(ctx.depth == 0) << "a completed partial read must not leave depth raised";
+
+      const std::string second = R"({"a":1,"b":2})";
+      const std::vector<char> buf2{second.begin(), second.end()};
+      partial_reuse_pair_t p{};
+      expect(glz::read<options>(p, std::string_view{buf2.data(), buf2.size()}, ctx) == glz::error_code::none);
+      expect(p.a == 1);
+      expect(p.b == 2);
    };
 
    "bool write"_test = [] {

--- a/tests/networking_tests/registry_view_test/registry_view_test.cpp
+++ b/tests/networking_tests/registry_view_test/registry_view_test.cpp
@@ -372,6 +372,10 @@ suite unterminated_buffer_tests = [] {
 
       auto result = glz::repe::parse_request({response_buf.data(), response_buf.size()});
       expect(result.request.error() != glz::error_code::none) << "Truncated body should not report success";
+      // Every registry read runs without a terminator, so a body that ends with containers still
+      // open reports end_reached internally. That code is documented as a non-error, so putting it
+      // in a response header would tell the client the request parsed and merely stopped early.
+      expect(result.request.error() == glz::error_code::unexpected_end) << "Expected unexpected_end";
    };
 
    "whitespace_only_body_is_an_error"_test = [] {


### PR DESCRIPTION
`error_code::end_reached` is documented in the enum as a non-error code. It is meant to be internal to a non-null-terminated read, saying only "the buffer ran out here" — which is a completed read or a truncated one depending on where it happened. Nothing settled which, so it escaped to callers.

Any non-null-terminated read of truncated JSON returned it:

```cpp
static constexpr glz::opts options{.null_terminated = false};
glz::generic j{};
glz::read<options>(j, "[1,2");  // end_reached, a documented non-error
```

Since #2732 every registry read runs non-null-terminated, so this reached the wire: a truncated REPE body answered its client with `end_reached` in the response header, telling it the request parsed and merely stopped early. The existing `truncated_body_is_an_error` test asserted only `!= none`, so it passed either way.

## The fix

`ctx.depth` already carries the answer. A value that closed cleanly leaves it at zero, so the buffer ended exactly where the value did and the read succeeded. Any other depth means the buffer ran out with containers still open, which is truncated input.

`settle_end_reached` applies that at the top level, called from `finalize_read_context` so buffered and streaming reads settle identically and no call site can forget. `end_reached` no longer escapes a read at all; `json_stream_reader`, which raises it itself to signal end of stream, is unaffected.

The enum comment now says what the code is for and who is allowed to see it.

## Tests

- `json_test`: truncated non-null-terminated input reports `unexpected_end` across six shapes (`[1,2`, `[[1,2],[3`, `{"a":1`, ...), and six complete documents still report `none`.
- `istream_buffer_test`: a truncated stream, and a truncation only discovered after several refills.
- `registry_view_test`: `truncated_body_is_an_error` now names `unexpected_end` instead of accepting any non-`none` code.

Full suite: 108/108.
