### PR TITLE
Support ERL_BINARY_EXT tag in eetf_to_json

### DIFF
--- a/cmake/FindErlang.cmake
+++ b/cmake/FindErlang.cmake
@@ -28,10 +28,6 @@ This will define the following variables:
 
 ``Erlang_FOUND``
   True if the system has the Erlang library.
-``Erlang_RUNTIME``
-  The path to the Erlang runtime.
-``Erlang_COMPILE``
-  The path to the Erlang compiler.
 ``Erlang_EI_PATH``
   The path to the Erlang erl_interface path.
 ``Erlang_ERTS_PATH``
@@ -49,123 +45,82 @@ This will define the following variables:
 
 #]=======================================================================]
 include(FindPackageHandleStandardArgs)
+include(CMakePrintHelpers)
 
-SET(Erlang_BIN_PATH
-  $ENV{ERLANG_HOME}/bin
-  /opt/bin
-  /sw/bin
-  /usr/bin
-  /usr/local/bin
-  /opt/local/bin
+function(execute_erlang IN_ERL_EXECUTABLE OUT_ERLROOT_DIR OUT_INCLUDE_DIR OUT_LIBRARY_DIR)
+  EXECUTE_PROCESS(
+    COMMAND ${IN_ERL_EXECUTABLE} -noshell -eval "io:format(\"~s\", [code:lib_dir()])" -s erlang halt
+    OUTPUT_VARIABLE Erlang_OTP_LIB_DIR
   )
 
-FIND_PROGRAM(Erlang_RUNTIME
-  NAMES erl
-  PATHS ${Erlang_BIN_PATH}
+  EXECUTE_PROCESS(
+    COMMAND ${IN_ERL_EXECUTABLE} -noshell -eval "io:format(\"~s\", [code:root_dir()])" -s erlang halt
+    OUTPUT_VARIABLE Erlang_OTP_ROOT_DIR
   )
 
-FIND_PROGRAM(Erlang_COMPILE
-  NAMES erlc
-  PATHS ${Erlang_BIN_PATH}
+  EXECUTE_PROCESS(
+    COMMAND ${IN_ERL_EXECUTABLE} -noshell -eval "io:format(\"~s\",[filename:basename(code:lib_dir('erl_interface'))])" -s erlang halt
+    OUTPUT_VARIABLE Erlang_EI_DIR
   )
 
-EXECUTE_PROCESS(
-  COMMAND         erl -noshell -eval "io:format(\"~s\", [code:lib_dir()])" -s erlang halt
-  OUTPUT_VARIABLE Erlang_OTP_LIB_DIR
-  )
+  SET(${OUT_ERLROOT_DIR} ${Erlang_OTP_ROOT_DIR} PARENT_SCOPE)
+  SET(${OUT_INCLUDE_DIR} ${Erlang_OTP_LIB_DIR}/${Erlang_EI_DIR}/include PARENT_SCOPE)
+  SET(${OUT_LIBRARY_DIR} ${Erlang_OTP_LIB_DIR}/${Erlang_EI_DIR}/lib PARENT_SCOPE)
+endfunction(execute_erlang)
 
-EXECUTE_PROCESS(
-  COMMAND         erl -noshell -eval "io:format(\"~s\", [code:root_dir()])" -s erlang halt
-  OUTPUT_VARIABLE Erlang_OTP_ROOT_DIR
-  )
+cmake_print_variables(ERLANG_ROOT ERLANG_EI_LIB ERLANG_EI_LIB)
 
-EXECUTE_PROCESS(
-  COMMAND         erl -noshell -eval "io:format(\"~s\",[filename:basename(code:lib_dir('erl_interface'))])" -s erlang halt
-  OUTPUT_VARIABLE Erlang_EI_DIR
-  )
-
-EXECUTE_PROCESS(
-  COMMAND         erl -noshell -eval "io:format(\"~s\",[filename:basename(code:lib_dir('erts'))])" -s erlang halt
-  OUTPUT_VARIABLE Erlang_ERTS_DIR
-  )
-
-EXECUTE_PROCESS(
-  COMMAND         erl -noshell -eval "io:format(\"~s\", [erlang:system_info(otp_release)])" -s erlang halt
-  OUTPUT_VARIABLE Erlang_OTP_VERSION
-  )
-
-SET(Erlang_EI_PATH           ${Erlang_OTP_LIB_DIR}/${Erlang_EI_DIR})
-SET(Erlang_EI_INCLUDE_DIRS   ${Erlang_OTP_LIB_DIR}/${Erlang_EI_DIR}/include)
-SET(Erlang_EI_LIBRARY_PATH   ${Erlang_OTP_LIB_DIR}/${Erlang_EI_DIR}/lib)
-
-SET(Erlang_ERTS_PATH         ${Erlang_OTP_ROOT_DIR}/${Erlang_ERTS_DIR})
-SET(Erlang_ERTS_INCLUDE_DIRS ${Erlang_OTP_ROOT_DIR}/${Erlang_ERTS_DIR}/include)
-SET(Erlang_ERTS_LIBRARY_PATH ${Erlang_OTP_ROOT_DIR}/${Erlang_ERTS_DIR}/lib)
-
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(
-  Erlang
-  DEFAULT_MSG
-  Erlang_RUNTIME
-  Erlang_COMPILE
-  Erlang_OTP_LIB_DIR
-  Erlang_OTP_ROOT_DIR
-  Erlang_EI_DIR
-  Erlang_ERTS_DIR
-  Erlang_OTP_VERSION
-  )
-
-if(Erlang_FOUND)
-  if(NOT TARGET Erlang::Erlang)
-    add_library(Erlang::Erlang INTERFACE IMPORTED)
-    set_target_properties(Erlang::Erlang
-      PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES ${Erlang_OTP_ROOT_DIR}/usr/include
-      )
+if (NOT ERLANG_ROOT)
+  if ((NOT ERLANG_EI_LIB) OR (NOT ERLANG_EI_INCLUDE))
+    SET(Erlang_BIN_PATH
+      /opt/bin
+      /sw/bin
+      /usr/bin
+      /usr/local/bin
+      /opt/local/bin
+    )
+    FIND_PROGRAM(Erlang_RUNTIME
+      NAMES erl
+      PATHS ${Erlang_BIN_PATH}
+    )
+    execute_erlang(${Erlang_RUNTIME} Erlang_OTP_ROOT_DIR Erlang_EI_INCLUDE_DIRS Erlang_EI_LIBRARY_PATH)
+  else()
+    SET(Erlang_OTP_ROOT_DIR ${CMAKE_FIND_ROOT_PATH}/${ERLANG_ROOT})
+    SET(Erlang_EI_LIBRARY_PATH ${ERLANG_EI_LIB})
+    SET(Erlang_EI_INCLUDE_DIRS ${ERLANG_EI_INCLUDE})
   endif()
+else()
+  execute_erlang(${ERLANG_ROOT}/bin/erl Erlang_OTP_ROOT_DIR Erlang_EI_INCLUDE_DIRS Erlang_EI_LIBRARY_PATH)
+endif()
 
-  if(NOT TARGET Erlang::ERTS)
-    add_library(Erlang::ERTS STATIC IMPORTED)
-    set_target_properties(Erlang::ERTS
-      PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES ${Erlang_ERTS_INCLUDE_DIRS}
-      IMPORTED_LOCATION             ${Erlang_ERTS_LIBRARY_PATH}/liberts.a
-      )
-  endif()
+SET(Erlang_EI_LIBRARY_NAME   libei.a)
+set(Erlang_FOUND ON)
 
-  if(NOT TARGET Erlang::EI)
-    add_library(erlang_ei STATIC IMPORTED)
-    set_property(TARGET erlang_ei PROPERTY
-      IMPORTED_LOCATION ${Erlang_EI_LIBRARY_PATH}/libei.a
-      )
-    add_library(Erlang::EI INTERFACE IMPORTED)
-    set_property(TARGET Erlang::EI PROPERTY
-      INTERFACE_INCLUDE_DIRECTORIES ${Erlang_EI_INCLUDE_DIRS}
-      )
-    set_property(TARGET Erlang::EI PROPERTY
-      INTERFACE_LINK_LIBRARIES erlang_ei
-      )
-  endif()
-endif(Erlang_FOUND)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Erlang
+  Erlang_EI_LIBRARY_PATH
+  Erlang_EI_INCLUDE_DIRS
+  Erlang_FOUND
+)
 
+if(NOT TARGET Erlang::Erlang)
+  add_library(Erlang::Erlang INTERFACE IMPORTED)
+  set_target_properties(Erlang::Erlang
+    PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES ${Erlang_OTP_ROOT_DIR}/usr/include
+    )
+endif()
 
+if(NOT TARGET Erlang::EI)
+  add_library(erlang_ei STATIC IMPORTED)
+  set_property(TARGET erlang_ei PROPERTY
+    IMPORTED_LOCATION ${Erlang_EI_LIBRARY_PATH}/${Erlang_EI_LIBRARY_NAME}
+  )
 
-#[[
-https://gist.github.com/JayKickliter/dd0016bd5545de466e7ca158d4b19417
-How I compile Erlang from source on macOS
-
-CFLAGS="-Og -ggdb3 -fno-omit-frame-pointer" \
-CXXFLAGS="-Og -ggdb3 -fno-omit-frame-pointer" \
-./configure \
-      --prefix=$HOME/.local \
-      --disable-silent-rules \
-      --enable-dynamic-ssl-lib \
-      --with-ssl=/usr/local/opt/openssl \
-      --disable-hipe \
-      --enable-sctp \
-      --enable-shared-zlib \
-      --enable-smp-support \
-      --enable-threads \
-      --enable-wx \
-      --without-javac \
-      --enable-darwin-64bit
-]]
+  add_library(Erlang::EI INTERFACE IMPORTED)
+  set_property(TARGET Erlang::EI PROPERTY
+    INTERFACE_INCLUDE_DIRECTORIES ${Erlang_EI_INCLUDE_DIRS}
+  )
+  set_property(TARGET Erlang::EI PROPERTY
+    INTERFACE_LINK_LIBRARIES erlang_ei
+  )
+endif()

