### PR TITLE
Add an opt-in streaming cursor to lazy JSON iteration

### DIFF
--- a/docs/lazy-json.md
+++ b/docs/lazy-json.md
@@ -335,6 +335,55 @@ If you need to re-scan from the beginning:
 doc.reset_parse_pos();  // Next access starts from beginning
 ```
 
+## Streaming Cursor (opt-in)
+
+When you iterate a large container and fully consume each element, the iterator normally has to re-scan the element it just handed you in order to find where the next one begins. `read_into` already walked those same bytes, so the scan is pure repeated work.
+
+The `lazy_streaming_cursor` option removes it. When a value is consumed end to end, its byte extent is recorded on the document, and the next advance jumps straight to the recorded end:
+
+```cpp
+struct stream_opts : glz::opts
+{
+   bool lazy_streaming_cursor = true;
+};
+
+inline constexpr stream_opts stream{};
+
+auto doc = glz::lazy_json<stream>(buffer);
+
+for (auto& row : (*doc)["rows"]) {
+   Row parsed{};
+   if (not row.read_into(parsed)) {
+      use(parsed);  // the next ++ skips the re-scan of this row
+   }
+}
+```
+
+The optimization composes through nesting: an inner iterator that runs to its closing bracket records the whole inner container, so the outer advance skips it too.
+
+An extent is only used when it starts exactly at the element the iterator is positioned on. A byte offset identifies exactly one value in the buffer, so this check is what keeps the single shared slot safe when iterators are interleaved or abandoned partway. Anything that does not match falls back to a normal scan.
+
+### What it costs
+
+Two `size_t` on `lazy_document` when enabled, and nothing when disabled, so a document that does not opt in is byte-for-byte what it was before. Views and iterators are unchanged in either case.
+
+### When it does not help
+
+- **Elements consumed key by key** via `operator[]`. Those are already served by the progressive `parse_pos_` scan described above; no extent is produced.
+- **Elements that are skipped rather than read.** Nothing was consumed, so there is nothing to record.
+- **`partial_read`.** That option deliberately stops the parser as soon as the target's known keys are filled, which leaves it short of the element's true end. No extent is recorded in that case, so iteration stays correct and simply falls back to scanning.
+
+### Measured effect
+
+A 9 MB array of three-field objects, `read_into` per row, Apple M1, clang `-O3`:
+
+| | throughput |
+|---|---:|
+| cursor off | 575 MB/s |
+| cursor on | 955 MB/s (**+66%**) |
+
+The gain scales with how much of each element `read_into` consumes; containers whose elements are large benefit most, since those are the scans being elided.
+
 ## Type Checking
 
 Check the type of a value before extracting:

--- a/docs/lazy-json.md
+++ b/docs/lazy-json.md
@@ -367,11 +367,27 @@ An extent is only used when it starts exactly at the element the iterator is pos
 
 Two `size_t` on `lazy_document` when enabled, and nothing when disabled, so a document that does not opt in is byte-for-byte what it was before. Views and iterators are unchanged in either case.
 
+### Thread safety
+
+Recording an extent writes to the document, from a `const` method. Two threads calling `read_into` on **disjoint** subviews of the same `lazy_document` do not race with the option off, but do with it on. Give each thread its own `lazy_document` (copying one is cheap — it holds a pointer and a length, not the buffer) or leave the option off.
+
+Note that a `lazy_document` is already not safe to share for keyed access either way, because `operator[]` advances the cached root view's scan position.
+
 ### When it does not help
 
+- **Scalar elements.** Only containers are recorded (see below); numbers, strings, booleans and nulls are skipped by the cheap paths anyway.
 - **Elements consumed key by key** via `operator[]`. Those are already served by the progressive `parse_pos_` scan described above; no extent is produced.
 - **Elements that are skipped rather than read.** Nothing was consumed, so there is nothing to record.
-- **`partial_read`.** That option deliberately stops the parser as soon as the target's known keys are filled, which leaves it short of the element's true end. No extent is recorded in that case, so iteration stays correct and simply falls back to scanning.
+- **`partial_read`.** That option deliberately stops the parser as soon as the target's known keys are filled, which leaves it short of the element's true end.
+- **The final element of a bounded (non-null-terminated) buffer**, which ends on `end_reached` rather than on a close bracket.
+
+### What the cursor trusts, and what it verifies
+
+`read_into` hands the iterator to `parse<JSON>::op`, and where that leaves it is up to the `from<JSON, T>` specialization. Glaze's own readers stop at the value's end, but that is a convention, not something the cursor can check for free — `glz::text` deliberately swallows the rest of the buffer, and a custom reader may consume only a prefix. Trusting the stopping point blindly is how a cursor turns a well-formed document into a short or mis-valued element stream with no error reported anywhere.
+
+So an extent is recorded only when **the element is a container and the parse finished exactly on that container's own closing bracket**. That covers the case worth accelerating (large elements, where re-scanning is expensive) and rejects readers that stopped somewhere else.
+
+One residual limitation: a custom reader that consumes a *complete inner container* but stops before the element's own end (for example reading `[[1],2]` and stopping after `[1]`) produces an extent that passes this check and is still wrong. Such a reader is already incompatible with ordinary `glz::read_json` on nested structures, since it would misparse whatever follows. If you write custom `from<JSON, T>` specializations, leave the iterator at the value's end.
 
 ### Measured effect
 

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -186,6 +186,14 @@ namespace glz
    // or when validation should be deferred.
 
    // ---
+   // bool lazy_streaming_cursor = false;
+   // Lets lazy JSON iteration skip re-scanning values it has already consumed. When a
+   // lazy_json_view::read_into fully consumes an element, or a nested container iterator runs to
+   // its close, the byte extent is recorded on the document and the next lazy_iterator advance
+   // jumps straight past it instead of re-scanning with skip_value_lazy. Costs two size_t on
+   // lazy_document when enabled and nothing at all when disabled. See docs/lazy-json.md.
+
+   // ---
    // bool linear_search = false;
    // Uses linear key search instead of hash-based lookup for JSON object fields.
    // This eliminates 256-byte hash tables per struct type, significantly reducing binary size.
@@ -711,6 +719,16 @@ namespace glz
    {
       if constexpr (requires { Opts.assume_sufficient_buffer; }) {
          return Opts.assume_sufficient_buffer;
+      }
+      else {
+         return false;
+      }
+   }
+
+   consteval bool check_lazy_streaming_cursor(auto&& Opts)
+   {
+      if constexpr (requires { Opts.lazy_streaming_cursor; }) {
+         return Opts.lazy_streaming_cursor;
       }
       else {
          return false;

--- a/include/glaze/json/lazy.hpp
+++ b/include/glaze/json/lazy.hpp
@@ -4,10 +4,12 @@
 #pragma once
 
 #include <string_view>
+#include <type_traits>
 
 #include "glaze/json/read.hpp"
 #include "glaze/json/skip.hpp"
 #include "glaze/json/write.hpp"
+#include "glaze/tuplet/tuple.hpp" // GLZ_NO_UNIQUE_ADDRESS
 #include "glaze/util/expected.hpp"
 
 namespace glz
@@ -184,6 +186,64 @@ namespace glz
          }
          }
       }
+
+      // ============================================================================
+      // Streaming cursor storage (lazy_streaming_cursor option)
+      // ============================================================================
+      //
+      // A single slot on lazy_document remembering the byte extent of the most recently
+      // consumed value. lazy_iterator::operator++ jumps to the recorded end instead of
+      // re-scanning, but only when the recorded extent starts exactly at the element the
+      // iterator is sitting on. That pointer-identity check is what makes a stale slot
+      // harmless: a byte offset in the buffer identifies exactly one value, so an extent
+      // that starts where the iterator stands always describes the value it is about to
+      // skip. Anything else falls back to a normal scan.
+
+      // Disabled: an empty type, so lazy_document pays nothing under GLZ_NO_UNIQUE_ADDRESS.
+      struct lazy_extent_disabled
+      {
+         static constexpr void clear() noexcept {}
+         static constexpr void set(const char*, const char*, const char*) noexcept {}
+         [[nodiscard]] static constexpr bool try_jump(const char*, const char*, const char*&) noexcept { return false; }
+      };
+
+      // Offsets rather than pointers so a copied/moved document rebases onto its own buffer.
+      // end_off == 0 means "no extent recorded" - a real value can never end at offset 0.
+      struct lazy_extent
+      {
+         size_t start_off{};
+         size_t end_off{};
+
+         void clear() noexcept { end_off = 0; }
+
+         void set(const char* base, const char* start, const char* end) noexcept
+         {
+            if (!base || start < base || end < start) [[unlikely]] {
+               clear();
+               return;
+            }
+            start_off = size_t(start - base);
+            end_off = size_t(end - base);
+         }
+
+         [[nodiscard]] bool try_jump(const char* base, const char* pos, const char*& out) noexcept
+         {
+            if (end_off == 0 || !base) {
+               return false;
+            }
+            if (pos != base + start_off) {
+               // The extent describes some other value; leave it in place, it may still match a
+               // later advance (an inner iterator can record before an outer one asks).
+               return false;
+            }
+            out = base + end_off;
+            clear(); // consumed exactly once
+            return true;
+         }
+      };
+
+      template <auto Opts>
+      using lazy_extent_for = std::conditional_t<check_lazy_streaming_cursor(Opts), lazy_extent, lazy_extent_disabled>;
    } // namespace detail
 
    // ============================================================================
@@ -277,9 +337,24 @@ namespace glz
          auto it = data_;
          auto end = json_end();
          parse<JSON>::op<Opts>(value, ctx, it, end);
+         // Capture completeness before finalize_read_context, which downgrades
+         // partial_read_complete and a depth-zero end_reached to success. Those leave `it`
+         // short of the value's true end, so `it` is only the real extent when the parse
+         // reported nothing at all.
+         const bool consumed_whole_value = ctx.error == error_code::none;
          finalize_read_context<Opts>(ctx);
          if (bool(ctx.error)) {
             return error_ctx{static_cast<size_t>(it - data_), ctx.error};
+         }
+         // Streaming cursor: the value spans [data_, it). Record it so a subsequent iterator
+         // advance over this element can jump rather than re-scan. Under partial_read the
+         // parse deliberately stops early, so nothing is recorded and iteration falls back to
+         // scanning - correct, just not accelerated.
+         if constexpr (check_lazy_streaming_cursor(Opts)) {
+            // doc_ is null only for detached subviews; lazy_json() views always carry it.
+            if (doc_ && consumed_whole_value) [[likely]] {
+               doc_->consumed_.set(doc_->json_data(), data_, it);
+            }
          }
          return {};
       }
@@ -345,6 +420,11 @@ namespace glz
       const char* root_data_{};
       mutable lazy_json_view<Opts> root_view_{}; // Cached root view with parse_pos_
 
+      // Streaming cursor slot (lazy_streaming_cursor option). Empty, and therefore free, when
+      // the option is off. Mutable because recording an extent is a caching side effect of
+      // otherwise const traversal.
+      GLZ_NO_UNIQUE_ADDRESS mutable detail::lazy_extent_for<Opts> consumed_{};
+
       friend struct lazy_json_view<Opts>;
       friend class lazy_iterator<Opts>;
 
@@ -359,7 +439,8 @@ namespace glz
       lazy_document() = default;
 
       // Copy constructor - fix doc_ pointer and preserve parse_pos_
-      lazy_document(const lazy_document& other) : json_(other.json_), len_(other.len_), root_data_(other.root_data_)
+      lazy_document(const lazy_document& other)
+         : json_(other.json_), len_(other.len_), root_data_(other.root_data_), consumed_(other.consumed_)
       {
          init_root_view();
          root_view_.parse_pos_ = other.root_view_.parse_pos_;
@@ -371,6 +452,7 @@ namespace glz
             json_ = other.json_;
             len_ = other.len_;
             root_data_ = other.root_data_;
+            consumed_ = other.consumed_;
             init_root_view();
             root_view_.parse_pos_ = other.root_view_.parse_pos_;
          }
@@ -378,7 +460,8 @@ namespace glz
       }
 
       // Move constructor - fix doc_ pointer and transfer parse_pos_
-      lazy_document(lazy_document&& other) noexcept : json_(other.json_), len_(other.len_), root_data_(other.root_data_)
+      lazy_document(lazy_document&& other) noexcept
+         : json_(other.json_), len_(other.len_), root_data_(other.root_data_), consumed_(other.consumed_)
       {
          init_root_view();
          root_view_.parse_pos_ = other.root_view_.parse_pos_;
@@ -390,6 +473,7 @@ namespace glz
             json_ = other.json_;
             len_ = other.len_;
             root_data_ = other.root_data_;
+            consumed_ = other.consumed_;
             init_root_view();
             root_view_.parse_pos_ = other.root_view_.parse_pos_;
          }
@@ -427,10 +511,27 @@ namespace glz
      private:
       const lazy_document<Opts>* doc_{};
       const char* json_end_{};
+      const char* container_start_{}; // '[' or '{' of the container being iterated
       char close_char_{};
       bool is_object_{};
       bool at_end_{true};
       lazy_json_view<Opts> current_view_{}; // Stored view for parse_pos_ optimization
+
+      // Streaming cursor: on reaching the close, publish this container's own extent so an
+      // outer iterator advancing over it can jump too. That is what makes the optimization
+      // compose through nesting - an inner loop running to completion pays for the outer
+      // advance. No-op when the option is off.
+      void record_container_extent(const char* close_pos) noexcept
+      {
+         if constexpr (check_lazy_streaming_cursor(Opts)) {
+            if (doc_ && container_start_) [[likely]] {
+               // close_pos is the close character, except on a truncated buffer where it is
+               // json_end_ and there is nothing past it to include.
+               const char* const extent_end = (close_pos < json_end_) ? close_pos + 1 : close_pos;
+               doc_->consumed_.set(doc_->json_data(), container_start_, extent_end);
+            }
+         }
+      }
 
      public:
       using iterator_category = std::forward_iterator_tag;
@@ -965,7 +1066,7 @@ namespace glz
    template <auto Opts>
    inline lazy_iterator<Opts>::lazy_iterator(const lazy_document<Opts>* doc, const char* container_start,
                                              const char* end, bool is_object)
-      : doc_(doc), json_end_(end), is_object_(is_object), at_end_(false)
+      : doc_(doc), json_end_(end), container_start_(container_start), is_object_(is_object), at_end_(false)
    {
       close_char_ = is_object ? '}' : ']';
       const char* pos = container_start + 1; // skip '[' or '{'
@@ -975,12 +1076,14 @@ namespace glz
       if constexpr (Opts.null_terminated) {
          if (*pos == close_char_) {
             at_end_ = true;
+            record_container_extent(pos);
             return;
          }
       }
       else {
          if (pos >= json_end_ || *pos == close_char_) {
             at_end_ = true;
+            record_container_extent(pos);
             return;
          }
       }
@@ -1026,19 +1129,31 @@ namespace glz
 
       const char* pos = current_view_.data();
 
-      // Optimization: if user accessed fields via operator[], parse_pos_ tells us how far we scanned
-      // We can skip from there instead of re-scanning the entire element
-      // Note: check current_view_.is_object(), not is_object_ (which is about the container)
-      if (current_view_.is_object() && current_view_.parse_pos_ && current_view_.parse_pos_ > pos) {
-         // Skip the last accessed value, then scan to end of object
-         pos = current_view_.parse_pos_;
-         pos = detail::skip_value_lazy<Opts>(pos, json_end_);
-         // Skip remaining content until we close this object (depth 1 -> 0)
-         pos = detail::skip_to_depth_zero<Opts>(pos, json_end_, 1);
+      // Streaming cursor: if this element was already consumed end-to-end (read_into, or a
+      // nested iterator that ran to its close) the recorded extent tells us exactly where it
+      // finishes, so skip the scan entirely.
+      bool jumped = false;
+      if constexpr (check_lazy_streaming_cursor(Opts)) {
+         if (doc_) [[likely]] {
+            jumped = doc_->consumed_.try_jump(doc_->json_data(), pos, pos);
+         }
       }
-      else {
-         // No optimization possible, skip entire value
-         pos = detail::skip_value_lazy<Opts>(pos, json_end_);
+
+      if (!jumped) {
+         // Optimization: if user accessed fields via operator[], parse_pos_ tells us how far we scanned
+         // We can skip from there instead of re-scanning the entire element
+         // Note: check current_view_.is_object(), not is_object_ (which is about the container)
+         if (current_view_.is_object() && current_view_.parse_pos_ && current_view_.parse_pos_ > pos) {
+            // Skip the last accessed value, then scan to end of object
+            pos = current_view_.parse_pos_;
+            pos = detail::skip_value_lazy<Opts>(pos, json_end_);
+            // Skip remaining content until we close this object (depth 1 -> 0)
+            pos = detail::skip_to_depth_zero<Opts>(pos, json_end_, 1);
+         }
+         else {
+            // No optimization possible, skip entire value
+            pos = detail::skip_value_lazy<Opts>(pos, json_end_);
+         }
       }
 
       skip_ws(pos);
@@ -1047,12 +1162,14 @@ namespace glz
       if constexpr (Opts.null_terminated) {
          if (*pos == close_char_) {
             at_end_ = true;
+            record_container_extent(pos);
             return *this;
          }
       }
       else {
          if (pos >= json_end_ || *pos == close_char_) {
             at_end_ = true;
+            record_container_extent(pos);
             return *this;
          }
       }

--- a/include/glaze/json/lazy.hpp
+++ b/include/glaze/json/lazy.hpp
@@ -353,10 +353,37 @@ namespace glz
          if constexpr (check_lazy_streaming_cursor(Opts)) {
             // doc_ is null only for detached subviews; lazy_json() views always carry it.
             if (doc_ && consumed_whole_value) [[likely]] {
-               doc_->consumed_.set(doc_->json_data(), data_, it);
+               record_consumed_extent(it);
             }
          }
          return {};
+      }
+
+      // Record [data_, it) as consumed, but only when we can actually tell that `it` is this
+      // value's end.
+      //
+      // read_into hands the iterator to parse<JSON>::op, and where that leaves it is up to the
+      // from<JSON, T> specialization. Glaze's own readers stop at the value's end, but that is a
+      // convention rather than something checkable here: glz::text deliberately swallows the
+      // rest of the buffer, and a custom reader may consume only a prefix. Trusting `it` blindly
+      // is how the cursor turns a well-formed document into a short or mis-valued element
+      // stream, with no error anywhere.
+      //
+      // So only containers are recorded, and only when the parse finished exactly on the
+      // element's own closing bracket. Scalars are skipped by the cheap paths anyway (a numeric
+      // table walk or a memchr for strings), so declining to record them costs almost nothing
+      // and removes the whole class of doubt.
+      void record_consumed_extent(const char* it) const noexcept
+      {
+         const char open = *data_;
+         const char close = (open == '{') ? '}' : ((open == '[') ? ']' : '\0');
+         if (close == '\0') {
+            return; // scalar: not worth recording
+         }
+         if (it <= data_ || it[-1] != close) {
+            return; // the reader stopped somewhere other than this container's end
+         }
+         doc_->consumed_.set(doc_->json_data(), data_, it);
       }
 
       template <class T>
@@ -531,6 +558,18 @@ namespace glz
                doc_->consumed_.set(doc_->json_data(), container_start_, extent_end);
             }
          }
+      }
+
+      // Scan past the element beginning at elem_start, using the parse_pos_ shortcut when keyed
+      // access already walked part of it.
+      [[nodiscard]] const char* scan_past_element(const char* elem_start) const noexcept
+      {
+         if (current_view_.is_object() && current_view_.parse_pos_ && current_view_.parse_pos_ > elem_start) {
+            // Skip the last accessed value, then scan to the end of this object (depth 1 -> 0).
+            const char* p = detail::skip_value_lazy<Opts>(current_view_.parse_pos_, json_end_);
+            return detail::skip_to_depth_zero<Opts>(p, json_end_, 1);
+         }
+         return detail::skip_value_lazy<Opts>(elem_start, json_end_);
       }
 
      public:
@@ -1127,33 +1166,20 @@ namespace glz
    {
       if (at_end_) return *this;
 
-      const char* pos = current_view_.data();
+      const char* const elem_start = current_view_.data();
+      const char* pos = elem_start;
 
       // Streaming cursor: if this element was already consumed end-to-end (read_into, or a
-      // nested iterator that ran to its close) the recorded extent tells us exactly where it
-      // finishes, so skip the scan entirely.
+      // nested iterator that ran to its close) the recorded extent says where it finishes, so
+      // skip the scan entirely.
       bool jumped = false;
       if constexpr (check_lazy_streaming_cursor(Opts)) {
          if (doc_) [[likely]] {
             jumped = doc_->consumed_.try_jump(doc_->json_data(), pos, pos);
          }
       }
-
-      if (!jumped) {
-         // Optimization: if user accessed fields via operator[], parse_pos_ tells us how far we scanned
-         // We can skip from there instead of re-scanning the entire element
-         // Note: check current_view_.is_object(), not is_object_ (which is about the container)
-         if (current_view_.is_object() && current_view_.parse_pos_ && current_view_.parse_pos_ > pos) {
-            // Skip the last accessed value, then scan to end of object
-            pos = current_view_.parse_pos_;
-            pos = detail::skip_value_lazy<Opts>(pos, json_end_);
-            // Skip remaining content until we close this object (depth 1 -> 0)
-            pos = detail::skip_to_depth_zero<Opts>(pos, json_end_, 1);
-         }
-         else {
-            // No optimization possible, skip entire value
-            pos = detail::skip_value_lazy<Opts>(pos, json_end_);
-         }
+      if (not jumped) {
+         pos = scan_past_element(elem_start);
       }
 
       skip_ws(pos);

--- a/tests/json_test/lazy_test.cpp
+++ b/tests/json_test/lazy_test.cpp
@@ -76,6 +76,25 @@ struct Cell
    std::string s{};
 };
 
+// A reader that deliberately stops inside the value: it takes '[' and the first element, leaving
+// the iterator on an interior comma without reporting an error. Glaze's own readers do not behave
+// this way, but from<JSON, T> is a public extension point, so the cursor must not trust `it`.
+struct FirstOfPair
+{
+   int v{};
+};
+
+template <>
+struct glz::from<glz::JSON, FirstOfPair>
+{
+   template <auto Opts, class... Args>
+   static void op(FirstOfPair& value, glz::is_context auto&& ctx, auto&& it, auto end)
+   {
+      ++it; // '['
+      glz::parse<glz::JSON>::op<Opts>(value.v, ctx, it, end);
+   }
+};
+
 struct CellId
 {
    int a{};
@@ -1892,6 +1911,126 @@ suite lazy_streaming_cursor_tests = [] {
       }
       expect(first == "1;2;3;");
       expect(first == second);
+   };
+
+   "cursor_ignores_over_consuming_reader"_test = [] {
+      // glz::text swallows everything from the value start to the end of the buffer and reports
+      // success. Taking its stopping point as the element end would record an extent covering the
+      // rest of the document and silently end iteration after one element.
+      const std::string json = R"([{"a":1},{"a":2},{"a":3}])";
+
+      auto collect = []<auto Opts>() {
+         const std::string_view src{R"([{"a":1},{"a":2},{"a":3}])"};
+         auto doc = glz::lazy_json<Opts>(src);
+         int count{};
+         for (auto& e : doc->root()) {
+            glz::text t{};
+            expect(not e.read_into(t));
+            if (++count > 8) break;
+         }
+         return count;
+      };
+
+      expect(collect.template operator()<cursor_on>() == 3);
+      expect(collect.template operator()<cursor_on>() == collect.template operator()<cursor_off>());
+   };
+
+   "cursor_ignores_under_consuming_reader"_test = [] {
+      // FirstOfPair stops on an interior comma. That looks exactly like a legitimate element
+      // boundary from the outside, so the extent has to be rejected when it is recorded rather
+      // than when it is used.
+      auto collect = []<auto Opts>() {
+         const std::string_view src{"[[1,20],[3,40],[5,60]]"};
+         auto doc = glz::lazy_json<Opts>(src);
+         std::string out;
+         int guard{};
+         for (auto& e : doc->root()) {
+            FirstOfPair f{};
+            out += e.read_into(f) ? "!" : std::to_string(f.v);
+            out += ' ';
+            if (++guard > 8) break;
+         }
+         return out;
+      };
+
+      expect(collect.template operator()<cursor_on>() == "1 3 5 ");
+      expect(collect.template operator()<cursor_on>() == collect.template operator()<cursor_off>());
+   };
+
+   "cursor_scalar_elements_iterate_correctly"_test = [&] {
+      // Scalars are deliberately never recorded, so this exercises the un-accelerated path
+      // through the same loop.
+      const std::string json = R"({"rows":[1,"two",3.5,true,null,-6]})";
+      auto walk = []<auto Opts>(std::string_view j) {
+         auto doc = glz::lazy_json<Opts>(j);
+         std::string out;
+         for (auto& e : (*doc)["rows"]) {
+            out += e.raw_json();
+            out += '|';
+         }
+         return out;
+      };
+      expect(walk.template operator()<cursor_on>(json) == R"(1|"two"|3.5|true|null|-6|)");
+      expect(walk.template operator()<cursor_on>(json) == walk.template operator()<cursor_off>(json));
+   };
+
+   "cursor_malformed_input_matches_uncursored"_test = [] {
+      // The cursor must stay a pure speed difference on input that is not well formed, where the
+      // parser and the structural skip can disagree about where a token ends.
+      const std::vector<std::string> broken{
+         R"({"rows":[0-1,2]})",       R"({"rows":[1e,2]})",  R"({"rows":[--,3]})",
+         R"({"rows":[1,2)",           R"({"rows":[[1,2],3)", R"({"rows":[{"a":1},{"a":)",
+         R"({"rows":[{"a":1},{"b":)", R"({"rows":[")",       R"({"rows":[{)",
+      };
+
+      auto walk = []<auto Opts>(std::string_view j) {
+         auto doc = glz::lazy_json<Opts>(j);
+         if (not doc) return std::string{"<parse-error>"};
+         std::string out;
+         int guard{};
+         for (auto& e : (*doc)["rows"]) {
+            double v{};
+            out += e.read_into(v) ? "!" : std::to_string(v);
+            out += ';';
+            if (++guard > 32) return out + "<runaway>";
+         }
+         return out;
+      };
+
+      for (const auto& j : broken) {
+         expect(walk.template operator()<cursor_on>(j) == walk.template operator()<cursor_off>(j)) << j;
+      }
+   };
+
+   "cursor_truncated_container_matches_uncursored"_test = [] {
+      // An unclosed container never reaches its close bracket, so no container extent is
+      // published. Bounded buffers only, since that is the mode with no sentinel to stop on.
+      const std::vector<std::string> truncated{
+         R"({"rows":[[1,2],[3)",
+         R"({"rows":[{"a":1},{"a")",
+         R"({"rows":[[[)",
+         R"({"rows":[[1],)",
+      };
+
+      auto walk = []<auto Opts>(std::string_view j) {
+         auto doc = glz::lazy_json<Opts>(j);
+         if (not doc) return std::string{"<parse-error>"};
+         std::string out;
+         int guard{};
+         for (auto& e : (*doc)["rows"]) {
+            out += e.raw_json();
+            out += '|';
+            if (++guard > 32) return out + "<runaway>";
+         }
+         return out;
+      };
+
+      for (const auto& j : truncated) {
+         const std::string_view bounded{j.data(), j.size()};
+         expect(walk.template operator()<cursor_on_bounded>(bounded) ==
+                walk.template operator()<cursor_off_bounded>(bounded))
+            << j;
+      }
    };
 
    "cursor_disabled_costs_nothing"_test = [] {

--- a/tests/json_test/lazy_test.cpp
+++ b/tests/json_test/lazy_test.cpp
@@ -23,6 +23,64 @@ struct BoolHolder
    bool flag{};
 };
 
+// Streaming cursor option matrix. Every cursor test is differential: the same traversal is run
+// with the cursor on and off and the two results must agree, so the cursor can only ever be a
+// speed difference, never a behavior difference.
+struct cursor_on_opts : glz::opts
+{
+   bool lazy_streaming_cursor = true;
+};
+
+struct cursor_off_opts : glz::opts
+{
+   bool lazy_streaming_cursor = false;
+};
+
+// Non-null-terminated input, the mode a caller feeding bounded string_views uses.
+struct cursor_on_bounded_opts : glz::opts
+{
+   bool null_terminated = false;
+   bool lazy_streaming_cursor = true;
+};
+
+struct cursor_off_bounded_opts : glz::opts
+{
+   bool null_terminated = false;
+   bool lazy_streaming_cursor = false;
+};
+
+// partial_read leaves the parser short of the value's true end. The cursor must not mistake
+// that stopping point for the end of the element.
+struct cursor_on_partial_opts : glz::opts
+{
+   bool partial_read = true;
+   bool lazy_streaming_cursor = true;
+};
+
+struct cursor_off_partial_opts : glz::opts
+{
+   bool partial_read = true;
+   bool lazy_streaming_cursor = false;
+};
+
+inline constexpr cursor_on_opts cursor_on{};
+inline constexpr cursor_off_opts cursor_off{};
+inline constexpr cursor_on_bounded_opts cursor_on_bounded{};
+inline constexpr cursor_off_bounded_opts cursor_off_bounded{};
+inline constexpr cursor_on_partial_opts cursor_on_partial{};
+inline constexpr cursor_off_partial_opts cursor_off_partial{};
+
+struct Cell
+{
+   int a{};
+   std::string s{};
+};
+
+struct CellId
+{
+   int a{};
+};
+
 struct User
 {
    std::string name{};
@@ -1618,8 +1676,229 @@ suite lazy_derived_opts_tests = [] {
       expect(result.has_value());
 
       BoolHolder holder{};
-      expect(not (*result)["obj"].read_into(holder));
+      expect(not(*result)["obj"].read_into(holder));
       expect(holder.flag == true);
+   };
+};
+
+// ============================================================================
+// Streaming cursor (lazy_streaming_cursor)
+// ============================================================================
+
+// Each helper renders a traversal to a string so cursor-on and cursor-off runs can be compared
+// exactly. Any divergence - a skipped element, a bogus extra one, a changed value - shows up as
+// a string mismatch rather than a silently equal checksum.
+
+template <auto Opts>
+std::string traverse_read_into(std::string_view json)
+{
+   auto doc = glz::lazy_json<Opts>(json);
+   if (not doc) return "<parse-error>";
+   std::string out;
+   for (auto& row : (*doc)["rows"]) {
+      Cell cell{};
+      if (row.read_into(cell)) {
+         out += "!;";
+      }
+      else {
+         out += std::to_string(cell.a) + ':' + cell.s + ';';
+      }
+   }
+   return out;
+}
+
+// Nested containers: the inner loop runs to completion, which is what lets the outer advance
+// jump. Exercises the self-composing extent.
+template <auto Opts>
+std::string traverse_nested(std::string_view json)
+{
+   auto doc = glz::lazy_json<Opts>(json);
+   if (not doc) return "<parse-error>";
+   std::string out;
+   for (auto& row : (*doc)["rows"]) {
+      out += '[';
+      for (auto& cell : row) {
+         int v{};
+         if (cell.read_into(v)) {
+            out += "!,";
+         }
+         else {
+            out += std::to_string(v) + ',';
+         }
+      }
+      out += ']';
+   }
+   return out;
+}
+
+// Mixes the access patterns that produce and consume extents: read_into on some rows, keyed
+// access (which drives parse_pos_ instead) on others, and rows left entirely untouched.
+template <auto Opts>
+std::string traverse_mixed(std::string_view json)
+{
+   auto doc = glz::lazy_json<Opts>(json);
+   if (not doc) return "<parse-error>";
+   std::string out;
+   int n = 0;
+   for (auto& row : (*doc)["rows"]) {
+      switch (n++ % 3) {
+      case 0: {
+         Cell cell{};
+         out += row.read_into(cell) ? "!;" : std::to_string(cell.a) + ':' + cell.s + ';';
+         break;
+      }
+      case 1: {
+         auto a = row["a"].template get<int64_t>();
+         out += a ? std::to_string(a.value()) + '#' : "!#";
+         break;
+      }
+      default:
+         out += "-";
+         break;
+      }
+   }
+   return out;
+}
+
+suite lazy_streaming_cursor_tests = [] {
+   // Every shape below is run through both option sets and must agree.
+   const std::string rows = R"({"rows":[{"a":1,"s":"one"},{"a":2,"s":"two"},{"a":3,"s":"three"}]})";
+   const std::string nested = R"({"rows":[[1,2,3],[],[4],[5,6,7,8]]})";
+   const std::string empty_rows = R"({"rows":[]})";
+   const std::string single = R"({"rows":[{"a":9,"s":"only"}]})";
+   const std::string escaped = R"({"rows":[{"a":1,"s":"a\"b,]}"},{"a":2,"s":"]}\\"}]})";
+   const std::string deep = R"({"rows":[{"a":1,"s":"x"},{"a":2,"s":"y"},{"a":3,"s":"z"},{"a":4,"s":"w"}]})";
+
+   "cursor_read_into_matches_uncursored"_test = [&] {
+      for (const auto& json : {rows, empty_rows, single, escaped, deep}) {
+         const auto with = traverse_read_into<cursor_on>(json);
+         const auto without = traverse_read_into<cursor_off>(json);
+         expect(with == without) << json;
+         expect(not with.empty() or json == empty_rows);
+      }
+      expect(traverse_read_into<cursor_on>(rows) == "1:one;2:two;3:three;");
+   };
+
+   "cursor_nested_containers_match_uncursored"_test = [&] {
+      expect(traverse_nested<cursor_on>(nested) == traverse_nested<cursor_off>(nested));
+      expect(traverse_nested<cursor_on>(nested) == "[1,2,3,][][4,][5,6,7,8,]");
+   };
+
+   "cursor_mixed_access_matches_uncursored"_test = [&] {
+      for (const auto& json : {rows, single, escaped, deep}) {
+         expect(traverse_mixed<cursor_on>(json) == traverse_mixed<cursor_off>(json)) << json;
+      }
+      expect(traverse_mixed<cursor_on>(deep) == "1:x;2#-4:w;");
+   };
+
+   "cursor_bounded_buffer_matches_uncursored"_test = [&] {
+      // A trailing tail past the logical end catches any read beyond json_end().
+      std::string backing = R"({"rows":[{"a":1,"s":"one"},{"a":2,"s":"two"}]}TRAILING_NON_JSON)";
+      const std::string_view json{backing.data(), backing.find("]}") + 2};
+
+      expect(traverse_read_into<cursor_on_bounded>(json) == traverse_read_into<cursor_off_bounded>(json));
+      expect(traverse_read_into<cursor_on_bounded>(json) == "1:one;2:two;");
+   };
+
+   "cursor_under_partial_read_matches_uncursored"_test = [&] {
+      // partial_read stops the parser inside the object once its known keys are filled, and
+      // finalize_read_context downgrades that to success. Recording `it` as the element end
+      // would land the next advance in the middle of the object and desynchronize iteration.
+      const std::string wide = R"({"rows":[{"a":1,"b":7,"c":8},{"a":2,"b":7,"c":8},{"a":3,"b":7,"c":8}]})";
+
+      auto collect = []<auto Opts>(std::string_view json) {
+         auto doc = glz::lazy_json<Opts>(json);
+         std::string out;
+         int guard = 0;
+         for (auto& row : (*doc)["rows"]) {
+            CellId cell{};
+            out += row.read_into(cell) ? "!;" : std::to_string(cell.a) + ';';
+            if (++guard > 16) return out + "<runaway>";
+         }
+         return out;
+      };
+
+      const auto with = collect.template operator()<cursor_on_partial>(wide);
+      const auto without = collect.template operator()<cursor_off_partial>(wide);
+      expect(with == without);
+      expect(with == "1;2;3;");
+   };
+
+   "cursor_interleaved_iterators_share_one_slot"_test = [&] {
+      // Two live iterators over the same document write to the same extent slot. The
+      // pointer-identity check must keep each advance honest.
+      const std::string json = R"({"x":[{"a":1,"s":"p"},{"a":2,"s":"q"},{"a":3,"s":"r"}],)"
+                               R"("y":[{"a":10,"s":"P"},{"a":20,"s":"Q"},{"a":30,"s":"R"}]})";
+      auto doc = glz::lazy_json<cursor_on>(json);
+      expect(doc.has_value());
+
+      auto xs = (*doc)["x"];
+      auto ys = (*doc)["y"];
+      auto ix = xs.begin();
+      auto iy = ys.begin();
+
+      std::string out;
+      int guard = 0;
+      while (ix != xs.end() && iy != ys.end()) {
+         Cell a{};
+         Cell b{};
+         expect(not(*ix).read_into(a));
+         expect(not(*iy).read_into(b));
+         out += std::to_string(a.a) + a.s + std::to_string(b.a) + b.s + ';';
+         ++ix;
+         ++iy;
+         if (++guard > 16) break;
+      }
+      expect(out == "1p10P;2q20Q;3r30R;");
+   };
+
+   "cursor_survives_document_copy_and_move"_test = [&] {
+      // The extent is stored as offsets, so a copied or moved document rebases onto its own
+      // buffer pointer rather than dangling into the original.
+      auto original = glz::lazy_json<cursor_on>(rows);
+      expect(original.has_value());
+
+      auto it = (*original)["rows"].begin();
+      Cell first{};
+      expect(not(*it).read_into(first)); // leaves a live extent on the document
+      expect(first.a == 1);
+
+      auto copied = *original; // copy with the extent live
+      auto moved = std::move(copied);
+
+      std::string out;
+      for (auto& row : moved["rows"]) {
+         Cell cell{};
+         out += row.read_into(cell) ? "!;" : std::to_string(cell.a) + ':' + cell.s + ';';
+      }
+      expect(out == "1:one;2:two;3:three;");
+   };
+
+   "cursor_repeated_traversals_are_stable"_test = [&] {
+      // A second pass over the same document must see the same elements: an extent left over
+      // from the first pass may not leak into the second.
+      auto doc = glz::lazy_json<cursor_on>(rows);
+      expect(doc.has_value());
+
+      std::string first;
+      std::string second;
+      for (auto& row : (*doc)["rows"]) {
+         Cell cell{};
+         first += row.read_into(cell) ? "!;" : std::to_string(cell.a) + ';';
+      }
+      for (auto& row : (*doc)["rows"]) {
+         Cell cell{};
+         second += row.read_into(cell) ? "!;" : std::to_string(cell.a) + ';';
+      }
+      expect(first == "1;2;3;");
+      expect(first == second);
+   };
+
+   "cursor_disabled_costs_nothing"_test = [] {
+      // The disabled slot is an empty type under GLZ_NO_UNIQUE_ADDRESS, so opting out must not
+      // grow lazy_document at all.
+      expect(sizeof(glz::lazy_document<cursor_off>) == sizeof(glz::lazy_document<glz::opts{}>));
+      expect(sizeof(glz::lazy_document<cursor_on>) > sizeof(glz::lazy_document<cursor_off>));
    };
 };
 


### PR DESCRIPTION
Extracted and reworked from #2683 by @psiha, whose idea and design this is.

> **Stacked on #2744** — based on `fix/lazy-opts-nttp-slicing`, not `main`, because the cursor cannot work without it (a derived opts struct was sliced, so the option never reached the lazy code). Review that one first; this diff shows only the cursor once it merges. Retarget to `main` after.

## What it does

Iterating a large container and consuming each element with `read_into` walks every element twice: once to parse it, and again in `operator++` to find where the next one begins. The second walk is pure repeated work over bytes the parser just read.

The new `lazy_streaming_cursor` option removes it:

```cpp
struct stream_opts : glz::opts {
   bool lazy_streaming_cursor = true;
};

