### PR TITLE
Keep the lazy view writers inside their own buffer

### DIFF
--- a/docs/lazy-beve.md
+++ b/docs/lazy-beve.md
@@ -500,6 +500,21 @@ auto user_bytes = (*result)["user"].raw_beve();
 
 > **Note**: For deserialization, use `glz::read_beve(value, view)` instead of `glz::read_beve(value, view.raw_beve())` for better performance.
 
+## Writing Lazy Views
+
+Lazy views can be written back to BEVE:
+
+```cpp
+auto result = glz::lazy_beve(buffer);
+auto address = (*result)["address"];
+
+std::string output;
+auto ec = glz::write_beve(address, output);
+// output holds the BEVE encoding of just the "address" member
+```
+
+The bytes written are the same bytes `raw_beve()` returns, so writing a view copies the original encoding rather than re-encoding it. A view with no data writes BEVE null (the single tag byte `0`).
+
 ## Best Practices
 
 1. **Access keys in document order**: This is the most important optimization. Sequential access gives O(n) total complexity.

--- a/docs/lazy-json.md
+++ b/docs/lazy-json.md
@@ -622,6 +622,12 @@ auto ec = glz::write_json(user, output);
 // output contains the JSON for just the "user" field
 ```
 
+The bytes written are the same bytes `raw_json()` returns, so writing a view is a copy of the original text rather than a re-serialization: formatting, key order, and number spelling are all preserved exactly.
+
+The writer determines the value's extent under the *document's* options, which means a view over a buffer opened with `null_terminated = false` stays inside that buffer. It reports an error rather than writing anything if the value is truncated: a container that never reaches its closing bracket, or a string that never reaches its closing quote. A scalar that runs to the last byte of the document is complete, not truncated, and is written normally.
+
+Like the rest of the lazy API, the writer does not validate scalars. A malformed literal is copied through as-is, exactly as `raw_json()` would return it.
+
 ## Options
 
 Use compile-time options for non-null-terminated buffers:

--- a/include/glaze/beve/lazy.hpp
+++ b/include/glaze/beve/lazy.hpp
@@ -1270,13 +1270,13 @@ namespace glz
          }
          if (!view.data()) {
             // Write null
-            dump_type<tag::null>(b, ix);
+            dump_type(ctx, uint8_t{tag::null}, b, ix);
             return;
          }
 
          auto it = view.data();
          context parse_ctx{};
-         skip_value<BEVE>::op<opts{}>(parse_ctx, it, view.beve_end());
+         skip_value<BEVE>::op<Opts>(parse_ctx, it, view.beve_end());
          if (bool(parse_ctx.error)) [[unlikely]] {
             ctx.error = parse_ctx.error;
             return;

--- a/include/glaze/json/lazy.hpp
+++ b/include/glaze/json/lazy.hpp
@@ -168,6 +168,20 @@ namespace glz
          return p;
       }
 
+      // skip_value stops a scalar on the byte that follows it, so a scalar occupying the tail of
+      // a document reports unexpected_end: it runs out of buffer (bounded) or reaches the '\0'
+      // sentinel (null-terminated) with nothing left to look at. Nothing is truncated at the
+      // document edge, so that report is spurious and the value is complete -- the same
+      // situation finalize_read_context settles for readers that land there.
+      //
+      // Containers and strings are deliberately excluded. Each carries its own terminator, so
+      // reaching the edge without one is genuine truncation and must stay an error.
+      [[nodiscard]] inline bool lazy_scalar_reaches_end(const char lead, const error_code ec, const char* it,
+                                                        const char* end) noexcept
+      {
+         return ec == error_code::unexpected_end && it == end && lead != '{' && lead != '[' && lead != '"';
+      }
+
       // Skip any JSON value - optimized container skip
       // Returns pointer after the value
       template <auto Opts>
@@ -1402,7 +1416,7 @@ namespace glz
          }
          auto it = data_;
          context ctx{};
-         skip_value<JSON>::op<opts{}>(ctx, it, end);
+         skip_value<JSON>::op<Opts>(ctx, it, end);
          if (bool(ctx.error)) {
             return unexpected(error_ctx{0, ctx.error});
          }
@@ -1500,15 +1514,35 @@ namespace glz
             return;
          }
 
+         const char* const view_end = view.json_end();
          auto it = view.data();
          context parse_ctx{};
-         skip_value<JSON>::op<opts{}>(parse_ctx, it, view.json_end());
+         // Skip under the document's own options, not a default-constructed set. `opts{}` has
+         // null_terminated = true, so a view over a buffer without a '\0' sentinel would scan
+         // past json_end() looking for one and copy out-of-window bytes into the output.
+         skip_value<JSON>::op<Opts>(parse_ctx, it, view_end);
          if (bool(parse_ctx.error)) [[unlikely]] {
-            ctx.error = parse_ctx.error;
-            return;
+            if (!detail::lazy_scalar_reaches_end(*view.data(), parse_ctx.error, it, view_end)) {
+               ctx.error = parse_ctx.error;
+               return;
+            }
+            // Complete after all: trim the run of whitespace skip_value walked into so the
+            // written bytes match raw_json() exactly.
+            while (it > view.data() && whitespace_table[uint8_t(it[-1])]) {
+               --it;
+            }
          }
 
          const size_t n = static_cast<size_t>(it - view.data());
+         if (n == 0) [[unlikely]] {
+            // No JSON value is zero bytes. skip_value consumes nothing when the view is not on a
+            // value at all, which navigation can produce on malformed input: looking up "a" in
+            // {"a":} leaves the view on the closing brace. Writing nothing while reporting
+            // success would splice invalid JSON into the caller's buffer, so refuse.
+            ctx.error = error_code::syntax_error;
+            return;
+         }
+
          if constexpr (resizable<B>) {
             if (ix + n > b.size()) [[unlikely]] {
                b.resize((std::max)(b.size() * 2, ix + n));

--- a/tests/beve_test/lazy_beve_test.cpp
+++ b/tests/beve_test/lazy_beve_test.cpp
@@ -1250,4 +1250,84 @@ suite lazy_beve_derived_opts_tests = [] {
    };
 };
 
+// glz::write_beve on a lazy BEVE view did not compile: the null branch called
+// dump_type<tag::null>(b, ix), and dump_type takes its value as a function argument rather than
+// a template parameter. Nothing in the suite instantiated the writer, so the whole public path
+// stayed broken. These tests exist to instantiate it.
+suite lazy_beve_writer_tests = [] {
+   "write_beve_round_trips_a_lazy_view"_test = [] {
+      std::string buffer{};
+      const lazy_beve_test::User user{"Alice", 30, true};
+      expect(not glz::write_beve(user, buffer));
+
+      auto doc = glz::lazy_beve<glz::opts{.format = glz::BEVE}>(buffer);
+      expect(doc.has_value());
+      if (not doc) return;
+
+      std::string out{};
+      expect(not glz::write_beve(doc->root(), out));
+      expect(out == buffer) << "rewrote " << out.size() << " of " << buffer.size() << " bytes";
+
+      // The rewritten bytes have to be BEVE a reader still accepts, not merely equal-length.
+      lazy_beve_test::User restored{};
+      expect(not glz::read_beve(restored, out));
+      expect(restored.name == user.name);
+      expect(restored.age == user.age);
+      expect(restored.active == user.active);
+   };
+
+   "write_beve_empty_view_writes_the_null_tag"_test = [] {
+      // The branch that failed to compile. A view with no data writes BEVE null, which is the
+      // single tag byte 0, and a reader has to accept it as such.
+      glz::lazy_beve_view<glz::opts{.format = glz::BEVE}> empty{};
+      expect(not empty.has_error());
+      expect(empty.data() == nullptr);
+
+      std::string out{};
+      expect(not glz::write_beve(empty, out));
+      expect(out.size() == 1u) << out.size();
+      expect(out == std::string(1, '\0'));
+
+      std::optional<int> restored{42};
+      expect(not glz::read_beve(restored, out));
+      expect(not restored.has_value());
+   };
+
+   "write_beve_nested_view_stops_at_its_own_end"_test = [] {
+      // A member view's beve_end() is the whole document's end, so writing one must emit that
+      // member alone rather than everything that follows it.
+      std::string buffer{};
+      const lazy_beve_test::Person person{"Bob", {"Paris", "France"}};
+      expect(not glz::write_beve(person, buffer));
+
+      auto doc = glz::lazy_beve<glz::opts{.format = glz::BEVE}>(buffer);
+      expect(doc.has_value());
+      if (not doc) return;
+
+      std::string out{};
+      expect(not glz::write_beve((*doc)["address"], out));
+      expect(out.size() < buffer.size());
+
+      lazy_beve_test::Address restored{};
+      expect(not glz::read_beve(restored, out));
+      expect(restored.city == person.address.city);
+      expect(restored.country == person.address.country);
+   };
+
+   "write_beve_respects_derived_opts"_test = [] {
+      // Instantiating the writer on a derived option struct has to compile too; the skip inside
+      // it used a default-constructed opts{}, which sliced the pack away.
+      std::string buffer{};
+      expect(not glz::write_beve(lazy_beve_test::User{"Carol", 41, false}, buffer));
+
+      auto doc = glz::lazy_beve<derived_beve_opts>(buffer);
+      expect(doc.has_value());
+      if (not doc) return;
+
+      std::string out{};
+      expect(not glz::write_beve(doc->root(), out));
+      expect(out == buffer);
+   };
+};
+
 int main() { return 0; }

--- a/tests/json_test/lazy_test.cpp
+++ b/tests/json_test/lazy_test.cpp
@@ -2,6 +2,8 @@
 // For the license information refer to glaze.hpp
 
 #include <concepts>
+#include <utility>
+#include <vector>
 
 #include "glaze/json.hpp"
 #include "ut/ut.hpp"
@@ -2211,6 +2213,213 @@ suite lazy_wide_number_skip_tests = [] {
       const auto on = traverse_raw<wide_num_on>(json);
       const auto off = traverse_raw<wide_num_off>(json);
       expect(on == off);
+   };
+};
+
+// The shapes every writer test runs over. Each string is a complete document, so writing its
+// root must reproduce it byte for byte.
+inline const std::vector<std::string> writer_shapes{
+   R"({"a":1,"b":2})",
+   R"({"rows":[{"id":1,"tags":["x","y"]},{"id":2,"tags":[]}]})",
+   R"([1,2,3])",
+   R"([])",
+   R"({})",
+   R"([[[1]]])",
+   R"({"s":"has \"escapes\" and \\ backslashes"})",
+   R"("plain string")",
+   R"(1234567890123)",
+   R"(-4.25e-11)",
+   R"(true)",
+   R"(false)",
+   R"(null)",
+   R"(0)",
+};
+
+// validate_skipped routes skip_value down its validating path, which the writer must not
+// undermine when it settles a scalar sitting at the document edge.
+struct validating_bounded_opts : glz::opts
+{
+   bool null_terminated = false;
+   bool validate_skipped = true;
+};
+
+inline constexpr validating_bounded_opts validating_bounded{};
+
+// A document held in an exactly-sized heap allocation: no '\0' sentinel, and a sanitizer
+// redzone immediately after the last byte. Any read past json_end() trips ASAN here, which is
+// what makes these tests a memory-safety guard rather than only a behavior check.
+struct exact_buffer
+{
+   std::vector<char> bytes{};
+
+   explicit exact_buffer(std::string_view doc, std::string_view trailing = {})
+   {
+      bytes.reserve(doc.size() + trailing.size());
+      bytes.insert(bytes.end(), doc.begin(), doc.end());
+      bytes.insert(bytes.end(), trailing.begin(), trailing.end());
+      bytes.shrink_to_fit();
+   }
+
+   // Deliberately excludes `trailing`: the writer must never reach past this.
+   [[nodiscard]] std::string_view window(size_t n) const { return {bytes.data(), n}; }
+};
+
+suite lazy_writer_bounds_tests = [] {
+   "write_bounded_stays_inside_the_window"_test = [] {
+      // The regression this suite exists for: the writer skipped with a default-constructed
+      // `opts{}`, whose null_terminated = true made it scan past json_end() for a sentinel that
+      // a bounded buffer does not have. Scalars were the reachable case -- `42` was written out
+      // as `429187` when those digits happened to follow in memory.
+      for (const auto& doc : writer_shapes) {
+         const exact_buffer buf{doc, "9187SECRET_TOKEN"};
+         auto d = glz::lazy_json<cursor_off_bounded>(buf.window(doc.size()));
+         expect(d.has_value()) << doc;
+         if (not d) continue;
+
+         std::string out{};
+         expect(not glz::write_json(d->root(), out)) << doc;
+         expect(out == doc) << doc << " wrote " << out;
+      }
+   };
+
+   "write_bounded_matches_null_terminated"_test = [] {
+      // Bounded and null-terminated documents describe the same value, so the writer must not
+      // be able to tell them apart. This is the property that keeps the two skip paths honest.
+      for (const auto& doc : writer_shapes) {
+         const exact_buffer buf{doc};
+
+         std::string bounded_out{};
+         auto bounded_doc = glz::lazy_json<cursor_off_bounded>(buf.window(doc.size()));
+         expect(bounded_doc.has_value()) << doc;
+         const auto bounded_ec = glz::write_json(bounded_doc->root(), bounded_out);
+
+         std::string terminated_out{};
+         auto terminated_doc = glz::lazy_json<glz::opts{}>(doc);
+         expect(terminated_doc.has_value()) << doc;
+         const auto terminated_ec = glz::write_json(terminated_doc->root(), terminated_out);
+
+         expect(bounded_ec.ec == terminated_ec.ec) << doc;
+         expect(bounded_out == terminated_out) << doc;
+      }
+   };
+
+   "write_matches_raw_json"_test = [] {
+      // raw_json() and the writer are two implementations of "the bytes of this value". They
+      // are reached through different skips, so they are only equal if both agree on the extent
+      // -- including for a scalar sitting at the very end of the buffer.
+      for (const auto& doc : writer_shapes) {
+         const exact_buffer buf{doc};
+         auto d = glz::lazy_json<cursor_off_bounded>(buf.window(doc.size()));
+         expect(d.has_value()) << doc;
+         if (not d) continue;
+
+         std::string out{};
+         expect(not glz::write_json(d->root(), out)) << doc;
+         expect(out == d->root().raw_json()) << doc;
+      }
+   };
+
+   "write_nested_view_stops_at_its_own_end"_test = [] {
+      // A nested view's json_end() is the whole document's end, so an element that over-skips
+      // swallows its siblings instead of running off the buffer. Bounded and terminated modes
+      // must both stop at the element.
+      const std::string doc = R"({"a":[1,2],"b":"tail","c":{"d":3},"e":42})";
+      const exact_buffer buf{doc};
+
+      auto check = [&]<auto Opts>(std::string_view json) {
+         auto d = glz::lazy_json<Opts>(json);
+         expect(d.has_value());
+         if (not d) return;
+         const std::vector<std::pair<const char*, const char*>> expected{
+            {"a", "[1,2]"}, {"b", R"("tail")"}, {"c", R"({"d":3})"}, {"e", "42"}};
+         for (const auto& [key, want] : expected) {
+            std::string out{};
+            expect(not glz::write_json((*d)[key], out)) << key;
+            expect(out == want) << key << " wrote " << out;
+         }
+      };
+
+      check.template operator()<cursor_off_bounded>(buf.window(doc.size()));
+      check.template operator()<glz::opts{}>(doc);
+   };
+
+   "write_truncated_container_still_errors"_test = [] {
+      // Settling a scalar at the document edge must not settle a container or string that never
+      // reached its terminator: those are genuinely truncated and the writer has to say so.
+      const std::vector<std::string> truncated{
+         R"({"a":1)", R"([1,2)", R"("unterminated)", R"({"a":[1,)", R"([{"a")",
+      };
+
+      for (const auto& doc : truncated) {
+         const exact_buffer buf{doc, "SECRET_TOKEN"};
+         auto d = glz::lazy_json<cursor_off_bounded>(buf.window(doc.size()));
+         if (not d) continue; // rejected at construction is also a refusal
+         std::string out{};
+         expect(bool(glz::write_json(d->root(), out).ec)) << doc << " wrote " << out;
+      }
+   };
+
+   "write_never_succeeds_without_writing"_test = [] {
+      // Navigation to a key with no value leaves the view on the closing brace, where the skip
+      // consumes nothing. Emitting zero bytes and reporting success would splice invalid JSON
+      // into whatever the caller is building, so the writer has to refuse.
+      const std::string doc = R"({"a":})";
+      const exact_buffer buf{doc};
+
+      auto check = [&]<auto Opts>(std::string_view json) {
+         auto d = glz::lazy_json<Opts>(json);
+         if (not d) return; // rejecting the document outright is also a refusal
+         std::string out{};
+         const auto ec = glz::write_json((*d)["a"], out);
+         // Reporting success here is the failure mode: glz::write only truncates the buffer to
+         // the bytes written once the write succeeds, so a zero-byte success is an empty value
+         // the caller would go on to treat as JSON.
+         expect(bool(ec.ec));
+         expect(ec.ec != glz::error_code::none);
+      };
+
+      check.template operator()<cursor_off_bounded>(buf.window(doc.size()));
+      check.template operator()<glz::opts{}>(doc);
+   };
+
+   "write_settle_does_not_weaken_validate_skipped"_test = [] {
+      // The settle keys off unexpected_end, which is what skip_value reports when it simply runs
+      // out of bytes. A caller who opted into validate_skipped gets syntax_error for a malformed
+      // scalar instead, so the settle never sees it and their validation still holds.
+      // Only inputs the validating skip actually rejects. "01" is not one of them: skip_number
+      // stops cleanly after the leading zero, so the view is a complete "0" with trailing bytes
+      // the lazy API never claims to check.
+      const std::vector<std::string> malformed{"1.2e", "tru", "nul", "+5"};
+      for (const auto& doc : malformed) {
+         const exact_buffer buf{doc};
+         auto d = glz::lazy_json<validating_bounded>(buf.window(doc.size()));
+         if (not d) continue;
+         std::string out{};
+         expect(bool(glz::write_json(d->root(), out).ec)) << doc << " wrote " << out;
+      }
+
+      // Well-formed scalars at the document edge still write under the same options.
+      for (const auto& doc : {std::string{"42"}, std::string{"true"}, std::string{"-4.25e-11"}}) {
+         const exact_buffer buf{doc};
+         auto d = glz::lazy_json<validating_bounded>(buf.window(doc.size()));
+         expect(d.has_value()) << doc;
+         if (not d) continue;
+         std::string out{};
+         expect(not glz::write_json(d->root(), out)) << doc;
+         expect(out == doc) << doc << " wrote " << out;
+      }
+   };
+
+   "write_respects_derived_opts"_test = [] {
+      // The writer skips under the document's own options. Instantiating on a derived struct
+      // must compile and behave, which it cannot if the option pack is sliced back to glz::opts.
+      const std::string doc = R"({"a":[1,2,3]})";
+      const exact_buffer buf{doc};
+      auto d = glz::lazy_json<cursor_on_bounded>(buf.window(doc.size()));
+      expect(d.has_value());
+      std::string out{};
+      expect(not glz::write_json(d->root(), out));
+      expect(out == doc) << out;
    };
 };
 


### PR DESCRIPTION
Three defects in the lazy view writers, one of them a memory-safety bug.

## 1. `write_json` read past the end of a bounded buffer

`to<JSON, lazy_json_view<Opts>>::op` found the value's extent with `skip_value<JSON>::op<opts{}>`. A default-constructed `opts` has `null_terminated = true`, so on a document opened with `null_terminated = false` the skip ignored `json_end()` and scanned for a `'\0'` sentinel the buffer does not have.

Scalars were the reachable case. Writing a lazy view of the two-byte document `42` walked past the end and emitted whatever digits happened to follow in memory:

```cpp
struct bounded_opts : glz::opts { bool null_terminated = false; };