--- a/include/glaze/eetf/eetf_to_json.hpp
+++ b/include/glaze/eetf/eetf_to_json.hpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <cstring>
 
+#include "glaze/base64/base64.hpp"
 #include "glaze/eetf/ei.hpp"
 #include "glaze/eetf/opts.hpp"
 #include "glaze/json/write.hpp"
@@ -27,6 +28,16 @@ namespace glz
          if (check_invalid_offset(ctx, it, end, 2)) return 0;
          const std::size_t b1 = std::size_t(static_cast<uint8_t>(*it++)) << 8;
          return b1 | static_cast<uint8_t>(*it++);
+      }
+
+      template <class It0, class It1>
+      GLZ_ALWAYS_INLINE size_t get32be(auto&& ctx, It0&& it, It1&& end) noexcept
+      {
+         if (check_invalid_offset(ctx, it, end, sizeof(uint32_t))) return 0;
+         const std::size_t b1 = std::size_t(static_cast<uint8_t>(*it++)) << 24;
+         const std::size_t b2 = std::size_t(static_cast<uint8_t>(*it++)) << 16;
+         const std::size_t b3 = std::size_t(static_cast<uint8_t>(*it++)) << 8;
+         return b1 | b2 | b3 | static_cast<uint8_t>(*it++);
       }
 
       template <auto Opts, typename I>
