### PR TITLE
Stop cyclic YAML aliases from recursing off the stack

### DIFF
--- a/include/glaze/yaml/common.hpp
+++ b/include/glaze/yaml/common.hpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "glaze/core/common.hpp"
@@ -73,6 +74,21 @@ namespace glz::yaml
 
       std::unordered_map<std::string, anchor_span, transparent_string_hash, transparent_string_equal> anchors{};
 
+      // Anchor spans an alias is currently replaying, innermost last. An anchor is invisible to
+      // itself while it expands: a mapping key's anchor is registered over the key text before
+      // that text is parsed, so the span can hold an alias back to the name being defined, and
+      // replaying it would expand forever. Spans point into the input buffer, which outlives the
+      // read, so they stay valid even though `anchors` itself is replaced during speculation.
+      std::vector<std::pair<const char*, const char*>> active_alias_spans{};
+
+      bool alias_span_is_replaying(const char* begin, const char* end) const noexcept
+      {
+         for (const auto& [b, e] : active_alias_spans) {
+            if (b == begin && e == end) return true;
+         }
+         return false;
+      }
+
       // True while parsing the value payload of a "- item" block-sequence entry.
       // Used to distinguish indentless-sequence continuation from next sibling items.
       bool sequence_item_value_context = false;
@@ -112,6 +128,7 @@ namespace glz::yaml
          yaml_context c{};
          c.indent_stack = indent_stack;
          c.anchors = anchors;
+         c.active_alias_spans = active_alias_spans;
          c.sequence_item_value_context = sequence_item_value_context;
          c.sequence_dash_indent = sequence_dash_indent;
          c.explicit_mapping_key_context = explicit_mapping_key_context;

--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -239,12 +239,30 @@ namespace glz
             return true;
          }
 
-         auto& span = anchor_it->second;
+         // Copied rather than referenced: the replay below can replace ctx.anchors wholesale
+         // (a speculative parse hands its own map back), which would dangle a reference here.
+         const auto span = anchor_it->second;
 
          // Empty anchor span (anchor on null/empty node) — leave value as default
          if (span.begin == span.end) {
             return true;
          }
+
+         // An anchor is invisible to itself while it expands. A span that aliases the name it
+         // defines -- reachable because a mapping key's anchor is registered over the key text
+         // before that text is parsed -- would otherwise replay itself forever.
+         if (ctx.alias_span_is_replaying(span.begin, span.end)) [[unlikely]] {
+            ctx.error = error_code::syntax_error; // cyclic alias
+            return true;
+         }
+
+         // Replaying an anchor re-enters the reader directly, bypassing the variant reader's
+         // depth guard, so this is the only depth accounting a chain of aliases into a
+         // non-variant target gets. The cycle check above stops the unbounded case; this bounds
+         // a legitimate but deeply chained one.
+         depth_guard guard{ctx};
+         if (!guard) [[unlikely]]
+            return true;
 
          auto replay_it = span.begin;
          auto replay_end = span.end;
@@ -256,8 +274,12 @@ namespace glz
             ctx.push_indent(span.base_indent - 1);
          }
 
+         ctx.active_alias_spans.emplace_back(span.begin, span.end);
+
          using V = std::remove_cvref_t<T>;
          from<YAML, V>::template op<Opts>(std::forward<T>(value), ctx, replay_it, replay_end);
+
+         ctx.active_alias_spans.pop_back();
 
          // Restore indent context
          ctx.indent_stack = std::move(saved_indent_stack);
@@ -5696,6 +5718,15 @@ namespace glz
                            return;
                         }
                         if (*key_start == '\n' || *key_start == '\r') {
+                           ctx.error = error_code::syntax_error;
+                           return;
+                        }
+
+                        // Re-apply the anchor-on-alias rule now that the tag is consumed. The
+                        // check above ran before the tag, so "&anchor !tag *alias" reached the
+                        // key-span registration below while the untagged spelling was rejected;
+                        // an alias node carries no other properties either way.
+                        if (*key_start == '*' && !yaml::alias_token_is_mapping_key(key_start, end)) {
                            ctx.error = error_code::syntax_error;
                            return;
                         }

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -4243,6 +4243,42 @@ other: *a5)";
       expect(json == R"({"key5":"value4","other":"key5"})") << json;
    };
 
