### PR TITLE
Bound YAML alias expansion

### DIFF
--- a/include/glaze/core/context.hpp
+++ b/include/glaze/core/context.hpp
@@ -109,7 +109,9 @@ namespace glz
       // Encoding errors
       invalid_utf8, // Malformed UTF-8 in a string; checked on read unless validate_utf8 is disabled
       // Streaming errors
-      streaming_unsupported // Document outruns the buffer window and this format's reader cannot refill
+      streaming_unsupported, // Document outruns the buffer window and this format's reader cannot refill
+      // Expansion errors
+      exceeded_max_alias_expansion // YAML aliases replay more source text than the read budgets
    };
 
    // Unified error context for all read/write operations

--- a/include/glaze/core/error_category.hpp
+++ b/include/glaze/core/error_category.hpp
@@ -81,7 +81,8 @@ struct glz::meta<glz::error_code>
                                     "buffer_overflow",
                                     "invalid_length",
                                     "invalid_utf8",
-                                    "streaming_unsupported"};
+                                    "streaming_unsupported",
+                                    "exceeded_max_alias_expansion"};
    static constexpr std::array value{none, //
                                      version_mismatch, //
                                      invalid_header, //
@@ -162,5 +163,7 @@ struct glz::meta<glz::error_code>
                                      // Encoding errors
                                      invalid_utf8, //
                                      // Streaming errors
-                                     streaming_unsupported};
+                                     streaming_unsupported, //
+                                     // Expansion errors
+                                     exceeded_max_alias_expansion};
 };

--- a/include/glaze/yaml/common.hpp
+++ b/include/glaze/yaml/common.hpp
@@ -18,6 +18,21 @@
 
 namespace glz::yaml
 {
+   // How many times over the input an alias may replay before the read gives up. Deliberately
+   // looser than the speculative-parse factor: re-parsing the same bytes to resolve a variant is
+   // waste to be capped, while replaying an anchor is the feature working as intended, and a
+   // generated config that references a large anchor from thousands of entries is ordinary. What
+   // this stops is growth that does not track the input at all, and that case is caught by the
+   // floor below rather than by this factor.
+   inline constexpr size_t max_alias_expansion_factor = 64;
+
+   // ...plus a floor, since the factor alone is meaningless for the small inputs where the
+   // exponential shape lives: a 306 byte document expands 60000x, so any multiple of its own
+   // size stops it. The floor is what every ordinary document actually reads against, and it is
+   // set where the exponential case costs a bounded ~40 MB and a tenth of a second instead of
+   // gigabytes and minutes -- while staying far above what a hand-written document replays.
+   inline constexpr size_t min_alias_expansion_bytes = 8 << 20;
+
    // YAML-specific context extending the base context
    // Adds indent tracking needed for block-style parsing
    struct yaml_context : context
@@ -89,6 +104,31 @@ namespace glz::yaml
          return false;
       }
 
+      // Source bytes an alias may still replay. Resolving one re-parses the anchor's text, so
+      // anchors that each reference the previous one several times expand exponentially without
+      // nesting: eight levels of eightfold reuse turn 348 bytes of input into gigabytes of nodes,
+      // and neither the depth guard nor the indent stack sees anything unusual. The bound is on
+      // total replayed bytes rather than on how often a name is reused or how deeply anchors
+      // nest, because replayed bytes are what the time and the memory both track.
+      // Seeded per read from the input; 0 means unbudgeted (a nested or hand-rolled parse).
+      size_t alias_expansion_budget = 0;
+
+      // Charge `bytes` of alias replay. Returns false once the budget is spent, at which point
+      // the caller must stop expanding. A spent budget latches at 1 rather than reaching 0,
+      // which would read as "unbudgeted" and hand the document a fresh allowance.
+      [[nodiscard]] bool charge_alias_expansion(const size_t bytes) noexcept
+      {
+         if (alias_expansion_budget == 0) {
+            return true; // unbudgeted
+         }
+         if (bytes >= alias_expansion_budget) {
+            alias_expansion_budget = 1; // latch: spent, and still not "unbudgeted"
+            return false;
+         }
+         alias_expansion_budget -= bytes;
+         return true;
+      }
+
       // True while parsing the value payload of a "- item" block-sequence entry.
       // Used to distinguish indentless-sequence continuation from next sibling items.
       bool sequence_item_value_context = false;
@@ -129,6 +169,9 @@ namespace glz::yaml
          c.indent_stack = indent_stack;
          c.anchors = anchors;
          c.active_alias_spans = active_alias_spans;
