### PR TITLE
Take lazy JSON/BEVE options as `auto` so derived opts are not sliced

### DIFF
--- a/include/glaze/beve/lazy.hpp
+++ b/include/glaze/beve/lazy.hpp
@@ -14,13 +14,13 @@
 namespace glz
 {
    // Forward declarations
-   template <opts Opts>
+   template <auto Opts>
    struct lazy_beve_document;
-   template <opts Opts>
+   template <auto Opts>
    class lazy_beve_iterator;
-   template <opts Opts>
+   template <auto Opts>
    struct indexed_lazy_beve_view;
-   template <opts Opts>
+   template <auto Opts>
    class indexed_lazy_beve_iterator;
 
    // ============================================================================
@@ -39,7 +39,7 @@ namespace glz
       // keeps this from being a stack overflow -- so a lazy view over such a value can no longer
       // reach the members past it. Distinguishing "too deep" from "absent" needs an error channel
       // through the lazy API, which these accessors do not have.
-      template <opts Opts>
+      template <auto Opts>
       GLZ_ALWAYS_INLINE const char* skip_value_beve_lazy(const char* p, const char* end) noexcept
       {
          if (p >= end) return p;
@@ -134,7 +134,7 @@ namespace glz
     * For objects, parse_pos_ tracks the current scan position to enable
     * efficient sequential key access (O(n) total instead of O(n²)).
     */
-   template <opts Opts = opts{}>
+   template <auto Opts = opts{}>
    struct lazy_beve_view
    {
      private:
@@ -297,7 +297,7 @@ namespace glz
    // lazy_beve_document - Minimal container
    // ============================================================================
 
-   template <opts Opts = opts{}>
+   template <auto Opts = opts{}>
    struct lazy_beve_document
    {
      private:
@@ -309,7 +309,7 @@ namespace glz
       friend struct lazy_beve_view<Opts>;
       friend class lazy_beve_iterator<Opts>;
 
-      template <opts O, class Buffer>
+      template <auto O, class Buffer>
       friend expected<lazy_beve_document<O>, error_ctx> lazy_beve(Buffer&&);
 
       void init_root_view() noexcept { root_view_ = lazy_beve_view<Opts>{this, root_data_}; }
@@ -404,7 +404,7 @@ namespace glz
    // lazy_beve_iterator - Forward iterator with lazy scanning
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    class lazy_beve_iterator
    {
      private:
@@ -455,7 +455,7 @@ namespace glz
    // indexed_lazy_beve_view - Pre-built index for O(1) access
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    struct indexed_lazy_beve_view
    {
      private:
@@ -540,7 +540,7 @@ namespace glz
    // indexed_lazy_beve_iterator - O(1) advancement
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    class indexed_lazy_beve_iterator
    {
      private:
@@ -653,13 +653,13 @@ namespace glz
    // Implementation: lazy_beve_view methods
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    inline const char* lazy_beve_view<Opts>::beve_end() const noexcept
    {
       return doc_ ? doc_->beve_ + doc_->len_ : nullptr;
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline lazy_beve_view<Opts> lazy_beve_view<Opts>::operator[](size_t index) const
    {
       if (has_error()) return *this;
@@ -716,7 +716,7 @@ namespace glz
       }
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline lazy_beve_view<Opts> lazy_beve_view<Opts>::operator[](std::string_view key) const
    {
       if (has_error()) return *this;
@@ -800,14 +800,14 @@ namespace glz
       return make_error(error_code::key_not_found);
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline bool lazy_beve_view<Opts>::contains(std::string_view key) const
    {
       auto result = (*this)[key];
       return !result.has_error();
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline size_t lazy_beve_view<Opts>::size() const
    {
       if (has_error() || !data_) return 0;
@@ -839,7 +839,7 @@ namespace glz
       return 0;
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline bool lazy_beve_view<Opts>::empty() const noexcept
    {
       if (has_error() || !data_) return true;
@@ -855,7 +855,7 @@ namespace glz
    // lazy_beve_iterator implementation
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    inline lazy_beve_iterator<Opts>::lazy_beve_iterator(const lazy_beve_document<Opts>* doc, const char* container_start,
                                                        const char* end, bool is_object, bool is_typed_array)
       : doc_(doc), beve_end_(end), is_object_(is_object), is_typed_array_(is_typed_array), at_end_(false)
@@ -896,7 +896,7 @@ namespace glz
       advance_to_current_element();
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline void lazy_beve_iterator<Opts>::advance_to_current_element()
    {
       std::string_view key{};
@@ -924,7 +924,7 @@ namespace glz
       current_view_ = lazy_beve_view<Opts>{doc_, current_pos_, key};
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline lazy_beve_iterator<Opts>& lazy_beve_iterator<Opts>::operator++()
    {
       if (at_end_) return *this;
@@ -947,7 +947,7 @@ namespace glz
       return *this;
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline lazy_beve_iterator<Opts> lazy_beve_view<Opts>::begin() const
    {
       if (has_error() || !data_) return end();
@@ -958,7 +958,7 @@ namespace glz
       return lazy_beve_iterator<Opts>{doc_, data_, beve_end(), is_object(), is_typed};
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline lazy_beve_iterator<Opts> lazy_beve_view<Opts>::end() const
    {
       return lazy_beve_iterator<Opts>{};
@@ -968,19 +968,19 @@ namespace glz
    // indexed_lazy_beve_view implementation
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    inline indexed_lazy_beve_iterator<Opts> indexed_lazy_beve_view<Opts>::begin() const
    {
       return indexed_lazy_beve_iterator<Opts>{this, 0};
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline indexed_lazy_beve_iterator<Opts> indexed_lazy_beve_view<Opts>::end() const
    {
       return indexed_lazy_beve_iterator<Opts>{this, value_starts_.size()};
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline indexed_lazy_beve_view<Opts> lazy_beve_view<Opts>::index() const
    {
       if (has_error() || !data_ || (!is_array() && !is_object())) {
@@ -1080,7 +1080,7 @@ namespace glz
    // lazy_beve_view::get<T>() implementation
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    template <class T>
    [[nodiscard]] inline expected<T, error_ctx> lazy_beve_view<Opts>::get() const
    {
@@ -1166,7 +1166,7 @@ namespace glz
    }
 
    // Helper to read numeric value directly given tag info (for typed array elements)
-   template <opts Opts>
+   template <auto Opts>
    template <class T>
    [[nodiscard]] inline expected<T, error_ctx> lazy_beve_view<Opts>::read_numeric_from_tag(uint8_t tag,
                                                                                            const char* value_ptr,
@@ -1258,7 +1258,7 @@ namespace glz
    // BEVE writer for lazy_beve_view
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    struct to<BEVE, lazy_beve_view<Opts>>
    {
       template <auto WriteOpts, class B>
@@ -1310,7 +1310,7 @@ namespace glz
     * @param buffer The BEVE buffer (must remain valid for document lifetime)
     * @return lazy_beve_document on success, error_ctx on failure
     */
-   template <opts Opts = opts{}, class Buffer>
+   template <auto Opts = opts{}, class Buffer>
    [[nodiscard]] inline expected<lazy_beve_document<Opts>, error_ctx> lazy_beve(Buffer&& buffer)
    {
       lazy_beve_document<Opts> doc;
@@ -1343,13 +1343,13 @@ namespace glz
    // read_beve overload for lazy_beve_view
    // ============================================================================
 
-   template <class T, opts Opts>
+   template <class T, auto Opts>
    [[nodiscard]] inline error_ctx read_beve(T& value, const lazy_beve_view<Opts>& view)
    {
       return view.template read_into<T>(value);
    }
 
-   template <class T, opts Opts>
+   template <class T, auto Opts>
    [[nodiscard]] inline error_ctx read_beve(T& value, lazy_beve_view<Opts>&& view)
    {
       return view.template read_into<T>(value);

--- a/include/glaze/json/lazy.hpp
+++ b/include/glaze/json/lazy.hpp
@@ -13,13 +13,13 @@
 namespace glz
 {
    // Forward declarations (needed for circular references)
-   template <opts Opts>
+   template <auto Opts>
    struct lazy_document;
-   template <opts Opts>
+   template <auto Opts>
    class lazy_iterator;
-   template <opts Opts>
+   template <auto Opts>
    struct indexed_lazy_view;
-   template <opts Opts>
+   template <auto Opts>
    class indexed_lazy_iterator;
 
    // ============================================================================
@@ -29,7 +29,7 @@ namespace glz
    namespace detail
    {
       // Skip string - returns position after closing quote
-      template <opts Opts>
+      template <auto Opts>
       GLZ_ALWAYS_INLINE const char* skip_string_fast(const char* p, const char* end) noexcept
       {
          const char* const start = p;
@@ -61,7 +61,7 @@ namespace glz
 
       // Skip from current position to depth zero (end of enclosing container)
       // Used after partial scanning to find container end efficiently
-      template <opts Opts>
+      template <auto Opts>
       GLZ_ALWAYS_INLINE const char* skip_to_depth_zero(const char* p, const char* end, int depth) noexcept
       {
          using enum lazy_char_type;
@@ -103,7 +103,7 @@ namespace glz
 
       // Skip any JSON value - optimized container skip
       // Returns pointer after the value
-      template <opts Opts>
+      template <auto Opts>
       GLZ_ALWAYS_INLINE const char* skip_value_lazy(const char* p, const char* end) noexcept
       {
          using enum lazy_char_type;
@@ -206,7 +206,7 @@ namespace glz
     * - error_: error code (4 bytes)
     * - padding: 4/0 bytes
     */
-   template <opts Opts = opts{}>
+   template <auto Opts = opts{}>
    struct lazy_json_view
    {
      private:
@@ -336,7 +336,7 @@ namespace glz
    // lazy_document - Minimal container, no upfront processing
    // ============================================================================
 
-   template <opts Opts = opts{}>
+   template <auto Opts = opts{}>
    struct lazy_document
    {
      private:
@@ -349,7 +349,7 @@ namespace glz
       friend class lazy_iterator<Opts>;
 
       // Factory method for lazy_json
-      template <opts O, class Buffer>
+      template <auto O, class Buffer>
       friend expected<lazy_document<O>, error_ctx> lazy_json(Buffer&&);
 
       // Helper to initialize root_view_ with correct doc_ pointer
@@ -421,7 +421,7 @@ namespace glz
    // lazy_iterator - Forward iterator with lazy scanning
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    class lazy_iterator
    {
      private:
@@ -489,7 +489,7 @@ namespace glz
     *
     * Memory: Base view + 8 bytes per element (+ 16 bytes per element for objects with keys)
     */
-   template <opts Opts>
+   template <auto Opts>
    struct indexed_lazy_view
    {
      private:
@@ -582,7 +582,7 @@ namespace glz
    // indexed_lazy_iterator - O(1) advancement using pre-built index
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    class indexed_lazy_iterator
    {
      private:
@@ -689,13 +689,13 @@ namespace glz
    // Implementation: lazy_json_view methods (truly lazy - no structural index)
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    inline const char* lazy_json_view<Opts>::json_end() const noexcept
    {
       return doc_ ? doc_->json_ + doc_->len_ : nullptr;
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline std::string_view lazy_json_view<Opts>::parse_key(const char*& p, const char* end) noexcept
    {
       // A non-null-terminated buffer has no '\0' sentinel, so a scan loop can reach the next
@@ -735,7 +735,7 @@ namespace glz
       return std::string_view{key_start, static_cast<size_t>(p - key_start)};
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline lazy_json_view<Opts> lazy_json_view<Opts>::operator[](size_t index) const
    {
       if (has_error()) return *this;
@@ -769,7 +769,7 @@ namespace glz
       return {doc_, p};
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline lazy_json_view<Opts> lazy_json_view<Opts>::operator[](std::string_view key) const
    {
       if (has_error()) return *this;
@@ -881,14 +881,14 @@ namespace glz
       return make_error(error_code::key_not_found);
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline bool lazy_json_view<Opts>::contains(std::string_view key) const
    {
       auto result = (*this)[key];
       return !result.has_error();
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline size_t lazy_json_view<Opts>::size() const
    {
       if (has_error() || !data_) return 0;
@@ -940,7 +940,7 @@ namespace glz
       }
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline bool lazy_json_view<Opts>::empty() const noexcept
    {
       if (has_error() || !data_) return true;
@@ -962,7 +962,7 @@ namespace glz
    // lazy_iterator implementation (truly lazy)
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    inline lazy_iterator<Opts>::lazy_iterator(const lazy_document<Opts>* doc, const char* container_start,
                                              const char* end, bool is_object)
       : doc_(doc), json_end_(end), is_object_(is_object), at_end_(false)
@@ -989,7 +989,7 @@ namespace glz
       advance_to_next_element(pos);
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline void lazy_iterator<Opts>::advance_to_next_element(const char*& pos)
    {
       std::string_view key{};
@@ -1019,7 +1019,7 @@ namespace glz
       current_view_ = lazy_json_view<Opts>{doc_, pos, key};
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline lazy_iterator<Opts>& lazy_iterator<Opts>::operator++()
    {
       if (at_end_) return *this;
@@ -1069,7 +1069,7 @@ namespace glz
       return *this;
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline lazy_iterator<Opts> lazy_json_view<Opts>::begin() const
    {
       if (has_error() || !data_) return end();
@@ -1077,7 +1077,7 @@ namespace glz
       return lazy_iterator<Opts>{doc_, data_, json_end(), is_object()};
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline lazy_iterator<Opts> lazy_json_view<Opts>::end() const
    {
       return lazy_iterator<Opts>{};
@@ -1087,13 +1087,13 @@ namespace glz
    // indexed_lazy_view implementation
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    inline indexed_lazy_iterator<Opts> indexed_lazy_view<Opts>::begin() const
    {
       return indexed_lazy_iterator<Opts>{this, 0};
    }
 
-   template <opts Opts>
+   template <auto Opts>
    inline indexed_lazy_iterator<Opts> indexed_lazy_view<Opts>::end() const
    {
       return indexed_lazy_iterator<Opts>{this, value_starts_.size()};
@@ -1103,7 +1103,7 @@ namespace glz
    // lazy_json_view::index() implementation
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    inline indexed_lazy_view<Opts> lazy_json_view<Opts>::index() const
    {
       // Return empty indexed view for non-containers or errors
@@ -1172,7 +1172,7 @@ namespace glz
    // lazy_json_view::get<T>() implementation
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    template <class T>
    [[nodiscard]] inline expected<T, error_ctx> lazy_json_view<Opts>::get() const
    {
@@ -1283,7 +1283,7 @@ namespace glz
    // JSON writer for lazy_json_view
    // ============================================================================
 
-   template <opts Opts>
+   template <auto Opts>
    struct to<JSON, lazy_json_view<Opts>>
    {
       template <auto WriteOpts, class B>
@@ -1337,7 +1337,7 @@ namespace glz
     * @param buffer The JSON text buffer (must remain valid for document lifetime)
     * @return lazy_document on success, error_ctx on failure
     */
-   template <opts Opts = opts{}, class Buffer>
+   template <auto Opts = opts{}, class Buffer>
    [[nodiscard]] inline expected<lazy_document<Opts>, error_ctx> lazy_json(Buffer&& buffer)
    {
       lazy_document<Opts> doc;
@@ -1381,7 +1381,7 @@ namespace glz
    /// @param view The lazy view to read from
    /// @return Error context if parsing failed
    /// @note This provides the familiar glz::read_json API while using the efficient single-pass read_into internally
-   template <class T, opts Opts>
+   template <class T, auto Opts>
    [[nodiscard]] inline error_ctx read_json(T& value, const lazy_json_view<Opts>& view)
    {
       return view.template read_into<T>(value);
@@ -1389,7 +1389,7 @@ namespace glz
 
    /// @brief Read JSON from a lazy_json_view rvalue into a C++ type
    /// @note Handles temporaries like glz::read_json(value, doc["field"])
-   template <class T, opts Opts>
+   template <class T, auto Opts>
    [[nodiscard]] inline error_ctx read_json(T& value, lazy_json_view<Opts>&& view)
    {
       return view.template read_into<T>(value);

--- a/tests/beve_test/lazy_beve_test.cpp
+++ b/tests/beve_test/lazy_beve_test.cpp
@@ -1,6 +1,8 @@
 // Glaze Library
 // For the license information refer to glaze.hpp
 
+#include <concepts>
+
 #include "glaze/glaze.hpp"
 #include "ut/ut.hpp"
 
@@ -94,7 +96,27 @@ namespace lazy_beve_test
       std::map<int, std::string> num_map{{1, "hello"}, {2, "world"}};
       std::string after{"after_map"};
    };
+
+   struct DoubleField
+   {
+      double value{3.5};
+   };
+
+   struct FloatField
+   {
+      float value{};
+   };
 }
+
+// A user options struct that derives from glz::opts to carry an extra field, which is the
+// pattern glz::opts documents ("Add these fields to a custom options struct if you want to
+// use them"). The lazy API must instantiate on the exact type so the derived field survives.
+struct custom_lazy_beve_opts : glz::opts
+{
+   bool allow_conversions = false;
+};
+
+inline constexpr custom_lazy_beve_opts derived_beve_opts{glz::opts{.format = glz::BEVE}};
 
 suite lazy_beve_tests = [] {
    "lazy_beve_read_basic"_test = [] {
@@ -1199,6 +1221,32 @@ suite lazy_beve_tests = [] {
       // Booleans and nulls return 0 for size
       expect(result->size["flag"] == 0u);
       expect(result->size["empty"] == 0u);
+   };
+};
+
+// Regression coverage for the lazy API taking `opts` (a concrete base-class NTTP) rather than
+// `auto`, which sliced any derived user options struct down to glz::opts and silently dropped
+// every extra field.
+suite lazy_beve_derived_opts_tests = [] {
+   "lazy_beve_derived_opts_preserve_exact_type"_test = [] {
+      // Sliced to glz::opts, these would collapse to the same instantiation.
+      expect(not std::same_as<glz::lazy_beve_document<derived_beve_opts>,
+                              glz::lazy_beve_document<glz::opts{.format = glz::BEVE}>>);
+      expect(
+         not std::same_as<glz::lazy_beve_view<derived_beve_opts>, glz::lazy_beve_view<glz::opts{.format = glz::BEVE}>>);
+   };
+
+   "lazy_beve_derived_opts_reach_read_into"_test = [] {
+      // allow_conversions only exists on the derived struct and defaults to true when absent, so
+      // the double -> float read is refused only if the lazy API instantiated on the exact type.
+      std::string buffer{};
+      expect(not glz::write_beve(lazy_beve_test::DoubleField{}, buffer));
+
+      auto result = glz::lazy_beve<derived_beve_opts>(buffer);
+      expect(result.has_value());
+
+      lazy_beve_test::FloatField narrowed{};
+      expect(bool((*result).root().read_into(narrowed)));
    };
 };
 

--- a/tests/json_test/lazy_test.cpp
+++ b/tests/json_test/lazy_test.cpp
@@ -1,10 +1,27 @@
 // Glaze Library
 // For the license information refer to glaze.hpp
 
+#include <concepts>
+
 #include "glaze/json.hpp"
 #include "ut/ut.hpp"
 
 using namespace ut;
+
+// A user options struct that derives from glz::opts to carry an extra field, which is the
+// pattern glz::opts documents ("Add these fields to a custom options struct if you want to
+// use them"). The lazy API must instantiate on the exact type so the derived field survives.
+struct custom_lazy_opts : glz::opts
+{
+   bool bools_as_numbers = true;
+};
+
+inline constexpr custom_lazy_opts derived_opts{};
+
+struct BoolHolder
+{
+   bool flag{};
+};
 
 struct User
 {
@@ -1580,6 +1597,29 @@ suite dynamic_key_custom_tests = [] {
       expect((*result).root().size() == 1u); // '@' scalar, then bounded by json_end_
       expect((*result).root().index().size() == 1u);
       expect((*result).root()[1].has_error()); // nothing past the lone scalar
+   };
+};
+
+// Regression coverage for the lazy API taking `opts` (a concrete base-class NTTP) rather than
+// `auto`, which sliced any derived user options struct down to glz::opts and silently dropped
+// every extra field.
+suite lazy_derived_opts_tests = [] {
+   "lazy_derived_opts_preserve_exact_type"_test = [] {
+      // Sliced to glz::opts, these would collapse to the same instantiation.
+      expect(not std::same_as<glz::lazy_document<derived_opts>, glz::lazy_document<glz::opts{}>>);
+      expect(not std::same_as<glz::lazy_json_view<derived_opts>, glz::lazy_json_view<glz::opts{}>>);
+   };
+
+   "lazy_derived_opts_reach_read_into"_test = [] {
+      // bools_as_numbers only exists on the derived struct, so it reaches the parser only if
+      // the lazy API instantiated on custom_lazy_opts rather than on a sliced glz::opts.
+      std::string buffer = R"({"obj":{"flag":1}})";
+      auto result = glz::lazy_json<derived_opts>(buffer);
+      expect(result.has_value());
+
+      BoolHolder holder{};
+      expect(not (*result)["obj"].read_into(holder));
+      expect(holder.flag == true);
    };
 };
 


### PR DESCRIPTION
Extracted from #2683 by @psiha, which diagnosed this. Standalone bug fix; nothing else from that PR is included here.

## The bug

The lazy APIs declared their options NTTP as `template <opts Opts>` — a concrete base-class parameter. A user options struct that derives from `glz::opts` to carry extra fields, which is the pattern `glz::opts` itself documents:

```cpp
// Add these fields to a custom options struct if you want to use them
```

was therefore **sliced to `glz::opts`** at that boundary, dropping every derived field. Every `check_*(Opts)` inside the lazy code then saw the default rather than the user's value, so custom options were silently ignored rather than rejected.

```cpp
struct my_opts : glz::opts {
   bool bools_as_numbers = true;
};

auto doc = glz::lazy_json<my_opts{}>(buffer);  // compiles, but bools_as_numbers is gone
```

This affects both lazy surfaces: `include/glaze/json/lazy.hpp` and `include/glaze/beve/lazy.hpp`.

## The fix

The rest of the read/write API already takes `template <auto Opts>`, which preserves the exact type. This aligns both lazy headers with that convention. The change is mechanical — only template heads move.

**Source compatibility, precisely.** Ordinary call sites (`glz::lazy_json(buf)`, `glz::lazy_json<glz::opts{...}>(buf)`) are unaffected, and mangling is byte-identical for `glz::opts`-valued instantiations, so there is no ODR/ABI hazard across mixed-version TUs. Partial specializations and function templates that deduce `template <glz::opts O>` from `lazy_json_view<O>` still work. Two patterns do break, and are worth calling out rather than glossing:

- A user forward declaration written as `template <glz::opts Opts> struct lazy_document;` now fails to redeclare. Glaze's own headers used exactly that form, so anyone who copied it is affected.
- `glz::lazy_document<glz::opts{}> d = *glz::lazy_json<derived_opts>(buf);` no longer converts. That one is the slicing going away, i.e. the point of the fix.

A minor ergonomic cost: a garbage NTTP such as `glz::lazy_json<42>(buf)` now produces an error inside the header rather than "no matching function". That matches the rest of glaze's `template <auto Opts>` surface.

`include/glaze/util/parse.hpp` also takes concrete options types (`ws_opts`, `skip_string_opts`, …), but those are purpose-built narrow structs where the conversion is intended, so they are left alone.

## Tests

Four assertions, all of which fail against the previous headers:

- **Type identity** — `lazy_document<derived>` and `lazy_document<glz::opts{}>` must be distinct instantiations. Under slicing they collapse to the same type.
- **The field actually reaches the parser** — `bools_as_numbers` for JSON (reads `1` into a `bool`) and `allow_conversions` for BEVE (refuses a `double` → `float` read).

Verified by compiling the new tests against the unpatched headers: 7 failed assertions before (4 JSON + 3 BEVE), 0 after. Both files still *compile* against the old headers — the slicing was entirely silent, which is what made it worth a runtime test rather than a static one.

```
before:  tests: 87 (85 passed, 2 failed)   asserts: 441 (437 passed, 4 failed)   [JSON]
         tests: 60 (58 passed, 2 failed)   asserts: 310 (307 passed, 3 failed)   [BEVE]
after:   both suites green
```

## Related bugs found, not fixed here

Three sites in these files still hardcode `skip_value<...>::op<opts{}>` instead of forwarding `Opts` — `lazy.hpp` `get<std::string>()`, `lazy.hpp` `to<JSON, lazy_json_view>::op`, and `beve/lazy.hpp` `to<BEVE, lazy_beve_view>::op`. These are pre-existing and independent of the slicing, but one of them is memory-unsafe:

**`glz::write_json` on a `lazy_json_view` with `null_terminated = false` reads past the document and reports success.** Confirmed on `main` under ASAN — heap-buffer-overflow, and on a framed buffer it silently emits bytes from outside the document window:

```
raw_json()   = '42'                    <- correct (uses skip_value_lazy<Opts>)
write_json() = '42SECRET_TOKEN' err=0  <- wrong, and no error reported
```

Separately, `to<BEVE, lazy_beve_view<Opts>>::op` does not compile when instantiated (`dump_type<tag::null>(b, ix)` has no matching function), so that writer appears never to have been exercised.

Both deserve their own PR against `main` rather than being folded in here.
