### PR TITLE
Exclude msgpack_roundtrip_string from the OSS-Fuzz build

### DIFF
--- a/fuzzing/ossfuzz.sh
+++ b/fuzzing/ossfuzz.sh
@@ -8,7 +8,7 @@ set -eux
 
 $CXX --version
 
-for SRCFILE in $(ls fuzzing/*.cpp |grep -v -E '(exhaustive|main\.cpp)'); do
+for SRCFILE in $(ls fuzzing/*.cpp |grep -v -E '(exhaustive|main\.cpp|msgpack_roundtrip_string\.cpp)'); do
     NAME=$(basename $SRCFILE .cpp)
     $CXX $CXXFLAGS -std=c++23 -g -Iinclude \
          $SRCFILE -o $OUT/$NAME \


### PR DESCRIPTION
Excludes fuzzing/msgpack_roundtrip_string.cpp from the OSS-Fuzz build in fuzzing/ossfuzz.sh.

This is required because clang-22 (OSS-Fuzz base image) segfaults when compiling this file with -std=c++23: a bare glz::write_msgpack (std::string, buffer) call triggers a clang bug (stack exhaustion in the partial ordering of constrained partial specializations), reproducible at -O0 through -O3. The file was introduced by commit 4cbddc3e and is the only affected fuzzer; all other fuzzers build fine, and the remaining msgpack fuzzers keep msgpack coverage.

Because the exclusion lives in the upstream fuzzing/ossfuzz.sh (the entry point already used by OSS-Fuzz), no change to the OSS-Fuzz project config is needed. Verified: OSS-Fuzz check_build (afl/address/x86_64) passes.
Note: once the clang-22 crash is fixed (upstream LLVM or a newer OSS-Fuzz base image), msgpack_roundtrip_string.cpp should be re-enabled by removing it from the exclusion.