### PR TITLE
Replace http_headers matching_iterator with filter views

### DIFF
--- a/include/glaze/net/http_headers.hpp
+++ b/include/glaze/net/http_headers.hpp
@@ -58,6 +58,102 @@ namespace glz
       using const_iterator = std::vector<value_type>::const_iterator;
       using size_type = std::vector<value_type>::size_type;
 
+     private:
+      template <bool IsConst>
+      class matching_iterator
+      {
+         using owner_type = std::conditional_t<IsConst, const http_headers*, http_headers*>;
+
+        public:
+         using iterator_concept = std::bidirectional_iterator_tag;
+         using iterator_category = std::bidirectional_iterator_tag;
+         using difference_type = ptrdiff_t;
+         using value_type = http_headers::value_type;
+         using reference = std::conditional_t<IsConst, const value_type&, value_type&>;
+         using pointer = std::conditional_t<IsConst, const value_type*, value_type*>;
+
+         matching_iterator() = default;
+         matching_iterator(const matching_iterator&) = default;
+         matching_iterator(matching_iterator&&) = default;
+         matching_iterator& operator=(const matching_iterator&) = default;
+         matching_iterator& operator=(matching_iterator&&) = default;
+         ~matching_iterator() = default;
+
+         matching_iterator(owner_type owner, size_t start_index, std::string_view key)
+            : owner_(owner), index_(start_index), key_(key)
+         {
+            seek_forward();
+         }
+
+         [[nodiscard]] reference operator*() const noexcept { return owner_->headers_[index_]; }
+         [[nodiscard]] pointer operator->() const noexcept { return std::addressof(owner_->headers_[index_]); }
+
+         matching_iterator& operator++() noexcept
+         {
+            if (index_ < owner_->headers_.size()) {
+               ++index_;
+               seek_forward();
+            }
+            return *this;
+         }
+
+         matching_iterator operator++(int) noexcept
+         {
+            auto copy = *this;
+            ++(*this);
+            return copy;
+         }
+
+         matching_iterator& operator--() noexcept
+         {
+            seek_backward();
+            return *this;
+         }
+
+         matching_iterator operator--(int) noexcept
+         {
+            auto copy = *this;
+            --(*this);
+            return copy;
+         }
+
+         [[nodiscard]] friend bool operator==(const matching_iterator& left, const matching_iterator& right) noexcept
+         {
+            return left.owner_ == right.owner_ && left.index_ == right.index_ && glz::striequal(left.key_, right.key_);
+         }
+
+        private:
+         void seek_forward() noexcept
+         {
+            while (index_ < owner_->headers_.size()) {
+               const auto& current = owner_->headers_[index_].name;
+               if (glz::striequal(current, key_)) {
+                  return;
+               }
+               ++index_;
+            }
+         }
+
+         // Precondition: a preceding match exists, as required of a bidirectional iterator
+         void seek_backward() noexcept
+         {
+            while (index_ > 0) {
+               --index_;
+               if (glz::striequal(owner_->headers_[index_].name, key_)) {
+                  return;
+               }
+            }
+         }
+
+         owner_type owner_{};
+         size_t index_{0};
+         std::string_view key_;
+      };
+
+     public:
+      using range_iterator = matching_iterator<false>;
+      using const_range_iterator = matching_iterator<true>;
+
       http_headers() = default;
       http_headers(std::initializer_list<http_header> fields) : headers_(fields) {}
 
@@ -92,14 +188,16 @@ namespace glz
 
       [[nodiscard]] auto fields(std::string_view name GLZ_LIFETIMEBOUND) &
       {
-         return headers_ |
-                std::views::filter([name](const http_header& field) { return glz::striequal(field.name, name); });
+         auto first = range_iterator{this, 0, name};
+         auto last = range_iterator{this, headers_.size(), name};
+         return std::ranges::subrange{first, last};
       }
 
       [[nodiscard]] auto fields(std::string_view name GLZ_LIFETIMEBOUND) const&
       {
-         return headers_ |
-                std::views::filter([name](const http_header& field) { return glz::striequal(field.name, name); });
+         auto first = const_range_iterator{this, 0, name};
+         auto last = const_range_iterator{this, headers_.size(), name};
+         return std::ranges::subrange{first, last};
       }
 
       [[nodiscard]] auto names() const&
@@ -116,10 +214,8 @@ namespace glz
 
       [[nodiscard]] auto values(std::string_view name GLZ_LIFETIMEBOUND) const&
       {
-         return headers_ |
-                std::views::filter([name](const http_header& field) { return glz::striequal(field.name, name); }) |
-                std::views::transform(
-                   [](const http_header& field) noexcept -> std::string_view { return field.value; });
+         return fields(name) | std::views::transform(
+                                  [](const http_header& field) noexcept -> std::string_view { return field.value; });
       }
 
       [[nodiscard]] size_t count(std::string_view name) const& noexcept

