### PR TITLE
Stop meta::skip from instantiating the field it skips

### DIFF
--- a/docs/skip-keys.md
+++ b/docs/skip-keys.md
@@ -153,6 +153,32 @@ glz::read_json(obj, json);
 // obj.computed_field retains "computed_value", obj.input_only_field becomes "new_input"
 ```
 
+## Skipped Fields Need No Serializer
+
+Because `skip` is a compile-time decision, Glaze never instantiates the reader or writer for a field it excludes. A field can therefore be skipped *because* its type cannot be handled in that direction:
+
+```cpp
+struct info_t {
+    int idx{};
+    std::string_view name{};  // a view into the buffer being parsed
+};
+
+template <>
+struct glz::meta<info_t> {
+    static constexpr bool skip(const std::string_view key, const meta_context&) {
+        return key == "name";
+    }
+};
+
+// Streaming reads reject non-owning views (they would point into a window that gets refilled),
+// but `name` is skipped, so this compiles and parses `idx`:
+glz::basic_istream_buffer in{stream};
+info_t value{};
+auto ec = glz::read_json(value, in);
+```
+
+The same applies to a field whose type has no Glaze serializer at all: skipping it for both operations removes the requirement entirely. Fields skipped on parse are also not treated as missing under `error_on_missing_keys`.
+
 ## Value-Based Skipping with `skip_if`
 
 While `skip` allows skipping fields based on their key names at compile time, `skip_if` enables runtime skipping based on the actual field values. This is useful for omitting fields with default values or applying conditional logic based on the data.

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -631,11 +631,33 @@ namespace glz
       }
    }();
 
+   // Whether `meta<T>::skip` excludes any field at all from the given operation.
+   //
+   // `meta::skip` is answered at compile time, so a `skip()` that never fires for an operation costs
+   // that operation nothing. Asking this rather than whether `meta<T>::skip` merely exists is what
+   // lets a read-side skip leave the writers alone.
+   template <class T, operation Op>
+   inline constexpr bool any_skipped_by_meta = [] {
+      constexpr auto N = reflect<T>::size;
+      if constexpr (meta_has_skip<T> && N > 0) {
+         return []<size_t... I>(std::index_sequence<I...>) {
+            return (skipped_by_meta<T, I, Op> || ...);
+         }(std::make_index_sequence<N>{});
+      }
+      else {
+         return false;
+      }
+   }();
+
    template <auto Opts, class T>
    inline constexpr bool maybe_skipped = [] {
       if constexpr (reflect<T>::size > 0) {
          constexpr auto N = reflect<T>::size;
-         if constexpr (meta_has_skip<T> || meta_has_skip_if<T>) {
+         // skip_if decides per value at runtime, so its mere presence forces the dynamic path. skip
+         // decides at compile time, so it only forces the dynamic path when it actually excludes a
+         // field from serialization -- a skip() that only fires on parse leaves writing on the static
+         // path, where separators and member counts are placed at compile time.
+         if constexpr (meta_has_skip_if<T> || any_skipped_by_meta<T, operation::serialize>) {
             return true;
          }
          else {

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -612,6 +612,24 @@ namespace glz
       }
    }
 
+   // Whether `meta<T>::skip` excludes the field at index I from the given operation.
+   //
+   // Consume this as `if constexpr (skipped_by_meta<...>) { ... } else { serialize/parse }`, never as
+   // an early `return` inside an `if constexpr` block. A `return` stops the field from being touched
+   // at runtime, but the code that follows it in the same block is still instantiated -- so the
+   // skipped field's serializer is compiled anyway, and a field skipped precisely because its type
+   // cannot be serialized in this context (a type with no `to`/`from`, or a non-owning view that
+   // GLZ_ASSERT_OWNS_ITS_BYTES rejects for a streaming read) still breaks the build.
+   template <class T, size_t I, operation Op>
+   inline constexpr bool skipped_by_meta = [] {
+      if constexpr (meta_has_skip<T>) {
+         return meta<std::remove_cvref_t<T>>::skip(reflect<T>::keys[I], meta_context{.op = Op});
+      }
+      else {
+         return false;
+      }
+   }();
+
    template <auto Opts, class T>
    inline constexpr bool maybe_skipped = [] {
       if constexpr (reflect<T>::size > 0) {

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -622,8 +622,9 @@ namespace glz
    // GLZ_ASSERT_OWNS_ITS_BYTES rejects for a streaming read) still breaks the build.
    template <class T, size_t I, operation Op>
    inline constexpr bool skipped_by_meta = [] {
-      if constexpr (meta_has_skip<T>) {
-         return meta<std::remove_cvref_t<T>>::skip(reflect<T>::keys[I], meta_context{.op = Op});
+      using V = std::remove_cvref_t<T>;
+      if constexpr (meta_has_skip<V>) {
+         return meta<V>::skip(reflect<V>::keys[I], meta_context{.op = Op});
       }
       else {
          return false;
@@ -801,12 +802,9 @@ namespace glz
             }
 
             // Check if field is skipped during parse - if so, don't require it
-            if constexpr (meta_has_skip<T>) {
-               constexpr auto key = reflect<T>::keys[I];
-               if constexpr (meta<T>::skip(key, {operation::parse})) {
-                  fields[I] = false;
-                  return;
-               }
+            if constexpr (skipped_by_meta<T, I, operation::parse>) {
+               fields[I] = false;
+               return;
             }
 
             // Check if meta<T>::requires_key customization point exists

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -276,49 +276,46 @@ namespace glz
             }
          }
 
-         // Check for operation-specific skipping
-         if constexpr (meta_has_skip<std::remove_cvref_t<T>>) {
-            if constexpr (meta<std::remove_cvref_t<T>>::skip(Key, {glz::operation::parse})) {
-               skip_value<JSON>::op<Opts>(ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]]
-                  return; // Propagate error from skip_value
-               if constexpr (Opts.error_on_missing_keys || Opts.partial_read) {
-                  ((selected_index = I), ...); // Mark as handled even if skipped
-               }
-               return;
-            }
-         }
-
-         using V = refl_t<T, I>;
-
-         if constexpr (const_value_v<V>) {
-            if constexpr (check_error_on_const_read(Opts)) {
-               ctx.error = error_code::attempt_const_read;
-            }
-            else {
-               // do not read anything into the const value
-               skip_value<JSON>::op<Opts>(ctx, it, end);
-            }
-         }
-         else if constexpr (is_function_ptr_or_ref<V>) {
-            // Function pointers cannot be deserialized from JSON.
-            // When write_function_pointers is enabled the writer emits a type-name string,
-            // but there is nothing meaningful to reconstruct on read — just skip the value.
-            // When write_function_pointers is off the key is never written, so this branch
-            // is unreachable in that case.
+         // Check for operation-specific skipping. The field's reader must live in the else branch so
+         // that a skipped field is never instantiated -- see `skipped_by_meta`.
+         if constexpr (skipped_by_meta<std::remove_cvref_t<T>, I, operation::parse>) {
             skip_value<JSON>::op<Opts>(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return; // Propagate error from skip_value
          }
          else {
-            if constexpr (glaze_object_t<T>) {
-               from<JSON, std::remove_cvref_t<V>>::template op<ws_handled<Opts>()>(
-                  get_member(value, get<I>(reflect<T>::values)), ctx, it, end);
+            using V = refl_t<T, I>;
+
+            if constexpr (const_value_v<V>) {
+               if constexpr (check_error_on_const_read(Opts)) {
+                  ctx.error = error_code::attempt_const_read;
+               }
+               else {
+                  // do not read anything into the const value
+                  skip_value<JSON>::op<Opts>(ctx, it, end);
+               }
+            }
+            else if constexpr (is_function_ptr_or_ref<V>) {
+               // Function pointers cannot be deserialized from JSON.
+               // When write_function_pointers is enabled the writer emits a type-name string,
+               // but there is nothing meaningful to reconstruct on read — just skip the value.
+               // When write_function_pointers is off the key is never written, so this branch
+               // is unreachable in that case.
+               skip_value<JSON>::op<Opts>(ctx, it, end);
             }
             else {
-               from<JSON, std::remove_cvref_t<V>>::template op<ws_handled<Opts>()>(
-                  get_member(value, get<I>(to_tie(value))), ctx, it, end);
+               if constexpr (glaze_object_t<T>) {
+                  from<JSON, std::remove_cvref_t<V>>::template op<ws_handled<Opts>()>(
+                     get_member(value, get<I>(reflect<T>::values)), ctx, it, end);
+               }
+               else {
+                  from<JSON, std::remove_cvref_t<V>>::template op<ws_handled<Opts>()>(
+                     get_member(value, get<I>(to_tie(value))), ctx, it, end);
+               }
             }
          }
 
+         // Mark as handled even when the field was skipped
          if constexpr (Opts.error_on_missing_keys || Opts.partial_read) {
             ((selected_index = I), ...);
          }
@@ -434,41 +431,37 @@ namespace glz
                }
             }
 
-            // Check for operation-specific skipping
-            if constexpr (meta_has_skip<std::remove_cvref_t<T>>) {
-               constexpr auto Key = get<I>(reflect<T>::keys);
-               if constexpr (meta<std::remove_cvref_t<T>>::skip(Key, {glz::operation::parse})) {
-                  skip_value<JSON>::op<Opts>(ctx, it, end);
-                  if (bool(ctx.error)) [[unlikely]]
-                     return;
-                  if constexpr (Opts.error_on_missing_keys || Opts.partial_read) {
-                     ((selected_index = I), ...);
-                  }
+            // Check for operation-specific skipping. The field's reader must live in the else branch
+            // so that a skipped field is never instantiated -- see `skipped_by_meta`.
+            if constexpr (skipped_by_meta<std::remove_cvref_t<T>, I, operation::parse>) {
+               skip_value<JSON>::op<Opts>(ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]]
                   return;
-               }
-            }
-
-            using V = refl_t<T, I>;
-            if constexpr (const_value_v<V>) {
-               if constexpr (check_error_on_const_read(Opts)) {
-                  ctx.error = error_code::attempt_const_read;
-               }
-               else {
-                  skip_value<JSON>::op<Opts>(ctx, it, end);
-               }
             }
             else {
-               // For linear_search, use Opts directly to avoid duplicate template instantiations
-               // We've already skipped whitespace before reaching here
-               if constexpr (glaze_object_t<T>) {
-                  from<JSON, std::remove_cvref_t<V>>::template op<Opts>(get_member(value, get<I>(reflect<T>::values)),
-                                                                        ctx, it, end);
+               using V = refl_t<T, I>;
+               if constexpr (const_value_v<V>) {
+                  if constexpr (check_error_on_const_read(Opts)) {
+                     ctx.error = error_code::attempt_const_read;
+                  }
+                  else {
+                     skip_value<JSON>::op<Opts>(ctx, it, end);
+                  }
                }
                else {
-                  from<JSON, std::remove_cvref_t<V>>::template op<Opts>(get_member(value, get<I>(to_tie(value))), ctx,
-                                                                        it, end);
+                  // For linear_search, use Opts directly to avoid duplicate template instantiations
+                  // We've already skipped whitespace before reaching here
+                  if constexpr (glaze_object_t<T>) {
+                     from<JSON, std::remove_cvref_t<V>>::template op<Opts>(
+                        get_member(value, get<I>(reflect<T>::values)), ctx, it, end);
+                  }
+                  else {
+                     from<JSON, std::remove_cvref_t<V>>::template op<Opts>(get_member(value, get<I>(to_tie(value))),
+                                                                           ctx, it, end);
+                  }
                }
             }
+            // Mark as handled even when the field was skipped
             if constexpr (Opts.error_on_missing_keys || Opts.partial_read) {
                ((selected_index = I), ...);
             }

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -228,6 +228,83 @@ namespace glz
       return N; // not found
    }
 
+   // Parse the value of field I once the ':' and the whitespace around it have been consumed.
+   // Shared by the hash-dispatch and the linear-search object paths. `FieldOpts` is what the field's
+   // own parser receives: the hash path has already consumed the leading whitespace (ws_handled),
+   // the linear path passes Opts through unchanged to avoid a second set of instantiations.
+   //
+   // `meta::skip` is a compile-time decision, so the field's reader lives in the `else` branch rather
+   // than after an early `return`. A `return` inside an `if constexpr` stops the field from being read
+   // at runtime, but the code that follows it is still instantiated -- which defeats skipping a field
+   // precisely because its type has no reader (no `from` specialization, or a non-owning view that
+   // GLZ_ASSERT_OWNS_ITS_BYTES rejects for a streaming read).
+   template <auto Opts, auto FieldOpts, class T, size_t I, class Value, class... SelectedIndex>
+      requires(glaze_object_t<T> || reflectable<T>)
+   GLZ_ALWAYS_INLINE void decode_field_value(Value&& value, is_context auto&& ctx, auto&& it, auto&& end,
+                                             SelectedIndex&&... selected_index)
+   {
+      // Check for null value skipping on read
+      if constexpr (check_skip_null_members_on_read(Opts)) {
+         if (*it == 'n') {
+            ++it;
+            if constexpr (not Opts.null_terminated) {
+               if (it == end) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
+            }
+            match<"ull", Opts>(ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
+            // Successfully matched "null", skip it
+            if constexpr (Opts.error_on_missing_keys || Opts.partial_read) {
+               ((selected_index = I), ...); // Mark as handled even if skipped
+            }
+            return;
+         }
+      }
+
+      if constexpr (skipped_by_meta<T, I, operation::parse>) {
+         skip_value<JSON>::op<Opts>(ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]]
+            return; // Propagate error from skip_value
+      }
+      else {
+         using V = refl_t<T, I>;
+
+         if constexpr (const_value_v<V>) {
+            if constexpr (check_error_on_const_read(Opts)) {
+               ctx.error = error_code::attempt_const_read;
+            }
+            else {
+               // do not read anything into the const value
+               skip_value<JSON>::op<Opts>(ctx, it, end);
+            }
+         }
+         else if constexpr (is_function_ptr_or_ref<V>) {
+            // Function pointers cannot be deserialized from JSON.
+            // When write_function_pointers is enabled the writer emits a type-name string,
+            // but there is nothing meaningful to reconstruct on read — just skip the value.
+            // When write_function_pointers is off the key is never written, so this branch
+            // is unreachable in that case.
+            skip_value<JSON>::op<Opts>(ctx, it, end);
+         }
+         else if constexpr (glaze_object_t<T>) {
+            from<JSON, std::remove_cvref_t<V>>::template op<FieldOpts>(get_member(value, get<I>(reflect<T>::values)),
+                                                                       ctx, it, end);
+         }
+         else {
+            from<JSON, std::remove_cvref_t<V>>::template op<FieldOpts>(get_member(value, get<I>(to_tie(value))), ctx,
+                                                                       it, end);
+         }
+      }
+
+      // The key was present and handled, even when the value itself was skipped
+      if constexpr (Opts.error_on_missing_keys || Opts.partial_read) {
+         ((selected_index = I), ...);
+      }
+   }
+
    template <auto Opts, class T, size_t I, class Value, class... SelectedIndex>
       requires(glaze_object_t<T> || reflectable<T>)
    void decode_index(Value&& value, is_context auto&& ctx, auto&& it, auto&& end, SelectedIndex&&... selected_index)
@@ -255,70 +332,8 @@ namespace glz
             return;
          }
 
-         // Check for null value skipping on read
-         if constexpr (check_skip_null_members_on_read(Opts)) {
-            if (*it == 'n') {
-               ++it;
-               if constexpr (not Opts.null_terminated) {
-                  if (it == end) [[unlikely]] {
-                     ctx.error = error_code::unexpected_end;
-                     return;
-                  }
-               }
-               match<"ull", Opts>(ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]]
-                  return;
-               // Successfully matched "null", skip it
-               if constexpr (Opts.error_on_missing_keys || Opts.partial_read) {
-                  ((selected_index = I), ...); // Mark as handled even if skipped
-               }
-               return;
-            }
-         }
-
-         // Check for operation-specific skipping. The field's reader must live in the else branch so
-         // that a skipped field is never instantiated -- see `skipped_by_meta`.
-         if constexpr (skipped_by_meta<std::remove_cvref_t<T>, I, operation::parse>) {
-            skip_value<JSON>::op<Opts>(ctx, it, end);
-            if (bool(ctx.error)) [[unlikely]]
-               return; // Propagate error from skip_value
-         }
-         else {
-            using V = refl_t<T, I>;
-
-            if constexpr (const_value_v<V>) {
-               if constexpr (check_error_on_const_read(Opts)) {
-                  ctx.error = error_code::attempt_const_read;
-               }
-               else {
-                  // do not read anything into the const value
-                  skip_value<JSON>::op<Opts>(ctx, it, end);
-               }
-            }
-            else if constexpr (is_function_ptr_or_ref<V>) {
-               // Function pointers cannot be deserialized from JSON.
-               // When write_function_pointers is enabled the writer emits a type-name string,
-               // but there is nothing meaningful to reconstruct on read — just skip the value.
-               // When write_function_pointers is off the key is never written, so this branch
-               // is unreachable in that case.
-               skip_value<JSON>::op<Opts>(ctx, it, end);
-            }
-            else {
-               if constexpr (glaze_object_t<T>) {
-                  from<JSON, std::remove_cvref_t<V>>::template op<ws_handled<Opts>()>(
-                     get_member(value, get<I>(reflect<T>::values)), ctx, it, end);
-               }
-               else {
-                  from<JSON, std::remove_cvref_t<V>>::template op<ws_handled<Opts>()>(
-                     get_member(value, get<I>(to_tie(value))), ctx, it, end);
-               }
-            }
-         }
-
-         // Mark as handled even when the field was skipped
-         if constexpr (Opts.error_on_missing_keys || Opts.partial_read) {
-            ((selected_index = I), ...);
-         }
+         // The hash path has already consumed the whitespace before the value
+         decode_field_value<Opts, ws_handled<Opts>(), T, I>(value, ctx, it, end, selected_index...);
       }
       else [[unlikely]] {
          decode_index_unknown_key<Opts, T>(value, ctx, it, end);
@@ -412,62 +427,14 @@ namespace glz
             return;
          }
 
-         // Fold expression dispatch - avoids jump table overhead for smaller binary size
-         auto parse_field = [&]<size_t I>() {
-            if constexpr (check_skip_null_members_on_read(Opts)) {
-               if (*it == 'n') {
-                  ++it;
-                  if constexpr (not Opts.null_terminated) {
-                     if (it == end) [[unlikely]] {
-                        ctx.error = error_code::unexpected_end;
-                        return;
-                     }
-                  }
-                  match<"ull", Opts>(ctx, it, end);
-                  if constexpr (Opts.error_on_missing_keys || Opts.partial_read) {
-                     ((selected_index = I), ...);
-                  }
-                  return;
-               }
-            }
-
-            // Check for operation-specific skipping. The field's reader must live in the else branch
-            // so that a skipped field is never instantiated -- see `skipped_by_meta`.
-            if constexpr (skipped_by_meta<std::remove_cvref_t<T>, I, operation::parse>) {
-               skip_value<JSON>::op<Opts>(ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]]
-                  return;
-            }
-            else {
-               using V = refl_t<T, I>;
-               if constexpr (const_value_v<V>) {
-                  if constexpr (check_error_on_const_read(Opts)) {
-                     ctx.error = error_code::attempt_const_read;
-                  }
-                  else {
-                     skip_value<JSON>::op<Opts>(ctx, it, end);
-                  }
-               }
-               else {
-                  // For linear_search, use Opts directly to avoid duplicate template instantiations
-                  // We've already skipped whitespace before reaching here
-                  if constexpr (glaze_object_t<T>) {
-                     from<JSON, std::remove_cvref_t<V>>::template op<Opts>(
-                        get_member(value, get<I>(reflect<T>::values)), ctx, it, end);
-                  }
-                  else {
-                     from<JSON, std::remove_cvref_t<V>>::template op<Opts>(get_member(value, get<I>(to_tie(value))),
-                                                                           ctx, it, end);
-                  }
-               }
-            }
-            // Mark as handled even when the field was skipped
-            if constexpr (Opts.error_on_missing_keys || Opts.partial_read) {
-               ((selected_index = I), ...);
-            }
-         };
+         // Fold expression dispatch - avoids jump table overhead for smaller binary size.
+         // For linear_search, pass Opts through to the field parser to avoid duplicate template
+         // instantiations; the whitespace before the value has already been skipped either way.
          [&]<size_t... Is>(std::index_sequence<Is...>) {
-            (void)(((index == Is ? (parse_field.template operator()<Is>(), true) : false) || ...));
+            (void)(((index == Is
+                        ? (decode_field_value<Opts, Opts, T, Is>(value, ctx, it, end, selected_index...), true)
+                        : false) ||
+                    ...));
          }(std::make_index_sequence<N>{});
       }
       else {

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -2347,29 +2347,29 @@ namespace glz
                for_each<N>([&]<size_t I>() {
                   using val_t = field_t<T, I>;
 
-                  if constexpr (meta_has_skip<T>) {
-                     static constexpr meta_context mctx{.op = operation::serialize};
-                     if constexpr (meta<T>::skip(reflect<T>::keys[I], mctx)) return;
-                  }
-                  if constexpr (meta_has_skip_if<T>) {
-                     static constexpr auto key = glz::get<I>(reflect<T>::keys);
-                     static constexpr meta_context mctx{.op = operation::serialize};
-                     decltype(auto) field_value = [&]() -> decltype(auto) {
-                        if constexpr (reflectable<T>) {
-                           return get<I>(t);
-                        }
-                        else {
-                           return get_member(value, glz::get<I>(reflect<T>::values));
-                        }
-                     }();
-                     if (meta<T>::skip_if(field_value, key, mctx)) return;
-                  }
-
+                  // `meta<T>::skip` joins the other compile-time exclusions here rather than returning
+                  // early, so that a skipped field's writer is never instantiated -- see
+                  // `skipped_by_meta`.
                   constexpr bool write_function_pointers = check_write_function_pointers(Opts);
-                  if constexpr (always_skipped<val_t> || (!write_function_pointers && is_any_function_ptr<val_t>)) {
+                  if constexpr (skipped_by_meta<T, I, operation::serialize> || always_skipped<val_t> ||
+                                (!write_function_pointers && is_any_function_ptr<val_t>)) {
                      return;
                   }
                   else {
+                     if constexpr (meta_has_skip_if<T>) {
+                        static constexpr auto skip_if_key = glz::get<I>(reflect<T>::keys);
+                        static constexpr meta_context mctx{.op = operation::serialize};
+                        decltype(auto) field_value = [&]() -> decltype(auto) {
+                           if constexpr (reflectable<T>) {
+                              return get<I>(t);
+                           }
+                           else {
+                              return get_member(value, glz::get<I>(reflect<T>::values));
+                           }
+                        }();
+                        if (meta<T>::skip_if(field_value, skip_if_key, mctx)) return;
+                     }
+
                      if constexpr (null_t<val_t> && Opts.skip_null_members) {
                         if constexpr (always_null_t<val_t>)
                            return;

--- a/include/glaze/yaml/write.hpp
+++ b/include/glaze/yaml/write.hpp
@@ -1133,7 +1133,10 @@ namespace glz
 
             using val_t = field_t<V, I>;
 
-            if constexpr (!always_skipped<val_t>) {
+            // meta::skip (compile-time) gates the field here rather than returning from inside the
+            // block, so that a skipped field's writer is never instantiated -- see `skipped_by_meta`.
+            // meta::skip_if is a runtime check and stays below.
+            if constexpr (!always_skipped<val_t> && !skipped_by_meta<V, I, operation::serialize>) {
                static constexpr sv key = get<I>(reflect<V>::keys);
 
                // Get member value (supports both glaze_object_t and reflectable)
@@ -1146,11 +1149,7 @@ namespace glz
                   }
                }();
 
-               // Skip fields based on meta::skip (compile-time) and meta::skip_if (runtime)
-               if constexpr (meta_has_skip<V>) {
-                  static constexpr meta_context mctx{.op = operation::serialize};
-                  if constexpr (meta<V>::skip(reflect<V>::keys[I], mctx)) return;
-               }
+               // Skip fields based on meta::skip_if (runtime)
                if constexpr (meta_has_skip_if<V>) {
                   static constexpr auto k = glz::get<I>(reflect<V>::keys);
                   static constexpr meta_context mctx{.op = operation::serialize};
@@ -1370,7 +1369,9 @@ namespace glz
 
             using val_t = field_t<V, I>;
 
-            if constexpr (!always_skipped<val_t>) {
+            // A field excluded by meta::skip is excluded from flow style too, and gating it here keeps
+            // its writer uninstantiated -- see `skipped_by_meta`.
+            if constexpr (!always_skipped<val_t> && !skipped_by_meta<V, I, operation::serialize>) {
                static constexpr sv key = get<I>(reflect<V>::keys);
 
                // Get member value (supports both glaze_object_t and reflectable)

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -2080,6 +2080,22 @@ struct nothing
    };
 };
 
+struct parse_skipped_t
+{
+   int a{};
+   double skipped_on_parse{};
+   std::string s{};
+};
+
+template <>
+struct glz::meta<parse_skipped_t>
+{
+   static constexpr bool skip(const std::string_view key, const meta_context& ctx)
+   {
+      return key == "skipped_on_parse" && ctx.op == operation::parse;
+   }
+};
+
 suite skip_test = [] {
    "skip"_test = [] {
       full f{};
@@ -2099,6 +2115,24 @@ suite skip_test = [] {
 
       nothing obj{};
       expect(!glz::read<glz::opts{.format = glz::BEVE, .error_on_unknown_keys = false}>(obj, s));
+   };
+
+   // A skip() that only fires on parse excludes nothing from serialization, so the object writes all
+   // three members and the member count in the header has to say three. The count and the members
+   // themselves are decided by separate code, and this is what catches them disagreeing.
+   //
+   // meta::skip is a JSON/YAML customization point; BEVE does not consult it in either direction, so
+   // the skipped member also survives the read here.
+   "a parse-only meta::skip writes every member"_test = [] {
+      parse_skipped_t obj{7, 2.5, "written"};
+      std::string s{};
+      expect(not glz::write_beve(obj, s));
+
+      parse_skipped_t restored{};
+      expect(!glz::read_beve(restored, s));
+      expect(restored.a == 7);
+      expect(restored.skipped_on_parse == 2.5);
+      expect(restored.s == "written");
    };
 };
 

--- a/tests/istream_buffer_test/istream_buffer_test.cpp
+++ b/tests/istream_buffer_test/istream_buffer_test.cpp
@@ -4664,6 +4664,22 @@ struct glz::meta<formatted_date_t>
    static constexpr auto value = object("when", glz::date_format(&T::when, "%Y-%m-%d %H:%M:%S"));
 };
 
+// meta::skip decides at compile time that a field is not part of the parse, so its reader must never
+// be instantiated -- otherwise the guard fires on a field the user has already opted out of, and the
+// only way to stream the type is to change a member the read does not touch (issue #2780).
+struct skipped_view_t
+{
+   int idx{};
+   std::string_view name{};
+   std::string tail{};
+};
+
+template <>
+struct glz::meta<skipped_view_t>
+{
+   static constexpr bool skip(const std::string_view key, const glz::meta_context&) { return key == "name"; }
+};
+
 // A refill moves the window, so a view handed out before one points at bytes that have since been
 // overwritten, while the read still reports success. There is no runtime signal to check, so the
 // readers that alias the buffer refuse at compile time instead.
@@ -4737,6 +4753,30 @@ suite streaming_view_rejection_tests = [] {
       const auto expected = std::chrono::sys_days{std::chrono::year{2024} / std::chrono::March / std::chrono::day{4}} +
                             std::chrono::hours{5} + std::chrono::minutes{6} + std::chrono::seconds{7};
       expect(value.when == expected);
+   };
+
+   "a view excluded by meta::skip still streams"_test = [] {
+      std::istringstream in{R"({"idx":1337,"name":"Hello, World!","tail":"end"})"};
+      glz::basic_istream_buffer<std::istringstream, 512> buffer{in};
+      skipped_view_t value{.name = "untouched"};
+      expect(!glz::read_json(value, buffer));
+      expect(value.idx == 1337);
+      expect(value.name == "untouched");
+      expect(value.tail == "end");
+   };
+
+   // The skipped value is stepped over by the same window the rest of the parse reads through, so it
+   // has to survive a value larger than that window: a skip that mishandled a refill would swallow
+   // the fields behind it.
+   "a skipped value wider than the window still streams"_test = [] {
+      const std::string doc = R"({"idx":5,"name":")" + std::string(4096, 'x') + R"(","tail":"end"})";
+      std::istringstream in{doc};
+      glz::basic_istream_buffer<std::istringstream, 512> buffer{in};
+      skipped_view_t value{};
+      expect(!glz::read_json(value, buffer));
+      expect(value.idx == 5);
+      expect(value.name.empty());
+      expect(value.tail == "end");
    };
 
    // The guard only applies to streaming. A buffered read owns its whole document for the duration

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -13307,6 +13307,25 @@ suite error_on_missing_keys_with_skip_tests = [] {
       expect(obj.skipped_field == 42); // Unchanged because field is skipped during parse
       expect(obj.normal_field == 100);
    };
+
+   // A skip() that only fires on parse excludes nothing from serialization, so the writer places its
+   // separators at compile time as if no skip existed. Every field must still be written, with commas
+   // between all of them.
+   "meta::skip on parse leaves serialization untouched"_test = [] {
+      skip_on_parse_t obj{"test", 42, 100};
+      expect(glz::write_json(obj) == R"({"name":"test","skipped_field":42,"normal_field":100})")
+         << glz::write_json(obj).value();
+
+      // Prettified output carries the separators through indentation and newlines, so it is worth
+      // confirming that the statically placed ones land there too
+      std::string pretty{};
+      expect(!glz::write<glz::opts{.prettify = true}>(obj, pretty));
+      expect(pretty == R"({
+   "name": "test",
+   "skipped_field": 42,
+   "normal_field": 100
+})") << pretty;
+   };
 };
 
 struct large_struct_t

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -12880,6 +12880,50 @@ suite skip_first_and_last_tests = [] {
    };
 };
 
+// A skipped field is not part of the parse or the serialization, so neither direction may instantiate
+// its reader or writer -- a field can only be skipped for being unserializable if skipping it stops
+// the build from demanding a serializer for it (issue #2780).
+class opaque_field_t
+{
+   int value_{7};
+
+  public:
+   opaque_field_t() = default;
+   int value() const { return value_; }
+};
+
+struct holds_opaque_field
+{
+   int i{1};
+   opaque_field_t opaque{};
+   std::string s{"end"};
+};
+
+template <>
+struct glz::meta<holds_opaque_field>
+{
+   static constexpr bool skip(const std::string_view key, const meta_context&) { return key == "opaque"; }
+};
+
+suite skip_unserializable_field_tests = [] {
+   "skipped field needs no serializer"_test = [] {
+      holds_opaque_field obj{};
+      expect(glz::write_json(obj) == R"({"i":1,"s":"end"})") << glz::write_json(obj).value();
+
+      holds_opaque_field parsed{};
+      expect(!glz::read_json(parsed, R"({"i":9,"opaque":{"value":1},"s":"tail"})"));
+      expect(parsed.i == 9);
+      expect(parsed.s == "tail");
+      expect(parsed.opaque.value() == 7);
+   };
+
+   "a skipped key is not a missing key"_test = [] {
+      holds_opaque_field parsed{};
+      expect(!glz::read<glz::opts{.error_on_missing_keys = true}>(parsed, R"({"i":9,"s":"tail"})"));
+      expect(parsed.i == 9);
+   };
+};
+
 template <size_t N>
 struct FixedName
 {

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -8902,6 +8902,15 @@ suite yaml_skip_tests = [] {
       expect(yaml.find("secret") == std::string::npos) << "secret field should be skipped";
    };
 
+   // Flow style writes the same fields as block style, so a field meta::skip excludes is excluded
+   // from both -- and the excluded field's writer is never instantiated in either.
+   "yaml_write_skip_excludes_field_in_flow_style"_test = [] {
+      yaml_skip_struct obj{"abc", "top_secret", 42};
+      std::string yaml;
+      expect(!glz::write<glz::yaml::yaml_opts{.flow_style = true}>(obj, yaml));
+      expect(yaml == R"({id: abc, count: 42})") << yaml;
+   };
+
    "yaml_write_skip_if_excludes_default_value"_test = [] {
       yaml_skip_if_struct obj{"Alice", 0, "NYC"};
       std::string yaml;


### PR DESCRIPTION
Fixes #2780.

`meta::skip` is a compile-time decision, but every reader and writer that honored it returned early from inside an `if constexpr` block rather than placing the field's serializer in the `else` branch:

```cpp
if constexpr (meta_has_skip<T>) {
   if constexpr (meta<T>::skip(Key, {operation::parse})) { skip_value(...); return; }
}
using V = refl_t<T, I>;
from<JSON, V>::op<...>(...);   // instantiated for the skipped field anyway
```

The `return` stops the field from being touched at runtime, but the code after the block is not discarded, so the skipped field's serializer was compiled regardless. A field could therefore not be skipped for the one reason a user most needs to skip it: that its type cannot be handled in that direction.

The reported case is a streaming read of a struct holding a `std::string_view`. The field was skipped, but the view's reader was still instantiated and `GLZ_ASSERT_OWNS_ITS_BYTES` rejected the read. The write side had the same defect in a quieter form: a skipped field whose type has no serializer at all failed with `implicit instantiation of undefined template 'glz::to<10, T>'`.

## Fix

The check now goes through `skipped_by_meta<T, I, Op>`, consumed as `if constexpr`/`else` at every site:

- **`json/read.hpp`** — both object paths (hash dispatch and linear search). The `selected_index` bookkeeping moves out of the branches, which also drops the copy each skip path was carrying.
- **`json/write.hpp`** — `meta::skip` joins the other compile-time exclusions (`always_skipped`, function pointers) in one condition. The runtime `skip_if` check moves into the `else`, so a field excluded at compile time no longer reaches it.
- **`yaml/write.hpp`** — block mappings use the same gate. The flow mapping writer did not consult `meta::skip` at all, so flow style emitted fields that block style excluded; that is now consistent.

## Tests

- `istream_buffer_test` — the reported streaming case, plus a skipped value wider than the window so the skip spans a refill.
- `json_test` — a skipped field whose type has no serializer in either direction, and that a skipped key is not a missing key under `error_on_missing_keys`.
- `yaml_test` — flow style honors `meta::skip`.
- `streaming_view_rejection` still fails to compile for views that genuinely alias the window, so the guard is unchanged for the case it exists to catch.

Verified on Apple Clang 17 and GCC 15; full ctest suite green (118/118).