@@ -233,9 +244,9 @@ namespace glz
                // is_string/is_atom accept the raw, un-normalized tag, and term_to_json_value re-reads
                // and bounds-checks the full key below. Widen to int so the tag clears the int_t
                // constraint on is_string/is_atom (uint8_t is a char type and would be rejected).
-               const int key_type = uint8_t(*it);
+               const auto key_type = uint8_t(*it);
                // support only string or atom keys in json
-               if (!eetf::is_string(key_type) && !eetf::is_atom(key_type)) {
+               if (!(eetf::is_string(key_type) || eetf::is_atom(key_type) || eetf::is_binary(key_type))) {
                   ctx.error = error_code::syntax_error;
                   ctx.custom_error_message = "unsupported key type";
                   return;
@@ -267,8 +278,33 @@ namespace glz
             break;
          }
 
+         case ERL_BINARY_EXT: {
+            ++it; // skip type
+            const size_t len = get32be(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            // bound binary length
+            if (check_invalid_offset(ctx, it, end, len)) return;
+            if constexpr (check_binary_as_base64(Opts)) {
+               dump('"', out, ix);
+               glz::write_base64_to(ctx, reinterpret_cast<const uint8_t*>(it), len, out, ix);
+               if (bool(ctx.error)) [[unlikely]] {
+                  return;
+               }
+               dump('"', out, ix);
+            }
+            else {
+               const sv value{reinterpret_cast<const char*>(it), len};
+               to<JSON, sv>::template op<Opts>(value, ctx, out, ix);
+            }
+            std::advance(it, len);
+            break;
+         }
+
          default: {
             ctx.error = error_code::syntax_error;
+            ctx.custom_error_message = "unsupported type";
             return;
          }
          }

--- a/include/glaze/eetf/eetf_to_json.hpp
+++ b/include/glaze/eetf/eetf_to_json.hpp
@@ -5,7 +5,9 @@
 
 #include <cstdint>
 #include <cstring>
+#include <string_view>
 
+#include "glaze/base64/base64.hpp"
 #include "glaze/eetf/ei.hpp"
 #include "glaze/eetf/opts.hpp"
 #include "glaze/json/write.hpp"
@@ -27,6 +29,16 @@ namespace glz
          if (check_invalid_offset(ctx, it, end, 2)) return 0;
          const std::size_t b1 = std::size_t(static_cast<uint8_t>(*it++)) << 8;
          return b1 | static_cast<uint8_t>(*it++);
+      }
+
+      template <class It0, class It1>
+      GLZ_ALWAYS_INLINE size_t get32be(auto&& ctx, It0&& it, It1&& end) noexcept
+      {
+         if (check_invalid_offset(ctx, it, end, sizeof(uint32_t))) return 0;
+         const std::size_t b1 = std::size_t(static_cast<uint8_t>(*it++)) << 24;
+         const std::size_t b2 = std::size_t(static_cast<uint8_t>(*it++)) << 16;
+         const std::size_t b3 = std::size_t(static_cast<uint8_t>(*it++)) << 8;
+         return b1 | b2 | b3 | static_cast<uint8_t>(*it++);
       }
 
       template <auto Opts, typename I>
