### PR TITLE
Stop a handler from announcing a transfer coding on a buffered response

### DIFF
--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -3066,6 +3066,19 @@ namespace glz
             if (header_field_has_crlf(name, value)) [[unlikely]] {
                continue;
             }
+            // This writer sends a complete, already-buffered body and frames it with
+            // the Content-Length below, so it never applies a transfer coding. A
+            // handler-set Transfer-Encoding would announce a framing the bytes do not
+            // follow: a recipient told "chunked" reads the body's first line as a
+            // chunk size, and alongside the Content-Length it is the two-framings
+            // shape behind response smuggling (RFC 9112 6.3). There is no value worth
+            // keeping - the field describes an encoding only this writer could have
+            // applied - so drop it rather than emit a self-contradicting response.
+            // Streaming responses declare their own through
+            // streaming_connection::send_headers, which does chunk what it sends.
+            if (glz::striequal(name, "transfer-encoding")) [[unlikely]] {
+               continue;
+            }
             h.append(name);
             h.append(": ");
             h.append(value);

--- a/tests/networking_tests/http_smuggling_test/http_smuggling_test.cpp
+++ b/tests/networking_tests/http_smuggling_test/http_smuggling_test.cpp
@@ -67,6 +67,15 @@ suite http_smuggling_suite = [] {
       res.status(200);
       res.body("smuggled");
    });
+   // A handler that announces a transfer coding the buffered response writer never
+   // applies. The body below is deliberately shaped like a valid chunked stream, so
+   // a recipient that believed the Transfer-Encoding would decode "smuggled!" as a
+   // chunk while a recipient that believed the Content-Length would not.
+   server.get("/handler-sets-te", [&](const glz::request&, glz::response& res) {
+      res.header("Transfer-Encoding", "chunked");
+      res.status(200);
+      res.body("9\r\nsmuggled!\r\n0\r\n\r\n");
+   });
    server.bind(test_host, 0);
    const uint16_t test_port = server.port();
    server.start(0);
@@ -193,6 +202,49 @@ suite http_smuggling_suite = [] {
          << "Expected 400 for case-varied conflicting Content-Length";
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
       expect(smuggled_hits.load(std::memory_order_relaxed) == 0) << "Smuggled request reached a route handler";
+   };
+
+   // The buffered response writer always frames with Content-Length, so it must not
+   // let a handler advertise a transfer coding it does not apply. Emitting both
+   // fields is the response-side twin of the CL.TE request desync the cases above
+   // cover: two recipients read two different body boundaries from one response.
+   "Handler-set Transfer-Encoding is dropped, not emitted alongside Content-Length"_test = [&] {
+      const std::string payload =
+         "GET /handler-sets-te HTTP/1.1\r\n"
+         "Host: localhost\r\n"
+         "Connection: close\r\n"
+         "\r\n";
+
+      std::future<std::string> f = std::async(std::launch::async, [&] { return send_raw(test_port, payload); });
+
+      auto future_timeout = std::chrono::system_clock::now() + std::chrono::seconds(5);
+      std::string response;
+      if (std::future_status::ready == f.wait_until(future_timeout)) {
+         response = f.get();
+      }
+
+      // Field names are matched case-insensitively: response::header() lowercases
+      // today but is not required to, and a case-sensitive search would silently
+      // stop testing anything the day that changes.
+      const auto count_fields = [](std::string_view haystack, std::string_view field) {
+         size_t found = 0;
+         for (size_t i = 0; i + field.size() <= haystack.size(); ++i) {
+            if (glz::striequal(haystack.substr(i, field.size()), field)) {
+               ++found;
+            }
+         }
+         return found;
+      };
+
+      expect(response.find("HTTP/1.1 200") != std::string::npos) << "The response itself should still be served";
+      expect(count_fields(response, "Transfer-Encoding") == 0)
+         << "A transfer coding this writer never applies must not reach the wire, got: " << response;
+
+      // Exactly one framing field, and it must describe the bytes actually sent.
+      const size_t content_length_fields = count_fields(response, "Content-Length");
+      expect(content_length_fields == 1) << "Expected exactly one Content-Length, found " << content_length_fields;
+      expect(count_fields(response, "Content-Length: 19") == 1)
+         << "Content-Length must match the unencoded body length, got: " << response;
    };
 
    server.stop();


### PR DESCRIPTION
Found while reviewing #2718, but independent of it: this touches only the response serializer loop, which #2718 does not modify, so the two merge cleanly in either order.

## The problem

`send_response_with_conn` sends a complete, already-buffered body and frames it with the `Content-Length` it generates. It never applies a transfer coding. It nonetheless copied a handler-set `Transfer-Encoding` straight onto the wire:

```cpp
server.get("/x", [](const glz::request&, glz::response& res) {
    res.header("Transfer-Encoding", "chunked");
    res.body("9\r\nsmuggled!\r\n0\r\n\r\n");
});
```

produced

```
HTTP/1.1 200 OK
transfer-encoding: chunked
Content-Length: 19
...
```

Two framing fields on one response. A recipient that honors `Transfer-Encoding` reads the body's first line as a chunk size; one that honors `Content-Length` reads the declared byte count. They disagree about where the response ends and therefore about what the following bytes are — the response-side twin of the CL.TE request desync `http_smuggling_test` already covers (RFC 9112 §6.3). The body isn't chunk-encoded either, so the "chunked" reading is a parse error at best and a desync at worst.

## The fix

Drop the field. Unlike a conflicting `Content-Length`, there is no correct value to keep: `Transfer-Encoding` describes an encoding only this writer could have applied, and it didn't.

Streaming responses are unaffected — they declare their own `Transfer-Encoding` through `streaming_connection::send_headers`, which does chunk what it sends.

## Testing

New case in `http_smuggling_test` asserting no `Transfer-Encoding` reaches the wire and that exactly one `Content-Length` does, matching the unencoded body length. I confirmed it fails against the unfixed serializer.

It matches field names case-insensitively on purpose: `response::header()` lowercases today but isn't required to (#2718 changes exactly that), and a case-sensitive search would silently stop testing anything the day it changes — which is how the first draft of this test passed against the bug.

Full suite: 117/117.