+   "anchor_on_tagged_alias_key_is_rejected"_test = [] {
+      // An anchor property on an alias node is malformed, and the check for it ran before the
+      // key's tag was consumed -- so "&a !tag *a" slipped through and registered the anchor
+      // over a key span that aliased itself. Replaying that span expanded it forever.
+      // (The ']' terminates the anchor name; colons are legal inside one.)
+      for (const std::string_view yaml : {"&a ! *a]:", "&a !!str *a]: 1", "&a ! *a]: 1\nother: *a\n"}) {
+         glz::generic parsed{};
+         const auto ec = glz::read_yaml<glz::opts{.error_on_unknown_keys = false}>(parsed, yaml);
+         expect(ec == glz::error_code::syntax_error) << yaml;
+      }
+   };
+
+   "alias_as_tagged_mapping_key_still_parses"_test = [] {
+      // The rejection above must not swallow an alias used as a mapping key, which is valid:
+      // the alias token ends at the space, so the ':' is the key/value separator.
+      const std::string_view yaml = "a: &b x\n&c !!str *b : 1\nd: *c\n";
+      glz::generic parsed{};
+      const auto ec = glz::read_yaml<glz::opts{.error_on_unknown_keys = false}>(parsed, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      const auto json = glz::write_json(parsed).value_or("WRITE_ERR");
+      expect(json == R"({"a":"x","*b":1,"d":"x"})") << json;
+   };
+
+   "cyclic_anchor_span_is_rejected"_test = [] {
+      // Anchors on mapping keys are registered over the key text before it is parsed, so a
+      // span can alias the name it defines. Expanding one must report a malformed document
+      // rather than recursing until the stack is gone. Covers a self-referential span, one
+      // reached through a second tag, and a mutual cycle between two anchors.
+      for (const std::string_view yaml :
+           {"&a [*a]: 1\nother: *a\n", "&a ! ! *a]: 1\nother: *a\n", "&a [*b]: 1\n&b [*a]: 2\nother: *a\n"}) {
+         glz::generic parsed{};
+         const auto ec = glz::read_yaml<glz::opts{.error_on_unknown_keys = false}>(parsed, yaml);
+         expect(bool(ec)) << yaml;
+      }
+   };
+
    "tag_then_anchor_on_key"_test = [] {
       std::string yaml = R"(!!str &a key: value
 other: *a)";


### PR DESCRIPTION
Fixes a stack overflow found by OSS-Fuzz on the `yaml_generic` target (testcase 5030342277529600). Minimized reproducer, 9 bytes:

```
&a ! *a]:
```

## Root cause

A mapping key's anchor is registered over the key text *before* that text is parsed, so the recorded span can contain an alias back to the name being defined. `handle_alias` replays the span, immediately re-enters the same alias, and recurses without bound.

The specific way in: the anchor-on-alias rule (an alias node carries no other properties) was checked *before* the key's tag was consumed, so `&a !tag *a` slipped past a check that already rejected the untagged `&a *a`.

## Fix

An anchor is now invisible to itself while it expands. `yaml_context` tracks the spans an alias is currently replaying, and re-entering one that is already open is reported as a malformed document instead of recursing. This covers the spellings a syntax check alone misses: a second tag (`&a ! ! *a]:`), a flow key (`&a [*a]:`), and a mutual cycle between two anchors.

Alongside it:

- **`handle_alias` takes a `depth_guard`.** It replays into the reader directly, so a chain of aliases into a non-variant target had no depth accounting at all — the variant reader is entered only once for the whole cycle. Unguarded it overflowed a 64 MB stack, not just the default one. Cost: a legitimate chained-alias document now caps at 84 levels instead of 126.
- **The anchor map entry is copied by value.** `handle_alias` held `auto& span = anchor_it->second` across the recursive call, which a speculative parse can replace wholesale (`ctx.anchors = std::move(temp_ctx.anchors)`). Safe only by statement ordering; now not a hazard.
- **The anchor-on-alias rule is re-applied after the key's tag**, so the tagged spelling is rejected like the untagged one. An alias used as a mapping key (`&c !!str *b : 1`) stays valid, and there is now a test pinning that.

## Testing

- `yaml_test` 718/718, `yaml_conformance` 402/402, `yaml_conformance_struct` 105/105
- Original reproducer, the minimization, and 8 hand-derived cycle spellings clean under ASan+UBSan with `-fno-sanitize-recover=all`
- 300k mutated inputs over the anchor/alias/tag grammar through `fuzzing/yaml_generic.cpp` (exact-size non-null-terminated buffers): clean
- Valid anchor behavior unchanged: block-mapping replay, flow anchors, anchors on plain/quoted/tagged keys, repeated aliases

Three regression tests added to the anchor suite in `tests/yaml_test/yaml_test.cpp`.

## Not addressed here

Alias expansion is exponential (306 input bytes → 89 MB, 288 ms; ~348 bytes → ~700 MB). Verified identical on unmodified `main`, so it predates this change and nothing here affects it — nesting depth stays around 8, so neither guard bounds it. Worth a separate expansion budget along the lines of `charge_speculation`.