### PR TITLE
Fix tests with OpenSSL 4, backwards compatible with OpenSSL 3

### DIFF
--- a/tests/networking_tests/http_client_ssl_test/http_client_ssl_test.cpp
+++ b/tests/networking_tests/http_client_ssl_test/http_client_ssl_test.cpp
@@ -136,7 +136,7 @@ class CertificateGenerator
       X509_gmtime_adj(X509_get_notAfter(x509), static_cast<long>(days) * 24 * 60 * 60);
       X509_set_pubkey(x509, pkey);
 
-      X509_NAME* name = X509_get_subject_name(x509);
+      X509_NAME* name = X509_NAME_new();
       X509_NAME_add_entry_by_txt(name, "C", MBSTRING_ASC, reinterpret_cast<const unsigned char*>("US"), -1, -1, 0);
       X509_NAME_add_entry_by_txt(name, "ST", MBSTRING_ASC, reinterpret_cast<const unsigned char*>("Test"), -1, -1, 0);
       X509_NAME_add_entry_by_txt(name, "L", MBSTRING_ASC, reinterpret_cast<const unsigned char*>("Test"), -1, -1, 0);
@@ -144,7 +144,9 @@ class CertificateGenerator
       X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, reinterpret_cast<const unsigned char*>(subject.c_str()), -1,
                                  -1, 0);
 
+      X509_set_subject_name(x509, name);
       X509_set_issuer_name(x509, name);
+      X509_NAME_free(name);
 
       if (subject == "localhost") {
          X509V3_CTX ctx;

--- a/tests/networking_tests/https_test/https_test.cpp
+++ b/tests/networking_tests/https_test/https_test.cpp
@@ -98,7 +98,7 @@ class CertificateGenerator
       X509_set_pubkey(x509, pkey);
 
       // Set subject name
-      X509_NAME* name = X509_get_subject_name(x509);
+      X509_NAME* name = X509_NAME_new();
       X509_NAME_add_entry_by_txt(name, "C", MBSTRING_ASC, reinterpret_cast<const unsigned char*>("US"), -1, -1, 0);
       X509_NAME_add_entry_by_txt(name, "ST", MBSTRING_ASC, reinterpret_cast<const unsigned char*>("Test"), -1, -1, 0);
       X509_NAME_add_entry_by_txt(name, "L", MBSTRING_ASC, reinterpret_cast<const unsigned char*>("Test"), -1, -1, 0);
@@ -106,8 +106,10 @@ class CertificateGenerator
       X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, reinterpret_cast<const unsigned char*>(subject.c_str()), -1,
                                  -1, 0);
 
+      X509_set_subject_name(x509, name);
       // Set issuer name (same as subject for self-signed)
       X509_set_issuer_name(x509, name);
+      X509_NAME_free(name);
 
       // Add extensions for server certificate
       if (subject == "localhost") {

--- a/tests/networking_tests/websocket_test/wss_test.cpp
+++ b/tests/networking_tests/websocket_test/wss_test.cpp
@@ -80,10 +80,12 @@ namespace
       X509_gmtime_adj(X509_get_notAfter(x509), static_cast<long>(days) * 24 * 60 * 60);
       X509_set_pubkey(x509, pkey);
 
-      X509_NAME* name = X509_get_subject_name(x509);
+      X509_NAME* name = X509_NAME_new();
       X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, reinterpret_cast<const unsigned char*>("localhost"), -1, -1,
                                  0);
+      X509_set_subject_name(x509, name);
       X509_set_issuer_name(x509, name);
+      X509_NAME_free(name);
 
       // Add SAN extension
       X509V3_CTX ctx;


### PR DESCRIPTION
Fix tests with OpenSSL 4, backwards compatible with OpenSSL 3

Ubuntu bug: https://bugs.launchpad.net/ubuntu/+source/glaze/+bug/2162954