### PR TITLE
Report which SIMD backend each subsystem compiled to

### DIFF
--- a/.github/workflows/simd-backends.yml
+++ b/.github/workflows/simd-backends.yml
@@ -42,14 +42,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # expect_isa and expect differ on the baseline: SSE2 has no byte-granular shuffle, so the
+          # validator falls back to scalar while the rest of Glaze still uses its SSE2 paths.
           - name: x86-64 SSE2 baseline (scalar fallback)
             flags: "-mno-ssse3"
+            expect_isa: SSE2
             expect: scalar
           - name: x86-64 SSSE3
             flags: "-mssse3 -mno-avx"
+            expect_isa: SSSE3
             expect: SSSE3
           - name: x86-64 AVX2
             flags: "-mavx2"
+            expect_isa: AVX2
             expect: AVX2
 
     steps:
@@ -57,25 +62,22 @@ jobs:
 
       - name: Confirm the intended backend was selected
         run: |
+          # Reads the library's own constants rather than restating its #if chain, so this cannot
+          # drift from what Glaze actually compiled. utf8_validation_test asserts the constants
+          # against the register width the selected backend defines, which is what keeps this from
+          # being a string the workflow reads back to itself.
           cat > /tmp/backend.cpp << 'EOF'
           #include "glaze/simd/utf8_validation.hpp"
-          #include <cstdio>
-          int main() {
-          #if defined(GLZ_USE_AVX512BW)
-            std::puts("AVX512BW");
-          #elif defined(GLZ_USE_AVX2)
-            std::puts("AVX2");
-          #elif defined(GLZ_USE_SSSE3)
-            std::puts("SSSE3");
-          #else
-            std::puts("scalar");
-          #endif
-            return 0;
-          }
+          #include <iostream>
+          int main() { std::cout << glz::simd_isa << ' ' << glz::utf8_validation_backend << '\n'; }
           EOF
           g++ -std=c++23 ${{ matrix.flags }} -I include /tmp/backend.cpp -o /tmp/backend
