### PR TITLE
Give the NDJSON reader refill points

### DIFF
--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -137,13 +137,24 @@ Passing an `istream_buffer` to any format is safe: the read is bounded by the wi
 
 ### What still has to fit in the window
 
-Refill points sit *between* values, never inside one. A single JSON string or number is read in one piece, so it has to fit in what the window holds when it starts — the buffer capacity is the practical ceiling on one token, not on the document. A token that outruns the window reports `error_code::streaming_unsupported`, which names the buffer rather than blaming the document. Raise the capacity if you hit it:
+Refill points sit *between* values, never inside one. A single JSON string or number is read in one piece, so it has to fit in the window; the capacity is the ceiling on one token, not on the document. For NDJSON the unit is the record: a record and its newline have to fit, and a record only has to fit in the *window*, not in whatever the record before it left over. Outrunning the window reports `error_code::streaming_unsupported`, which names the buffer rather than blaming the document. Raise the capacity if you hit it:
 
 ```cpp
 glz::basic_istream_buffer<std::ifstream, 1 << 20> buffer(file);  // 1 MB window
 ```
 
 Leading whitespace is also read without refilling, so whitespace wider than the window stops a read before it reaches the value behind it.
+
+### Non-owning types are unsafe to stream
+
+A refill moves the window, so anything pointing into it dangles. Reading into a type that holds `std::string_view` or `glz::raw_json_view` — directly, or as a member, or as the element of a container — gives views into bytes that have since been overwritten, and the read still reports success. This is not currently diagnosed.
+
+```cpp
+std::vector<std::string_view> views{};
+glz::read_json(views, buffer);  // silently wrong once the document outruns one window
+```
+
+Read into owning types (`std::string`, `glz::raw_json`) when the source is a stream. This applies to every streaming read, not just NDJSON.
 
 ## See Also
 

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -124,11 +124,26 @@ static_assert(glz::byte_input_stream<std::ifstream>);
 
 ## Format Support
 
-| Format | Output Streaming | Input Streaming |
-|--------|-----------------|-----------------|
-| JSON   | `ostream_buffer` | `istream_buffer` |
-| BEVE   | `ostream_buffer` | `istream_buffer` |
-| NDJSON | `ostream_buffer` | `json_stream_reader` |
+Reading a document larger than the buffer window requires the format's reader to be able to refill partway through a parse. Not every reader can, and `glz::format_supports_streaming<Format>` says which:
+
+| Format | Output streaming | Reads past one window |
+|--------|------------------|-----------------------|
+| JSON   | `ostream_buffer` | yes, refills between array elements and object members |
+| NDJSON | `ostream_buffer` | yes, refills between records |
+| BEVE   | `ostream_buffer` | no |
+| others | `ostream_buffer` | no |
+
+Passing an `istream_buffer` to any format is safe: the read is bounded by the window either way. A format whose reader cannot refill simply sees the first window, and a document that outruns it fails with `error_code::streaming_unsupported` rather than silently returning the part that fit.
+
+### What still has to fit in the window
+
+Refill points sit *between* values, never inside one. A single JSON string or number is read in one piece, so it has to fit in what the window holds when it starts — the buffer capacity is the practical ceiling on one token, not on the document. A token that outruns the window reports `error_code::streaming_unsupported`, which names the buffer rather than blaming the document. Raise the capacity if you hit it:
+
+```cpp
+glz::basic_istream_buffer<std::ifstream, 1 << 20> buffer(file);  // 1 MB window
+```
+
+Leading whitespace is also read without refilling, so whitespace wider than the window stops a read before it reaches the value behind it.
 
 ## See Also
 

--- a/include/glaze/core/streaming_state.hpp
+++ b/include/glaze/core/streaming_state.hpp
@@ -111,4 +111,47 @@ namespace glz
    concept has_streaming_state = is_context<std::remove_cvref_t<T>> && requires(std::remove_cvref_t<T>& ctx) {
       { ctx.stream } -> std::same_as<streaming_state&>;
    };
+
+   // Re-derive the window's edge after handing the input to another reader.
+   //
+   // parse<Format>::op takes `end` by value, so a reader that refills partway through leaves the
+   // caller holding an edge from the window the parse started in. `it` moved with the refill, and
+   // the two stop describing the same span -- offsets taken from them then run past the buffer.
+   template <class Ctx, class End>
+   GLZ_ALWAYS_INLINE void resync_window_end(Ctx& ctx, End& end) noexcept
+   {
+      if constexpr (has_streaming_state<Ctx>) {
+         if (ctx.stream.enabled()) {
+            end = ctx.stream.data() + ctx.stream.size();
+         }
+      }
+   }
+
+   // A refill point for a reader parsing a sequence of independent values: called between two of
+   // them, it releases what has been parsed and pulls more input into the space behind it. Both
+   // iterators move, since a refill relocates the window.
+   //
+   // Refilling once the window is half spent rather than only once it is drained is what keeps
+   // whole values inside it. A reader can refill between values but not inside one, so the next
+   // value has to fit in what is left; leaving half the window is the margin that buys. A value
+   // wider than that margin still runs out of window, which is the standing limit of streaming.
+   //
+   // A context with no streaming state -- every buffered read -- compiles this away to nothing.
+   template <class Ctx, class It, class End>
+   GLZ_ALWAYS_INLINE void refill_between_values(Ctx& ctx, It& it, End& end) noexcept
+   {
+      if constexpr (has_streaming_state<Ctx>) {
+         if (ctx.stream.enabled()) {
+            const size_t window = ctx.stream.size();
+            const size_t consumed = size_t(it - ctx.stream.data());
+            if (it >= end || (window - consumed) <= window / 2) {
+               const char* new_it;
+               const char* new_end;
+               ctx.stream.consume_and_refill(consumed, new_it, new_end);
+               it = new_it;
+               end = new_end;
+            }
+         }
+      }
+   }
 }

