### PR TITLE
Add a compile-time option to disable UTF-8 validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1215,6 +1215,8 @@ By default Glaze is strictly conformant with the latest JSON standard except in 
 - `validate_trailing_whitespace`
   This option validates the trailing whitespace in a parsed document. Because Glaze parses C++ structs, there is typically no need to continue parsing after the object of interest has been read. Turn on this option if you want to ensure that the rest of the document has valid whitespace, otherwise Glaze will just ignore the content after the content of interest has been parsed.
 
+UTF-8 encoding is validated on read, as RFC 8259 section 8.1 requires. The `validate_utf8` option turns this off for input whose encoding is already guaranteed, at the cost of conformance. See [UTF-8 Validation](https://stephenberry.github.io/glaze/json/#utf-8-validation).
+
 > [!NOTE]
 >
 > By default, Glaze does not unicode escape control characters (e.g. `"\x1f"` to `"\u001f"`), as this poses a risk of embedding null characters and other invisible characters in strings. The compile time option `escape_control_characters` is available for those who desire to write out control characters as escaped unicode in strings.

--- a/docs/json.md
+++ b/docs/json.md
@@ -736,7 +736,7 @@ auto ec = glz::write_json(large_object, buffer);
 
 ## JSON Conformance
 
-Glaze is RFC 8259 compliant. UTF-8 encoding is always validated when reading. Two further checks are off by default for performance:
+Glaze is RFC 8259 compliant. UTF-8 encoding is validated when reading unless you opt out with `validate_utf8 = false`. Two further checks are off by default for performance:
 
 - `validate_skipped = false`: Faster parsing by not fully validating skipped values (does not affect resulting C++ objects)
 - `validate_trailing_whitespace = false`: Stops parsing after the target object
@@ -756,7 +756,7 @@ auto ec = glz::read<strict_opts{}>(obj, json_data);
 
 ### UTF-8 Validation
 
-RFC 8259 section 8.1 requires JSON text to be encoded in UTF-8, and Glaze enforces it on every read. There is no option to disable it: read input is by definition someone else's data, and accepting malformed encodings silently propagates them into your program.
+RFC 8259 section 8.1 requires JSON text to be encoded in UTF-8, and Glaze enforces it on read. It is on by default because read input is by definition someone else's data, and accepting malformed encodings silently propagates them into your program. See [Disabling validation](#disabling-validation) below for the option that turns it off.
 
 ```cpp
 std::vector<std::string> v{};
@@ -765,7 +765,9 @@ auto ec = glz::read_json(v, "[\"a\xFF\"]"); // ec == glz::error_code::invalid_ut
 
 This rejects lone continuation bytes, overlong encodings, truncated sequences, encoded UTF-16 surrogate halves, and code points above U+10FFFF. Escape sequences are validated separately, so `"\ud800"` without a matching low surrogate is rejected as well.
 
-Validation applies to every string the reader passes over, including keys, values you do not model, and values reached through `glz::skip` or `glz::raw_json`. A malformed byte in a field you never look at still fails the parse. This is the change most likely to affect existing code: input that previously parsed will now return an error.
+Validation applies to every string the reader materializes, including map keys, keys that match no member, values you do not model, and values reached through `glz::skip` or `glz::raw_json`. A malformed byte in a field you never look at still fails the parse. This is the change most likely to affect existing code: input that previously parsed will now return an error.
+
+The one string not checked is an object key that matches a member name in your `glz::meta` or reflected struct. Matching compares the input bytes against the program's own literal, so a match proves the key is whatever you wrote in your C++ source, and no separate pass can tell you anything new. Keys read into a `std::map` or `glz::generic` are materialized and so are checked.
 
 Validation uses the Lemire & Keiser vector algorithm, with backends for AVX-512BW, AVX2, SSSE3, AArch64 NEON, and WebAssembly SIMD128. Targets without a byte-granular shuffle fall back to a scalar validator. Reading a string value skips validation entirely when the string is pure ASCII, because the scan that finds its closing quote already proves no byte has the high bit set. Object keys and skipped strings are located with `memchr`, which proves nothing about the bytes it passed over, so those always run a full pass.
 
@@ -774,6 +776,21 @@ Cost therefore tracks how much of a document is non-ASCII. Measured on `twitter.
 Writing is **not** validated. Data you serialize is your own, so Glaze does not pay to re-check it; validate before writing if you have a specific reason to. Note that this makes round-tripping asymmetric: a `std::string` holding non-UTF-8 bytes will write successfully and then fail to read back.
 
 JSONC comments are skipped without validation, since comments are not part of RFC 8259 and their bytes never reach your program.
+
+#### Disabling validation
+
+The inheritable `validate_utf8` option turns the check off, which restores the pre-validation behavior and its performance:
+
+```cpp
+struct unchecked_opts : glz::opts {
+   bool validate_utf8 = false;
+};
+
+std::vector<std::string> v{};
+auto ec = glz::read<unchecked_opts{}>(v, "[\"a\xFF\"]"); // no error; v[0] holds the raw bytes
+```
+
+Disabling it makes the parse non-conformant, so reach for it only when the encoding is already guaranteed by an earlier stage, or when the bytes are deliberately not UTF-8 and you accept that the resulting `std::string` may hold anything. The option is a compile-time setting like every other Glaze option, so it inherits into custom option structs and applies to nested values, keys, and skipped fields alike. It also governs `lazy_json_view::get<std::string>()`. Everything else still applies: unpaired `\uXXXX` surrogate escapes, raw control characters, and unterminated strings are rejected regardless.
 
 ## See Also
 

--- a/docs/lazy-json.md
+++ b/docs/lazy-json.md
@@ -51,6 +51,8 @@ To maximize performance, `lazy_json` does no validation during initial parsing o
 
 If you need validated UTF-8 strings and unescaping, use `get<std::string>()`. Otherwise `get<std::string_view>()` is faster, but the bytes it returns are unchecked. To validate a whole document up front, run `glz::validate_json` over the buffer. See [Reading](./json.md#utf-8-validation).
 
+`get<std::string>()` honors the document's `validate_utf8` option, so a `lazy_json` opened with that option set to `false` returns the raw bytes rather than an error.
+
 > glz::lazy_json will ensure that any instantiated C++ values are valid JSON (except for std::string_view), but it doesn't validate the entire document, because this is often not a requirement for lazy parsing. If you want high performance full validation it is best to use C++ structs. Or, use glz::validate_json for pure validation passes.
 
 ## Nested Object Access

--- a/docs/options.md
+++ b/docs/options.md
@@ -37,6 +37,7 @@ These options are **not** in `glz::opts` by default. Add them to a custom option
 | `bool structs_as_arrays` | `false` | Handle structs without keys (as arrays) |
 | `bool validate_skipped` | `false` | Perform full validation on skipped values |
 | `bool validate_trailing_whitespace` | `false` | Validate whitespace after parsing completes |
+| `bool validate_utf8` | `true` | Validate that strings read are well formed UTF-8 |
 | `bool bools_as_numbers` | `false` | Read/write booleans as `1` and `0` |
 | `bool write_function_pointers` | `false` | Serialize function pointers (both member and non-member) in `glz::meta` as their type name (off by default) |
 | `bool concatenate` | `true` | Concatenate ranges of `std::pair` into single objects |
@@ -172,6 +173,19 @@ Performs full JSON validation on values that are skipped (unknown keys). Without
 
 #### `validate_trailing_whitespace`
 Validates that content after the parsed value contains only valid whitespace.
+
+#### `validate_utf8`
+On by default, because RFC 8259 section 8.1 requires JSON text to be UTF-8. Every string the reader materializes is checked, including map keys, unknown keys, and values that are skipped; malformed input fails with `error_code::invalid_utf8`.
+
+```cpp
+struct unchecked_opts : glz::opts {
+   bool validate_utf8 = false;
+};
+
+auto ec = glz::read<unchecked_opts{}>(obj, json_data); // malformed encodings accepted
+```
+
+Turn it off only when the encoding is guaranteed by an earlier stage, or when the bytes are deliberately not UTF-8 and you accept that the resulting `std::string` may hold anything. See [UTF-8 Validation](json.md#utf-8-validation) for what the check covers and what it costs.
 
 #### `skip_read_constraint`
 Skips `read_constraint` validation during deserialization. Useful for performance when data is known to be valid.

--- a/include/glaze/core/context.hpp
+++ b/include/glaze/core/context.hpp
@@ -107,7 +107,7 @@ namespace glz
       buffer_overflow, // Write would exceed fixed buffer capacity
       invalid_length, // Length exceeds allowed limit (buffer size or user-configured max)
       // Encoding errors
-      invalid_utf8, // Malformed UTF-8 in a string; always checked on read
+      invalid_utf8, // Malformed UTF-8 in a string; checked on read unless validate_utf8 is disabled
       // Streaming errors
       streaming_unsupported // Document outruns the buffer window and this format's reader cannot refill
    };

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -126,6 +126,14 @@ namespace glz
    // If, after parsing a value, we want to validate the trailing whitespace
 
    // ---
+   // bool validate_utf8 = true;
+   // Validate that strings encountered while reading are well formed UTF-8, as RFC 8259 section 8.1
+   // requires. Malformed input fails with error_code::invalid_utf8. On by default: read input is by
+   // definition someone else's data, and accepting malformed encodings propagates them into your
+   // program. Turn it off only when the encoding is guaranteed by some earlier stage, or when the
+   // bytes are deliberately not UTF-8 and you accept what that means for your strings.
+
+   // ---
    // bool concatenate = true;
    // Concatenates ranges of std::pair into single objects when writing
 
@@ -429,6 +437,16 @@ namespace glz
       }
       else {
          return false;
+      }
+   }
+
+   consteval bool check_validate_utf8(auto&& Opts)
+   {
+      if constexpr (requires { Opts.validate_utf8; }) {
+         return Opts.validate_utf8;
+      }
+      else {
+         return true;
       }
    }
 