--- a/include/glaze/net/http_headers.hpp
+++ b/include/glaze/net/http_headers.hpp
@@ -58,78 +58,6 @@ namespace glz
       using const_iterator = std::vector<value_type>::const_iterator;
       using size_type = std::vector<value_type>::size_type;
 
-     private:
-      template <bool IsConst>
-      class matching_iterator
-      {
-         using owner_type = std::conditional_t<IsConst, const http_headers*, http_headers*>;
-
-        public:
-         using iterator_concept = std::forward_iterator_tag;
-         using iterator_category = std::forward_iterator_tag;
-         using difference_type = ptrdiff_t;
-         using value_type = http_headers::value_type;
-         using reference = std::conditional_t<IsConst, const value_type&, value_type&>;
-         using pointer = std::conditional_t<IsConst, const value_type*, value_type*>;
-
-         matching_iterator() = default;
-         matching_iterator(const matching_iterator&) = default;
-         matching_iterator(matching_iterator&&) = default;
-         matching_iterator& operator=(const matching_iterator&) = default;
-         matching_iterator& operator=(matching_iterator&&) = default;
-         ~matching_iterator() = default;
-
-         matching_iterator(owner_type owner, size_t start_index, std::string_view key)
-            : owner_(owner), index_(start_index), key_(key)
-         {
-            seek_forward();
-         }
-
-         [[nodiscard]] reference operator*() const noexcept { return owner_->headers_[index_]; }
-         [[nodiscard]] pointer operator->() const noexcept { return std::addressof(owner_->headers_[index_]); }
-
-         matching_iterator& operator++() noexcept
-         {
-            if (index_ < owner_->headers_.size()) {
-               ++index_;
-               seek_forward();
-            }
-            return *this;
-         }
-
-         matching_iterator operator++(int) noexcept
-         {
-            auto copy = *this;
-            ++(*this);
-            return copy;
-         }
-
-         [[nodiscard]] friend bool operator==(const matching_iterator& left, const matching_iterator& right) noexcept
-         {
-            return left.owner_ == right.owner_ && left.index_ == right.index_ && glz::striequal(left.key_, right.key_);
-         }
-
-        private:
-         void seek_forward() noexcept
-         {
-            while (index_ < owner_->headers_.size()) {
-               const auto& current = owner_->headers_[index_].name;
-               if (glz::striequal(current, key_)) {
-                  return;
-               }
-               ++index_;
-            }
-         }
-
-         owner_type owner_{};
-         size_t index_{0};
-         std::string_view key_;
-      };
-
-     public:
-      using range_iterator = matching_iterator<false>;
-      using const_range_iterator = matching_iterator<true>;
-
       http_headers() = default;
       http_headers(std::initializer_list<http_header> fields) : headers_(fields) {}
 
@@ -164,16 +92,14 @@ namespace glz
 
       [[nodiscard]] auto fields(std::string_view name GLZ_LIFETIMEBOUND) &
       {
-         auto first = range_iterator{this, 0, name};
-         auto last = range_iterator{this, headers_.size(), name};
-         return std::ranges::subrange{first, last};
+         return headers_ |
+                std::views::filter([name](const http_header& field) { return glz::striequal(field.name, name); });
       }
 
       [[nodiscard]] auto fields(std::string_view name GLZ_LIFETIMEBOUND) const&
       {
-         auto first = const_range_iterator{this, 0, name};
-         auto last = const_range_iterator{this, headers_.size(), name};
-         return std::ranges::subrange{first, last};
+         return headers_ |
+                std::views::filter([name](const http_header& field) { return glz::striequal(field.name, name); });
       }
 
       [[nodiscard]] auto names() const&
@@ -190,8 +116,10 @@ namespace glz
 
       [[nodiscard]] auto values(std::string_view name GLZ_LIFETIMEBOUND) const&
       {
-         return fields(name) | std::views::transform(
-                                  [](const http_header& field) noexcept -> std::string_view { return field.value; });
+         return headers_ |
+                std::views::filter([name](const http_header& field) { return glz::striequal(field.name, name); }) |
+                std::views::transform(
+                   [](const http_header& field) noexcept -> std::string_view { return field.value; });
       }
 
       [[nodiscard]] size_t count(std::string_view name) const& noexcept
@@ -320,7 +248,7 @@ namespace glz
       std::vector<value_type> headers_;
    };
 
-   static_assert(std::ranges::forward_range<decltype(std::declval<http_headers&>().fields(""))>);
-   static_assert(std::ranges::forward_range<decltype(std::declval<http_headers&>().names())>);
-   static_assert(std::ranges::forward_range<decltype(std::declval<http_headers&>().values(""))>);
+   static_assert(std::ranges::bidirectional_range<decltype(std::declval<http_headers&>().fields(""))>);
+   static_assert(std::ranges::bidirectional_range<decltype(std::declval<http_headers&>().names())>);
+   static_assert(std::ranges::bidirectional_range<decltype(std::declval<http_headers&>().values(""))>);
 }

