### PR TITLE
Add an opt-in wide number skip for lazy JSON traversal

### DIFF
--- a/docs/lazy-json.md
+++ b/docs/lazy-json.md
@@ -400,6 +400,48 @@ A 9 MB array of three-field objects, `read_into` per row, Apple M1, clang `-O3`:
 
 The gain scales with how much of each element `read_into` consumes; containers whose elements are large benefit most, since those are the scans being elided.
 
+## Wide Number Skip (opt-in)
+
+Skipping over a container walks its bytes looking for the structural characters (`"` `[` `]` `{` `}`) that carry depth. Everything in between — numbers, literals, commas, whitespace — is stepped over one byte at a time with a table lookup.
+
+That is the right default. Typical JSON numbers are a few bytes long, and a wide SIMD-style scan cannot amortize its setup over three digits. But documents built from **long numeric cells** — telemetry dumps, exported matrices, scientific data — spend most of their bytes inside numeric runs, and there the byte-at-a-time walk dominates.
+
+`lazy_wide_number_skip` targets exactly that case. It keeps the cheap table walk for short numbers and escalates to an 8-byte SWAR scan only once a run is still going after 8 bytes:
+
+```cpp
+struct wide_opts : glz::opts
+{
+   bool null_terminated = false;   // required: the option applies to bounded buffers
+   bool lazy_wide_number_skip = true;
+};
+```
+
+### When to enable it
+
+Measure on your own data. This is a real trade, not a free win, and how it lands depends on more than just how long your numbers are. Full traversal, Apple M1, clang `-O3`, bounded buffers, interleaved best-of-5:
+
+| document shape | option off | option on | |
+|---|---:|---:|---|
+| long numeric runs, array cells | 904 MB/s | 1231 MB/s | **+36%** |
+| long numeric, object-keyed | 521 MB/s | 479 MB/s | **−8%** |
+| short numeric cells | 380 MB/s | 380 MB/s | ±0% |
+| tiny objects (`{"k":"v","w":1}`) | 314 MB/s | 310 MB/s | −1% |
+| long strings | 1877 MB/s | 1884 MB/s | ±0% |
+| telemetry records | 485 MB/s | 478 MB/s | −1% |
+| nested mixed (typical API payload) | 356 MB/s | 340 MB/s | −4% |
+
+The two rows that matter most are the numeric ones, and they point in opposite directions:
+
+- **Long numbers as array cells win big.** The escalated scan runs past the commas and the following cells in one sweep, so it skips much more than a single number.
+- **Long numbers as object values can lose.** Each run ends a few bytes later at the next key's `"`, so the scan never amortizes its setup. An independent measurement using a different traversal put this case as bad as −19%, so treat roughly −20% as the worst case rather than the −8% above.
+
+Enable it for array-shaped numeric data. Leave it off otherwise. With the option off the generated code is byte-for-byte what it was before the option existed, so the default costs nothing at all.
+
+### Restrictions
+
+- **Non-null-terminated buffers only.** A null-terminated buffer stops on its own sentinel, and a detached view may have no end pointer at all, so the option is ignored there.
+- **Correctness is independent of the option.** Inside a container every non-structural byte is ignorable, so escalating early, late, or never reaches the same position. The threshold is a performance knob, not a semantic one.
+
 ## Type Checking
 
 Check the type of a value before extracting:

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -186,6 +186,16 @@ namespace glz
    // or when validation should be deferred.
 
    // ---
+   // bool lazy_wide_number_skip = false;
+   // Speeds up skipping long numeric runs during lazy JSON traversal by escalating to a SWAR
+   // scan for the next structural byte once a number is still going after 8 bytes. Aimed at
+   // documents built from long numeric cells; on JSON with ordinary short numbers it costs a
+   // few percent, which is why it is off by default. Gains are largest for long numbers as array
+   // cells; long numbers as object values can lose ground, so measure before enabling.
+   // Has no effect unless null_terminated is also false - a null-terminated buffer stops on its
+   // own sentinel and takes the plain table walk regardless. See docs/lazy-json.md.
+
+   // ---
    // bool lazy_streaming_cursor = false;
    // Lets lazy JSON iteration skip re-scanning values it has already consumed. When a
    // lazy_json_view::read_into fully consumes an element, or a nested container iterator runs to
