### PR TITLE
Bound YAML complex-key expansion

### DIFF
--- a/include/glaze/core/context.hpp
+++ b/include/glaze/core/context.hpp
@@ -111,7 +111,10 @@ namespace glz
       // Streaming errors
       streaming_unsupported, // Document outruns the buffer window and this format's reader cannot refill
       // Expansion errors
-      exceeded_max_alias_expansion // YAML aliases replay more source text than the read budgets
+      // A YAML read produced more text than its budgets allow. Both budgets bound the same thing
+      // -- text a small document can multiply into an unbounded amount -- and both call for the
+      // same response, so they share a code; custom_error_message names which one ran away.
+      exceeded_max_expansion
    };
 
    // Unified error context for all read/write operations

--- a/include/glaze/core/error_category.hpp
+++ b/include/glaze/core/error_category.hpp
@@ -82,7 +82,7 @@ struct glz::meta<glz::error_code>
                                     "invalid_length",
                                     "invalid_utf8",
                                     "streaming_unsupported",
-                                    "exceeded_max_alias_expansion"};
+                                    "exceeded_max_expansion"};
    static constexpr std::array value{none, //
                                      version_mismatch, //
                                      invalid_header, //
@@ -165,5 +165,5 @@ struct glz::meta<glz::error_code>
                                      // Streaming errors
                                      streaming_unsupported, //
                                      // Expansion errors
-                                     exceeded_max_alias_expansion};
+                                     exceeded_max_expansion};
 };

--- a/include/glaze/core/read.hpp
+++ b/include/glaze/core/read.hpp
@@ -145,6 +145,15 @@ namespace glz
             (proportional > min_speculative_parse_bytes ? proportional : min_speculative_parse_bytes) + 2;
       }
 
+      // A YAML context marks its outermost parse with stream_begin and seeds its expansion budgets
+      // there, so clearing it here is what makes those budgets per-read like the one above. A
+      // reused context would otherwise carry a spent budget into the next document and reject a
+      // valid one, and would leave stream_begin pointing into the buffer of the previous read.
+      // Nested YAML parses do not route through glz::read, so they still cannot reseed themselves.
+      if constexpr (requires { ctx.stream_begin; }) {
+         ctx.stream_begin = nullptr;
+      }
+
       if constexpr (use_padded) {
          parse<Opts.format>::template op<is_padded_on<Opts>()>(value, ctx, it, end);
       }

--- a/include/glaze/yaml/common.hpp
+++ b/include/glaze/yaml/common.hpp
@@ -33,6 +33,21 @@ namespace glz::yaml
    // gigabytes and minutes -- while staying far above what a hand-written document replays.
    inline constexpr size_t min_alias_expansion_bytes = 8 << 20;
 
+   // How many times over the input a read may materialize complex-key text, and the floor it
+   // reads against. A mapping key that is not a scalar is stored by its JSON form, and JSON
+   // escaping is multiplicative under nesting: every level that carries the previous one as its
+   // key doubles that level's backslashes, so each `? ` in `? ? ? ...` doubles the key while
+   // adding two bytes to the input. 52 bytes of input reach a 134 MB key, 72 bytes reach more
+   // memory than a machine has, and nothing about the shape looks unusual on the way down --
+   // nesting is linear in the input, so the recursion guard is no help: by its 84-level limit the
+   // key would be 2^84 bytes.
+   // Bounding materialized bytes is what the memory and the time both track. The constants match
+   // the alias budget for the same reason it chose them: a complex key's JSON form is comparable
+   // to the YAML that produced it, so any multiple of the document stops growth that does not
+   // track the document at all, and the floor is what ordinary documents actually read against.
+   inline constexpr size_t max_key_expansion_factor = 64;
+   inline constexpr size_t min_key_expansion_bytes = 8 << 20;
+
    // YAML-specific context extending the base context
    // Adds indent tracking needed for block-style parsing
    struct yaml_context : context
@@ -129,6 +144,26 @@ namespace glz::yaml
          return true;
       }
 