--- a/include/glaze/core/streaming_state.hpp
+++ b/include/glaze/core/streaming_state.hpp
@@ -127,30 +127,34 @@ namespace glz
       }
    }
 
-   // A refill point for a reader parsing a sequence of independent values: called between two of
-   // them, it releases what has been parsed and pulls more input into the space behind it. Both
-   // iterators move, since a refill relocates the window.
+   // Release everything up to `it` and pull more input into the space behind it. Both iterators
+   // move, since a refill relocates the window.
    //
-   // Refilling once the window is half spent rather than only once it is drained is what keeps
-   // whole values inside it. A reader can refill between values but not inside one, so the next
-   // value has to fit in what is left; leaving half the window is the margin that buys. A value
-   // wider than that margin still runs out of window, which is the standing limit of streaming.
+   // This is mechanism only: when to refill is the calling reader's decision, because only it knows
+   // where one value ends and the next begins. Calling this anywhere else -- in the middle of a
+   // value -- invalidates every pointer the reader is holding into the window.
+   //
+   // `it` is clamped to the window rather than trusted. A reader can leave it past `end` on an
+   // error path, and a variant alternative resolved by shape rewinds it, so an unclamped
+   // subtraction underflows the byte count handed to consume(); the buffer's size then wraps and
+   // the next refill memmoves a garbage length.
    //
    // A context with no streaming state -- every buffered read -- compiles this away to nothing.
    template <class Ctx, class It, class End>
-   GLZ_ALWAYS_INLINE void refill_between_values(Ctx& ctx, It& it, End& end) noexcept
+   GLZ_ALWAYS_INLINE void refill_window(Ctx& ctx, It& it, End& end) noexcept
    {
       if constexpr (has_streaming_state<Ctx>) {
          if (ctx.stream.enabled()) {
-            const size_t window = ctx.stream.size();
-            const size_t consumed = size_t(it - ctx.stream.data());
-            if (it >= end || (window - consumed) <= window / 2) {
-               const char* new_it;
-               const char* new_end;
-               ctx.stream.consume_and_refill(consumed, new_it, new_end);
-               it = new_it;
-               end = new_end;
-            }
+            const char* const window = ctx.stream.data();
+            const size_t size = ctx.stream.size();
+            const size_t offset = (it > window) ? size_t(it - window) : 0;
+            const size_t consumed = (offset < size) ? offset : size;
+
+            const char* new_it;
+            const char* new_end;
+            ctx.stream.consume_and_refill(consumed, new_it, new_end);
+            it = new_it;
+            end = new_end;
          }
       }
    }

--- a/include/glaze/forward.hpp
+++ b/include/glaze/forward.hpp
@@ -49,18 +49,22 @@ namespace glz
    inline constexpr std::uint32_t JSONRPC = 30200;
 
    // Whether a format's reader can refill from an input stream mid-parse, and so read a document
-   // larger than the buffer window. Only the JSON reader has refill points today; every other
-   // reader sees one window and stops at its edge. Reading a longer document through such a format
-   // fails with error_code::streaming_unsupported rather than silently returning what fit.
+   // larger than the buffer window. The binary readers cannot: each sees one window and stops at
+   // its edge. Reading a longer document through such a format fails with
+   // error_code::streaming_unsupported rather than silently returning what fit.
    //
-   // This is a property of the reader, not of the format's grammar: NDJSON is false because its
-   // line loop cannot refill between lines, even though the per-line values it delegates to the
-   // JSON reader can. A user-defined format that gives its reader refill points specializes this.
+   // This is a property of the reader, not of the format's grammar. A user-defined format that
+   // gives its reader refill points specializes this.
    template <std::uint32_t Format>
    inline constexpr bool format_supports_streaming = false;
 
    template <>
    inline constexpr bool format_supports_streaming<JSON> = true;
+
+   // The NDJSON reader refills between records. A single record still has to fit in the window,
+   // since nothing refills inside one; a record that does not reports streaming_unsupported.
+   template <>
+   inline constexpr bool format_supports_streaming<NDJSON> = true;
 
    // Reflection metadata customization point.
    template <class T>

--- a/include/glaze/json/ndjson.hpp
+++ b/include/glaze/json/ndjson.hpp
@@ -30,6 +30,115 @@ namespace glz
       }
    };
 
