### PR TITLE
Fix YAML block values that a nullable wrapper or a short indent silently truncated

### DIFF
--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -1063,6 +1063,55 @@ namespace glz
          }
       }
 
+      // Is the plain scalar that just ended at `it` a mapping key rather than a scalar node?
+      // A trailing ": " (or ':' at a line end) means the node being read is the mapping that
+      // starts with this key, so "null: 1" is a mapping, not the null scalar.
+      template <class It, class End>
+      inline bool plain_scalar_is_mapping_key(It it, End end) noexcept
+      {
+         skip_inline_ws(it, end);
+         if (it == end || *it != ':') return false;
+         const auto after = it + 1;
+         return after == end || whitespace_or_line_end_table[static_cast<uint8_t>(*after)];
+      }
+
+      // Does a block node's content start on a line after `it`? Content indented past the
+      // enclosing block belongs to the node that begins at this line break, so an empty plain
+      // scalar there means "not started yet", not "empty". This is the shape an alias to a
+      // block node replays as: the recorded anchor span begins at the line break following
+      // the anchor name, since the content's own indentation is part of the span.
+      template <class Ctx, class It, class End>
+      inline bool block_node_content_follows(Ctx& ctx, It it, End end) noexcept
+      {
+         while (it != end) {
+            if (*it == '\n' || *it == '\r') {
+               skip_newline(it, end);
+               continue;
+            }
+
+            int32_t line_indent = 0;
+            auto line = it;
+            while (line != end && (*line == ' ' || *line == '\t')) {
+               ++line_indent;
+               ++line;
+            }
+
+            if (line == end) return false;
+            if (*line == '\n' || *line == '\r') { // blank line
+               it = line;
+               continue;
+            }
+            if (*line == '#') { // comment line
+               skip_comment(line, end);
+               it = line;
+               continue;
+            }
+
+            return line_indent > ctx.current_indent();
+         }
+         return false;
+      }
+
       // Parse a multiline plain scalar with folding (for block context)
       // This handles plain scalars that span multiple lines, where continuation
       // lines are indented more than the base indent level.
@@ -2273,12 +2322,30 @@ namespace glz
          if (yaml::handle_alias<Opts>(value, ctx, it, end)) return;
          // Anchors (&name) pass through to the inner type handler
 