// A 2-byte heap allocation holding "42", with no NUL.
auto d = glz::lazy_json<bounded_opts{}>(std::string_view{buf, 2});
std::string out;
auto ec = glz::write_json(d->root(), out);
// out == "429187", ec.ec == error_code::none
```

ASAN reports this as a heap-buffer-overflow read inside `skip_value`. The skip now runs under the document's own options and stops at `json_end()`.

## 2. Writing a root scalar failed in *both* modes

Bounding the skip surfaced a second defect underneath it. `skip_value` stops a scalar on the byte that follows it, so a scalar occupying the tail of a document reports `unexpected_end` — it runs out of buffer, or reaches the `'\0'`, with nothing left to look at. Checking against the null-terminated path showed the same failure there, so this never worked in either mode:

```cpp
glz::write_json(view_of("42"))    // error_code::unexpected_end
glz::write_json(view_of("true"))  // error_code::unexpected_end
glz::write_json(view_of("null"))  // error_code::unexpected_end
```

Nothing is truncated at the document edge, so the report is spurious. `lazy_scalar_reaches_end` settles it the way `finalize_read_context` settles a reader that lands there. Containers and strings are excluded: each carries its own terminator, so reaching the edge without one is genuine truncation and still errors.

The settle keys off `unexpected_end` specifically, which is what `skip_value` reports when it simply runs out of bytes. A caller who opted into `validate_skipped` gets `syntax_error` for a malformed scalar instead, so their validation is untouched — there is a test pinning that.

## 3. Success while writing nothing

Navigating to a key whose value is missing (`{"a":}`) leaves the view on the closing brace, where the skip consumes zero bytes. `glz::write` only truncates the buffer to the bytes written once the write succeeds, so this handed the caller an empty value to go on and treat as JSON. No JSON value is zero bytes, so it is now a `syntax_error`.

## 4. `write_beve` on a lazy BEVE view did not compile

`to<BEVE, lazy_beve_view<Opts>>::op` called `dump_type<tag::null>(b, ix)`, but `dump_type` takes its value as a function argument rather than a template parameter. Nothing in the suite instantiated the writer, so the whole public path was broken:

```
error: no matching function for call to 'dump_type'
```

Fixed, and the suite now instantiates it. Both lazy writers also skip under `Opts` rather than a sliced `opts{}`, matching the rest of the lazy API after #2744.

## Testing

Tests hold each document in an exactly-sized heap allocation, which gives ASAN a redzone immediately after the last byte — that is what makes them a memory-safety guard rather than only a behavior check. Three properties are asserted over a shared set of shapes: the written bytes equal the document, they equal `raw_json()`, and they equal what the same document produces null-terminated.

Each fix was verified load-bearing by reintroducing it:

| reintroduced | caught by |
|---|---|
| hardcoded `opts{}` | ASAN in `write_bounded_stays_inside_the_window` |
| settle removed | `write_matches_raw_json`, 24 assertions |
| settle widened to containers | `write_truncated_container_still_errors` |
| zero-byte guard removed | `write_never_succeeds_without_writing` |
| original `dump_type` call | fails to compile |

Full suite: 116/116 passing under ASAN/UBSAN, 0 build errors.

## Note on scope

`glz::lazy_json_view::get<std::string>()` had the same hardcoded `opts{}`. It is not reachable as an overrun — the string skip is bounded either way, verified under ASAN — but it is the same latent hazard and is parameterized here for consistency.