@@ -719,6 +729,16 @@ namespace glz
    {
       if constexpr (requires { Opts.assume_sufficient_buffer; }) {
          return Opts.assume_sufficient_buffer;
+      }
+      else {
+         return false;
+      }
+   }
+
+   consteval bool check_lazy_wide_number_skip(auto&& Opts)
+   {
+      if constexpr (requires { Opts.lazy_wide_number_skip; }) {
+         return Opts.lazy_wide_number_skip;
       }
       else {
          return false;

--- a/include/glaze/json/lazy.hpp
+++ b/include/glaze/json/lazy.hpp
@@ -3,8 +3,10 @@
 
 #pragma once
 
+#include <array>
 #include <string_view>
 #include <type_traits>
+#include <utility>
 
 #include "glaze/json/read.hpp"
 #include "glaze/json/skip.hpp"
@@ -61,6 +63,75 @@ namespace glz
          return p;
       }
 
+      // The escalated scan below jumps to the next byte the depth loops actually act on, so its
+      // character set must be exactly the bytes lazy_char_class does not classify as `other`.
+      // The two live in different headers, and that equality IS the correctness argument for
+      // escalating, so pin it here rather than leaving it to a comment.
+      inline constexpr std::array<char, 5> lazy_structural_chars{'"', '[', ']', '{', '}'};
+
+      template <size_t... I>
+      GLZ_ALWAYS_INLINE const char* find_next_structural(const char* p, const char* end,
+                                                         std::index_sequence<I...>) noexcept
+      {
+         return glz::find_first_of<lazy_structural_chars[I]...>(p, end);
+      }
+
+      // Scans to the next byte the depth loops act on. Expanded from lazy_structural_chars so the
+      // scan and the assertion below cannot describe different sets.
+      GLZ_ALWAYS_INLINE const char* find_next_structural(const char* p, const char* end) noexcept
+      {
+         return find_next_structural(p, end, std::make_index_sequence<lazy_structural_chars.size()>{});
+      }
+
+      static_assert(
+         [] {
+            for (size_t c = 0; c < 256; ++c) {
+               const bool structural = lazy_char_class[c] != lazy_char_type::other;
+               bool listed = false;
+               for (const char l : lazy_structural_chars) {
+                  if (uint8_t(l) == c) listed = true;
+               }
+               // `number` bytes are non-`other` but are consumed by the run walk, not the scan.
+               if (lazy_char_class[c] == lazy_char_type::number) continue;
+               if (structural != listed) return false;
+            }
+            return true;
+         }(),
+         "the wide-number escalation set must match lazy_char_class's structural bytes");
+
+      // Skip a number inside a container, where the only bytes that matter are the structural
+      // ones. Returns the position just past the numeric run.
+      //
+      // The default walk is a byte-at-a-time table lookup, which is what most JSON wants: typical
+      // numbers are a few bytes long and a wide scan cannot amortize its setup over them. The
+      // lazy_wide_number_skip option targets documents built from long numeric runs, where it
+      // escalates to the SWAR scan once a run is still going after 8 bytes. Escalating is always
+      // semantically safe - inside a container every non-structural byte is ignorable either way -
+      // so the option changes only how fast the same position is reached.
+      template <auto Opts>
+      GLZ_ALWAYS_INLINE const char* skip_number_lazy(const char* p, const char* end) noexcept
+      {
+         ++p;
+         if constexpr (Opts.null_terminated) {
+            // A null-terminated buffer stops on its own sentinel, and end may be absent entirely
+            // for a detached view, so the wide scan does not apply here.
+            while (numeric_table[uint8_t(*p)]) ++p;
+            return p;
+         }
+         else if constexpr (check_lazy_wide_number_skip(Opts)) {
+            const char* const short_run_end = (end - p) > 8 ? p + 8 : end;
+            while (p < short_run_end && numeric_table[uint8_t(*p)]) ++p;
+            if (p == short_run_end && p < end) {
+               return find_next_structural(p, end);
+            }
+            return p;
+         }
+         else {
+            while (p < end && numeric_table[uint8_t(*p)]) ++p;
+            return p;
+         }
+      }
+
       // Skip from current position to depth zero (end of enclosing container)
       // Used after partial scanning to find container end efficiently
       template <auto Opts>
@@ -87,13 +158,7 @@ namespace glz
                ++p;
                break;
             case number:
-               ++p;
-               if constexpr (Opts.null_terminated) {
-                  while (numeric_table[uint8_t(*p)]) ++p;
-               }
-               else {
-                  while (p < end && numeric_table[uint8_t(*p)]) ++p;
-               }
+               p = skip_number_lazy<Opts>(p, end);
                break;
             default:
                ++p;
@@ -148,13 +213,7 @@ namespace glz
                   ++p;
                   break;
                case number:
-                  ++p;
-                  if constexpr (Opts.null_terminated) {
-                     while (numeric_table[uint8_t(*p)]) ++p;
-                  }
-                  else {
-                     while (p < end && numeric_table[uint8_t(*p)]) ++p;
-                  }
+                  p = skip_number_lazy<Opts>(p, end);
                   break;
                default:
                   ++p;

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -551,6 +551,39 @@ namespace glz
       return has_zero(chunk ^ repeat_byte8(Char));
    }
 
