### PR TITLE
Give every serializable Eigen type a stable glz::meta name

### DIFF
--- a/include/glaze/ext/eigen.hpp
+++ b/include/glaze/ext/eigen.hpp
@@ -343,8 +343,9 @@ namespace glz
       }
    };
 
-   template <typename Scalar, int Dim, int Mode>
-   struct from<JSON, Eigen::Transform<Scalar, Dim, Mode>>
+   // Options only selects alignment, so it affects neither the coefficient layout nor the size
+   template <typename Scalar, int Dim, int Mode, int Options>
+   struct from<JSON, Eigen::Transform<Scalar, Dim, Mode, Options>>
    {
       template <auto Opts>
       static void op(auto& value, is_context auto&& ctx, auto&& it, auto end)
@@ -355,8 +356,8 @@ namespace glz
       }
    };
 
-   template <typename Scalar, int Dim, int Mode>
-   struct to<JSON, Eigen::Transform<Scalar, Dim, Mode>>
+   template <typename Scalar, int Dim, int Mode, int Options>
+   struct to<JSON, Eigen::Transform<Scalar, Dim, Mode, Options>>
    {
       template <auto Opts>
       static void op(auto&& value, is_context auto&& ctx, auto&& b, auto& ix)
@@ -369,13 +370,179 @@ namespace glz
    };
 }
 