+         // Speculative work is real work: a probe that expands aliases spends the same budget,
+         // and the sites that adopt a probe's anchors adopt what it spent along with them.
+         c.alias_expansion_budget = alias_expansion_budget;
          c.sequence_item_value_context = sequence_item_value_context;
          c.sequence_dash_indent = sequence_dash_indent;
          c.explicit_mapping_key_context = explicit_mapping_key_context;

--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -34,6 +34,14 @@ namespace glz
          if constexpr (requires { ctx.stream_begin; }) {
             if (!ctx.stream_begin && it != end) {
                ctx.stream_begin = &*it;
+               // Seed the alias replay budget from the document this read was handed. Done here
+               // rather than in glz::read so every YAML entry point is covered, and only on the
+               // outermost parse so a nested document does not hand itself a fresh budget.
+               if constexpr (requires { ctx.alias_expansion_budget; } && requires { size_t(end - it); }) {
+                  const size_t scaled = size_t(end - it) * yaml::max_alias_expansion_factor;
+                  ctx.alias_expansion_budget =
+                     scaled > yaml::min_alias_expansion_bytes ? scaled : yaml::min_alias_expansion_bytes;
+               }
             }
          }
          // Skip YAML directives and document start marker (---) if present
@@ -263,6 +271,11 @@ namespace glz
          depth_guard guard{ctx};
          if (!guard) [[unlikely]]
             return true;
+
+         if (!ctx.charge_alias_expansion(static_cast<size_t>(span.end - span.begin))) [[unlikely]] {
+            ctx.error = error_code::exceeded_max_alias_expansion;
+            return true;
+         }
 
          auto replay_it = span.begin;
          auto replay_end = span.end;
@@ -1441,6 +1454,12 @@ namespace glz
             if (span.begin == span.end) {
                key.clear(); // empty anchor
             }