--- a/tests/networking_tests/http_headers_test/http_headers_test.cpp
+++ b/tests/networking_tests/http_headers_test/http_headers_test.cpp
@@ -18,6 +18,15 @@ std::vector<std::string> values_of(const glz::http_headers& fields, std::string_
    return values;
 }
 
+std::vector<std::string> reversed_values_of(auto&& headers, std::string_view name)
+{
+   std::vector<std::string> values{};
+   for (auto&& field : headers.fields(name) | std::views::reverse) {
+      values.emplace_back(field.value);
+   }
+   return values;
+}
+
 bool contains_value(const glz::http_headers& fields, std::string_view name, std::string_view expected_value)
 {
    auto values = fields.values(name);
@@ -322,6 +331,106 @@ suite http_headers = [] {
 
       expect(std::ranges::empty(range));
       expect(std::ranges::distance(range) == 0);
+   };
+
+   "fields view iterates matching pairs in reverse order"_test = [] {
+      glz::http_headers fields{};
+      fields.add("Set-Cookie", "a=1");
+      fields.add("X", "x");
+      fields.add("set-cookie", "b=2");
+      fields.add("Y", "y");
+      fields.add("SET-COOKIE", "c=3");
+
+      auto collected_values = reversed_values_of(fields, "set-cookie");
+
+      expect(collected_values.size() == 3U);
+      if (collected_values.size() == 3U) {
+         expect(collected_values[0] == "c=3");
+         expect(collected_values[1] == "b=2");
+         expect(collected_values[2] == "a=1");
+      }
+   };
+
+   "fields view on const iterates in reverse order"_test = [] {
+      glz::http_headers mutable_fields{};
+      mutable_fields.add("Set-Cookie", "a=1");
+      mutable_fields.add("X", "x");
+      mutable_fields.add("set-cookie", "b=2");
+
+      const auto& fields = mutable_fields;
+
+      auto collected_values = reversed_values_of(fields, "SET-COOKIE");
+
+      expect(collected_values.size() == 2U);
+      if (collected_values.size() == 2U) {
+         expect(collected_values[0] == "b=2");
+         expect(collected_values[1] == "a=1");
+      }
+   };
+
+   "fields iterator decrements from end to the last match"_test = [] {
+      glz::http_headers fields{};
+      fields.add("A", "1");
+      fields.add("Set-Cookie", "a=1");
+      fields.add("B", "2");
+      fields.add("set-cookie", "b=2");
+      fields.add("C", "3");
+
+      auto range = fields.fields("set-cookie");
+      auto iterator = range.end();
+
+      --iterator;
+      expect(iterator->value == "b=2");
+
+      --iterator;
+      expect(iterator->value == "a=1");
+      expect(iterator == range.begin());
+   };
+
+   "fields iterator round-trips between increment and decrement"_test = [] {
+      glz::http_headers fields{};
+      fields.add("Set-Cookie", "a=1");
+      fields.add("X", "x");
+      fields.add("set-cookie", "b=2");
+
+      auto range = fields.fields("set-cookie");
+      auto iterator = range.begin();
+
+      ++iterator;
+      expect(iterator->value == "b=2");
+
+      --iterator;
+      expect(iterator->value == "a=1");
+      expect(iterator == range.begin());
+   };
+
+   "fields view with a single match reverses to the same element"_test = [] {
+      glz::http_headers fields{};
+      fields.add("X", "x");
+      fields.add("Set-Cookie", "a=1");
+      fields.add("Y", "y");
+
+      auto collected_values = reversed_values_of(fields, "set-cookie");
+
+      expect(collected_values.size() == 1U);
+      if (collected_values.size() == 1U) {
+         expect(collected_values[0] == "a=1");
+      }
+   };
+
+   "values view iterates matching values in reverse order"_test = [] {
+      glz::http_headers fields{{"Set-Cookie", "a=1"}, {"X", "x"}, {"set-cookie", "b=2"}};
+
+      std::vector<std::string> collected_values;
+      for (std::string_view value : fields.values("SET-COOKIE") | std::views::reverse) {
+         collected_values.emplace_back(value);
+      }
+
+      expect(collected_values.size() == 2U);
+      if (collected_values.size() == 2U) {
+         expect(collected_values[0] == "b=2");
+         expect(collected_values[1] == "a=1");
+      }
    };
 
    "names view returns every name in insertion order"_test = [] {


### PR DESCRIPTION
Recently, while looking through the `glz::http_headers` class, I suddenly realized that we could replace the entire `glz::http_headers::matching_iterator` code with a regular C++20 `std::views::filter`

No public `glz::http_headers` API changes.

## Pros
- Ranges returned by the `.fields()` method will be updated from `forward_range` to `bidirectional_range`, providing users with greater flexibility
- Less code, less responsibility, better maintainability

## Cons
None