### PR TITLE
quote integer map keys in cbor_to_json

### DIFF
--- a/include/glaze/cbor/cbor_to_json.hpp
+++ b/include/glaze/cbor/cbor_to_json.hpp
@@ -78,6 +78,9 @@ namespace glz
       }
 
       template <auto Opts, class Buffer>
+      inline void cbor_to_json_key(auto&& ctx, auto&& it, auto&& end, Buffer& out, auto&& ix, uint32_t recursive_depth);
+
+      template <auto Opts, class Buffer>
       inline void cbor_to_json_value(auto&& ctx, auto&& it, auto&& end, Buffer& out, auto&& ix,
                                      uint32_t recursive_depth)
       {
@@ -344,7 +347,7 @@ namespace glz
                   first = false;
 
                   // Key (must be string for JSON compatibility)
-                  cbor_to_json_value<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
+                  cbor_to_json_key<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
                   if (bool(ctx.error)) [[unlikely]]
                      return;
 
@@ -376,7 +379,7 @@ namespace glz
                   }
 
                   // Key
-                  cbor_to_json_value<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
+                  cbor_to_json_key<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
                   if (bool(ctx.error)) [[unlikely]]
                      return;
 
@@ -657,6 +660,59 @@ namespace glz
          default:
             ctx.error = error_code::syntax_error;
             break;
+         }
+      }
+
+      // A JSON object key must be a string. RFC 8949 section 6.1 maps a CBOR
+      // map's non-string keys onto their string form; integer keys (pervasive in
+      // COSE/CWT/WebAuthn) become quoted decimal strings. Emitting them bare
+      // produced structurally invalid JSON while reporting success. Text keys
+      // pass through, other key types have no JSON string form and are rejected.
+      // Mirrors the string/integer key handling in beve_to_json_value's object case.
+      template <auto Opts, class Buffer>
+      inline void cbor_to_json_key(auto&& ctx, auto&& it, auto&& end, Buffer& out, auto&& ix, uint32_t recursive_depth)
+      {
+         using namespace cbor;
+
+         if (it >= end) [[unlikely]] {
+            ctx.error = error_code::unexpected_end;
+            return;
+         }
+
+         uint8_t initial;
+         std::memcpy(&initial, it, 1);
+         const uint8_t major_type = get_major_type(initial);
+         const uint8_t additional_info = get_additional_info(initial);
+
+         switch (major_type) {
+         case major::tstr:
+            // Already a JSON string once written; emit with normal escaping.
+            cbor_to_json_value<Opts>(ctx, it, end, out, ix, recursive_depth);
+            return;
+         case major::uint: {
+            ++it;
+            const uint64_t value = cbor_to_json_decode_arg(ctx, it, end, additional_info);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
+            dump('"', out, ix);
+            to<JSON, uint64_t>::template op<Opts>(value, ctx, out, ix);
+            dump('"', out, ix);
+            return;
+         }
+         case major::nint: {
+            ++it;
+            const uint64_t n = cbor_to_json_decode_arg(ctx, it, end, additional_info);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
+            const int64_t value = static_cast<int64_t>(~n);
+            dump('"', out, ix);
+            to<JSON, int64_t>::template op<Opts>(value, ctx, out, ix);
+            dump('"', out, ix);
+            return;
+         }
+         default:
+            ctx.error = error_code::syntax_error;
+            return;
          }
       }
    }

--- a/include/glaze/cbor/cbor_to_json.hpp
+++ b/include/glaze/cbor/cbor_to_json.hpp
@@ -663,16 +663,23 @@ namespace glz
          }
       }
 