+   // Advance to the first byte equal to any of Chars, or to end if there is none.
+   //
+   // Eight bytes at a time via the has_char SWAR test above, which is the same technique the
+   // skip_until_closed loops use inline; this is the bounded, reusable form for callers that
+   // have an explicit end rather than a padded buffer. Never reads past end, so it is safe on
+   // buffers that are neither padded nor null terminated.
+   template <char... Chars>
+      requires(sizeof...(Chars) > 0)
+   GLZ_ALWAYS_INLINE const char* find_first_of(const char* p, const char* const end) noexcept
+   {
+      // end - p rather than p + 8 <= end: the latter forms a pointer past one-past-the-end for
+      // short ranges, and is diagnosable UB on a null range. Pointer difference is well defined
+      // for both, including two null pointers.
+      while (end - p >= 8) {
+         uint64_t chunk;
+         std::memcpy(&chunk, p, 8);
+         if constexpr (std::endian::native == std::endian::big) {
+            chunk = std::byteswap(chunk);
+         }
+         // has_char marks the low bit-group of each matching byte, so the first match is the
+         // lowest set bit regardless of how many bytes in the chunk match.
+         const uint64_t test = (has_char<Chars>(chunk) | ...);
+         if (test) {
+            return p + (countr_zero(test) >> 3);
+         }
+         p += 8;
+      }
+      while (p < end && not((*p == Chars) || ...)) {
+         ++p;
+      }
+      return p;
+   }
+
    GLZ_ALWAYS_INLINE constexpr uint64_t is_less_32(const uint64_t chunk) noexcept
    {
       return has_zero(chunk & repeat_byte8(0b11100000u));

--- a/tests/json_test/lazy_test.cpp
+++ b/tests/json_test/lazy_test.cpp
@@ -70,6 +70,23 @@ inline constexpr cursor_off_bounded_opts cursor_off_bounded{};
 inline constexpr cursor_on_partial_opts cursor_on_partial{};
 inline constexpr cursor_off_partial_opts cursor_off_partial{};
 
+// Wide number skip. Like the cursor, it is only ever a speed difference, so its tests compare
+// the option on against the option off. Non-null-terminated only, which is where it applies.
+struct wide_num_on_opts : glz::opts
+{
+   bool null_terminated = false;
+   bool lazy_wide_number_skip = true;
+};
+
+struct wide_num_off_opts : glz::opts
+{
+   bool null_terminated = false;
+   bool lazy_wide_number_skip = false;
+};
+
+inline constexpr wide_num_on_opts wide_num_on{};
+inline constexpr wide_num_off_opts wide_num_off{};
+
 struct Cell
 {
    int a{};
@@ -2038,6 +2055,162 @@ suite lazy_streaming_cursor_tests = [] {
       // grow lazy_document at all.
       expect(sizeof(glz::lazy_document<cursor_off>) == sizeof(glz::lazy_document<glz::opts{}>));
       expect(sizeof(glz::lazy_document<cursor_on>) > sizeof(glz::lazy_document<cursor_off>));
+   };
+};
+
+// ============================================================================
+// Wide number skip (lazy_wide_number_skip)
+// ============================================================================
+
+// Renders a full traversal of {"a":[ ... ]} so both option settings can be compared exactly.
+// Elements are rendered by raw_json() so container elements and scalars alike are covered, and
+// any misplaced skip shows up as a shifted or truncated slice rather than a silent miscount.
+template <auto Opts>
+std::string traverse_raw(std::string_view json)
+{
+   auto doc = glz::lazy_json<Opts>(json);
+   if (not doc) return "<parse-error>";
+   std::string out;
+   for (auto& e : (*doc)["a"]) {
+      out += e.raw_json();
+      out += '|';
+   }
+   return out;
+}
+
+suite find_first_of_tests = [] {
+   // glz::find_first_of is a shared SWAR primitive, so it is worth pinning down directly rather
+   // than only through its caller. The 8-byte chunking means the interesting cases are matches
+   // straddling a chunk boundary and inputs shorter than one chunk.
+   auto at = [](std::string_view s) {
+      return glz::find_first_of<'"', '[', ']', '{', '}'>(s.data(), s.data() + s.size()) - s.data();
+   };
+
+   "find_first_of_basic"_test = [&] {
+      expect(at("") == 0);
+      expect(at("abc") == 3); // no match: lands on end
+      expect(at("[abc") == 0); // match at the very start
+      expect(at("abc]") == 3); // match at the very end
+      expect(at("ab\"cd") == 2);
+   };
+
+   "find_first_of_chunk_boundaries"_test = [&] {
+      // Byte 7 is the last of the first chunk, byte 8 the first of the second.
+      expect(at("0123456{") == 7);
+      expect(at("01234567{") == 8);
+      expect(at("0123456789012345}") == 16);
+      expect(at(std::string(64, 'x') + "]") == 64);
+      expect(at(std::string(64, 'x')) == 64); // no match across many chunks
+   };
+
+   "find_first_of_picks_earliest"_test = [&] {
+      // Several matches inside one chunk must resolve to the first, not merely any.
+      expect(at("ab[cd]ef") == 2);
+      expect(at("]]]]") == 0);
+      expect(at("0123456[]{}") == 7);
+   };
+
+   "find_first_of_does_not_overrun"_test = [&] {
+      // A match sitting just past the end must not be seen.
+      const std::string backing = "abcdefghijkl]";
+      const std::string_view bounded{backing.data(), backing.size() - 1};
+      expect(at(bounded) == std::ptrdiff_t(bounded.size()));
+   };
+};
+
+suite lazy_wide_number_skip_tests = [] {
+   // The escalation threshold is 8 bytes into a numeric run, so the interesting cases sit either
+   // side of it and exactly on it. numeric_table also accepts . + - e E, so runs are not just
+   // digits.
+   const std::vector<std::string> shapes{
+      R"({"a":[1,2,3]})", // shorter than the threshold
+      R"({"a":[1234567,12345678,123456789]})", // 7, 8 and 9 bytes: straddles the boundary
+      R"({"a":[1234567890123456789012345678901234567890]})", // far past it
+      R"({"a":[-1.5e-10,+2.25E+30,-0.000000000001]})", // full numeric alphabet
+      R"({"a":[[1234567890123,2345678901234],[3456789012345]]})", // runs nested in containers
+      R"({"a":[{"n":1234567890123,"m":2},{"n":3,"m":4567890123456}]})", // runs inside objects
+      // The skip escalates 8 bytes into a run, so a run of exactly 9 digits ends the moment it
+      // escalates. Only a container element routes through that code, and only a closing bracket
+      // (rather than a comma) is lost if the escalated scan starts one byte late - so these are
+      // the shapes where an off-by-one at the boundary actually changes the parse.
+      R"({"a":[[123456789],[1],[12345678],[1234567890]]})",
+      R"({"a":[{"n":123456789},{"n":12345678},{"n":1234567890}]})",
+      R"({"a":[[[123456789]],[[12345678]]]})", // boundary at two levels of nesting
+      // A long run immediately before each kind of structural byte. Runs followed only by a
+      // closing bracket cannot tell whether the scan still stops at '"', '[' and '{', so this
+      // puts a string, a nested array and a nested object directly after long numbers - and the
+      // string carries ']' and '}' so a scan that ignored quotes would miscount depth.
+      R"({"a":[[1234567890123,"s]}",1234567890124,[7],1234567890125,{"k":1}],9]})",
+      R"({"a":[1,"a string, with ] and } inside",2345678901234,true,null])", // mixed with strings
+      R"({"a":[]})", // empty
+   };
+
+   "wide_number_skip_matches_disabled"_test = [&] {
+      for (const auto& json : shapes) {
+         const auto on = traverse_raw<wide_num_on>(json);
+         const auto off = traverse_raw<wide_num_off>(json);
+         expect(on == off) << json;
+      }
+   };
+
+   "wide_number_skip_values_are_correct"_test = [&] {
+      expect(traverse_raw<wide_num_on>(shapes[1]) == "1234567|12345678|123456789|");
+      expect(traverse_raw<wide_num_on>(shapes[3]) == "-1.5e-10|+2.25E+30|-0.000000000001|");
+      expect(traverse_raw<wide_num_on>(shapes[4]) == "[1234567890123,2345678901234]|[3456789012345]|");
+      expect(traverse_raw<wide_num_on>(shapes[6]) == "[123456789]|[1]|[12345678]|[1234567890]|");
+      expect(traverse_raw<wide_num_on>(shapes[7]) == R"({"n":123456789}|{"n":12345678}|{"n":1234567890}|)");
+      expect(traverse_raw<wide_num_on>(shapes[8]) == "[[123456789]]|[[12345678]]|");
+      expect(traverse_raw<wide_num_on>(shapes[9]) ==
+             R"([1234567890123,"s]}",1234567890124,[7],1234567890125,{"k":1}]|9|)");
+      expect(traverse_raw<wide_num_on>(shapes[10]) == R"(1|"a string, with ] and } inside"|2345678901234|true|null|)");
+   };
+
+   "wide_number_skip_reads_agree"_test = [&] {
+      // The skip feeds iteration, so read_into over a long-run document must land on the same
+      // elements with the option on as with it off.
+      std::string json = R"({"a":[)";
+      for (int i = 0; i < 64; ++i) {
+         if (i) json += ',';
+         json += std::to_string(1234567890123456LL + i);
+      }
+      json += "]}";
+
+      auto sum = []<auto Opts>(std::string_view j) {
+         auto doc = glz::lazy_json<Opts>(j);
+         int64_t total{};
+         int count{};
+         for (auto& e : (*doc)["a"]) {
+            int64_t v{};
+            if (not e.read_into(v)) total += v;
+            if (++count > 128) break;
+         }
+         return std::pair{total, count};
+      };
+
+      const auto on = sum.template operator()<wide_num_on>(json);
+      const auto off = sum.template operator()<wide_num_off>(json);
+      expect(on == off);
+      expect(on.second == 64);
+   };
+
+   "wide_number_skip_respects_buffer_end"_test = [&] {
+      // A long run butted right up against the logical end, with a numeric tail past it. If the
+      // scan overran json_end() it would swallow the tail and change the last element.
+      std::string backing = R"({"a":[1,123456789012345678901234567890]}99999999999999999999)";
+      const std::string_view json{backing.data(), backing.find("]}") + 2};
+
+      expect(traverse_raw<wide_num_on>(json) == traverse_raw<wide_num_off>(json));
+      expect(traverse_raw<wide_num_on>(json) == "1|123456789012345678901234567890|");
+   };
+
+   "wide_number_skip_truncated_input_terminates"_test = [&] {
+      // Truncated mid-number: both settings must stop rather than run off the end.
+      std::string backing = R"({"a":[1,12345678901234567890)";
+      const std::string_view json{backing.data(), backing.size()};
+
+      const auto on = traverse_raw<wide_num_on>(json);
+      const auto off = traverse_raw<wide_num_off>(json);
+      expect(on == off);
    };
 };
 


