### PR TITLE
Update ut to v1.2.1 and bump CMake dep to 3.31

### DIFF
--- a/.github/workflows/p2996-reflection.yml
+++ b/.github/workflows/p2996-reflection.yml
@@ -40,7 +40,7 @@ jobs:
           -w /glaze \
           ${{ env.P2996_IMAGE }} \
           /bin/sh -c "
-            git clone --depth 1 --branch v1.1.0 https://github.com/openalgz/ut /tmp/ut &&
+            git clone --depth 1 --branch v1.2.1 https://github.com/openalgz/ut /tmp/ut &&
             clang++ -std=c++26 -freflection -fexpansion-statements -stdlib=libc++ \
               -I/glaze/include -I/tmp/ut/include -DGLZ_REFLECTION26=1 \
               -Wl,-rpath,${{ env.P2996_LIB_PATH }} \

--- a/.github/workflows/p2996-reflection.yml
+++ b/.github/workflows/p2996-reflection.yml
@@ -18,6 +18,9 @@ env:
   P2996_IMAGE: vsavkov/clang-p2996:amd64
   # Library path for runtime linking
   P2996_LIB_PATH: /opt/p2996/clang/lib/x86_64-unknown-linux-gnu
+  # The image is Ubuntu 24.04, whose apt cmake is 3.28 — older than the 3.31 that
+  # ut requires since v1.2.0. Install an official Kitware build instead of apt's.
+  CMAKE_TARBALL: https://github.com/Kitware/CMake/releases/download/v4.4.2/cmake-4.4.2-linux-x86_64.tar.gz
 
 jobs:
   test-p2996:
@@ -55,7 +58,9 @@ jobs:
           -w /glaze \
           ${{ env.P2996_IMAGE }} \
           /bin/sh -c "
-            apt-get update && apt-get install -y cmake &&
+            apt-get update && apt-get install -y curl &&
+            curl -fsSL ${{ env.CMAKE_TARBALL }} | tar xz --strip-components=1 -C /usr/local &&
+            cmake --version &&
             cmake -B build \
               -DCMAKE_CXX_COMPILER=clang++ \
               -DCMAKE_CXX_FLAGS='-std=c++26 -freflection -fexpansion-statements -stdlib=libc++' \

--- a/.github/workflows/simd-backends.yml
+++ b/.github/workflows/simd-backends.yml
@@ -209,7 +209,7 @@ jobs:
         run: |
           set -euo pipefail
           source /tmp/emsdk/emsdk_env.sh
-          git clone --depth 1 --branch v1.1.0 https://github.com/openalgz/ut /tmp/ut
+          git clone --depth 1 --branch v1.2.1 https://github.com/openalgz/ut /tmp/ut
           # Both configurations escape with SWAR: Glaze has no WASM escape helper. Pinning the
           # backend in the same compile that builds the suite means a toolchain change that quietly
           # drops SIMD128 fails to build, rather than running the scalar path twice and passing.
@@ -239,7 +239,7 @@ jobs:
       - name: Build and run at each width
         run: |
           set -euo pipefail
-          git clone --depth 1 --branch v1.1.0 https://github.com/openalgz/ut /tmp/ut
+          git clone --depth 1 --branch v1.2.1 https://github.com/openalgz/ut /tmp/ut
           for w in 16 32 64; do
             echo "::group::generic width $w"
             # Pin the portable backend, or the vector path could compile away and all three widths

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.31)
 
 include(cmake/prelude.cmake)
 

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.31)
 project(glaze_benchmarks)
 
 set(CMAKE_CXX_STANDARD 23)

--- a/cmake/ci/windows-header-compatibility/CMakeLists.txt
+++ b/cmake/ci/windows-header-compatibility/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.31)
 
 project(glaze_windows_header_compatibility LANGUAGES CXX)
 

--- a/cmake/dev-mode.cmake
+++ b/cmake/dev-mode.cmake
@@ -1,9 +1,7 @@
 enable_language(CXX)
 
-# Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
-if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
-  cmake_policy(SET CMP0135 NEW)
-endif()
+# CMP0135 (DOWNLOAD_EXTRACT_TIMESTAMP) arrived in CMake 3.24 and so already
+# defaults to NEW under our 3.31 minimum. No explicit cmake_policy needed.
 
 set_property(GLOBAL PROPERTY USE_FOLDERS YES)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -229,7 +229,7 @@ See the **[ASIO Setup Guide](networking/asio-setup.md)** for detailed instructio
 
 ### Complete CMakeLists.txt Example
 ```cmake
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.31)
 project(MyGlazeProject LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 23)

--- a/docs/networking/asio-setup.md
+++ b/docs/networking/asio-setup.md
@@ -135,7 +135,7 @@ system package instead of downloading one.
 ### Complete Example with ASIO
 
 ```cmake
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.31)
 project(MyNetworkingApp LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 23)
