### PR TITLE
Only pool a streaming socket that reached the end of its response

### DIFF
--- a/include/glaze/net/http_client.hpp
+++ b/include/glaze/net/http_client.hpp
@@ -902,6 +902,13 @@ namespace glz
       std::shared_ptr<asio::streambuf> buffer; // Use unified streambuf for all reads
       bool is_connected{false};
       std::atomic<bool> should_stop{false};
+      // Set only once the response has been read to its framed end, leaving the
+      // socket positioned at the start of whatever the server sends next. Every
+      // other way a stream ends - a timeout, a caller-initiated disconnect part way
+      // through the body, a read error, or a body framed by connection close -
+      // leaves either unread response bytes or a dead peer behind, so the socket
+      // must be closed rather than handed to the next request.
+      std::atomic<bool> response_complete{false};
       stream_read_strategy strategy{stream_read_strategy::bulk_transfer}; // Default strategy
       std::function<bool(int)> status_is_error{}; // Evaluated before treating status as failure
       bool is_https{false}; // Track if this is an HTTPS connection
@@ -1426,9 +1433,21 @@ namespace glz
             if (user_on_disconnect) {
                user_on_disconnect();
             }
-            // Return the connection to the pool for reuse
             if (connection->socket) {
-               connection_pool->return_connection(url.host, url.port, use_https, std::move(*connection->socket));
+               // Only a socket sitting at the end of a fully-read response can serve
+               // the next request. Pooling one that timed out, errored, or was
+               // abandoned part way through the body hands the next request a socket
+               // with the tail of this response still arriving on it, which that
+               // request reads as its own status line - the same desync a conflicting
+               // Content-Length produces, reached through the pool instead. A body
+               // framed by connection close leaves the socket at EOF, which is dead
+               // rather than dangerous, but equally unusable.
+               if (connection->response_complete.load(std::memory_order_relaxed)) {
+                  connection_pool->return_connection(url.host, url.port, use_https, std::move(*connection->socket));
+               }
+               else {
+                  detail::close_socket(*connection->socket, connection_pool->graceful_ssl_shutdown());
+               }
             }
          };
 
@@ -1726,7 +1745,9 @@ namespace glz
                      connection->buffer->consume(bytes_transferred);
 
                      if (chunk_size == 0) {
-                        // Last chunk
+                        // Terminal chunk: the response is framed to its end here, so this
+                        // is the one exit that leaves the socket reusable.
+                        connection->response_complete.store(true, std::memory_order_relaxed);
                         if (on_disconnect) on_disconnect();
                         return;
                      }

--- a/include/glaze/net/http_client.hpp
+++ b/include/glaze/net/http_client.hpp
@@ -1433,10 +1433,12 @@ namespace glz
          auto internal_on_disconnect = [this, user_on_disconnect = std::move(on_disconnect), connection, url,
                                         use_https]() {
             connection->is_connected = false;
-            // Call the user's handler if provided
-            if (user_on_disconnect) {
-               user_on_disconnect();
-            }
+            // Settle the socket before telling the caller the stream ended, matching the
+            // non-streaming paths, which return the connection and only then run the
+            // completion handler. The other order publishes "finished" while the socket is
+            // still in hand, so a caller that starts its next request from on_disconnect
+            // finds an empty pool and dials a second connection - never reusing the very
+            // socket the code below is about to make reusable.
             if (connection->socket) {
                // Only a socket sitting at the end of a fully-read response can serve
                // the next request. Pooling one that timed out, errored, or was
@@ -1452,6 +1454,12 @@ namespace glz
                else {
                   detail::close_socket(*connection->socket, connection_pool->graceful_ssl_shutdown());
                }
+            }
+            // Returning the socket leaves a null shared_ptr in the variant; every accessor
+            // guards on it, so the disconnect() that http_stream_connection runs from its
+            // destructor is a no-op rather than a dereference of a moved-from socket.
+            if (user_on_disconnect) {
+               user_on_disconnect();
             }
          };
 

--- a/include/glaze/net/http_client.hpp
+++ b/include/glaze/net/http_client.hpp
@@ -902,13 +902,17 @@ namespace glz
       std::shared_ptr<asio::streambuf> buffer; // Use unified streambuf for all reads
       bool is_connected{false};
       std::atomic<bool> should_stop{false};
