### PR TITLE
Name types through glz::name_meta so glz::meta stays the user's

### DIFF
--- a/docs/advanced-api-usage.md
+++ b/docs/advanced-api-usage.md
@@ -434,7 +434,7 @@ The type hash for a type `T` includes:
 ```c++
 // Pseudo-code showing what gets hashed
 hash = hash128(
-  name,                        // Type name from glz::meta
+  name,                        // Type name from glz::name_v
   sizeof(T),                   // Size in bytes
   version.major,               // Version components
   version.minor,
@@ -479,6 +479,27 @@ glz::name_v<std::function<void()>>                      // "std::function<void()
 glz::name_v<std::function<double(const int&, const double&)>>
   // "std::function<double(const int32_t&,const double&)>"
 ```
+
+### Customizing Type Names
+
+`glz::name_v<T>` resolves in this order:
+
+1. `T::glaze::name`
+2. `glz::meta<T>::name`
+3. `glz::name_meta<T>::name` — the built-in names above
+4. the compiler's name for `T`
+
+`glz::name_meta` is where Glaze names fundamental types, `const`/reference/pointer types, and standard containers. Naming these through `glz::name_meta` rather than through partial specializations of `glz::meta` keeps `glz::meta` entirely yours: a specialization written against a concept rather than an exact type, such as
+
+```c++
+template <std::derived_from<my_base> T>
+struct glz::meta<T>
+{
+   static constexpr auto value = /* ... */;
+};
+```
+
+claims every type it matches, including `const T`, without becoming ambiguous with a Glaze specialization.
 
 ### Debugging Type Mismatches
 

--- a/docs/glaze-interfaces.md
+++ b/docs/glaze-interfaces.md
@@ -270,9 +270,9 @@ This makes the 128-bit hash more than sufficient for any practical application.
 
 ## Name
 
-By default custom type names from `glz::name_v` will be `"Unnamed"`. It is best practice to give types the same name as it has in C++, including the namespace (at least the local namespace).
+Without a name of its own, a type falls back to the name the compiler gives it, which varies between compilers. It is best practice to give types the same name as they have in C++, including the namespace (at least the local namespace).
 
