### PR TITLE
fix reversed-range inner_template in stencil section reader

### DIFF
--- a/include/glaze/stencil/stencil.hpp
+++ b/include/glaze/stencil/stencil.hpp
@@ -130,9 +130,14 @@ namespace glz
                         return {size_t(it - outer_start), ctx.error, "Closing tag not found for section"};
                      }
 
-                     if (it + 1 < end) {
-                        it += 2; // Skip '}}'
+                     // The opening tag must close with '}}' before the section body. Without this
+                     // check a tag left open (e.g. "{{#key {{/key}}") advances past closing_pos and
+                     // std::string_view(it, closing_pos) becomes a reversed range of length (size_t)-2.
+                     if (it + 1 >= end || *it != '}' || *(it + 1) != '}') [[unlikely]] {
+                        ctx.error = error_code::syntax_error;
+                        return {size_t(it - outer_start), ctx.error, "Expected '}}' to close section tag"};
                      }
+                     it += 2; // Skip '}}'
 
                      // Extract inner template between current position and closing tag
                      std::string_view inner_template(it, closing_pos);

--- a/tests/stencil/stencil_test.cpp
+++ b/tests/stencil/stencil_test.cpp
@@ -166,6 +166,16 @@ suite stencil_tests = [] {
       expect(result.error() == glz::error_code::unexpected_end);
    };
 
+   "section_opening_tag_not_closed"_test = [] {
+      // The opening tag "{{#employed " is never closed by "}}"; the closing tag follows directly.
+      std::string_view layout = R"({{#employed {{/employed}})";
+
+      person p{"Alice", "Johnson", 28, false, true}; // employed is true
+      auto result = glz::stencil(layout, p);
+      expect(not result.has_value());
+      expect(result.error() == glz::error_code::syntax_error);
+   };
+
    // **Inverted Section Tests**
 
    "inverted_section_true"_test = [] {
@@ -238,6 +248,16 @@ suite stencil_tests = [] {
       auto result = glz::stencil(layout, p);
       expect(not result.has_value());
       expect(result.error() == glz::error_code::unexpected_end);
+   };
+
+   "inverted_section_opening_tag_not_closed"_test = [] {
+      // The opening tag "{{^hungry " is never closed by "}}"; the closing tag follows directly.
+      std::string_view layout = R"({{^hungry {{/hungry}})";
+
+      person p{"Henry", "Foster", 34, false}; // hungry is false, so the inverted body would render
+      auto result = glz::stencil(layout, p);
+      expect(not result.has_value());
+      expect(result.error() == glz::error_code::syntax_error);
    };
 };
 


### PR DESCRIPTION
libc++ hardening, template `{{#employed {{/employed}}`:

    string_view:341: libc++ Hardening assertion (__end - __begin) >= 0 failed: std::string_view::string_view(iterator, sentinel) received invalid range

`stencil()`/`mustache()` find a section's `{{/key}}` with `std::search`, then skip the opening tag's `}}` with an unconditional `it += 2`. When the opening tag is never closed by `}}` (the body starts right after the key), `it` is already sitting on the closing tag, so `std::search` returns `closing_pos == it` and the skip moves `it` two bytes past `closing_pos`. `std::string_view inner_template(it, closing_pos)` then stores `closing_pos - it` as its length, a reversed range of `(size_t)-2`, and the recursive `stencil(inner_template, ...)` computes `end = data + size` (UBSan `pointer-overflow` in core/read.hpp; abort under libc++ hardening as above).

Before: a section whose opening tag is not closed by `}}` builds a `(size_t)-2`-length view and recurses on it. Under a hardened standard library that aborts; otherwise the pointer wraps and the section body is silently dropped.

After: the reader requires `}}` to close the section opening tag and returns `syntax_error` when it is missing, the same shape as the "closing tag not found" rejection a few lines above.

Tradeoff: a section tag carrying trailing non-`}}` content (never valid mustache) now errors instead of emitting truncated output. The template is untrusted input to these APIs, so the reader is the layer that has to reject it. This is `stencil.hpp`, separate from the earlier `stencilcount.hpp` end-guard work. Tests cover the `{{#…` and `{{^…` forms.