--- a/include/glaze/json/lazy.hpp
+++ b/include/glaze/json/lazy.hpp
@@ -32,6 +32,22 @@ namespace glz
 
    namespace detail
    {
+      // lazy_json_view::get<std::string> unescapes its raw span by re-reading it through the JSON
+      // reader. That read is independent of the document's options except for UTF-8 validation,
+      // which the caller can turn off and must not be silently reinstated here.
+      struct lazy_string_opts : opts
+      {
+         bool validate_utf8 = true;
+      };
+
+      template <auto Opts>
+      consteval lazy_string_opts lazy_string_opts_for()
+      {
+         lazy_string_opts o{};
+         o.validate_utf8 = check_validate_utf8(Opts);
+         return o;
+      }
+
       // Skip string - returns position after closing quote
       template <auto Opts>
       GLZ_ALWAYS_INLINE const char* skip_string_fast(const char* p, const char* end) noexcept
@@ -1421,8 +1437,15 @@ namespace glz
             return unexpected(error_ctx{0, ctx.error});
          }
          std::string_view raw{data_, static_cast<size_t>(it - data_)};
-         return glz::read_json<std::string>(raw);
-         // read_json validates UTF-8, so the returned string is guaranteed well formed.
+         // The read validates UTF-8 unless the document's options turned it off, so the returned
+         // string is well formed whenever validation is enabled.
+         static constexpr auto string_opts = detail::lazy_string_opts_for<Opts>();
+         std::string unescaped{};
+         context read_ctx{};
+         if (const error_ctx ec = glz::read<string_opts>(unescaped, raw, read_ctx)) {
+            return unexpected(ec);
+         }
+         return unescaped;
       }
       else if constexpr (std::is_same_v<T, std::string_view>) {
          if (!is_string()) {

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -183,7 +183,7 @@ namespace glz
          skip_string_view(ctx, it, end);
          if (bool(ctx.error)) [[unlikely]]
             return;
-         if (validate_utf8_span(ctx, start, it)) [[unlikely]]
+         if (validate_utf8_span<Opts>(ctx, start, it)) [[unlikely]]
             return;
          const sv key = {start, size_t(it - start)};
          ++it;
@@ -381,7 +381,7 @@ namespace glz
             }
             else {
                // it sits one past the closing quote, so the raw key spans [key_start, it - 1)
-               if (validate_utf8_span(ctx, key_start, it - 1)) [[unlikely]] {
+               if (validate_utf8_span<Opts>(ctx, key_start, it - 1)) [[unlikely]] {
                   return;
                }
                const sv key{key_start, size_t(it - key_start - 1)};
@@ -495,7 +495,7 @@ namespace glz
                skip_string_view(ctx, it, end);
                if (bool(ctx.error)) [[unlikely]]
                   return;
-               if (validate_utf8_span(ctx, start, it)) [[unlikely]]
+               if (validate_utf8_span<Opts>(ctx, start, it)) [[unlikely]]
                   return;
                const sv key = {start, size_t(it - start)};
                ++it; // skip the quote
@@ -987,7 +987,7 @@ namespace glz
                   }
                }
 
-               if (validate_utf8_span(ctx, start, it, ascii_acc)) [[unlikely]] {
+               if (validate_utf8_span<Opts>(ctx, start, it, ascii_acc)) [[unlikely]] {
                   return;
                }
 
@@ -1068,7 +1068,7 @@ namespace glz
                if (bool(ctx.error)) [[unlikely]]
                   return;
 
-               if (validate_utf8_span(ctx, start, it)) [[unlikely]] {
+               if (validate_utf8_span<Opts>(ctx, start, it)) [[unlikely]] {
                   return;
                }
 
@@ -1169,7 +1169,7 @@ namespace glz
 
                continue_decode:
 
-                  if (validate_utf8_span(ctx, start, it, ascii_acc)) [[unlikely]] {
+                  if (validate_utf8_span<Opts>(ctx, start, it, ascii_acc)) [[unlikely]] {
                      return;
                   }
 
@@ -1304,7 +1304,7 @@ namespace glz
                   while (it < end) [[likely]] {
                      *p = *it;
                      if (*it == '"') {
-                        if (validate_utf8_span(ctx, utf8_start, it)) [[unlikely]] {
+                        if (validate_utf8_span<Opts>(ctx, utf8_start, it)) [[unlikely]] {
                            return;
                         }
                         const size_t n = size_t(p - buffer.data());
@@ -1372,7 +1372,7 @@ namespace glz
                if (bool(ctx.error)) [[unlikely]]
                   return;
 
-               if (validate_utf8_span(ctx, start, it)) [[unlikely]] {
+               if (validate_utf8_span<Opts>(ctx, start, it)) [[unlikely]] {
                   return;
                }
 
@@ -1448,7 +1448,7 @@ namespace glz
                   }
                }
 
-               if (validate_utf8_span(ctx, start, it, ascii_acc)) [[unlikely]] {
+               if (validate_utf8_span<Opts>(ctx, start, it, ascii_acc)) [[unlikely]] {
                   return;
                }
 
@@ -1529,7 +1529,7 @@ namespace glz
                if (bool(ctx.error)) [[unlikely]]
                   return;
 
-               if (validate_utf8_span(ctx, start, it)) [[unlikely]] {
+               if (validate_utf8_span<Opts>(ctx, start, it)) [[unlikely]] {
                   return;
                }
 
@@ -1630,7 +1630,7 @@ namespace glz
 
                continue_decode_u8:
 
-                  if (validate_utf8_span(ctx, start, it, ascii_acc)) [[unlikely]] {
+                  if (validate_utf8_span<Opts>(ctx, start, it, ascii_acc)) [[unlikely]] {
                      return;
                   }
 
@@ -1765,7 +1765,7 @@ namespace glz
                   while (it < end) [[likely]] {
                      *p = *it;
                      if (*it == '"') {
-                        if (validate_utf8_span(ctx, utf8_start, it)) [[unlikely]] {
+                        if (validate_utf8_span<Opts>(ctx, utf8_start, it)) [[unlikely]] {
                            return;
                         }
                         value.assign(reinterpret_cast<const char8_t*>(buffer.data()), size_t(p - buffer.data()));
@@ -1829,7 +1829,7 @@ namespace glz
                if (bool(ctx.error)) [[unlikely]]
                   return;
 
-               if (validate_utf8_span(ctx, start, it)) [[unlikely]] {
+               if (validate_utf8_span<Opts>(ctx, start, it)) [[unlikely]] {
                   return;
                }
 
@@ -1920,7 +1920,7 @@ namespace glz
          if (bool(ctx.error)) [[unlikely]]
             return;
 
-         if (validate_utf8_span(ctx, start, it)) [[unlikely]] {
+         if (validate_utf8_span<Opts>(ctx, start, it)) [[unlikely]] {
             return;
          }
 
@@ -3128,7 +3128,7 @@ namespace glz
                   skip_string_view(ctx, it, end);
                   if (bool(ctx.error)) [[unlikely]]
                      return;
-                  if (validate_utf8_span(ctx, start, it)) [[unlikely]]
+                  if (validate_utf8_span<Opts>(ctx, start, it)) [[unlikely]]
                      return;
                   const sv key{start, size_t(it - start)};
                   ++it;
@@ -3317,7 +3317,7 @@ namespace glz
                      skip_string_view(ctx, it, end);
                      if (bool(ctx.error)) [[unlikely]]
                         return;
-                     if (validate_utf8_span(ctx, start, it)) [[unlikely]]
+                     if (validate_utf8_span<Opts>(ctx, start, it)) [[unlikely]]
                         return;
                      const sv key{start, size_t(it - start)};
                      ++it;
@@ -3383,7 +3383,7 @@ namespace glz
                      skip_string_view(ctx, it, end);
                      if (bool(ctx.error)) [[unlikely]]
                         return;
-                     if (validate_utf8_span(ctx, start, it)) [[unlikely]]
+                     if (validate_utf8_span<Opts>(ctx, start, it)) [[unlikely]]
                         return;
                      const sv key{start, size_t(it - start)};
                      ++it;
@@ -3974,7 +3974,7 @@ namespace glz
                if (bool(ctx.error)) [[unlikely]] {
                   return false;
                }
-               if (validate_utf8_span(ctx, key_start, it)) [[unlikely]] {
+               if (validate_utf8_span<Opts>(ctx, key_start, it)) [[unlikely]] {
                   return false;
                }
                const sv key{key_start, size_t(it - key_start)};
@@ -4198,7 +4198,7 @@ namespace glz
                      skip_string_view(ctx, it, end);
                      if (bool(ctx.error)) [[unlikely]]
                         return;
-                     if (validate_utf8_span(ctx, key_start, it)) [[unlikely]]
+                     if (validate_utf8_span<Opts>(ctx, key_start, it)) [[unlikely]]
                         return;
                      const sv key = {key_start, size_t(it - key_start)};
 

--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -815,9 +815,10 @@ namespace glz
    }
 
    // Validates the raw bytes of a JSON string. RFC 8259 section 8.1 requires JSON text to be UTF-8,
-   // and read input is by definition someone else's, so this is unconditional rather than opt-in.
-   // Only the raw span needs checking: escape sequences are ASCII, and handle_unicode_code_point
-   // independently rejects unpaired surrogates in \uXXXX escapes.
+   // and read input is by definition someone else's, so this is on by default; the inheritable
+   // `validate_utf8` option turns it off. Only the raw span needs checking: escape sequences are
+   // ASCII, and handle_unicode_code_point independently rejects unpaired surrogates in \uXXXX
+   // escapes.
    //
    // ascii_acc lets a caller skip the pass entirely for pure ASCII strings, which is the common
    // case. Scan loops already load the string in 8 byte chunks to find the closing quote, so they
@@ -825,17 +826,26 @@ namespace glz
    // bytes than the string itself (a chunk can overrun the closing quote); that only costs a
    // needless validation pass, it never skips one. Callers with no accumulator take the default
    // and always validate.
+   template <auto Opts>
    GLZ_ALWAYS_INLINE bool validate_utf8_span(is_context auto&& ctx, const auto* start, const auto* fin,
                                              const uint64_t ascii_acc = repeat_byte8(0b10000000)) noexcept
    {
-      if ((ascii_acc & repeat_byte8(0b10000000)) == 0) {
-         return false; // pure ASCII is trivially well formed UTF-8
+      if constexpr (not check_validate_utf8(Opts)) {
+         // Everything the caller computed for us is dead, which lets its scan loop drop the
+         // accumulator entirely.
+         (void)ctx, (void)start, (void)fin, (void)ascii_acc;
+         return false;
       }
-      if (!validate_utf8(start, size_t(fin - start))) [[unlikely]] {
-         ctx.error = error_code::invalid_utf8;
-         return true;
+      else {
+         if ((ascii_acc & repeat_byte8(0b10000000)) == 0) {
+            return false; // pure ASCII is trivially well formed UTF-8
+         }
+         if (!validate_utf8(start, size_t(fin - start))) [[unlikely]] {
+            ctx.error = error_code::invalid_utf8;
+            return true;
+         }
+         return false;
       }
-      return false;
    }
 
    GLZ_ALWAYS_INLINE void skip_till_quote(is_context auto&& ctx, auto&& it, auto end) noexcept
@@ -878,6 +888,7 @@ namespace glz
       bool padded;
       bool opening_handled;
       bool validate_skipped;
+      bool validate_utf8;
       bool null_terminated;
 
       // Convert from any opts-like type (consteval because check_* functions are consteval)
@@ -886,17 +897,20 @@ namespace glz
          : padded{check_is_padded(opts)},
            opening_handled{check_opening_handled(opts)},
            validate_skipped{check_validate_skipped(opts)},
+           validate_utf8{check_validate_utf8(opts)},
            null_terminated{check_null_terminated(opts)}
       {}
 
-      // Direct construction - null_terminated defaults to true for the structural (non-validating)
-      // skip_until_closed call sites, which route through the end-bounded skip_string_view path
-      // and so are independent of this flag.
-      consteval skip_string_opts(bool padded_, bool opening_handled_, bool validate_skipped_,
-                                 bool null_terminated_ = true) noexcept
+      // Direct construction - all values required. No defaults on purpose: a caller that forgets
+      // validate_utf8_ would silently validate against the user's explicit choice to turn it off,
+      // and a caller that forgets null_terminated_ would silently read past the end of a bounded
+      // buffer. Both are invisible at the call site, so make omission a compile error instead.
+      consteval skip_string_opts(bool padded_, bool opening_handled_, bool validate_skipped_, bool validate_utf8_,
+                                 bool null_terminated_) noexcept
          : padded{padded_},
            opening_handled{opening_handled_},
            validate_skipped{validate_skipped_},
+           validate_utf8{validate_utf8_},
            null_terminated{null_terminated_}
       {}
    };
@@ -954,7 +968,7 @@ namespace glz
                }
                if ((backslash_count & 1) == 0) {
                   // Even number of backslashes => not escaped => closing quote found
-                  validate_utf8_span(ctx, utf8_start, it);
+                  validate_utf8_span<Opts>(ctx, utf8_start, it);
                   ++it;
                   return;
                }
@@ -993,7 +1007,7 @@ namespace glz
          if (bool(ctx.error)) [[unlikely]] {
             return;
          }
-         if (validate_utf8_span(ctx, utf8_start, it)) [[unlikely]] {
+         if (validate_utf8_span<Opts>(ctx, utf8_start, it)) [[unlikely]] {
             return;
          }
          ++it; // skip the quote
@@ -1028,7 +1042,7 @@ namespace glz
 
             switch (*it) {
             case '"': {
-               validate_utf8_span(ctx, utf8_start, it);
+               validate_utf8_span<Opts>(ctx, utf8_start, it);
                ++it;
                return;
             }
@@ -1066,7 +1080,7 @@ namespace glz
          if (bool(ctx.error)) [[unlikely]] {
             return;
          }
-         if (validate_utf8_span(ctx, utf8_start, it)) [[unlikely]] {
+         if (validate_utf8_span<Opts>(ctx, utf8_start, it)) [[unlikely]] {
             return;
          }
          ++it; // skip the quote
@@ -1078,14 +1092,18 @@ namespace glz
    {
       bool padded;
       bool comments;
+      bool validate_utf8;
 
       // Convert from any opts-like type (consteval because check_is_padded is consteval)
       template <typename T>
-      consteval skip_until_closed_opts(const T& opts) noexcept : padded{check_is_padded(opts)}, comments{opts.comments}
+      consteval skip_until_closed_opts(const T& opts) noexcept
+         : padded{check_is_padded(opts)}, comments{opts.comments}, validate_utf8{check_validate_utf8(opts)}
       {}
 
       // Direct construction - all values required
-      consteval skip_until_closed_opts(bool padded_, bool comments_) noexcept : padded{padded_}, comments{comments_} {}
+      consteval skip_until_closed_opts(bool padded_, bool comments_, bool validate_utf8_) noexcept
+         : padded{padded_}, comments{comments_}, validate_utf8{validate_utf8_}
+      {}
    };
 
    template <skip_until_closed_opts Opts, char open, char close, size_t Depth = 1>
@@ -1094,6 +1112,9 @@ namespace glz
    {
       static constexpr bool opening_not_handled = false;
       static constexpr bool skip_validation = false;
+      // skip_validation routes skip_string through the end-bounded skip_string_view path, which
+      // stops on `end` rather than on a sentinel, so this flag has no effect from here.
+      static constexpr bool null_terminated_unused = true;
 
       size_t depth = Depth;
 
@@ -1109,7 +1130,8 @@ namespace glz
 
             switch (*it) {
             case '"': {
-               skip_string<skip_string_opts{Opts.padded, opening_not_handled, skip_validation}>(ctx, it, end);
+               skip_string<skip_string_opts{Opts.padded, opening_not_handled, skip_validation, Opts.validate_utf8,
+                                            null_terminated_unused}>(ctx, it, end);
                if (bool(ctx.error)) [[unlikely]] {
                   return;
                }
@@ -1148,6 +1170,9 @@ namespace glz
    {
       static constexpr bool opening_not_handled = false;
       static constexpr bool skip_validation = false;
+      // skip_validation routes skip_string through the end-bounded skip_string_view path, which
+      // stops on `end` rather than on a sentinel, so this flag has no effect from here.
+      static constexpr bool null_terminated_unused = true;
 
       size_t depth = Depth;
 
@@ -1163,7 +1188,8 @@ namespace glz
 
             switch (*it) {
             case '"': {
-               skip_string<skip_string_opts{Opts.padded, opening_not_handled, skip_validation}>(ctx, it, end);
+               skip_string<skip_string_opts{Opts.padded, opening_not_handled, skip_validation, Opts.validate_utf8,
+                                            null_terminated_unused}>(ctx, it, end);
                if (bool(ctx.error)) [[unlikely]] {
                   return;
                }
@@ -1209,6 +1235,9 @@ namespace glz
    {
       static constexpr bool opening_not_handled = false;
       static constexpr bool skip_validation = false;
+      // skip_validation routes skip_string through the end-bounded skip_string_view path, which
+      // stops on `end` rather than on a sentinel, so this flag has no effect from here.
+      static constexpr bool null_terminated_unused = true;
 
       size_t depth = Depth;
 
@@ -1224,7 +1253,8 @@ namespace glz
 
             switch (*it) {
             case '"': {
-               skip_string<skip_string_opts{Opts.padded, opening_not_handled, skip_validation}>(ctx, it, end);
+               skip_string<skip_string_opts{Opts.padded, opening_not_handled, skip_validation, Opts.validate_utf8,
+                                            null_terminated_unused}>(ctx, it, end);
                if (bool(ctx.error)) [[unlikely]] {
                   return;
                }
@@ -1258,7 +1288,8 @@ namespace glz
       while (it < end) {
          switch (*it) {
          case '"': {
-            skip_string<skip_string_opts{Opts.padded, opening_not_handled, skip_validation}>(ctx, it, end);
+            skip_string<skip_string_opts{Opts.padded, opening_not_handled, skip_validation, Opts.validate_utf8,
+                                         null_terminated_unused}>(ctx, it, end);
             if (bool(ctx.error)) [[unlikely]] {
                return;
             }
@@ -1299,6 +1330,9 @@ namespace glz
    {
       static constexpr bool opening_not_handled = false;
       static constexpr bool skip_validation = false;
+      // skip_validation routes skip_string through the end-bounded skip_string_view path, which
+      // stops on `end` rather than on a sentinel, so this flag has no effect from here.
+      static constexpr bool null_terminated_unused = true;
 
       size_t depth = Depth;
 
@@ -1314,7 +1348,8 @@ namespace glz
 
             switch (*it) {
             case '"': {
-               skip_string<skip_string_opts{Opts.padded, opening_not_handled, skip_validation}>(ctx, it, end);
+               skip_string<skip_string_opts{Opts.padded, opening_not_handled, skip_validation, Opts.validate_utf8,
+                                            null_terminated_unused}>(ctx, it, end);
                if (bool(ctx.error)) [[unlikely]] {
                   return;
                }
@@ -1355,7 +1390,8 @@ namespace glz
       while (it < end) {
          switch (*it) {
          case '"': {
-            skip_string<skip_string_opts{Opts.padded, opening_not_handled, skip_validation}>(ctx, it, end);
+            skip_string<skip_string_opts{Opts.padded, opening_not_handled, skip_validation, Opts.validate_utf8,
+                                         null_terminated_unused}>(ctx, it, end);
             if (bool(ctx.error)) [[unlikely]] {
                return;
             }

--- a/tests/json_test/utf8_validation_test.cpp
+++ b/tests/json_test/utf8_validation_test.cpp
@@ -622,4 +622,323 @@ suite json_integration = [] {
    };
 };
 
+// The `validate_utf8` option turns the checker off. Validation is on by default because RFC 8259
+// requires it, so every test here has to prove both halves: that the default still rejects the
+// input, and that the same read with the option off accepts it and hands back the original bytes.
+
+// A named namespace rather than an anonymous one, because reflected types need linkage.
+namespace utf8_option_test
+{
+   struct unchecked_opts : glz::opts
+   {
+      bool validate_utf8 = false;
+   };
+
+   // Options compose by inheritance, so a struct derived from another custom options struct has to
+   // keep carrying the flag.
+   struct unchecked_validate_skipped_opts : unchecked_opts
+   {
+      bool validate_skipped = true;
+   };
+
+   // Fields that glz::opts already declares are set on an instance rather than redeclared in a
+   // derived struct. Redeclaring shadows the base member, which still reads correctly through
+   // check_* but silently defeats opt_true/opt_false on &glz::opts::that_member.
+   template <class Opts>
+   consteval Opts with_unknown_keys_allowed()
+   {
+      Opts o{};
+      o.error_on_unknown_keys = false;
+      return o;
+   }
+
+   consteval unchecked_opts unchecked_unterminated()
+   {
+      unchecked_opts o{};
+      o.null_terminated = false;
+      return o;
+   }
+
+   consteval unchecked_opts unchecked_comments()
+   {
+      unchecked_opts o{};
+      o.comments = true;
+      o.error_on_unknown_keys = false;
+      return o;
+   }
+
+   consteval glz::opts checked_comments()
+   {
+      glz::opts o{};
+      o.comments = true;
+      o.error_on_unknown_keys = false;
+      return o;
+   }
+
+   struct unchecked_raw_string_opts : unchecked_opts
+   {
+      bool raw_string = true;
+   };
+
+   struct nested
+   {
+      std::string name{};
+   };
+
+   struct outer
+   {
+      nested nested_value{};
+      std::vector<std::string> tags{};
+      int id{};
+   };
+
+   struct partial
+   {
+      int id{};
+   };
+
+   struct matched_key
+   {
+      int a{};
+      int b{};
+   };
+}
+
+template <>
+struct glz::meta<utf8_option_test::matched_key>
+{
+   using T = utf8_option_test::matched_key;
+   // A key that is itself malformed UTF-8, so a read that matches it never materializes a string.
+   static constexpr auto value = object("k\xFF!", &T::a, "b", &T::b);
+};
+
+suite validate_utf8_option = [] {
+   using namespace utf8_option_test;
+
+   "disabled accepts every malformed case"_test = [] {
+      for (const auto& c : malformed()) {
+         const std::string doc = "[\"" + c.data + "\"]";
+         std::vector<std::string> v;
+         expect(bool(glz::read_json(v, doc))) << c.name;
+         expect(!glz::read<unchecked_opts{}>(v, doc)) << c.name;
+         expect(v.size() == 1u) << c.name;
+         expect(v[0] == c.data) << c.name;
+      }
+   };
+
+   "disabled accepts across string target types"_test = [] {
+      const std::string doc = "[\"a\xFF!b\"]";
+      {
+         std::vector<std::string> v;
+         expect(!glz::read<unchecked_opts{}>(v, doc));
+         expect(v[0] == "a\xFF!b");
+      }
+      {
+         std::vector<std::string_view> v;
+         expect(!glz::read<unchecked_opts{}>(v, doc));
+         expect(v[0] == "a\xFF!b");
+      }
+      {
+         std::vector<std::u8string> v;
+         expect(glz::read_json(v, doc) == glz::error_code::invalid_utf8);
+         expect(!glz::read<unchecked_opts{}>(v, doc));
+         expect(v[0] == std::u8string{u8"a\xFF!b"});
+      }
+      {
+         glz::generic g;
+         expect(glz::read_json(g, doc) == glz::error_code::invalid_utf8);
+         expect(!glz::read<unchecked_opts{}>(g, doc));
+         expect(g[0].get_string() == "a\xFF!b");
+      }
+   };
+
+   "disabled accepts malformed object keys"_test = [] {
+      const std::string doc = "{\"k\xFF!\":1}";
+      {
+         std::map<std::string, int> m;
+         expect(glz::read_json(m, doc) == glz::error_code::invalid_utf8);
+         expect(!glz::read<unchecked_opts{}>(m, doc));
+         expect(m.begin()->first == "k\xFF!");
+      }
+      {
+         glz::generic g;
+         expect(glz::read_json(g, doc) == glz::error_code::invalid_utf8);
+         expect(!glz::read<unchecked_opts{}>(g, doc));
+      }
+   };
+
+   "a key matching a member name is never materialized"_test = [] {
+      // Documented behavior, pinned here so it cannot drift silently: matching compares input bytes
+      // against the program's own literal, so a matched key is checked by neither setting of the
+      // option. Only keys that get materialized -- map keys, keys matching nothing -- are validated.
+      matched_key v{};
+      expect(!glz::read_json(v, std::string("{\"k\xFF!\":5,\"b\":6}")));
+      expect(v.a == 5);
+      expect(v.b == 6);
+   };
+
+   "disabled accepts malformed bytes in skipped values"_test = [] {
+      // A malformed byte in a field the target does not model is the likeliest reason to reach for
+      // this option, and skipped strings run through a different reader than modelled ones.
+      const std::string doc = "{\"other\":\"\xC0\x80\",\"id\":3}";
+      partial v{};
+      expect(glz::read<glz::opts{.error_on_unknown_keys = false}>(v, doc) == glz::error_code::invalid_utf8);
+      expect(!glz::read<with_unknown_keys_allowed<unchecked_opts>()>(v, doc));
+      expect(v.id == 3);
+
+      // The same field with full validation of skipped values enabled.
+      partial v2{};
+      expect(!glz::read<with_unknown_keys_allowed<unchecked_validate_skipped_opts>()>(v2, doc));
+      expect(v2.id == 3);
+   };
+
+   "disabled accepts malformed bytes in skipped values under JSONC"_test = [] {
+      // The comment-aware skip_until_closed overloads are separate instantiations from the ones
+      // above, and they reach skip_string through their own skip_string_opts constructions.
+      const std::string doc = "{/*c*/\"other\":{\"x\":\"a\xFF!b\"},\"id\":7}";
+      partial v{};
+      expect(glz::read<checked_comments()>(v, doc) == glz::error_code::invalid_utf8);
+      expect(!glz::read<unchecked_comments()>(v, doc));
+      expect(v.id == 7);
+
+      // A malformed byte inside a comment is skipped without validation either way, since comment
+      // bytes never reach the program.
+      partial v2{};
+      const std::string commented = "{/* \xFF */\"id\":9}";
+      expect(!glz::read<checked_comments()>(v2, commented));
+      expect(v2.id == 9);
+   };
+
+   "disabled propagates into nested values"_test = [] {
+      const std::string doc = R"({"nested_value":{"name":"a)"
+                              "\xFF"
+                              R"(b"},"tags":["c)"
+                              "\xFE"
+                              R"(d"],"id":5})";
+      outer v{};
+      expect(glz::read_json(v, doc) == glz::error_code::invalid_utf8);
+      expect(!glz::read<unchecked_opts{}>(v, doc));
+      expect(v.nested_value.name ==
+             "a\xFF"
+             "b");
+      expect(v.tags.size() == 1u);
+      expect(v.tags[0] ==
+             "c\xFE"
+             "d");
+      expect(v.id == 5);
+   };
+
+   "disabled on the non null terminated paths"_test = [] {
+      // A heap buffer with no terminator, so the reader really has to stop on `end`. Reading out of
+      // a std::string would not stress this: its data() is NUL terminated regardless.
+      const std::string_view source = "[\"a\xFF!b\"]";
+      std::vector<char> raw(source.begin(), source.end());
+      const std::string_view sv{raw.data(), raw.size()};
+      std::vector<std::string> v;
+      expect(glz::read<glz::opts{.null_terminated = false}>(v, sv) == glz::error_code::invalid_utf8);
+      expect(!glz::read<unchecked_unterminated()>(v, sv));
+      expect(v[0] == "a\xFF!b");
+   };
+
+   "disabled on the raw_string path"_test = [] {
+      const std::string doc = "[\"a\xFF!b\"]";
+      std::vector<std::string> v;
+      struct raw_opts : glz::opts
+      {
+         bool raw_string = true;
+      };
+      expect(glz::read<raw_opts{}>(v, doc) == glz::error_code::invalid_utf8);
+      expect(!glz::read<unchecked_raw_string_opts{}>(v, doc));
+      expect(v[0] == "a\xFF!b");
+   };
+
+   "disabled at many string lengths"_test = [] {
+      for (size_t n = 1; n <= 100; ++n) {
+         for (size_t pos = 0; pos < n; pos += 7) {
+            std::string payload(n, 'a');
+            payload[pos] = char(0xFF);
+            const std::string doc = "[\"" + payload + "\"]";
+            std::vector<std::string> v;
+            expect(glz::read_json(v, doc) == glz::error_code::invalid_utf8) << n << "@" << pos;
+            expect(!glz::read<unchecked_opts{}>(v, doc)) << n << "@" << pos;
+            expect(v[0] == payload) << n << "@" << pos;
+         }
+      }
+   };
+
+   "disabled in lazy JSON"_test = [] {
+      const std::string doc = "{\"s\":\"a\xFF!b\"}";
+      {
+         auto d = glz::lazy_json(doc);
+         expect(d.has_value());
+         const auto s = (*d)["s"].get<std::string>();
+         expect(!s.has_value());
+         expect(s.error() == glz::error_code::invalid_utf8);
+      }
+      {
+         auto d = glz::lazy_json<unchecked_opts{}>(doc);
+         expect(d.has_value());
+         const auto s = (*d)["s"].get<std::string>();
+         expect(s.has_value());
+         expect(s.value() == "a\xFF!b");
+      }
+   };
+
+   "disabled still decodes well formed input"_test = [] {
+      // Turning the check off must not change what a conforming document parses to.
+      for (const auto& c : well_formed()) {
+         if (c.data.find('\0') != std::string::npos) continue; // control chars need escaping
+         const std::string doc = "[\"" + c.data + "\"]";
+         std::vector<std::string> v;
+         expect(!glz::read<unchecked_opts{}>(v, doc)) << c.name;
+         expect(v.size() == 1u) << c.name;
+         expect(v[0] == c.data) << c.name;
+      }
+   };
+
+   "disabled still decodes escapes to multibyte sequences"_test = [] {
+      // \uXXXX escapes are ASCII on the wire and decode through a separate path, so the option
+      // must not disturb them.
+      for (const uint32_t cp : {0xE9u, 0x20ACu, 0x1F600u}) {
+         std::vector<std::string> escaped;
+         char buf[32];
+         if (cp > 0xFFFF) {
+            const uint32_t u = cp - 0x10000;
+            std::snprintf(buf, sizeof(buf), R"(["\u%04X\u%04X"])", 0xD800 + (u >> 10), 0xDC00 + (u & 0x3FF));
+         }
+         else {
+            std::snprintf(buf, sizeof(buf), R"(["\u%04X"])", cp);
+         }
+         expect(!glz::read<unchecked_opts{}>(escaped, std::string(buf))) << cp;
+         expect(escaped[0] == utf8(cp)) << cp;
+      }
+   };
+
+   "disabled still rejects other errors"_test = [] {
+      // Turning off the encoding check must not turn off anything else.
+      std::vector<std::string> v;
+      expect(bool(glz::read<unchecked_opts{}>(v, std::string(R"(["a\ud800b"])")))); // lone surrogate escape
+      expect(bool(glz::read<unchecked_opts{}>(v, std::string("[\"a\x01\x62\"]")))); // raw control character
+      expect(bool(glz::read<unchecked_opts{}>(v, std::string("[\"abc]")))); // unterminated string
+   };
+
+   "validate_json validates regardless of the caller"_test = [] {
+      // validate_json takes no options, so there is no way to hand it a disabled check. This pins
+      // that, because the documented conformance guarantee depends on it.
+      static_assert(glz::check_validate_utf8(glz::opts_validate{}));
+      expect(glz::validate_json(std::string("[\"a\xFF!b\"]")) == glz::error_code::invalid_utf8);
+   };
+
+   "enabled by default for opts without the field"_test = [] {
+      static_assert(glz::check_validate_utf8(glz::opts{}));
+      static_assert(glz::check_validate_utf8(glz::opts_validate{}));
+      static_assert(glz::check_validate_utf8(glz::opts_csv{}));
+      static_assert(!glz::check_validate_utf8(unchecked_opts{}));
+      static_assert(!glz::check_validate_utf8(unchecked_validate_skipped_opts{}));
+      static_assert(!glz::check_validate_utf8(with_unknown_keys_allowed<unchecked_opts>()));
+      static_assert(!glz::check_validate_utf8(unchecked_comments()));
+      static_assert(!glz::check_validate_utf8(unchecked_raw_string_opts{}));
+   };
+};
+
 int main() { return 0; }

--- a/tests/json_test/utf8_validation_test.cpp
+++ b/tests/json_test/utf8_validation_test.cpp
@@ -740,9 +740,13 @@ suite validate_utf8_option = [] {
       }
       {
          std::vector<std::u8string> v;
+         // Spelled out as code units rather than u8"a\xFF!b": MSVC treats a hex escape in a UTF-8
+         // literal as a code point and encodes it (0xFF becomes 0xC3 0xBF), while GCC and Clang
+         // emit the single byte. Only the byte sequence below is the same on all three.
+         const std::u8string expected{char8_t{'a'}, char8_t{0xFF}, char8_t{'!'}, char8_t{'b'}};
          expect(glz::read_json(v, doc) == glz::error_code::invalid_utf8);
          expect(!glz::read<unchecked_opts{}>(v, doc));
-         expect(v[0] == std::u8string{u8"a\xFF!b"});
+         expect(v[0] == expected);
       }
       {
          glz::generic g;


### PR DESCRIPTION
#2733 made UTF-8 validation unconditional on read, and it was requested that there be a way to turn it off. It should stay on by default, since RFC 8259 section 8.1 requires it and read input is by definition someone else's, but callers whose encoding is already guaranteed by an earlier stage currently have no way to opt out.

Adds the inheritable `validate_utf8` option, defaulting to `true`:

```cpp
struct unchecked_opts : glz::opts {
   bool validate_utf8 = false;
};

std::vector<std::string> v{};
auto ec = glz::read<unchecked_opts{}>(v, "[\"a\xFF\"]"); // no error; v[0] holds the raw bytes
```

Any options struct without the field still validates, so nothing changes for existing code.

## Implementation

`validate_utf8_span` becomes a template on the options, with no default argument, so a missed call site is a compile error rather than a silent bypass. The disabled branch compiles away and the caller's ASCII accumulator dies with it.

Verified at the assembly level:

- **Option on**: output is identical to before this change on clang, and differs only in internal `LFB`/`LLSDA` label numbering on GCC. No added runtime branch.
- **Option off**: output matches a build with every `ascii_acc |= …` physically deleted, at `-O1`, `-O2` and `-Os`. No `utf8` symbols survive.

Measured on documents built from 6000 records of four 32-byte strings:

| document | validation on | off |
|---|---|---|
| ASCII (925 KB) | 0.440 ms | 0.431 ms |
| 60% non-ASCII (1375 KB) | 0.893 ms | 0.540 ms |

`skip_string_opts` and `skip_until_closed_opts` carry the flag so skipped strings honor it too. Both direct constructors now require every argument. `validate_utf8_` lands before the pre-existing `null_terminated_`, and a caller that omitted either would silently get behavior the user did not ask for — invisibly, since the failure mode is a stricter parse rather than a crash. Making omission a compile error costs nothing; all six call sites are in `parse.hpp`.

`lazy_json_view::get<std::string>` re-read its raw span through `glz::read_json`, which hardcodes `opts{}` and so would have silently reinstated validation. It now derives the options from the document's. Behavior is otherwise unchanged: same effective options, same buffer overload, same `error_ctx`.

## Documentation correction

Validation was described as applying to "every string the reader passes over, including keys". That is not true of a key matching a member name: matching compares input bytes against the program's own literal, so a matched key is never materialized and a second pass could not tell you anything new. Map keys and keys matching nothing *are* materialized and *are* checked. Corrected in `docs/json.md` and stated in `docs/options.md`, with a test pinning the behavior.

## Tests

`utf8_validation_test.cpp` goes from 38 to 44 tests. Every case asserts both halves — that the default rejects the input, and that the same read with the option off accepts it and returns the original bytes — so a stub in either direction fails.

The real gap was JSONC. Three of the six edited `skip_string_opts` constructions live in the comment-aware `skip_until_closed` overloads, and nothing in the suite instantiated them; a hardcoded `true` there would have passed all 38 tests. Confirmed by mutation: hardcoding those sites now fails the new test.

Also added: `glz::validate_json`, the `raw_string` path, a genuinely non-terminated heap buffer (reading out of a `std::string` does not stress that path, since `data()` is terminated regardless), surrogate-pair escapes decoding to 4-byte sequences, a well-formed round trip with the option off, and the matched-key behavior above. Strengthened the `std::u8string` and `glz::generic` cases, which previously asserted only the accepting half.

Not changed, deliberately: `glz::validate_json` and `opts_validate` do not force validation on. `validate_json` takes no options template parameter, so a caller cannot hand it a disabled check and the conformance guarantee already holds. Hardcoding it into `opts_validate` would stop nobody determined (a derived struct can shadow it back) while breaking the legitimate composition `struct mine : unchecked_opts { bool validate_skipped = true; };`.

## Verification

- 117/117 tests pass.
- `utf8_validation_test.cpp` builds clean under `-Wall -Wextra -pedantic -Werror` on clang and GCC 15.
- A 20-path harness covering struct, JSONC, minified, `partial_read`, `validate_skipped`, `validate_json`, `glz::raw_json`, `raw_string`, NDJSON, jmespath, json_ptr, streaming, `glz::generic`, variants, map keys, non-terminated spans, `std::u8string`, 64-byte SIMD-path strings and `\uXXXX` escapes: all reject by default and accept with the option off.
- The `lazy.hpp` change checked under ASan and UBSan on a heap buffer with no terminator, `null_terminated` on and off, short and long strings.