-      // A JSON object key must be a string. RFC 8949 section 6.1 maps a CBOR
-      // map's non-string keys onto their string form; integer keys (pervasive in
-      // COSE/CWT/WebAuthn) become quoted decimal strings. Emitting them bare
-      // produced structurally invalid JSON while reporting success. Text keys
-      // pass through, other key types have no JSON string form and are rejected.
+      // A JSON object key must be a string. Integer keys (pervasive in
+      // COSE/CWT/WebAuthn) become quoted decimal strings, one of the string
+      // forms RFC 8949 section 6.1 allows a converter to choose. Emitting them
+      // bare produced structurally invalid JSON while reporting success. Text
+      // and byte-string keys already emit as JSON strings via the value path,
+      // a tag on a key is unwrapped and the tagged content re-checked, and key
+      // types with no JSON string form (array, map, float, simple) are rejected.
       // Mirrors the string/integer key handling in beve_to_json_value's object case.
       template <auto Opts, class Buffer>
       inline void cbor_to_json_key(auto&& ctx, auto&& it, auto&& end, Buffer& out, auto&& ix, uint32_t recursive_depth)
       {
          using namespace cbor;
+
+         if (recursive_depth >= max_recursive_depth_limit) [[unlikely]] {
+            ctx.error = error_code::exceeded_max_recursive_depth;
+            return;
+         }
 
          if (it >= end) [[unlikely]] {
             ctx.error = error_code::unexpected_end;
@@ -686,9 +693,25 @@ namespace glz
 
          switch (major_type) {
          case major::tstr:
-            // Already a JSON string once written; emit with normal escaping.
+         case major::bstr:
+            // Both already emit as a JSON string (tstr escaped, bstr hex-quoted).
             cbor_to_json_value<Opts>(ctx, it, end, out, ix, recursive_depth);
             return;
+         case major::tag: {
+            // Unwrap the tag and key-check the tagged content, so e.g. a tag-0
+            // datetime text key still emits as a string. Typed-array tags
+            // (RFC 8746) decode to a JSON array and are rejected below.
+            ++it;
+            const uint64_t tag_num = cbor_to_json_decode_arg(ctx, it, end, additional_info);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
+            if (typed_array::get_info(tag_num).valid) [[unlikely]] {
+               ctx.error = error_code::syntax_error;
+               return;
+            }
+            cbor_to_json_key<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
+            return;
+         }
          case major::uint: {
             ++it;
             const uint64_t value = cbor_to_json_decode_arg(ctx, it, end, additional_info);

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -2256,6 +2256,46 @@ void cbor_to_json_tests()
       expect(bool(glz::cbor_to_json(cbor_buffer, json)));
    };
 
+   "cbor_to_json_byte_string_key"_test = [] {
+      // map(1){ h'01ff': 2 } -- a byte-string key emits as a quoted hex string,
+      // same as the value path.
+      const std::array<uint8_t, 5> cbor_buffer{0xa1, 0x42, 0x01, 0xff, 0x02};
+      std::string json;
+      expect(not glz::cbor_to_json(cbor_buffer, json));
+      expect(json == "{\"01ff\":2}");
+   };
+
+   "cbor_to_json_tagged_text_key"_test = [] {
+      // map(1){ 0("2013-03-21T20:04:00Z"): 1 } -- the tag is unwrapped and the
+      // tagged text key emits as a plain string.
+      const std::array<uint8_t, 24> cbor_buffer{0xa1, 0xc0, 0x74, '2', '0', '1', '3', '-',  '0', '3', '-', '2',
+                                                '1',  'T',  '2',  '0', ':', '0', '4', ':',  '0', '0', 'Z', 0x01};
+      std::string json;
+      expect(not glz::cbor_to_json(cbor_buffer, json));
+      expect(json == "{\"2013-03-21T20:04:00Z\":1}");
+   };
+
+   "cbor_to_json_typed_array_tag_key_rejected"_test = [] {
+      // map(1){ 64(h'01'): 2 } -- an RFC 8746 typed-array tag decodes to a JSON
+      // array, which has no string form as a key.
+      const std::array<uint8_t, 6> cbor_buffer{0xa1, 0xd8, 0x40, 0x41, 0x01, 0x02};
+      std::string json;
+      expect(bool(glz::cbor_to_json(cbor_buffer, json)));
+   };
+
+   "cbor_to_json_tag_chain_key_depth_limited"_test = [] {
+      // map(1){ 0(0(0(...(1)))): 2 } -- a long tag chain on a key must hit the
+      // recursion depth limit instead of recursing unboundedly.
+      std::vector<uint8_t> cbor_buffer{0xa1};
+      cbor_buffer.insert(cbor_buffer.end(), 300, 0xc0);
+      cbor_buffer.push_back(0x01);
+      cbor_buffer.push_back(0x02);
+      std::string json;
+      const auto ec = glz::cbor_to_json(cbor_buffer, json);
+      expect(bool(ec));
+      expect(ec.ec == glz::error_code::exceeded_max_recursive_depth);
+   };
+
    "cbor_to_json_bool"_test = [] {
       std::string cbor_buffer;
       expect(not glz::write_cbor(true, cbor_buffer));

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -2226,6 +2226,36 @@ void cbor_to_json_tests()
       expect(json == "{\"a\":1,\"b\":2}" || json == "{\"b\":2,\"a\":1}");
    };
 
+   "cbor_to_json_integer_keys"_test = [] {
+      // COSE/CWT and many CBOR profiles key maps by integers. A JSON object key
+      // must be a string, so the integer key is emitted as a quoted decimal.
+      std::map<int, int> m = {{1, 2}, {500, 3}};
+      std::string cbor_buffer;
+      expect(not glz::write_cbor(m, cbor_buffer));
+
+      std::string json;
+      expect(not glz::cbor_to_json(cbor_buffer, json));
+      // Bare integer keys ("{1:2,...}") are not valid JSON; they must be quoted.
+      expect(json == "{\"1\":2,\"500\":3}");
+   };
+
+   "cbor_to_json_negative_key"_test = [] {
+      std::map<int, int> m = {{-1, 7}};
+      std::string cbor_buffer;
+      expect(not glz::write_cbor(m, cbor_buffer));
+
+      std::string json;
+      expect(not glz::cbor_to_json(cbor_buffer, json));
+      expect(json == "{\"-1\":7}");
+   };
+
+   "cbor_to_json_non_string_key_rejected"_test = [] {
+      // map(1){ [1]: 2 } -- an array key has no JSON string form.
+      const std::array<uint8_t, 4> cbor_buffer{0xa1, 0x81, 0x01, 0x02};
+      std::string json;
+      expect(bool(glz::cbor_to_json(cbor_buffer, json)));
+   };
+
    "cbor_to_json_bool"_test = [] {
       std::string cbor_buffer;
       expect(not glz::write_cbor(true, cbor_buffer));


### PR DESCRIPTION
`glz::cbor_to_json` on a CBOR map with integer keys, before:

    a1 01 02           ->  {1:2}         (returns success)
    a2 01 02 61 61 03  ->  {1:2,"a":3}   (returns success)

Neither output re-parses as JSON, because a map key has to be a string. Integer keys are the norm for COSE/CWT/WebAuthn and other RFC 8949 profiles, so this is ordinary input, and the converter reported no error on it.

Before: every map key ran through the value dispatcher, so a non-string key was written in its native form (a bare number, or `[...]`/`{...}`).

After: `cbor_to_json_key` emits a text or byte-string key as before (byte strings keep their quoted-hex form), quotes an unsigned or negative integer key as a decimal string (one of the string forms RFC 8949 6.1 permits a converter to choose, matching what `beve_to_json` does for integer object keys), unwraps a tag on a key and re-checks the tagged content (so a tag-0 datetime key still emits as a plain string), and rejects a key type that has no JSON string form. `cbor_to_json_key` checks the recursion depth limit, so a tag chain on a key cannot recurse unboundedly.

Tradeoff: a key that is an array, map, float, bool, or typed-array tag was previously written as invalid JSON with a success code, and is now a `syntax_error`. Text-keyed and byte-string-keyed maps are byte for byte unchanged, and tagged keys keep their prior output.