-template <class Scalar, int Rows, int Cols>
-struct glz::meta<Eigen::Matrix<Scalar, Rows, Cols>>
+namespace glz::detail
 {
-   static constexpr std::string_view name = join_v<chars<"Eigen::Matrix<">, name_v<Scalar>, chars<",">, //
-                                                   chars<num_to_string<Rows>::value>, chars<",">, //
-                                                   chars<num_to_string<Cols>::value>, chars<",">, //
-                                                   chars<">">>;
+   // Characters needed to spell n in decimal, counting a leading '-'.
+   // Negating through long long keeps the most negative int representable.
+   consteval size_t eigen_int_length(int n)
+   {
+      size_t count = (n < 0) ? 2 : 1;
+      for (long long magnitude = (n < 0) ? -static_cast<long long>(n) : n; magnitude >= 10; magnitude /= 10) {
+         ++count;
+      }
+      return count;
+   }
+
+   // Decimal spelling of an Eigen template parameter. glz::num_to_string only handles unsigned
+   // values, and Eigen::Dynamic is -1, so dynamic extents need a signed spelling.
+   template <int N>
+   inline constexpr auto eigen_int_chars = [] {
+      std::array<char, eigen_int_length(N) + 1> buffer{};
+      size_t i = buffer.size() - 1;
+      buffer[i] = '\0';
+      long long magnitude = (N < 0) ? -static_cast<long long>(N) : N;
+      do {
+         buffer[--i] = char('0' + (magnitude % 10));
+         magnitude /= 10;
+      } while (magnitude);
+      if constexpr (N < 0) {
+         buffer[--i] = '-';
+      }
+      return buffer;
+   }();
+
+   template <int N>
+   inline constexpr std::string_view eigen_int_v{eigen_int_chars<N>.data(), eigen_int_chars<N>.size() - 1};
+
+   // Eigen::Transform modes are a small closed set, so spell them the way a user writes them.
+   template <int Mode>
+   inline constexpr std::string_view eigen_transform_mode_v = [] {
+      if constexpr (Mode == Eigen::TransformTraits::Isometry) {
+         return std::string_view{"Eigen::Isometry"};
+      }
+      else if constexpr (Mode == Eigen::TransformTraits::Affine) {
+         return std::string_view{"Eigen::Affine"};
+      }
+      else if constexpr (Mode == Eigen::TransformTraits::AffineCompact) {
+         return std::string_view{"Eigen::AffineCompact"};
+      }
+      else if constexpr (Mode == Eigen::TransformTraits::Projective) {
+         return std::string_view{"Eigen::Projective"};
+      }
+      else {
+         return eigen_int_v<Mode>;
+      }
+   }();
+}
+
+// Names for the Eigen types this extension serializes: Matrix, Array, Transform, and the Map and Ref
+// views (with the stride types that appear inside their names). Without a name, glz::name_v falls
+// back to a compiler-specific spelling, so JSON schema $defs keys (and glz::api type hashes) differ
+// between compilers for the same type. Each name mirrors how the type is written in C++: the
+// trailing template parameters are elided when they are Eigen's defaults, and written out in full
+// otherwise so that distinct types never share a name.
+
+template <class Scalar, int Rows, int Cols, int Options, int MaxRows, int MaxCols>
+struct glz::meta<Eigen::Matrix<Scalar, Rows, Cols, Options, MaxRows, MaxCols>>
+{
+   static constexpr std::string_view name = [] {
+      if constexpr (std::same_as<Eigen::Matrix<Scalar, Rows, Cols, Options, MaxRows, MaxCols>,
+                                 Eigen::Matrix<Scalar, Rows, Cols>>) {
+         return join_v<chars<"Eigen::Matrix<">, name_v<Scalar>, chars<",">, //
+                       detail::eigen_int_v<Rows>, chars<",">, //
+                       detail::eigen_int_v<Cols>, chars<">">>;
+      }
+      else {
+         return join_v<chars<"Eigen::Matrix<">, name_v<Scalar>, chars<",">, //
+                       detail::eigen_int_v<Rows>, chars<",">, //
+                       detail::eigen_int_v<Cols>, chars<",">, //
+                       detail::eigen_int_v<Options>, chars<",">, //
+                       detail::eigen_int_v<MaxRows>, chars<",">, //
+                       detail::eigen_int_v<MaxCols>, chars<">">>;
+      }
+   }();
+};
+
+template <class Scalar, int Rows, int Cols, int Options, int MaxRows, int MaxCols>
+struct glz::meta<Eigen::Array<Scalar, Rows, Cols, Options, MaxRows, MaxCols>>
+{
+   static constexpr std::string_view name = [] {
+      if constexpr (std::same_as<Eigen::Array<Scalar, Rows, Cols, Options, MaxRows, MaxCols>,
+                                 Eigen::Array<Scalar, Rows, Cols>>) {
+         return join_v<chars<"Eigen::Array<">, name_v<Scalar>, chars<",">, //
+                       detail::eigen_int_v<Rows>, chars<",">, //
+                       detail::eigen_int_v<Cols>, chars<">">>;
+      }
+      else {
+         return join_v<chars<"Eigen::Array<">, name_v<Scalar>, chars<",">, //
+                       detail::eigen_int_v<Rows>, chars<",">, //
+                       detail::eigen_int_v<Cols>, chars<",">, //
+                       detail::eigen_int_v<Options>, chars<",">, //
+                       detail::eigen_int_v<MaxRows>, chars<",">, //
+                       detail::eigen_int_v<MaxCols>, chars<">">>;
+      }
+   }();
+};
+
+template <class Scalar, int Dim, int Mode, int Options>
+struct glz::meta<Eigen::Transform<Scalar, Dim, Mode, Options>>
+{
+   static constexpr std::string_view name = [] {
+      if constexpr (std::same_as<Eigen::Transform<Scalar, Dim, Mode, Options>, Eigen::Transform<Scalar, Dim, Mode>>) {
+         return join_v<chars<"Eigen::Transform<">, name_v<Scalar>, chars<",">, //
+                       detail::eigen_int_v<Dim>, chars<",">, //
+                       detail::eigen_transform_mode_v<Mode>, chars<">">>;
+      }
+      else {
+         return join_v<chars<"Eigen::Transform<">, name_v<Scalar>, chars<",">, //
+                       detail::eigen_int_v<Dim>, chars<",">, //
+                       detail::eigen_transform_mode_v<Mode>, chars<",">, //
+                       detail::eigen_int_v<Options>, chars<">">>;
+      }
+   }();
+};
+
+// Eigen::InnerStride and Eigen::OuterStride derive from Eigen::Stride rather than aliasing it,
+// so each needs its own name. They only appear within an Eigen::Ref name.
+template <int Outer, int Inner>
+struct glz::meta<Eigen::Stride<Outer, Inner>>
+{
+   static constexpr std::string_view name = join_v<chars<"Eigen::Stride<">, detail::eigen_int_v<Outer>, chars<",">, //
+                                                   detail::eigen_int_v<Inner>, chars<">">>;
+};
+
+template <int Value>
+struct glz::meta<Eigen::InnerStride<Value>>
+{
+   static constexpr std::string_view name =
+      join_v<chars<"Eigen::InnerStride<">, detail::eigen_int_v<Value>, chars<">">>;
+};
+
+template <int Value>
+struct glz::meta<Eigen::OuterStride<Value>>
+{
+   static constexpr std::string_view name =
+      join_v<chars<"Eigen::OuterStride<">, detail::eigen_int_v<Value>, chars<">">>;
+};
+
+template <class PlainObjectType, int MapOptions, class StrideType>
+struct glz::meta<Eigen::Map<PlainObjectType, MapOptions, StrideType>>
+{
+   static constexpr std::string_view name = [] {
+      if constexpr (std::same_as<Eigen::Map<PlainObjectType, MapOptions, StrideType>, Eigen::Map<PlainObjectType>>) {
+         return join_v<chars<"Eigen::Map<">, name_v<PlainObjectType>, chars<">">>;
+      }
+      else {
+         return join_v<chars<"Eigen::Map<">, name_v<PlainObjectType>, chars<",">, //
+                       detail::eigen_int_v<MapOptions>, chars<",">, //
+                       name_v<StrideType>, chars<">">>;
+      }
+   }();
+};
+
+template <class PlainObjectType, int Options, class StrideType>
+struct glz::meta<Eigen::Ref<PlainObjectType, Options, StrideType>>
+{
+   static constexpr std::string_view name = [] {
+      if constexpr (std::same_as<Eigen::Ref<PlainObjectType, Options, StrideType>, Eigen::Ref<PlainObjectType>>) {
+         return join_v<chars<"Eigen::Ref<">, name_v<PlainObjectType>, chars<">">>;
+      }
+      else {
+         return join_v<chars<"Eigen::Ref<">, name_v<PlainObjectType>, chars<",">, //
+                       detail::eigen_int_v<Options>, chars<",">, //
+                       name_v<StrideType>, chars<">">>;
+      }
+   }();
 };
 
 // Register Eigen types as having specified Glaze serialization
