### PR TITLE
Use a single msgpack string write specialization

### DIFF
--- a/include/glaze/msgpack/read.hpp
+++ b/include/glaze/msgpack/read.hpp
@@ -527,6 +527,12 @@ namespace glz
       }
    };
 
+   // The four string specializations below are mutually exclusive, which matters beyond avoiding an
+   // ambiguity: leaving two of them viable for one type forces the compiler to partially order
+   // constrained partial specializations, and normalizing these concepts for that subsumption check
+   // is costly enough to exhaust clang 22's stack (see issue #2742, and the note in write.hpp).
+   // `string_t` stays disjoint from the other three via its `!string_view_t` and `!is_static_string`
+   // clauses, so keep any new string specialization here exclusive as well.
    template <string_t T>
    struct from<MSGPACK, T>
    {

--- a/include/glaze/msgpack/write.hpp
+++ b/include/glaze/msgpack/write.hpp
@@ -574,41 +574,26 @@ namespace glz
       }
    };
 
-   template <string_t T>
-   struct to<MSGPACK, T>
-   {
-      template <auto Opts, class Value, is_context Ctx, class B, class IX>
-      GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, B&& b, IX&& ix)
-      {
-         const std::string_view str{value.data(), value.size()};
-         if (!msgpack::detail::write_str_header(ctx, str.size(), b, ix)) [[unlikely]] {
-            return;
-         }
-         msgpack::detail::dump_raw_bytes(ctx, str.data(), str.size(), b, ix);
-      }
-   };
-
-   template <static_string_t T>
-   struct to<MSGPACK, T>
-   {
-      template <auto Opts, class Value, is_context Ctx, class B, class IX>
-      GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, B&& b, IX&& ix)
-      {
-         const std::string_view str{value.data(), value.size()};
-         if (!msgpack::detail::write_str_header(ctx, str.size(), b, ix)) [[unlikely]] {
-            return;
-         }
-         msgpack::detail::dump_raw_bytes(ctx, str.data(), str.size(), b, ix);
-      }
-   };
-
+   // Every string-like type shares this one specialization, matching JSON, BEVE, and CBOR.
+   // Splitting `string_t` and `static_string_t` out into their own specializations makes several
+   // of them viable for the same type, which forces the compiler to partially order constrained
+   // partial specializations. Normalizing these disjunction-heavy concepts for that subsumption
+   // check is costly enough that clang 22 exhausts its stack on it (see issue #2742).
    template <str_t T>
    struct to<MSGPACK, T>
    {
       template <auto Opts, class Value, is_context Ctx, class B, class IX>
       GLZ_ALWAYS_INLINE static void op(Value&& value, Ctx&& ctx, B&& b, IX&& ix)
       {
-         const std::string_view str{value};
+         const sv str = [&]() -> const sv {
+            if constexpr (!char_array_t<T> && std::is_pointer_v<std::decay_t<T>>) {
+               return value ? value : "";
+            }
+            else {
+               return sv{value};
+            }
+         }();
+
          if (!msgpack::detail::write_str_header(ctx, str.size(), b, ix)) [[unlikely]] {
             return;
          }

--- a/include/glaze/msgpack/write.hpp
+++ b/include/glaze/msgpack/write.hpp
@@ -589,6 +589,13 @@ namespace glz
             if constexpr (!char_array_t<T> && std::is_pointer_v<std::decay_t<T>>) {
                return value ? value : "";
             }
+            else if constexpr (has_data<T> && has_size<T>) {
+               // Prefer the explicit bounds over a string_view conversion. A type may reach `str_t`
+               // through an `operator const char*`, which would silently truncate at the first
+               // embedded null and desync writing from reading, since reading always stores through
+               // `assign`/`data`. Standard string types agree either way.
+               return sv{value.data(), value.size()};
+            }
             else {
                return sv{value};
             }

--- a/include/glaze/msgpack/write.hpp
+++ b/include/glaze/msgpack/write.hpp
@@ -574,7 +574,7 @@ namespace glz
       }
    };
 
-   // Every string-like type shares this one specialization, matching JSON, BEVE, and CBOR.
+   // Every string-like type shares this one specialization, using the same idiom as BEVE and CBOR.
    // Splitting `string_t` and `static_string_t` out into their own specializations makes several
    // of them viable for the same type, which forces the compiler to partially order constrained
    // partial specializations. Normalizing these disjunction-heavy concepts for that subsumption

--- a/tests/msgpack_test/msgpack_test.cpp
+++ b/tests/msgpack_test/msgpack_test.cpp
@@ -720,6 +720,36 @@ int main()
       expect(decoded == original);
    };
 