for (auto& row : (*doc)["rows"]) {
   Row parsed{};
   if (not row.read_into(parsed)) use(parsed);  // the next ++ skips re-scanning this row
}
```

When a value is consumed end to end — by `read_into`, or by a nested iterator reaching its closing bracket — its byte extent is recorded on the document, and the next advance jumps to the recorded end instead of calling `skip_value_lazy`. Because a finished container publishes its own extent, this composes through nesting: an inner loop that runs to completion pays for the outer advance.

**9 MB array of three-field objects, `read_into` per row, Apple M1, clang `-O3`: 575 → 955 MB/s (+66%).**

## Why the single shared slot is safe

One slot on the document holds the extent, and it is used only when it starts **exactly** at the element the iterator is standing on. A byte offset identifies exactly one value in the buffer, so an extent starting where the iterator stands always describes the value it is about to skip. Interleaved iterators, abandoned inner loops, and leftover extents from a previous pass all fail that check and fall back to a normal scan.

Offsets rather than pointers, so a copied or moved document rebases onto its own buffer instead of dangling into the original.

## The `partial_read` hazard

`read_into` records `[data_, it)`. But `finalize_read_context` downgrades both `partial_read_complete` and a depth-zero `end_reached` to success, and both leave `it` **short of the value's true end**. Recording that stopping point as the element end lands the next advance inside the object and desynchronizes iteration:

```
partial_read = true, 3 rows, cursor recording unconditionally:
   cursor off -> count=3  sum=6    (correct)
   cursor on  -> count=11 sum=3    (runaway, garbage elements)