-Concepts exist for naming `const`, pointer (`*`), and reference (`&`), versions of types as they are used. Many standard library containers are also supported.
+Glaze names `const`, pointer (`*`), and reference (`&`) versions of types as they are used, along with many standard library containers. These names live in `glz::name_meta` rather than `glz::meta` — see [Customizing Type Names](./advanced-api-usage.md#customizing-type-names).
 
 ```c++
 expect(glz::name_v<std::vector<float>> == "std::vector<float>");

--- a/include/glaze/api/std/array.hpp
+++ b/include/glaze/api/std/array.hpp
@@ -31,7 +31,7 @@ namespace glz
    {};
 
    template <class T, size_t N>
-   struct meta<std::array<T, N>>
+   struct name_meta<std::array<T, N>>
    {
       static constexpr std::string_view name =
          join_v<chars<"std::array<">, name_v<T>, chars<",">, chars<num_to_string<N>::value>, chars<">">>;

--- a/include/glaze/api/std/deque.hpp
+++ b/include/glaze/api/std/deque.hpp
@@ -10,7 +10,7 @@
 namespace glz
 {
    template <class T>
-   struct meta<std::deque<T>>
+   struct name_meta<std::deque<T>>
    {
       static constexpr std::string_view name = join_v<chars<"std::deque<">, name_v<T>, chars<">">>;
    };

--- a/include/glaze/api/std/functional.hpp
+++ b/include/glaze/api/std/functional.hpp
@@ -40,7 +40,7 @@ namespace glz
    concept function = is_specialization_v<T, std::function>;
 
    template <function T>
-   struct meta<T>
+   struct name_meta<T>
    {
       static constexpr auto impl() noexcept
       {

--- a/include/glaze/api/std/list.hpp
+++ b/include/glaze/api/std/list.hpp
@@ -10,7 +10,7 @@
 namespace glz
 {
    template <class T>
-   struct meta<std::list<T>>
+   struct name_meta<std::list<T>>
    {
       static constexpr std::string_view name = join_v<chars<"std::list<">, name_v<T>, chars<">">>;
    };

--- a/include/glaze/api/std/map.hpp
+++ b/include/glaze/api/std/map.hpp
@@ -10,7 +10,7 @@
 namespace glz
 {
    template <class Key, class Mapped>
-   struct meta<std::map<Key, Mapped>>
+   struct name_meta<std::map<Key, Mapped>>
    {
       static constexpr std::string_view name =
          join_v<chars<"std::map<">, name_v<Key>, chars<",">, name_v<Mapped>, chars<">">>;

--- a/include/glaze/api/std/optional.hpp
+++ b/include/glaze/api/std/optional.hpp
@@ -10,7 +10,7 @@
 namespace glz
 {
    template <class T>
-   struct meta<std::optional<T>>
+   struct name_meta<std::optional<T>>
    {
       static constexpr std::string_view name = join_v<chars<"std::optional<">, name_v<T>, chars<">">>;
    };

--- a/include/glaze/api/std/set.hpp
+++ b/include/glaze/api/std/set.hpp
@@ -10,7 +10,7 @@
 namespace glz
 {
    template <class T>
-   struct meta<std::set<T>>
+   struct name_meta<std::set<T>>
    {
       static constexpr std::string_view name = join_v<chars<"std::set<">, name_v<T>, chars<">">>;
    };

--- a/include/glaze/api/std/shared_ptr.hpp
+++ b/include/glaze/api/std/shared_ptr.hpp
@@ -10,7 +10,7 @@
 namespace glz
 {
    template <class T>
-   struct meta<std::shared_ptr<T>>
+   struct name_meta<std::shared_ptr<T>>
    {
       static constexpr std::string_view name = join_v<chars<"std::shared_ptr<">, name_v<T>, chars<">">>;
    };

--- a/include/glaze/api/std/span.hpp
+++ b/include/glaze/api/std/span.hpp
@@ -19,7 +19,7 @@ namespace glz
    concept span = is_span_v<T, std::span>;
 
    template <span T>
-   struct meta<T>
+   struct name_meta<T>
    {
       using V = typename T::element_type;
       static constexpr std::string_view extent = to_sv<T::extent>();

--- a/include/glaze/api/std/string.hpp
+++ b/include/glaze/api/std/string.hpp
@@ -11,7 +11,7 @@
 namespace glz
 {
    template <>
-   struct meta<std::string>
+   struct name_meta<std::string>
    {
       static constexpr std::string_view name = "std::string";
    };

--- a/include/glaze/api/std/tuple.hpp
+++ b/include/glaze/api/std/tuple.hpp
@@ -10,7 +10,7 @@
 namespace glz
 {
    template <class... T>
-   struct meta<std::tuple<T...>>
+   struct name_meta<std::tuple<T...>>
    {
       static constexpr std::string_view name = []<size_t... I>(std::index_sequence<I...>) {
          return join_v<chars<"std::tuple<">,

--- a/include/glaze/api/std/unique_ptr.hpp
+++ b/include/glaze/api/std/unique_ptr.hpp
@@ -10,7 +10,7 @@
 namespace glz
 {
    template <class T>
-   struct meta<std::unique_ptr<T>>
+   struct name_meta<std::unique_ptr<T>>
    {
       static constexpr std::string_view name = join_v<chars<"std::unique_ptr<">, name_v<T>, chars<">">>;
    };

--- a/include/glaze/api/std/unordered_map.hpp
+++ b/include/glaze/api/std/unordered_map.hpp
@@ -10,7 +10,7 @@
 namespace glz
 {
    template <class Key, class Mapped>
-   struct meta<std::unordered_map<Key, Mapped>>
+   struct name_meta<std::unordered_map<Key, Mapped>>
    {
       static constexpr std::string_view name =
          join_v<chars<"std::unordered_map<">, name_v<Key>, chars<",">, name_v<Mapped>, chars<">">>;

--- a/include/glaze/api/std/unordered_set.hpp
+++ b/include/glaze/api/std/unordered_set.hpp
@@ -10,7 +10,7 @@
 namespace glz
 {
    template <class T>
-   struct meta<std::unordered_set<T>>
+   struct name_meta<std::unordered_set<T>>
    {
       static constexpr std::string_view name = join_v<chars<"std::unordered_set<">, name_v<T>, chars<">">>;
    };

--- a/include/glaze/api/std/variant.hpp
+++ b/include/glaze/api/std/variant.hpp
@@ -10,7 +10,7 @@
 namespace glz
 {
    template <class... T>
-   struct meta<std::variant<T...>>
+   struct name_meta<std::variant<T...>>
    {
       static constexpr std::string_view name = []<size_t... I>(std::index_sequence<I...>) {
          return join_v<chars<"std::variant<">,
@@ -19,7 +19,7 @@ namespace glz
    };
 
    template <>
-   struct meta<std::monostate>
+   struct name_meta<std::monostate>
    {
       static constexpr std::string_view name = "std::monostate";
    };

--- a/include/glaze/api/std/vector.hpp
+++ b/include/glaze/api/std/vector.hpp
@@ -10,7 +10,7 @@
 namespace glz
 {
    template <class T>
-   struct meta<std::vector<T>>
+   struct name_meta<std::vector<T>>
    {
       static constexpr std::string_view name = join_v<chars<"std::vector<">, name_v<T>, chars<">">>;
    };

--- a/include/glaze/api/tuplet.hpp
+++ b/include/glaze/api/tuplet.hpp
@@ -9,7 +9,7 @@
 namespace glz
 {
    template <class... T>
-   struct meta<glz::tuple<T...>>
+   struct name_meta<glz::tuple<T...>>
    {
       static constexpr std::string_view name = []<size_t... I>(std::index_sequence<I...>) {
          return join_v<chars<"glz::tuple<">,

--- a/include/glaze/api/type_support.hpp
+++ b/include/glaze/api/type_support.hpp
@@ -9,11 +9,16 @@
 #include "glaze/core/meta.hpp"
 #include "glaze/util/for_each.hpp"
 
+// These specializations name built-in and compound types for the Glaze API and JSON schema.
+// They specialize `glz::name_meta`, never `glz::meta`: `meta` is the user's customization point, and
+// a Glaze partial specialization matching something as broad as "every const type" is ambiguous with a
+// user specialization constrained on a concept (e.g. `template <std::derived_from<Base> T> struct
+// glz::meta<T>`), leaving the user no recourse short of enumerating exact types.
 namespace glz
 {
 #define specialize(type)                              \
    template <>                                        \
-   struct meta<type>                                  \
+   struct name_meta<type>                             \
    {                                                  \
       static constexpr std::string_view name = #type; \
    };
@@ -25,7 +30,7 @@ namespace glz
 
             template <std::same_as<long long> long_long_t>
       requires requires { !std::same_as<long long, int64_t>; }
-   struct meta<long_long_t>
+   struct name_meta<long_long_t>
    {
       static_assert(sizeof(long long) == 8);
       static constexpr std::string_view name{"int64_t"};
@@ -34,7 +39,7 @@ namespace glz
 
    template <std::same_as<unsigned long long> unsigned_long_long_t>
       requires requires { !std::same_as<unsigned long long, uint64_t>; }
-   struct meta<unsigned_long_long_t>
+   struct name_meta<unsigned_long_long_t>
    {
       static_assert(sizeof(unsigned long long) == 8);
       static constexpr std::string_view name{"uint64_t"};
@@ -43,7 +48,7 @@ namespace glz
 
    template <class T>
       requires(std::is_lvalue_reference_v<T>)
-   struct meta<T>
+   struct name_meta<T>
    {
       using V = std::remove_reference_t<T>;
       static constexpr std::string_view name = join_v<name_v<V>, chars<"&">>;
@@ -51,7 +56,7 @@ namespace glz
 
    template <class T>
       requires(std::is_rvalue_reference_v<T>)
-   struct meta<T>
+   struct name_meta<T>
    {
       using V = std::remove_reference_t<T>;
       static constexpr std::string_view name = join_v<name_v<V>, chars<"&&">>;
@@ -59,29 +64,32 @@ namespace glz
 
    template <class T>
       requires(std::is_const_v<T>)
-   struct meta<T>
+   struct name_meta<T>
    {
       using V = std::remove_const_t<T>;
       static constexpr std::string_view name = join_v<chars<"const ">, name_v<V>>;
    };
 
+   // `!std::is_const_v<T>` keeps a const pointer such as `int* const` from matching both this and the
+   // const specialization above, which would be ambiguous. The const one handles it and recurses here
+   // for the pointee, so the const survives in the name.
    template <class T>
-      requires(std::is_pointer_v<T>)
-   struct meta<T>
+      requires(std::is_pointer_v<T> && !std::is_const_v<T>)
+   struct name_meta<T>
    {
       using V = std::remove_pointer_t<T>;
       static constexpr std::string_view name = join_v<name_v<V>, chars<"*">>;
    };
 
    template <class Ret, class Obj, class... Args>
-   struct meta<Ret (Obj::*)(Args...)>
+   struct name_meta<Ret (Obj::*)(Args...)>
    {
       static constexpr std::string_view name =
          join_v<name_v<Ret>, chars<" (">, name_v<Obj>, chars<"::*)(">, name_v<Args>..., chars<")">>;
    };
 
    template <class Ret, class Obj, class... Args>
-   struct meta<Ret (Obj::*)(Args...) volatile>
+   struct name_meta<Ret (Obj::*)(Args...) volatile>
    {
       static constexpr std::string_view name =
          join_v<type_name<Ret>, chars<" (">, name_v<Obj>, chars<"::*)(">, name_v<Args>..., chars<") volatile">>;

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -142,7 +142,7 @@ namespace glz
    };
 
    template <class T>
-   struct meta<includer<T>>
+   struct name_meta<includer<T>>
    {
       static constexpr std::string_view name = join_v<chars<"includer<">, name_v<T>, chars<">">>;
    };
@@ -192,7 +192,7 @@ namespace glz
    using raw_json_view = basic_raw_json<std::string_view>;
 
    template <class T>
-   struct meta<basic_raw_json<T>>
+   struct name_meta<basic_raw_json<T>>
    {
       static constexpr std::string_view name = "raw_json";
    };

--- a/include/glaze/core/meta.hpp
+++ b/include/glaze/core/meta.hpp
@@ -34,14 +34,26 @@ namespace glz
 
    // Primary template for glz::meta lives in glaze/forward.hpp.
 
+   // `name_meta` is how Glaze itself names types, and is deliberately separate from `glz::meta`.
+   // `meta` belongs to the user: Glaze declaring broadly constrained partial specializations of it
+   // (for `const T`, `T&`, `T*`, ...) makes any user specialization that is constrained on a concept
+   // rather than written for an exact type ambiguous with Glaze's, which is a hard error.
+   // Specialize this trait with a `name` member to give a type its Glaze name; `name_v` consults it
+   // only after the user's own `meta<T>::name` and `T::glaze::name`.
+   template <class T>
+   struct name_meta
+   {};
+
    template <>
-   struct meta<std::string_view>
+   struct name_meta<std::string_view>
    {
       static constexpr std::string_view name = "std::string_view";
    };
 
+   // Spelled out rather than left to the generic const specialization in glaze/api/type_support.hpp,
+   // which a translation unit that includes only core headers never sees.
    template <>
-   struct meta<const std::string_view>
+   struct name_meta<const std::string_view>
    {
       static constexpr std::string_view name = "const std::string_view";
    };
@@ -627,7 +639,7 @@ namespace glz
       !std::is_same_v<std::decay_t<decltype(self_constraint_v<std::decay_t<T>>)>, empty>;
 
    template <class T>
-   concept named = requires { meta<T>::name; } || requires { T::glaze::name; };
+   concept named = requires { meta<T>::name; } || requires { T::glaze::name; } || requires { name_meta<T>::name; };
 
    template <class T>
    inline constexpr std::string_view name_v = [] {
@@ -635,8 +647,11 @@ namespace glz
          if constexpr (requires { T::glaze::name; }) {
             return T::glaze::name;
          }
-         else {
+         else if constexpr (requires { meta<T>::name; }) {
             return meta<T>::name;
+         }
+         else {
+            return name_meta<T>::name;
          }
       }
       else if constexpr (std::is_void_v<T>) {
@@ -668,7 +683,7 @@ namespace glz
    }
 
    // Opts-aware name: like name_v but respects qualified_type_names option for the fallback.
-   // Priority: meta<T>::name > T::glaze::name > type_name_for_opts
+   // Priority: T::glaze::name > meta<T>::name > name_meta<T>::name > type_name_for_opts
    template <class T, auto Opts>
    consteval auto name_for_opts()
    {
@@ -676,8 +691,11 @@ namespace glz
          if constexpr (requires { T::glaze::name; }) {
             return std::string_view{T::glaze::name};
          }
-         else {
+         else if constexpr (requires { meta<T>::name; }) {
             return std::string_view{meta<T>::name};
+         }
+         else {
+            return std::string_view{name_meta<T>::name};
          }
       }
       else if constexpr (std::is_void_v<T>) {

--- a/include/glaze/ext/eigen.hpp
+++ b/include/glaze/ext/eigen.hpp
@@ -370,7 +370,7 @@ namespace glz
 }
 
 template <class Scalar, int Rows, int Cols>
-struct glz::meta<Eigen::Matrix<Scalar, Rows, Cols>>
+struct glz::name_meta<Eigen::Matrix<Scalar, Rows, Cols>>
 {
    static constexpr std::string_view name = join_v<chars<"Eigen::Matrix<">, name_v<Scalar>, chars<",">, //
                                                    chars<num_to_string<Rows>::value>, chars<",">, //

--- a/include/glaze/file/hostname_include.hpp
+++ b/include/glaze/file/hostname_include.hpp
@@ -27,7 +27,7 @@ namespace glz
    }
 
    template <class T>
-   struct meta<detail::hostname_includer<T>>
+   struct name_meta<detail::hostname_includer<T>>
    {
       static constexpr std::string_view name = join_v<chars<"hostname_includer<">, name_v<T>, chars<">">>;
    };

--- a/tests/json_test/CMakeLists.txt
+++ b/tests/json_test/CMakeLists.txt
@@ -70,6 +70,14 @@ target_link_libraries(jsonschema_test PRIVATE glz_test_common)
 
 add_test(NAME jsonschema_test COMMAND jsonschema_test)
 
+## Constrained meta test - test for issue #2775
+
+add_executable(constrained_meta_test constrained_meta_test.cpp)
+
+target_link_libraries(constrained_meta_test PRIVATE glz_test_common)
+
+add_test(NAME constrained_meta_test COMMAND constrained_meta_test)
+
 ## Variant ambiguous test - test for ambiguous variant handling
 
 add_executable(variant_ambiguous_test variant_ambiguous_test.cpp)

--- a/tests/json_test/constrained_meta_test.cpp
+++ b/tests/json_test/constrained_meta_test.cpp
@@ -1,0 +1,136 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+// Tests that a concept-constrained glz::meta specialization owns every type it matches.
+// Glaze names built-in and compound types through glz::name_meta rather than through partial
+// specializations of glz::meta, so a user specialization written against a concept (rather than an
+// exact type) is never ambiguous with Glaze's own. See issue #2775.
+
+#include <concepts>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "glaze/glaze.hpp"
+#include "ut/ut.hpp"
+
+using namespace ut;
+
+// glz::meta must carry no Glaze specialization that a user's constrained specialization could tie
+// with. This has to go through a concept: glz::meta's primary template is only declared, so a bare
+// requires-expression on glz::meta<T>::name at namespace scope is a hard error rather than false.
+template <class T>
+concept meta_named = requires { glz::meta<T>::name; };
+
+static_assert(!meta_named<int32_t>);
+static_assert(!meta_named<const int32_t>);
+static_assert(!meta_named<int32_t&>);
+static_assert(!meta_named<int32_t*>);
+static_assert(!meta_named<std::string>);
+static_assert(!meta_named<std::string_view>);
+static_assert(!meta_named<std::vector<int32_t>>);
+static_assert(!meta_named<std::shared_ptr<int32_t>>);
+
+struct shape_base
+{
+   int id = 0;
+};
+
+struct circle : shape_base
+{
+   circle() : shape_base{.id = 1} {}
+};
+
+template <std::derived_from<shape_base> T>
+struct glz::meta<T>
+{
+   static constexpr auto write_id = [](const T& t) { return t.id; };
+   static constexpr auto value = custom<skip{}, write_id>;
+};
+
+struct shape_source
+{
+   std::shared_ptr<const shape_base> get() const { return std::make_shared<circle>(); }
+   std::vector<std::shared_ptr<const shape_base>> get_all() const
+   {
+      return {std::make_shared<circle>(), std::make_shared<circle>()};
+   }
+};
+
+template <>
+struct glz::meta<shape_source>
+{
+   static constexpr auto value =
+      object("value", custom<skip{}, &shape_source::get>, "values", custom<skip{}, &shape_source::get_all>);
+};
+
+// A second, disjoint hierarchy: a constrained specialization that reflects members, to check that a
+// concept-constrained meta drives reading as well as writing.
+struct record_base
+{
+   int count = 0;
+};
+
+struct counter : record_base
+{};
+
+template <std::derived_from<record_base> T>
+struct glz::meta<T>
+{
+   static constexpr auto value = object("count", &T::count);
+};
+
+// A user name for a type Glaze also names must win over glz::name_meta.
+struct tag_t
+{
+   int v = 0;
+};
+
+template <>
+struct glz::meta<std::vector<tag_t>>
+{
+   static constexpr std::string_view name = "tag_list";
+};
+
+suite constrained_meta_tests = [] {
+   // std::derived_from also accepts cv-qualified types, so the constrained specialization matches
+   // `const circle`. Naming `const T` through glz::meta would have made this ambiguous.
+   "constrained meta claims cv-qualified types"_test = [] {
+      static_assert(requires { glz::meta<circle>::value; });
+      static_assert(requires { glz::meta<const circle>::value; });
+      // GCC reports the ambiguity here rather than at the meta<const circle> use above: clang treats
+      // it as a substitution failure and silently falls back to the compiler's spelling.
+      static_assert(glz::name_v<const circle> == "const circle");
+   };
+
+   "writes through pointers to const base"_test = [] {
+      std::string buffer{};
+      expect(not glz::write_json(shape_source{}, buffer));
+      expect(buffer == R"({"value":1,"values":[1,1]})") << buffer;
+   };
+
+   "constrained meta round trips"_test = [] {
+      std::string buffer{};
+      expect(not glz::write_json(counter{{7}}, buffer));
+      expect(buffer == R"({"count":7})") << buffer;
+
+      counter parsed{};
+      expect(not glz::read_json(parsed, buffer));
+      expect(parsed.count == 7);
+   };
+
+   // Glaze's own names still apply to types the user has not claimed, and give way to one the user
+   // supplies through glz::meta.
+   "name resolution order"_test = [] {
+      static_assert(glz::name_v<int32_t> == "int32_t");
+      static_assert(glz::name_v<const int32_t> == "const int32_t");
+      static_assert(glz::name_v<int32_t&> == "int32_t&");
+      static_assert(glz::name_v<int32_t*> == "int32_t*");
+      static_assert(glz::name_v<int32_t* const> == "const int32_t*");
+      static_assert(glz::name_v<std::vector<int32_t>> == "std::vector<int32_t>");
+      static_assert(glz::name_v<std::string> == "std::string");
+      static_assert(glz::name_v<std::vector<tag_t>> == "tag_list");
+   };
+};
+
+int main() { return 0; }

--- a/tests/json_test/json_variant_support_test.cpp
+++ b/tests/json_test/json_variant_support_test.cpp
@@ -164,17 +164,11 @@ suite tagged_variant_tests = [] {
 #if !defined(_MSC_VER)
    "tagged_variant_schema_tests"_test = [] {
       auto s = glz::write_json_schema<tagged_variant>().value_or("error");
-      // P2996 reflection: Bloomberg Clang returns unqualified names, GCC returns qualified names
-      // Accept both forms for the title
-      auto expected_qualified =
-         R"({"type":"object","$defs":{"int32_t":{"type":"integer","minimum":-2147483648,"maximum":2147483647}},"oneOf":[{"type":"object","properties":{"action":{"const":"PUT"},"data":{"type":"object","additionalProperties":{"$ref":"#/$defs/int32_t"}}},"additionalProperties":false,"required":["action"],"title":"PUT"},{"type":"object","properties":{"action":{"const":"DELETE"},"data":{"type":"string"}},"additionalProperties":false,"required":["action"],"title":"DELETE"}],"title":"std::variant<put_action, delete_action>"})";
-#if GLZ_REFLECTION26
-      auto expected_unqualified =
-         R"({"type":"object","$defs":{"int32_t":{"type":"integer","minimum":-2147483648,"maximum":2147483647}},"oneOf":[{"type":"object","properties":{"action":{"const":"PUT"},"data":{"type":"object","additionalProperties":{"$ref":"#/$defs/int32_t"}}},"additionalProperties":false,"required":["action"],"title":"PUT"},{"type":"object","properties":{"action":{"const":"DELETE"},"data":{"type":"string"}},"additionalProperties":false,"required":["action"],"title":"DELETE"}],"title":"variant<put_action, delete_action>"})";
-      expect(s == expected_qualified || s == expected_unqualified) << s;
-#else
-      expect(s == expected_qualified) << s;
-#endif
+      // Glaze names std::variant itself (glz::name_meta), so the title no longer varies with the
+      // compiler's spelling of the type, even though glz::meta<tagged_variant> is specialized.
+      auto expected =
+         R"({"type":"object","$defs":{"int32_t":{"type":"integer","minimum":-2147483648,"maximum":2147483647}},"oneOf":[{"type":"object","properties":{"action":{"const":"PUT"},"data":{"type":"object","additionalProperties":{"$ref":"#/$defs/int32_t"}}},"additionalProperties":false,"required":["action"],"title":"PUT"},{"type":"object","properties":{"action":{"const":"DELETE"},"data":{"type":"string"}},"additionalProperties":false,"required":["action"],"title":"DELETE"}],"title":"std::variant<put_action,delete_action>"})";
+      expect(s == expected) << s;
    };
 #endif
 
@@ -208,17 +202,10 @@ suite tagged_variant_tests = [] {
 #if !defined(_MSC_VER)
    "shared_ptr variant schema"_test = [] {
       const auto schema = glz::write_json_schema<std::shared_ptr<tagged_variant2>>().value_or("error");
-      // P2996 reflection: Bloomberg Clang returns unqualified names, GCC returns qualified names
-      // Accept both forms for the title
-      auto expected_qualified =
-         R"({"type":["object","null"],"$defs":{"int32_t":{"type":"integer","minimum":-2147483648,"maximum":2147483647}},"oneOf":[{"type":"object","properties":{"data":{"type":"object","additionalProperties":{"$ref":"#/$defs/int32_t"}},"type":{"const":"put_action"}},"additionalProperties":false,"required":["type"],"title":"put_action"},{"type":"object","properties":{"data":{"type":"string"},"type":{"const":"delete_action"}},"additionalProperties":false,"required":["type"],"title":"delete_action"},{"type":"object","properties":{"type":{"const":"std::monostate"}},"additionalProperties":false,"required":["type"],"title":"std::monostate"}],"title":"std::shared_ptr<std::variant<put_action, delete_action, std::monostate>>"})";
-#if GLZ_REFLECTION26
-      auto expected_unqualified =
-         R"({"type":["object","null"],"$defs":{"int32_t":{"type":"integer","minimum":-2147483648,"maximum":2147483647}},"oneOf":[{"type":"object","properties":{"data":{"type":"object","additionalProperties":{"$ref":"#/$defs/int32_t"}},"type":{"const":"put_action"}},"additionalProperties":false,"required":["type"],"title":"put_action"},{"type":"object","properties":{"data":{"type":"string"},"type":{"const":"delete_action"}},"additionalProperties":false,"required":["type"],"title":"delete_action"},{"type":"object","properties":{"type":{"const":"std::monostate"}},"additionalProperties":false,"required":["type"],"title":"std::monostate"}],"title":"std::shared_ptr<variant<put_action, delete_action, monostate>>"})";
-      expect(schema == expected_qualified || schema == expected_unqualified) << schema;
-#else
-      expect(schema == expected_qualified) << schema;
-#endif
+      // As above: std::shared_ptr, std::variant, and std::monostate are all named by Glaze.
+      auto expected =
+         R"({"type":["object","null"],"$defs":{"int32_t":{"type":"integer","minimum":-2147483648,"maximum":2147483647}},"oneOf":[{"type":"object","properties":{"data":{"type":"object","additionalProperties":{"$ref":"#/$defs/int32_t"}},"type":{"const":"put_action"}},"additionalProperties":false,"required":["type"],"title":"put_action"},{"type":"object","properties":{"data":{"type":"string"},"type":{"const":"delete_action"}},"additionalProperties":false,"required":["type"],"title":"delete_action"},{"type":"object","properties":{"type":{"const":"std::monostate"}},"additionalProperties":false,"required":["type"],"title":"std::monostate"}],"title":"std::shared_ptr<std::variant<put_action,delete_action,std::monostate>>"})";
+      expect(schema == expected) << schema;
    };
 #endif
 };

--- a/tests/reflection/reflection.cpp
+++ b/tests/reflection/reflection.cpp
@@ -1439,7 +1439,8 @@ suite qualified_type_names_tests = [] {
    };
 
    // =========================================================================
-   // name_for_opts tests - priority: meta<T>::name > T::glaze::name > type_name_for_opts
+   // name_for_opts tests - priority: T::glaze::name > meta<T>::name > name_meta<T>::name >
+   // type_name_for_opts
    // =========================================================================
 
    "name_for_opts falls back to type_name_for_opts"_test = [] {


### PR DESCRIPTION
Fixes #2775.

Glaze named built-in and compound types through partial specializations of `glz::meta` itself, three of which match by constraint rather than by pattern:

```cpp
template <class T> requires(std::is_const_v<T>) struct meta<T>;
template <class T> requires(std::is_lvalue_reference_v<T>) struct meta<T>;
template <class T> requires(std::is_pointer_v<T>) struct meta<T>;
```

That is the same shape a user writes for a concept-constrained meta, so neither is more specialized and neither constraint subsumes the other. A user specialization such as

```cpp
template <std::derived_from<Base> T> struct glz::meta<T>;
```

is ambiguous with Glaze's own the moment a `const` version of a matching type is named, which `std::derived_from` accepts. MSVC reports C2752 (as in the issue), GCC an ambiguous instantiation; clang treats it as a substitution failure and silently drops the user's meta.

The pattern-shaped specializations (`meta<std::vector<T>>`, `meta<int32_t>`, ...) fail differently and more quietly: they win partial ordering, so a constrained user meta that matches a named container is discarded with no diagnostic at all. A user asking every `std::vector<tag_t>` to serialize as a count gets the default array instead:

```
[{"v":1},{"v":2},{"v":3}]   // user's meta silently ignored
3                           // with this change
```

## Fix

Glaze's names move to a new trait, `glz::name_meta`, leaving `glz::meta` with no Glaze specialization for a user's to tie with or lose to. `name_v` resolves `T::glaze::name`, then `meta<T>::name`, then `name_meta<T>::name`, then the compiler's name — so a name a user has already given a type still wins, and existing `glz::meta<T>::name` specializations are unaffected.

Two details fell out of the move:

- `name_meta<const std::string_view>` is spelled out in `core/meta.hpp` rather than left to the generic const specialization, which lives in `api/type_support.hpp` and is not visible to a translation unit that includes only core headers.
- The pointer specialization gains `!std::is_const_v<T>`. As sibling specializations of the same trait, `int* const` matched both it and the const one; the const specialization handles it and recurses for the pointee, so the const survives in the name.

## Behavior change

A JSON schema title changes where a type carries a user `glz::meta` with no `name` member. The user's specialization no longer hides Glaze's name, so `std::variant` and `std::shared_ptr` titles now come from Glaze rather than from the compiler's spelling:

```
"title":"std::variant<put_action, delete_action>"   // compiler spelling, varied by compiler
"title":"std::variant<put_action,delete_action>"    // Glaze's name, stable
```

`json_variant_support_test` drops its `GLZ_REFLECTION26` branches as a result — the title no longer varies between Bloomberg Clang and GCC.

## Tests

`constrained_meta_test` (new) pins the invariant that makes this work: `glz::meta` carries no Glaze specialization, asserted for `int32_t`, `const int32_t`, `int32_t&`, `int32_t*`, `std::string`, `std::string_view`, `std::vector<int32_t>`, and `std::shared_ptr<int32_t>`. It also covers a concept-constrained meta claiming cv-qualified types, driving both reads and writes, and a user name winning over Glaze's.

The issue's reproducer compiles and prints `{"value":1}` on Clang 17 and GCC 15. Full ctest suite green.