@@ -384,8 +551,16 @@ template <typename Scalar, int Rows, int Cols, int Options, int MaxRows, int Max
 struct glz::specified<Eigen::Matrix<Scalar, Rows, Cols, Options, MaxRows, MaxCols>> : std::true_type
 {};
 
-template <typename Scalar, int Dim, int Mode>
-struct glz::specified<Eigen::Transform<Scalar, Dim, Mode>> : std::true_type
+template <typename Scalar, int Rows, int Cols, int Options, int MaxRows, int MaxCols>
+struct glz::specified<Eigen::Array<Scalar, Rows, Cols, Options, MaxRows, MaxCols>> : std::true_type
+{};
+
+template <typename Scalar, int Dim, int Mode, int Options>
+struct glz::specified<Eigen::Transform<Scalar, Dim, Mode, Options>> : std::true_type
+{};
+
+template <typename PlainObjectType, int MapOptions, typename StrideType>
+struct glz::specified<Eigen::Map<PlainObjectType, MapOptions, StrideType>> : std::true_type
 {};
 
 template <typename PlainObjectType, int Options, typename StrideType>

--- a/tests/eigen_test/eigen_test.cpp
+++ b/tests/eigen_test/eigen_test.cpp
@@ -17,6 +17,7 @@
 #include "glaze/json/json_ptr.hpp"
 #include "glaze/json/ptr.hpp"
 #include "glaze/json/read.hpp"
+#include "glaze/json/schema.hpp"
 #include "glaze/json/write.hpp"
 #include "ut/ut.hpp"
 