@@ -267,8 +279,24 @@ namespace glz
             break;
          }
 
+         case ERL_BINARY_EXT: {
+            ++it; // skip type
+            const size_t len = get32be(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            // bound binary length
+            if (check_invalid_offset(ctx, it, end, len)) return;
+            dump('"', out, ix);
+            glz::write_base64_to(ctx, reinterpret_cast<const uint8_t*>(&*it), len, out, ix);
+            dump('"', out, ix);
+            std::advance(it, len);
+            break;
+         }
+
          default: {
             ctx.error = error_code::syntax_error;
+            ctx.custom_error_message = "unsupported type";
             return;
          }
          }

--- a/include/glaze/eetf/opts.hpp
+++ b/include/glaze/eetf/opts.hpp
@@ -2,25 +2,41 @@
 
 #include "glaze/core/opts.hpp"
 
-namespace glz::eetf
+namespace glz
 {
-
-   // layout erlang term
-   inline constexpr uint8_t map_layout = 0;
-   inline constexpr uint8_t proplist_layout = 1;
-
-   struct eetf_opts
+   namespace eetf
    {
-      uint32_t format = EETF;
-      uint32_t internal{};
-      uint8_t layout = map_layout;
-      bool error_on_unknown_keys = true;
-      bool shrink_to_fit = false;
-      bool prettify = false;
-      bool quoted_num = false; // treat numbers as quoted or array-like types as having quoted numbers
-      bool string_as_number = false; // treats all types like std::string as numbers: read/write these quoted numbers
-      bool unquoted = false; // write out string like values without quotes
-      bool raw_string = false; // do not decode/encode escaped characters for strings (improves read/write performance)
-   };
 
-} // namespace glz::eetf
+      // layout erlang term
+      inline constexpr uint8_t map_layout = 0;
+      inline constexpr uint8_t proplist_layout = 1;
+
+      struct eetf_opts
+      {
+         uint32_t format = EETF;
+         uint32_t internal{};
+         uint8_t layout = map_layout;
+         bool error_on_unknown_keys = true;
+         bool shrink_to_fit = false;
+         bool prettify = false;
+         bool quoted_num = false; // treat numbers as quoted or array-like types as having quoted numbers
+         bool string_as_number = false; // treats all types like std::string as numbers: read/write these quoted numbers
+         bool unquoted = false; // write out string like values without quotes
+         bool raw_string =
+            false; // do not decode/encode escaped characters for strings (improves read/write performance)
+         bool binary_as_base64 = false; // write ERL_BINARY_EXT as base64 string instead of a raw string
+      };
+
+   } // namespace eetf
+
+   consteval bool check_binary_as_base64(auto&& Opts)
+   {
+      if constexpr (requires { Opts.binary_as_base64; }) {
+         return Opts.binary_as_base64;
+      }
+      else {
+         return false;
+      }
+   }
+
+} // namespace glz