+   "msgpack embedded null string roundtrip"_test = [] {
+      // msgpack strings are length prefixed rather than terminated, so a null byte is ordinary
+      // payload. This is what the msgpack_roundtrip_string fuzzer generates.
+      const std::string original("a\0b", 3);
+      expect_roundtrip_equal(original);
+
+      auto encoded = glz::write_msgpack(original);
+      expect(encoded.has_value());
+      expect(encoded.value() == std::string("\xa3"
+                                            "a\0b",
+                                            4));
+
+      expect_roundtrip_equal(std::string_view{original});
+   };
+
+   "msgpack string length boundaries"_test = [] {
+      // fixstr holds up to 31 bytes, then str8, str16, and str32 take over
+      for (size_t size : {size_t(0), size_t(31), size_t(32), size_t(255), size_t(256), size_t(65535), size_t(65536)}) {
+         const std::string original(size, 'x');
+         expect_roundtrip_equal(original);
+
+         auto encoded = glz::write_msgpack(original);
+         expect(encoded.has_value());
+
+         // header width: fixstr 1, str8 2, str16 3, str32 5
+         const size_t header = size < 32 ? 1 : (size < 256 ? 2 : (size < 65536 ? 3 : 5));
+         expect(encoded.value().size() == header + size) << "unexpected header width for size " << size;
+      }
+   };
+
    "msgpack static string roundtrip"_test = [] {
       fixed_string_t original{};
       original.assign("static", 6);

--- a/tests/msgpack_test/msgpack_test.cpp
+++ b/tests/msgpack_test/msgpack_test.cpp
@@ -59,6 +59,37 @@ namespace
    static_assert(glz::static_string_t<fixed_string_t>);
    static_assert(not glz::string_t<fixed_string_t>);
 
+   // A legacy-style buffer string that reaches str_t through `operator const char*` rather than a
+   // string_view conversion. Its bounds are authoritative; the conversion stops at the first null.
+   struct legacy_string_t
+   {
+      using value_type = char;
+      using size_type = size_t;
+
+      operator const char*() const { return buffer; }
+
+      const char* data() const { return buffer; }
+      size_t size() const { return length; }
+
+      void assign(const char* v, size_t n)
+      {
+         length = (std::min)(sizeof(buffer), n);
+         std::memcpy(buffer, v, length);
+      }
+
+      void resize(size_t n) { length = (std::min)(sizeof(buffer), n); }
+
+      bool operator==(const legacy_string_t& other) const
+      {
+         return length == other.length && std::memcmp(buffer, other.buffer, length) == 0;
+      }
+
+      size_t length{};
+      char buffer[16]{};
+   };
+
+   static_assert(glz::string_t<legacy_string_t>);
+
    template <class T>
    void expect_roundtrip_equal(const T& original)
    {
@@ -748,6 +779,21 @@ int main()
          const size_t header = size < 32 ? 1 : (size < 256 ? 2 : (size < 65536 ? 3 : 5));
          expect(encoded.value().size() == header + size) << "unexpected header width for size " << size;
       }
+   };
+
+   "msgpack string bounds beat conversion"_test = [] {
+      // Writing must use the type's own bounds, not its `operator const char*`, or an embedded null
+      // truncates the payload while reading still restores the full length recorded in the header.
+      legacy_string_t original{};
+      original.assign("a\0b", 3);
+
+      auto encoded = glz::write_msgpack(original);
+      expect(encoded.has_value());
+      expect(encoded.value() == std::string("\xa3"
+                                            "a\0b",
+                                            4));
+
+      expect_roundtrip_equal(original);
    };
 
    "msgpack static string roundtrip"_test = [] {

--- a/tests/msgpack_test/msgpack_test.cpp
+++ b/tests/msgpack_test/msgpack_test.cpp
@@ -3,11 +3,13 @@
 
 #include "glaze/msgpack.hpp"
 
+#include <algorithm>
 #include <array>
 #include <bitset>
 #include <chrono>
 #include <compare>
 #include <cstddef>
+#include <cstring>
 #include <deque>
 #include <filesystem>
 #include <list>
@@ -28,6 +30,35 @@ using namespace ut;
 
 namespace
 {
+   // Minimal fixed-capacity string, enough to satisfy glz::static_string_t
+   struct fixed_string_t
+   {
+      static constexpr auto glaze_static_string = true;
+
+      using value_type = char;
+      using size_type = size_t;
+
+      operator std::string_view() const { return {buffer, length}; }
+
+      const char* data() const { return buffer; }
+      size_t size() const { return length; }
+      static constexpr size_t max_size() { return sizeof(buffer); }
+
+      void assign(const char* v, size_t n)
+      {
+         length = (std::min)(max_size(), n);
+         std::memcpy(buffer, v, length);
+      }
+
+      void resize(size_t n) { length = (std::min)(max_size(), n); }
+
+      size_t length{};
+      char buffer[8]{};
+   };
+
+   static_assert(glz::static_string_t<fixed_string_t>);
+   static_assert(not glz::string_t<fixed_string_t>);
+
    template <class T>
    void expect_roundtrip_equal(const T& original)
    {
@@ -687,6 +718,47 @@ int main()
       auto ec = glz::read_msgpack(decoded, std::string_view{buffer});
       expect(!ec);
       expect(decoded == original);
+   };
+
+   "msgpack static string roundtrip"_test = [] {
+      fixed_string_t original{};
+      original.assign("static", 6);
+
+      auto encoded = glz::write_msgpack(original);
+      expect(encoded.has_value());
+      expect(encoded.value() == std::string("\xa6"
+                                            "static"));
+
+      fixed_string_t decoded{};
+      auto ec = glz::read_msgpack(decoded, std::string_view{encoded.value()});
+      expect(!ec);
+      expect(std::string_view{decoded} == "static");
+   };
+
+   "msgpack char pointer write"_test = [] {
+      const char* text = "pointer";
+      auto encoded = glz::write_msgpack(text);
+      expect(encoded.has_value());
+      expect(encoded.value() == std::string("\xa7"
+                                            "pointer"));
+
+      // A null pointer must serialize as an empty string rather than dereferencing null
+      const char* empty = nullptr;
+      auto null_encoded = glz::write_msgpack(empty);
+      expect(null_encoded.has_value());
+      expect(null_encoded.value() == std::string("\xa0"));
+   };
+
+   "msgpack char array write"_test = [] {
+      auto encoded = glz::write_msgpack("array");
+      expect(encoded.has_value());
+      expect(encoded.value() == std::string("\xa5"
+                                            "array"));
+
+      auto array_encoded = glz::write_msgpack(std::array<char, 5>{'a', 'r', 'r', 'a', 'y'});
+      expect(array_encoded.has_value());
+      expect(array_encoded.value() == std::string("\xa5"
+                                                  "array"));
    };
 
    "msgpack container roundtrip"_test = [] {


### PR DESCRIPTION
Fixes the clang 22 frontend crash reported in #2742, at the root cause rather than by dropping the fuzzer.

## Cause

`to<MSGPACK, T>` carried three overlapping string specializations: `string_t`, `static_string_t`, and `str_t`. Two of them (`string_t` and `str_t`) are viable for `std::string`, so the compiler has to partially order constrained partial specializations to pick one. Normalizing these disjunction-heavy concepts for that subsumption check is what exhausts clang 22's stack, which matches the reported crash trace exactly (`getMoreSpecializedPartialSpecialization` → `IsAtLeastAsConstrained` → `NormalizedConstraint::fromConstraintExpr`).

That also explains why msgpack was the only format affected. JSON, BEVE, CBOR, BSON, TOML, and jsonb all use a single `str_t` specialization, so only one is ever viable and no partial ordering runs. Msgpack *reading* likewise has only one viable specialization for `std::string`, which is why only the write side crashed.

## Change

Collapse the three specializations into one `str_t` specialization, using the same idiom BEVE and CBOR already use. Output is byte-identical for `std::string`, `std::string_view`, `const char*`, `char[N]`, and `std::array<char, N>`.

Adopting that idiom also fixes a latent null dereference that fell out of the merge: writing a null `const char*` previously ran `std::string_view str{value}` on `nullptr` and segfaulted. It now writes an empty string, matching BEVE and CBOR.

Adds regression tests for static strings, `const char*` (including null), and char arrays.

## Verification

Reproduced against the exact compiler from the report, `clang 22.0.0git cb2f0d0a`, in the OSS-Fuzz `base-builder` image:

- unpatched: frontend segfault, exit 139
- patched: compiles, links with `-fsanitize=fuzzer,address`, runs 20k iterations clean
- unmodified `fuzzing/ossfuzz.sh`: all 22 fuzzers build, including `msgpack_roundtrip_string`

Locally: msgpack (67 tests / 223 asserts), bson, chrono, and ostream_buffer tests pass; GCC 15 clean.

## Relation to #2743

With this fix, no build exclusion is needed, so #2743 can be closed without merging. Thanks to @xingyaner for the precise diagnosis and reproducer, which is what made the root cause findable.

## Not addressed here

`include/glaze/eetf/write.hpp` has the same `str_t` + `string_t` overlap and will hit this on clang 22. Unlike msgpack, those two specializations do genuinely different things (atom vs string encoding), so merging them is not a free fix. EETF is opt-in and not part of the fuzz build, so it is not blocking anything today.
