### PR TITLE
Keep clang-cl out of the MSVC AVX-512BW fallback

### DIFF
--- a/include/glaze/simd/simd.hpp
+++ b/include/glaze/simd/simd.hpp
@@ -20,9 +20,15 @@
 #define GLZ_USE_AVX2
 #endif
 // AVX-512BW supplies the byte-granular shuffle and saturating subtract at 512 bits.
-// MSVC has no __AVX512BW__ macro; /arch:AVX512 defines __AVX512F__ alongside it.
+//
+// The _MSC_VER arm is for MSVC, which reports AVX-512 only as __AVX512F__. clang-cl also defines
+// _MSC_VER but does define __AVX512BW__, so it must not take that arm: __AVX512F__ does not imply
+// __AVX512BW__, and /clang:-mavx512f would otherwise select _mm512_shuffle_epi8 without the feature
+// and fail to compile. The SSSE3 fallback above needs no such guard, because __AVX__ does imply
+// __SSSE3__.
+//
 // Covered by the simd-backends workflow, which runs the UTF-8 suite under Intel SDE.
-#if defined(__AVX512BW__) || (defined(_MSC_VER) && defined(__AVX512F__))
+#if defined(__AVX512BW__) || (defined(_MSC_VER) && !defined(__clang__) && defined(__AVX512F__))
 #define GLZ_USE_AVX512BW
 #endif
 #elif defined(__aarch64__) || defined(_M_ARM64) || defined(__ARM_NEON)


### PR DESCRIPTION
`clang-cl /clang:-mavx512f` fails to compile Glaze. One-line predicate fix.

## The bug

`simd/simd.hpp` enables `GLZ_USE_AVX512BW` on `__AVX512BW__`, or on `_MSC_VER` with `__AVX512F__`:

```c++
#if defined(__AVX512BW__) || (defined(_MSC_VER) && defined(__AVX512F__))
```

The fallback exists because MSVC reports AVX-512 only as `__AVX512F__`. But **clang-cl also defines `_MSC_VER`**, and unlike MSVC it *does* define the fine-grained `__AVX512*__` macros. So a clang-cl build given only AVX-512F takes the fallback and selects the AVX-512BW branch of the UTF-8 validator without the feature:

```
$ clang++ --target=x86_64-pc-windows-msvc -mavx512f -dM -E -x c++ /dev/null | grep -E "_MSC_VER|__AVX512"
#define _MSC_VER 1933
#define __AVX512F__ 1          <- present
                               <- __AVX512BW__ absent
```

That branch uses `_mm512_shuffle_epi8` and `_mm512_subs_epu8`, which fail at codegen:

```
error: always_inline function '_mm512_shuffle_epi8' requires target feature 'avx512bw',
but would be inlined into function 'f' that is compiled without support for 'avx512bw'
```

## The fix

```diff
-#if defined(__AVX512BW__) || (defined(_MSC_VER) && defined(__AVX512F__))
+#if defined(__AVX512BW__) || (defined(_MSC_VER) && !defined(__clang__) && defined(__AVX512F__))
```

Real MSVC keeps the fallback. clang-cl goes through `__AVX512BW__` like every other clang target.

## Why the SSSE3 fallback two lines up is fine

It has the same shape:

```c++
#if defined(__SSSE3__) || (defined(_MSC_VER) && defined(__AVX__))
```

but it is not reachable in the same way, because `__AVX__` implies `__SSSE3__` — so on clang-cl the first disjunct already fires and the fallback never decides anything:

| clang-cl flags | `__SSSE3__` | `__AVX__` |
|---|---|---|
| `-mavx` | 1 | 1 |
| `-mavx2` | 1 | 1 |
| `-mavx512f` | 1 | 1 |

`__AVX512F__` does **not** imply `__AVX512BW__`. That asymmetry is the whole bug, and it's why only the AVX-512 line needs the guard. I left the SSSE3 line alone.

## Verification

Predicate evaluated at every relevant configuration:

| target | flags | before | after | want |
|---|---|---|---|---|
| clang-cl | `-mavx512f` | **ON** | off | off |
| clang-cl | `-mavx512bw` | ON | ON | ON |
| clang-cl | none | off | off | off |
| linux clang/gcc | `-mavx512f` | off | off | off |
| linux clang/gcc | `-mavx512bw` | ON | ON | ON |
| linux clang/gcc | baseline | off | off | off |
| MSVC (simulated) | `_MSC_VER` + `__AVX512F__`, no `__clang__` | ON | **ON** | ON |

The MSVC row is a preprocessor simulation (`-undef -D_MSC_VER=1939 -D__AVX512F__=1`), not a real compile: there is **no MSVC `/arch:AVX512` job in CI**, so that path is untested here either way. The point of the row is that the fix does not disturb it.

Native builds unaffected: arm64, x86-64 `-mavx512f -mavx512bw`, and x86-64 `-mavx512f` (the configuration that previously mis-selected) all build and run.

## Note on the comment

The old comment said "MSVC has no `__AVX512BW__` macro". That is wrong — MSVC does define it under `/arch:AVX512`, which means the fallback may be entirely removable. I did not remove it, because there is no MSVC AVX-512 CI job to confirm that, and keeping it costs nothing now that clang-cl is excluded. The comment is corrected to describe what the arm is actually for.

Found while working on #2749, which documented it but deliberately did not bundle the fix.
