### PR TITLE
Accept an exponent directly after a leading zero when validating numbers

### DIFF
--- a/include/glaze/util/parse.hpp
+++ b/include/glaze/util/parse.hpp
@@ -1461,6 +1461,12 @@ namespace glz
       auto frac_start_it = end;
       if (it != end && *it == '0') {
          ++it;
+         // RFC 8259 section 6: number = [ minus ] int [ frac ] [ exp ]. The exponent may follow
+         // the integer part directly, with no fractional part in between (e.g. "0e4").
+         if (it != end && (*it | ('E' ^ 'e')) == 'e') {
+            ++it;
+            goto exp_start;
+         }
          if (it == end || *it != '.') {
             return;
          }

--- a/tests/json_conformance/json_conformance.cpp
+++ b/tests/json_conformance/json_conformance.cpp
@@ -556,6 +556,64 @@ suite utf8_validation = [] {
    };
 };
 
+struct opts_validate_skipped : glz::opts
+{
+   bool error_on_unknown_keys = false;
+   bool validate_skipped = true;
+};
+
+// RFC 8259 section 6: number = [ minus ] int [ frac ] [ exp ], where int = zero / (digit1-9 *DIGIT).
+// The exponent may follow the integer part directly, so "0e4" is valid despite having no fractional
+// part. The validating skip path used to reject a leading zero followed by anything but '.'.
+suite number_grammar = [] {
+   static constexpr sv valid[]{"0",     "-0",   "1",    "-1",    "123",  "0.0",    "-0.0",
+                               "1.5",   "0.5",  "-0.5", "1e4",   "1E4",  "1e+4",   "1e-4",
+                               "0e4",   "0E4",  "0e+4", "0e-4",  "-0e4", "-0E+4",  "0e0",
+                               "-0e-0", "0e00", "1e00", "0.0e4", "10e4", "1.5e10", "123456789012345678901234567890"};
+
+   static constexpr sv invalid[]{"00",  "01",  "00e4", "-00",  "-01",   "0x1",   "0X1",  ".5",  "5.",
+                                 "0.",  "-.5", "+1",   "1e",   "1e+",   "1e-",   "0e",   "0E",  "0e+",
+                                 "0e-", "-",   "1..2", "0..1", "1.2.3", "0e4e5", "0ee4", "1_0", "0b1"};
+
+   // Every context that routes through the validating number scanner.
+   auto check = [](const sv num, const bool is_valid) {
+      const std::string scalar{num};
+      const std::string array = "[" + scalar + "]";
+      const std::string object = R"({"a":)" + scalar + "}";
+      const std::string skipped = R"({"unknown":)" + scalar + R"(,"i":1})";
+
+      expect(bool(glz::validate_json(scalar)) != is_valid) << "scalar " << scalar;
+      expect(bool(glz::validate_json(array)) != is_valid) << "array " << array;
+      expect(bool(glz::validate_json(object)) != is_valid) << "object " << object;
+
+      // A skipped unknown value is scanned by the same routine when validate_skipped is on.
+      int_object obj{};
+      expect(bool(glz::read<opts_validate_skipped{}>(obj, skipped)) != is_valid) << "skipped " << skipped;
+
+      // Validation must agree with the real number parser. The array form is used because a bare
+      // scalar read stops at the first non-number byte and ignores the rest by default.
+      std::vector<double> v{};
+      expect(bool(glz::read_json(v, array)) != is_valid) << "parse " << array;
+   };
+
+   "valid numbers"_test = [check] {
+      for (const auto num : valid) check(num, true);
+   };
+
+   "invalid numbers"_test = [check] {
+      for (const auto num : invalid) check(num, false);
+   };
+
+   // The scanner is also used on buffers without a trailing null, where it must stay inside `end`.
+   "exponent at end of non-null-terminated buffer"_test = [] {
+      static constexpr char accepted[]{'[', '0', 'e', '4', ']'};
+      expect(!glz::validate_json(sv{accepted, sizeof(accepted)}));
+
+      static constexpr char truncated[]{'[', '0', 'e', ']'};
+      expect(bool(glz::validate_json(sv{truncated, sizeof(truncated)})));
+   };
+};
+
 suite json_conformance = [] {
    "error_on_unknown_keys = true"_test = [] {
       should_fail<glz::opts{}>();


### PR DESCRIPTION
`glz::validate_json` rejected `0e4`, which is a valid JSON number.

```cpp
glz::validate_json("0e4");          // 1:2: syntax_error
glz::validate_json("[0e4]");        // 1:3: expected_bracket
glz::validate_json(R"({"a":0e4})"); // 1:7: expected_brace

std::vector<double> v;
glz::read_json(v, "[0e4]");         // ok — the number parser accepted it all along
```

Also affected: `0E4`, `0e+4`, `0e-4`, `-0e4`. Not affected: `1e4`, `10e4`, `0.0e4`, `0`.

## Cause

`skip_number_with_validation` only allowed `.` to follow a leading zero:

```cpp
if (it != end && *it == '0') {
   ++it;
   if (it == end || *it != '.') {
      return;          // returns with `it` still on the 'e'
   }
   ...
}
```

RFC 8259 section 6 defines `number = [ minus ] int [ frac ] [ exp ]` with `int = zero / (digit1-9 *DIGIT)`, so the exponent may follow the integer part with no fractional part in between. Because the scan returned early with the iterator parked on the `e`, the caller tripped over the stray character, which is why the error surfaced as `expected_bracket`/`expected_brace` rather than a number error.

This is not validator-only: `validate_skipped` drives the skipping of unknown keys, so valid documents were rejected there too.

## Fix

Handle `e`/`E` in the leading-zero branch the same way the non-zero branch already does. The `it != end` guard preserves the non-null-terminated contract.

Checked the other number validators for the same mistake — `is_json_number` in `jsonb_to_json.hpp` and `simple_float::from_chars` both already handle `0e4` correctly, so the fix is confined to this one scanner.

## Tests

New `number_grammar` suite in `tests/json_conformance`: 28 valid and 27 invalid numbers, each exercised in all four contexts that reach the scanner (scalar, array element, object value, and skipped unknown value under `validate_skipped`), cross-checked against the real number parser, plus non-null-terminated buffer cases for `[0e4]` and truncated `[0e]`.

The parser cross-check uses the array form deliberately: a bare scalar `read_json<double>("0x1")` succeeds with value `0` because `validate_trailing_whitespace` is off by default and the read stops at the first non-number byte. Inside `[...]` the number must be fully consumed.

Reverting the fix with the tests in place produces 37 failed asserts across 2 tests.

- `json_conformance`: 111 tests / 564 asserts pass
- Full non-networking suite: 90/90 pass
- `repe` + `jsonrpc` (direct `validate_json` callers): 7/7 pass