-      // Set only once the response has been read to its framed end, leaving the
-      // socket positioned at the start of whatever the server sends next. Every
-      // other way a stream ends - a timeout, a caller-initiated disconnect part way
-      // through the body, a read error, or a body framed by connection close -
-      // leaves either unread response bytes or a dead peer behind, so the socket
-      // must be closed rather than handed to the next request.
+      // Set only once the response has been read to its framed end - terminal chunk,
+      // trailer section and the final CRLF all consumed - leaving the socket
+      // positioned at the start of whatever the server sends next. Every other way a
+      // stream ends - a timeout, a caller-initiated disconnect part way through the
+      // body, a read error, or a body framed by connection close - leaves either
+      // unread response bytes or a dead peer behind, so the socket must be closed
+      // rather than handed to the next request.
       std::atomic<bool> response_complete{false};
+      // The response asked for the connection to be closed once it is delivered, so
+      // the socket is single-use no matter how cleanly the body ends.
+      std::atomic<bool> peer_will_close{false};
       stream_read_strategy strategy{stream_read_strategy::bulk_transfer}; // Default strategy
       std::function<bool(int)> status_is_error{}; // Evaluated before treating status as failure
       bool is_https{false}; // Track if this is an HTTPS connection
@@ -1669,6 +1673,10 @@ namespace glz
                      connection->is_connected = true;
                      connection->timer->cancel();
 
+                     connection->peer_will_close.store(
+                        response_headers.response_headers.contains_token("connection", "close"),
+                        std::memory_order_relaxed);
+
                      if (on_connect) {
                         on_connect(response_headers);
                      }
@@ -1745,16 +1753,52 @@ namespace glz
                      connection->buffer->consume(bytes_transferred);
 
                      if (chunk_size == 0) {
-                        // Terminal chunk: the response is framed to its end here, so this
-                        // is the one exit that leaves the socket reusable.
-                        connection->response_complete.store(true, std::memory_order_relaxed);
-                        if (on_disconnect) on_disconnect();
+                        // Terminal chunk. The trailer section and the final CRLF still sit in
+                        // front of the next response, so the socket is only reusable once they
+                        // have been consumed too (RFC 9112 7.1).
+                        consume_trailers(connection, std::move(on_disconnect));
                         return;
                      }
 
                      read_chunk_body(connection, chunk_size, std::move(on_data), std::move(on_error),
                                      std::move(on_disconnect));
                   });
+            },
+            *connection->socket);
+      }
+
+      // After the terminal chunk, skip the optional trailer section and the final CRLF
+      // (RFC 9112 7.1.2). Only then does the socket sit at the start of whatever the
+      // server sends next, which is the one state that makes it reusable.
+      void consume_trailers(std::shared_ptr<http_stream_connection> connection, http_disconnect_handler on_disconnect)
+      {
+         std::visit(
+            [&, this](auto& sock) {
+               asio::async_read_until(*sock, *connection->buffer, "\r\n",
+                                      [this, connection, on_disconnect = std::move(on_disconnect)](
+                                         asio::error_code ec, std::size_t bytes_transferred) mutable {
+                                         // The body is already delivered in full, so a failure here is not reported
+                                         // to the caller - it only means the socket cannot be reused.
+                                         if (ec || connection->should_stop) {
+                                            if (on_disconnect) on_disconnect();
+                                            return;
+                                         }
+
+                                         const bool end_of_trailers = (bytes_transferred == 2); // just "\r\n"
+                                         connection->buffer->consume(bytes_transferred);
+
+                                         if (!end_of_trailers) {
+                                            consume_trailers(connection,
+                                                             std::move(on_disconnect)); // trailer field line
+                                            return;
+                                         }
+
+                                         // A response that asked to close is single-use however cleanly it ended.
+                                         if (!connection->peer_will_close.load(std::memory_order_relaxed)) {
+                                            connection->response_complete.store(true, std::memory_order_relaxed);
+                                         }
+                                         if (on_disconnect) on_disconnect();
+                                      });
             },
             *connection->socket);
       }