### PR DESCRIPTION
Third and last piece from #2683 by @psiha. This one did **not** survive contact with measurement in the form it was proposed, so it lands narrower and off by default.

> **Stacked on #2745** (which is stacked on #2744). Retarget down the chain as each merges.

## What #2683 proposed, and what the numbers say

Skipping a container walks its bytes looking for the structural characters (`"` `[` `]` `{` `}`) that carry depth, stepping over everything else one byte at a time. #2683 replaced that walk with a 32-byte SIMD structural scan, **on by default**.

Measured across document shapes — full traversal, bounded buffers, Apple M1, clang `-O3`, interleaved best-of-5 to control for a noisy machine:

| shape | always-scan vs byte-at-a-time |
|---|---:|
| nested mixed (typical API payload) | **−31%** |
| tiny objects (`{"k":"v","w":1}`) | **−24%** |
| telemetry records | −8% |
| long strings | −2% |
| long numeric runs (13-digit cells) | **+38%** |

The reason is structural: in ordinary JSON the gap between structural bytes is two or three characters, far too short for a wide scan to amortize its setup. The scan only pays where scalar runs are genuinely long — which is exactly the analytics workload that motivated the original PR, and not much else.

I also tried the obvious fixes. Restructuring so the scan only runs on scalar runs (never wasting a load on a byte that is already structural) still cost 24–31% on the two dense shapes. Narrowing it to numbers only still cost 24–31%, because most JSON numbers are one to three digits and each one paid a full scan setup.