@@ -370,7 +370,7 @@ int main() {
 
 ```cmake
 # CMakeLists.txt
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.31)
 project(hello_server LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 23)

--- a/docs/networking/tls-support.md
+++ b/docs/networking/tls-support.md
@@ -14,7 +14,7 @@ The `http_server` has been enhanced with a template parameter `<bool EnableTLS>`
 ### Prerequisites
 
 - OpenSSL development libraries
-- CMake 3.21 or later
+- CMake 3.31 or later
 - C++23 compatible compiler
 
 ### CMake Configuration

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
   ut
   GIT_REPOSITORY https://github.com/openalgz/ut
-  GIT_TAG v1.1.0
+  GIT_TAG v1.2.1
   GIT_SHALLOW TRUE
 )
 

--- a/tests/find_package/CMakeLists.txt
+++ b/tests/find_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.31)
 
 project(
    glaze_example

--- a/tests/networking_tests/http_chunked_test/CMakeLists.txt
+++ b/tests/networking_tests/http_chunked_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.31)
 project(http_chunked_test)
 
 add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)

--- a/tests/networking_tests/http_client_pool_test/CMakeLists.txt
+++ b/tests/networking_tests/http_client_pool_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.31)
 project(http_client_pool_test)
 
 add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)

--- a/tests/networking_tests/http_client_ssl_test/CMakeLists.txt
+++ b/tests/networking_tests/http_client_ssl_test/CMakeLists.txt
@@ -1,5 +1,5 @@
 # HTTP Client SSL Test CMakeLists.txt
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.31)
 project(http_client_ssl_test)
 
 # Only build if OpenSSL is available

--- a/tests/networking_tests/http_content_length_test/CMakeLists.txt
+++ b/tests/networking_tests/http_content_length_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.31)
 project(http_content_length_test)
 
 add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)

--- a/tests/networking_tests/http_header_strictness_test/CMakeLists.txt
+++ b/tests/networking_tests/http_header_strictness_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.31)
 project(http_header_strictness_test)
 
 add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)

--- a/tests/networking_tests/http_headers_test/CMakeLists.txt
+++ b/tests/networking_tests/http_headers_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.31)
 project(http_headers_test)
 
 add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)

--- a/tests/networking_tests/http_response_splitting_test/CMakeLists.txt
+++ b/tests/networking_tests/http_response_splitting_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.31)
 project(http_response_splitting_test)
 
 add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)

--- a/tests/networking_tests/http_server_post_test/CMakeLists.txt
+++ b/tests/networking_tests/http_server_post_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.31)
 project(http_server_post_test)
 
 add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)

--- a/tests/networking_tests/http_smuggling_test/CMakeLists.txt
+++ b/tests/networking_tests/http_smuggling_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.31)
 project(http_smuggling_test)
 
 add_executable(${PROJECT_NAME} ${PROJECT_NAME}.cpp)

--- a/tests/networking_tests/https_test/CMakeLists.txt
+++ b/tests/networking_tests/https_test/CMakeLists.txt
@@ -1,5 +1,5 @@
 # HTTPS Test CMakeLists.txt
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.31)
 project(https_test)
 
 # Only build if OpenSSL is available

--- a/util/glaze.spec
+++ b/util/glaze.spec
@@ -10,7 +10,7 @@ License:        MIT
 URL:            https://github.com/stephenberry/glaze
 Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 
-BuildRequires:  cmake
+BuildRequires:  cmake >= 3.31
 BuildRequires:  gcc-c++
 BuildRequires:  xxhashct-static
 BuildRequires:  fast_float-devel


### PR DESCRIPTION
Updates the test framework dependency from [ut](https://github.com/openalgz/ut) v1.1.0 to [v1.2.1](https://github.com/openalgz/ut/releases/tag/v1.2.1), and raises the declared CMake minimum to match what the build actually requires.

## ut v1.2.1

Bumped at all four call sites so no build path is left on the old tag:

- `tests/CMakeLists.txt` — the `FetchContent` `GIT_TAG`
- `.github/workflows/simd-backends.yml` — both jobs that clone ut directly
- `.github/workflows/p2996-reflection.yml` — the reflection job's clone

v1.2.0 added C++20 modules support; v1.2.1 fixed the `import std` gate, which v1.2.0 pinned to a single experimental UUID and which therefore could not configure on CMake 4.3+.

Glaze consumes ut as headers only, so the modules work does not apply here. The only header change across `v1.1.0...v1.2.1` is the C++23 guard on `operator[]`, which switched from `__cplusplus >= 202300L` to `__cpp_multidimensional_subscript >= 202211L && !defined(_MSC_VER)` — a more accurate feature test for the same overload, so the assertion API is unchanged.

## CMake minimum raised to 3.31

ut has required CMake 3.31 since v1.2.0, so building the test suite already needed it. Declaring 3.21 at the root while a dependency demands 3.31 made the stated floor a fiction — anyone on 3.21 got an error from inside FetchContent instead of a clear message from our own `cmake_minimum_required`:

```
CMake Error at build/_deps/ut-src/CMakeLists.txt:1
  CMake 3.31 or higher is required. You are running version 3.28.3
```

Every `cmake_minimum_required` in the repo moves to 3.31 (root, benchmarks, the standalone networking test projects, the find_package test, the Windows header-compatibility CI project), and the Fedora spec spells out the same version in `BuildRequires`.

3.31 dates to November 2024 and is what every CI image already provides. The gcc:15 containers ship exactly 3.31.6 from apt, so going higher would mean provisioning CMake in those jobs as well.

This also makes the `CMP0135` guard in `cmake/dev-mode.cmake` dead — that policy arrived in 3.24, so a 3.31 minimum already defaults it to NEW — so the explicit `cmake_policy` call is dropped.

Docs quoting an older minimum are updated to match.

## P2996 CI job

That job installed cmake from apt inside an Ubuntu 24.04 image, pinning it to 3.28.3, which is below ut's floor. Replaced with an official Kitware binary tarball, pinned so the toolchain cannot drift silently. It is the only job that needed this: every other job already runs a new enough CMake, and this job's first step compiles ut headers directly without CMake.

## Verification

- Full suite locally against v1.2.1 with the raised minimum: **117/117 pass**, no policy or deprecation warnings
- Benchmarks project configures at the new minimum
- P2996 change verified inside `vsavkov/clang-p2996:amd64` itself — CMake install, the exact configure command from the workflow, plus a build and ctest run to confirm the generated build works under CMake 4