@@ -248,6 +249,123 @@ suite additional_eigen_tests = [] {
       Eigen::Matrix<double, 3, 3, Eigen::RowMajor> expected;
       expected << 9, 8, 7, 6, 5, 4, 3, 2, 1;
       expect(m == expected);
+   };
+};
+
+// Every Eigen type Glaze serializes needs a glz::meta name. Without one, glz::name_v falls back to a
+// compiler-specific spelling and JSON schema $defs keys differ between compilers for the same type.
+struct schema_holder
+{
+   Eigen::Matrix3d m{};
+   Eigen::MatrixXd dynamic{};
+   Eigen::Isometry3d pose{};
+   Eigen::ArrayXXd array{};
+};
+
+suite eigen_type_names = [] {
+   "matrix names"_test = [] {
+      static_assert(glz::name_v<Eigen::Matrix3d> == "Eigen::Matrix<double,3,3>");
+      static_assert(glz::name_v<Eigen::Vector3d> == "Eigen::Matrix<double,3,1>");
+      static_assert(glz::name_v<Eigen::RowVector3d> == "Eigen::Matrix<double,1,3>");
+      // float, not int: name_v<int> is "int32_t" only when glaze/api/type_support.hpp is in the TU
+      static_assert(glz::name_v<Eigen::Matrix<float, 100, 250>> == "Eigen::Matrix<float,100,250>");
+      // Eigen::Dynamic is -1, which an unsigned spelling cannot represent
+      static_assert(glz::name_v<Eigen::MatrixXd> == "Eigen::Matrix<double,-1,-1>");
+      static_assert(glz::name_v<Eigen::VectorXf> == "Eigen::Matrix<float,-1,1>");
+      // Non-default storage order and maximum extents are distinct types, so they get distinct names
+      static_assert(glz::name_v<Eigen::Matrix<double, 3, 3, Eigen::RowMajor>> == "Eigen::Matrix<double,3,3,1,3,3>");
+      static_assert(glz::name_v<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, 4, 4>> ==
+                    "Eigen::Matrix<double,-1,-1,0,4,4>");
+      static_assert(glz::name_v<Eigen::Matrix3d> != glz::name_v<Eigen::Matrix<double, 3, 3, Eigen::RowMajor>>);
+   };
+
+   "array names"_test = [] {
+      static_assert(glz::name_v<Eigen::Array3d> == "Eigen::Array<double,3,1>");
+      static_assert(glz::name_v<Eigen::ArrayXXf> == "Eigen::Array<float,-1,-1>");
+      static_assert(glz::name_v<Eigen::Array<double, 2, 2, Eigen::RowMajor>> == "Eigen::Array<double,2,2,1,2,2>");
+      static_assert(glz::name_v<Eigen::Array3d> != glz::name_v<Eigen::Vector3d>);
+      // Keeps P2996 reflection from serializing an Array as an object of its members
+      static_assert(glz::is_specified<Eigen::Array3d>);
+      static_assert(glz::is_specified<Eigen::ArrayXXd>);
+   };
+
+   "array round trip"_test = [] {
+      Eigen::Array3d a{1, 2, 3};
+      std::string json;
+      expect(not glz::write_json(a, json));
+      expect(json == "[1,2,3]") << json;
+      Eigen::Array3d parsed{};
+      expect(not glz::read_json(parsed, json));
+      expect((a == parsed).all());
+
+      Eigen::ArrayXXd dynamic(2, 2);
+      dynamic << 1, 2, 3, 4;
+      expect(not glz::write_json(dynamic, json));
+      expect(json == "[[2,2],[1,3,2,4]]") << json;
+      Eigen::ArrayXXd dynamic_parsed;
+      expect(not glz::read_json(dynamic_parsed, json));
+      expect((dynamic == dynamic_parsed).all());
+   };
+
+   "transform names"_test = [] {
+      static_assert(glz::name_v<Eigen::Isometry3d> == "Eigen::Transform<double,3,Eigen::Isometry>");
+      static_assert(glz::name_v<Eigen::Affine3d> == "Eigen::Transform<double,3,Eigen::Affine>");
+      static_assert(glz::name_v<Eigen::AffineCompact2d> == "Eigen::Transform<double,2,Eigen::AffineCompact>");
+      static_assert(glz::name_v<Eigen::Projective3f> == "Eigen::Transform<float,3,Eigen::Projective>");
+      static_assert(glz::name_v<Eigen::Transform<float, 3, Eigen::Affine, Eigen::DontAlign>> ==
+                    "Eigen::Transform<float,3,Eigen::Affine,2>");
+   };
+
+   // Options only selects alignment, so a DontAlign transform serializes like any other
+   "transform alignment round trip"_test = [] {
+      Eigen::Transform<double, 3, Eigen::Isometry, Eigen::DontAlign> pose;
+      pose.setIdentity();
+      pose.translation() << 1.0, 2.0, 3.0;
+      std::string json;
+      expect(not glz::write_json(pose, json));
+      expect(json == "[1,0,0,0,0,1,0,0,0,0,1,0,1,2,3,1]") << json;
+
+      Eigen::Transform<double, 3, Eigen::Isometry, Eigen::DontAlign> parsed;
+      expect(not glz::read_json(parsed, json));
+      expect(pose.matrix() == parsed.matrix());
+   };
+
+   "map and ref names"_test = [] {
+      static_assert(glz::name_v<Eigen::Map<Eigen::MatrixXd>> == "Eigen::Map<Eigen::Matrix<double,-1,-1>>");
+      static_assert(glz::name_v<Eigen::Map<const Eigen::Vector3d>> == "Eigen::Map<const Eigen::Matrix<double,3,1>>");
+      static_assert(glz::name_v<Eigen::Ref<Eigen::Matrix3d>> == "Eigen::Ref<Eigen::Matrix<double,3,3>>");
+      static_assert(glz::name_v<Eigen::Ref<const Eigen::VectorXd>> == "Eigen::Ref<const Eigen::Matrix<double,-1,1>>");
+      static_assert(glz::name_v<Eigen::Ref<Eigen::MatrixXd, 0, Eigen::Stride<8, 2>>> ==
+                    "Eigen::Ref<Eigen::Matrix<double,-1,-1>,0,Eigen::Stride<8,2>>");
+      static_assert(glz::name_v<Eigen::Ref<Eigen::VectorXd, 0, Eigen::InnerStride<2>>> ==
+                    "Eigen::Ref<Eigen::Matrix<double,-1,1>,0,Eigen::InnerStride<2>>");
+      // OuterStride is the default stride for a Ref over a matrix, so it only surfaces in a full form
+      static_assert(glz::name_v<Eigen::OuterStride<>> == "Eigen::OuterStride<-1>");
+      static_assert(glz::name_v<Eigen::Ref<Eigen::MatrixXd, Eigen::Aligned16>> ==
+                    "Eigen::Ref<Eigen::Matrix<double,-1,-1>,16,Eigen::OuterStride<-1>>");
+   };
+
+   "map round trip"_test = [] {
+      std::array<double, 4> storage{1, 2, 3, 4};
+      Eigen::Map<Eigen::Matrix2d> m(storage.data());
+      std::string json;
+      expect(not glz::write_json(m, json));
+      expect(json == "[1,2,3,4]") << json;
+
+      Eigen::Matrix2d parsed;
+      expect(not glz::read_json(parsed, json));
+      expect(m == parsed);
+   };
+
+   "schema definitions use stable names"_test = [] {
+      const auto schema = glz::write_json_schema<schema_holder>().value();
+      expect(schema.find(R"("#/$defs/Eigen::Matrix<double,3,3>")") != std::string::npos) << schema;
+      expect(schema.find(R"("#/$defs/Eigen::Matrix<double,-1,-1>")") != std::string::npos) << schema;
+      expect(schema.find(R"("#/$defs/Eigen::Transform<double,3,Eigen::Isometry>")") != std::string::npos) << schema;
+      expect(schema.find(R"("#/$defs/Eigen::Array<double,-1,-1>")") != std::string::npos) << schema;
+      // A compiler-derived name would carry spaces after the commas
+      expect(schema.find("Eigen::Matrix<double, ") == std::string::npos) << schema;
+      expect(schema.find("Eigen::Transform<double, ") == std::string::npos) << schema;
    };
 };
 


### PR DESCRIPTION
Resolves #2765.

The Eigen extension named only `Eigen::Matrix`, and that one specialization was itself broken.

## What was wrong

| Type | Before | After |
|---|---|---|
| `Eigen::Matrix3d` | `Eigen::Matrix<double,3,3,` (stray trailing comma) | `Eigen::Matrix<double,3,3>` |
| `Eigen::MatrixXd` | **hard compile error** | `Eigen::Matrix<double,-1,-1>` |
| `Matrix<double,3,3,RowMajor>` | `Eigen::Matrix<double, 3, 3, 1>` (compiler string) | `Eigen::Matrix<double,3,3,1,3,3>` |
| `Eigen::Isometry3d` | `Eigen::Transform<double, 3, 1>` (compiler string) | `Eigen::Transform<double,3,Eigen::Isometry>` |
| `Eigen::ArrayXXf` | `Eigen::Array<float, -1, -1>` (compiler string) | `Eigen::Array<float,-1,-1>` |

The `MatrixXd` row is the sharpest: `num_to_string` takes `unsigned` and `Eigen::Dynamic` is `-1`, so `glz::name_v<Eigen::MatrixXd>` was a narrowing error. Generating a JSON schema for any struct holding a dynamically sized Eigen matrix simply did not compile.

The row-major row shows the 3-parameter specialization never matched a non-default `Options`, so even `Matrix` reached the compiler-derived `type_name` in that case. Compiler strings are unstable across compilers, versions, and standard libraries, which is what makes schema `$defs` keys move.

## What this does

Names `Matrix`, `Array`, `Transform`, `Map`, and `Ref`, plus the `Stride`/`InnerStride`/`OuterStride` types that appear inside a `Ref` name. Each name mirrors the C++ spelling: trailing template parameters are elided when they are Eigen's defaults and written out in full otherwise, so distinct types can never share a name. A `same_as<T, T-spelled-with-defaults>` check decides, so no Eigen internals are duplicated. `Transform` modes read as `Eigen::Isometry`, `Eigen::Affine`, `Eigen::AffineCompact`, `Eigen::Projective`.

Two supporting changes:

- The JSON `Transform` serializers are widened to their `Options` parameter, which selects alignment and affects neither `.data()` layout nor size. Without this, a `DontAlign` transform would have a name but no serializer.
- `Eigen::Array` and `Eigen::Map` are registered with `glz::specified`, so P2996 reflection does not serialize them as objects of their members. `Array` was missing this entirely.

## Verification

64 tests / 200 asserts pass under Apple Clang and GCC 15, against Eigen 3.4.0 (what CI fetches) and 5.0.1. Both compilers produce byte-identical names.

- The new assertions were checked against the old header: every `static_assert` fires and the schema test fails with the old keys, so they are not vacuous.
- A sweep of 2832 type registrations produced 1120 distinct names with zero collisions, comparing `glz::name_v<T>` against `typeid`.
- Serialization output was diffed between the old and new headers across JSON and BEVE for matrices, arrays, transforms and a reflected struct containing them: identical. A name-only `meta` has no `::value`, so it does not satisfy `glaze_t` and changes no dispatch.
- An `-H` include trace confirms nothing pulls in `<Eigen/Geometry>`; everything referenced is reachable from `<Eigen/Core>` alone.

## Breaking change

Name strings feed JSON schema `$defs` keys, variant tag ids (`ids_v` defaults to `name_v`), and `glz::api` cross-library type hashes. All three change for Eigen types:

- Checked-in schema golden files with Eigen members will need regenerating.
- A `glz::meta::tag`-ed variant over Eigen alternatives emits new tags, so previously persisted JSON will not read back.
- A shared library built with the old header and a consumer built with the new one will report a type mismatch; both sides must be rebuilt.

These names were already compiler-dependent, so cross-compiler consumers were broken beforehand. This converts a silent mismatch into a one-time rebuild.

## Known gaps, not addressed here

- **`std::complex` scalars still fall back to the compiler spelling**, so `Eigen::MatrixXcd` is `Eigen::Matrix<std::complex<double>,-1,-1>` only by the good graces of libstdc++ and libc++. Fixing it means adding `meta<std::complex<T>>::name` in core, which pulls `<complex>` into a core header.
- **Scalar names are TU-dependent**: `name_v<int>` is `"int"` or `"int32_t"` depending on whether `glaze/api/type_support.hpp` is in the translation unit, so two TUs can disagree on the same type's name. This is library-wide rather than Eigen-specific (`meta<std::vector<T>>`, `meta<std::array<T,N>>` and `meta<std::optional<T>>` embed `name_v<T>` the same way) and wants a deliberate fix in core.
- **A strided `Eigen::Ref` serializes the wrong data.** A `Ref` over `big.topLeftCorner(2,2)` whose view is `[0,4,1,5]` writes `[[2,2],[0,1,2,3]]`, because the writers use `value.data()` and `value.size()` and ignore the stride. Silent corruption, unrelated to naming, and worth its own issue.
- **Eigen types still have no real JSON schema**; they generate the permissive any-type. Fixed-size matrices serialize as a flat array of N scalars and dynamic ones as `[[rows,cols],[data]]`, both of which are describable.