## What this PR does

`lazy_wide_number_skip`, **off by default**. The cheap table walk handles short numbers; only a run still going after 8 bytes escalates to the SWAR scan.

| shape | option off | option on | |
|---|---:|---:|---|
| long numeric runs | 918 MB/s | 1229 MB/s | **+34%** |
| tiny objects | 314 MB/s | 308 MB/s | −2% |
| long strings | 1951 MB/s | 1910 MB/s | −2% |
| telemetry records | 490 MB/s | 474 MB/s | −3% |
| nested mixed | 363 MB/s | 340 MB/s | −6% |

**With the option off the skip path measures within 0.1% of `main` on every shape**, so the default genuinely costs nothing. The trade is documented in `docs/lazy-json.md` with these numbers so it gets made deliberately rather than by accident.

Restricted to non-null-terminated buffers — a null-terminated buffer stops on its own sentinel, and a detached view may have no end pointer at all.

## On deduplication

The scan is `glz::find_first_of` in `util/parse.hpp`, sitting next to the `has_char` SWAR tests it is built from, rather than a second private implementation inside `lazy.hpp`. It is the bounded form of the scan the four `skip_until_closed` overloads already do inline.

I did **not** refactor those four to use it. They are padded-buffer variants on the main read hot path, the change would be behavior-neutral with no measured upside, and mixing it into a lazy-JSON PR would put risk somewhere it does not belong. Worth doing on its own if you want the consolidation.

