### PR TITLE
Add a generic YAML fuzzer

### DIFF
--- a/fuzzing/CMakeLists.txt
+++ b/fuzzing/CMakeLists.txt
@@ -62,6 +62,7 @@ create_fuzztest(json_roundtrip_int)
 create_fuzztest(json_roundtrip_string)
 create_fuzztest(json_with_comments)
 create_fuzztest(jsonb_reflection)
+create_fuzztest(yaml_generic)
 create_fuzztest(repe_registry)
 create_fuzztest(jsonrpc_registry)
 

--- a/fuzzing/yaml_generic.cpp
+++ b/fuzzing/yaml_generic.cpp
@@ -1,0 +1,60 @@
+#include <cstddef>
+#include <cstdint>
+#include <glaze/glaze.hpp>
+#include <glaze/yaml.hpp>
+#include <vector>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+   // The YAML reader is bounded by `end` and never consults a trailing sentinel, so it must
+   // parse a buffer that has no '\0' after it. An exact-size heap buffer puts the ASAN
+   // redzone immediately after the last byte, so any read past the end fails here.
+   {
+      const std::vector<char> buffer{Data, Data + Size};
+
+      static constexpr glz::opts opts{.format = glz::YAML, .null_terminated = false};
+      glz::generic yaml{};
+      auto ec = glz::read<opts>(yaml, buffer);
+      if (!ec) {
+         [[maybe_unused]] auto s = yaml.size();
+      }
+   }
+
+   // glz::yaml_opts has no null_terminated member at all, so this covers the default
+   // read_yaml path, where check_null_terminated falls back to false.
+   {
+      const std::vector<char> buffer{Data, Data + Size};
+
+      glz::generic yaml{};
+      auto ec = glz::read_yaml(yaml, buffer);
+      if (!ec) {
+         [[maybe_unused]] auto s = yaml.size();
+      }
+   }
+
+   // use a vector with null termination instead of a std::string to avoid
+   // small string optimization to hide bounds problems
+   std::vector<char> buffer{Data, Data + Size};
+   buffer.push_back('\0');
+
+   // const qualified input buffer
+   {
+      const auto& input = buffer;
+      glz::generic yaml{};
+      auto ec = glz::read_yaml(yaml, input);
+      if (!ec) {
+         [[maybe_unused]] auto s = yaml.size();
+      }
+   }
+
+   // non-const input buffer
+   {
+      glz::generic yaml{};
+      auto ec = glz::read_yaml(yaml, buffer);
+      if (!ec) {
+         [[maybe_unused]] auto s = yaml.size();
+      }
+   }
+
+   return 0;
+}


### PR DESCRIPTION
Adds a generic YAML fuzz target. YAML is the largest parser in the tree with no fuzz coverage — every other format Glaze reads (JSON, BEVE, CBOR, MsgPack, CSV, JSONB) already has one.

The target follows the `json_generic` pattern, with one YAML-specific addition:

- **Exact-size, non-null-terminated buffer first.** The YAML reader is bounded by `end` and never consults a trailing sentinel, so it has to parse a buffer with no `'\0'` after it. Sizing the allocation exactly puts the ASAN redzone immediately after the last byte, so a read past the end is caught rather than landing in allocator slack.
- **The default `read_yaml` path is covered separately**, because `glz::yaml_opts` has no `null_terminated` member at all and `check_null_terminated` falls back to `false` there. That is a different code path from passing the option explicitly, so both are exercised.
- Then the usual null-terminated const and non-const buffers.

It is registered in `fuzzing/CMakeLists.txt`. That matters more than it looks: `create_fuzztest` compiles the source regardless of whether the toolchain has libFuzzer, which is exactly what keeps a fuzz target from rotting. An unregistered file silently stops compiling the first time the API moves.

No bugs found so far, which is the expected state for a new target on already-tested code — the value is regression protection on a parser that is still moving. What I ran locally, all under ASAN + UBSAN with `-fno-sanitize-recover=all`:

- ~400k mutated inputs over a YAML-weighted alphabet plus seeded documents
- every truncation of a document using anchors, aliases, tags and block scalars
- deep flow and block nesting to depth 20k, and alias fan-out to 2k — timings scale linearly, no blowup
- unterminated scalars, quotes and indicators sitting at the exact end of the buffer

Note that Apple clang reports `haslibfuzzer - Failed`, so locally this builds against the `main.cpp` fallback and only replays a corpus; real fuzzing happens on Linux clang and OSS-Fuzz.