+   // Consume the line breaks that separate two records.
+   //
+   // A null-terminated buffer stops on the trailing '\0' sentinel. A non-null-terminated buffer has
+   // no sentinel, so bound the scan on it != end.
+   template <auto Opts>
+   GLZ_ALWAYS_INLINE void skip_record_separators(is_context auto& ctx, auto& it, auto& end) noexcept
+   {
+      if constexpr (Opts.null_terminated) {
+         while (*it == '\r') {
+            ++it;
+            if (*it == '\n') {
+               ++it;
+            }
+            else {
+               ctx.error = error_code::syntax_error; // Expected '\n' after '\r'
+               return;
+            }
+         }
+         while (*it == '\n') {
+            ++it;
+         }
+      }
+      else {
+         while (it != end && *it == '\r') {
+            ++it;
+            if (it != end && *it == '\n') {
+               ++it;
+            }
+            else {
+               ctx.error = error_code::syntax_error; // Expected '\n' after '\r'
+               return;
+            }
+         }
+         while (it != end && *it == '\n') {
+            ++it;
+         }
+      }
+   }
+
+   // Position `it` at the next record, and report whether there is one.
+   //
+   // Records are independent, so the gap between two of them is where a streaming window can
+   // release what has been parsed and pull in more. Doing that here is what lets a document larger
+   // than the window be read at all; without it the read stops at the first window's edge, carrying
+   // only the records that happened to fit and calling that a complete document.
+   //
+   // Returns false both when the input is exhausted and when the separators were malformed; the
+   // caller tells them apart from ctx.error, which is what distinguishes a document that ended from
+   // one that broke.
+   template <auto Opts, class Ctx>
+   bool ndjson_has_next_record(Ctx& ctx, auto& it, auto& end) noexcept
+   {
+      // A run of separators can be wider than the window, so this loops: each pass consumes at
+      // least the byte the previous refill made available, and stops as soon as the source runs
+      // dry. Without it a window ending in separators looks like the start of a record.
+      while (true) {
+         refill_between_values(ctx, it, end);
+         if (it >= end) {
+            return false;
+         }
+
+         skip_record_separators<Opts>(ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]] {
+            return false;
+         }
+         if (it < end) {
+            return true;
+         }
+      }
+   }
+
+   // Read one record into `record`. Returns false on error.
+   //
+   // A record that closed cleanly leaves ctx.depth at zero, so end_reached there means the input
+   // ran out exactly where the record ended rather than in the middle of it -- the record is
+   // complete either way, and whether anything follows it is the next iteration's question.
+   //
+   // Any other way of running out of input means the record itself was cut short. For a buffer that
+   // is a truncated document. For a stream with input still pending it is instead the window that
+   // ran out: the JSON reader refills between the members of an object and the elements of an
+   // array, but nothing refills in the middle of a string or a number, so a single token has to fit
+   // in the window. Naming that beats reporting a truncated document, since the document is fine
+   // and the buffer is the thing to change.
+   template <auto Opts, class Ctx>
+   bool read_ndjson_record(auto&& record, Ctx& ctx, auto& it, auto& end)
+   {
+      parse<JSON>::op<Opts>(record, ctx, it, end);
+      resync_window_end(ctx, end); // the JSON reader may have refilled inside the record
+
+      if (!bool(ctx.error)) [[likely]] {
+         return true;
+      }
+      if (ctx.error == error_code::end_reached && ctx.depth == 0) {
+         ctx.error = error_code::none;
+         return true;
+      }
+
+      if constexpr (has_streaming_state<Ctx>) {
+         const bool ran_out_of_input = ctx.error == error_code::end_reached || ctx.error == error_code::unexpected_end;
+         if (ran_out_of_input && ctx.stream.enabled() && !ctx.stream.source_at_eof()) {
+            ctx.error = error_code::streaming_unsupported;
+            ctx.custom_error_message =
+               "a string or number in this NDJSON record is wider than the buffer window; nothing "
+               "refills inside a single token";
+         }
+      }
+      return false;
+   }
+
    template <class T>
       requires readable_array_t<T> && (emplace_backable<T> || !resizable<T>)
    struct from<NDJSON, T>
@@ -55,75 +164,40 @@ namespace glz
 
          auto value_it = value.begin();
 