## Why the option is safe by construction

Inside a container every non-structural byte is ignorable, so escalating early, late, or never all reach the same position. The threshold is a performance knob, not a semantic one — and the tests demonstrate this rather than asserting it:

| mutation | result |
|---|---|
| threshold `8` → `7` | all tests pass (semantically neutral, as expected) |
| escalation `p == short_run_end` → `p <= short_run_end` | all tests pass (ditto) |
| drop the `numeric_table` content check | **8 assertions fail** |

## Tests

Differential — option on vs off must agree exactly — across shapes that straddle the 8-byte boundary. Worth calling out one case, because my first draft of these tests **missed a real bug**: an off-by-one in the escalated scan only changes the parse when a numeric run is exactly nine digits *and* is closed by a bracket rather than a comma *and* sits inside a container element (scalars at the top level never route through this code). Verified by reintroducing that off-by-one and watching six assertions fail.

`glz::find_first_of` is also covered directly: chunk boundaries at bytes 7/8, multiple matches in one chunk resolving to the earliest, sub-chunk inputs, and a match just past `end` that must not be seen.

Full suite: **108/108**, plus ASAN + UBSAN clean.


---

## Update after adversarial review

Three findings, all addressed.

### 1. A structural coupling that nothing enforced

The escalated scan's character set must equal exactly the bytes `lazy_char_class` treats as structural — and **that equality is the entire correctness argument for escalating**. The two lived in different headers with nothing tying them together.

