### PR TITLE
Give the file-IO tests their own scratch directory

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,8 @@ option(glaze_ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSan
 add_library(glz_test_common INTERFACE)
 target_compile_features(glz_test_common INTERFACE cxx_std_23)
 target_link_libraries(glz_test_common INTERFACE ut::ut glaze::glaze glaze::asio)
+# scratch_directory.hpp, included by the suites that write files to isolate themselves
+target_include_directories(glz_test_common INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 
 if(MSVC)
     target_compile_options(glz_test_common INTERFACE /GR- /bigobj)
@@ -58,6 +60,7 @@ endif()
 add_library(glz_test_exceptions INTERFACE)
 target_compile_features(glz_test_exceptions INTERFACE cxx_std_23)
 target_link_libraries(glz_test_exceptions INTERFACE ut::ut glaze::glaze glaze::asio)
+target_include_directories(glz_test_exceptions INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 if(MSVC)
     target_compile_options(glz_test_exceptions INTERFACE /GR- /bigobj)
     target_compile_options(glz_test_exceptions INTERFACE /W4 /wd4459 /wd4805)

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -31,6 +31,7 @@
 #include "glaze/json/read.hpp"
 #include "glaze/trace/trace.hpp"
 #include "ut/ut.hpp"
+#include "scratch_directory.hpp"
 
 using namespace ut;
 
@@ -1428,6 +1429,12 @@ void bench()
 }
 
 using namespace ut;
+
+
+// Relative scratch paths in this file resolve inside a private directory rather than
+// wherever the binary was launched from. This must precede the first suite: ut runs a
+// suite from its constructor, during static initialization.
+const glz_test::scratch_directory scratch{"beve_test"};
 
 suite beve_helpers = [] {
    "beve_helpers"_test = [] {

--- a/tests/eetf_test/eetf_test.cpp
+++ b/tests/eetf_test/eetf_test.cpp
@@ -16,12 +16,19 @@
 #include "glaze/eetf/write.hpp"
 #include "glaze/trace/trace.hpp"
 #include "ut/ut.hpp"
+#include "scratch_directory.hpp"
 
 using namespace glz::eetf;
 
 using namespace ut;
 
 glz::trace trace{};
+
+// Relative scratch paths in this file resolve inside a private directory rather than
+// wherever the binary was launched from. This must precede the first suite: ut runs a
+// suite from its constructor, during static initialization.
+const glz_test::scratch_directory scratch{"eetf_test"};
+
 suite start_trace = [] { trace.begin("eetf_test", "Full test suite duration."); };
 
 /*

--- a/tests/exceptions_test/exceptions_test.cpp
+++ b/tests/exceptions_test/exceptions_test.cpp
@@ -11,6 +11,7 @@
 #include "glaze/thread/shared_async_vector.hpp"
 #include "glaze/thread/threadpool.hpp"
 #include "ut/ut.hpp"
+#include "scratch_directory.hpp"
 
 using namespace ut;
 
@@ -34,6 +35,12 @@ struct glz::meta<my_struct>
       "arr", &T::arr //
    );
 };
+
+
+// Relative scratch paths in this file resolve inside a private directory rather than
+// wherever the binary was launched from. This must precede the first suite: ut runs a
+// suite from its constructor, during static initialization.
+const glz_test::scratch_directory scratch{"exceptions_test"};
 
 suite starter = [] {
    "example"_test = [] {

--- a/tests/json_performance/json_perf_benchmark.cpp
+++ b/tests/json_performance/json_perf_benchmark.cpp
@@ -6,6 +6,7 @@
 #include "glaze/glaze.hpp"
 #include "json_perf_common.hpp"
 #include "ut/ut.hpp"
+#include "scratch_directory.hpp"
 
 using namespace ut;
 using namespace glz::perf;
@@ -341,6 +342,12 @@ auto benchmark_tester()
 
    return r;
 }
+
+
+// Relative scratch paths in this file resolve inside a private directory rather than
+// wherever the binary was launched from. This must precede the first suite: ut runs a
+// suite from its constructor, during static initialization.
+const glz_test::scratch_directory scratch{"json_perf_benchmark"};
 
 suite benchmark_test = [] { "benchmark"_test = [] { benchmark_tester<glz::opts{}>(); }; };
 

--- a/tests/json_performance/json_performance.cpp
+++ b/tests/json_performance/json_performance.cpp
@@ -6,6 +6,7 @@
 
 #include "glaze/glaze.hpp"
 #include "ut/ut.hpp"
+#include "scratch_directory.hpp"
 
 static constexpr bool skip = false;
 
@@ -49,6 +50,12 @@ inline std::string generate_basic_string()
    }
    return result;
 }
+
+
+// Relative scratch paths in this file resolve inside a private directory rather than
+// wherever the binary was launched from. This must precede the first suite: ut runs a
+// suite from its constructor, during static initialization.
+const glz_test::scratch_directory scratch{"json_performance"};
 
 suite string_performance = [] {
    "string_performance"_test = [] {

--- a/tests/json_test/CMakeLists.txt
+++ b/tests/json_test/CMakeLists.txt
@@ -3,20 +3,6 @@ project(json_test)
 set(JSON_TEST_SOURCES json_test.cpp)
 set(JSON_VARIANT_SUPPORT_SOURCES json_variant_support_test.cpp)
 
-# These tests write and read scratch files/directories using relative paths
-# (e.g. "./dir", "./start.jsonc", "../file.json"). ctest runs the targets in
-# parallel, so without isolation the identical json_test / json_test_non_null
-# binaries would race on the same files in a shared working directory and fail
-# intermittently. Give each test its own working directory nested one level
-# deep so that both "./" and "../" relative paths resolve to a per-target
-# location. The directory is created at configure time so it exists before the
-# test runs.
-function(glz_add_isolated_test target)
-    set(work_dir ${CMAKE_CURRENT_BINARY_DIR}/${target}.workdir/cwd)
-    file(MAKE_DIRECTORY ${work_dir})
-    add_test(NAME ${target} COMMAND ${target} WORKING_DIRECTORY ${work_dir})
-endfunction()
-
 function(add_glz_json_test target)
     add_executable(${target} ${ARGN})
     target_link_libraries(${target} PRIVATE glz_test_common)
@@ -25,7 +11,7 @@ function(add_glz_json_test target)
         target_compile_options(${target} PRIVATE "-Wa,-mbig-obj")
     endif ()
 
-    glz_add_isolated_test(${target})
+    add_test(NAME ${target} COMMAND ${target})
 
     target_code_coverage(${target} AUTO ALL)
 
@@ -38,7 +24,7 @@ function(add_glz_json_test target)
         target_compile_options(${non_null_target} PRIVATE "-Wa,-mbig-obj")
     endif ()
 
-    glz_add_isolated_test(${non_null_target})
+    add_test(NAME ${non_null_target} COMMAND ${non_null_target})
 endfunction()
 
 add_glz_json_test(${PROJECT_NAME} ${JSON_TEST_SOURCES})

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -41,6 +41,7 @@
 #include "glaze/trace/trace.hpp"
 #include "json_test_shared_types.hpp"
 #include "ut/ut.hpp"
+#include "scratch_directory.hpp"
 
 using namespace ut;
 
@@ -63,6 +64,12 @@ struct jsonc_comment_config
    std::vector<int> array_1{};
    std::vector<int> array_2{};
 };
+
+
+// Relative scratch paths in this file resolve inside a private directory rather than
+// wherever the binary was launched from. This must precede the first suite: ut runs a
+// suite from its constructor, during static initialization.
+const glz_test::scratch_directory scratch{"json_test"};
 
 suite start_trace = [] { trace.begin("json_test", "Full test suite duration."); };
 

--- a/tests/scratch_directory.hpp
+++ b/tests/scratch_directory.hpp
@@ -1,0 +1,103 @@
+// Glaze Library
+// For the license information refer to glaze.hpp
+
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#if defined(_WIN32)
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
+// Several suites exercise the file APIs by writing scratch files through relative paths, and some of
+// those paths deliberately reach upward ("../file.json") to prove that an include resolves relative
+// to the document that names it. A relative path resolves against the process working directory, so
+// where those files land is decided by whoever launched the binary, not by the test: under ctest the
+// working directory is set per test, but running the binary directly writes them into -- and one
+// level above -- whatever directory the shell happened to be in. Nothing fails when that happens.
+// The tests pass and the stray files are noticed later, somewhere else, by someone else.
+//
+// Declaring one of these ahead of the first suite moves the process into a private directory under
+// the system temporary directory, so every relative path in the file resolves inside it however the
+// binary was started. The directory is nested one level deep so that "../" stays inside it too, and
+// it carries the process id so that two binaries built from the same source (json_test and
+// json_test_non_null) cannot collide under `ctest -j`.
+//
+// It is a namespace-scope object rather than something main() does because ut runs a suite from its
+// constructor, during static initialization, long before main() is entered. Declaration order within
+// a translation unit is what sequences this ahead of the suites, so it belongs above the first one.
+//
+// The tree is removed on normal exit. A test that crashes or aborts leaves it behind, which is the
+// case where the files are worth looking at.
+namespace glz_test
+{
+   inline int process_id()
+   {
+#if defined(_WIN32)
+      return ::_getpid();
+#else
+      return static_cast<int>(::getpid());
+#endif
+   }
+
+   struct scratch_directory final
+   {
+      explicit scratch_directory(const std::string_view test_name)
+      {
+         std::error_code ec{};
+         const auto base = std::filesystem::temp_directory_path(ec);
+         if (ec) {
+            return; // no temp directory to move into; leave the working directory alone
+         }
+
+         previous = std::filesystem::current_path(ec);
+         if (ec) {
+            previous.clear();
+            return;
+         }
+
+         root = base / ("glaze_" + std::string{test_name} + "." + std::to_string(process_id()));
+
+         // A recycled process id can leave the previous run's tree in place, and these tests assert
+         // on files they expect to have created themselves.
+         std::filesystem::remove_all(root, ec);
+
+         const auto cwd = root / "cwd";
+         std::filesystem::create_directories(cwd, ec);
+         if (ec) {
+            root.clear();
+            previous.clear();
+            return;
+         }
+
+         std::filesystem::current_path(cwd, ec);
+         if (ec) {
+            std::filesystem::remove_all(root, ec);
+            root.clear();
+            previous.clear();
+         }
+      }
+
+      ~scratch_directory()
+      {
+         if (root.empty()) {
+            return;
+         }
+         std::error_code ec{};
+         // Step out before removing: Windows refuses to remove the working directory.
+         std::filesystem::current_path(previous, ec);
+         std::filesystem::remove_all(root, ec);
+      }
+
+      scratch_directory(const scratch_directory&) = delete;
+      scratch_directory& operator=(const scratch_directory&) = delete;
+
+      std::filesystem::path root{};
+      std::filesystem::path previous{};
+   };
+}

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -25,6 +25,7 @@
 
 #include "glaze/json/generic.hpp"
 #include "ut/ut.hpp"
+#include "scratch_directory.hpp"
 
 using namespace ut;
 
@@ -315,6 +316,12 @@ struct yaml_multi_empty_arrays_struct
    int x{42};
    bool operator==(const yaml_multi_empty_arrays_struct&) const = default;
 };
+
+
+// Relative scratch paths in this file resolve inside a private directory rather than
+// wherever the binary was launched from. This must precede the first suite: ut runs a
+// suite from its constructor, during static initialization.
+const glz_test::scratch_directory scratch{"yaml_test"};
 
 suite yaml_write_tests = [] {
    "write_simple_struct"_test = [] {


### PR DESCRIPTION
Several suites exercise the file APIs by writing scratch files through relative paths, and some of those paths deliberately reach upward (`"../file.json"`) to prove that an include resolves relative to the document that names it. A relative path resolves against the process working directory, so where those files land is decided by whoever launched the binary rather than by the test.

Under ctest that was handled: `glz_add_isolated_test` gave each `json_test` target a working directory nested one level deep, so both `./x` and `../x` stayed inside it. Run a test binary directly — which is what happens when working on one suite — and the same writes land in the current directory and one level above it. Nothing fails: the tests pass, and the files are found later, somewhere else.

```
~/Develop/repos/file.json
~/Develop/repos/alabastar.json
glaze/auto.json
glaze/Stephens-MacBook-Pro-2.local_config.json
```

`.gitignore` covers `*.json` and `*.beve`, so the ones landing inside the repo never showed up in `git status`, and the ones landing above it were outside the repo entirely.

## Fix

The binaries now isolate themselves. `tests/scratch_directory.hpp` moves the process into a private directory under the system temp directory:

- nested one level deep, so `../` stays inside it
- named with the process id, so `json_test` and `json_test_non_null` — same source, two targets — cannot collide under `ctest -j`, which is the race the old CMake comment described
- removed on normal exit, left behind on a crash, which is the case where the files are worth looking at
- `std::error_code` overloads throughout, since the test targets build with `-fno-exceptions`; if the directory cannot be created it leaves the working directory alone and the tests behave exactly as before

It is a namespace-scope object rather than something `main()` does because ut runs a suite from its constructor (`suite(auto&& tests) { tests(); }`), during static initialization, long before `main()` is entered. Declaration order within the translation unit sequences it ahead of the suites, so it sits above the first one with a comment saying why.

With the binaries isolating themselves, `glz_add_isolated_test` has nothing left to do and the `json_test` targets go back to a plain `add_test`.

Applied to the seven translation units that write scratch files: `json_test`, `beve_test`, `exceptions_test`, `yaml_test`, `eetf_test`, `json_performance`, `json_perf_benchmark`. No test reads fixture data through a relative path — `lib_test` locates its shared library through an absolute `GLZ_TEST_DIRECTORY` — so moving the working directory affects only these writes.

## Verification

- Full suite green: 117/117.
- `json_test`, `beve_test`, and `yaml_test` run **directly** from an empty directory: all pass, and both that directory and its parent are still empty afterwards. Before this change the same three runs scattered `file.json`, `alabastar.json`, `alabastar.beve`, `auto.json`, and `<hostname>_config.json` across two directories.
- No `*.workdir` trees and no leftover `/tmp/glaze_*` directories after a full ctest run.
- Warning-clean under the strict Debug flag set (`-Wall -Wextra -pedantic -Werror -fno-exceptions -fno-rtti`) on GCC 15 and Clang.