+            else if (!ctx.charge_alias_expansion(static_cast<size_t>(span.end - span.begin))) [[unlikely]] {
+               // A key alias replays its anchor the same way a value alias does, and a complex
+               // key hands the span to the full reader, so it is charged the same way.
+               ctx.error = error_code::exceeded_max_alias_expansion;
+               return false;
+            }
             else {
                // Replay the anchor span to extract the key string
                auto replay_it = span.begin;
@@ -1457,6 +1476,7 @@ namespace glz
                   auto temp_ctx = ctx.make_speculative();
                   from<YAML, glz::generic>::template op<flow_context_on<opts{.error_on_unknown_keys = false}>()>(
                      key_node, temp_ctx, replay_it, replay_end);
+                  ctx.alias_expansion_budget = temp_ctx.alias_expansion_budget; // charged even if rejected
                   if (bool(temp_ctx.error)) [[unlikely]] {
                      ctx.error = temp_ctx.error;
                      return false;
@@ -1508,6 +1528,7 @@ namespace glz
                      auto temp_ctx = ctx.make_speculative();
                      from<YAML, glz::generic>::template op<opts{.error_on_unknown_keys = false}>(key_node, temp_ctx,
                                                                                                  replay_it, replay_end);
+                     ctx.alias_expansion_budget = temp_ctx.alias_expansion_budget; // charged even if rejected
                      if (bool(temp_ctx.error)) [[unlikely]] {
                         ctx.error = temp_ctx.error;
                         return false;
@@ -5005,6 +5026,11 @@ namespace glz
                   auto temp_ctx = ctx.make_speculative();
                   from<YAML, V>::template op<Opts>(std::get<V>(value), temp_ctx, it, end);
 
+                  // Charged whether or not the alternative fit: a rejected probe still replayed
+                  // whatever aliases it reached, and an attempt that is never billed is an
+                  // attempt that can be repeated for free.
+                  ctx.alias_expansion_budget = temp_ctx.alias_expansion_budget;
+
                   if (!bool(temp_ctx.error)) {
                      found_match = true;
                      ctx.anchors = std::move(temp_ctx.anchors);
@@ -5140,6 +5166,7 @@ namespace glz
          auto temp_ctx = ctx.make_speculative();
          process_yaml_variant_alternatives<Variant, is_yaml_variant_object>::template op<Opts>(value, temp_ctx, it,
                                                                                                end);
+         ctx.alias_expansion_budget = temp_ctx.alias_expansion_budget; // charged even if rejected
          if (!bool(temp_ctx.error)) {
             ctx.anchors = std::move(temp_ctx.anchors);
             return true;
@@ -5326,11 +5353,13 @@ namespace glz
    }
 
    // Resolve a tagged variant's alternative index by scanning the mapping for the discriminator
-   // key (tag_v<V>). Operates on copies of the context and iterator so the caller's parse
-   // position is left untouched. Returns ids_v<V>.size() (the not-found sentinel) when the tag
-   // key is absent or its value matches no known id.
+   // key (tag_v<V>). Operates on a speculative context and a copy of the iterator so the caller's
+   // parse position is left untouched -- the context is the caller's to own, because what the
+   // scan spends of the alias budget is real work the caller has to account for. Returns
+   // ids_v<V>.size() (the not-found sentinel) when the tag key is absent or its value matches no
+   // known id.
    template <class V, auto Opts, class Ctx, class It, class End>
-   inline size_t scan_variant_tag_index(Ctx ctx, It it, End end, int32_t mapping_indent)
+   inline size_t scan_variant_tag_index(Ctx& ctx, It it, End end, int32_t mapping_indent)
    {
       using id_type = std::decay_t<decltype(ids_v<V>[0])>;
       size_t resolved = ids_v<V>.size();
@@ -5415,7 +5444,9 @@ namespace glz
                // item, etc. each push a different offset), not this mapping's true column (see helper).
                const int32_t mapping_column =
                   tagged_mapping_visual_indent(it, ctx.stream_begin, ctx.current_indent() + 1);
-               const size_t index = scan_variant_tag_index<V, Opts>(ctx.make_speculative(), it, end, mapping_column);
+               auto tag_ctx = ctx.make_speculative();
+               const size_t index = scan_variant_tag_index<V, Opts>(tag_ctx, it, end, mapping_column);
+               ctx.alias_expansion_budget = tag_ctx.alias_expansion_budget; // charged even if no tag matched
                if (index < ids_v<V>.size()) {
                   static constexpr auto tag_literal = string_literal_from_view<tag_v<V>.size()>(tag_v<V>);
                   emplace_runtime_variant(value, index);
@@ -6241,6 +6272,7 @@ namespace glz
                   auto temp_ctx = ctx.make_speculative();
                   process_yaml_variant_alternatives<V, is_yaml_variant_num>::template op<Opts>(value, temp_ctx, it,
                                                                                                end);
+                  ctx.alias_expansion_budget = temp_ctx.alias_expansion_budget; // charged even if rejected
                   if (!bool(temp_ctx.error)) {
                      ctx.anchors = std::move(temp_ctx.anchors);
                      return; // Successfully parsed as number
@@ -6262,6 +6294,7 @@ namespace glz
                      auto temp_ctx = ctx.make_speculative();
                      process_yaml_variant_alternatives<V, is_yaml_variant_num>::template op<Opts>(value, temp_ctx, it,
                                                                                                   end);
+                     ctx.alias_expansion_budget = temp_ctx.alias_expansion_budget; // charged even if rejected
                      if (!bool(temp_ctx.error)) {
                         ctx.anchors = std::move(temp_ctx.anchors);
                         return; // Successfully parsed as number
@@ -6288,6 +6321,7 @@ namespace glz
             V v{};
             auto temp_ctx = ctx.make_speculative();
             from<YAML, V>::template op<Opts>(v, temp_ctx, it, end);
+            ctx.alias_expansion_budget = temp_ctx.alias_expansion_budget; // charged even if rejected
 
             if (!bool(temp_ctx.error)) {
                value = std::move(v);

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -4279,6 +4279,42 @@ other: *a5)";
       }
    };
 
+   "exponential_alias_expansion_is_bounded"_test = [] {
+      // Each anchor references the previous one eight times, so the expansion multiplies by
+      // eight per line while the document grows by 42 bytes. Nesting depth stays at two, so
+      // only the replay budget sees anything wrong. Unbounded, twelve levels is hundreds of
+      // gigabytes of nodes.
+      std::string yaml = "l0: &a0 lol\n";
+      for (int level = 1; level <= 12; ++level) {
+         yaml += "l" + std::to_string(level) + ": &a" + std::to_string(level) + " [";
+         for (int use = 0; use < 8; ++use) {
+            if (use) yaml += ',';
+            yaml += "*a" + std::to_string(level - 1);
+         }
+         yaml += "]\n";
+      }
+      glz::generic parsed{};
+      const auto ec = glz::read_yaml<glz::opts{.error_on_unknown_keys = false}>(parsed, yaml);
+      expect(ec == glz::error_code::exceeded_max_alias_expansion) << glz::format_error(ec, yaml);
+   };
+
+   "heavy_anchor_reuse_still_parses"_test = [] {
+      // The budget must not punish reuse, which is what anchors are for: a generated config
+      // that pulls a sizable template into thousands of entries is ordinary, and its cost
+      // tracks its own size rather than exploding.
+      std::string yaml = "tpl: &t\n";
+      for (int field = 0; field < 30; ++field) {
+         yaml += "  field" + std::to_string(field) + ": " + std::string(20, 'v') + "\n";
+      }
+      for (int job = 0; job < 5000; ++job) {
+         yaml += "job" + std::to_string(job) + ": *t\n";
+      }
+      glz::generic parsed{};
+      const auto ec = glz::read_yaml<glz::opts{.error_on_unknown_keys = false}>(parsed, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(parsed.size() == 5001);
+   };
+
    "tag_then_anchor_on_key"_test = [] {
       std::string yaml = R"(!!str &a key: value
 other: *a)";


### PR DESCRIPTION
Follow-up to #2763, which fixed the cyclic-alias stack overflow and left this noted as a separate problem.

## The problem

Anchors are stored as spans of source text (`yaml_context::anchors` maps a name to `{begin, end}` pointers into the input) and resolving an alias replays that text through the reader. Anchors that each reference the previous one several times therefore multiply, without nesting anywhere:

```yaml
l0: &a0 lol
l1: &a1 [*a0,*a0,*a0,*a0,*a0,*a0,*a0,*a0]
l2: &a2 [*a1,*a1,*a1,*a1,*a1,*a1,*a1,*a1]
```

Each line adds 42 bytes and multiplies the work by eight. Measured on `main`: 306 bytes → 89 MB / 288 ms, ~348 bytes → ~700 MB, and it keeps going. Nesting depth stays at two throughout, so neither the depth guard nor the indent stack sees anything unusual. This is the classic billion-laughs shape, live on the `yaml_generic` fuzz target.

## The fix

A per-read budget on **total replayed bytes**, modeled on the existing `charge_speculation`. Seeded once at the outermost `parse<YAML>::op` as `max(input × 64, 8 MB)` and charged wherever an anchor span is replayed. Exhausting it reports the new `error_code::exceeded_max_alias_expansion`.

Replayed bytes is the right metric because it is what the time and the memory both track. Bounding reuse count or nesting depth would punish documents that are merely large while missing this one, which is neither deeply nested nor unusually repetitive at any single site.

The factor is deliberately looser than `max_speculative_parse_factor`: re-parsing bytes to resolve a variant is waste worth capping, whereas replaying an anchor is the feature working as intended. The exponential case is caught by the floor, not the factor, so the factor only has to be generous enough not to punish real documents.

Speculative parses work on a copy of the context, so the spend is carried back at all 8 sites that create one — including on the rejection path, since a probe that expanded aliases and then failed still did the work, and an attempt that is never billed can be repeated for free. That is also why `scan_variant_tag_index` now takes its context by reference rather than by value: it was handed a temporary, so the tagged-variant discriminator scan expanded aliases for free.

## Effect

| shape | before | after |
|---|---|---|
| 8 levels, 8-way (348 B) | ~700 MB, seconds | 39 MB, 134 ms |
| 12 levels (538 B) | hundreds of GB | 39 MB, 134 ms |
| 30 levels, fan-out 2/3/8/16 | unbounded | ≤55 MB, ≤157 ms |

Growth stops: adding levels no longer changes the cost.

Legitimate reuse is unaffected — 500 uses of a 20-field anchor, 2000 uses of a small anchor, 5000 uses of a 1 KB anchor (60 KB input), 60 uses of a 10 KB anchor, and 60 levels of linear chaining all parse. The one non-attack document rejected is 40 levels of twofold reuse, which is 2^40 nodes and cannot be materialized either way.

## Testing

- `yaml_test` 720/720, `yaml_conformance` 402/402, `yaml_conformance_struct` 105/105
- Bounded across fan-outs 2/3/8/16 × depths 8/16/30; through flow-mapping values, alias-as-key, explicit `? *alias` keys, and a reflected struct target (no variant reader in the loop)
- Budget seeding confirmed on `read_yaml` (string, string_view, vector), non-null-terminated `read`, and `read_file_yaml`
- `charge_alias_expansion` boundaries checked: zero charge, exactly-equal, over-budget, repeated charges after exhaustion, and `size_t(-1)` — no wrap, latches at 1 rather than falling to 0 (which would read as unbudgeted)
- Fuzz target clean on all prior reproducers plus 300k mutated inputs under ASan+UBSan
- New error code round-trips through `format_error` and enum reflection; appended to the enum and both `glz::meta` arrays so no existing enumerator value shifts

Two tests added. They cost ~207 ms of the ~1.5 s suite; the larger half is irreducible, since proving the budget stops the expansion means spending the budget.

## Judgment calls worth a second opinion

The two constants (factor 64, floor 8 MB) are the part I am least certain about. The floor is what every realistic document actually reads against — the factor only engages above 128 KB of input. If you would rather trade a tighter worst case for a higher false-positive risk, the floor is the knob.