Review confirmed the gap was real, not theoretical: dropping `'"'`, `'['` or `'{'` from the set left **all 517 assertions passing** while silently miscounting depth:

```
{"a":[[1234567890123,"x]]]y"],9]}
  correct   -> [1234567890123,"x]]]y"]|9|
  drop '"'  -> [1234567890123,"x]|          <- ran into the string, ate its ']'
```

My test shapes all put long numeric runs before a *closing* bracket, so none of them could distinguish this.

Rather than only adding a test, the scan is now expanded from the same constant a `static_assert` checks against `lazy_char_class`, so **a mismatch fails to compile**:

```
include/glaze/json/lazy.hpp:86:21: error: static assertion failed
  "the wide-number escalation set must match lazy_char_class's structural bytes"
```

A test shape covering all three cases is added as well (a long run before a string carrying `]` and `}`, before a nested array, and before a nested object).

### 2. Pointer-overflow UB in `find_first_of`

`while (p + 8 <= end)` forms a pointer more than one-past-the-end for short ranges, and is diagnosable UB on a null range:

```
include/glaze/util/parse.hpp:564: runtime error: applying non-zero offset 8 to null pointer
```

Not reachable from `skip_number_lazy` today (the depth loops guard `p >= end` first), but this is published in `glz::` as a reusable primitive and the next caller may not be so lucky. Changed to `end - p >= 8`, which is well defined for every case including two null pointers. Verified clean under `-fsanitize=undefined,pointer-overflow`.

### 3. The documented cost was too narrow

I had written "−2% to −6% elsewhere". That understated it. Re-measured, the two numeric shapes point in **opposite** directions and that is the thing worth knowing:

| document shape | option off | option on | |
|---|---:|---:|---|
| long numeric runs, **array cells** | 904 MB/s | 1231 MB/s | **+36%** |
| long numeric, **object-keyed** | 521 MB/s | 479 MB/s | **−8%** |
| short numeric cells | 380 MB/s | 380 MB/s | ±0% |
| tiny objects | 314 MB/s | 310 MB/s | −1% |
| long strings | 1877 MB/s | 1884 MB/s | ±0% |
| telemetry records | 485 MB/s | 478 MB/s | −1% |
| nested mixed | 356 MB/s | 340 MB/s | −4% |

Long numbers as *array cells* win big because the escalated scan sweeps past the commas and following cells in one go. Long numbers as *object values* lose, because each run ends a few bytes later at the next key's `"` and the scan never amortizes. An independent measurement on a different traversal put that case as bad as −19%, so the docs now say to treat roughly −20% as the worst case and to enable this for array-shaped numeric data specifically.

### Also confirmed by review, no change needed

- `find_first_of` survived brute-force differential testing against a naive byte loop: every length 0-40 × all 256 byte values × a match at every position, 400k randomized buffers, and an exhaustive pass over the adversarial alphabet that stresses `has_zero`'s borrow chain. Zero mismatches.
- High-bit bytes (0x80-0xFF, UTF-8 continuations) are safe: `has_zero` can set a false bit, but always at a *higher* index than the true match, and `countr_zero` takes the lowest.
- The big-endian path is correct, verified by emulating the BE branch against the naive loop.
- The escalation is semantically neutral — 300k+ randomized differential traversals, plus 200k generated documents across four option combinations, all agreeing, ASan/UBSan clean.
- The outer/inner `skip_value_lazy` asymmetry is correct and is test-protected: making the outer scalar path escalate too is killed by 8 assertions.
- **"Option off is identical to base" is a compile-time fact, not a measurement** — the same benchmark compiled against base and PR headers produces byte-identical machine code.

Also noted in `opts.hpp`: the option is a silent no-op unless `null_terminated` is also false.