-          got=$(/tmp/backend)
-          echo "selected backend: $got (expected ${{ matrix.expect }})"
+          out=$(/tmp/backend)
+          got_isa=${out%% *}
+          got=${out##* }
+          echo "simd_isa: $got_isa (expected ${{ matrix.expect_isa }})"
+          echo "utf8 backend: $got (expected ${{ matrix.expect }})"
+          test "$got_isa" = "${{ matrix.expect_isa }}"
           test "$got" = "${{ matrix.expect }}"
 
       - name: Configure
@@ -137,15 +139,10 @@ jobs:
         run: |
           cat > /tmp/backend.cpp << 'EOF'
           #include "glaze/simd/utf8_validation.hpp"
-          #include <cstdio>
+          #include <iostream>
           int main() {
-          #if defined(GLZ_USE_AVX512BW)
-            std::printf("AVX512BW width=%zu\n", glz::detail::utf8_simd::width);
-            return 0;
-          #else
-            std::puts("WRONG BACKEND");
-            return 1;
-          #endif
+            std::cout << glz::simd_isa << ' ' << glz::utf8_validation_backend << '\n';
+            return (glz::simd_isa == "AVX512BW" && glz::utf8_validation_backend == "AVX512BW") ? 0 : 1;
           }
           EOF
           g++ -std=c++23 -mavx512f -mavx512bw -mavx512vl -I include /tmp/backend.cpp -o /tmp/backend
@@ -208,17 +205,10 @@ jobs:
           git clone --depth 1 --branch v1.1.0 https://github.com/openalgz/ut /tmp/ut
           cat > /tmp/backend.cpp << 'EOF'
           #include "glaze/simd/utf8_validation.hpp"
-          #include <cstdio>
-          int main() {
-          #if defined(GLZ_USE_WASM_SIMD128)
-            std::puts("SIMD128");
-          #else
-            std::puts("scalar");
-          #endif
-            return 0;
-          }
+          #include <iostream>
+          int main() { std::cout << glz::utf8_validation_backend << '\n'; }
           EOF
-          for cfg in "-msimd128:SIMD128" ":scalar"; do
+          for cfg in "-msimd128:WASM_SIMD128" ":scalar"; do
             flags="${cfg%%:*}"; label="${cfg##*:}"
             echo "::group::WASM $label"
             # Assert the backend before testing it, so a toolchain change that quietly drops SIMD128
@@ -251,27 +241,20 @@ jobs:
           git clone --depth 1 --branch v1.1.0 https://github.com/openalgz/ut /tmp/ut
           cat > /tmp/backend.cpp << 'EOF'
           #include "glaze/simd/utf8_validation.hpp"
-          #include <cstdio>
-          int main() {
-          #if defined(GLZ_UTF8_SIMD)
-            std::printf("%zu\n", glz::detail::utf8_simd::width);
-            return 0;
-          #else
-            std::puts("scalar");
-            return 1;
-          #endif
-          }
+          #include <iostream>
+          int main() { std::cout << glz::utf8_validation_backend << '\n'; }
           EOF
           for w in 16 32 64; do
             echo "::group::generic width $w"
-            # This runner is x86-64 with no -m flags, so the baseline is SSE2 and no native backend
-            # is selected. Assert the portable backend really is active at the requested width:
-            # otherwise the vector path compiles away and all three widths silently test the scalar
-            # validator against itself.
+            # Assert the portable backend really is active at the requested width: otherwise the
+            # vector path compiles away and all three widths silently test the scalar validator
+            # against itself. The name is checked rather than the width alone, because width does
+            # not identify a backend -- AVX2 and generic32 are both 32, so a runner that happened to
+            # enable AVX2 would satisfy a width-only check for w=32 without running portable code.
             g++ -std=c++23 -DGLZ_UTF8_GENERIC_WIDTH=$w -I include /tmp/backend.cpp -o /tmp/backend
             got=$(/tmp/backend)
-            echo "active width: $got (expected $w)"
-            test "$got" = "$w"
+            echo "active backend: $got (expected generic$w)"
+            test "$got" = "generic$w"
             g++ -std=c++23 -O2 -DGLZ_UTF8_GENERIC_WIDTH=$w \
               -I include -I /tmp/ut/include \
               tests/json_test/utf8_validation_test.cpp -o /tmp/utf8_generic_$w

--- a/.github/workflows/simd-backends.yml
+++ b/.github/workflows/simd-backends.yml
@@ -62,14 +62,15 @@ jobs:
 
       - name: Confirm the intended backend was selected
         run: |
-          # Reads the library's own constants rather than restating its #if chain, so this cannot
-          # drift from what Glaze actually compiled. utf8_validation_test asserts the constants
-          # against the register width the selected backend defines, which is what keeps this from
-          # being a string the workflow reads back to itself.
+          # Reads the library's own names rather than restating its #if chain, so this cannot drift
+          # from what Glaze actually compiled. glz::simd_isa is public; the validator's own name is
+          # internal, which is fine to reach for from Glaze's own workflow. utf8_validation_test
+          # asserts both against the register width the selected backend defines, which is what
+          # keeps this from being a string the workflow reads back to itself.
           cat > /tmp/backend.cpp << 'EOF'
           #include "glaze/simd/utf8_validation.hpp"
           #include <iostream>
-          int main() { std::cout << glz::simd_isa << ' ' << glz::utf8_validation_backend << '\n'; }
+          int main() { std::cout << glz::simd_isa << ' ' << glz::detail::utf8_simd::backend << '\n'; }
           EOF
           g++ -std=c++23 ${{ matrix.flags }} -I include /tmp/backend.cpp -o /tmp/backend
           out=$(/tmp/backend)
@@ -141,8 +142,8 @@ jobs:
           #include "glaze/simd/utf8_validation.hpp"
           #include <iostream>
           int main() {
-            std::cout << glz::simd_isa << ' ' << glz::utf8_validation_backend << '\n';
-            return (glz::simd_isa == "AVX512BW" && glz::utf8_validation_backend == "AVX512BW") ? 0 : 1;
+            std::cout << glz::simd_isa << ' ' << glz::detail::utf8_simd::backend << '\n';
+            return (glz::simd_isa == "AVX512BW" && glz::detail::utf8_simd::backend == "AVX512BW") ? 0 : 1;
           }
           EOF
           g++ -std=c++23 -mavx512f -mavx512bw -mavx512vl -I include /tmp/backend.cpp -o /tmp/backend
@@ -206,7 +207,7 @@ jobs:
           cat > /tmp/backend.cpp << 'EOF'
           #include "glaze/simd/utf8_validation.hpp"
           #include <iostream>
-          int main() { std::cout << glz::utf8_validation_backend << '\n'; }
+          int main() { std::cout << glz::detail::utf8_simd::backend << '\n'; }
           EOF
           for cfg in "-msimd128:WASM_SIMD128" ":scalar"; do
             flags="${cfg%%:*}"; label="${cfg##*:}"
@@ -242,7 +243,7 @@ jobs:
           cat > /tmp/backend.cpp << 'EOF'
           #include "glaze/simd/utf8_validation.hpp"
           #include <iostream>
-          int main() { std::cout << glz::utf8_validation_backend << '\n'; }
+          int main() { std::cout << glz::detail::utf8_simd::backend << '\n'; }
           EOF
           for w in 16 32 64; do
             echo "::group::generic width $w"

--- a/.github/workflows/simd-backends.yml
+++ b/.github/workflows/simd-backends.yml
@@ -42,52 +42,38 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # "detected utf8_validation string_escape". The three columns differ on purpose, which is
-          # the point of asserting all of them: SSE2 has no byte-granular shuffle so the validator
-          # falls back to scalar, and there is no SSSE3 escape helper so SSSE3 escapes with SSE2.
+          # The three expectations differ on purpose, which is the point of pinning all of them:
+          # SSE2 has no byte-granular shuffle so the validator falls back to scalar, and there is no
+          # SSSE3 escape helper so SSSE3 escapes with SSE2.
+          #
+          # `expect` is appended to the same CMAKE_CXX_FLAGS as `flags`, so the assertion is
+          # compiled into the suite by the very flags under test. Dropping the flags cannot leave a
+          # green job testing the host default: the expectation goes with them.
           - name: x86-64 SSE2 baseline (scalar fallback)
             flags: "-mno-ssse3"
-            expect: "SSE2 scalar SSE2"
+            expect: "-DGLZ_EXPECT_DETECTED=SSE2 -DGLZ_EXPECT_UTF8_VALIDATION=scalar -DGLZ_EXPECT_STRING_ESCAPE=SSE2"
           - name: x86-64 SSSE3
             flags: "-mssse3 -mno-avx"
-            expect: "SSSE3 SSSE3 SSE2"
+            expect: "-DGLZ_EXPECT_DETECTED=SSSE3 -DGLZ_EXPECT_UTF8_VALIDATION=SSSE3 -DGLZ_EXPECT_STRING_ESCAPE=SSE2"
           - name: x86-64 AVX2
             flags: "-mavx2"
-            expect: "AVX2 AVX2 AVX2"
+            expect: "-DGLZ_EXPECT_DETECTED=AVX2 -DGLZ_EXPECT_UTF8_VALIDATION=AVX2 -DGLZ_EXPECT_STRING_ESCAPE=AVX2"
+          # Not a backend, but the one build where all four fields must agree that nothing is
+          # vectorized -- including float_write, which otherwise ignores Glaze's detection entirely.
+          # utf8_validation_test asserts that spanning promise, and this is what compiles it.
+          - name: No SIMD (GLZ_DISABLE_SIMD)
+            flags: "-DGLZ_DISABLE_SIMD"
+            expect: "-DGLZ_EXPECT_DETECTED=scalar -DGLZ_EXPECT_UTF8_VALIDATION=scalar -DGLZ_EXPECT_STRING_ESCAPE=SWAR"
 
     steps:
       - uses: actions/checkout@v6
-
-      - name: Confirm the intended backend was selected
-        run: |
-          set -euo pipefail
-          # Reads glz::simd_info rather than restating Glaze's #if chain, so this cannot drift from
-          # what Glaze actually compiled. utf8_validation_test anchors those names to the register
-          # width each backend branch defines and to the escape helper the write path invokes, which
-          # is what keeps this from being a string the workflow reads back to itself.
-          #
-          # Compared as one whole line on purpose. Splitting into fields lets a probe that prints
-          # fewer values than expected satisfy every field test at once.
-          cat > /tmp/backend.cpp << 'EOF'
-          #include "glaze/simd/backends.hpp"
-          #include <iostream>
-          int main() {
-            std::cout << glz::simd_info.detected << ' ' << glz::simd_info.utf8_validation << ' '
-                      << glz::simd_info.string_escape << '\n';
-          }
-          EOF
-          g++ -std=c++23 ${{ matrix.flags }} -I include /tmp/backend.cpp -o /tmp/backend
-          out=$(/tmp/backend)
-          echo "got:      $out"
-          echo "expected: ${{ matrix.expect }}"
-          test "$out" = "${{ matrix.expect }}"
 
       - name: Configure
         run: |
           cmake -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_CXX_STANDARD=23 \
-            -DCMAKE_CXX_FLAGS="${{ matrix.flags }}" \
+            -DCMAKE_CXX_FLAGS="${{ matrix.flags }} ${{ matrix.expect }}" \
             -Dglaze_BUILD_NETWORKING_TESTS=OFF \
             -Dglaze_BUILD_PERFORMANCE_TESTS=OFF \
             -Dglaze_ENABLE_FUZZING=OFF
@@ -96,7 +82,39 @@ jobs:
         run: cmake --build build -j"$(nproc)" --target utf8_validation_test json_conformance json_test
 
       - name: Test
-        run: ctest --test-dir build --output-on-failure -R "$UTF8_TESTS"
+        # --no-tests=error: ctest exits 0 when -R matches nothing, so without it a renamed test
+        # leaves this step green while running none of the suites the job exists to run.
+        run: ctest --test-dir build --output-on-failure --no-tests=error -R "$UTF8_TESTS"
+
+  arm-backends:
+    runs-on: ubuntu-24.04-arm
+    # force_sde targets the AVX-512 job, so skip the jobs a dispatch run would only repeat.
+    if: ${{ !inputs.force_sde }}
+    name: AArch64 NEON64
+    # The NEON64 backend was previously reached only incidentally, by the one macos-latest job in
+    # clang.yml. Native AArch64 runners are free for public repositories, so the backend that every
+    # Apple Silicon and most server ARM users actually run gets a job of its own here.
+    #
+    # 32 bit NEON is a different backend -- no vqtbl1q_u8, so the validator falls back to scalar --
+    # and is covered by armv7.yml under QEMU.
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Configure
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_STANDARD=23 \
+            -DCMAKE_CXX_FLAGS="-DGLZ_EXPECT_DETECTED=NEON64 -DGLZ_EXPECT_UTF8_VALIDATION=NEON64 -DGLZ_EXPECT_STRING_ESCAPE=NEON" \
+            -Dglaze_BUILD_NETWORKING_TESTS=OFF \
+            -Dglaze_BUILD_PERFORMANCE_TESTS=OFF \
+            -Dglaze_ENABLE_FUZZING=OFF
+
+      - name: Build
+        run: cmake --build build -j"$(nproc)" --target utf8_validation_test json_conformance json_test
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure --no-tests=error -R "$UTF8_TESTS"
 
   avx512:
     runs-on: ubuntu-24.04
@@ -137,34 +155,14 @@ jobs:
           /tmp/sde/sde64 -version | head -3
           echo "SDE=/tmp/sde/sde64" >> "$GITHUB_ENV"
 
-      - name: Confirm AVX-512BW backend was selected
-        run: |
-          set -euo pipefail
-          cat > /tmp/backend.cpp << 'EOF'
-          #include "glaze/simd/backends.hpp"
-          #include <iostream>
-          int main() {
-            std::cout << glz::simd_info.detected << ' ' << glz::simd_info.utf8_validation << ' '
-                      << glz::simd_info.string_escape << '\n';
-          }
-          EOF
-          g++ -std=c++23 -mavx512f -mavx512bw -mavx512vl -I include /tmp/backend.cpp -o /tmp/backend
-          # Compiled for AVX-512 but only the preprocessor result matters, so run it under SDE when
-          # the runner cannot execute AVX-512 itself. Checked in the shell rather than by the
-          # program's exit status, so a wrong answer fails here even if the emulator mishandles it.
-          if [ -n "${SDE:-}" ]; then out=$("$SDE" -future -- /tmp/backend); else out=$(/tmp/backend); fi
-          # Escaping stays AVX2: Glaze has no AVX-512 escape helper. That is the divergence a single
-          # backend name would hide, so this job is the one that pins it.
-          echo "got:      $out"
-          echo "expected: AVX512BW AVX512BW AVX2"
-          test "$out" = "AVX512BW AVX512BW AVX2"
-
       - name: Configure
+        # Escaping stays AVX2: Glaze has no AVX-512 escape helper. That divergence is the reason
+        # this job pins all three rather than just the validator.
         run: |
           cmake -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_CXX_STANDARD=23 \
-            -DCMAKE_CXX_FLAGS="-mavx512f -mavx512bw -mavx512vl" \
+            -DCMAKE_CXX_FLAGS="-mavx512f -mavx512bw -mavx512vl -DGLZ_EXPECT_DETECTED=AVX512BW -DGLZ_EXPECT_UTF8_VALIDATION=AVX512BW -DGLZ_EXPECT_STRING_ESCAPE=AVX2" \
             -Dglaze_BUILD_NETWORKING_TESTS=OFF \
             -Dglaze_BUILD_PERFORMANCE_TESTS=OFF \
             -Dglaze_ENABLE_FUZZING=OFF
@@ -174,7 +172,7 @@ jobs:
 
       - name: Test (native)
         if: steps.mode.outputs.emulator == ''
-        run: ctest --test-dir build --output-on-failure -R "$UTF8_TESTS"
+        run: ctest --test-dir build --output-on-failure --no-tests=error -R "$UTF8_TESTS"
 
       - name: Test (Intel SDE)
         if: steps.mode.outputs.emulator == 'sde'
@@ -212,21 +210,15 @@ jobs:
           set -euo pipefail
           source /tmp/emsdk/emsdk_env.sh
           git clone --depth 1 --branch v1.1.0 https://github.com/openalgz/ut /tmp/ut
-          cat > /tmp/backend.cpp << 'EOF'
-          #include "glaze/simd/backends.hpp"
-          #include <iostream>
-          int main() { std::cout << glz::simd_info.utf8_validation << '\n'; }
-          EOF
+          # Both configurations escape with SWAR: Glaze has no WASM escape helper. Pinning the
+          # backend in the same compile that builds the suite means a toolchain change that quietly
+          # drops SIMD128 fails to build, rather than running the scalar path twice and passing.
           for cfg in "-msimd128:WASM_SIMD128" ":scalar"; do
             flags="${cfg%%:*}"; label="${cfg##*:}"
             echo "::group::wasm ${label}"
-            # Assert the backend before testing it, so a toolchain change that quietly drops SIMD128
-            # fails here instead of running the scalar path twice and reporting success.
-            em++ -std=c++23 $flags -I include /tmp/backend.cpp -o /tmp/backend.js -sEXIT_RUNTIME=1
-            got=$(node /tmp/backend.js | tr -d '\r')
-            echo "selected backend: $got (expected $label)"
-            test "$got" = "$label"
             em++ -std=c++23 -O2 $flags \
+              -DGLZ_EXPECT_DETECTED=$label -DGLZ_EXPECT_UTF8_VALIDATION=$label \
+              -DGLZ_EXPECT_STRING_ESCAPE=SWAR \
               -I include -I /tmp/ut/include \
               tests/json_test/utf8_validation_test.cpp \
               -o /tmp/utf8_wasm.js -sALLOW_MEMORY_GROWTH=1 -sEXIT_RUNTIME=1 -sTOTAL_STACK=8MB
@@ -248,23 +240,17 @@ jobs:
         run: |
           set -euo pipefail
           git clone --depth 1 --branch v1.1.0 https://github.com/openalgz/ut /tmp/ut
-          cat > /tmp/backend.cpp << 'EOF'
-          #include "glaze/simd/backends.hpp"
-          #include <iostream>
-          int main() { std::cout << glz::simd_info.utf8_validation << '\n'; }
-          EOF
           for w in 16 32 64; do
             echo "::group::generic width $w"
-            # Assert the portable backend really is active at the requested width: otherwise the
-            # vector path compiles away and all three widths silently test the scalar validator
-            # against itself. Naming the backend rather than reading back the width also survives a
-            # future reordering of the selection chain, which currently puts the generic branch
-            # first and so makes a width-only check pass no matter which backend won.
-            g++ -std=c++23 -DGLZ_UTF8_GENERIC_WIDTH=$w -I include /tmp/backend.cpp -o /tmp/backend
-            got=$(/tmp/backend)
-            echo "active backend: $got (expected generic$w)"
-            test "$got" = "generic$w"
-            g++ -std=c++23 -O2 -DGLZ_UTF8_GENERIC_WIDTH=$w \
+            # Pin the portable backend, or the vector path could compile away and all three widths
+            # would silently test the scalar validator against itself. Naming the backend rather
+            # than reading back the width also survives a future reordering of the selection chain,
+            # which currently puts the generic branch first and so would make a width-only check
+            # pass no matter which backend won.
+            #
+            # Only the validator is pinned here: what the runner detects underneath the hook is not
+            # this job's to promise.
+            g++ -std=c++23 -O2 -DGLZ_UTF8_GENERIC_WIDTH=$w -DGLZ_EXPECT_UTF8_VALIDATION=generic$w \
               -I include -I /tmp/ut/include \
               tests/json_test/utf8_validation_test.cpp -o /tmp/utf8_generic_$w
             /tmp/utf8_generic_$w

--- a/.github/workflows/simd-backends.yml
+++ b/.github/workflows/simd-backends.yml
@@ -42,44 +42,45 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # expect_isa and expect differ on the baseline: SSE2 has no byte-granular shuffle, so the
-          # validator falls back to scalar while the rest of Glaze still uses its SSE2 paths.
+          # "detected utf8_validation string_escape". The three columns differ on purpose, which is
+          # the point of asserting all of them: SSE2 has no byte-granular shuffle so the validator
+          # falls back to scalar, and there is no SSSE3 escape helper so SSSE3 escapes with SSE2.
           - name: x86-64 SSE2 baseline (scalar fallback)
             flags: "-mno-ssse3"
-            expect_isa: SSE2
-            expect: scalar
+            expect: "SSE2 scalar SSE2"
           - name: x86-64 SSSE3
             flags: "-mssse3 -mno-avx"
-            expect_isa: SSSE3
-            expect: SSSE3
+            expect: "SSSE3 SSSE3 SSE2"
           - name: x86-64 AVX2
             flags: "-mavx2"
-            expect_isa: AVX2
-            expect: AVX2
+            expect: "AVX2 AVX2 AVX2"
 
     steps:
       - uses: actions/checkout@v6
 
       - name: Confirm the intended backend was selected
         run: |
-          # Reads the library's own names rather than restating its #if chain, so this cannot drift
-          # from what Glaze actually compiled. glz::simd_isa is public; the validator's own name is
-          # internal, which is fine to reach for from Glaze's own workflow. utf8_validation_test
-          # asserts both against the register width the selected backend defines, which is what
-          # keeps this from being a string the workflow reads back to itself.
+          set -euo pipefail
+          # Reads glz::simd_info rather than restating Glaze's #if chain, so this cannot drift from
+          # what Glaze actually compiled. utf8_validation_test anchors those names to the register
+          # width each backend branch defines and to the escape helper the write path invokes, which
+          # is what keeps this from being a string the workflow reads back to itself.
+          #
+          # Compared as one whole line on purpose. Splitting into fields lets a probe that prints
+          # fewer values than expected satisfy every field test at once.
           cat > /tmp/backend.cpp << 'EOF'
-          #include "glaze/simd/utf8_validation.hpp"
+          #include "glaze/simd/backends.hpp"
           #include <iostream>
-          int main() { std::cout << glz::simd_isa << ' ' << glz::detail::utf8_simd::backend << '\n'; }
+          int main() {
+            std::cout << glz::simd_info.detected << ' ' << glz::simd_info.utf8_validation << ' '
+                      << glz::simd_info.string_escape << '\n';
+          }
           EOF
           g++ -std=c++23 ${{ matrix.flags }} -I include /tmp/backend.cpp -o /tmp/backend
           out=$(/tmp/backend)
-          got_isa=${out%% *}
-          got=${out##* }
-          echo "simd_isa: $got_isa (expected ${{ matrix.expect_isa }})"
-          echo "utf8 backend: $got (expected ${{ matrix.expect }})"
-          test "$got_isa" = "${{ matrix.expect_isa }}"
-          test "$got" = "${{ matrix.expect }}"
+          echo "got:      $out"
+          echo "expected: ${{ matrix.expect }}"
+          test "$out" = "${{ matrix.expect }}"
 
       - name: Configure
         run: |
@@ -138,18 +139,25 @@ jobs:
 
       - name: Confirm AVX-512BW backend was selected
         run: |
+          set -euo pipefail
           cat > /tmp/backend.cpp << 'EOF'
-          #include "glaze/simd/utf8_validation.hpp"
+          #include "glaze/simd/backends.hpp"
           #include <iostream>
           int main() {
-            std::cout << glz::simd_isa << ' ' << glz::detail::utf8_simd::backend << '\n';
-            return (glz::simd_isa == "AVX512BW" && glz::detail::utf8_simd::backend == "AVX512BW") ? 0 : 1;
+            std::cout << glz::simd_info.detected << ' ' << glz::simd_info.utf8_validation << ' '
+                      << glz::simd_info.string_escape << '\n';
           }
           EOF
           g++ -std=c++23 -mavx512f -mavx512bw -mavx512vl -I include /tmp/backend.cpp -o /tmp/backend
           # Compiled for AVX-512 but only the preprocessor result matters, so run it under SDE when
-          # the runner cannot execute AVX-512 itself.
-          if [ -n "${SDE:-}" ]; then "$SDE" -future -- /tmp/backend; else /tmp/backend; fi
+          # the runner cannot execute AVX-512 itself. Checked in the shell rather than by the
+          # program's exit status, so a wrong answer fails here even if the emulator mishandles it.
+          if [ -n "${SDE:-}" ]; then out=$("$SDE" -future -- /tmp/backend); else out=$(/tmp/backend); fi
+          # Escaping stays AVX2: Glaze has no AVX-512 escape helper. That is the divergence a single
+          # backend name would hide, so this job is the one that pins it.
+          echo "got:      $out"
+          echo "expected: AVX512BW AVX512BW AVX2"
+          test "$out" = "AVX512BW AVX512BW AVX2"
 
       - name: Configure
         run: |
@@ -205,13 +213,13 @@ jobs:
           source /tmp/emsdk/emsdk_env.sh
           git clone --depth 1 --branch v1.1.0 https://github.com/openalgz/ut /tmp/ut
           cat > /tmp/backend.cpp << 'EOF'
-          #include "glaze/simd/utf8_validation.hpp"
+          #include "glaze/simd/backends.hpp"
           #include <iostream>
-          int main() { std::cout << glz::detail::utf8_simd::backend << '\n'; }
+          int main() { std::cout << glz::simd_info.utf8_validation << '\n'; }
           EOF
           for cfg in "-msimd128:WASM_SIMD128" ":scalar"; do
             flags="${cfg%%:*}"; label="${cfg##*:}"
-            echo "::group::WASM $label"
+            echo "::group::wasm ${label}"
             # Assert the backend before testing it, so a toolchain change that quietly drops SIMD128
             # fails here instead of running the scalar path twice and reporting success.
             em++ -std=c++23 $flags -I include /tmp/backend.cpp -o /tmp/backend.js -sEXIT_RUNTIME=1
@@ -241,17 +249,17 @@ jobs:
           set -euo pipefail
           git clone --depth 1 --branch v1.1.0 https://github.com/openalgz/ut /tmp/ut
           cat > /tmp/backend.cpp << 'EOF'
-          #include "glaze/simd/utf8_validation.hpp"
+          #include "glaze/simd/backends.hpp"
           #include <iostream>
-          int main() { std::cout << glz::detail::utf8_simd::backend << '\n'; }
+          int main() { std::cout << glz::simd_info.utf8_validation << '\n'; }
           EOF
           for w in 16 32 64; do
             echo "::group::generic width $w"
             # Assert the portable backend really is active at the requested width: otherwise the
             # vector path compiles away and all three widths silently test the scalar validator
-            # against itself. The name is checked rather than the width alone, because width does
-            # not identify a backend -- AVX2 and generic32 are both 32, so a runner that happened to
-            # enable AVX2 would satisfy a width-only check for w=32 without running portable code.
+            # against itself. Naming the backend rather than reading back the width also survives a
+            # future reordering of the selection chain, which currently puts the generic branch
+            # first and so makes a width-only check pass no matter which backend won.
             g++ -std=c++23 -DGLZ_UTF8_GENERIC_WIDTH=$w -I include /tmp/backend.cpp -o /tmp/backend
             got=$(/tmp/backend)
             echo "active backend: $got (expected generic$w)"

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ To report what a build actually compiled, read `glz::simd_info`:
 
 ```c++
 std::string report;
-glz::write_json(glz::simd_info, report);
+std::ignore = glz::write_json(glz::simd_info, report);
 // {"detected":"AVX512BW","utf8_validation":"AVX512BW","string_escape":"AVX2","float_write":"SSE4.1"}
 ```
 

--- a/README.md
+++ b/README.md
@@ -269,15 +269,15 @@ Glaze requires a C++ standard conformant pre-processor, which requires the `/Zc:
 
 ### SIMD Architecture Detection
 
-Glaze automatically detects the target architecture and enables platform-specific SIMD optimizations using compiler-predefined macros:
+Glaze automatically detects the target architecture and enables platform-specific SIMD optimizations using compiler-predefined macros, covering SSE2 through AVX-512BW on x86-64, NEON on ARM, and SIMD128 on WebAssembly. Since these are target-architecture macros set by the compiler, cross-compilation works automatically (e.g., an x86 host cross-compiling for ARM will not enable x86 SIMD paths). See [Optimizing Performance](./docs/optimizing-performance.md#simd-architecture-flags) for the full table.
 
-| Flag | Detected When | Architecture |
-|------|--------------|--------------|
-| `GLZ_USE_SSE2` | `__x86_64__` or `_M_X64` | x86-64 (always has SSE2) |
-| `GLZ_USE_AVX2` | `__AVX2__` (in addition to x86-64) | x86-64 with AVX2 |
-| `GLZ_USE_NEON` | `__aarch64__`, `_M_ARM64`, or `__ARM_NEON` | ARM64 / AArch64 |
+To report what a build actually compiled, read `glz::simd_info`:
 
-Since these are target-architecture macros set by the compiler, cross-compilation works automatically (e.g., an x86 host cross-compiling for ARM will not enable x86 SIMD paths).
+```c++
+std::string report;
+glz::write_json(glz::simd_info, report);
+// {"detected":"AVX512BW","utf8_validation":"AVX512BW","string_escape":"AVX2","float_write":"SSE4.1"}
+```
 
 To disable SIMD optimizations:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -152,10 +152,16 @@ Glaze automatically detects the target architecture and enables platform-specifi
 | Flag | Detected When | Architecture |
 |------|--------------|--------------|
 | `GLZ_USE_SSE2` | `__x86_64__` or `_M_X64` | x86-64 (always has SSE2) |
-| `GLZ_USE_AVX2` | `__AVX2__` (in addition to x86-64) | x86-64 with AVX2 |
-| `GLZ_USE_NEON` | `__aarch64__`, `_M_ARM64`, or `__ARM_NEON` | ARM64 / AArch64 |
+| `GLZ_USE_SSSE3` | `__SSSE3__`, or `__AVX__` on MSVC | x86-64 with byte-granular shuffle |
+| `GLZ_USE_AVX2` | `__AVX2__` | x86-64 with AVX2 |
+| `GLZ_USE_AVX512BW` | `__AVX512BW__`, or `__AVX512F__` on MSVC | x86-64 with AVX-512BW |
+| `GLZ_USE_NEON` | `__aarch64__`, `_M_ARM64`, or `__ARM_NEON` | ARM with NEON |
+| `GLZ_USE_NEON64` | `__aarch64__` or `_M_ARM64` | AArch64 |
+| `GLZ_USE_WASM_SIMD128` | `__wasm_simd128__` | WebAssembly |
 
 Detection uses compiler-predefined macros that reflect the target architecture, so cross-compilation works correctly without any manual configuration.
+
+To check what a build actually selected, read `glz::simd_isa` and `glz::utf8_validation_backend`. See [Querying the Selected Backend](./optimizing-performance.md#querying-the-selected-backend).
 
 ### Disable SIMD
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -161,7 +161,7 @@ Glaze automatically detects the target architecture and enables platform-specifi
 
 Detection uses compiler-predefined macros that reflect the target architecture, so cross-compilation works correctly without any manual configuration.
 
-To check what a build actually selected, read `glz::simd_isa` and `glz::utf8_validation_backend`. See [Querying the Selected Backend](./optimizing-performance.md#querying-the-selected-backend).
+To check what a build actually selected, read `glz::simd_isa`. See [Querying the Selected Backend](./optimizing-performance.md#querying-the-selected-backend).
 
 ### Disable SIMD
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -149,19 +149,9 @@ Since Glaze is header-only, you can simply:
 
 Glaze automatically detects the target architecture and enables platform-specific SIMD optimizations:
 
-| Flag | Detected When | Architecture |
-|------|--------------|--------------|
-| `GLZ_USE_SSE2` | `__x86_64__` or `_M_X64` | x86-64 (always has SSE2) |
-| `GLZ_USE_SSSE3` | `__SSSE3__`, or `__AVX__` on MSVC | x86-64 with byte-granular shuffle |
-| `GLZ_USE_AVX2` | `__AVX2__` | x86-64 with AVX2 |
-| `GLZ_USE_AVX512BW` | `__AVX512BW__`, or `__AVX512F__` on MSVC | x86-64 with AVX-512BW |
-| `GLZ_USE_NEON` | `__aarch64__`, `_M_ARM64`, or `__ARM_NEON` | ARM with NEON |
-| `GLZ_USE_NEON64` | `__aarch64__` or `_M_ARM64` | AArch64 |
-| `GLZ_USE_WASM_SIMD128` | `__wasm_simd128__` | WebAssembly |
+Detection covers SSE2 through AVX-512BW on x86-64, NEON on ARM, and SIMD128 on WebAssembly, using compiler-predefined macros that reflect the target architecture, so cross-compilation works correctly without any manual configuration. The full table of `GLZ_USE_*` flags and their conditions is in [Optimizing Performance](./optimizing-performance.md#simd-architecture-flags).
 
-Detection uses compiler-predefined macros that reflect the target architecture, so cross-compilation works correctly without any manual configuration.
-
-To check what a build actually selected, read `glz::simd_isa`. See [Querying the Selected Backend](./optimizing-performance.md#querying-the-selected-backend).
+To check what a build actually compiled, read `glz::simd_info`. See [Querying the Selected Backend](./optimizing-performance.md#querying-the-selected-backend).
 
 ### Disable SIMD
 

--- a/docs/optimizing-performance.md
+++ b/docs/optimizing-performance.md
@@ -28,38 +28,23 @@ The flags are cumulative rather than exclusive. When AVX2 is available, `GLZ_USE
 
 ### Querying the Selected Backend
 
-Glaze selects its SIMD paths entirely in the preprocessor, with no runtime dispatch. Two `constexpr` names report what a translation unit compiled.
-
-`glz::simd_isa`, in `glaze/simd/simd.hpp`, names the widest instruction set the detection above enabled. It is one of `"AVX512BW"`, `"AVX2"`, `"SSSE3"`, `"SSE2"`, `"NEON64"`, `"NEON"`, `"WASM_SIMD128"`, or `"scalar"`.
-
-`glz::utf8_validation_backend`, in `glaze/simd/utf8_validation.hpp`, names the UTF-8 validator that was compiled. It is one of `"AVX512BW"`, `"AVX2"`, `"SSSE3"`, `"NEON64"`, `"WASM_SIMD128"`, `"generic16"`, `"generic32"`, `"generic64"`, or `"scalar"`.
+`glz::simd_isa` names the widest instruction set the detection above enabled. It is one of `"AVX512BW"`, `"AVX2"`, `"SSSE3"`, `"SSE2"`, `"NEON64"`, `"NEON"`, `"WASM_SIMD128"`, or `"scalar"`.
 
 ```c++
-#include "glaze/glaze.hpp"
-#include <iostream>
-
-std::cout << glz::simd_isa << '\n';                 // e.g. AVX2
-std::cout << glz::utf8_validation_backend << '\n';  // e.g. AVX2
+std::cout << glz::simd_isa << '\n';  // e.g. AVX2
 ```
 
-Both are `std::string_view`, so they compare by value and are usable in `constexpr` contexts:
+It is a `std::string_view`, so it compares by value and works in `constexpr` contexts:
 
 ```c++
 static_assert(glz::simd_isa != "scalar", "this build was expected to have a vector path");
 ```
 
-Both describe the binary, not the machine running it. A build reporting `"AVX2"` runs AVX2 on a host that also supports AVX-512, and crashes on one that supports neither.
+Selection happens entirely in the preprocessor, with no runtime dispatch, so this describes the binary rather than the machine running it. A build reporting `"AVX2"` runs AVX2 on a host that also supports AVX-512, and crashes on one that supports neither.
 
-> [!IMPORTANT]
+> [!NOTE]
 >
-> `glz::simd_isa` is the detection result, which is an upper bound rather than the name of a single code path. Subsystems consume the `GLZ_USE_*` macros independently and do not all reach the same level:
->
-> - **JSON string escaping** has no AVX-512 helper. An AVX-512 build reports `simd_isa == "AVX512BW"` while escaping runs the AVX2 and SSE2 helpers.
-> - **UTF-8 validation** needs a byte-granular shuffle, which plain SSE2 and 32-bit NEON do not have. Those targets report `simd_isa == "SSE2"` or `"NEON"` alongside `utf8_validation_backend == "scalar"`: validation runs the scalar validator while the rest of Glaze still uses its vector paths.
->
-> Compare against `glz::utf8_validation_backend` when validation specifically is what you care about.
-
-The `generic*` values come from `GLZ_UTF8_GENERIC_WIDTH`, a testing hook that selects a portable width-generic validator written in plain C++ so the algorithm can be exercised at register sizes the host cannot execute. No ordinary build selects it, and it is the one case where `utf8_validation_backend` is unrelated to `simd_isa`.
+> This is the detection result, which is an upper bound rather than the name of a single code path. Not every subsystem reaches it: string escaping has no AVX-512 helper, so an AVX-512 build escapes with AVX2 and SSE2, and UTF-8 validation needs a byte-granular shuffle that plain SSE2 and 32-bit NEON lack, so those targets validate with the scalar validator while the rest of Glaze stays vectorized.
 
 ### Disabling SIMD
 

--- a/docs/optimizing-performance.md
+++ b/docs/optimizing-performance.md
@@ -15,12 +15,51 @@ Glaze automatically detects the target architecture using compiler-predefined ma
 | Flag | Detected When | Architecture |
 |------|--------------|--------------|
 | `GLZ_USE_SSE2` | `__x86_64__` or `_M_X64` | x86-64 (always has SSE2) |
-| `GLZ_USE_AVX2` | `__AVX2__` (in addition to x86-64) | x86-64 with AVX2 |
-| `GLZ_USE_NEON` | `__aarch64__`, `_M_ARM64`, or `__ARM_NEON` | ARM64 / AArch64 |
+| `GLZ_USE_SSSE3` | `__SSSE3__`, or `__AVX__` on MSVC | x86-64 with byte-granular shuffle |
+| `GLZ_USE_AVX2` | `__AVX2__` | x86-64 with AVX2 |
+| `GLZ_USE_AVX512BW` | `__AVX512BW__`, or `__AVX512F__` on MSVC | x86-64 with AVX-512BW |
+| `GLZ_USE_NEON` | `__aarch64__`, `_M_ARM64`, or `__ARM_NEON` | ARM with NEON |
+| `GLZ_USE_NEON64` | `__aarch64__` or `_M_ARM64` | AArch64 (has the full 16-byte table lookup) |
+| `GLZ_USE_WASM_SIMD128` | `__wasm_simd128__` | WebAssembly |
 
 These macros are set by the compiler based on the target architecture, so they work correctly when cross-compiling (e.g., an x86 host building for ARM will not define `__x86_64__`).
 
-When AVX2 is available, both `GLZ_USE_SSE2` and `GLZ_USE_AVX2` are defined. The AVX2 path handles 32-byte chunks, then the SSE2 path handles 16-byte remainders.
+The flags are cumulative rather than exclusive. When AVX2 is available, `GLZ_USE_SSE2`, `GLZ_USE_SSSE3`, and `GLZ_USE_AVX2` are all defined, and string escaping uses them together: the AVX2 path handles 32-byte chunks, then the SSE2 path handles the 16-byte remainder.
+
+### Querying the Selected Backend
+
+Glaze selects its SIMD paths entirely in the preprocessor, with no runtime dispatch. Two `constexpr` names report what a translation unit compiled.
+
+`glz::simd_isa`, in `glaze/simd/simd.hpp`, names the widest instruction set the detection above enabled. It is one of `"AVX512BW"`, `"AVX2"`, `"SSSE3"`, `"SSE2"`, `"NEON64"`, `"NEON"`, `"WASM_SIMD128"`, or `"scalar"`.
+
+`glz::utf8_validation_backend`, in `glaze/simd/utf8_validation.hpp`, names the UTF-8 validator that was compiled. It is one of `"AVX512BW"`, `"AVX2"`, `"SSSE3"`, `"NEON64"`, `"WASM_SIMD128"`, `"generic16"`, `"generic32"`, `"generic64"`, or `"scalar"`.
+
+```c++
+#include "glaze/glaze.hpp"
+#include <iostream>
+
+std::cout << glz::simd_isa << '\n';                 // e.g. AVX2
+std::cout << glz::utf8_validation_backend << '\n';  // e.g. AVX2
+```
+
+Both are `std::string_view`, so they compare by value and are usable in `constexpr` contexts:
+
+```c++
+static_assert(glz::simd_isa != "scalar", "this build was expected to have a vector path");
+```
+
+Both describe the binary, not the machine running it. A build reporting `"AVX2"` runs AVX2 on a host that also supports AVX-512, and crashes on one that supports neither.
+
+> [!IMPORTANT]
+>
+> `glz::simd_isa` is the detection result, which is an upper bound rather than the name of a single code path. Subsystems consume the `GLZ_USE_*` macros independently and do not all reach the same level:
+>
+> - **JSON string escaping** has no AVX-512 helper. An AVX-512 build reports `simd_isa == "AVX512BW"` while escaping runs the AVX2 and SSE2 helpers.
+> - **UTF-8 validation** needs a byte-granular shuffle, which plain SSE2 and 32-bit NEON do not have. Those targets report `simd_isa == "SSE2"` or `"NEON"` alongside `utf8_validation_backend == "scalar"`: validation runs the scalar validator while the rest of Glaze still uses its vector paths.
+>
+> Compare against `glz::utf8_validation_backend` when validation specifically is what you care about.
+
+The `generic*` values come from `GLZ_UTF8_GENERIC_WIDTH`, a testing hook that selects a portable width-generic validator written in plain C++ so the algorithm can be exercised at register sizes the host cannot execute. No ordinary build selects it, and it is the one case where `utf8_validation_backend` is unrelated to `simd_isa`.
 
 ### Disabling SIMD
 

--- a/docs/optimizing-performance.md
+++ b/docs/optimizing-performance.md
@@ -12,39 +12,60 @@ Use `-march=native` if you will be running your executable on the build platform
 
 Glaze automatically detects the target architecture using compiler-predefined macros and defines the appropriate SIMD flags:
 
+All of the x86 flags below are additionally conditional on the x86-64 branch (`__x86_64__` or `_M_X64`), and every flag is suppressed by `GLZ_DISABLE_SIMD`. A 32-bit x86 build defines none of them even with `-mavx2`.
+
 | Flag | Detected When | Architecture |
 |------|--------------|--------------|
-| `GLZ_USE_SSE2` | `__x86_64__` or `_M_X64` | x86-64 (always has SSE2) |
-| `GLZ_USE_SSSE3` | `__SSSE3__`, or `__AVX__` on MSVC | x86-64 with byte-granular shuffle |
+| `GLZ_USE_SSE2` | always, on x86-64 | x86-64 (always has SSE2) |
+| `GLZ_USE_SSSE3` | `__SSSE3__`, or `_MSC_VER` with `__AVX__` | x86-64 with byte-granular shuffle |
 | `GLZ_USE_AVX2` | `__AVX2__` | x86-64 with AVX2 |
-| `GLZ_USE_AVX512BW` | `__AVX512BW__`, or `__AVX512F__` on MSVC | x86-64 with AVX-512BW |
+| `GLZ_USE_AVX512BW` | `__AVX512BW__`, or `_MSC_VER` with `__AVX512F__` | x86-64 with AVX-512BW |
 | `GLZ_USE_NEON` | `__aarch64__`, `_M_ARM64`, or `__ARM_NEON` | ARM with NEON |
 | `GLZ_USE_NEON64` | `__aarch64__` or `_M_ARM64` | AArch64 (has the full 16-byte table lookup) |
 | `GLZ_USE_WASM_SIMD128` | `__wasm_simd128__` | WebAssembly |
 
 These macros are set by the compiler based on the target architecture, so they work correctly when cross-compiling (e.g., an x86 host building for ARM will not define `__x86_64__`).
 
-The flags are cumulative rather than exclusive. When AVX2 is available, `GLZ_USE_SSE2`, `GLZ_USE_SSSE3`, and `GLZ_USE_AVX2` are all defined, and string escaping uses them together: the AVX2 path handles 32-byte chunks, then the SSE2 path handles the 16-byte remainder.
+The flags are cumulative rather than exclusive. When AVX2 is available, `GLZ_USE_SSE2` and `GLZ_USE_AVX2` are both defined, and string escaping uses them together: the AVX2 path handles 32-byte chunks, then the SSE2 path handles the 16-byte remainder.
 
 ### Querying the Selected Backend
 
-`glz::simd_isa` names the widest instruction set the detection above enabled. It is one of `"AVX512BW"`, `"AVX2"`, `"SSSE3"`, `"SSE2"`, `"NEON64"`, `"NEON"`, `"WASM_SIMD128"`, or `"scalar"`.
+`glz::simd_info` reports which SIMD path each accelerated subsystem compiled to. It is reflectable, so a benchmark harness can emit the whole thing:
 
 ```c++
-std::cout << glz::simd_isa << '\n';  // e.g. AVX2
+std::string report;
+glz::write_json(glz::simd_info, report);
+// {"detected":"AVX512BW","utf8_validation":"AVX512BW","string_escape":"AVX2","float_write":"SSE4.1"}
 ```
 
-It is a `std::string_view`, so it compares by value and works in `constexpr` contexts:
+Each field is a `std::string_view`, so they compare by value and work in `constexpr` contexts.
 
-```c++
-static_assert(glz::simd_isa != "scalar", "this build was expected to have a vector path");
-```
+| Field | Meaning | Values |
+|---|---|---|
+| `detected` | Widest instruction set the flags above enabled | `AVX512BW`, `AVX2`, `SSSE3`, `SSE2`, `NEON64`, `NEON`, `WASM_SIMD128`, `scalar` |
+| `utf8_validation` | UTF-8 validator | `AVX512BW`, `AVX2`, `SSSE3`, `NEON64`, `WASM_SIMD128`, `scalar` |
+| `string_escape` | Widest JSON string-escape helper | `AVX2`, `SSE2`, `NEON`, `SWAR` |
+| `float_write` | Float serialization | `NEON`, `SSE4.1`, `SSE2`, `scalar` |
 
-Selection happens entirely in the preprocessor, with no runtime dispatch, so this describes the binary rather than the machine running it. A build reporting `"AVX2"` runs AVX2 on a host that also supports AVX-512, and crashes on one that supports neither.
-
-> [!NOTE]
+> [!IMPORTANT]
 >
-> This is the detection result, which is an upper bound rather than the name of a single code path. Not every subsystem reaches it: string escaping has no AVX-512 helper, so an AVX-512 build escapes with AVX2 and SSE2, and UTF-8 validation needs a byte-granular shuffle that plain SSE2 and 32-bit NEON lack, so those targets validate with the scalar validator while the rest of Glaze stays vectorized.
+> **The fields disagree with each other, which is why this is a struct rather than one name.** `detected` is an upper bound, and reporting it alone would misdescribe most builds. For example:
+>
+> - **String escaping** has no AVX-512 helper and no WASM helper, so an AVX-512 build escapes with AVX2 and a WASM build escapes with SWAR.
+> - **UTF-8 validation** needs a byte-granular shuffle, which plain SSE2 and 32-bit NEON lack. Those targets validate with the scalar validator while the rest of Glaze stays vectorized.
+> - **Float writing** runs its own detection off `__SSE2__` / `__ARM_NEON` rather than Glaze's `GLZ_USE_*` macros, honouring only `GLZ_DISABLE_SIMD`. It is the one field `detected` does not bound: a 32-bit x86 build with SSE2 reports `detected == "scalar"` and `float_write == "SSE2"`.
+>
+> This list is illustrative, not exhaustive — check the field you care about rather than inferring it from `detected`.
+
+Selection happens entirely in the preprocessor, with no runtime dispatch, so this describes the *translation unit* rather than the machine running it. A build reporting `"AVX2"` runs AVX2 on a host that also supports AVX-512, and crashes on one that supports neither.
+
+> [!WARNING]
+>
+> Compiling different translation units with different `-march` flags gives them different values for `glz::simd_info`, which is an ODR violation on that object. The linker keeps one arbitrarily, so the reported values may describe a translation unit other than the one doing the work.
+
+`utf8_validation` has three further values — `generic16`, `generic32`, and `generic64` — which mean `GLZ_UTF8_GENERIC_WIDTH` selected a portable width-generic validator written in plain C++. That is a testing hook for exercising the algorithm at register sizes the host cannot execute; no ordinary build selects it.
+
+For compile-time *branching*, prefer the `GLZ_USE_*` macros above. A `static_assert` on a string compares equal only to the exact spelling, so a typo produces a permanently satisfied assertion rather than an error.
 
 ### Disabling SIMD
 

--- a/docs/optimizing-performance.md
+++ b/docs/optimizing-performance.md
@@ -34,7 +34,7 @@ The flags are cumulative rather than exclusive. When AVX2 is available, `GLZ_USE
 
 ```c++
 std::string report;
-glz::write_json(glz::simd_info, report);
+std::ignore = glz::write_json(glz::simd_info, report);
 // {"detected":"AVX512BW","utf8_validation":"AVX512BW","string_escape":"AVX2","float_write":"SSE4.1"}
 ```
 
@@ -45,7 +45,11 @@ Each field is a `std::string_view`, so they compare by value and work in `conste
 | `detected` | Widest instruction set the flags above enabled | `AVX512BW`, `AVX2`, `SSSE3`, `SSE2`, `NEON64`, `NEON`, `WASM_SIMD128`, `scalar` |
 | `utf8_validation` | UTF-8 validator | `AVX512BW`, `AVX2`, `SSSE3`, `NEON64`, `WASM_SIMD128`, `scalar` |
 | `string_escape` | Widest JSON string-escape helper | `AVX2`, `SSE2`, `NEON`, `SWAR` |
-| `float_write` | Float serialization | `NEON`, `SSE4.1`, `SSE2`, `scalar` |
+| `float_write` | Float serialization, via the zmij writer | `NEON`, `SSE4.1`, `SSE2`, `scalar` |
+
+`SWAR` means SIMD-within-a-register: eight bytes at a time packed into a `uint64_t`, needing no intrinsics. It is Glaze's fallback everywhere, so `scalar` in the other fields does not mean the work is done a byte at a time.
+
+`float_write` describes the default float path only. Setting the `float_format` option routes floats through `std::format` instead, which no field reports.
 
 > [!IMPORTANT]
 >
@@ -53,15 +57,13 @@ Each field is a `std::string_view`, so they compare by value and work in `conste
 >
 > - **String escaping** has no AVX-512 helper and no WASM helper, so an AVX-512 build escapes with AVX2 and a WASM build escapes with SWAR.
 > - **UTF-8 validation** needs a byte-granular shuffle, which plain SSE2 and 32-bit NEON lack. Those targets validate with the scalar validator while the rest of Glaze stays vectorized.
-> - **Float writing** runs its own detection off `__SSE2__` / `__ARM_NEON` rather than Glaze's `GLZ_USE_*` macros, honouring only `GLZ_DISABLE_SIMD`. It is the one field `detected` does not bound: a 32-bit x86 build with SSE2 reports `detected == "scalar"` and `float_write == "SSE2"`.
+> - **Float writing** runs its own detection off `__SSE2__` / `__ARM_NEON` rather than Glaze's `GLZ_USE_*` macros, honouring only `GLZ_DISABLE_SIMD`. `detected` does not even bound it from above: a 32-bit x86 build with SSE2 reports `detected == "scalar"` and `float_write == "SSE2"`.
 >
 > This list is illustrative, not exhaustive — check the field you care about rather than inferring it from `detected`.
 
 Selection happens entirely in the preprocessor, with no runtime dispatch, so this describes the *translation unit* rather than the machine running it. A build reporting `"AVX2"` runs AVX2 on a host that also supports AVX-512, and crashes on one that supports neither.
 
-> [!WARNING]
->
-> Compiling different translation units with different `-march` flags gives them different values for `glz::simd_info`, which is an ODR violation on that object. The linker keeps one arbitrarily, so the reported values may describe a translation unit other than the one doing the work.
+`glz::simd_info` has internal linkage, so each translation unit gets its own copy holding its own answer. A project compiling some files with `-mavx2` and others without gets accurate values in both, and the one you read is the one for the file you read it from.
 
 `utf8_validation` has three further values — `generic16`, `generic32`, and `generic64` — which mean `GLZ_UTF8_GENERIC_WIDTH` selected a portable width-generic validator written in plain C++. That is a testing hook for exercising the algorithm at register sizes the host cannot execute; no ordinary build selects it.
 

--- a/include/glaze/glaze.hpp
+++ b/include/glaze/glaze.hpp
@@ -41,5 +41,6 @@
 #include "glaze/file/read_directory.hpp"
 #include "glaze/file/write_directory.hpp"
 #include "glaze/json.hpp"
+#include "glaze/simd/backends.hpp"
 #include "glaze/stencil/stencil.hpp"
 #include "glaze/util/key_transformers.hpp"

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -10,7 +10,6 @@
 
 #include "glaze/core/chrono.hpp"
 #include "glaze/simd/avx.hpp"
-#include "glaze/simd/backends.hpp"
 #include "glaze/simd/neon.hpp"
 #include "glaze/simd/simd.hpp"
 #include "glaze/simd/sse.hpp"
@@ -943,18 +942,15 @@ namespace glz
                      ++c;
                   };
 
-                  // simd_info.string_escape names the widest helper invoked below. Each branch
-                  // asserts it, so adding a wider helper here without naming it in simd/backends.hpp
-                  // fails to compile rather than silently making the reported name too narrow.
+                  // Adding a helper here means adding a branch to string_escape_simd() in
+                  // simd/backends.hpp, which names the widest one this cascade invokes, and a row
+                  // to known_builds in tests/json_test/utf8_validation_test.cpp, which checks it.
 #if defined(GLZ_USE_AVX2)
-                  static_assert(simd_info.string_escape == "AVX2");
                   detail::avx2_string_escape(c, e, data, n, write_escape);
 #endif
 #if defined(GLZ_USE_SSE2)
-                  static_assert(simd_info.string_escape == "AVX2" || simd_info.string_escape == "SSE2");
                   detail::sse2_string_escape(c, e, data, n, write_escape);
 #elif defined(GLZ_USE_NEON)
-                  static_assert(simd_info.string_escape == "NEON");
                   detail::neon_string_escape(c, e, data, n, write_escape);
 #endif
 

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -10,6 +10,7 @@
 
 #include "glaze/core/chrono.hpp"
 #include "glaze/simd/avx.hpp"
+#include "glaze/simd/backends.hpp"
 #include "glaze/simd/neon.hpp"
 #include "glaze/simd/simd.hpp"
 #include "glaze/simd/sse.hpp"
@@ -942,12 +943,18 @@ namespace glz
                      ++c;
                   };
 
+                  // simd_info.string_escape names the widest helper invoked below. Each branch
+                  // asserts it, so adding a wider helper here without naming it in simd/backends.hpp
+                  // fails to compile rather than silently making the reported name too narrow.
 #if defined(GLZ_USE_AVX2)
+                  static_assert(simd_info.string_escape == "AVX2");
                   detail::avx2_string_escape(c, e, data, n, write_escape);
 #endif
 #if defined(GLZ_USE_SSE2)
+                  static_assert(simd_info.string_escape == "AVX2" || simd_info.string_escape == "SSE2");
                   detail::sse2_string_escape(c, e, data, n, write_escape);
 #elif defined(GLZ_USE_NEON)
+                  static_assert(simd_info.string_escape == "NEON");
                   detail::neon_string_escape(c, e, data, n, write_escape);
 #endif
 

--- a/include/glaze/simd/backends.hpp
+++ b/include/glaze/simd/backends.hpp
@@ -16,18 +16,18 @@ namespace glz
    // Selection happens entirely in the preprocessor -- Glaze has no runtime dispatch -- so these
    // describe the translation unit, not the host. A build reporting "AVX2" runs AVX2 on a machine
    // that also supports AVX-512, and crashes on one that supports neither. Compiling different
-   // files with different -march flags gives them different values, and linking those together is
-   // an ODR violation on this object; a mixed build reports whichever one the linker kept.
+   // files with different -march flags gives each of them its own values; see simd_info below for
+   // what that means when they are linked together.
    //
-   // The fields disagree with each other on purpose, which is the reason this is a struct rather
-   // than a single name. No one instruction set is "the SIMD Glaze is using": the widest one
-   // detected is an upper bound that most subsystems do not reach, and one of them does not even
-   // read Glaze's detection.
+   // Four fields rather than one name because they genuinely disagree; docs/optimizing-performance.md
+   // has the cases and why they arise.
    struct simd_backends
    {
-      // Widest instruction set the detection in simd.hpp enabled. Bounds every field below except
-      // float_write. One of "AVX512BW", "AVX2", "SSSE3", "SSE2", "NEON64", "NEON", "WASM_SIMD128",
-      // or "scalar".
+      // Widest instruction set the detection in simd.hpp enabled. One of "AVX512BW", "AVX2",
+      // "SSSE3", "SSE2", "NEON64", "NEON", "WASM_SIMD128", or "scalar".
+      //
+      // An upper bound on string_escape, but not on the other two: float_write runs its own
+      // detection, and GLZ_UTF8_GENERIC_WIDTH overrides utf8_validation outright.
       std::string_view detected{};
 
       // UTF-8 validation. Needs a byte-granular shuffle, which plain SSE2 and 32 bit NEON lack, so
@@ -44,9 +44,12 @@ namespace glz
 
       // Float writing, through the zmij port in util/zmij.hpp. It runs its own detection off
       // __SSE2__ / __ARM_NEON rather than Glaze's GLZ_USE_* macros, and only honours
-      // GLZ_DISABLE_SIMD from Glaze. That makes it the one field `detected` does not bound: a 32 bit
-      // x86 build with SSE2 reports detected == "scalar" and float_write == "SSE2", because Glaze's
-      // own detection requires __x86_64__ and zmij's does not.
+      // GLZ_DISABLE_SIMD from Glaze. `detected` does not even bound it from above: a 32 bit x86
+      // build with SSE2 reports detected == "scalar" and float_write == "SSE2", because Glaze's own
+      // detection requires __x86_64__ and zmij's does not.
+      //
+      // Names zmij's path only. Setting opts::float_format routes floats through std::format
+      // instead (core/write_chars.hpp), which this field does not describe.
       std::string_view float_write{};
    };
 
@@ -76,8 +79,15 @@ namespace glz
 #endif
       }
 
-      // Mirrors the escape cascade in json/write.hpp. Kept in step by static_asserts at that
-      // cascade, so a helper added there without a name here fails to compile.
+      // Mirrors the escape cascade in json/write.hpp, whose branches static_assert against the
+      // result. Those asserts key off the same macros as this chain, so what they catch is an edit
+      // here that the cascade did not make: rename a branch and every translation unit that writes
+      // JSON stops compiling.
+      //
+      // They cannot catch the reverse. A helper added to the cascade under a macro this chain does
+      // not test -- an AVX-512 or WASM escape helper, the two Glaze lacks -- compiles cleanly and
+      // leaves this reporting a name that is too narrow. Adding one means adding a branch here in
+      // the same commit; the cascade says so at the point of change.
       consteval std::string_view string_escape_simd() noexcept
       {
 #if defined(GLZ_USE_AVX2)
@@ -110,13 +120,18 @@ namespace glz
    // Report what this build compiled. Reflectable, so a benchmark harness can emit it directly:
    //
    //    std::string s;
-   //    glz::write_json(glz::simd_info, s);
+   //    std::ignore = glz::write_json(glz::simd_info, s);
    //    // {"detected":"AVX512BW","utf8_validation":"AVX512BW",
    //    //  "string_escape":"AVX2","float_write":"SSE4.1"}
    //
+   // Deliberately not `inline`. The values come from the preprocessor, so every translation unit
+   // must keep its own answer, which internal linkage gives it. Under `inline` the copies merge
+   // and a project compiling some files with -mavx2 and others without reports the survivor's
+   // answer for all of them, including through the write_json call above.
+   //
    // These spellings are public API. Renaming one breaks every comparison against it, and inserting
    // a wider entry changes what an already-working build reports, so treat both as deliberate.
-   inline constexpr simd_backends simd_info{
+   constexpr simd_backends simd_info{
       .detected = detail::detected_simd(),
       .utf8_validation = detail::utf8_simd::backend,
       .string_escape = detail::string_escape_simd(),

--- a/include/glaze/simd/backends.hpp
+++ b/include/glaze/simd/backends.hpp
@@ -1,0 +1,125 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include <string_view>
+
+#include "glaze/simd/simd.hpp"
+#include "glaze/simd/utf8_validation.hpp"
+#include "glaze/util/zmij.hpp"
+
+namespace glz
+{
+   // Which SIMD path each of Glaze's accelerated subsystems compiled to.
+   //
+   // Selection happens entirely in the preprocessor -- Glaze has no runtime dispatch -- so these
+   // describe the translation unit, not the host. A build reporting "AVX2" runs AVX2 on a machine
+   // that also supports AVX-512, and crashes on one that supports neither. Compiling different
+   // files with different -march flags gives them different values, and linking those together is
+   // an ODR violation on this object; a mixed build reports whichever one the linker kept.
+   //
+   // The fields disagree with each other on purpose, which is the reason this is a struct rather
+   // than a single name. No one instruction set is "the SIMD Glaze is using": the widest one
+   // detected is an upper bound that most subsystems do not reach, and one of them does not even
+   // read Glaze's detection.
+   struct simd_backends
+   {
+      // Widest instruction set the detection in simd.hpp enabled. Bounds every field below except
+      // float_write. One of "AVX512BW", "AVX2", "SSSE3", "SSE2", "NEON64", "NEON", "WASM_SIMD128",
+      // or "scalar".
+      std::string_view detected{};
+
+      // UTF-8 validation. Needs a byte-granular shuffle, which plain SSE2 and 32 bit NEON lack, so
+      // those targets validate with the scalar validator in parse.hpp while the rest of Glaze stays
+      // vectorized. "generic16" / "generic32" / "generic64" mean GLZ_UTF8_GENERIC_WIDTH selected the
+      // portable width-generic validator, a testing hook no ordinary build uses.
+      std::string_view utf8_validation{};
+
+      // JSON string escaping. A cascade rather than a single path: the widest helper compiled takes
+      // whole registers, narrower ones take the remainder, and SWAR finishes the tail. This names
+      // the widest. Glaze has no AVX-512 or WASM escape helper, so an AVX-512 build reports "AVX2"
+      // here and a wasm build reports "SWAR".
+      std::string_view string_escape{};
+
+      // Float writing, through the zmij port in util/zmij.hpp. It runs its own detection off
+      // __SSE2__ / __ARM_NEON rather than Glaze's GLZ_USE_* macros, and only honours
+      // GLZ_DISABLE_SIMD from Glaze. That makes it the one field `detected` does not bound: a 32 bit
+      // x86 build with SSE2 reports detected == "scalar" and float_write == "SSE2", because Glaze's
+      // own detection requires __x86_64__ and zmij's does not.
+      std::string_view float_write{};
+   };
+
+   namespace detail
+   {
+      // Mirrors the macros defined in simd.hpp, widest first.
+      consteval std::string_view detected_simd() noexcept
+      {
+#if defined(GLZ_USE_AVX512BW)
+         return "AVX512BW";
+#elif defined(GLZ_USE_AVX2)
+         return "AVX2";
+#elif defined(GLZ_USE_SSSE3)
+         return "SSSE3";
+#elif defined(GLZ_USE_SSE2)
+         return "SSE2";
+#elif defined(GLZ_USE_NEON64)
+         return "NEON64";
+#elif defined(GLZ_USE_NEON)
+         return "NEON";
+#elif defined(GLZ_USE_WASM_SIMD128)
+         return "WASM_SIMD128";
+#else
+         // GLZ_DISABLE_SIMD, or a target the detection does not cover. Glaze still uses SWAR
+         // everywhere, which needs no intrinsics, so this does not mean "no acceleration".
+         return "scalar";
+#endif
+      }
+
+      // Mirrors the escape cascade in json/write.hpp. Kept in step by static_asserts at that
+      // cascade, so a helper added there without a name here fails to compile.
+      consteval std::string_view string_escape_simd() noexcept
+      {
+#if defined(GLZ_USE_AVX2)
+         return "AVX2";
+#elif defined(GLZ_USE_SSE2)
+         return "SSE2";
+#elif defined(GLZ_USE_NEON)
+         return "NEON";
+#else
+         return "SWAR";
+#endif
+      }
+
+      // Mirrors zmij's own ZMIJ_USE_* selection. These are defined to 0 or 1 rather than
+      // defined/undefined, so they are tested by value.
+      consteval std::string_view float_write_simd() noexcept
+      {
+#if ZMIJ_USE_NEON
+         return "NEON";
+#elif ZMIJ_USE_SSE4_1
+         return "SSE4.1";
+#elif ZMIJ_USE_SSE
+         return "SSE2";
+#else
+         return "scalar";
+#endif
+      }
+   }
+
+   // Report what this build compiled. Reflectable, so a benchmark harness can emit it directly:
+   //
+   //    std::string s;
+   //    glz::write_json(glz::simd_info, s);
+   //    // {"detected":"AVX512BW","utf8_validation":"AVX512BW",
+   //    //  "string_escape":"AVX2","float_write":"SSE4.1"}
+   //
+   // These spellings are public API. Renaming one breaks every comparison against it, and inserting
+   // a wider entry changes what an already-working build reports, so treat both as deliberate.
+   inline constexpr simd_backends simd_info{
+      .detected = detail::detected_simd(),
+      .utf8_validation = detail::utf8_simd::backend,
+      .string_escape = detail::string_escape_simd(),
+      .float_write = detail::float_write_simd(),
+   };
+}

--- a/include/glaze/simd/simd.hpp
+++ b/include/glaze/simd/simd.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <string_view>
+
 #if !defined(GLZ_DISABLE_SIMD)
 #if defined(__x86_64__) || defined(_M_X64)
 #if defined(_MSC_VER)
@@ -37,3 +39,43 @@
 #define GLZ_USE_WASM_SIMD128
 #endif
 #endif
+
+namespace glz
+{
+   // The widest instruction set the detection above enabled for this translation unit.
+   //
+   // Glaze has no runtime dispatch: every SIMD path is chosen in the preprocessor, so this is fixed
+   // for the binary and reports what it was compiled for rather than what the host can execute. A
+   // build that reports "AVX2" runs AVX2 on a machine that supports AVX-512, and crashes on one
+   // that supports neither.
+   //
+   // This is the detection result, which is an upper bound rather than the name of a single code
+   // path. Subsystems consume the GLZ_USE_* macros independently and do not all reach the same
+   // level: JSON string escaping has no AVX-512 helper, so an AVX-512 build reports "AVX512BW" here
+   // while escaping runs the AVX2 and SSE2 ones. Use `glz::utf8_validation_backend`, declared in
+   // simd/utf8_validation.hpp, for what the UTF-8 validator itself selected -- it names the
+   // width-generic backend, which this constant cannot see.
+   //
+   // These spellings are public API. Renaming one breaks every equality comparison against it, and
+   // inserting a wider entry changes what an already-working build reports, so treat both as
+   // deliberate rather than incidental.
+#if defined(GLZ_USE_AVX512BW)
+   inline constexpr std::string_view simd_isa = "AVX512BW";
+#elif defined(GLZ_USE_AVX2)
+   inline constexpr std::string_view simd_isa = "AVX2";
+#elif defined(GLZ_USE_SSSE3)
+   inline constexpr std::string_view simd_isa = "SSSE3";
+#elif defined(GLZ_USE_SSE2)
+   inline constexpr std::string_view simd_isa = "SSE2";
+#elif defined(GLZ_USE_NEON64)
+   inline constexpr std::string_view simd_isa = "NEON64";
+#elif defined(GLZ_USE_NEON)
+   inline constexpr std::string_view simd_isa = "NEON";
+#elif defined(GLZ_USE_WASM_SIMD128)
+   inline constexpr std::string_view simd_isa = "WASM_SIMD128";
+#else
+   // No vector path: either GLZ_DISABLE_SIMD, or a target the detection above does not cover.
+   // Glaze still uses SWAR everywhere, which needs no intrinsics, so this is not "no acceleration".
+   inline constexpr std::string_view simd_isa = "scalar";
+#endif
+}

--- a/include/glaze/simd/simd.hpp
+++ b/include/glaze/simd/simd.hpp
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <string_view>
-
 #if !defined(GLZ_DISABLE_SIMD)
 #if defined(__x86_64__) || defined(_M_X64)
 #if defined(_MSC_VER)
@@ -39,43 +37,3 @@
 #define GLZ_USE_WASM_SIMD128
 #endif
 #endif
-
-namespace glz
-{
-   // The widest instruction set the detection above enabled for this translation unit.
-   //
-   // Glaze has no runtime dispatch: every SIMD path is chosen in the preprocessor, so this is fixed
-   // for the binary and reports what it was compiled for rather than what the host can execute. A
-   // build that reports "AVX2" runs AVX2 on a machine that supports AVX-512, and crashes on one
-   // that supports neither.
-   //
-   // This is the detection result, which is an upper bound rather than the name of a single code
-   // path. Subsystems consume the GLZ_USE_* macros independently and do not all reach the same
-   // level: JSON string escaping has no AVX-512 helper, so an AVX-512 build reports "AVX512BW" here
-   // while escaping runs the AVX2 and SSE2 ones, and UTF-8 validation needs a byte-granular shuffle
-   // that plain SSE2 and 32 bit NEON lack, so those report an instruction set here while validating
-   // with the scalar validator.
-   //
-   // These spellings are public API. Renaming one breaks every equality comparison against it, and
-   // inserting a wider entry changes what an already-working build reports, so treat both as
-   // deliberate rather than incidental.
-#if defined(GLZ_USE_AVX512BW)
-   inline constexpr std::string_view simd_isa = "AVX512BW";
-#elif defined(GLZ_USE_AVX2)
-   inline constexpr std::string_view simd_isa = "AVX2";
-#elif defined(GLZ_USE_SSSE3)
-   inline constexpr std::string_view simd_isa = "SSSE3";
-#elif defined(GLZ_USE_SSE2)
-   inline constexpr std::string_view simd_isa = "SSE2";
-#elif defined(GLZ_USE_NEON64)
-   inline constexpr std::string_view simd_isa = "NEON64";
-#elif defined(GLZ_USE_NEON)
-   inline constexpr std::string_view simd_isa = "NEON";
-#elif defined(GLZ_USE_WASM_SIMD128)
-   inline constexpr std::string_view simd_isa = "WASM_SIMD128";
-#else
-   // No vector path: either GLZ_DISABLE_SIMD, or a target the detection above does not cover.
-   // Glaze still uses SWAR everywhere, which needs no intrinsics, so this is not "no acceleration".
-   inline constexpr std::string_view simd_isa = "scalar";
-#endif
-}

--- a/include/glaze/simd/simd.hpp
+++ b/include/glaze/simd/simd.hpp
@@ -52,9 +52,9 @@ namespace glz
    // This is the detection result, which is an upper bound rather than the name of a single code
    // path. Subsystems consume the GLZ_USE_* macros independently and do not all reach the same
    // level: JSON string escaping has no AVX-512 helper, so an AVX-512 build reports "AVX512BW" here
-   // while escaping runs the AVX2 and SSE2 ones. Use `glz::utf8_validation_backend`, declared in
-   // simd/utf8_validation.hpp, for what the UTF-8 validator itself selected -- it names the
-   // width-generic backend, which this constant cannot see.
+   // while escaping runs the AVX2 and SSE2 ones, and UTF-8 validation needs a byte-granular shuffle
+   // that plain SSE2 and 32 bit NEON lack, so those report an instruction set here while validating
+   // with the scalar validator.
    //
    // These spellings are public API. Renaming one breaks every equality comparison against it, and
    // inserting a wider entry changes what an already-working build reports, so treat both as

--- a/include/glaze/simd/utf8_validation.hpp
+++ b/include/glaze/simd/utf8_validation.hpp
@@ -18,6 +18,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <string_view>
 
 #include "glaze/simd/simd.hpp"
 #include "glaze/util/inline.hpp"
@@ -140,6 +141,10 @@ namespace glz::detail::utf8_simd
    };
    inline constexpr size_t width = GLZ_UTF8_GENERIC_WIDTH;
    static_assert(width == 16 || width == 32 || width == 64, "generic width must be 16, 32, or 64");
+   // Named apart from the native backends of the same width, so a build that meant to exercise the
+   // portable path cannot mistake a native one for it. Width alone is ambiguous: AVX2 and generic32
+   // both report 32.
+   inline constexpr std::string_view backend = width == 64 ? "generic64" : (width == 32 ? "generic32" : "generic16");
 
    GLZ_ALWAYS_INLINE vec load(const uint8_t* p) noexcept
    {
@@ -215,6 +220,7 @@ namespace glz::detail::utf8_simd
 #elif defined(GLZ_USE_AVX512BW)
    using vec = __m512i;
    inline constexpr size_t width = 64;
+   inline constexpr std::string_view backend = "AVX512BW";
 
    GLZ_ALWAYS_INLINE vec load(const uint8_t* p) noexcept { return _mm512_loadu_si512(p); }
    GLZ_ALWAYS_INLINE vec zero() noexcept { return _mm512_setzero_si512(); }
@@ -246,6 +252,7 @@ namespace glz::detail::utf8_simd
 #elif defined(GLZ_USE_AVX2)
    using vec = __m256i;
    inline constexpr size_t width = 32;
+   inline constexpr std::string_view backend = "AVX2";
 
    GLZ_ALWAYS_INLINE vec load(const uint8_t* p) noexcept
    {
@@ -278,6 +285,7 @@ namespace glz::detail::utf8_simd
 #elif defined(GLZ_USE_SSSE3)
    using vec = __m128i;
    inline constexpr size_t width = 16;
+   inline constexpr std::string_view backend = "SSSE3";
 
    GLZ_ALWAYS_INLINE vec load(const uint8_t* p) noexcept
    {
@@ -306,6 +314,7 @@ namespace glz::detail::utf8_simd
 #elif defined(GLZ_USE_NEON64)
    using vec = uint8x16_t;
    inline constexpr size_t width = 16;
+   inline constexpr std::string_view backend = "NEON64";
 
    GLZ_ALWAYS_INLINE vec load(const uint8_t* p) noexcept { return vld1q_u8(p); }
    GLZ_ALWAYS_INLINE vec zero() noexcept { return vdupq_n_u8(0); }
@@ -328,6 +337,7 @@ namespace glz::detail::utf8_simd
 #elif defined(GLZ_USE_WASM_SIMD128)
    using vec = v128_t;
    inline constexpr size_t width = 16;
+   inline constexpr std::string_view backend = "WASM_SIMD128";
 
    GLZ_ALWAYS_INLINE vec load(const uint8_t* p) noexcept { return wasm_v128_load(p); }
    GLZ_ALWAYS_INLINE vec zero() noexcept { return wasm_i8x16_splat(0); }
@@ -453,3 +463,23 @@ namespace glz::detail::utf8_simd
 }
 
 #endif
+
+namespace glz
+{
+   // The UTF-8 validator this translation unit compiled: "AVX512BW", "AVX2", "SSSE3", "NEON64",
+   // "WASM_SIMD128", "generic16" / "generic32" / "generic64", or "scalar".
+   //
+   // This is not always `glz::simd_isa`. The validator needs a byte-granular shuffle, so plain SSE2
+   // and 32 bit NEON have no vector path here and fall back to the scalar validator while other
+   // subsystems still use their vector paths. GLZ_UTF8_GENERIC_WIDTH overrides everything with the
+   // portable backend, which no GLZ_USE_* macro records.
+   //
+   // Each branch of the selection chain above names itself alongside its register width, so a new
+   // backend that forgets to declare one fails to compile here rather than reporting its
+   // predecessor's name.
+#if defined(GLZ_UTF8_SIMD)
+   inline constexpr std::string_view utf8_validation_backend = detail::utf8_simd::backend;
+#else
+   inline constexpr std::string_view utf8_validation_backend = "scalar";
+#endif
+}

--- a/include/glaze/simd/utf8_validation.hpp
+++ b/include/glaze/simd/utf8_validation.hpp
@@ -462,24 +462,14 @@ namespace glz::detail::utf8_simd
    }
 }
 
-#endif
-
-namespace glz
-{
-   // The UTF-8 validator this translation unit compiled: "AVX512BW", "AVX2", "SSSE3", "NEON64",
-   // "WASM_SIMD128", "generic16" / "generic32" / "generic64", or "scalar".
-   //
-   // This is not always `glz::simd_isa`. The validator needs a byte-granular shuffle, so plain SSE2
-   // and 32 bit NEON have no vector path here and fall back to the scalar validator while other
-   // subsystems still use their vector paths. GLZ_UTF8_GENERIC_WIDTH overrides everything with the
-   // portable backend, which no GLZ_USE_* macro records.
-   //
-   // Each branch of the selection chain above names itself alongside its register width, so a new
-   // backend that forgets to declare one fails to compile here rather than reporting its
-   // predecessor's name.
-#if defined(GLZ_UTF8_SIMD)
-   inline constexpr std::string_view utf8_validation_backend = detail::utf8_simd::backend;
 #else
-   inline constexpr std::string_view utf8_validation_backend = "scalar";
-#endif
+
+namespace glz::detail::utf8_simd
+{
+   // No vector path on this target, so validation runs the scalar validator in parse.hpp. Declared
+   // here so the tests and the simd-backends workflow can name the fallback the same way they name
+   // a backend, without a second spelling for "there isn't one".
+   inline constexpr std::string_view backend = "scalar";
 }
+
+#endif

--- a/include/glaze/simd/utf8_validation.hpp
+++ b/include/glaze/simd/utf8_validation.hpp
@@ -361,6 +361,12 @@ namespace glz::detail::utf8_simd
    }
 #endif
 
+   // Anchors the width each branch declares to the register type it picked alongside it. Everything
+   // downstream trusts `width` -- regs_per_step, the tail handling, the incomplete_max offset -- so
+   // a branch that names a width its vec does not have corrupts validation rather than failing to
+   // build. The name/width pairing is checked separately, in utf8_validation_test.cpp.
+   static_assert(sizeof(vec) == width, "a UTF-8 backend declared a width its register type does not have");
+
    // Number of registers consumed per 64 byte step of the main loop.
    inline constexpr size_t regs_per_step = 64 / width;
 

--- a/tests/json_test/utf8_validation_test.cpp
+++ b/tests/json_test/utf8_validation_test.cpp
@@ -131,17 +131,46 @@ namespace
 // -------------------------------------------------------------------------------------------
 // Backend identification
 //
-// glz::simd_isa is public and names the widest instruction set detection enabled.
-// glz::detail::utf8_simd::backend is internal and names the validator that was actually compiled;
-// the two differ whenever the validator has no vector path at the detected level.
-//
-// The assertions live here because this is the file the simd-backends workflow runs against every
-// target, so each one is checked on every backend Glaze can select rather than only on the host.
+// glz::simd_info names what each accelerated subsystem compiled to. The assertions live here
+// because this is the file the simd-backends workflow runs against every target, so each one is
+// checked on every backend Glaze can select rather than only on the host.
 // -------------------------------------------------------------------------------------------
 
 namespace
 {
-   inline constexpr size_t unknown_backend = size_t(-1);
+   // Every value simd_info.detected can take, paired with what the other subsystems must report on
+   // a build that detected it. This table IS the divergence: reading down the columns shows why one
+   // name for "the SIMD Glaze is using" would be wrong on most builds.
+   //
+   // float_write is absent on purpose -- zmij runs its own detection off __SSE2__ / __ARM_NEON, so
+   // it is not a function of what Glaze detected. It is checked separately below.
+   struct build_shape
+   {
+      std::string_view detected{};
+      std::string_view utf8{}; // validator: needs a byte-granular shuffle, else falls back
+      std::string_view escape{}; // string escaping: no AVX-512 or WASM helper exists
+   };
+
+   inline constexpr build_shape known_builds[]{
+      {"AVX512BW", "AVX512BW", "AVX2"}, // no AVX-512 escape helper
+      {"AVX2", "AVX2", "AVX2"}, //
+      {"SSSE3", "SSSE3", "SSE2"}, // no SSSE3 escape helper
+      {"SSE2", "scalar", "SSE2"}, // SSE2 has no byte-granular shuffle
+      {"NEON64", "NEON64", "NEON"}, //
+      {"NEON", "scalar", "NEON"}, // 32 bit NEON has no vqtbl1q_u8
+      {"WASM_SIMD128", "WASM_SIMD128", "SWAR"}, // no WASM escape helper
+      {"scalar", "scalar", "SWAR"}, //
+   };
+
+   constexpr const build_shape* shape_for(std::string_view detected) noexcept
+   {
+      for (const auto& b : known_builds) {
+         if (b.detected == detected) return &b;
+      }
+      return nullptr;
+   }
+
+   inline constexpr size_t unknown_width = size_t(-1);
 
    struct utf8_backend_name
    {
@@ -154,67 +183,73 @@ namespace
       {"generic16", 16}, {"generic32", 32}, {"generic64", 64}, {"scalar", 0},
    };
 
-   inline constexpr std::string_view known_simd_isas[]{"AVX512BW", "AVX2",         "SSSE3", "SSE2",
-                                                       "NEON64",   "WASM_SIMD128", "NEON",  "scalar"};
-
    constexpr size_t width_for(std::string_view backend) noexcept
    {
       for (const auto& b : known_utf8_backends) {
          if (b.name == backend) return b.width;
       }
-      return unknown_backend;
+      return unknown_width;
    }
 
-   constexpr bool is_known_isa(std::string_view isa) noexcept
+   inline constexpr std::string_view known_float_write[]{"NEON", "SSE4.1", "SSE2", "scalar"};
+
+   constexpr bool is_known_float_write(std::string_view name) noexcept
    {
-      for (const auto& known : known_simd_isas) {
-         if (known == isa) return true;
+      for (const auto& known : known_float_write) {
+         if (known == name) return true;
       }
       return false;
    }
-
-   inline constexpr std::string_view utf8_backend = glz::detail::utf8_simd::backend;
 }
 
 // These spellings are public API, so a new one should be added here and to
 // docs/optimizing-performance.md deliberately rather than arriving as a side effect of adding a
 // backend.
-static_assert(is_known_isa(glz::simd_isa), "glz::simd_isa reports a name this test does not know");
+static_assert(shape_for(glz::simd_info.detected) != nullptr,
+              "simd_info.detected reports a value this test does not know");
+static_assert(width_for(glz::simd_info.utf8_validation) != unknown_width,
+              "simd_info.utf8_validation reports a value this test does not know");
+static_assert(is_known_float_write(glz::simd_info.float_write),
+              "simd_info.float_write reports a value this test does not know");
 
-static_assert(width_for(utf8_backend) != unknown_backend, "the UTF-8 validator reports a name this test does not know");
-
-#if defined(GLZ_UTF8_SIMD)
-// The name and the width come from the same branch of the selection chain, so a branch that copies
-// its neighbour's name is caught here. Without this the CI jobs would only be reading back a string
-// they had no independent way to check.
-static_assert(width_for(utf8_backend) == glz::detail::utf8_simd::width,
-              "a UTF-8 backend named itself as one register width and then defined another");
-#else
-static_assert(utf8_backend == "scalar");
-#endif
+// String escaping is a pure function of what was detected, with no testing hook to fence against.
+static_assert(shape_for(glz::simd_info.detected)->escape == glz::simd_info.string_escape,
+              "string escaping does not match the helper this build's instruction set selects");
 
 #if !defined(GLZ_UTF8_GENERIC_WIDTH)
-// Outside the portable-backend testing hook the two are locked together: the validator takes the
-// detected instruction set whenever it has a byte-granular shuffle at that level, and falls back to
-// the scalar validator when it does not. SSE2 and 32 bit NEON are the two that fall back, and they
-// are why glz::simd_isa is documented as an upper bound rather than as the name of a code path.
-static_assert(glz::simd_isa != "AVX512BW" || utf8_backend == "AVX512BW");
-static_assert(glz::simd_isa != "AVX2" || utf8_backend == "AVX2");
-static_assert(glz::simd_isa != "SSSE3" || utf8_backend == "SSSE3");
-static_assert(glz::simd_isa != "SSE2" || utf8_backend == "scalar");
-static_assert(glz::simd_isa != "NEON64" || utf8_backend == "NEON64");
-static_assert(glz::simd_isa != "NEON" || utf8_backend == "scalar");
-static_assert(glz::simd_isa != "WASM_SIMD128" || utf8_backend == "WASM_SIMD128");
-static_assert(glz::simd_isa != "scalar" || utf8_backend == "scalar");
+// GLZ_UTF8_GENERIC_WIDTH overrides the validator with the portable path, so the mapping only holds
+// when that hook is off. Without this fence the row for a target with no vector path (s390x, armv7
+// without NEON) would fire, since it expects "scalar" and would get "generic64".
+static_assert(shape_for(glz::simd_info.detected)->utf8 == glz::simd_info.utf8_validation,
+              "the UTF-8 validator does not match what this build's instruction set selects");
+#endif
+
+#if defined(GLZ_UTF8_SIMD)
+// Ties the reported name to the register width its own branch defines. The table above pins the
+// name, so what this adds is the width: a branch that declares the wrong width for its register
+// type would otherwise only surface as wrong validation results at runtime.
+static_assert(width_for(glz::simd_info.utf8_validation) == glz::detail::utf8_simd::width,
+              "a UTF-8 backend named itself as one register width and then defined another");
+#else
+static_assert(glz::simd_info.utf8_validation == "scalar");
+#endif
+
+#if defined(GLZ_DISABLE_SIMD)
+// The one promise that spans all four fields: asking for no vector path gets none anywhere,
+// including from zmij, which otherwise ignores Glaze's detection entirely.
+static_assert(glz::simd_info.detected == "scalar" && glz::simd_info.utf8_validation == "scalar" &&
+                 glz::simd_info.string_escape == "SWAR" && glz::simd_info.float_write == "scalar",
+              "GLZ_DISABLE_SIMD left a vector path enabled");
 #endif
 
 suite backend_identification = [] {
-   // Echoed so a failing run in any of the backend jobs says which backend it was, without needing
-   // a separate probe program to establish it.
-   "reports which backend it compiled"_test = [] {
-      std::cout << "glz::simd_isa = " << glz::simd_isa << ", UTF-8 validator = " << utf8_backend << '\n';
-      expect(!glz::simd_isa.empty());
-      expect(!utf8_backend.empty());
+   // Echoed so a failing run in any of the backend jobs says which build it was, without needing a
+   // separate probe program to establish it. Written as JSON because that is the form a benchmark
+   // report wants, and it exercises the reflection users will actually use.
+   "reports what this build compiled"_test = [] {
+      std::string report;
+      expect(not glz::write_json(glz::simd_info, report));
+      std::cout << report << '\n';
    };
 };
 

--- a/tests/json_test/utf8_validation_test.cpp
+++ b/tests/json_test/utf8_validation_test.cpp
@@ -131,8 +131,11 @@ namespace
 // -------------------------------------------------------------------------------------------
 // Backend identification
 //
-// glz::simd_isa and glz::utf8_validation_backend name what this translation unit compiled. The
-// assertions live here because this is the file the simd-backends workflow runs against every
+// glz::simd_isa is public and names the widest instruction set detection enabled.
+// glz::detail::utf8_simd::backend is internal and names the validator that was actually compiled;
+// the two differ whenever the validator has no vector path at the detected level.
+//
+// The assertions live here because this is the file the simd-backends workflow runs against every
 // target, so each one is checked on every backend Glaze can select rather than only on the host.
 // -------------------------------------------------------------------------------------------
 
@@ -169,59 +172,49 @@ namespace
       }
       return false;
    }
+
+   inline constexpr std::string_view utf8_backend = glz::detail::utf8_simd::backend;
 }
 
-// The spellings are public API, so a new one should be added here and to
+// These spellings are public API, so a new one should be added here and to
 // docs/optimizing-performance.md deliberately rather than arriving as a side effect of adding a
 // backend.
 static_assert(is_known_isa(glz::simd_isa), "glz::simd_isa reports a name this test does not know");
 
-static_assert(width_for(glz::utf8_validation_backend) != unknown_backend,
-              "glz::utf8_validation_backend reports a name this test does not know");
+static_assert(width_for(utf8_backend) != unknown_backend, "the UTF-8 validator reports a name this test does not know");
 
 #if defined(GLZ_UTF8_SIMD)
 // The name and the width come from the same branch of the selection chain, so a branch that copies
 // its neighbour's name is caught here. Without this the CI jobs would only be reading back a string
 // they had no independent way to check.
-static_assert(width_for(glz::utf8_validation_backend) == glz::detail::utf8_simd::width,
+static_assert(width_for(utf8_backend) == glz::detail::utf8_simd::width,
               "a UTF-8 backend named itself as one register width and then defined another");
 #else
-static_assert(glz::utf8_validation_backend == "scalar");
+static_assert(utf8_backend == "scalar");
 #endif
 
 #if !defined(GLZ_UTF8_GENERIC_WIDTH)
-// Outside the portable-backend testing hook the two constants are locked together: the validator
-// takes the detected instruction set whenever it has a byte-granular shuffle at that level, and
-// falls back to the scalar validator when it does not. SSE2 and 32 bit NEON are the two that fall
-// back, and they are the reason a single "the backend" name cannot be correct for all of Glaze.
-static_assert(glz::simd_isa != "AVX512BW" || glz::utf8_validation_backend == "AVX512BW");
-static_assert(glz::simd_isa != "AVX2" || glz::utf8_validation_backend == "AVX2");
-static_assert(glz::simd_isa != "SSSE3" || glz::utf8_validation_backend == "SSSE3");
-static_assert(glz::simd_isa != "SSE2" || glz::utf8_validation_backend == "scalar");
-static_assert(glz::simd_isa != "NEON64" || glz::utf8_validation_backend == "NEON64");
-static_assert(glz::simd_isa != "NEON" || glz::utf8_validation_backend == "scalar");
-static_assert(glz::simd_isa != "WASM_SIMD128" || glz::utf8_validation_backend == "WASM_SIMD128");
-static_assert(glz::simd_isa != "scalar" || glz::utf8_validation_backend == "scalar");
+// Outside the portable-backend testing hook the two are locked together: the validator takes the
+// detected instruction set whenever it has a byte-granular shuffle at that level, and falls back to
+// the scalar validator when it does not. SSE2 and 32 bit NEON are the two that fall back, and they
+// are why glz::simd_isa is documented as an upper bound rather than as the name of a code path.
+static_assert(glz::simd_isa != "AVX512BW" || utf8_backend == "AVX512BW");
+static_assert(glz::simd_isa != "AVX2" || utf8_backend == "AVX2");
+static_assert(glz::simd_isa != "SSSE3" || utf8_backend == "SSSE3");
+static_assert(glz::simd_isa != "SSE2" || utf8_backend == "scalar");
+static_assert(glz::simd_isa != "NEON64" || utf8_backend == "NEON64");
+static_assert(glz::simd_isa != "NEON" || utf8_backend == "scalar");
+static_assert(glz::simd_isa != "WASM_SIMD128" || utf8_backend == "WASM_SIMD128");
+static_assert(glz::simd_isa != "scalar" || utf8_backend == "scalar");
 #endif
 
 suite backend_identification = [] {
    // Echoed so a failing run in any of the backend jobs says which backend it was, without needing
    // a separate probe program to establish it.
    "reports which backend it compiled"_test = [] {
-      std::cout << "glz::simd_isa = " << glz::simd_isa
-                << ", glz::utf8_validation_backend = " << glz::utf8_validation_backend << '\n';
+      std::cout << "glz::simd_isa = " << glz::simd_isa << ", UTF-8 validator = " << utf8_backend << '\n';
       expect(!glz::simd_isa.empty());
-      expect(!glz::utf8_validation_backend.empty());
-   };
-
-   // The constants are consumed by shell (`test "$got" = ...`) in the simd-backends workflow, which
-   // would silently compare against a name carrying a stray newline or quote.
-   "names are bare identifiers"_test = [] {
-      for (const std::string_view name : {glz::simd_isa, glz::utf8_validation_backend}) {
-         for (const char c : name) {
-            expect((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_') << name;
-         }
-      }
+      expect(!utf8_backend.empty());
    };
 };
 

--- a/tests/json_test/utf8_validation_test.cpp
+++ b/tests/json_test/utf8_validation_test.cpp
@@ -139,8 +139,7 @@ namespace
 namespace
 {
    // Every value simd_info.detected can take, paired with what the other subsystems must report on
-   // a build that detected it. This table IS the divergence: reading down the columns shows why one
-   // name for "the SIMD Glaze is using" would be wrong on most builds.
+   // a build that detected it.
    //
    // float_write is absent on purpose -- zmij runs its own detection off __SSE2__ / __ARM_NEON, so
    // it is not a function of what Glaze detected. It is checked separately below.
@@ -191,15 +190,6 @@ namespace
       return unknown_width;
    }
 
-   inline constexpr std::string_view known_float_write[]{"NEON", "SSE4.1", "SSE2", "scalar"};
-
-   constexpr bool is_known_float_write(std::string_view name) noexcept
-   {
-      for (const auto& known : known_float_write) {
-         if (known == name) return true;
-      }
-      return false;
-   }
 }
 
 // These spellings are public API, so a new one should be added here and to
@@ -209,7 +199,11 @@ static_assert(shape_for(glz::simd_info.detected) != nullptr,
               "simd_info.detected reports a value this test does not know");
 static_assert(width_for(glz::simd_info.utf8_validation) != unknown_width,
               "simd_info.utf8_validation reports a value this test does not know");
-static_assert(is_known_float_write(glz::simd_info.float_write),
+// Registration only. Which of these zmij picks is not checkable here: any mapping would have to
+// read the same ZMIJ_USE_* macros float_write_simd() reads, and so would agree with it by
+// construction. This catches a new spelling entering public API without the docs following.
+static_assert(glz::simd_info.float_write == "NEON" || glz::simd_info.float_write == "SSE4.1" ||
+                 glz::simd_info.float_write == "SSE2" || glz::simd_info.float_write == "scalar",
               "simd_info.float_write reports a value this test does not know");
 
 // String escaping is a pure function of what was detected, with no testing hook to fence against.
@@ -225,14 +219,43 @@ static_assert(shape_for(glz::simd_info.detected)->utf8 == glz::simd_info.utf8_va
 #endif
 
 #if defined(GLZ_UTF8_SIMD)
-// Ties the reported name to the register width its own branch defines. The table above pins the
-// name, so what this adds is the width: a branch that declares the wrong width for its register
-// type would otherwise only surface as wrong validation results at runtime.
+// Ties the reported name to the register width its own branch defines, catching a branch that
+// copied a neighbour's name without its width. That the width matches the register type is a
+// separate question, and utf8_validation.hpp asserts it there with sizeof(vec) == width, where the
+// type is in scope.
 static_assert(width_for(glz::simd_info.utf8_validation) == glz::detail::utf8_simd::width,
               "a UTF-8 backend named itself as one register width and then defined another");
-#else
-static_assert(glz::simd_info.utf8_validation == "scalar");
 #endif
+
+// Everything above checks that the reported names agree with each other. None of it can say which
+// backend this build was supposed to select: a job whose flags quietly stopped taking effect gets a
+// different backend that is just as self-consistent, and every assert above stays green.
+//
+// So the simd-backends workflow pins the answer, passing e.g. -DGLZ_EXPECT_DETECTED=SSSE3 through
+// the same flags that compile this file. Compiling it here rather than in a standalone probe is the
+// point: a probe is a second compilation that can drift from the one that builds the suite, and
+// then it confirms its own flags while the tests run on whatever the build actually used.
+//
+// Each is optional, because not every job can pin every field. The generic-width job pins only the
+// validator; what the host detects underneath it is not the runner's to promise.
+#define GLZ_EXPECTED_NAME_2(x) #x
+#define GLZ_EXPECTED_NAME(x) GLZ_EXPECTED_NAME_2(x)
+
+#if defined(GLZ_EXPECT_DETECTED)
+static_assert(glz::simd_info.detected == GLZ_EXPECTED_NAME(GLZ_EXPECT_DETECTED),
+              "detected is not the instruction set this build was configured to select");
+#endif
+#if defined(GLZ_EXPECT_UTF8_VALIDATION)
+static_assert(glz::simd_info.utf8_validation == GLZ_EXPECTED_NAME(GLZ_EXPECT_UTF8_VALIDATION),
+              "utf8_validation is not the backend this build was configured to select");
+#endif
+#if defined(GLZ_EXPECT_STRING_ESCAPE)
+static_assert(glz::simd_info.string_escape == GLZ_EXPECTED_NAME(GLZ_EXPECT_STRING_ESCAPE),
+              "string_escape is not the helper this build was configured to select");
+#endif
+
+#undef GLZ_EXPECTED_NAME
+#undef GLZ_EXPECTED_NAME_2
 
 #if defined(GLZ_DISABLE_SIMD)
 // The one promise that spans all four fields: asking for no vector path gets none anywhere,

--- a/tests/json_test/utf8_validation_test.cpp
+++ b/tests/json_test/utf8_validation_test.cpp
@@ -6,8 +6,11 @@
 // much of this file sweeps byte offsets: a bug in cross-register carry or in the padded tail block
 // only shows up when a sequence straddles a boundary the host happens to use.
 
+#include "glaze/simd/utf8_validation.hpp"
+
 #include <array>
 #include <cstdint>
+#include <iostream>
 #include <map>
 #include <random>
 #include <string>
@@ -124,6 +127,103 @@ namespace
       return v;
    }
 }
+
+// -------------------------------------------------------------------------------------------
+// Backend identification
+//
+// glz::simd_isa and glz::utf8_validation_backend name what this translation unit compiled. The
+// assertions live here because this is the file the simd-backends workflow runs against every
+// target, so each one is checked on every backend Glaze can select rather than only on the host.
+// -------------------------------------------------------------------------------------------
+
+namespace
+{
+   inline constexpr size_t unknown_backend = size_t(-1);
+
+   struct utf8_backend_name
+   {
+      std::string_view name{};
+      size_t width{}; // register width the validator uses under this name; 0 for the scalar fallback
+   };
+
+   inline constexpr utf8_backend_name known_utf8_backends[]{
+      {"AVX512BW", 64},  {"AVX2", 32},      {"SSSE3", 16},     {"NEON64", 16}, {"WASM_SIMD128", 16},
+      {"generic16", 16}, {"generic32", 32}, {"generic64", 64}, {"scalar", 0},
+   };
+
+   inline constexpr std::string_view known_simd_isas[]{"AVX512BW", "AVX2",         "SSSE3", "SSE2",
+                                                       "NEON64",   "WASM_SIMD128", "NEON",  "scalar"};
+
+   constexpr size_t width_for(std::string_view backend) noexcept
+   {
+      for (const auto& b : known_utf8_backends) {
+         if (b.name == backend) return b.width;
+      }
+      return unknown_backend;
+   }
+
+   constexpr bool is_known_isa(std::string_view isa) noexcept
+   {
+      for (const auto& known : known_simd_isas) {
+         if (known == isa) return true;
+      }
+      return false;
+   }
+}
+
+// The spellings are public API, so a new one should be added here and to
+// docs/optimizing-performance.md deliberately rather than arriving as a side effect of adding a
+// backend.
+static_assert(is_known_isa(glz::simd_isa), "glz::simd_isa reports a name this test does not know");
+
+static_assert(width_for(glz::utf8_validation_backend) != unknown_backend,
+              "glz::utf8_validation_backend reports a name this test does not know");
+
+#if defined(GLZ_UTF8_SIMD)
+// The name and the width come from the same branch of the selection chain, so a branch that copies
+// its neighbour's name is caught here. Without this the CI jobs would only be reading back a string
+// they had no independent way to check.
+static_assert(width_for(glz::utf8_validation_backend) == glz::detail::utf8_simd::width,
+              "a UTF-8 backend named itself as one register width and then defined another");
+#else
+static_assert(glz::utf8_validation_backend == "scalar");
+#endif
+
+#if !defined(GLZ_UTF8_GENERIC_WIDTH)
+// Outside the portable-backend testing hook the two constants are locked together: the validator
+// takes the detected instruction set whenever it has a byte-granular shuffle at that level, and
+// falls back to the scalar validator when it does not. SSE2 and 32 bit NEON are the two that fall
+// back, and they are the reason a single "the backend" name cannot be correct for all of Glaze.
+static_assert(glz::simd_isa != "AVX512BW" || glz::utf8_validation_backend == "AVX512BW");
+static_assert(glz::simd_isa != "AVX2" || glz::utf8_validation_backend == "AVX2");
+static_assert(glz::simd_isa != "SSSE3" || glz::utf8_validation_backend == "SSSE3");
+static_assert(glz::simd_isa != "SSE2" || glz::utf8_validation_backend == "scalar");
+static_assert(glz::simd_isa != "NEON64" || glz::utf8_validation_backend == "NEON64");
+static_assert(glz::simd_isa != "NEON" || glz::utf8_validation_backend == "scalar");
+static_assert(glz::simd_isa != "WASM_SIMD128" || glz::utf8_validation_backend == "WASM_SIMD128");
+static_assert(glz::simd_isa != "scalar" || glz::utf8_validation_backend == "scalar");
+#endif
+
+suite backend_identification = [] {
+   // Echoed so a failing run in any of the backend jobs says which backend it was, without needing
+   // a separate probe program to establish it.
+   "reports which backend it compiled"_test = [] {
+      std::cout << "glz::simd_isa = " << glz::simd_isa
+                << ", glz::utf8_validation_backend = " << glz::utf8_validation_backend << '\n';
+      expect(!glz::simd_isa.empty());
+      expect(!glz::utf8_validation_backend.empty());
+   };
+
+   // The constants are consumed by shell (`test "$got" = ...`) in the simd-backends workflow, which
+   // would silently compare against a name carrying a stray newline or quote.
+   "names are bare identifiers"_test = [] {
+      for (const std::string_view name : {glz::simd_isa, glz::utf8_validation_backend}) {
+         for (const char c : name) {
+            expect((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_') << name;
+         }
+      }
+   };
+};
 
 // -------------------------------------------------------------------------------------------
 // The validator itself


### PR DESCRIPTION
Glaze had no way to answer "what SIMD is this build using". #2747 proposed a constant for it. This ships the feature with the answer that is actually true, which turns out not to be a single name.

## What ships

`glz::simd_info`, a reflectable struct naming what each accelerated subsystem compiled to:

```c++
std::string report;
std::ignore = glz::write_json(glz::simd_info, report);
// {"detected":"AVX512BW","utf8_validation":"AVX512BW","string_escape":"AVX2","float_write":"SSE4.1"}
```

Each field is a `std::string_view`, so they compare by value and work in `constexpr` contexts.

| Field | Values |
|---|---|
| `detected` | `AVX512BW`, `AVX2`, `SSSE3`, `SSE2`, `NEON64`, `NEON`, `WASM_SIMD128`, `scalar` |
| `utf8_validation` | `AVX512BW`, `AVX2`, `SSSE3`, `NEON64`, `WASM_SIMD128`, `scalar` (+ `generic16/32/64` under the `GLZ_UTF8_GENERIC_WIDTH` testing hook) |
| `string_escape` | `AVX2`, `SSE2`, `NEON`, `SWAR` |
| `float_write` | `NEON`, `SSE4.1`, `SSE2`, `scalar` |

## Why a struct rather than one name

Because the fields genuinely disagree. Measured on this branch, compiling for real targets:

| flags | `detected` | `utf8_validation` | `string_escape` |
|---|---|---|---|
| `-march=x86-64` | SSE2 | **scalar** | SSE2 |
| `-mssse3 -mno-avx` | SSSE3 | SSSE3 | **SSE2** |
| `-mavx2` | AVX2 | AVX2 | AVX2 |
| `-mavx512f -mavx512bw` | AVX512BW | AVX512BW | **AVX2** |

Three causes, all real:

- **String escaping** has no AVX-512 helper and no WASM helper (`json/write.hpp`), so an AVX-512 build escapes with AVX2 and a wasm build escapes with SWAR.
- **UTF-8 validation** needs a byte-granular shuffle, which plain SSE2 and 32-bit NEON lack, so those targets validate with the scalar validator while the rest of Glaze stays vectorized.
- **Float writing** goes through the zmij port, which runs its own detection off `__SSE2__` / `__ARM_NEON` and honours only `GLZ_DISABLE_SIMD` from Glaze (`util/zmij.hpp`). `detected` does not even bound it from above: a 32-bit x86 build reports `detected == "scalar"` with `float_write == "SSE2"`.

Two of those three subsystems had no queryable name at all before this PR. Reporting only the detected instruction set would tell someone benchmarking Glaze that an AVX-512 build was AVX-512 throughout, which is wrong about two of its three accelerated paths.

## Each translation unit reports its own answer

`simd_info` is `constexpr`, not `inline constexpr`, and that is deliberate. The values come from the preprocessor, so a project compiling some files with `-mavx2` and others without needs each to keep its own answer. Under `inline` the copies merge and the linker's survivor answers for all of them — through `write_json(glz::simd_info, s)`, the call this feature exists to serve, because passing the object binds a reference to it:

```
inline constexpr:   TU built at the x86-64 baseline printed  {"detected":"AVX2", ... ,"float_write":"SSE4.1"}
                    while validating scalar, escaping SSE2, writing floats with SSE2
constexpr:          same TU prints  {"detected":"SSE2","utf8_validation":"scalar","string_escape":"SSE2","float_write":"SSE2"}
```

Internal linkage costs nothing here: `std::string_view` compares by content, so per-TU copies change no comparison.

## Keeping the names honest

All four chains live in the new `simd/backends.hpp`, which lets `simd/simd.hpp` go back to being the pure macro header it was. The header is included once, from `glaze.hpp`; nothing on the JSON write path depends on it.

Names are anchored to the code they describe:

- Each UTF-8 backend branch declares its name next to the register width it already defines, and `utf8_validation.hpp` asserts `sizeof(vec) == width`, so a branch declaring a width its register type does not have fails to build. Everything downstream trusts `width`, so that mismatch would otherwise corrupt validation rather than break the build.
- The `detected` → `{utf8_validation, string_escape}` mapping is one table of `static_assert`s.

Verified against five sabotages, each caught by a distinct assertion:

| reintroduced | caught by |
|---|---|
| backend renamed to a **same-width** neighbour | the mapping table |
| backend declares the wrong register width | `sizeof(vec) == width` |
| backend declares no name | fails to compile |
| escape chain names the wrong helper | the mapping table |
| float-write name not in the known set | the membership check |

That first row is the case an earlier revision missed: SSSE3, NEON64 and WASM_SIMD128 are all 16 bytes, so a width check cannot distinguish them.

## CI

**The expected backend is now compiled into the suite**, not checked by a separate probe. A probe is a second compilation that can drift from the one that builds the tests: if `CMAKE_CXX_FLAGS` ever lost the matrix flags, every probe would still agree with its own flags while all four rows quietly tested the host default. Each job now passes `-DGLZ_EXPECT_DETECTED=SSSE3` and friends through the same flags that compile the suite, so the assertion travels with the flags under test. Verified by simulating the dropped-flags case for every job — all of them now fail to build.

That removed four probe programs and 32 lines of workflow.

**An AArch64 job.** NEON64 was previously reached only incidentally, by the single `macos-latest` job in `clang.yml`, despite being what every Apple Silicon and most server ARM user runs. Native ARM runners are free for public repositories. 32-bit NEON is a different backend (no `vqtbl1q_u8`, so the validator falls back to scalar) and stays in `armv7.yml` under QEMU.

**A `GLZ_DISABLE_SIMD` row**, which is what finally compiles the assertion spanning all four fields. Nothing in CI had ever built it.

**`--no-tests=error` on both `ctest` calls.** `ctest` exits 0 when `-R` matches nothing, so a renamed test left the step green while running none of the suites the job exists to run. Pre-existing.

Earlier in this branch, a probe split one line into two fields with `${out%% *}` and `${out##* }`, which return the same token when the line has no space — two of three matrix rows could have gone green while checking nothing. That probe is gone entirely now.

## Documentation corrections

Found while verifying my own claims:

- String escaping never consumed `GLZ_USE_SSSE3` — its only consumer anywhere is the UTF-8 validator.
- The x86 flags are all conditional on the `__x86_64__` branch. A `-m32 -mavx2` build defines none of them, and `gcc-x86.yml` builds `-m32`.
- `README.md` held a **third** copy of the flag table, still listing three of seven flags. The canonical table now lives in `optimizing-performance.md` and the other two link to it.
- `detected` does not bound every other field: `GLZ_UTF8_GENERIC_WIDTH` overrides `utf8_validation` as well.
- `float_write` names zmij's path only; `opts::float_format` routes floats through `std::format`, which no field describes.
- `SWAR` is defined, including that it is Glaze's fallback everywhere — so `scalar` in another field does not mean the work is done a byte at a time.
- The documented snippet no longer discards a `[[nodiscard]]` result.

## Testing

Full suite green locally (116/116). `glz::simd_info` verified by compiling and running at: AArch64 native, x86-64 at SSE2/SSSE3/AVX2/AVX512BW, `GLZ_DISABLE_SIMD`, and `GLZ_UTF8_GENERIC_WIDTH` 16/32/64. Every CI expectation was verified against a real compilation before being written into the workflow, and each was then re-verified to fail when its flags are removed.

## Not in this PR

A **pre-existing** bug at `simd/simd.hpp:25`: the `_MSC_VER && __AVX512F__` fallback also fires on clang-cl, which defines `_MSC_VER` and the fine-grained `__AVX512*__` macros, so `clang-cl /clang:-mavx512f` selects `_mm512_shuffle_epi8` without AVX-512BW and fails to build. The justifying comment is also wrong — MSVC does define `__AVX512BW__` under `/arch:AVX512`. Sent separately so it gets its own bisectable commit and its own clang-cl run.

## Credit

The idea, and the case that Glaze should expose this at all, are RealTimeChris's from #2747, which this supersedes. No code is shared with that PR.