-         // Check for null value (without tag)
+         // Check for null value (without tag). The probe runs on a copy: a null-looking
+         // token only settles the node when the token really is this node's scalar, and
+         // otherwise the inner parser has to start from where this began.
          if (tag == yaml::yaml_tag::none) {
             std::string str;
-            yaml::parse_plain_scalar(str, ctx, it, end, yaml::check_flow_context(Opts));
+            auto probe = it;
+            yaml::parse_plain_scalar(str, ctx, probe, end, yaml::check_flow_context(Opts));
 
-            if (yaml::is_yaml_null(str)) {
+            bool is_null = yaml::is_yaml_null(str);
+            if (is_null) {
+               if (yaml::plain_scalar_is_mapping_key(probe, end)) {
+                  // "null: 1" is a mapping whose first key happens to look null.
+                  is_null = false;
+               }
+               else if (str.empty() && !yaml::check_flow_context(Opts) &&
+                        yaml::block_node_content_follows(ctx, probe, end)) {
+                  // A block node whose content begins on a following line reads as an
+                  // empty scalar here. In flow context an empty node really is null.
+                  is_null = false;
+               }
+            }
+
+            if (is_null) {
+               it = probe;
                value = {};
                return;
             }
@@ -2422,6 +2489,61 @@ namespace glz
 
    namespace yaml
    {
+      // A parent that hands a block-style value the lines below it pushes an indent for the
+      // value to judge itself against. What that indent must be depends on how the value
+      // reads a block mapping, so the two predicates below classify the value type. Both
+      // treat wrappers as transparent: glaze_value_t and nullable types (std::optional,
+      // smart/raw pointers) delegate the block parse to what they hold, unchanged.
+
+      // Maps -- and variants, which may resolve to one -- run parse_block_mapping_loop in
+      // discover mode: they find their own key column and judge dedent against the pushed
+      // indent as a strict parent. The parent must therefore push the column *outside* the
+      // value (nested_indent - 1).
+      template <class T>
+      constexpr bool discovers_own_block_mapping_indent()
+      {
+         using V = std::remove_cvref_t<T>;
+         if constexpr (readable_map_t<V> || is_variant<V>) {
+            return true;
+         }
+         else if constexpr (glaze_value_t<V>) {
+            return discovers_own_block_mapping_indent<
+               std::decay_t<decltype(get_member(std::declval<V&>(), meta_wrapper_v<V>))>>();
+         }
+         else if constexpr (nullable_like<V>) {
+            return discovers_own_block_mapping_indent<std::remove_cvref_t<decltype(*std::declval<V&>())>>();
+         }
+         else {
+            return false;
+         }
+      }
+
+      // Structs read the pushed indent as their own key column: from<YAML, T> for objects
+      // passes ctx.current_indent() straight through as parse_block_mapping's mapping_indent.
+      // The parent must push the column *of* the value (nested_indent), otherwise a key one
+      // column short of its siblings still clears the dedent check and is folded in.
+      //
+      // Every other value type (scalars, sequences) reads the pushed indent as an enclosing
+      // baseline and is not covered by either predicate.
+      template <class T>
+      constexpr bool receives_block_mapping_column()
+      {
+         using V = std::remove_cvref_t<T>;
+         if constexpr (glaze_object_t<V> || reflectable<V>) {
+            return true;
+         }
+         else if constexpr (glaze_value_t<V>) {
+            return receives_block_mapping_column<
+               std::decay_t<decltype(get_member(std::declval<V&>(), meta_wrapper_v<V>))>>();
+         }
+         else if constexpr (nullable_like<V>) {
+            return receives_block_mapping_column<std::remove_cvref_t<decltype(*std::declval<V&>())>>();
+         }
+         else {
+            return false;
+         }
+      }
+
       // Reading a YAML sequence node into a container OVERWRITES its previous
       // contents rather than appending to them, matching the JSON parser
       // (see json/read.hpp). Growable containers are cleared up front so that
@@ -3188,10 +3310,13 @@ namespace glz
                   // This prevents content at column 0 from being treated as nested.
                   const int32_t effective_line_indent = (line_indent < 0) ? 0 : line_indent;
                   if (nested_indent > effective_line_indent) {
-                     // Save and set indent for nested parsing
-                     // Set parent indent to one less than content indent so items at
-                     // content indent pass the "indent > parent" check and continue parsing
-                     if (!ctx.push_indent(nested_indent - 1)) [[unlikely]]
+                     // Save and set indent for nested parsing.
+                     // A struct element reads the pushed indent as its own key column; every
+                     // other element type reads it as the enclosing baseline, so it gets one
+                     // less than the content indent and its content passes "indent > parent".
+                     const int32_t element_indent =
+                        receives_block_mapping_column<value_type>() ? nested_indent : nested_indent - 1;
+                     if (!ctx.push_indent(element_indent)) [[unlikely]]
                         return;
                      const bool prev_sequence_item_value_context = ctx.sequence_item_value_context;
                      const int32_t prev_sequence_dash_indent = ctx.sequence_dash_indent;
@@ -3785,22 +3910,7 @@ namespace glz
                               int32_t nested_indent = detect_nested_value_indent(ctx, it, end, line_indent);
                               if (nested_indent >= 0) {
                                  skip_to_content(it, end);
-                                 constexpr bool uses_discovered_block_mapping_indent = [] {
-                                    if constexpr (readable_map_t<member_type> || is_variant<member_type>) {
-                                       return true;
-                                    }
-                                    else if constexpr (glaze_value_t<member_type>) {
-                                       using unwrapped_member_type = std::decay_t<decltype(get_member(
-                                          std::declval<member_type&>(), meta_wrapper_v<member_type>))>;
-                                       return readable_map_t<unwrapped_member_type> ||
-                                              is_variant<unwrapped_member_type>;
-                                    }
-                                    else {
-                                       return false;
-                                    }
-                                 }();
-
-                                 if constexpr (uses_discovered_block_mapping_indent) {
+                                 if constexpr (discovers_own_block_mapping_indent<member_type>()) {
                                     if (!ctx.push_indent(nested_indent - 1)) [[unlikely]]
                                        return false;
                                  }
@@ -4630,7 +4740,11 @@ namespace glz
                               ctx.error = error_code::syntax_error;
                               return false;
                            }
-                           if (!ctx.push_indent(nested_indent - 1)) [[unlikely]]
+                           // A struct value reads the pushed indent as its own key column;
+                           // every other value type reads it as the enclosing baseline.
+                           const int32_t value_indent =
+                              yaml::receives_block_mapping_column<val_t>() ? nested_indent : nested_indent - 1;
+                           if (!ctx.push_indent(value_indent)) [[unlikely]]
                               return false;
                            from<YAML, val_t>::template op<Opts>(val, ctx, it, end);
                            ctx.pop_indent();

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -10922,4 +10922,514 @@ suite short_ids_write_guard = [] {
    };
 };
 
+// ============================================================
+// Nullable-wrapped block mappings as struct members
+// ============================================================
+
+// A block mapping discovers its own key column, so the parent must push the
+// column just outside it. A nullable wrapper (optional/smart pointer) delegates
+// the block parse to the mapping unchanged, so it must not change that column:
+// pushing the column itself made the mapping dedent out after its first entry
+// and the sibling entry surfaced as an unknown key on the enclosing struct.
+namespace nullable_block_mapping
+{
+   struct leaf
+   {
+      int id{};
+   };
+
+   struct branch
+   {
+      int id{};
+      std::optional<std::map<std::string, leaf>> leaves{};
+   };
+
+   struct root
+   {
+      std::optional<std::map<std::string, branch>> branches{};
+   };
+
+   struct optional_map_obj
+   {
+      std::optional<std::map<std::string, int>> m{};
+      int after{};
+   };
+
+   struct unique_ptr_map_obj
+   {
+      std::unique_ptr<std::map<std::string, int>> m{};
+      int after{};
+   };
+
+   struct optional_variant_map_obj
+   {
+      std::optional<std::variant<int, std::map<std::string, int>>> m{};
+      int after{};
+   };
+
+   struct optional_variant_sequence_obj
+   {
+      std::optional<std::variant<int, std::vector<int>>> m{};
+      int after{};
+   };
+
+   struct optional_generic_obj
+   {
+      std::optional<glz::generic> m{};
+      int after{};
+   };
+
+   struct sequence_of_optional_map_obj
+   {
+      std::vector<optional_map_obj> items{};
+   };
+
+   struct lenient_opts_t : glz::opts
+   {
+      bool error_on_unknown_keys = true;
+   };
+}
+
+suite yaml_nullable_block_mapping_tests = [] {
+   "optional_map_member_reads_all_entries"_test = [] {
+      using namespace nullable_block_mapping;
+      optional_map_obj obj{};
+      const std::string yaml = "m:\n  a: 1\n  b: 2\nafter: 7\n";
+      auto ec = glz::read_yaml(obj, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(obj.m.has_value());
+      if (obj.m) {
+         expect(obj.m->size() == 2u);
+         expect(obj.m->at("a") == 1);
+         expect(obj.m->at("b") == 2);
+      }
+      expect(obj.after == 7);
+   };
+
+   "unique_ptr_map_member_reads_all_entries"_test = [] {
+      using namespace nullable_block_mapping;
+      unique_ptr_map_obj obj{};
+      const std::string yaml = "m:\n  a: 1\n  b: 2\nafter: 7\n";
+      auto ec = glz::read_yaml(obj, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(obj.m != nullptr);
+      if (obj.m) {
+         expect(obj.m->size() == 2u);
+         expect(obj.m->at("a") == 1);
+         expect(obj.m->at("b") == 2);
+      }
+      expect(obj.after == 7);
+   };
+
+   "optional_variant_map_member_reads_all_entries"_test = [] {
+      using namespace nullable_block_mapping;
+      optional_variant_map_obj obj{};
+      const std::string yaml = "m:\n  a: 1\n  b: 2\nafter: 7\n";
+      auto ec = glz::read_yaml(obj, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(obj.m.has_value());
+      if (obj.m) {
+         using map_t = std::map<std::string, int>;
+         expect(std::holds_alternative<map_t>(*obj.m));
+         if (std::holds_alternative<map_t>(*obj.m)) expect(std::get<map_t>(*obj.m).size() == 2u);
+      }
+      expect(obj.after == 7);
+   };
+
+   "optional_map_member_with_deeper_indent"_test = [] {
+      using namespace nullable_block_mapping;
+      optional_map_obj obj{};
+      const std::string yaml = "m:\n      a: 1\n      b: 2\nafter: 7\n";
+      auto ec = glz::read_yaml(obj, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(obj.m.has_value());
+      if (obj.m) {
+         expect(obj.m->size() == 2u);
+         expect(obj.m->at("a") == 1);
+         expect(obj.m->at("b") == 2);
+      }
+      expect(obj.after == 7);
+   };
+
+   // The pushed column is one *outside* the mapping, so a single-space child
+   // indent is the boundary that proves it cannot swallow the parent's siblings.
+   "optional_map_member_with_single_space_indent"_test = [] {
+      using namespace nullable_block_mapping;
+      optional_map_obj obj{};
+      const std::string yaml = "m:\n a: 1\n b: 2\nafter: 7\n";
+      auto ec = glz::read_yaml(obj, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(obj.m.has_value());
+      if (obj.m) {
+         expect(obj.m->size() == 2u);
+         expect(obj.m->at("a") == 1);
+         expect(obj.m->at("b") == 2);
+      }
+      expect(obj.after == 7);
+   };
+
+   // Without error_on_unknown_keys the truncation is silent: the dropped entry
+   // is skipped as an unknown key of the enclosing struct instead of erroring.
+   "optional_map_member_reads_all_entries_without_unknown_key_errors"_test = [] {
+      using namespace nullable_block_mapping;
+      optional_map_obj obj{};
+      const std::string yaml = "m:\n  a: 1\n  b: 2\nafter: 7\n";
+      constexpr lenient_opts_t opts{{.format = glz::YAML}, false};
+      auto ec = glz::read<opts>(obj, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(obj.m.has_value());
+      if (obj.m) {
+         expect(obj.m->size() == 2u);
+         expect(obj.m->at("b") == 2);
+      }
+      expect(obj.after == 7);
+   };
+
+   // Block sequences truncate silently too, so the wrapped type must forward
+   // even when the value is not a mapping.
+   "optional_variant_sequence_member_reads_all_elements"_test = [] {
+      using namespace nullable_block_mapping;
+      optional_variant_sequence_obj obj{};
+      const std::string yaml = "m:\n  - 1\n  - 2\nafter: 7\n";
+      auto ec = glz::read_yaml(obj, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(obj.m.has_value());
+      if (obj.m) {
+         using vec_t = std::vector<int>;
+         expect(std::holds_alternative<vec_t>(*obj.m));
+         if (std::holds_alternative<vec_t>(*obj.m)) expect(std::get<vec_t>(*obj.m) == vec_t{1, 2});
+      }
+      expect(obj.after == 7);
+   };
+
+   // glz::generic is a glaze_value_t wrapping a variant, so an optional one
+   // exercises two levels of wrapper unwrapping.
+   "optional_generic_member_reads_all_elements"_test = [] {
+      using namespace nullable_block_mapping;
+      optional_generic_obj obj{};
+      const std::string yaml = "m:\n  - 1\n  - 2\nafter: 7\n";
+      auto ec = glz::read_yaml(obj, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(obj.m.has_value());
+      if (obj.m) {
+         expect(obj.m->is_array());
+         if (obj.m->is_array()) expect(obj.m->get_array().size() == 2u);
+      }
+      expect(obj.after == 7);
+   };
+
+   "optional_map_member_of_sequence_element"_test = [] {
+      using namespace nullable_block_mapping;
+      sequence_of_optional_map_obj obj{};
+      const std::string yaml = "items:\n  - m:\n      a: 1\n      b: 2\n    after: 3\n";
+      auto ec = glz::read_yaml(obj, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(obj.items.size() == 1u);
+      if (obj.items.size() == 1u) {
+         expect(obj.items[0].m.has_value());
+         if (obj.items[0].m) {
+            expect(obj.items[0].m->size() == 2u);
+            expect(obj.items[0].m->at("b") == 2);
+         }
+         expect(obj.items[0].after == 3);
+      }
+   };
+
+   "nested_optional_maps_roundtrip"_test = [] {
+      using namespace nullable_block_mapping;
+      const std::string yaml =
+         "branches:\n"
+         "  first:\n"
+         "    id: 1\n"
+         "    leaves:\n"
+         "      a:\n"
+         "        id: 10\n"
+         "      b:\n"
+         "        id: 20\n"
+         "  second:\n"
+         "    id: 2\n";
+
+      root value{};
+      auto ec = glz::read_yaml(value, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(value.branches.has_value());
+      if (!value.branches) return;
+      expect(value.branches->size() == 2u);
+      expect(value.branches->at("first").id == 1);
+      expect(value.branches->at("second").id == 2);
+      expect(value.branches->at("first").leaves.has_value());
+      if (value.branches->at("first").leaves) {
+         auto& leaves = *value.branches->at("first").leaves;
+         expect(leaves.size() == 2u);
+         expect(leaves.at("a").id == 10);
+         expect(leaves.at("b").id == 20);
+      }
+
+      std::string buffer{};
+      expect(!glz::write_yaml(value, buffer));
+      root reread{};
+      auto rec = glz::read_yaml(reread, buffer);
+      expect(!rec) << glz::format_error(rec, buffer);
+      expect(reread.branches.has_value());
+      if (reread.branches && reread.branches->at("first").leaves) {
+         expect(reread.branches->size() == 2u);
+         expect(reread.branches->at("first").leaves->size() == 2u);
+      }
+   };
+
+   "optional_map_member_null_and_flow_still_read"_test = [] {
+      using namespace nullable_block_mapping;
+      {
+         optional_map_obj obj{};
+         expect(!glz::read_yaml(obj, std::string{"m: null\nafter: 7\n"}));
+         expect(!obj.m.has_value());
+         expect(obj.after == 7);
+      }
+      {
+         optional_map_obj obj{};
+         expect(!glz::read_yaml(obj, std::string{"m: {a: 1, b: 2}\nafter: 7\n"}));
+         expect(obj.m.has_value());
+         if (obj.m) expect(obj.m->size() == 2u);
+         expect(obj.after == 7);
+      }
+   };
+};
+
+// ============================================================
+// The speculative null probe in the nullable reader
+// ============================================================
+
+// Reading a nullable first probes for a plain "null"/"~"/empty scalar. The probe only
+// settles the node when the token it read really is this node's scalar -- a token
+// followed by ": " is a mapping key, and an empty token in block context can mean the
+// node's content simply starts on a later line. Getting either wrong silently nulls a
+// node that has data in it, so these pin a nullable to the same result as its
+// non-nullable counterpart.
+namespace nullable_null_probe
+{
+   struct anchored_optional
+   {
+      std::optional<std::map<std::string, int>> src{};
+      std::optional<std::map<std::string, int>> dst{};
+   };
+
+   struct anchored_plain
+   {
+      std::map<std::string, int> src{};
+      std::map<std::string, int> dst{};
+   };
+
+   struct optional_map_holder
+   {
+      std::optional<std::map<std::string, int>> m{};
+      int after{};
+   };
+}
+
+suite yaml_nullable_null_probe_tests = [] {
+   "null_looking_first_key_is_a_mapping_key_not_a_null_node"_test = [] {
+      using namespace nullable_null_probe;
+      for (const auto& key : {"null", "Null", "NULL", "~"}) {
+         const std::string yaml = "m:\n  " + std::string{key} + ": 1\n  b: 2\nafter: 7\n";
+         optional_map_holder obj{};
+         auto ec = glz::read_yaml(obj, yaml);
+         expect(!ec) << key << ": " << glz::format_error(ec, yaml);
+         expect(obj.m.has_value()) << key;
+         if (obj.m) {
+            expect(obj.m->size() == 2u) << key;
+            expect(obj.m->at(key) == 1) << key;
+            expect(obj.m->at("b") == 2) << key;
+         }
+         expect(obj.after == 7) << key;
+      }
+   };
+
+   "null_looking_key_at_document_root_reads_as_a_mapping"_test = [] {
+      const std::string yaml = "null: 1\nb: 2\n";
+      std::optional<std::map<std::string, int>> opt{};
+      auto ec = glz::read_yaml(opt, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(opt.has_value());
+      if (opt) {
+         expect(opt->size() == 2u);
+         expect(opt->at("null") == 1);
+      }
+
+      // The nullable must agree with the plain map on the same document.
+      std::map<std::string, int> plain{};
+      expect(!glz::read_yaml(plain, yaml));
+      expect(opt.has_value() && *opt == plain);
+   };
+
+   // A null value keyed under a null-looking key is still null: the guard keys off
+   // the ": " that follows the token, not off the token itself.
+   "null_value_under_a_null_looking_key_stays_null"_test = [] {
+      std::map<std::string, std::optional<int>> m{};
+      const std::string yaml = "null: null\nb: 2\n";
+      auto ec = glz::read_yaml(m, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(m.size() == 2u);
+      expect(!m.at("null").has_value());
+      expect(m.at("b").has_value());
+      if (m.at("b")) expect(*m.at("b") == 2);
+   };
+
+   // An anchor on a block node records a span beginning at the line break after the
+   // anchor name, so replaying it hands the nullable reader an empty leading scalar.
+   "alias_to_a_block_node_fills_a_nullable"_test = [] {
+      using namespace nullable_null_probe;
+      const std::string yaml = "src: &a\n  a: 1\n  b: 2\ndst: *a\n";
+
+      anchored_optional opt{};
+      auto ec = glz::read_yaml(opt, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(opt.dst.has_value());
+      if (opt.dst) {
+         expect(opt.dst->size() == 2u);
+         expect(opt.dst->at("a") == 1);
+         expect(opt.dst->at("b") == 2);
+      }
+
+      anchored_plain plain{};
+      expect(!glz::read_yaml(plain, yaml));
+      expect(opt.src.has_value() && *opt.src == plain.src);
+      expect(opt.dst.has_value() && *opt.dst == plain.dst);
+   };
+
+   "alias_to_a_flow_node_still_fills_a_nullable"_test = [] {
+      using namespace nullable_null_probe;
+      anchored_optional opt{};
+      const std::string yaml = "src: &a {a: 1, b: 2}\ndst: *a\n";
+      auto ec = glz::read_yaml(opt, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(opt.dst.has_value());
+      if (opt.dst) expect(opt.dst->size() == 2u);
+   };
+
+   // The guards must not start claiming genuinely empty nodes are non-null.
+   "genuinely_empty_nullable_nodes_are_still_null"_test = [] {
+      using namespace nullable_null_probe;
+      {
+         optional_map_holder obj{};
+         expect(!glz::read_yaml(obj, std::string{"m:\nafter: 7\n"}));
+         expect(!obj.m.has_value());
+         expect(obj.after == 7);
+      }
+      {
+         optional_map_holder obj{};
+         expect(!glz::read_yaml(obj, std::string{"m: ~\nafter: 7\n"}));
+         expect(!obj.m.has_value());
+         expect(obj.after == 7);
+      }
+      {
+         // An empty node inside a flow mapping is null even though it reads as an
+         // empty scalar -- the block-context guard must not reach it.
+         std::map<std::string, std::optional<int>> m{};
+         expect(!glz::read_yaml(m, std::string{"{a: , b: 2}"}));
+         expect(m.size() == 2u);
+         expect(!m.at("a").has_value());
+      }
+      {
+         std::optional<int> opt{42};
+         expect(!glz::read_yaml(opt, std::string{"null"}));
+         expect(!opt.has_value());
+      }
+   };
+};
+
+// ============================================================
+// Block values one column short of their siblings
+// ============================================================
+
+// A struct value reads the indent its parent pushed as its own key column, so the
+// parent must push the column of the value itself. Pushing one less left the struct
+// dedent check satisfied by a key one column short of its siblings, folding a
+// malformed entry in instead of rejecting it. Map and sequence values already
+// rejected the same shape, so this is what makes the three agree.
+namespace under_indented_block_value
+{
+   struct point
+   {
+      int x{};
+      int y{};
+   };
+}
+
+suite yaml_under_indented_block_value_tests = [] {
+   "under_indented_key_in_a_map_value_is_rejected"_test = [] {
+      using namespace under_indented_block_value;
+      std::map<std::string, point> m{};
+      expect(bool(glz::read_yaml(m, std::string{"first:\n  x: 1\n y: 2\n"})));
+
+      // A map value already rejected it; a struct value now agrees.
+      std::map<std::string, std::map<std::string, int>> nested{};
+      expect(bool(glz::read_yaml(nested, std::string{"first:\n  a: 1\n b: 2\n"})));
+   };
+
+   "under_indented_key_in_a_sequence_element_is_rejected"_test = [] {
+      using namespace under_indented_block_value;
+      std::vector<point> v{};
+      expect(bool(glz::read_yaml(v, std::string{"-\n  x: 1\n y: 2\n"})));
+
+      std::vector<std::map<std::string, int>> nested{};
+      expect(bool(glz::read_yaml(nested, std::string{"-\n  a: 1\n b: 2\n"})));
+   };
+
+   "under_indented_key_in_a_nullable_value_is_rejected"_test = [] {
+      using namespace under_indented_block_value;
+      std::map<std::string, std::optional<point>> m{};
+      expect(bool(glz::read_yaml(m, std::string{"first:\n  x: 1\n y: 2\n"})));
+   };
+
+   // Consistently indented block values must keep reading, at any column.
+   "consistently_indented_block_values_still_read"_test = [] {
+      using namespace under_indented_block_value;
+      {
+         std::map<std::string, point> m{};
+         const std::string yaml = "k:\n  x: 1\n  y: 2\nz:\n  x: 3\n";
+         auto ec = glz::read_yaml(m, yaml);
+         expect(!ec) << glz::format_error(ec, yaml);
+         expect(m.size() == 2u);
+         expect(m.at("k").y == 2);
+         expect(m.at("z").x == 3);
+      }
+      {
+         // One-space children are consistent, so they are valid.
+         std::map<std::string, point> m{};
+         const std::string yaml = "k:\n x: 1\n y: 2\n";
+         auto ec = glz::read_yaml(m, yaml);
+         expect(!ec) << glz::format_error(ec, yaml);
+         expect(m.at("k").x == 1);
+         expect(m.at("k").y == 2);
+      }
+      {
+         std::vector<point> v{};
+         const std::string yaml = "-\n  x: 1\n  y: 2\n-\n  x: 3\n";
+         auto ec = glz::read_yaml(v, yaml);
+         expect(!ec) << glz::format_error(ec, yaml);
+         expect(v.size() == 2u);
+         expect(v[0].y == 2);
+         expect(v[1].x == 3);
+      }
+      {
+         // Scalar and sequence values read the pushed indent as a baseline rather
+         // than a key column, so they must be unaffected.
+         std::map<std::string, std::string> m{};
+         const std::string yaml = "k:\n  hello\n  world\nz: end\n";
+         auto ec = glz::read_yaml(m, yaml);
+         expect(!ec) << glz::format_error(ec, yaml);
+         expect(m.at("k") == "hello world");
+         expect(m.at("z") == "end");
+      }
+      {
+         std::map<std::string, std::vector<int>> m{};
+         const std::string yaml = "k:\n  - 1\n  - 2\nz:\n- 3\n";
+         auto ec = glz::read_yaml(m, yaml);
+         expect(!ec) << glz::format_error(ec, yaml);
+         expect(m.at("k") == std::vector{1, 2});
+         expect(m.at("z") == std::vector{3});
+      }
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
Fixes #2768, plus two related defects found while verifying that fix.

## 1. Nullable wrappers were not transparent when choosing a block value's indent

Fixes #2768.

When a struct member's value is a block node on the following lines, the parent pushes an indent for the value to judge itself against. Which column it must push depends on how the value type reads a block mapping:

- **Maps and variants** run `parse_block_mapping_loop` in discover mode: they find their own key column and treat the pushed indent as a strict parent, so the parent must push the column *outside* the value (`nested_indent - 1`).
- **Structs** are handed their key column directly (`from<YAML, T>` for objects passes `ctx.current_indent()` straight into `parse_block_mapping`), so the parent pushes `nested_indent`.

The type test unwrapped `glaze_value_t` but not nullable wrappers, so `std::optional<std::map<...>>` was classified as struct-like and pushed one column too deep. The map then saw `parent_indent == its own key column` and terminated after the first entry; the enclosing struct resumed on the sibling and reported `unknown_key`.

The issue reports this as an error, but it also **silently truncated data** in three shapes:

| member type + input | before | after |
|---|---|---|
| `optional<map>`, `error_on_unknown_keys = false` | `{"m":{"a":1},"after":7}` | `{"m":{"a":1,"b":2},"after":7}` |
| `optional<glz::generic>`, block sequence | `{"m":[1],"after":0}` | `{"m":[1,2],"after":7}` |
| `optional<variant<int,vector<int>>>`, block sequence | `{"m":[1],"after":0}` | `{"m":[1,2],"after":7}` |

Note the last two dropped the *following* member as well. Also affected: `unique_ptr<map>`, `shared_ptr<map>`, `optional<optional<map>>`, `optional<variant<..., map>>`, and an optional map inside a sequence element. `write_yaml` output failed to round-trip through `read_yaml`.

## 2. The nullable reader's null probe silently nulled non-null nodes

`from<YAML, T>` for `nullable_like` speculatively parses a plain scalar and accepts anything that looks null, without checking that the token is actually this node's scalar. Two ways that goes wrong:

- **A null-looking mapping key.** `null: 1` (also `~`, `Null`, `NULL`) is a mapping whose first key is that token, not the null scalar. `std::optional<std::map<std::string,int>>` reading `null: 1\nb: 2` returned `null` and discarded the document, while the plain `std::map` read it correctly. Only the first key was affected.
- **An empty probe standing in front of a block node.** A block node whose content begins on a following line reads as an empty scalar here, and `is_yaml_null("")` is true. This is exactly how an alias to a block node replays: `finalize_node_anchor` records the span starting at the line break after the anchor name, because the content's own indentation is part of the span. So `src: &a\n  a: 1\n  b: 2\ndst: *a` left `dst` null with no error whenever `dst` was `optional<map>` — the plain `map` and the flow-style anchor both worked.

The probe now runs on a copy of the iterator and only settles the node when the token really is a scalar of that node. In flow context an empty node is still null (conformance `C2DT`).

## 3. Block values one column short of their siblings were folded in

`parse_map_value` and the block-sequence element path pushed `nested_indent - 1` for *every* value type. Struct `mapping_indent` is only a lower bound — `parse_block_mapping_loop` dedents solely on `line_indent < mapping_indent` — so for valid input this was benign, but it accepted one class of malformed document: a struct key exactly one column under its siblings.

```yaml
first:
  x: 1
 y: 2        # column 1
```

`std::map<std::string, point>` returned `{"first":{"x":1,"y":2}}`, and `std::vector<point>` did the same for the `-\n  x: 1\n y: 2` shape. The equivalent struct-member shape and `map<string, map<string,int>>` both correctly errored, so the map and sequence readers were inconsistent with their own siblings. All three now agree.

Scalars and sequences read the pushed indent as an enclosing baseline rather than a key column, so their column is deliberately unchanged — flipping it would have moved multiline plain scalars and block scalars with no bug to justify the risk.

## Implementation

The single predicate is split in two, since the questions have different answers for scalars and sequences. Both unwrap `glaze_value_t` and nullable wrappers, which delegate the block parse to what they hold, unchanged:

- `discovers_own_block_mapping_indent<T>()` — maps and variants; parent pushes `nested_indent - 1`.
- `receives_block_mapping_column<T>()` — structs and reflectables; parent pushes `nested_indent`.

## Verification

- **Corpus replay**, 27,317 documents × 10 target types, this branch vs. `main`. `yaml_corpus`: zero output changes. The second corpus: 801 changed lines, all in the `optional<…>` columns, all going from silently-`null` to the correctly parsed document. The harness was first confirmed to detect each known repro.
- **Transparency invariant.** On the 23,273 tab-free documents, `std::optional<glz::generic>` diverged from bare `glz::generic` in **1,217** documents before and **1** after, with **zero** newly divergent. The remaining one is `---\r\r`, an empty document where optional's `null` is arguably more correct than `generic`'s error.
- **Targeted differential** over the map-value and sequence-element paths across every value-type family (plain/quoted multiline scalars, literal and folded block scalars, indented/indentless/flow sequences, objects, maps, variants, `glz::generic`, optionals, anchors): exactly the two intended rejections changed, nothing else.
- `yaml_test` 746 passed, `yaml_conformance` 402 passed, `yaml_conformance_struct` 105 passed.

## Tests

21 new tests across three suites. Each was confirmed to fail against `main` by compiling them in isolation against the pre-fix header. They include guards pinning behavior that must *not* change: genuinely empty nodes still null, flow-context empty still null, `null: null` still null, aliases to flow nodes still fill, consistently-indented block values at any column still read, and scalar/sequence folding untouched.
