### PR TITLE
reject bare CR/LF and non-token header fields in try_parse_request

### DIFF
--- a/include/glaze/net/http.hpp
+++ b/include/glaze/net/http.hpp
@@ -263,6 +263,20 @@ namespace glz
       return striequal(name, "content-length") || striequal(name, "transfer-encoding");
    }
 
+   // RFC 9110, Section 5.6.2:
+   // token = 1*tchar
+   // tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*"
+   //       / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
+   //       / DIGIT / ALPHA
+   // The single tchar predicate for the net stack: valid_header_name and the
+   // request-line method check both build on it.
+   [[nodiscard]] inline bool is_tchar(char ch) noexcept
+   {
+      return (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '!' ||
+             ch == '#' || ch == '$' || ch == '%' || ch == '&' || ch == '\'' || ch == '*' || ch == '+' || ch == '-' ||
+             ch == '.' || ch == '^' || ch == '_' || ch == '`' || ch == '|' || ch == '~';
+   }
+
    // RFC 7230 3.2.6: a header field-name is one or more token characters (tchar).
    // A name that is empty or carries any other byte (CR/LF, space, colon, a
    // control char, ...) cannot be written as a well-formed field. This is the
@@ -272,11 +286,8 @@ namespace glz
       if (name.empty()) {
          return false;
       }
-      for (const unsigned char c : name) {
-         const bool tchar = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '!' ||
-                            c == '#' || c == '$' || c == '%' || c == '&' || c == '\'' || c == '*' || c == '+' ||
-                            c == '-' || c == '.' || c == '^' || c == '_' || c == '`' || c == '|' || c == '~';
-         if (!tchar) {
+      for (const char c : name) {
+         if (!is_tchar(c)) {
             return false;
          }
       }

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -2650,6 +2650,19 @@ namespace glz
                if (const auto last = value_sv.find_last_not_of(" \t"); last != std::string_view::npos) {
                   value_sv.remove_suffix(value_sv.size() - (last + 1));
                }
+               // RFC 9112 2.2 / RFC 7230 3.2: the field-name must be a token and the
+               // field-value must carry no bare CR/LF or other control byte. Splitting
+               // on CRLF alone leaves a bare LF inside a field line intact, so glaze reads
+               // "X: 1\nContent-Length: 40" as one X field while an LF-tolerant proxy reads
+               // two fields and frames those bytes as the body: the Content-Length lookup
+               // here misses and the trailing bytes reparse as a second request (CL.0
+               // request smuggling). Validate with the net stack's shared predicates,
+               // which the WebSocket handshake path already uses, and reject with 400 and close.
+               if (!glz::valid_header_name(name_sv) || !glz::valid_header_value(value_sv)) {
+                  result.status = parse_status::error;
+                  send_error_response_with_close(conn, 400, "Bad Request");
+                  return result;
+               }
                // RFC 7230 3.3.2: multiple Content-Length fields with differing values make the
                // body framing unrecoverable. Lookups resolve to the first field, so a second
                // Content-Length carrying another length would leave a proxy that frames the body

--- a/include/glaze/net/http_server.hpp
+++ b/include/glaze/net/http_server.hpp
@@ -567,18 +567,6 @@ namespace glz
          return is_valid_hostname(uri_host);
       }
 
-      inline bool is_tchar(char ch) noexcept
-      {
-         // RFC 9110, Section 5.6.2:
-         // token = 1*tchar
-         // tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*"
-         //       / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
-         //       / DIGIT / ALPHA
-         return (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '!' ||
-                ch == '#' || ch == '$' || ch == '%' || ch == '&' || ch == '\'' || ch == '*' || ch == '+' || ch == '-' ||
-                ch == '.' || ch == '^' || ch == '_' || ch == '`' || ch == '|' || ch == '~';
-      }
-
       inline bool is_pct_encoded(std::string_view str) noexcept
       {
          // RFC 3986, Appendix A:
@@ -2631,16 +2619,6 @@ namespace glz
             auto colon_pos = line.find(':');
             if (colon_pos != std::string_view::npos) {
                std::string_view name_sv = line.substr(0, colon_pos);
-               // RFC 7230 3.2.4: no whitespace is allowed between the field-name and
-               // the colon. Tolerating it would store the name under a key with a
-               // trailing space/tab (e.g. "transfer-encoding ") that header lookups
-               // miss, so an obfuscated "Transfer-Encoding : chunked" would desync body
-               // framing (request smuggling). Reject with 400 and close.
-               if (!name_sv.empty() && (name_sv.back() == ' ' || name_sv.back() == '\t')) {
-                  result.status = parse_status::error;
-                  send_error_response_with_close(conn, 400, "Bad Request");
-                  return result;
-               }
                std::string_view value_sv = line.substr(colon_pos + 1);
                value_sv.remove_prefix((std::min)(value_sv.find_first_not_of(" \t"), value_sv.size()));
                // RFC 9110 §5.5 / RFC 9112 §5: a field value excludes trailing OWS as well;
@@ -2656,8 +2634,12 @@ namespace glz
                // "X: 1\nContent-Length: 40" as one X field while an LF-tolerant proxy reads
                // two fields and frames those bytes as the body: the Content-Length lookup
                // here misses and the trailing bytes reparse as a second request (CL.0
-               // request smuggling). Validate with the net stack's shared predicates,
-               // which the WebSocket handshake path already uses, and reject with 400 and close.
+               // request smuggling). The token rule also forbids whitespace before the
+               // colon (RFC 7230 3.2.4): tolerating it would store the name under a key
+               // with a trailing space/tab that header lookups miss, so an obfuscated
+               // "Transfer-Encoding : chunked" would desync body framing the same way.
+               // Validate with the net stack's shared predicates, which the WebSocket
+               // handshake path already uses, and reject with 400 and close.
                if (!glz::valid_header_name(name_sv) || !glz::valid_header_value(value_sv)) {
                   result.status = parse_status::error;
                   send_error_response_with_close(conn, 400, "Bad Request");

--- a/tests/networking_tests/http_header_strictness_test/http_header_strictness_test.cpp
+++ b/tests/networking_tests/http_header_strictness_test/http_header_strictness_test.cpp
@@ -163,6 +163,53 @@ suite http_header_strictness_suite = [] {
       expect(smuggled_hits.load(std::memory_order_relaxed) == 0) << "Smuggled request reached a route handler";
    };
 
+   "bare LF inside a header value is rejected, not desynced"_test = [&] {
+      // A bare LF splits the line for an LF-tolerant proxy but not for glaze's
+      // CRLF split, so the smuggled Content-Length rides inside X-Test's value.
+      const std::string payload =
+         "POST /front HTTP/1.1\r\n"
+         "Host: localhost\r\n"
+         "X-Test: 1\nContent-Length: 44\r\n"
+         "Connection: keep-alive\r\n"
+         "\r\n" +
+         smuggled_tail;
+
+      const std::string response = send_raw_timed(port, payload);
+      expect(response.find("400") != std::string::npos) << "Expected 400 for bare LF in header value";
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      expect(smuggled_hits.load(std::memory_order_relaxed) == 0) << "Smuggled request reached a route handler";
+   };
+
+   "bare CR inside a header value is rejected, not desynced"_test = [&] {
+      const std::string payload =
+         "POST /front HTTP/1.1\r\n"
+         "Host: localhost\r\n"
+         "X-Test: 1\rContent-Length: 44\r\n"
+         "Connection: keep-alive\r\n"
+         "\r\n" +
+         smuggled_tail;
+
+      const std::string response = send_raw_timed(port, payload);
+      expect(response.find("400") != std::string::npos) << "Expected 400 for bare CR in header value";
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      expect(smuggled_hits.load(std::memory_order_relaxed) == 0) << "Smuggled request reached a route handler";
+   };
+
+   "bare LF inside a header name is rejected, not desynced"_test = [&] {
+      const std::string payload =
+         "POST /front HTTP/1.1\r\n"
+         "Host: localhost\r\n"
+         "X-Test\nContent-Length: 44: v\r\n"
+         "Connection: keep-alive\r\n"
+         "\r\n" +
+         smuggled_tail;
+
+      const std::string response = send_raw_timed(port, payload);
+      expect(response.find("400") != std::string::npos) << "Expected 400 for bare LF in header name";
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      expect(smuggled_hits.load(std::memory_order_relaxed) == 0) << "Smuggled request reached a route handler";
+   };
+
    "well-formed headers still parse and route"_test = [&] {
       // Positive control: ordinary header names, and values that contain spaces
       // and colons, must continue to parse normally (no over-rejection).


### PR DESCRIPTION
try_parse_request splits header field lines on CRLF and stores each name and value as-is, so a bare LF or CR embedded in a field line survives into the stored value. A request whose value is `1\nContent-Length: 40` reaches glaze as a single X-Test field, the content-length lookup finds nothing, and the trailing bytes get reparsed as a second request. A front-end proxy that treats a bare LF as a line break instead reads a separate Content-Length and frames those bytes as the body, so the two sides disagree on where the message ends (CL.0 smuggling).

The fix runs each field name through glz::valid_header_name and each value through glz::valid_header_value inside the parse loop, answering 400 and closing on a violation. Those predicates already back the WebSocket handshake path and were written as the shared source of field validity, so this brings the server parser in line with the rest of the net stack instead of adding a separate check. Before, malformed field bytes were accepted and mis-framed; after, they are refused before body framing, while well-formed headers with spaces, colons, and obs-text in the value are unchanged.