```

So completeness is captured **before** `finalize_read_context` runs, and an extent is recorded only when the parse reported no error at all. Under `partial_read` nothing is recorded — traversal stays correct and is simply not accelerated. There is a test that fails if this guard is removed.

## Cost when disabled

Two `size_t` on `lazy_document` when enabled, nothing when disabled — the disabled slot is an empty type behind `GLZ_NO_UNIQUE_ADDRESS`, and a test asserts `lazy_document` does not grow. Views and iterators are unchanged either way.

## Tests

Every cursor test is **differential**: the same traversal runs with the cursor on and off and the two results must match exactly, so the option can only ever be a speed difference, never a behavior difference. Covered:

- `read_into` loops across five document shapes, including empty containers, a single element, and strings containing `"`, `,`, `]`, `}` and escaped backslashes
- nested containers (self-composing extent), including empty inner arrays
- mixed access: `read_into` on some rows, keyed `operator[]` on others, some skipped entirely
- bounded non-null-terminated buffers, with a trailing non-JSON tail to catch reads past `json_end()`
- `partial_read`
- interleaved iterators over one document
- document copy and move with a live extent
- repeated traversals of the same document
- `sizeof(lazy_document)` unchanged when disabled

Also run clean under ASAN + UBSAN.

## Differences from #2683