--- a/tests/eetf_test/eetf_test.cpp
+++ b/tests/eetf_test/eetf_test.cpp
@@ -96,6 +96,17 @@ struct glz::meta<atom_rw>
 static_assert(glz::write_supported<my_struct_meta, glz::EETF>);
 static_assert(glz::read_supported<my_struct_meta, glz::EETF>);
 
+namespace
+{
+
+   auto expect_unexpected_end = [](const auto& buffer) {
+      std::string json{};
+      const auto ec = glz::eetf_to_json(buffer, json);
+      expect(ec.ec == glz::error_code::unexpected_end);
+   };
+
+}
+
 suite etf_tests = [] {
    "read_map_term"_test = [] {
       trace.begin("read_map_term");
@@ -436,12 +447,6 @@ suite eetf_to_json_tests = [] {
    };
 
    "eetf_to_json truncated small big integer"_test = [] {
-      auto expect_unexpected_end = [](const auto& buffer) {
-         std::string json{};
-         const auto ec = glz::eetf_to_json(buffer, json);
-         expect(ec.ec == glz::error_code::unexpected_end);
-      };
-
       const std::array<std::uint8_t, 2> missing_size{uint8_t(glz::eetf_magic_version), uint8_t(ERL_SMALL_BIG_EXT)};
       const std::array<std::uint8_t, 3> missing_sign{uint8_t(glz::eetf_magic_version), uint8_t(ERL_SMALL_BIG_EXT), 1};
       const std::array<std::uint8_t, 4> missing_digits{uint8_t(glz::eetf_magic_version), uint8_t(ERL_SMALL_BIG_EXT), 8,
@@ -464,12 +469,6 @@ suite eetf_to_json_tests = [] {
    };
 
    "eetf_to_json truncated map"_test = [] {
-      auto expect_unexpected_end = [](const auto& buffer) {
-         std::string json{};
-         const auto ec = glz::eetf_to_json(buffer, json);
-         expect(ec.ec == glz::error_code::unexpected_end);
-      };
-
       // ERL_MAP_EXT declares arity 1 but the buffer ends before any key/value entry.
       const std::array<std::uint8_t, 6> missing_entries{
          uint8_t(glz::eetf_magic_version), uint8_t(ERL_MAP_EXT), 0, 0, 0, 1};
@@ -524,12 +523,6 @@ suite eetf_to_json_tests = [] {
    };
 
    "eetf_to_json truncated scalar"_test = [] {
-      auto expect_unexpected_end = [](const auto& buffer) {
-         std::string json{};
-         const auto ec = glz::eetf_to_json(buffer, json);
-         expect(ec.ec == glz::error_code::unexpected_end);
-      };
-
       // Numeric tags whose fixed payload is cut off after the tag: ei_decode_long/double must not
       // read it off the raw pointer before the bounds check.
       const std::array<std::uint8_t, 2> small_int{uint8_t(glz::eetf_magic_version), uint8_t(ERL_SMALL_INTEGER_EXT)};
@@ -547,12 +540,6 @@ suite eetf_to_json_tests = [] {
    };
 
    "eetf_to_json truncated container header"_test = [] {
-      auto expect_unexpected_end = [](const auto& buffer) {
-         std::string json{};
-         const auto ec = glz::eetf_to_json(buffer, json);
-         expect(ec.ec == glz::error_code::unexpected_end);
-      };
-
       // Container tags whose 1- or 4-byte arity is cut off after the tag: decode_*_header must not
       // read it off the raw pointer before the bounds check.
       const std::array<std::uint8_t, 2> list{uint8_t(glz::eetf_magic_version), uint8_t(ERL_LIST_EXT)};
@@ -616,6 +603,97 @@ suite eetf_to_json_tests = [] {
             std::string_view{buffer.data() + curr, static_cast<size_t>(index - curr)}, json));
          expect(json == std::format(R"({{"a":{}}})", idx));
       }
+   };
+
+   "eetf_to_json empty binary"_test = [] {
+      const std::array<std::uint8_t, 6> buffer{
+         uint8_t(glz::eetf_magic_version), uint8_t(ERL_BINARY_EXT), 0x0, 0x0, 0x0, 0x0};
+
+      std::string json{};
+      expect(!glz::eetf_to_json(buffer, json));
+      expect(json == "\"\"") << json;
+   };
+
+   "eetf_to_json 1-byte binary"_test = [] {
+      std::array<std::uint8_t, 7> buffer{
+         uint8_t(glz::eetf_magic_version), uint8_t(ERL_BINARY_EXT), 0x0, 0x0, 0x0, 0x1, 0};
+
+      std::string json{};
+      expect(!glz::eetf_to_json<glz::eetf::eetf_opts{.binary_as_base64 = true}>(buffer, json));
+      expect(json == "\"AA==\"") << json;
+
+      buffer[6] = '0';
+      expect(!glz::eetf_to_json<glz::eetf::eetf_opts{.binary_as_base64 = true}>(buffer, json));
+      expect(json == "\"MA==\"") << json;
+   };
+
+   "eetf_to_json check big-endian size"_test = [] {
+      constexpr std::array<std::uint8_t, 1006> buffer{
+         uint8_t(glz::eetf_magic_version), uint8_t(ERL_BINARY_EXT), 0, 0, 0x03, 0xE8};
+      std::string json{};
+      expect(!glz::eetf_to_json(buffer, json));
+   };
+
+   "eetf_to_json truncated binary"_test = [] {
+      constexpr std::array<std::uint8_t, 2> no_size{uint8_t(glz::eetf_magic_version), uint8_t(ERL_BINARY_EXT)};
+      constexpr std::array<std::uint8_t, 3> truncated_size{uint8_t(glz::eetf_magic_version), uint8_t(ERL_BINARY_EXT),
+                                                          0x1};
+      constexpr std::array<std::uint8_t, 6> truncated_body{
+         uint8_t(glz::eetf_magic_version), uint8_t(ERL_BINARY_EXT), 0x0, 0x0, 0x0, 0x1};
+
+      expect_unexpected_end(no_size);
+      expect_unexpected_end(truncated_size);
+      expect_unexpected_end(truncated_body);
+   };
+
+   "eetf_to_json binary key map"_test = [] {
+      constexpr std::array<std::uint8_t, 18> buffer{uint8_t(glz::eetf_magic_version),
+                                                uint8_t(ERL_MAP_EXT),
+                                                0,
+                                                0,
+                                                0,
+                                                1,
+                                                uint8_t(ERL_BINARY_EXT),
+                                                0,
+                                                0,
+                                                0,
+                                                1,
+                                                'a',
+                                                uint8_t(ERL_BINARY_EXT),
+                                                0,
+                                                0,
+                                                0,
+                                                1,
+                                                '1'};
+
+      std::string json{};
+      expect(!glz::eetf_to_json(buffer, json));
+      expect(json == R"({"a":"1"})") << json;
+   };
+
+   "eetf_to_json binary key map explicit convert"_test = [] {
+      constexpr std::array<std::uint8_t, 18> buffer{uint8_t(glz::eetf_magic_version),
+                                                uint8_t(ERL_MAP_EXT),
+                                                0,
+                                                0,
+                                                0,
+                                                1,
+                                                uint8_t(ERL_BINARY_EXT),
+                                                0,
+                                                0,
+                                                0,
+                                                1,
+                                                '0',
+                                                uint8_t(ERL_BINARY_EXT),
+                                                0,
+                                                0,
+                                                0,
+                                                1,
+                                                1};
+
+      std::string json{};
+      expect(!glz::eetf_to_json(buffer, json));
+      expect(json == "{\"0\":\"\001\"}") << json;
    };
 };
 

--- a/tests/eetf_test/eetf_test.cpp
+++ b/tests/eetf_test/eetf_test.cpp
@@ -96,6 +96,17 @@ struct glz::meta<atom_rw>
 static_assert(glz::write_supported<my_struct_meta, glz::EETF>);
 static_assert(glz::read_supported<my_struct_meta, glz::EETF>);
 
+namespace
+{
+
+   auto expect_unexpected_end = [](const auto& buffer) {
+      std::string json{};
+      const auto ec = glz::eetf_to_json(buffer, json);
+      expect(ec.ec == glz::error_code::unexpected_end);
+   };
+
+}
+
 suite etf_tests = [] {
    "read_map_term"_test = [] {
       trace.begin("read_map_term");
@@ -436,12 +447,6 @@ suite eetf_to_json_tests = [] {
    };
 
    "eetf_to_json truncated small big integer"_test = [] {
-      auto expect_unexpected_end = [](const auto& buffer) {
-         std::string json{};
-         const auto ec = glz::eetf_to_json(buffer, json);
-         expect(ec.ec == glz::error_code::unexpected_end);
-      };
-
       const std::array<std::uint8_t, 2> missing_size{uint8_t(glz::eetf_magic_version), uint8_t(ERL_SMALL_BIG_EXT)};
       const std::array<std::uint8_t, 3> missing_sign{uint8_t(glz::eetf_magic_version), uint8_t(ERL_SMALL_BIG_EXT), 1};
       const std::array<std::uint8_t, 4> missing_digits{uint8_t(glz::eetf_magic_version), uint8_t(ERL_SMALL_BIG_EXT), 8,
@@ -464,12 +469,6 @@ suite eetf_to_json_tests = [] {
    };
 
    "eetf_to_json truncated map"_test = [] {
-      auto expect_unexpected_end = [](const auto& buffer) {
-         std::string json{};
-         const auto ec = glz::eetf_to_json(buffer, json);
-         expect(ec.ec == glz::error_code::unexpected_end);
-      };
-
       // ERL_MAP_EXT declares arity 1 but the buffer ends before any key/value entry.
       const std::array<std::uint8_t, 6> missing_entries{
          uint8_t(glz::eetf_magic_version), uint8_t(ERL_MAP_EXT), 0, 0, 0, 1};
@@ -524,12 +523,6 @@ suite eetf_to_json_tests = [] {
    };
 
    "eetf_to_json truncated scalar"_test = [] {
-      auto expect_unexpected_end = [](const auto& buffer) {
-         std::string json{};
-         const auto ec = glz::eetf_to_json(buffer, json);
-         expect(ec.ec == glz::error_code::unexpected_end);
-      };
-
       // Numeric tags whose fixed payload is cut off after the tag: ei_decode_long/double must not
       // read it off the raw pointer before the bounds check.
       const std::array<std::uint8_t, 2> small_int{uint8_t(glz::eetf_magic_version), uint8_t(ERL_SMALL_INTEGER_EXT)};
@@ -547,12 +540,6 @@ suite eetf_to_json_tests = [] {
    };
 
    "eetf_to_json truncated container header"_test = [] {
-      auto expect_unexpected_end = [](const auto& buffer) {
-         std::string json{};
-         const auto ec = glz::eetf_to_json(buffer, json);
-         expect(ec.ec == glz::error_code::unexpected_end);
-      };
-
       // Container tags whose 1- or 4-byte arity is cut off after the tag: decode_*_header must not
       // read it off the raw pointer before the bounds check.
       const std::array<std::uint8_t, 2> list{uint8_t(glz::eetf_magic_version), uint8_t(ERL_LIST_EXT)};
@@ -616,6 +603,47 @@ suite eetf_to_json_tests = [] {
             std::string_view{buffer.data() + curr, static_cast<size_t>(index - curr)}, json));
          expect(json == std::format(R"({{"a":{}}})", idx));
       }
+   };
+
+   "eetf_to_json empty binary"_test = [] {
+      const std::array<std::uint8_t, 6> buffer{
+         uint8_t(glz::eetf_magic_version), uint8_t(ERL_BINARY_EXT), 0x0, 0x0, 0x0, 0x0};
+
+      std::string json{};
+      expect(!glz::eetf_to_json(buffer, json));
+      expect(json == "\"\"") << json;
+   };
+
+   "eetf_to_json 1-byte binary"_test = [] {
+      std::array<std::uint8_t, 7> buffer{
+         uint8_t(glz::eetf_magic_version), uint8_t(ERL_BINARY_EXT), 0x0, 0x0, 0x0, 0x1, 0};
+
+      std::string json{};
+      expect(!glz::eetf_to_json(buffer, json));
+      expect(json == "\"AA==\"") << json;
+
+      buffer[6] = '0';
+      expect(!glz::eetf_to_json(buffer, json));
+      expect(json == "\"MA==\"") << json;
+   };
+
+   "eetf_to_json check big-endian size"_test = [] {
+      constexpr std::array<std::uint8_t, 1006> buffer{
+         uint8_t(glz::eetf_magic_version), uint8_t(ERL_BINARY_EXT), 0, 0, 0x03, 0xE8};
+      std::string json{};
+      expect(!glz::eetf_to_json(buffer, json));
+   };
+
+   "eetf_to_json trucated binary"_test = [] {
+      constexpr std::array<std::uint8_t, 2> no_size{uint8_t(glz::eetf_magic_version), uint8_t(ERL_BINARY_EXT)};
+      constexpr std::array<std::uint8_t, 3> trucated_size{uint8_t(glz::eetf_magic_version), uint8_t(ERL_BINARY_EXT),
+                                                          0x1};
+      constexpr std::array<std::uint8_t, 6> trucated_body{
+         uint8_t(glz::eetf_magic_version), uint8_t(ERL_BINARY_EXT), 0x0, 0x0, 0x0, 0x1};
+
+      expect_unexpected_end(no_size);
+      expect_unexpected_end(trucated_size);
+      expect_unexpected_end(trucated_body);
    };
 };
 


### PR DESCRIPTION
Add support for ERL_BINARY_EXT tag. It writes base64 string as JSON field value
