### PR TITLE
validate payloads in jsonb_to_json before copying them out

### DIFF
--- a/include/glaze/jsonb/jsonb_to_json.hpp
+++ b/include/glaze/jsonb/jsonb_to_json.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <charconv>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -14,7 +15,7 @@
 #include "glaze/json/write.hpp"
 #include "glaze/jsonb/header.hpp"
 #include "glaze/jsonb/text_decode.hpp"
-#include "glaze/util/fast_float.hpp"
+#include "glaze/util/parse.hpp"
 
 namespace glz
 {
@@ -22,11 +23,33 @@ namespace glz
    {
       // Emit a JSON string literal from a raw UTF-8 byte payload. Uses the JSON writer so all
       // control characters and structural JSON chars are correctly escaped.
+      //
+      // Three writer options would each let payload bytes reach the output document unescaped,
+      // and all three are inheritable, so a caller's opts would otherwise silently reopen the
+      // hole this converter exists to close:
+      //   * escape_control_characters (off by default) leaves raw control bytes in place,
+      //   * raw_string emits the payload without escaping it at all,
+      //   * unquoted drops the surrounding quotes as well.
+      // Each default is reasonable for a C++ string being serialized, because that is the
+      // program's own data. None of them is reasonable for a blob, which is someone else's.
+      // The converter promises strict JSON, so it pins all three rather than inheriting them.
+      template <auto Opts>
+      inline constexpr auto raw_string_emit_opts =
+         opt_false<opt_false<opt_true<Opts, escape_control_characters_opt_tag{}>, raw_string_opt_tag{}>,
+                   unquoted_opt_tag{}>;
+
       template <auto Opts, class B>
       inline void emit_raw_string_as_json(is_context auto& ctx, const char* data, size_t size, B& out, size_t& ix)
       {
+         // RFC 8259 section 8.1 requires JSON text to be UTF-8, and these bytes came out of a
+         // blob rather than out of the program, so they get the same treatment the JSON reader
+         // gives its input. Honors the `validate_utf8` option, which compiles the check away.
+         // No accumulator is available here: nothing has scanned this payload yet.
+         if (validate_utf8_span<Opts>(ctx, data, data + size)) [[unlikely]] {
+            return;
+         }
          const sv s{data, size};
-         to<JSON, sv>::template op<Opts>(s, ctx, out, ix);
+         to<JSON, sv>::template op<raw_string_emit_opts<Opts>>(s, ctx, out, ix);
       }
 
       // The spec marks several payloads as "already valid JSON text" so that a converter can
@@ -40,7 +63,17 @@ namespace glz
       // (RFC 8259 section 7): no raw control character, no unescaped quote, and every
       // backslash introduces a well-formed escape. Surrogate escapes have to be properly
       // paired, matching what decode_json_escape enforces on the reader side.
-      [[nodiscard]] inline bool is_json_string_body(const char* data, size_t size) noexcept
+      //
+      // Every byte is visited here anyway, so each one is OR'd into `ascii_acc` on the way
+      // past. A caller hands that to validate_utf8_span, which then skips the UTF-8 pass
+      // outright for a pure ASCII payload — the case TEXT exists to make cheap.
+      //
+      // Note that validate_utf8_span documents the opposite bias for its accumulator: covering
+      // extra bytes only costs a needless pass, whereas covering too few would skip a needed
+      // one. So every byte is OR'd in unconditionally, including the ones consumed inside an
+      // escape. Those are all checked to be ASCII anyway, but making the accumulator depend on
+      // that would leave UTF-8 validation silently disabled if the escape set ever widened.
+      [[nodiscard]] inline bool is_json_string_body(const char* data, size_t size, uint64_t& ascii_acc) noexcept
       {
          // Reads the four hex digits at [pos, pos+4), or -1 if they are not all hex.
          auto hex4 = [&](size_t pos) -> int32_t {
@@ -50,6 +83,7 @@ namespace glz
             uint32_t v = 0;
             for (size_t k = 0; k < 4; ++k) {
                const auto h = static_cast<uint8_t>(data[pos + k]);
+               ascii_acc |= h;
                uint32_t d;
                if (h >= '0' && h <= '9')
                   d = h - '0';
@@ -66,6 +100,7 @@ namespace glz
 
          for (size_t i = 0; i < size; ++i) {
             const auto c = static_cast<uint8_t>(data[i]);
+            ascii_acc |= c;
             if (c < 0x20 || c == '"') {
                return false;
             }
@@ -73,6 +108,7 @@ namespace glz
                if (++i >= size) {
                   return false;
                }
+               ascii_acc |= static_cast<uint8_t>(data[i]);
                switch (data[i]) {
                case '"':
                case '\\':
@@ -97,6 +133,7 @@ namespace glz
                      if (size - i < 7 || data[i + 1] != '\\' || data[i + 2] != 'u') {
                         return false;
                      }
+                     ascii_acc |= static_cast<uint8_t>(data[i + 1]) | static_cast<uint8_t>(data[i + 2]);
                      const int32_t low = hex4(i + 3);
                      if (low < 0xDC00 || low > 0xDFFF) {
                         return false;
@@ -153,10 +190,17 @@ namespace glz
       }
 
       // Emit a string whose bytes are already a valid JSON string literal body (i.e. with
-      // RFC 8259 escapes already in the payload). We just wrap in quotes.
-      template <class B>
-      inline void emit_json_escaped_body(is_context auto& ctx, const char* data, size_t size, B& out, size_t& ix)
+      // RFC 8259 escapes already in the payload). We just wrap in quotes. `ascii_acc` is the
+      // OR of the payload's bytes, as produced by is_json_string_body.
+      template <auto Opts, class B>
+      inline void emit_json_escaped_body(is_context auto& ctx, const char* data, size_t size, uint64_t ascii_acc,
+                                         B& out, size_t& ix)
       {
+         // The escapes in the payload are ASCII, so only the raw bytes need the UTF-8 check;
+         // validate_utf8_span skips it entirely when the accumulator shows pure ASCII.
+         if (validate_utf8_span<Opts>(ctx, data, data + size, ascii_acc)) [[unlikely]] {
+            return;
+         }
          if (!ensure_space(ctx, out, ix + size + 2 + write_padding_bytes)) return;
          out[ix++] = static_cast<typename std::decay_t<B>::value_type>('"');
          if (size) {
@@ -329,21 +373,57 @@ namespace glz
                ix += 6;
                return;
             }
-            // What is left is JSON5 float syntax that strict JSON does not share, so parse it
-            // and re-render rather than copying it out. A leading '+' or '.' and a trailing
-            // '.' are all legal here and none of them are legal JSON. Mirrors the reader's
-            // parse_float_payload in jsonb/read.hpp, including its use of fast_float over
-            // std::from_chars for the floating-point overload.
-            const char* p = s.data();
-            const char* e = p + s.size();
-            if (p < e && *p == '+') ++p;
-            double d{};
-            auto [ptr, ec] = glz::fast_float::from_chars(p, e, d);
-            if (ec != std::errc{} || ptr != e) [[unlikely]] {
+            // What is left is JSON5 float syntax, which strict JSON does not share: a leading
+            // '+' is legal here, and so is a '.' with no digit on one side of it. Normalize
+            // those textually — supplying the digit the payload omits, the way SQLite's json()
+            // does — rather than parsing to a double and re-rendering. Re-rendering would round
+            // a payload carrying more precision than binary64 holds and would reject one whose
+            // magnitude is outside its range, even though both are already valid JSON once the
+            // JSON5-only spelling is gone. Whatever normalization produces still has to satisfy
+            // the JSON grammar before it is copied out: the blob is untrusted, and this arm is
+            // otherwise unconstrained.
+            sv body = s;
+            // Drop a leading '+' only when a number could actually follow it, so that a
+            // payload like "+-1.5" is left intact and rejected below rather than quietly
+            // becoming "-1.5".
+            if (body.size() > 1 && body.front() == '+' &&
+                ((body[1] >= '0' && body[1] <= '9') || body[1] == '.')) {
+               body.remove_prefix(1);
+            }
+
+            std::string scratch;
+            if (const size_t dot = body.find('.'); dot != sv::npos) {
+               const auto is_digit = [](char c) { return c >= '0' && c <= '9'; };
+               const bool has_int_digit = dot > 0 && is_digit(body[dot - 1]);
+               const bool has_frac_digit = dot + 1 < body.size() && is_digit(body[dot + 1]);
+               // Supply the missing digit only when the other side of the dot has one, so that
+               // a payload which is not JSON5 either ("." or ".e5") is left alone and rejected
+               // below rather than normalized into a number it never denoted.
+               if (has_int_digit && !has_frac_digit) {
+                  // "5." and "5.e3" omit the fraction digit.
+                  scratch.reserve(body.size() + 1);
+                  scratch.append(body.substr(0, dot + 1));
+                  scratch.push_back('0');
+                  scratch.append(body.substr(dot + 1));
+                  body = scratch;
+               }
+               else if (has_frac_digit && !has_int_digit) {
+                  // ".5" and "-.5" omit the integer digit.
+                  scratch.reserve(body.size() + 1);
+                  scratch.append(body.substr(0, dot));
+                  scratch.push_back('0');
+                  scratch.append(body.substr(dot));
+                  body = scratch;
+               }
+            }
+
+            if (!is_json_number(body.data(), body.size())) [[unlikely]] {
                ctx.error = error_code::parse_number_failure;
                return;
             }
-            to<JSON, double>::template op<Opts>(d, ctx, out, ix);
+            if (!ensure_space(ctx, out, ix + body.size() + write_padding_bytes)) return;
+            if (!body.empty()) std::memcpy(&out[ix], body.data(), body.size());
+            ix += body.size();
             return;
          }
          case jsonb::type::text:
@@ -355,11 +435,12 @@ namespace glz
             // is not an escape error, it just ends the string a character early.
             const auto* body = reinterpret_cast<const char*>(payload);
             const auto n = static_cast<size_t>(sz);
-            if (!is_json_string_body(body, n)) [[unlikely]] {
+            uint64_t ascii_acc{};
+            if (!is_json_string_body(body, n, ascii_acc)) [[unlikely]] {
                ctx.error = error_code::syntax_error;
                return;
             }
-            emit_json_escaped_body(ctx, body, n, out, ix);
+            emit_json_escaped_body<Opts>(ctx, body, n, ascii_acc, out, ix);
             return;
          }
          case jsonb::type::textraw:

--- a/include/glaze/jsonb/jsonb_to_json.hpp
+++ b/include/glaze/jsonb/jsonb_to_json.hpp
@@ -14,6 +14,7 @@
 #include "glaze/json/write.hpp"
 #include "glaze/jsonb/header.hpp"
 #include "glaze/jsonb/text_decode.hpp"
+#include "glaze/util/fast_float.hpp"
 
 namespace glz
 {
@@ -26,6 +27,129 @@ namespace glz
       {
          const sv s{data, size};
          to<JSON, sv>::template op<Opts>(s, ctx, out, ix);
+      }
+
+      // The spec marks several payloads as "already valid JSON text" so that a converter can
+      // copy them into the output document rather than re-encoding them. A blob from a
+      // foreign producer need not honor that, and a payload that does not is not merely
+      // rendered wrong: it is spliced into the document as structure, so a single scalar can
+      // introduce object members that were never in the blob. The two predicates below check
+      // the claim before any such copy.
+
+      // True if [data, data+size) can stand verbatim as the body of a JSON string literal
+      // (RFC 8259 section 7): no raw control character, no unescaped quote, and every
+      // backslash introduces a well-formed escape. Surrogate escapes have to be properly
+      // paired, matching what decode_json_escape enforces on the reader side.
+      [[nodiscard]] inline bool is_json_string_body(const char* data, size_t size) noexcept
+      {
+         // Reads the four hex digits at [pos, pos+4), or -1 if they are not all hex.
+         auto hex4 = [&](size_t pos) -> int32_t {
+            if (size - pos < 4) {
+               return -1;
+            }
+            uint32_t v = 0;
+            for (size_t k = 0; k < 4; ++k) {
+               const auto h = static_cast<uint8_t>(data[pos + k]);
+               uint32_t d;
+               if (h >= '0' && h <= '9')
+                  d = h - '0';
+               else if (h >= 'a' && h <= 'f')
+                  d = h - 'a' + 10;
+               else if (h >= 'A' && h <= 'F')
+                  d = h - 'A' + 10;
+               else
+                  return -1;
+               v = (v << 4) | d;
+            }
+            return static_cast<int32_t>(v);
+         };
+
+         for (size_t i = 0; i < size; ++i) {
+            const auto c = static_cast<uint8_t>(data[i]);
+            if (c < 0x20 || c == '"') {
+               return false;
+            }
+            if (c == '\\') {
+               if (++i >= size) {
+                  return false;
+               }
+               switch (data[i]) {
+               case '"':
+               case '\\':
+               case '/':
+               case 'b':
+               case 'f':
+               case 'n':
+               case 'r':
+               case 't':
+                  break;
+               case 'u': {
+                  const int32_t cp = hex4(i + 1);
+                  if (cp < 0) {
+                     return false;
+                  }
+                  i += 4;
+                  if (cp >= 0xDC00 && cp <= 0xDFFF) {
+                     return false; // low surrogate without a preceding high one
+                  }
+                  if (cp >= 0xD800 && cp <= 0xDBFF) {
+                     // A high surrogate has to be followed by \uDC00..\uDFFF.
+                     if (size - i < 7 || data[i + 1] != '\\' || data[i + 2] != 'u') {
+                        return false;
+                     }
+                     const int32_t low = hex4(i + 3);
+                     if (low < 0xDC00 || low > 0xDFFF) {
+                        return false;
+                     }
+                     i += 6;
+                  }
+                  break;
+               }
+               default:
+                  return false;
+               }
+            }
+         }
+         return true;
+      }
+
+      // True if [data, data+size) is a complete RFC 8259 section 6 number.
+      [[nodiscard]] inline bool is_json_number(const char* data, size_t size) noexcept
+      {
+         size_t i = 0;
+         auto digits = [&] {
+            const size_t start = i;
+            while (i < size && data[i] >= '0' && data[i] <= '9') {
+               ++i;
+            }
+            return i > start;
+         };
+
+         if (i < size && data[i] == '-') {
+            ++i;
+         }
+         if (i < size && data[i] == '0') {
+            ++i; // a leading zero may not be followed by more integer digits
+         }
+         else if (!digits()) {
+            return false;
+         }
+         if (i < size && data[i] == '.') {
+            ++i;
+            if (!digits()) {
+               return false;
+            }
+         }
+         if (i < size && (data[i] == 'e' || data[i] == 'E')) {
+            ++i;
+            if (i < size && (data[i] == '+' || data[i] == '-')) {
+               ++i;
+            }
+            if (!digits()) {
+               return false;
+            }
+         }
+         return i == size;
       }
 
       // Emit a string whose bytes are already a valid JSON string literal body (i.e. with
@@ -59,6 +183,15 @@ namespace glz
                out[ix++] = static_cast<typename std::decay_t<B>::value_type>(',');
             }
             first = false;
+            if (close == '}') {
+               // An object key has to be one of the text types (7..10). Any other type here
+               // would be rendered as a bare unquoted key, e.g. `{{}:false}`.
+               const uint8_t key_type = jsonb::get_type(static_cast<uint8_t>(*it));
+               if (key_type < jsonb::type::text || key_type > jsonb::type::textraw) [[unlikely]] {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
+            }
             jsonb_to_json_value<Opts>(ctx, it, stop, out, ix, depth);
             if (bool(ctx.error)) return;
 
@@ -124,7 +257,13 @@ namespace glz
             return;
          case jsonb::type::int_:
          case jsonb::type::float_: {
-            // Already valid JSON number text.
+            // Already valid JSON number text, so the payload is copied rather than parsed
+            // and re-rendered, which keeps the blob's exact decimal representation. Confirm
+            // the claim first: the blob is untrusted.
+            if (!is_json_number(reinterpret_cast<const char*>(payload), static_cast<size_t>(sz))) [[unlikely]] {
+               ctx.error = error_code::parse_number_failure;
+               return;
+            }
             if (!ensure_space(ctx, out, ix + sz + write_padding_bytes)) return;
             if (sz) std::memcpy(&out[ix], payload, sz);
             ix += sz;
@@ -190,32 +329,44 @@ namespace glz
                ix += 6;
                return;
             }
-            // Otherwise, best effort: strip leading '+'.
+            // What is left is JSON5 float syntax that strict JSON does not share, so parse it
+            // and re-render rather than copying it out. A leading '+' or '.' and a trailing
+            // '.' are all legal here and none of them are legal JSON. Mirrors the reader's
+            // parse_float_payload in jsonb/read.hpp, including its use of fast_float over
+            // std::from_chars for the floating-point overload.
             const char* p = s.data();
             const char* e = p + s.size();
             if (p < e && *p == '+') ++p;
-            const size_t n = static_cast<size_t>(e - p);
-            if (!ensure_space(ctx, out, ix + n + write_padding_bytes)) return;
-            if (n) std::memcpy(&out[ix], p, n);
-            ix += n;
+            double d{};
+            auto [ptr, ec] = glz::fast_float::from_chars(p, e, d);
+            if (ec != std::errc{} || ptr != e) [[unlikely]] {
+               ctx.error = error_code::parse_number_failure;
+               return;
+            }
+            to<JSON, double>::template op<Opts>(d, ctx, out, ix);
             return;
          }
          case jsonb::type::text:
-            // Spec: TEXT payload is already a valid JSON string body (no control chars,
-            // no unescaped " or \), so wrap in quotes and memcpy — no scan needed.
-            emit_json_escaped_body(ctx, reinterpret_cast<const char*>(payload), static_cast<size_t>(sz), out, ix);
+         case jsonb::type::textj: {
+            // Spec: a TEXT or TEXTJ payload is already a valid JSON string body (no control
+            // chars, no unescaped " or \), so wrap in quotes and memcpy — no unescaping
+            // needed. The blob is untrusted, so confirm it holds to that before copying it
+            // out. Decoding the escapes would not be enough on its own: an unescaped quote
+            // is not an escape error, it just ends the string a character early.
+            const auto* body = reinterpret_cast<const char*>(payload);
+            const auto n = static_cast<size_t>(sz);
+            if (!is_json_string_body(body, n)) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            emit_json_escaped_body(ctx, body, n, out, ix);
             return;
+         }
          case jsonb::type::textraw:
             // Raw bytes that may require escaping — run through the JSON string writer.
             emit_raw_string_as_json<Opts>(ctx, reinterpret_cast<const char*>(payload), static_cast<size_t>(sz), out,
                                           ix);
             return;
-         case jsonb::type::textj: {
-            // TEXTJ payload is already a valid JSON string body by spec. Emitting it
-            // verbatim wrapped in quotes is correct.
-            emit_json_escaped_body(ctx, reinterpret_cast<const char*>(payload), static_cast<size_t>(sz), out, ix);
-            return;
-         }
          case jsonb::type::text5: {
             // TEXT5 payloads may contain JSON5-only escapes (\xNN, \', \v, \0, line
             // continuations) that are not valid JSON. Decode to raw UTF-8 and re-emit via

--- a/include/glaze/jsonb/text_decode.hpp
+++ b/include/glaze/jsonb/text_decode.hpp
@@ -138,7 +138,14 @@ namespace glz::jsonb_detail
          const int hi = hex(static_cast<char>(it[0]));
          const int lo = hex(static_cast<char>(it[1]));
          if (hi < 0 || lo < 0) return false;
-         out.push_back(static_cast<char>((hi << 4) | lo));
+         // JSON5 `\xNN` denotes the code point U+00NN, not the byte 0xNN, so anything above
+         // U+007F has to be UTF-8 encoded rather than pushed raw — a raw 0x80..0xFF byte is
+         // not valid UTF-8 on its own and would make the decoded string ill-formed. SQLite
+         // reads it the same way: it renders JSON5 "\xFF" as the escape "\u00FF".
+         char utf8[4];
+         const uint32_t n = glz::code_point_to_utf8(static_cast<uint32_t>((hi << 4) | lo), utf8);
+         if (n == 0) return false;
+         out.append(utf8, n);
          it += 2;
          return true;
       }

--- a/include/glaze/jsonb/write.hpp
+++ b/include/glaze/jsonb/write.hpp
@@ -297,6 +297,14 @@ namespace glz
 
          using map_t = std::remove_cvref_t<decltype(value)>;
          using val_t = std::remove_cvref_t<detail::iterator_second_type<map_t>>;
+         // A JSONB object key must be one of the text types (7-10). Serializing a non-string
+         // key through the generic value writer would emit an INT (or worse) in the key slot,
+         // producing a blob that neither `read_jsonb` nor `jsonb_to_json` will accept and that
+         // SQLite renders as unquoted nonsense like `{1:2}`. Reject it here, matching the
+         // identical assertion in `from<JSONB, T>`.
+         using key_t = std::remove_cvref_t<detail::iterator_first_type<map_t>>;
+         static_assert(str_t<key_t> || std::same_as<key_t, std::string>,
+                       "JSONB objects only support string keys (types 7-10).");
          constexpr bool may_skip = null_t<val_t> && Opts.skip_null_members;
 
          for (auto&& [k, v] : value) {
@@ -323,6 +331,12 @@ namespace glz
       template <auto Opts>
       static void op(auto&& value, is_context auto&& ctx, auto&& b, auto& ix)
       {
+         // A pair becomes a single-entry object, so its first element lands in a key slot and
+         // is subject to the same text-type requirement as a map key.
+         using key_t = std::remove_cvref_t<typename std::remove_cvref_t<T>::first_type>;
+         static_assert(str_t<key_t> || std::same_as<key_t, std::string>,
+                       "JSONB objects only support string keys (types 7-10).");
+
          size_t header_pos{};
          if (!jsonb_detail::reserve_container_header(ctx, b, ix, header_pos)) [[unlikely]] {
             return;

--- a/tests/jsonb_test/jsonb_test.cpp
+++ b/tests/jsonb_test/jsonb_test.cpp
@@ -1241,7 +1241,13 @@ suite converter_tests = [] {
       // representation, so the payload has to be checked against the JSON grammar first.
       auto scalar = [](uint8_t type_code, const std::string& payload) {
          std::string buf;
-         buf.push_back(static_cast<char>((payload.size() << 4) | type_code));
+         if (payload.size() <= 11) {
+            buf.push_back(static_cast<char>((payload.size() << 4) | type_code));
+         }
+         else {
+            buf.push_back(static_cast<char>((12u << 4) | type_code)); // u8_follows
+            buf.push_back(static_cast<char>(payload.size()));
+         }
          buf += payload;
          return glz::jsonb_to_json(buf);
       };
@@ -1260,13 +1266,42 @@ suite converter_tests = [] {
          expect(!scalar(tc, "1,\"b\":2").has_value()); // would fabricate a sibling member
       }
 
-      // FLOAT5 carries JSON5-only float syntax, which has to be rendered rather than
-      // copied: none of these three payloads is valid JSON as written.
+      // FLOAT5 carries JSON5-only float syntax, which is normalized textually: a leading
+      // '+' is dropped and the digit the payload omits on one side of the '.' is supplied.
+      // These are the spellings SQLite's json() produces, byte for byte.
       expect(scalar(6, ".5").value() == "0.5");
       expect(scalar(6, "+1.5").value() == "1.5");
-      expect(scalar(6, "5.").value() == "5");
+      expect(scalar(6, "5.").value() == "5.0");
+      expect(scalar(6, "-.5").value() == "-0.5");
+      expect(scalar(6, "-5.").value() == "-5.0");
+      expect(scalar(6, "-0.").value() == "-0.0");
+      expect(scalar(6, "5.e3").value() == "5.0e3"); // the omitted digit is not always trailing
+      expect(scalar(6, ".5E+3").value() == "0.5E+3");
+      expect(scalar(6, "+.5").value() == "0.5");
+
+      // Normalizing textually rather than through a double keeps payloads that are already
+      // valid JSON exact, including ones binary64 cannot represent or even hold.
+      expect(scalar(6, "1e400").value() == "1e400");
+      expect(scalar(6, ".12345678901234567890123").value() == "0.12345678901234567890123");
+
       expect(!scalar(6, "1,\"b\":2").has_value());
       expect(!scalar(6, "abc").has_value());
+      expect(!scalar(6, "0x10").has_value()); // hex belongs to INT5
+      // A '.' with a digit on neither side is not JSON5 either, so it is rejected rather
+      // than normalized into a number it never denoted.
+      expect(!scalar(6, ".").has_value());
+      expect(!scalar(6, ".e5").has_value());
+      expect(!scalar(6, "1.2.3").has_value());
+      // fast_float would accept these spellings; none of them is JSON5.
+      expect(!scalar(6, "nan").has_value());
+      expect(!scalar(6, "inf").has_value());
+      expect(!scalar(6, "infinity").has_value());
+
+      // The JSON5 sentinels keep their existing renderings.
+      expect(scalar(6, "NaN").value() == "null");
+      expect(scalar(6, "Infinity").value() == "9e999");
+      expect(scalar(6, "+Infinity").value() == "9e999");
+      expect(scalar(6, "-Infinity").value() == "-9e999");
    };
 
    "jsonb_to_json rejects a non-text object key"_test = [] {
@@ -1289,6 +1324,151 @@ suite converter_tests = [] {
       expect(!object_with_key(11).has_value()); // array
       expect(!object_with_key(12).has_value()); // object
       expect(object_with_key(7).value() == R"({"":true})"); // text keys still work
+   };
+
+   "jsonb_to_json escapes control characters in TEXTRAW and TEXT5"_test = [] {
+      // These two arms hand the payload to the JSON string writer, which leaves control
+      // characters unescaped by default for performance. A blob is untrusted input, so the
+      // converter forces that option on: a raw control byte would otherwise be copied into
+      // the output document and the result would not be JSON.
+      auto scalar = [](uint8_t type_code, const std::string& payload) {
+         std::string buf;
+         buf.push_back(static_cast<char>((payload.size() << 4) | type_code));
+         buf += payload;
+         return glz::jsonb_to_json(buf);
+      };
+
+      expect(scalar(10, "a\x1c" "b").value() == R"("a\u001Cb")"); // TEXTRAW
+      expect(scalar(9, "a\x1c" "b").value() == R"("a\u001Cb")"); // TEXT5
+      expect(scalar(10, std::string("a\0b", 3)).value() == R"("a\u0000b")");
+      // The escapes with short forms still use them.
+      expect(scalar(10, "a\nb").value() == R"("a\nb")");
+      expect(scalar(10, "a\tb").value() == R"("a\tb")");
+   };
+
+   "jsonb_to_json pins the writer options that would leak payload bytes"_test = [] {
+      // escape_control_characters, raw_string and unquoted are all inheritable, so a caller's
+      // opts would otherwise decide whether the converter's output is JSON at all.
+      struct raw_opts : glz::opts
+      {
+         bool raw_string = true;
+      };
+      struct unquoted_opts : glz::opts
+      {
+         bool unquoted = true;
+      };
+
+      const std::string payload = "a\"b\\c\nd"; // quote, backslash and a control byte
+      std::string buf;
+      buf.push_back(static_cast<char>((payload.size() << 4) | 10u)); // TEXTRAW
+      buf += payload;
+
+      const std::string expected = R"("a\"b\\c\nd")";
+      expect(glz::jsonb_to_json(buf).value() == expected);
+      expect(glz::jsonb_to_json<raw_opts{}>(buf).value() == expected);
+      expect(glz::jsonb_to_json<unquoted_opts{}>(buf).value() == expected);
+   };
+
+   "jsonb_to_json rejects unpaired surrogate escapes"_test = [] {
+      // RFC 8259 section 7's grammar allows a lone \uD800 and SQLite's json() passes one
+      // through, but Glaze's own reader rejects unpaired surrogates, so accepting one here
+      // would mean emitting a document that glz::read_json refuses. Staying consistent with
+      // the reader is the deliberate choice; this pins it so the divergence is not silent.
+      auto textj = [](const std::string& payload) {
+         std::string buf;
+         if (payload.size() <= 11) {
+            buf.push_back(static_cast<char>((payload.size() << 4) | 8u)); // TEXTJ
+         }
+         else {
+            buf.push_back(static_cast<char>((12u << 4) | 8u)); // u8_follows
+            buf.push_back(static_cast<char>(payload.size()));
+         }
+         buf += payload;
+         return glz::jsonb_to_json(buf);
+      };
+
+      expect(!textj("\\uD800").has_value()); // lone high surrogate
+      expect(!textj("\\uDC00").has_value()); // lone low surrogate
+      // A proper pair is kept as written: TEXTJ is copied out, not decoded and re-encoded.
+      expect(textj("\\uD83D\\uDE00").value() == R"("\uD83D\uDE00")");
+   };
+
+   "jsonb_to_json validates UTF-8 in every text arm"_test = [] {
+      // RFC 8259 section 8.1 requires JSON text to be UTF-8. A blob's text payload is someone
+      // else's bytes, so all four text types get checked rather than copied on faith.
+      auto scalar = [](uint8_t type_code, const std::string& payload) {
+         std::string buf;
+         buf.push_back(static_cast<char>((payload.size() << 4) | type_code));
+         buf += payload;
+         return glz::jsonb_to_json(buf);
+      };
+
+      const std::string lone_ff = "a\xff" "b"; // 0xFF never appears in well-formed UTF-8
+      const std::string truncated = "a\xc3"; // 2-byte sequence cut short by the payload end
+      const std::string valid = "a\xc3\xa9" "b"; // U+00E9 as a well-formed 2-byte sequence
+
+      for (const uint8_t tc : {uint8_t(7), uint8_t(8), uint8_t(9), uint8_t(10)}) {
+         expect(!scalar(tc, lone_ff).has_value());
+         expect(!scalar(tc, truncated).has_value());
+         expect(scalar(tc, valid).value() == "\"" + valid + "\"");
+      }
+
+      // Pure ASCII takes the accumulator fast path and skips the scan entirely.
+      expect(scalar(7, "plain").value() == R"("plain")");
+   };
+
+   "jsonb_to_json honors the validate_utf8 opt-out"_test = [] {
+      // Callers whose blobs come from a stage that already guarantees the encoding can turn
+      // the check off, exactly as on the JSON read path.
+      struct unchecked_opts : glz::opts
+      {
+         bool validate_utf8 = false;
+      };
+
+      std::string buf;
+      const std::string payload = "a\xff" "b";
+      buf.push_back(static_cast<char>((payload.size() << 4) | 7u)); // TEXT
+      buf += payload;
+
+      expect(!glz::jsonb_to_json(buf).has_value());
+      expect(glz::jsonb_to_json<unchecked_opts{}>(buf).value() == "\"" + payload + "\"");
+   };
+
+   "jsonb TEXT5 \\xNN is a code point, not a byte"_test = [] {
+      // JSON5 "\xFF" denotes U+00FF, so it has to be UTF-8 encoded on decode. Pushing the raw
+      // byte would leave the string ill-formed. SQLite renders the same input as "ÿ".
+      std::string buf;
+      const std::string payload = "\\xFF";
+      buf.push_back(static_cast<char>((payload.size() << 4) | 9u)); // TEXT5
+      buf += payload;
+
+      expect(glz::jsonb_to_json(buf).value() == "\"\xc3\xbf\"");
+
+      // The same decoder backs read_jsonb, so it gets the fix too.
+      std::string s{};
+      expect(!glz::read_jsonb(s, buf));
+      expect(s == "\xc3\xbf");
+
+      // Below U+0080 the encoding is still a single byte.
+      std::string ascii_buf;
+      const std::string ascii_payload = "\\x41";
+      ascii_buf.push_back(static_cast<char>((ascii_payload.size() << 4) | 9u));
+      ascii_buf += ascii_payload;
+      expect(glz::jsonb_to_json(ascii_buf).value() == R"("A")");
+   };
+
+   "jsonb runtime map keys needing escapes convert correctly"_test = [] {
+      // A map key is written by the string writer, so one containing a quote is stored as
+      // TEXTRAW rather than TEXT and survives the converter's key check. (Reflected glz::meta
+      // names are the caller's contract to keep valid and are written as TEXT unconditionally.)
+      std::map<std::string, int> m{{"q\"uote", 1}};
+      std::string blob{};
+      expect(!glz::write_jsonb(m, blob));
+      expect(glz::jsonb_to_json(blob).value() == R"({"q\"uote":1})");
+
+      std::map<std::string, int> back{};
+      expect(!glz::read_jsonb(back, blob));
+      expect(back == m);
    };
 
    "jsonb_to_json TEXT5 with \\x produces strict JSON"_test = [] {

--- a/tests/jsonb_test/jsonb_test.cpp
+++ b/tests/jsonb_test/jsonb_test.cpp
@@ -1188,6 +1188,109 @@ suite converter_tests = [] {
       expect(j.value() == std::string("\"") + payload + "\"");
    };
 
+   "jsonb_to_json rejects a TEXT/TEXTJ payload that is not a JSON string body"_test = [] {
+      // TEXT and TEXTJ are emitted verbatim between quotes, so a payload that violates
+      // the spec would splice its own bytes into the output document.
+      auto scalar = [](uint8_t type_code, const std::string& payload) {
+         std::string buf;
+         if (payload.size() <= 11) {
+            buf.push_back(static_cast<char>((payload.size() << 4) | type_code));
+         }
+         else {
+            buf.push_back(static_cast<char>((12u << 4) | type_code)); // u8_follows
+            buf.push_back(static_cast<char>(payload.size()));
+         }
+         buf += payload;
+         return glz::jsonb_to_json(buf);
+      };
+
+      for (const uint8_t tc : {uint8_t(7), uint8_t(8)}) { // TEXT, TEXTJ
+         expect(!scalar(tc, "a\"b").has_value()); // unescaped quote ends the string early
+         expect(!scalar(tc, "a\\").has_value()); // dangling escape
+         expect(!scalar(tc, std::string("a\nb")).has_value()); // raw control character
+      }
+      expect(!scalar(8, "\\q").has_value()); // not a JSON escape
+      expect(!scalar(8, "\\u00g1").has_value()); // \u without four hex digits
+      expect(!scalar(8, "\\u00").has_value()); // \u truncated by the payload end
+      expect(!scalar(8, "\\uD83D").has_value()); // high surrogate with no low surrogate
+      expect(!scalar(8, "\\uDE00").has_value()); // low surrogate on its own
+      expect(!scalar(8, "\\uD83Dx").has_value()); // high surrogate not followed by \u
+      expect(scalar(8, "\\uD83D\\uDE00").value() == R"("\uD83D\uDE00")"); // a proper pair
+
+      // An unescaped quote in a TEXT value used to close the string and let the rest of
+      // the payload be read as further object members.
+      const std::string key = "a";
+      const std::string value = "x\",\"b\":\"y";
+      std::string members;
+      members.push_back(static_cast<char>((key.size() << 4) | 7u));
+      members += key;
+      members.push_back(static_cast<char>((value.size() << 4) | 7u));
+      members += value;
+      std::string blob;
+      blob.push_back(static_cast<char>((12u << 4) | 12u)); // object, size_nibble=u8_follows
+      blob.push_back(static_cast<char>(members.size()));
+      blob += members;
+      expect(!glz::jsonb_to_json(blob).has_value());
+
+      // The same bytes carried as TEXTRAW are escaped, not rejected.
+      expect(scalar(10, value).value() == R"("x\",\"b\":\"y")");
+   };
+
+   "jsonb_to_json rejects an INT/FLOAT payload that is not a JSON number"_test = [] {
+      // INT and FLOAT are copied out verbatim to preserve the blob's exact decimal
+      // representation, so the payload has to be checked against the JSON grammar first.
+      auto scalar = [](uint8_t type_code, const std::string& payload) {
+         std::string buf;
+         buf.push_back(static_cast<char>((payload.size() << 4) | type_code));
+         buf += payload;
+         return glz::jsonb_to_json(buf);
+      };
+
+      for (const uint8_t tc : {uint8_t(3), uint8_t(5)}) { // INT, FLOAT
+         expect(scalar(tc, "0").value() == "0");
+         expect(scalar(tc, "-7").value() == "-7");
+         expect(scalar(tc, "1e10").value() == "1e10"); // exact bytes preserved
+         expect(!scalar(tc, "").has_value());
+         expect(!scalar(tc, "-").has_value());
+         expect(!scalar(tc, "1e").has_value());
+         expect(!scalar(tc, "1.").has_value());
+         expect(!scalar(tc, "01").has_value()); // leading zero belongs to INT5
+         expect(!scalar(tc, "0x10").has_value()); // hex belongs to INT5
+         expect(!scalar(tc, "+1").has_value()); // leading plus belongs to INT5
+         expect(!scalar(tc, "1,\"b\":2").has_value()); // would fabricate a sibling member
+      }
+
+      // FLOAT5 carries JSON5-only float syntax, which has to be rendered rather than
+      // copied: none of these three payloads is valid JSON as written.
+      expect(scalar(6, ".5").value() == "0.5");
+      expect(scalar(6, "+1.5").value() == "1.5");
+      expect(scalar(6, "5.").value() == "5");
+      expect(!scalar(6, "1,\"b\":2").has_value());
+      expect(!scalar(6, "abc").has_value());
+   };
+
+   "jsonb_to_json rejects a non-text object key"_test = [] {
+      // A key slot holding anything but a text type would be emitted as a bare unquoted
+      // key, e.g. {{}:false}.
+      auto object_with_key = [](uint8_t key_type) {
+         std::string members;
+         members.push_back(static_cast<char>((0u << 4) | key_type)); // empty payload
+         members.push_back(static_cast<char>((1u << 4) | 1u)); // true, size 1
+         members.push_back('x');
+         std::string buf;
+         buf.push_back(static_cast<char>((12u << 4) | 12u)); // object, size_nibble=u8_follows
+         buf.push_back(static_cast<char>(members.size()));
+         buf += members;
+         return glz::jsonb_to_json(buf);
+      };
+
+      expect(!object_with_key(0).has_value()); // null
+      expect(!object_with_key(1).has_value()); // true
+      expect(!object_with_key(11).has_value()); // array
+      expect(!object_with_key(12).has_value()); // object
+      expect(object_with_key(7).value() == R"({"":true})"); // text keys still work
+   };
+
    "jsonb_to_json TEXT5 with \\x produces strict JSON"_test = [] {
       // TEXT5 payload "A\x20B" decodes to "A B" (space). Raw pass-through would emit
       // "A\x20B" which is invalid JSON.


### PR DESCRIPTION
`jsonb_to_json` copies the payload straight into the output document for every type the spec marks as already valid JSON text: INT, FLOAT, TEXT, TEXTJ, and the FLOAT5 fallback. That claim holds for blobs Glaze wrote, since `to<JSONB, str_t>` pre-scans with `string_needs_json_escape` and downgrades TEXT to TEXTRAW, and `read_jsonb` checks it on its own path, but the converter is aimed at SQLite BLOB columns that any writer can fill. Before: a TEXT value whose payload is `x","b":"y` renders a one-member object as `{"a":"x","b":"y"}`, an INT payload of `1,"b":9` does the same with no string involved, and payloads like `a\`, a raw control byte, or a lone `\uDE00` produce output that is not JSON while the call still reports success. An object key was unconstrained too, so a blob with an array in the key slot emitted `{{}:false}`.

After: each of those arms checks its payload against the JSON grammar before copying, and the key slot has to be one of the text types. Checking rather than re-encoding keeps the blob's exact decimal representation, so `1e10` and `-0.0` still come out byte for byte, and TEXTJ still passes through unchanged. FLOAT5 is the one arm whose shape changes: the JSON5 syntax it is left with (`.5`, `5.`, `+1.5`) is parsed and re-rendered the way INT5 already is, because none of it is legal JSON as written. The tradeoff is one pass over each payload where TEXT previously cost nothing, which is the same scan the writer already performs to pick TEXT over TEXTRAW.