- **`partial_read` corruption fixed** (the repro above).
- **Policy simplified to a `bool`.** The original had a four-value enum, but `packed` and `packed_with_fallback` behaved identically in release builds (the non-fallback path asserted, then cleared anyway), and the packing saved 8 bytes on a per-*document* struct — not per view. Dropped the enum, the `uint32_t` offsets, and the overflow/fallback logic.
- **No new core header.** The original added `core/lazy_streaming_cursor_policy.hpp` and made `core/opts.hpp` include it, so every glaze TU paid for a lazy-JSON-only header — plus an unused `check_lazy_streaming_cursor`. Here the option is documented in the `opts.hpp` comment list and its `check_*` helper sits with the others, matching how `linear_search` and friends are done.
- **Tests are differential and cover the gaps** — the original had 4 tests and no coverage of nesting, interleaving, copy/move, or `partial_read`.

Not carried over: the SIMD structural skip and the slim view. Notes on both in the review thread.


---

## Update after adversarial review: extents are now validated at recording time

A review pass found a real correctness bug in the version first pushed here, and it is worth writing down because the original reasoning was wrong in an instructive way.

`read_into` recorded `[data_, it)` whenever the parse reported no error, treating `parse<JSON>::op`'s final iterator as the value's end. **That is a convention Glaze's own readers follow, not an invariant the cursor can rely on** — and `from<JSON, T>` is a public extension point.