+      // Bytes of complex-key text this read may still materialize. Seeded per read from the
+      // input; 0 means unbudgeted (a nested or hand-rolled parse), matching the alias budget.
+      size_t key_expansion_budget = 0;
+
+      // Charge `bytes` of materialized key text. Returns false once the budget is spent, at which
+      // point the caller must stop and report exceeded_max_expansion. Latches at 1 rather than
+      // 0, which would read as "unbudgeted" and hand the document a fresh allowance.
+      [[nodiscard]] bool charge_key_expansion(const size_t bytes) noexcept
+      {
+         if (key_expansion_budget == 0) {
+            return true; // unbudgeted
+         }
+         if (bytes >= key_expansion_budget) {
+            key_expansion_budget = 1; // latch: spent, and still not "unbudgeted"
+            return false;
+         }
+         key_expansion_budget -= bytes;
+         return true;
+      }
+
       // True while parsing the value payload of a "- item" block-sequence entry.
       // Used to distinguish indentless-sequence continuation from next sibling items.
       bool sequence_item_value_context = false;
@@ -172,6 +207,9 @@ namespace glz::yaml
          // Speculative work is real work: a probe that expands aliases spends the same budget,
          // and the sites that adopt a probe's anchors adopt what it spent along with them.
          c.alias_expansion_budget = alias_expansion_budget;
+         // Likewise for key text: a probe that built a complex key did the work whether or not
+         // its alternative is adopted, and an attempt that is never billed can be repeated free.
+         c.key_expansion_budget = key_expansion_budget;
          c.sequence_item_value_context = sequence_item_value_context;
          c.sequence_dash_indent = sequence_dash_indent;
          c.explicit_mapping_key_context = explicit_mapping_key_context;

--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -23,6 +23,42 @@
 #include "glaze/yaml/opts.hpp"
 #include "glaze/yaml/skip.hpp"
 
+namespace glz::yaml
+{
+   // Store `key_node` as the string form of a mapping key: scalars keep their own text, everything
+   // else is canonicalized to JSON. That JSON is charged against the read's key budget, because a
+   // structured key nested as the key of another has its escapes doubled at every level and grows
+   // multiplicatively in the input. Every site that turns a parsed node into a key goes through
+   // here so the budget cannot be bypassed by adding one more.
+   // `empty_on_null` distinguishes the callers that spell a null key as the empty string (an
+   // explicit "? " with no key node) from the alias-replay sites, where the replayed span always
+   // names a node and a null one is written out as "null" like any other non-scalar.
+   template <bool empty_on_null = true, class Ctx>
+   [[nodiscard]] bool materialize_key(std::string& key, glz::generic& key_node, Ctx& ctx)
+   {
+      if constexpr (empty_on_null) {
+         if (key_node.is_null()) {
+            key.clear();
+            return true;
+         }
+      }
+      if (auto* s = key_node.template get_if<std::string>()) {
+         key = *s;
+         return true;
+      }
+      key.clear();
+      (void)glz::write_json(key_node, key);
+      if constexpr (requires { ctx.charge_key_expansion(size_t{}); }) {
+         if (!ctx.charge_key_expansion(key.size())) [[unlikely]] {
+            ctx.error = error_code::exceeded_max_expansion;
+            ctx.custom_error_message = "complex key expansion";
+            return false;
+         }
+      }
+      return true;
+   }
+}
+
 namespace glz
 {
    template <>
@@ -41,6 +77,13 @@ namespace glz
                   const size_t scaled = size_t(end - it) * yaml::max_alias_expansion_factor;
                   ctx.alias_expansion_budget =
                      scaled > yaml::min_alias_expansion_bytes ? scaled : yaml::min_alias_expansion_bytes;
+               }
+               // Same treatment for the text complex keys materialize, seeded on its own budget so
+               // exhausting one reports which of the two ran away.
+               if constexpr (requires { ctx.key_expansion_budget; } && requires { size_t(end - it); }) {
+                  const size_t scaled = size_t(end - it) * yaml::max_key_expansion_factor;
+                  ctx.key_expansion_budget =
+                     scaled > yaml::min_key_expansion_bytes ? scaled : yaml::min_key_expansion_bytes;
                }
             }
          }