-         auto read_new_lines = [&] {
-            // A null-terminated buffer stops on the trailing '\0' sentinel. A non-null-terminated
-            // buffer has no sentinel, so bound the scan on it != end while consuming the line
-            // breaks between records.
-            if constexpr (Opts.null_terminated) {
-               while (*it == '\r') {
-                  ++it;
-                  if (*it == '\n') {
-                     ++it;
-                  }
-                  else {
-                     ctx.error = error_code::syntax_error; // Expected '\n' after '\r'
-                     return;
-                  }
-               }
-               while (*it == '\n') {
-                  ++it;
-               }
-            }
-            else {
-               while (it != end && *it == '\r') {
-                  ++it;
-                  if (it != end && *it == '\n') {
-                     ++it;
-                  }
-                  else {
-                     ctx.error = error_code::syntax_error; // Expected '\n' after '\r'
-                     return;
-                  }
-               }
-               while (it != end && *it == '\n') {
-                  ++it;
+         const auto truncate_to = [&](auto first_unwritten) {
+            if constexpr (erasable<T>) {
+               // erase rather than resize, for element types that are not default constructible
+               value.erase(first_unwritten, value.end());
+
+               if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
+                  value.shrink_to_fit();
                }
             }
          };
 
          for (size_t i = 0; i < n; ++i) {
-            parse<JSON>::op<Opts>(*value_it++, ctx, it, end);
-            if (it == end) {
-               if constexpr (erasable<T>) {
-                  value.erase(value_it,
-                              value.end()); // use erase rather than resize for non-default constructible elements
-
-                  if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
-                     value.shrink_to_fit();
-                  }
+            if (!ndjson_has_next_record<Opts>(ctx, it, end)) {
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
                }
+               truncate_to(value_it);
                return;
             }
-
-            read_new_lines();
+            if (!read_ndjson_record<Opts>(*value_it, ctx, it, end)) [[unlikely]] {
+               return;
+            }
+            ++value_it;
          }
 
          // growing
          if constexpr (emplace_backable<T>) {
-            while (it < end) {
-               parse<JSON>::op<Opts>(value.emplace_back(), ctx, it, end);
-               if (bool(ctx.error)) {
-                  // A non-null-terminated buffer has no sentinel, so the last record reports
-                  // end_reached instead of stopping on '\0'. A depth of zero means that record was
-                  // parsed completely, which is the normal end of input rather than a failure. This
-                  // matches the condition finalize_read_context clears the code on.
-                  if (ctx.error == error_code::end_reached && ctx.depth == 0) {
-                     break;
-                  }
+            while (ndjson_has_next_record<Opts>(ctx, it, end)) {
+               if (!read_ndjson_record<Opts>(value.emplace_back(), ctx, it, end)) [[unlikely]] {
                   return;
                }
-
-               read_new_lines();
+            }
+            if (bool(ctx.error)) [[unlikely]] {
+               return; // malformed separators, not the end of the document
             }
 
             if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
@@ -156,57 +230,18 @@ namespace glz
             }
          }();
 
-         auto read_new_lines = [&] {
-            // A null-terminated buffer stops on the trailing '\0' sentinel. A non-null-terminated
-            // buffer has no sentinel, so bound the scan on it != end while consuming the line
-            // breaks between records.
-            if constexpr (Opts.null_terminated) {
-               while (*it == '\r') {
-                  ++it;
-                  if (*it == '\n') {
-                     ++it;
-                  }
-                  else {
-                     ctx.error = error_code::syntax_error; // Expected '\n' after '\r'
-                     return;
-                  }
-               }
-               while (*it == '\n') {
-                  ++it;
-               }
-            }
-            else {
-               while (it != end && *it == '\r') {
-                  ++it;
-                  if (it != end && *it == '\n') {
-                     ++it;
-                  }
-                  else {
-                     ctx.error = error_code::syntax_error; // Expected '\n' after '\r'
-                     return;
-                  }
-               }
-               while (it != end && *it == '\n') {
-                  ++it;
-               }
-            }
-         };
-
          for_each<N>([&]<auto I>() {
-            if (it == end) {
-               return;
-            }
-            if constexpr (I != 0) {
-               read_new_lines();
+            if (bool(ctx.error) || !ndjson_has_next_record<Opts>(ctx, it, end)) {
+               return; // for_each has no early exit; the guard above stands in for one
             }
             if constexpr (is_std_tuple<T>) {
-               parse<JSON>::op<Opts>(std::get<I>(value), ctx, it, end);
+               (void)read_ndjson_record<Opts>(std::get<I>(value), ctx, it, end);
             }
             else if constexpr (glaze_array_t<T>) {
-               parse<JSON>::op<Opts>(get_member(value, glz::get<I>(meta_v<T>)), ctx, it, end);
+               (void)read_ndjson_record<Opts>(get_member(value, glz::get<I>(meta_v<T>)), ctx, it, end);
             }
             else {
-               parse<JSON>::op<Opts>(glz::get<I>(value), ctx, it, end);
+               (void)read_ndjson_record<Opts>(glz::get<I>(value), ctx, it, end);
             }
          });
       }

--- a/include/glaze/json/ndjson.hpp
+++ b/include/glaze/json/ndjson.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cstring>
+
 #include "glaze/json/read.hpp"
 #include "glaze/json/write.hpp"
 
@@ -32,73 +34,163 @@ namespace glz
 
    // Consume the line breaks that separate two records.
    //
+   // Both line endings are handled by one loop rather than one after the other, so that a CRLF
+   // following a bare LF is still a separator. Scanning for all the CRs and then all the LFs stops
+   // at the first CR after an LF and calls it the start of a record.
+   //
+   // A '\r' whose '\n' has not arrived is left unconsumed rather than rejected. From in here a CRLF
+   // split by the window edge and a stray carriage return are the same two bytes; only the caller
+   // knows whether more input can still arrive. So this stops there without an error, and the
+   // caller either refills and calls again or reports the syntax error itself.
+   //
    // A null-terminated buffer stops on the trailing '\0' sentinel. A non-null-terminated buffer has
    // no sentinel, so bound the scan on it != end.
    template <auto Opts>
    GLZ_ALWAYS_INLINE void skip_record_separators(is_context auto& ctx, auto& it, auto& end) noexcept
    {
       if constexpr (Opts.null_terminated) {
-         while (*it == '\r') {
-            ++it;
+         while (true) {
             if (*it == '\n') {
                ++it;
+               continue;
             }
-            else {
+            if (*it == '\r') {
+               if (*(it + 1) == '\n') {
+                  it += 2;
+                  continue;
+               }
                ctx.error = error_code::syntax_error; // Expected '\n' after '\r'
-               return;
             }
-         }
-         while (*it == '\n') {
-            ++it;
+            return;
          }
       }
       else {
-         while (it != end && *it == '\r') {
-            ++it;
-            if (it != end && *it == '\n') {
+         while (it != end) {
+            if (*it == '\n') {
                ++it;
+               continue;
             }
-            else {
+            if (*it == '\r') {
+               if ((it + 1) == end) {
+                  return; // undecidable from this window; the caller refills or errors
+               }
+               if (*(it + 1) == '\n') {
+                  it += 2;
+                  continue;
+               }
                ctx.error = error_code::syntax_error; // Expected '\n' after '\r'
-               return;
             }
-         }
-         while (it != end && *it == '\n') {
-            ++it;
+            return;
          }
       }
    }
 
-   // Position `it` at the next record, and report whether there is one.
+   // Whether a record delimiter is anywhere in the window ahead of `it`.
    //
-   // Records are independent, so the gap between two of them is where a streaming window can
-   // release what has been parsed and pull in more. Doing that here is what lets a document larger
-   // than the window be read at all; without it the read stops at the first window's edge, carrying
-   // only the records that happened to fit and calling that a complete document.
+   // Either line ending closes a record, and '\r' has to count on its own: a CRLF can be split by
+   // the window edge, and a window holding the whole record plus the '\r' does hold a complete
+   // record. Requiring the '\n' would call that record unreadable while it is sitting right there.
    //
-   // Returns false both when the input is exhausted and when the separators were malformed; the
-   // caller tells them apart from ctx.error, which is what distinguishes a document that ended from
-   // one that broke.
+   // A raw '\r' or '\n' inside a JSON string is invalid -- both have to be escaped -- so the first
+   // one after the start of a record always ends it.
+   GLZ_ALWAYS_INLINE bool window_holds_record_end(const char* it, const char* end) noexcept
+   {
+      const size_t n = size_t(end - it);
+      if (n == 0) {
+         return false;
+      }
+      return std::memchr(it, '\n', n) != nullptr || std::memchr(it, '\r', n) != nullptr;
+   }
+
+   // Bring a whole record into the window, so the record reader is never handed a partial one.
+   //
+   // Records are newline delimited, which makes "does the window hold a complete record" a question
+   // that can be answered before parsing: look for the delimiter. Nothing weaker works. A refill
+   // policy driven by a byte count cannot tell "the window ran out in the middle of this record"
+   // from "this record ended with the buffer", and the JSON reader reports both the same way, as a
+   // value that parsed cleanly up to `end`. A bare number split by the window edge then reads as
+   // two numbers, and neither the reader nor the caller has anything to notice it by.
+   //
+   // Refilling until the delimiter appears also drops the ceiling a byte count imposes. A record no
+   // longer has to fit in whatever fraction of the window happened to be left over from the last
+   // one; it only has to fit in the window.
+   //
+   // Returns false when no refill can produce a delimiter, which means the record really is wider
+   // than the window -- the standing limit of streaming, since nothing refills inside a record.
+   template <class Ctx>
+   bool fill_window_to_record_end(Ctx& ctx, auto& it, auto& end) noexcept
+   {
+      if constexpr (has_streaming_state<Ctx>) {
+         if (ctx.stream.enabled()) {
+            while (!window_holds_record_end(it, end)) {
+               // The last record in a document may end without a delimiter, so a source with
+               // nothing left to give has already delivered the whole record.
+               if (ctx.stream.source_at_eof()) {
+                  return true;
+               }
+               const size_t available = size_t(end - it);
+               refill_window(ctx, it, end);
+               if (size_t(end - it) <= available) {
+                  return false; // the refill brought nothing new: the record does not fit
+               }
+            }
+         }
+      }
+      return true;
+   }
+
+   // Position `it` at the start of the next record, with the whole record in the window, and report
+   // whether there is one.
+   //
+   // Records are independent, so the gap between two of them is the only place a streaming window
+   // may release what has been parsed and pull in more. Doing that here is what lets a document
+   // larger than the window be read at all; without it the read stops at the first window's edge,
+   // carrying only the records that happened to fit and calling that a complete document.
+   //
+   // Returns false when the input is exhausted, when the separators were malformed, and when a
+   // record is wider than the window; the caller tells them apart from ctx.error, which is what
+   // distinguishes a document that ended from one that could not be read.
    template <auto Opts, class Ctx>
    bool ndjson_has_next_record(Ctx& ctx, auto& it, auto& end) noexcept
    {
-      // A run of separators can be wider than the window, so this loops: each pass consumes at
-      // least the byte the previous refill made available, and stops as soon as the source runs
-      // dry. Without it a window ending in separators looks like the start of a record.
+      // A run of separators can be wider than the window, so this loops: each pass either reaches a
+      // record byte or releases the separators it walked and pulls more input in behind them.
       while (true) {
-         refill_between_values(ctx, it, end);
-         if (it >= end) {
-            return false;
-         }
-
          skip_record_separators<Opts>(ctx, it, end);
          if (bool(ctx.error)) [[unlikely]] {
             return false;
          }
-         if (it < end) {
-            return true;
+         if (it < end && *it != '\r') {
+            break; // a record byte
+         }
+
+         // Either the window is spent, or it ends on a '\r' whose '\n' has not arrived. Both are
+         // answered by more input, and both are the end of the document if there is none.
+         bool progressed = false;
+         if constexpr (has_streaming_state<Ctx>) {
+            if (ctx.stream.enabled() && !ctx.stream.source_at_eof()) {
+               const size_t available = size_t(end - it);
+               refill_window(ctx, it, end);
+               progressed = size_t(end - it) > available;
+            }
+         }
+         if (!progressed) {
+            if (it < end) [[unlikely]] {
+               // a '\r' at the true end of the input, with no '\n' to pair it with
+               ctx.error = error_code::syntax_error;
+            }
+            return false;
          }
       }
+
+      if (!fill_window_to_record_end(ctx, it, end)) {
+         ctx.error = error_code::streaming_unsupported;
+         ctx.custom_error_message =
+            "this NDJSON record is wider than the buffer window; a record must fit in the window "
+            "because nothing refills inside one";
+         return false;
+      }
+      return true;
    }
 
    // Read one record into `record`. Returns false on error.
@@ -122,9 +214,23 @@ namespace glz
       if (!bool(ctx.error)) [[likely]] {
          return true;
       }
+
+      // "The input ran out exactly where this record ended" is only the same statement as "this
+      // record is complete" when the input that ran out was the document. If it was the window, the
+      // record was cut mid-token and the bytes after the cut are the rest of that same token --
+      // accepting it here splits one value into two and reports success, which is the one outcome a
+      // reader must never produce. ndjson_has_next_record is what normally prevents this, by
+      // refusing to start a record it cannot see the end of; this is the check that makes the
+      // guarantee local rather than something the caller has to be trusted to have arranged.
       if (ctx.error == error_code::end_reached && ctx.depth == 0) {
-         ctx.error = error_code::none;
-         return true;
+         bool cut_by_window = false;
+         if constexpr (has_streaming_state<Ctx>) {
+            cut_by_window = ctx.stream.enabled() && !ctx.stream.source_at_eof() && it >= end;
+         }
+         if (!cut_by_window) {
+            ctx.error = error_code::none;
+            return true;
+         }
       }
 
       if constexpr (has_streaming_state<Ctx>) {
@@ -132,8 +238,8 @@ namespace glz
          if (ran_out_of_input && ctx.stream.enabled() && !ctx.stream.source_at_eof()) {
             ctx.error = error_code::streaming_unsupported;
             ctx.custom_error_message =
-               "a string or number in this NDJSON record is wider than the buffer window; nothing "
-               "refills inside a single token";
+               "this NDJSON record is wider than the buffer window; a record must fit in the window "
+               "because nothing refills inside one";
          }
       }
       return false;

--- a/tests/istream_buffer_test/istream_buffer_test.cpp
+++ b/tests/istream_buffer_test/istream_buffer_test.cpp
@@ -8,6 +8,7 @@
 #include <limits>
 #include <map>
 #include <mutex>
+#include <random>
 #include <sstream>
 #include <thread>
 
@@ -4370,6 +4371,83 @@ suite ndjson_streaming_tests = [] {
       expect(!glz::read_ndjson(v, buffer));
       expect(v.size() == 6u);
       expect(v[5].name.size() == 300u);
+   };
+
+   // The test this feature needs. Streaming and buffered reads of the same document must agree,
+   // and mixed record widths are what break refill policies: a record's start lands at a different
+   // offset into the window every time, so the interesting alignments only show up under variety.
+   // Uniform widths pass almost anything.
+   //
+   // What this catches, and what nothing built from fixed-width records did: a bare token cut by
+   // the window edge parses cleanly up to `end`, so it reads as a complete record and its tail
+   // reads as the next one. One number silently becomes two, with a success code.
+   "streaming agrees with buffered across record widths"_test = [] {
+      std::mt19937_64 rng{12345};
+      size_t compared = 0;
+
+      for (int round = 0; round < 400; ++round) {
+         // bare numbers, so a cut record still parses as a valid value rather than erroring out
+         std::string doc{};
+         const int records = 1 + int(rng() % 5);
+         for (int i = 0; i < records; ++i) {
+            doc += "0." + std::string(1 + rng() % 420, char('1' + int(rng() % 9))) + "\n";
+         }
+
+         std::vector<double> buffered{};
+         const auto ec_buffered = glz::read_ndjson(buffered, doc);
+
+         std::istringstream iss{doc};
+         glz::basic_istream_buffer<std::istringstream, narrow_window> buffer(iss);
+         std::vector<double> streamed{};
+         const auto ec_streamed = glz::read_ndjson(streamed, buffer);
+
+         expect(ec_streamed.ec == ec_buffered.ec) << "round " << round;
+         expect(streamed == buffered) << "round " << round << ": " << streamed.size() << " vs " << buffered.size();
+         ++compared;
+      }
+      expect(compared == 400u);
+   };
+
+   // A separator run can be wider than the window, and a CRLF can be split across the edge, so the
+   // reader has to pull the '\n' in before deciding whether the '\r' was a separator or garbage.
+   "separators spanning the window edge still separate"_test = [] {
+      for (size_t pad = 500; pad < 510; ++pad) {
+         const std::string doc = "0." + std::string(pad, '5') + "\r\n7\r\n";
+
+         std::vector<double> buffered{};
+         expect(!glz::read_ndjson(buffered, doc)) << pad;
+
+         std::istringstream iss{doc};
+         glz::basic_istream_buffer<std::istringstream, narrow_window> buffer(iss);
+         std::vector<double> streamed{};
+         expect(!glz::read_ndjson(streamed, buffer)) << pad;
+         expect(streamed == buffered) << pad;
+      }
+
+      // a run of separators longer than the window, then a record behind it
+      const std::string doc = std::string(narrow_window - 1, '\n') + "\r\n42\n";
+      std::istringstream iss{doc};
+      glz::basic_istream_buffer<std::istringstream, narrow_window> buffer(iss);
+      std::vector<double> v{};
+      expect(!glz::read_ndjson(v, buffer));
+      expect(v.size() == 1u);
+      expect(v[0] == 42.0);
+   };
+
+   // A record only has to fit in the window, not in whatever the previous record happened to leave
+   // behind. Sizing the first record so the second starts past the halfway mark is what a
+   // byte-count refill policy gets wrong: it declares a perfectly ordinary record too wide.
+   "a record wider than the window's remainder still reads"_test = [] {
+      const std::string doc = "\"" + std::string(197, 'a') + "\"\n\"" + std::string(398, 'b') + "\"\n";
+
+      std::istringstream iss{doc};
+      glz::basic_istream_buffer<std::istringstream, narrow_window> buffer(iss);
+
+      std::vector<std::string> v{};
+      const auto ec = glz::read_ndjson(v, buffer);
+      expect(!ec) << "a 400 byte record fits a 512 byte window";
+      expect(v.size() == 2u);
+      expect(v[1].size() == 398u);
    };
 
    // Nothing refills in the middle of a string or a number, so a single token still has to fit.

--- a/tests/istream_buffer_test/istream_buffer_test.cpp
+++ b/tests/istream_buffer_test/istream_buffer_test.cpp
@@ -4219,29 +4219,13 @@ suite streaming_buffer_dispatch_tests = [] {
 };
 
 // Routing every format to read_streaming only removes the overrun; it does not give a reader
-// refill points it never had. JSON is the only reader that has them, so for the rest a document
-// longer than the window used to end in an answer that blamed the document: NDJSON reported
-// success carrying the elements that fit, BEVE reported unexpected_end. Both now say which it was.
+// refill points it never had. The binary readers still see one window, so for them a document
+// longer than it used to end in an answer that blamed the document -- BEVE reported unexpected_end
+// for input that was not truncated at all. That now says which it was.
 suite non_streaming_format_reporting = [] {
    static_assert(glz::format_supports_streaming<glz::JSON>);
-   static_assert(!glz::format_supports_streaming<glz::NDJSON>,
-                 "NDJSON's line loop cannot refill between lines, whatever its per-line values do");
+   static_assert(glz::format_supports_streaming<glz::NDJSON>, "the NDJSON reader refills between records");
    static_assert(!glz::format_supports_streaming<glz::BEVE>);
-
-   "NDJSON larger than the window does not silently truncate"_test = [] {
-      std::vector<int> src{};
-      for (int i = 0; i < 400; ++i) src.push_back(i);
-      std::string doc{};
-      expect(!glz::write_ndjson(src, doc));
-      expect(doc.size() > narrow_window) << "the document has to outrun the window to test anything";
-
-      std::istringstream iss{doc};
-      glz::basic_istream_buffer<std::istringstream, narrow_window> buffer(iss);
-
-      std::vector<int> v{};
-      const auto ec = glz::read_streaming<glz::opts{.format = glz::NDJSON}>(v, buffer);
-      expect(ec == glz::error_code::streaming_unsupported) << "a short read must be reported, not returned as success";
-   };
 
    "BEVE larger than the window names the window"_test = [] {
       std::vector<int> src{};
@@ -4314,6 +4298,182 @@ suite non_streaming_format_reporting = [] {
       std::vector<int> v{};
       expect(!glz::read_streaming<glz::opts{}>(v, buffer));
       expect(v.size() == 400u);
+   };
+};
+
+// Reflection needs external linkage, so this cannot live in the anonymous namespace below.
+struct ndjson_record_t
+{
+   int id{};
+   std::string name{};
+};
+
+namespace
+{
+   // Records wide enough that a 512 byte window holds only a handful, so the read has to refill
+   // many times to get through the document.
+   std::string ndjson_document(int count, size_t name_width = 8)
+   {
+      std::string doc{};
+      for (int i = 0; i < count; ++i) {
+         doc += "{\"id\":" + std::to_string(i) + ",\"name\":\"" + std::string(name_width, 'x') + "\"}\n";
+      }
+      return doc;
+   }
+}
+
+// NDJSON records are independent, so the gap between two of them is a refill point. Before there
+// was one, a document larger than the window came back as however many records happened to fit.
+suite ndjson_streaming_tests = [] {
+   "a document many windows long reads every record"_test = [] {
+      const auto doc = ndjson_document(400);
+      expect(doc.size() > 20 * narrow_window) << "the document has to outrun the window many times over";
+
+      std::istringstream iss{doc};
+      glz::basic_istream_buffer<std::istringstream, narrow_window> buffer(iss);
+
+      std::vector<ndjson_record_t> v{};
+      expect(!glz::read_ndjson(v, buffer));
+      expect(v.size() == 400u);
+
+      bool ids_in_order = v.size() == 400u;
+      for (size_t i = 0; ids_in_order && i < v.size(); ++i) {
+         ids_in_order = v[i].id == int(i);
+      }
+      expect(ids_in_order) << "every record must survive the refill it straddles";
+      expect(v.back().name == std::string(8, 'x'));
+   };
+
+   // The last record carries no trailing separator, so it is the one that ends flush against the
+   // end of the input rather than against a newline.
+   "a document with no trailing newline reads every record"_test = [] {
+      auto doc = ndjson_document(400);
+      doc.pop_back();
+
+      std::istringstream iss{doc};
+      glz::basic_istream_buffer<std::istringstream, narrow_window> buffer(iss);
+
+      std::vector<ndjson_record_t> v{};
+      expect(!glz::read_ndjson(v, buffer));
+      expect(v.size() == 400u);
+   };
+
+   // Records between half a window and a whole one are the ones a naive "refill only when drained"
+   // rule would report as too wide.
+   "records that nearly fill the window still read"_test = [] {
+      const auto doc = ndjson_document(6, 300);
+
+      std::istringstream iss{doc};
+      glz::basic_istream_buffer<std::istringstream, narrow_window> buffer(iss);
+
+      std::vector<ndjson_record_t> v{};
+      expect(!glz::read_ndjson(v, buffer));
+      expect(v.size() == 6u);
+      expect(v[5].name.size() == 300u);
+   };
+
+   // Nothing refills in the middle of a string or a number, so a single token still has to fit.
+   // The document is fine and the buffer is the thing to change, which is what the error says.
+   "a token wider than the window names the window"_test = [] {
+      const std::string doc = "{\"id\":1,\"name\":\"" + std::string(2000, 'x') + "\"}\n{\"id\":2}\n";
+
+      std::istringstream iss{doc};
+      glz::basic_istream_buffer<std::istringstream, narrow_window> buffer(iss);
+
+      std::vector<ndjson_record_t> v{};
+      const auto ec = glz::read_ndjson(v, buffer);
+      expect(ec == glz::error_code::streaming_unsupported)
+         << "unexpected_end would blame a document that is not malformed";
+   };
+
+   // A record cut off at the end of the source is a truncated document, and stays one: the source
+   // is exhausted, so the window is not what ran out.
+   "a truncated final record is still a truncated document"_test = [] {
+      const std::string doc = ndjson_document(200) + "{\"id\":";
+
+      std::istringstream iss{doc};
+      glz::basic_istream_buffer<std::istringstream, narrow_window> buffer(iss);
+
+      std::vector<ndjson_record_t> v{};
+      const auto ec = glz::read_ndjson(v, buffer);
+      expect(ec != glz::error_code::none);
+      expect(ec != glz::error_code::streaming_unsupported) << "the window held everything there was";
+   };
+
+   // A record that is malformed rather than cut short keeps its own error, whether or not the
+   // source still has input behind it.
+   "a malformed record keeps its own error"_test = [] {
+      const std::string doc = ndjson_document(40) + "{\"id\":]\n" + ndjson_document(40);
+
+      std::istringstream iss{doc};
+      glz::basic_istream_buffer<std::istringstream, narrow_window> buffer(iss);
+
+      std::vector<ndjson_record_t> v{};
+      const auto ec = glz::read_ndjson(v, buffer);
+      expect(ec != glz::error_code::none);
+      expect(ec != glz::error_code::streaming_unsupported) << "the record is broken, not too wide";
+   };
+
+   "an empty stream is an empty document"_test = [] {
+      std::istringstream iss{""};
+      glz::basic_istream_buffer<std::istringstream, narrow_window> buffer(iss);
+
+      std::vector<ndjson_record_t> v{};
+      expect(!glz::read_ndjson(v, buffer));
+      expect(v.empty());
+   };
+
+   "a stream of separators alone is an empty document"_test = [] {
+      std::istringstream iss{std::string(600, '\n')}; // outlasting the window
+      glz::basic_istream_buffer<std::istringstream, narrow_window> buffer(iss);
+
+      std::vector<ndjson_record_t> v{};
+      expect(!glz::read_ndjson(v, buffer));
+      expect(v.empty());
+   };
+
+   // Reading into a container that already holds elements takes the fixed-size path first, which
+   // fills what is there before growing. It needs its own refill points.
+   "a presized destination is filled across refills"_test = [] {
+      const auto doc = ndjson_document(400);
+
+      std::istringstream iss{doc};
+      glz::basic_istream_buffer<std::istringstream, narrow_window> buffer(iss);
+
+      std::vector<ndjson_record_t> v(400);
+      expect(!glz::read_ndjson(v, buffer));
+      expect(v.size() == 400u);
+      expect(v[399].id == 399);
+   };
+
+   // ...and shrinks to the records that were actually there when the document is shorter.
+   "a presized destination shrinks to the document"_test = [] {
+      const auto doc = ndjson_document(5);
+
+      std::istringstream iss{doc};
+      glz::basic_istream_buffer<std::istringstream, narrow_window> buffer(iss);
+
+      std::vector<ndjson_record_t> v(400);
+      expect(!glz::read_ndjson(v, buffer));
+      expect(v.size() == 5u);
+      expect(v[4].id == 4);
+   };
+
+   // The fixed-arity reader is a third loop over the same records and refills the same way.
+   "a tuple destination reads across refills"_test = [] {
+      std::string doc{};
+      for (int i = 0; i < 2; ++i) {
+         doc += "{\"id\":" + std::to_string(i) + ",\"name\":\"" + std::string(300, 'x') + "\"}\n";
+      }
+
+      std::istringstream iss{doc};
+      glz::basic_istream_buffer<std::istringstream, narrow_window> buffer(iss);
+
+      std::tuple<ndjson_record_t, ndjson_record_t> t{};
+      expect(!glz::read_ndjson(t, buffer));
+      expect(std::get<0>(t).id == 0);
+      expect(std::get<1>(t).id == 1);
+      expect(std::get<1>(t).name.size() == 300u);
    };
 };
 


### PR DESCRIPTION
The NDJSON reader never refilled, so a stream wider than the buffer window could not be read: 400 records through a 512-byte window failed. It now refills between records, and `format_supports_streaming<NDJSON>` is `true`.

Records are exactly where a refill belongs — they are independent values separated by newlines, so releasing what has been parsed and pulling in more input between two of them is always safe.

## Changes

**`refill_between_values` and `resync_window_end`** in `streaming_state.hpp`, both no-ops for a context without streaming state, so every buffered read compiles them away.

`refill_between_values` refills once the window is *half* spent rather than only once it is drained. A reader can refill between values but not inside one, so the next record has to fit in whatever is left; leaving half the window is the margin that buys.

**`resync_window_end` fixes a latent bug worth flagging on its own.** `parse<Format>::op(T&&, Ctx&&, It0&& it, It1 end)` takes `end` **by value**. The JSON reader refills inside objects and arrays; `it` moves with the refill but the caller's `end` still describes the old window, and offsets taken from the pair then run past the buffer. UBSan on the first draft of this branch:

```
streaming_state.hpp:71:27: runtime error: addition of unsigned offset to 0x615000002080 overflowed to 0x615000002030
```

Any caller that hands a streaming context to `parse::op` and keeps using its own `end` has this. NDJSON now re-derives `end` after every record.

**`ndjson.hpp`** had three copies of the separator scan, one per record loop, each with its own idea of when input ran out. They now share `skip_record_separators`, `ndjson_has_next_record`, and `read_ndjson_record`. `ndjson_has_next_record` loops rather than refilling once, because a run of separators can be wider than the window and a window ending in separators would otherwise look like the start of a record.

## What still has to fit in the window

A single record. Nothing refills inside one, which is the same contract JSON streaming already has at the token level.

An earlier draft tried to retry an over-wide record from a captured start pointer against a topped-up window. That is unsound for the reason above: the JSON reader refills *inside* the record, relocating the window and invalidating the pointer. Dropped it.

When a record does not fit and the source still has input, the reader now reports `streaming_unsupported` naming the buffer, rather than `unexpected_end` blaming a well-formed document. A record cut off at true EOF still reports `unexpected_end`, correctly.

## Tests

11 new tests in `istream_buffer_test`: 400 records through a 512-byte window, records at ~60% of the window, a record wider than the window, a truncated final record, separator-only streams, CRLF, content verification. The `non_streaming_format_reporting` static_asserts and the now-obsolete "NDJSON larger than the window does not silently truncate" test were updated and removed respectively.

`docs/streaming.md` gains a format-support table and a section on what has to fit in the window.

Full suite: 108/108.