--- a/tests/networking_tests/http_content_length_test/http_content_length_test.cpp
+++ b/tests/networking_tests/http_content_length_test/http_content_length_test.cpp
@@ -649,9 +649,25 @@ suite content_length_connection_reuse = [] {
          asio::write(socket, asio::buffer(std::string("X-Checksum: 1234\r\n\r\n")), ec);
 
          // Second request, on this same connection if the socket was pooled correctly.
+         // Polled against a deadline rather than blocking: if a regression stops the socket
+         // being reused, the request never arrives here and an unbounded read would hang the
+         // thread, and with it join() and the whole test, until ctest times it out.
          req_buf.consume(req_buf.size());
-         asio::read_until(socket, req_buf, "\r\n\r\n", ec);
-         if (!ec) {
+         socket.non_blocking(true, ec);
+         const auto request_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+         bool second_request_arrived = false;
+         while (std::chrono::steady_clock::now() < request_deadline) {
+            ec = {};
+            asio::read_until(socket, req_buf, "\r\n\r\n", ec);
+            if (!ec) {
+               second_request_arrived = true;
+               break;
+            }
+            if (ec != asio::error::would_block && ec != asio::error::try_again) break;
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+         }
+         socket.non_blocking(false, ec);
+         if (second_request_arrived) {
             asio::write(socket, asio::buffer(std::string("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nWORLD")), ec);
          }
          socket.shutdown(asio::ip::tcp::socket::shutdown_both, ec);
@@ -674,17 +690,24 @@ suite content_length_connection_reuse = [] {
       expect(stream_finished.wait_for(std::chrono::seconds(5)) == std::future_status::ready)
          << "stream should reach its end";
 
-      // POST so a failed read can't be masked by the idempotent-method retry path.
-      auto second = client.post_async(base, "two").get();
+      // POST so a failed read can't be masked by the idempotent-method retry path. Waited
+      // on with a deadline for the same reason the server polls: a socket that was not
+      // reused leaves this request talking to a server that has stopped accepting.
+      auto second_future = client.post_async(base, "two");
+      const bool second_answered = second_future.wait_for(std::chrono::seconds(10)) == std::future_status::ready;
+      expect(second_answered) << "follow-up request never completed; the pooled socket was not reused";
 
       server.join();
 
       expect(streamed == "STREAMED") << "stream body should arrive intact, got: " << streamed;
-      expect(second.has_value()) << "the pooled socket must sit at the start of the next response, not on the "
-                                    "trailer section that follows the terminal chunk";
-      if (second) {
-         expect(second->status_code == 200);
-         expect(second->response_body == "WORLD");
+      if (second_answered) {
+         auto second = second_future.get();
+         expect(second.has_value()) << "the pooled socket must sit at the start of the next response, not on the "
+                                       "trailer section that follows the terminal chunk";
+         if (second) {
+            expect(second->status_code == 200);
+            expect(second->response_body == "WORLD");
+         }
       }
       expect(accept_count->load() == 1) << "a stream read to its framed end should be reused, not reopened; got "
                                         << accept_count->load() << " connections";

--- a/tests/networking_tests/http_content_length_test/http_content_length_test.cpp
+++ b/tests/networking_tests/http_content_length_test/http_content_length_test.cpp
@@ -13,6 +13,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <future>
 #include <memory>
 #include <string>
 #include <thread>
@@ -531,6 +532,64 @@ suite content_length_connection_reuse = [] {
       server.join();
 
       expect(second.has_value()) << "after an EOF-truncated response the connection must not be pooled; the follow-up "
+                                    "request must open a fresh connection instead of reusing a dead socket";
+      if (second) {
+         expect(second->status_code == 200);
+         expect(second->response_body == "HELLO");
+      }
+      expect(accept_count->load() == 2) << "expected two server connections (dead socket not reused), got: "
+                                        << accept_count->load();
+   };
+
+   // The streaming path shares the same connection pool as ordinary requests, so a
+   // socket it hands back poisons whatever request draws it next. A stream whose
+   // body is framed by connection close ends at EOF: the socket is still "open" from
+   // this side, so it used to be pooled unconditionally and the next request drew a
+   // dead connection. Only a stream read to its framed end is reusable.
+   "eof_framed_stream_not_pooled"_test = [] {
+      auto listener = std::make_shared<asio::io_context>();
+      auto acceptor = std::make_shared<asio::ip::tcp::acceptor>(*listener);
+      asio::ip::tcp::endpoint ep(asio::ip::make_address("127.0.0.1"), 0);
+      acceptor->open(ep.protocol());
+      acceptor->set_option(asio::socket_base::reuse_address(true));
+      acceptor->bind(ep);
+      acceptor->listen(2);
+      const uint16_t port = acceptor->local_endpoint().port();
+
+      auto accept_count = std::make_shared<std::atomic<int>>(0);
+      std::vector<std::string> responses = {
+         // No Content-Length and no chunked framing: the body runs to the close that
+         // serve_sequence performs after writing.
+         "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nConnection: keep-alive\r\n\r\nSTREAMED",
+         "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nHELLO",
+      };
+      auto server = serve_sequence(listener, acceptor, responses, accept_count);
+
+      glz::http_client client;
+      // Force a pooled dead socket to be reused rather than culled by the acquire-time peek.
+      client.set_pool_active_liveness_check(false);
+
+      const std::string base = "http://127.0.0.1:" + std::to_string(port) + "/";
+
+      std::promise<void> stream_done;
+      auto stream_finished = stream_done.get_future();
+      std::string streamed;
+      auto conn = client.stream_request_v2({.url = base,
+                                            .on_data = [&](std::string_view data) { streamed.append(data); },
+                                            .on_error = [](std::error_code) {},
+                                            .on_disconnect = [&] { stream_done.set_value(); }});
+      expect(conn != nullptr) << "stream request should start";
+      expect(stream_finished.wait_for(std::chrono::seconds(5)) == std::future_status::ready)
+         << "stream should reach its end";
+
+      // POST, not GET: the transparent-retry path covers idempotent methods, so a GET
+      // would silently reopen on a dead socket and hide the bug this pins.
+      auto second = client.post_async(base, "two").get(); // must land on a fresh connection 2
+
+      server.join();
+
+      expect(streamed == "STREAMED") << "stream body should arrive intact, got: " << streamed;
+      expect(second.has_value()) << "after an EOF-framed stream the connection must not be pooled; the follow-up "
                                     "request must open a fresh connection instead of reusing a dead socket";
       if (second) {
          expect(second->status_code == 200);

--- a/tests/networking_tests/http_content_length_test/http_content_length_test.cpp
+++ b/tests/networking_tests/http_content_length_test/http_content_length_test.cpp
@@ -9,7 +9,9 @@
 //      as an error, not a short body. Covers both client paths.
 //   3. A connection whose body read ends with the peer closing the socket (EOF) is not
 //      returned to the pool. Pooling an EOF'd (half-closed) socket would hand the next
-//      request a dead connection.
+//      request a dead connection. The streaming path shares that pool, so the same rule
+//      applies to it: a stream is only reusable once its response is read to its framed
+//      end, terminal chunk and trailer section included.
 
 #include <atomic>
 #include <chrono>
@@ -598,6 +600,94 @@ suite content_length_connection_reuse = [] {
       }
       expect(accept_count->load() == 2) << "expected two server connections (dead socket not reused), got: "
                                         << accept_count->load();
+   };
+
+   // The other side of the same rule: a stream that reaches the end of its framing does
+   // leave a reusable socket, but only once the trailer section and the final CRLF that
+   // follow the terminal chunk have been consumed too (RFC 9112 7.1.2). Those bytes are
+   // written in a separate segment here, so they are still on the socket when the
+   // terminal chunk is parsed - pooling at that point hands the next request a socket
+   // with a trailer line in front of the status line.
+   "chunked_stream_pools_only_after_trailers"_test = [] {
+      auto listener = std::make_shared<asio::io_context>();
+      auto acceptor = std::make_shared<asio::ip::tcp::acceptor>(*listener);
+      asio::ip::tcp::endpoint ep(asio::ip::make_address("127.0.0.1"), 0);
+      acceptor->open(ep.protocol());
+      acceptor->set_option(asio::socket_base::reuse_address(true));
+      acceptor->bind(ep);
+      acceptor->listen(2);
+      const uint16_t port = acceptor->local_endpoint().port();
+
+      auto accept_count = std::make_shared<std::atomic<int>>(0);
+      auto server = std::thread([listener, acceptor, accept_count] {
+         asio::error_code ec;
+         acceptor->non_blocking(true, ec);
+         const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+         asio::ip::tcp::socket socket(*listener);
+         while (std::chrono::steady_clock::now() < deadline) {
+            acceptor->accept(socket, ec);
+            if (ec == asio::error::would_block || ec == asio::error::try_again) {
+               std::this_thread::sleep_for(std::chrono::milliseconds(5));
+               continue;
+            }
+            break;
+         }
+         if (ec) return;
+         accept_count->fetch_add(1);
+         socket.non_blocking(false, ec); // the accepted socket may inherit non-blocking mode
+
+         asio::streambuf req_buf;
+         asio::read_until(socket, req_buf, "\r\n\r\n", ec);
+         asio::write(socket,
+                     asio::buffer(std::string("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
+                                              "8\r\nSTREAMED\r\n"
+                                              "0\r\n")),
+                     ec);
+         // Separate segment: the trailer section must be read off the socket rather than
+         // found already sitting in the client's buffer.
+         std::this_thread::sleep_for(std::chrono::milliseconds(50));
+         asio::write(socket, asio::buffer(std::string("X-Checksum: 1234\r\n\r\n")), ec);
+
+         // Second request, on this same connection if the socket was pooled correctly.
+         req_buf.consume(req_buf.size());
+         asio::read_until(socket, req_buf, "\r\n\r\n", ec);
+         if (!ec) {
+            asio::write(socket, asio::buffer(std::string("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nWORLD")), ec);
+         }
+         socket.shutdown(asio::ip::tcp::socket::shutdown_both, ec);
+         socket.close(ec);
+      });
+
+      glz::http_client client;
+      client.set_pool_active_liveness_check(false);
+
+      const std::string base = "http://127.0.0.1:" + std::to_string(port) + "/";
+
+      std::promise<void> stream_done;
+      auto stream_finished = stream_done.get_future();
+      std::string streamed;
+      auto conn = client.stream_request_v2({.url = base,
+                                            .on_disconnect = [&] { stream_done.set_value(); },
+                                            .on_data = [&](std::string_view data) { streamed.append(data); },
+                                            .on_error = [](std::error_code) {}});
+      expect(conn != nullptr) << "stream request should start";
+      expect(stream_finished.wait_for(std::chrono::seconds(5)) == std::future_status::ready)
+         << "stream should reach its end";
+
+      // POST so a failed read can't be masked by the idempotent-method retry path.
+      auto second = client.post_async(base, "two").get();
+
+      server.join();
+
+      expect(streamed == "STREAMED") << "stream body should arrive intact, got: " << streamed;
+      expect(second.has_value()) << "the pooled socket must sit at the start of the next response, not on the "
+                                    "trailer section that follows the terminal chunk";
+      if (second) {
+         expect(second->status_code == 200);
+         expect(second->response_body == "WORLD");
+      }
+      expect(accept_count->load() == 1) << "a stream read to its framed end should be reused, not reopened; got "
+                                        << accept_count->load() << " connections";
    };
 };
 

--- a/tests/networking_tests/http_content_length_test/http_content_length_test.cpp
+++ b/tests/networking_tests/http_content_length_test/http_content_length_test.cpp
@@ -574,10 +574,11 @@ suite content_length_connection_reuse = [] {
       std::promise<void> stream_done;
       auto stream_finished = stream_done.get_future();
       std::string streamed;
+      // Designator order has to match declaration order; gcc and MSVC reject it otherwise.
       auto conn = client.stream_request_v2({.url = base,
+                                            .on_disconnect = [&] { stream_done.set_value(); },
                                             .on_data = [&](std::string_view data) { streamed.append(data); },
-                                            .on_error = [](std::error_code) {},
-                                            .on_disconnect = [&] { stream_done.set_value(); }});
+                                            .on_error = [](std::error_code) {}});
       expect(conn != nullptr) << "stream request should start";
       expect(stream_finished.wait_for(std::chrono::seconds(5)) == std::future_status::ready)
          << "stream should reach its end";


### PR DESCRIPTION
Found while reviewing #2718. Independent of it — this touches the streaming disconnect wrapper and `http_stream_connection`, neither of which #2718 modifies.

## The problem

`perform_stream_request` wraps the caller's disconnect handler in one that returns the socket to the pool:

```cpp
// Return the connection to the pool for reuse
if (connection->socket) {
    connection_pool->return_connection(url.host, url.port, use_https, std::move(*connection->socket));
}
```

Every way a stream can end runs through that handler. It is reached after:

- a connect/response timeout — `disconnect()` cancels pending operations but does not close the socket
- the caller calling `conn->disconnect()` part way through the body
- a mid-stream read error
- the EOF that ends a body framed by connection close

In each of those the socket is either dead or still has response bytes arriving on it. `return_connection` only checks `socket_is_open`, and none of these leave it closed, so all four get pooled.

The streaming path shares its pool with ordinary requests, so the next request to draw that socket reads the tail of the previous response as its own status line — the same desync a conflicting `Content-Length` produces, reached through the pool instead of through a header.

## The fix

A stream is reusable in exactly one case: the response has been read to the end of its framing, so the socket sits at the start of whatever the server sends next. `http_stream_connection` records that with a `response_complete` flag, and the disconnect wrapper closes the socket in every other case.

Reaching the end of the framing takes more than the terminal chunk. Two things had to be consumed or checked before the flag can be set:

**The trailer section.** The terminal chunk is not the end of the message — the trailer section and the final CRLF follow it (RFC 9112 §7.1.2). Setting the flag at the `chunk_size == 0` branch pooled the socket with those bytes still in front of the next response, which is the same desync one line further along. `consume_trailers` now reads trailer lines to the closing empty line first, and only then marks the response complete. This mirrors what the non-streaming paths already do via `async_consume_trailers`; the streaming reader was the one place that skipped it. A read failure there is not surfaced to the caller: the body is already delivered in full, so it only means the socket cannot be reused.

**`Connection: close`.** The streaming path never checked it, so a cleanly framed response from a server that is about to hang up still went into the pool. The async path checks it before `return_connection`; streaming now does too. Such a response is single-use however cleanly the body ended.

Deliberately unchanged: streaming applies no `Content-Length` framing at all. That is by design — the streaming API hands raw bytes to the caller — so it is not treated as a defect here.

## Testing

Two cases, one per direction of the rule.

`eof_framed_stream_not_pooled` covers a stream whose body is framed by connection close: the follow-up request has to open a fresh connection rather than draw the EOF'd socket.

`chunked_stream_pools_only_after_trailers` covers the reusable case. The server writes the trailer section in a separate segment, so those bytes are still on the socket when the terminal chunk is parsed rather than sitting in the client's buffer — which is what makes the bug reproducible instead of accidentally working. The follow-up request must then succeed **on the reused connection** (`accept_count == 1`), so the test pins both that a clean stream is pooled and that it is positioned correctly. It fails against the terminal-chunk-only version of the flag.

Both use `POST` for the follow-up request, not `GET`: transparent retry covers idempotent methods, so a `GET` quietly reopens on a dead socket and hides the bug — which is how the first draft of the EOF test passed against it.

Full networking suite green: `http_content_length_test` 26/26, `http_chunked_test` 59/59, `http_client_test` 39/39, `http_client_pool_test` 14/14. Clean under ASan and UBSan; TSan reports only the pre-existing asio kqueue-reactor warnings that also appear on unmodified `main`. The SSL variant syntax-checks under `-DGLZ_ENABLE_SSL`.

## Changes since the first push

- Rebased onto current `main` (the branch predated the `ssl.hpp` / `http_headers.hpp` extraction).
- Fixed the build failure that took out all twelve GCC/MSVC/asan jobs: the new test initialized `.on_disconnect` after `.on_data` and `.on_error`, but `stream_request_params_v2` declares `on_disconnect` first, and designators must appear in declaration order. Clang accepts the reordering as an extension, which is why every clang job was green. #2819 reorders the struct so the natural spelling is the correct one; whichever of the two merges second needs those designators flipped.
- Added the trailer handling, the `Connection: close` check, and the second test described above.