@@ -273,7 +316,8 @@ namespace glz
             return true;
 
          if (!ctx.charge_alias_expansion(static_cast<size_t>(span.end - span.begin))) [[unlikely]] {
-            ctx.error = error_code::exceeded_max_alias_expansion;
+            ctx.error = error_code::exceeded_max_expansion;
+            ctx.custom_error_message = "alias expansion";
             return true;
          }
 
@@ -1457,7 +1501,8 @@ namespace glz
             else if (!ctx.charge_alias_expansion(static_cast<size_t>(span.end - span.begin))) [[unlikely]] {
                // A key alias replays its anchor the same way a value alias does, and a complex
                // key hands the span to the full reader, so it is charged the same way.
-               ctx.error = error_code::exceeded_max_alias_expansion;
+               ctx.error = error_code::exceeded_max_expansion;
+               ctx.custom_error_message = "alias expansion";
                return false;
             }
             else {
@@ -1477,17 +1522,16 @@ namespace glz
                   from<YAML, glz::generic>::template op<flow_context_on<opts{.error_on_unknown_keys = false}>()>(
                      key_node, temp_ctx, replay_it, replay_end);
                   ctx.alias_expansion_budget = temp_ctx.alias_expansion_budget; // charged even if rejected
+                  ctx.key_expansion_budget = temp_ctx.key_expansion_budget;
                   if (bool(temp_ctx.error)) [[unlikely]] {
                      ctx.error = temp_ctx.error;
+                     ctx.custom_error_message = temp_ctx.custom_error_message;
                      return false;
                   }
                   ctx.anchors = std::move(temp_ctx.anchors);
 
-                  if (auto* s = key_node.template get_if<std::string>()) {
-                     key = *s;
-                  }
-                  else {
-                     (void)glz::write_json(key_node, key);
+                  if (!yaml::materialize_key<false>(key, key_node, ctx)) [[unlikely]] {
+                     return false;
                   }
                }
                else {
@@ -1529,17 +1573,16 @@ namespace glz
                      from<YAML, glz::generic>::template op<opts{.error_on_unknown_keys = false}>(key_node, temp_ctx,
                                                                                                  replay_it, replay_end);
                      ctx.alias_expansion_budget = temp_ctx.alias_expansion_budget; // charged even if rejected
+                     ctx.key_expansion_budget = temp_ctx.key_expansion_budget;
                      if (bool(temp_ctx.error)) [[unlikely]] {
                         ctx.error = temp_ctx.error;
+                        ctx.custom_error_message = temp_ctx.custom_error_message;
                         return false;
                      }
                      ctx.anchors = std::move(temp_ctx.anchors);
 
-                     if (auto* s = key_node.template get_if<std::string>()) {
-                        key = *s;
-                     }
-                     else {
-                        (void)glz::write_json(key_node, key);
+                     if (!yaml::materialize_key<false>(key, key_node, ctx)) [[unlikely]] {
+                        return false;
                      }
                   }
                   else {
@@ -2530,15 +2573,8 @@ namespace glz
                         return;
 
                      std::string key;
-                     if (key_node.is_null()) {
-                        key.clear();
-                     }
-                     else if (auto* s = key_node.template get_if<std::string>()) {
-                        key = *s;
-                     }
-                     else {
-                        (void)glz::write_json(key_node, key);
-                     }
+                     if (!yaml::materialize_key(key, key_node, ctx)) [[unlikely]]
+                        return;
 
                      glz::generic pair{};
                      pair[key] = std::move(mapped);
@@ -4382,17 +4418,8 @@ namespace glz
                         from<YAML, glz::generic>::template op<yaml::flow_context_on<Opts>()>(key_node, ctx, it, end);
                         if (bool(ctx.error)) [[unlikely]]
                            return;
-                        if (key_node.is_null()) {
-                           key.clear();
-                        }
-                        else if (auto* s = key_node.template get_if<std::string>()) {
-                           key = *s;
-                        }
-                        else {
-                           std::string key_json;
-                           (void)glz::write_json(key_node, key_json);
-                           key = std::move(key_json);
-                        }
+                        if (!yaml::materialize_key(key, key_node, ctx)) [[unlikely]]
+                           return;
                      }
                      else {
                         if (!yaml::parse_yaml_key(key, ctx, it, end, true)) {
@@ -4629,17 +4656,7 @@ namespace glz
                      key_t key{};
                      if constexpr (std::same_as<std::remove_cvref_t<key_t>, std::string>) {
                         auto to_string_key = [&](glz::generic& key_node) {
-                           if (key_node.is_null()) {
-                              key.clear();
-                           }
-                           else if (auto* s = key_node.template get_if<std::string>()) {
-                              key = *s;
-                           }
-                           else {
-                              std::string key_json;
-                              (void)glz::write_json(key_node, key_json);
-                              key = std::move(key_json);
-                           }
+                           return yaml::materialize_key(key, key_node, ctx);
                         };
 
                         auto key_it = it;
@@ -4760,7 +4777,8 @@ namespace glz
                            if (bool(ctx.error)) [[unlikely]]
                               return false;
                            it = key_node_it;
-                           to_string_key(key_node);
+                           if (!to_string_key(key_node)) [[unlikely]]
+                              return false;
                         }
                      }
                      else {
@@ -4843,17 +4861,8 @@ namespace glz
                         from<YAML, glz::generic>::template op<yaml::flow_context_on<Opts>()>(key_node, ctx, it, end);
                         if (bool(ctx.error)) [[unlikely]]
                            return false;
-                        if (key_node.is_null()) {
-                           key.clear();
-                        }
-                        else if (auto* s = key_node.template get_if<std::string>()) {
-                           key = *s;
-                        }
-                        else {
-                           std::string key_json;
-                           (void)glz::write_json(key_node, key_json);
-                           key = std::move(key_json);
-                        }
+                        if (!yaml::materialize_key(key, key_node, ctx)) [[unlikely]]
+                           return false;
                      }
                      else {
                         if (!yaml::parse_yaml_key(key, ctx, it, end, false)) {
@@ -5011,6 +5020,14 @@ namespace glz
             constexpr auto N = std::variant_size_v<Variant>;
             bool found_match{};
             size_t match_idx = 0;
+            // Only the last alternative propagates its error, so an alternative that exhausted an
+            // expansion budget would otherwise be reported as no_matching_variant_type -- a wrong
+            // diagnosis for a document that is hostile rather than merely the wrong shape. Held
+            // aside and used only if nothing matched, so an alternative that does succeed later
+            // (one that materializes no key text can still parse under a latched budget) is
+            // unaffected.
+            error_code expansion_error{};
+            std::string_view expansion_message{};
 
             for_each<N>([&]<size_t I>() {
                if (found_match) {
@@ -5030,6 +5047,7 @@ namespace glz
                   // whatever aliases it reached, and an attempt that is never billed is an
                   // attempt that can be repeated for free.
                   ctx.alias_expansion_budget = temp_ctx.alias_expansion_budget;
+                  ctx.key_expansion_budget = temp_ctx.key_expansion_budget;
 
                   if (!bool(temp_ctx.error)) {
                      found_match = true;
@@ -5037,12 +5055,17 @@ namespace glz
                   }
                   else {
                      it = copy_it;
+                     if (temp_ctx.error == error_code::exceeded_max_expansion && expansion_error == error_code::none) {
+                        expansion_error = temp_ctx.error;
+                        expansion_message = temp_ctx.custom_error_message;
+                     }
                      if (match_idx + 1 < category_count) {
                         // Not the last type, continue trying
                      }
                      else {
                         // Last type failed, propagate error
                         ctx.error = temp_ctx.error;
+                        ctx.custom_error_message = temp_ctx.custom_error_message;
                      }
                   }
                   ++match_idx;
@@ -5050,7 +5073,13 @@ namespace glz
             });
 
             if (!found_match && !bool(ctx.error)) {
-               ctx.error = error_code::no_matching_variant_type;
+               if (expansion_error != error_code::none) {
+                  ctx.error = expansion_error;
+                  ctx.custom_error_message = expansion_message;
+               }
+               else {
+                  ctx.error = error_code::no_matching_variant_type;
+               }
             }
          }
       }
@@ -5167,6 +5196,7 @@ namespace glz
          process_yaml_variant_alternatives<Variant, is_yaml_variant_object>::template op<Opts>(value, temp_ctx, it,
                                                                                                end);
          ctx.alias_expansion_budget = temp_ctx.alias_expansion_budget; // charged even if rejected
+         ctx.key_expansion_budget = temp_ctx.key_expansion_budget;
          if (!bool(temp_ctx.error)) {
             ctx.anchors = std::move(temp_ctx.anchors);
             return true;
@@ -5175,6 +5205,7 @@ namespace glz
          // This indicates malformed content (e.g., unclosed flow collection),
          // so propagate the error rather than silently falling back to string.
          ctx.error = temp_ctx.error;
+         ctx.custom_error_message = temp_ctx.custom_error_message;
          return false;
       }
    }
@@ -5447,6 +5478,7 @@ namespace glz
                auto tag_ctx = ctx.make_speculative();
                const size_t index = scan_variant_tag_index<V, Opts>(tag_ctx, it, end, mapping_column);
                ctx.alias_expansion_budget = tag_ctx.alias_expansion_budget; // charged even if no tag matched
+               ctx.key_expansion_budget = tag_ctx.key_expansion_budget;
                if (index < ids_v<V>.size()) {
                   static constexpr auto tag_literal = string_literal_from_view<tag_v<V>.size()>(tag_v<V>);
                   emplace_runtime_variant(value, index);
@@ -6273,6 +6305,7 @@ namespace glz
                   process_yaml_variant_alternatives<V, is_yaml_variant_num>::template op<Opts>(value, temp_ctx, it,
                                                                                                end);
                   ctx.alias_expansion_budget = temp_ctx.alias_expansion_budget; // charged even if rejected
+                  ctx.key_expansion_budget = temp_ctx.key_expansion_budget;
                   if (!bool(temp_ctx.error)) {
                      ctx.anchors = std::move(temp_ctx.anchors);
                      return; // Successfully parsed as number
@@ -6295,6 +6328,7 @@ namespace glz
                      process_yaml_variant_alternatives<V, is_yaml_variant_num>::template op<Opts>(value, temp_ctx, it,
                                                                                                   end);
                      ctx.alias_expansion_budget = temp_ctx.alias_expansion_budget; // charged even if rejected
+                     ctx.key_expansion_budget = temp_ctx.key_expansion_budget;
                      if (!bool(temp_ctx.error)) {
                         ctx.anchors = std::move(temp_ctx.anchors);
                         return; // Successfully parsed as number
@@ -6314,6 +6348,13 @@ namespace glz
          // For non-auto-deducible variants or fallback, try each type until one succeeds
          constexpr auto N = std::variant_size_v<std::remove_cvref_t<T>>;
 
+         // This fold discards each alternative's error and reports only that nothing fit, which
+         // misdiagnoses a document that exhausted an expansion budget as merely the wrong shape.
+         // Kept aside and used only if no alternative parsed, so a later one that does parse
+         // (possible under a latched budget if it materializes no key text) is unaffected.
+         error_code expansion_error{};
+         std::string_view expansion_message{};
+
          auto try_parse = [&]<size_t I>() -> bool {
             using V = std::variant_alternative_t<I, std::remove_cvref_t<T>>;
             auto start = it;
@@ -6322,6 +6363,7 @@ namespace glz
             auto temp_ctx = ctx.make_speculative();
             from<YAML, V>::template op<Opts>(v, temp_ctx, it, end);
             ctx.alias_expansion_budget = temp_ctx.alias_expansion_budget; // charged even if rejected
+            ctx.key_expansion_budget = temp_ctx.key_expansion_budget;
 
             if (!bool(temp_ctx.error)) {
                value = std::move(v);
@@ -6329,6 +6371,10 @@ namespace glz
                return true;
             }
 
+            if (temp_ctx.error == error_code::exceeded_max_expansion && expansion_error == error_code::none) {
+               expansion_error = temp_ctx.error;
+               expansion_message = temp_ctx.custom_error_message;
+            }
             it = start;
             return false;
          };
@@ -6339,7 +6385,13 @@ namespace glz
          }(std::make_index_sequence<N>{});
 
          if (!parsed) {
-            ctx.error = error_code::no_matching_variant_type;
+            if (expansion_error != error_code::none) {
+               ctx.error = expansion_error;
+               ctx.custom_error_message = expansion_message;
+            }
+            else {
+               ctx.error = error_code::no_matching_variant_type;
+            }
          }
       }
 #ifdef _MSC_VER

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -4295,7 +4295,8 @@ other: *a5)";
       }
       glz::generic parsed{};
       const auto ec = glz::read_yaml<glz::opts{.error_on_unknown_keys = false}>(parsed, yaml);
-      expect(ec == glz::error_code::exceeded_max_alias_expansion) << glz::format_error(ec, yaml);
+      expect(ec == glz::error_code::exceeded_max_expansion) << glz::format_error(ec, yaml);
+      expect(ec.custom_error_message == "alias expansion") << ec.custom_error_message;
    };
 
    "heavy_anchor_reuse_still_parses"_test = [] {
@@ -4313,6 +4314,97 @@ other: *a5)";
       const auto ec = glz::read_yaml<glz::opts{.error_on_unknown_keys = false}>(parsed, yaml);
       expect(!ec) << glz::format_error(ec, yaml);
       expect(parsed.size() == 5001);
+   };
+
+   "exponential_complex_key_expansion_is_bounded"_test = [] {
+      // A non-scalar mapping key is stored by its JSON form, and JSON escaping is multiplicative
+      // under nesting: each "? " makes the level below into a key, doubling its backslashes, so
+      // the key doubles for every two bytes of input. 52 bytes reached a 134 MB key and 141 bytes
+      // reached 17 GB and three minutes. Nesting is linear in the input the whole way, so the
+      // recursion guard never fires -- at its 84-level limit the key would be 2^84 bytes.
+      // Found by OSS-Fuzz's yaml_generic target.
+      //
+      // The levels are kept just past the cutoff (which sits at 22) on purpose. Unbudgeted, 24
+      // levels is a 33 MB key and 26 is 134 MB -- both large enough to prove the point, small
+      // enough that a regression here fails this assert instead of taking the machine with it.
+      // 30 levels would be ~8 GB and would OOM the runner before any assert could report.
+      for (const int levels : {24, 26}) {
+         std::string doc;
+         for (int i = 0; i < levels; ++i) doc += "? ";
+         glz::generic parsed{};
+         const auto ec = glz::read_yaml<glz::opts{.error_on_unknown_keys = false}>(parsed, doc);
+         expect(ec == glz::error_code::exceeded_max_expansion) << levels << ' ' << glz::format_error(ec, doc);
+         // The two budgets share a code, so the message is what tells them apart.
+         expect(ec.custom_error_message == "complex key expansion") << ec.custom_error_message;
+      }
+   };
+
+   "expansion_budgets_reseed_per_read"_test = [] {
+      // The budgets are seeded on the outermost parse, marked by ctx.stream_begin. A context
+      // reused across reads kept the spent (latched) budget of the previous one, so the next
+      // document -- however small and valid -- was rejected. glz::read clears stream_begin so
+      // the seeding runs again, the same way speculation_budget is reseeded per read.
+      glz::yaml::yaml_context ctx{};
+      std::string runaway;
+      for (int i = 0; i < 40; ++i) runaway += "? ";
+      glz::generic first{};
+      const auto ec_first = glz::read<glz::yaml::yaml_opts{}>(first, runaway, ctx);
+      expect(ec_first == glz::error_code::exceeded_max_expansion) << glz::format_error(ec_first, runaway);
+
+      ctx.error = glz::error_code::none; // a reused context carries its error for every format
+      ctx.custom_error_message = {};
+
+      const std::string valid = "? {a: 1}\n: 2\n";
+      glz::generic second{};
+      const auto ec_second = glz::read<glz::yaml::yaml_opts{}>(second, valid, ctx);
+      expect(!ec_second) << glz::format_error(ec_second, valid);
+      expect(ctx.key_expansion_budget > (1 << 20)) << ctx.key_expansion_budget;
+   };
+
+   "budget_exhaustion_survives_variant_dispatch"_test = [] {
+      // Variant alternatives are tried speculatively and only the last one's error escapes, so an
+      // exhausted budget used to surface as no_matching_variant_type with no message at all.
+      std::string runaway;
+      for (int i = 0; i < 40; ++i) runaway += "? ";
+      std::variant<std::map<std::string, std::string>, std::map<std::string, glz::generic>> value{};
+      const auto ec = glz::read_yaml<glz::opts{.error_on_unknown_keys = false}>(value, runaway);
+      expect(ec == glz::error_code::exceeded_max_expansion) << glz::format_error(ec, runaway);
+      expect(ec.custom_error_message == "complex key expansion") << ec.custom_error_message;
+
+      // ...but a document that is genuinely the wrong shape must still say so.
+      std::variant<double, bool> mismatch{};
+      const auto ec_mismatch = glz::read_yaml(mismatch, std::string("[1,2]"));
+      expect(ec_mismatch == glz::error_code::no_matching_variant_type) << glz::format_error(ec_mismatch, "[1,2]");
+   };
+
+   "nested_complex_keys_still_parse"_test = [] {
+      // The budget must not reject complex keys at the depths documents actually use: the JSON
+      // form of a key stays comparable to the YAML that produced it until nesting compounds it.
+      const std::pair<std::string_view, std::string_view> cases[]{
+         {"? {a: 1}\n: 2\n", R"({"{\"a\":1}":2})"},
+         {"? ? a\n: 2\n", R"({"{\"a\":null}":2})"},
+         {"? {a: {b: [1, 2]}}\n: 3\n", R"({"{\"a\":{\"b\":[1,2]}}":3})"},
+      };
+      for (const auto& [yaml, expected] : cases) {
+         glz::generic parsed{};
+         const auto ec = glz::read_yaml<glz::opts{.error_on_unknown_keys = false}>(parsed, yaml);
+         expect(!ec) << glz::format_error(ec, yaml);
+         const auto json = glz::write_json(parsed).value_or("WRITE_ERR");
+         expect(json == expected) << yaml << " -> " << json;
+      }
+   };
+
+   "many_flow_complex_keys_still_parse"_test = [] {
+      // Reuse of complex keys across a large document is ordinary and costs only what the
+      // document itself costs, so the budget must scale with the input rather than cap a count.
+      std::string yaml;
+      for (int entry = 0; entry < 5000; ++entry) {
+         yaml += "? {a: " + std::to_string(entry) + ", b: [1, 2, 3]}\n: " + std::to_string(entry) + "\n";
+      }
+      glz::generic parsed{};
+      const auto ec = glz::read_yaml<glz::opts{.error_on_unknown_keys = false}>(parsed, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(parsed.size() == 5000);
    };
 
    "tag_then_anchor_on_key"_test = [] {


### PR DESCRIPTION
## The bug

A YAML mapping key that is not a scalar is stored by its JSON form, and JSON escaping is multiplicative under nesting: each `? ` in `? ? ? ...` makes the level below into a key and doubles that level's backslashes. The key doubles for every two bytes of input.

| input | resulting key |
|---|---|
| 36 B | 524 KB |
| 44 B | 8.4 MB |
| 52 B | 134 MB |
| 141 B | 17.4 GB / 183 s |

The 141-byte case **parsed successfully** rather than erroring. Nesting is linear in the input the whole way down, so the recursion guard never fires — by its 84-level limit the key would be 2^84 bytes. The alias-expansion budget doesn't see it either, since no span is ever replayed.

Found by fuzzing the `yaml_generic` target.

## The fix

A per-read budget of materialized key bytes, seeded as `max(input * 64, 8 MB)` and charged wherever a node becomes a key string — the same shape as the alias budget in #2766, because the failure mode is the same. All six key-stringification sites now funnel through one `materialize_key` helper, so there is exactly one `write_json` call in the reader and the budget cannot be bypassed by adding a seventh. Speculative parses carry their spend back to the parent, so a discarded probe cannot repeat unbilled work.

**141 bytes now costs 5.7 ms and 18.7 MB.** The charge lands after `write_json` allocates, so peak memory overshoots the budget by one materialization — the bound is on rate, not on peak.

## Also in here

- **`exceeded_max_alias_expansion` → `exceeded_max_expansion`**, shared by both budgets, with `ctx.custom_error_message` naming which one ran away. Both bound the same thing and call for the same response, so a caller gains nothing from two codes. The old name landed after v8.0.0 and never shipped, so nothing external depended on it. Net change to `error_code`: zero new enumerators.
- **Four sites dropped `custom_error_message`** when adopting an error out of a speculative context, so any message raised inside a variant probe was lost on the way out. Pre-existing; affected more than this change.
- **A reused context kept a spent budget.** The budgets seed on the outermost parse, marked by `ctx.stream_begin`, which `glz::read` never cleared — so the next document was rejected however small and valid. Now cleared per read, as `speculation_budget` already is.
- **Two variant dispatch paths** discarded a failing alternative's error and reported `no_matching_variant_type`, hiding an exhausted budget behind a wrong diagnosis. The expansion error is held aside and used only when no alternative parsed, so an alternative that does parse under a latched budget is unaffected.

## Verification

- 725 YAML tests, 117/117 ctest targets, clang-format clean.
- 5 new regression tests; the blowup tests are pinned just past the cutoff (24 and 26 levels) so a regression fails an assert instead of OOM-ing the runner.
- Post-fix fuzzing: 1.23M execs / 301 s and 1.11M execs / 241 s, zero crashes, OOMs or timeouts, RSS flat.
- Output compared against the pre-change baseline across 33 hand-picked key-shape documents and 600,000 randomly generated ones — byte-identical error codes and JSON.
- No realistic document is affected: measured amplification is 1.00x for an 858 KB config with 20,000 complex keys; 64x is not reached until eight levels of key-within-key nesting.

## Floor tuning

I made the floor overridable in a scratch tree and measured both sides before settling on 8 MB.

What the floor costs the target, worst case at each setting:

| key floor | `"? " x 200` | `alias^14 fed into nested key` |
|---|---|---|
| 8 MB (this PR) | 4.7 ms, +17 MB | 26 ms, +9.8 MB |
| 1 MB | 0.6 ms, +0 MB | 26 ms, +5.1 MB |
| 256 KB | 0.24 ms | 26 ms, +3.2 MB |
| 64 KB | 0.12 ms | 26 ms, +3.2 MB |

Dropping it 128x buys about 4.5 ms and 17 MB.

What it costs legitimate documents: ordinary complex-key documents materialize 0.5-1.5x their input size in key bytes, well inside the 64x factor. One shape exceeds the factor - a single anchor replayed from many *key* positions:

```
1 anchor -> 800 key positions    in=9409    key_spent=632000    ratio=67.2
```

At 67x the factor no longer covers it and the floor is the only thing carrying it. It passes at 8 MB and at 1 MB, and fails at 256 KB and below. That is the shape #2766 deliberately permits, in key position, so a lower key floor would make the key budget stricter than the alias budget for the same construction. Verified to hold up to ~200 KB inputs (16,000 references, 350 ms, passes). Keeping 8 MB.

## Separately: the alias budget's unit

While measuring the above I found a more expensive construction, with no complex keys anywhere in it. It reproduces unchanged on `ba2a514b`, so it is not touched by this PR:

```
alias^16 wide-leaf, value position only    in=364    2110.92 ms    peak +143 MB
alias^20 wide-leaf, value position only    in=452    2763.21 ms    peak  +40 MB
```

364 bytes, 2.1 seconds. Lowering the *alias* floor to 1 MB takes it to 315 ms; the key floor does not affect it at all. The cause is the unit: the alias budget charges source span bytes replayed, but each replayed byte re-parses into `glz::generic` nodes, so 8 MB charged becomes ~150-270 MB resident and seconds of work, while key materialization charges real output bytes and runs ~0.6 ms/MB.

Out of scope here. Worth deciding separately whether to lower `min_alias_expansion_bytes` to 1 MB (the densest ordinary anchor document I measured spends 102 KB, leaving ~10x headroom) or to charge alias replay by nodes materialized rather than source bytes.