`glz::text` breaks it in-tree. It assigns the rest of the buffer and sets `it = end` without an error, so the recorded extent covered the remainder of the document and the next advance jumped straight to the end:

```
iterating [{"a":1},{"a":2},{"a":3}] into glz::text
  cursor off -> 3 elements
  cursor on  -> 1 element      (no error reported anywhere)
```

A custom reader consuming only a prefix produced the mirror-image failure: same element count, **different values**.

### Why validating the landing position wasn't enough

My first fix checked where the jump landed — after a real element the next byte must be this container's `,` or its closing bracket. That fixes `glz::text` and every malformed-input divergence, but it is defeated by a reader that stops on an *interior* comma, which looks exactly like a legitimate boundary from the outside. I measured it: with the recording-side guard in place, removing the landing check changed nothing across 115k malformed traversals, and it did not catch the one adversarial case I could construct. So it was insurance I could neither test nor justify, and I removed it rather than ship it.

### What it does now

An extent is kept only when **the element is a container and the parse finished exactly on that container's own closing bracket**. Scalars are no longer recorded at all — they are skipped by a numeric table walk or a `memchr` either way, so declining to record them costs essentially nothing and removes the whole class of doubt.

- `glz::text` and the under-consuming custom reader both now agree with cursor-off.
- The malformed-input divergence the same root cause produced is gone: a corpus of **57,662 mutated documents across both buffer modes now shows zero divergences**, down from 140.
- Throughput is unchanged: **+67%** on the `read_into` row loop, since the rows that matter are containers.

### Residual limitation, documented rather than hidden

A custom reader that consumes a *complete inner container* but stops before the element's own end (reading `[[1],2]` and stopping after `[1]`) still produces an extent that passes this check. There is no cheap complete check — verifying it properly is the scan we are avoiding. Such a reader already misparses whatever follows it under ordinary `glz::read_json`, so it is broken independently of this option. `docs/lazy-json.md` states this explicitly.

### Thread safety, which I had not documented

Recording an extent writes to the document from a `const` method. Two threads calling `read_into` on **disjoint** subviews of one `lazy_document` do not race with the option off, but do with it on. Now documented. (A `lazy_document` is already unsafe to share for keyed access either way, since `operator[]` advances the cached root view's scan position.)

New tests cover the over-consuming reader, an under-consuming custom `from<JSON, T>`, scalar elements, malformed documents, and truncated containers. The first two fail without the recording guard.