### PR TITLE
fix(cbor): support std::variant writes on MSVC and reads into non-indexable containers

### DIFF
--- a/include/glaze/cbor/read.hpp
+++ b/include/glaze/cbor/read.hpp
@@ -88,6 +88,32 @@ namespace glz
             return 0;
          }
       }
+
+      // Byteswap one typed-array element in place. An RFC 8746 tag names the producer's endianness,
+      // so an element whose tag disagrees with this platform is swapped through its bit pattern:
+      // V may be a floating point type, which has no byteswap of its own.
+      template <class V>
+      GLZ_ALWAYS_INLINE void byteswap_element(V& elem) noexcept
+      {
+         if constexpr (sizeof(V) == 2) {
+            uint16_t bits;
+            std::memcpy(&bits, &elem, sizeof(V));
+            bits = std::byteswap(bits);
+            std::memcpy(&elem, &bits, sizeof(V));
+         }
+         else if constexpr (sizeof(V) == 4) {
+            uint32_t bits;
+            std::memcpy(&bits, &elem, sizeof(V));
+            bits = std::byteswap(bits);
+            std::memcpy(&elem, &bits, sizeof(V));
+         }
+         else if constexpr (sizeof(V) == 8) {
+            uint64_t bits;
+            std::memcpy(&bits, &elem, sizeof(V));
+            bits = std::byteswap(bits);
+            std::memcpy(&elem, &bits, sizeof(V));
+         }
+      }
    }
 
    template <>
@@ -774,6 +800,14 @@ namespace glz
          using namespace cbor;
          using V = range_value_t<std::remove_cvref_t<T>>;
 
+         // Set-like containers (std::set, std::unordered_set, ...) can neither be resized nor
+         // back-inserted into: each element is parsed into a temporary and then emplaced.
+         constexpr bool set_like = !resizable<T> && !emplace_backable<T> && emplaceable<T>;
+         // Everything else either has a fixed size the input must fit, or grows to match the input.
+         // The definite- and indefinite-length branches below must agree on which is which, or the
+         // same container would accept one framing of an array and reject the other.
+         constexpr bool growable = resizable<T> || emplace_backable<T> || set_like;
+
          if (it >= end) [[unlikely]] {
             ctx.error = error_code::unexpected_end;
             return;
@@ -786,7 +820,7 @@ namespace glz
          const uint8_t additional_info = get_additional_info(initial);
 
          // Check for RFC 8746 typed array (tag + byte string)
-         if constexpr (num_t<V> && !std::same_as<V, bool> && contiguous<T>) {
+         if constexpr (num_t<V> && !std::same_as<V, bool>) {
             if (major_type == major::tag) {
                ++it; // consume the tag initial byte
 
@@ -843,7 +877,10 @@ namespace glz
                      }
                   }
 
-                  if constexpr (resizable<T>) {
+                  if constexpr (set_like) {
+                     value.clear();
+                  }
+                  else if constexpr (resizable<T>) {
                      value.resize(count);
                      if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
                         value.shrink_to_fit();
@@ -859,38 +896,49 @@ namespace glz
                   // Check if we need to byteswap
                   const bool need_swap = typed_array::needs_byteswap(tag_num);
 
-                  if (need_swap && sizeof(V) > 1) {
-                     // Need to byteswap each element
-                     for (size_t i = 0; i < count; ++i) {
-                        V elem;
-                        std::memcpy(&elem, it, sizeof(V));
-                        if constexpr (sizeof(V) == 2) {
-                           uint16_t bits;
-                           std::memcpy(&bits, &elem, sizeof(V));
-                           bits = std::byteswap(bits);
-                           std::memcpy(&elem, &bits, sizeof(V));
+                  if constexpr (contiguous<T>) {
+                     if (need_swap && sizeof(V) > 1) {
+                        // Need to byteswap each element
+                        for (size_t i = 0; i < count; ++i) {
+                           V elem;
+                           std::memcpy(&elem, it, sizeof(V));
+                           cbor_detail::byteswap_element(elem);
+                           value[i] = elem;
+                           it += sizeof(V);
                         }
-                        else if constexpr (sizeof(V) == 4) {
-                           uint32_t bits;
-                           std::memcpy(&bits, &elem, sizeof(V));
-                           bits = std::byteswap(bits);
-                           std::memcpy(&elem, &bits, sizeof(V));
+                     }
+                     else {
+                        // Native endianness or single-byte: bulk read
+                        if (byte_len > 0) {
+                           std::memcpy(value.data(), it, byte_len);
+                           it += byte_len;
                         }
-                        else if constexpr (sizeof(V) == 8) {
-                           uint64_t bits;
-                           std::memcpy(&bits, &elem, sizeof(V));
-                           bits = std::byteswap(bits);
-                           std::memcpy(&elem, &bits, sizeof(V));
-                        }
-                        value[i] = elem;
-                        it += sizeof(V);
                      }
                   }
                   else {
-                     // Native endianness or single-byte: bulk read
-                     if (byte_len > 0) {
-                        std::memcpy(value.data(), it, byte_len);
-                        it += byte_len;
+                     // std::list, std::set and friends have no contiguous storage to bulk read into,
+                     // so each element is decoded on its own.
+                     const bool swap_each = need_swap && sizeof(V) > 1;
+                     const auto next_element = [&] {
+                        V elem;
+                        std::memcpy(&elem, it, sizeof(V));
+                        if (swap_each) {
+                           cbor_detail::byteswap_element(elem);
+                        }
+                        it += sizeof(V);
+                        return elem;
+                     };
+
+                     if constexpr (set_like) {
+                        for (size_t i = 0; i < count; ++i) {
+                           value.emplace(next_element());
+                        }
+                     }
+                     else {
+                        auto dest = value.begin();
+                        for (size_t i = 0; i < count; ++i, ++dest) {
+                           *dest = next_element();
+                        }
                      }
                   }
                   return; // Done with typed array
@@ -904,7 +952,7 @@ namespace glz
          }
 
          // Check for complex array (tag 43001 with nested typed array)
-         if constexpr (complex_t<V> && contiguous<T>) {
+         if constexpr (complex_t<V>) {
             if (major_type == major::tag) {
                ++it; // consume the tag initial byte
 
@@ -990,7 +1038,10 @@ namespace glz
                      }
                   }
 
-                  if constexpr (resizable<T>) {
+                  if constexpr (set_like) {
+                     value.clear();
+                  }
+                  else if constexpr (resizable<T>) {
                      value.resize(count);
                      if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
                         value.shrink_to_fit();
@@ -1006,40 +1057,52 @@ namespace glz
                   // Check if we need to byteswap
                   const bool need_swap = typed_array::needs_byteswap(scalar_tag);
 
-                  if (need_swap && sizeof(Scalar) > 1) {
-                     // Need to byteswap each scalar in the interleaved data
-                     auto* dest = reinterpret_cast<Scalar*>(value.data());
-                     const size_t num_scalars = count * 2; // 2 scalars per complex
-                     for (size_t i = 0; i < num_scalars; ++i) {
-                        Scalar elem;
-                        std::memcpy(&elem, it, sizeof(Scalar));
-                        if constexpr (sizeof(Scalar) == 2) {
-                           uint16_t bits;
-                           std::memcpy(&bits, &elem, sizeof(Scalar));
-                           bits = std::byteswap(bits);
-                           std::memcpy(&elem, &bits, sizeof(Scalar));
+                  if constexpr (contiguous<T>) {
+                     if (need_swap && sizeof(Scalar) > 1) {
+                        // Need to byteswap each scalar in the interleaved data
+                        auto* dest = reinterpret_cast<Scalar*>(value.data());
+                        const size_t num_scalars = count * 2; // 2 scalars per complex
+                        for (size_t i = 0; i < num_scalars; ++i) {
+                           Scalar elem;
+                           std::memcpy(&elem, it, sizeof(Scalar));
+                           cbor_detail::byteswap_element(elem);
+                           dest[i] = elem;
+                           it += sizeof(Scalar);
                         }
-                        else if constexpr (sizeof(Scalar) == 4) {
-                           uint32_t bits;
-                           std::memcpy(&bits, &elem, sizeof(Scalar));
-                           bits = std::byteswap(bits);
-                           std::memcpy(&elem, &bits, sizeof(Scalar));
+                     }
+                     else {
+                        // Native endianness or single-byte: bulk read
+                        if (byte_len > 0) {
+                           std::memcpy(value.data(), it, byte_len);
+                           it += byte_len;
                         }
-                        else if constexpr (sizeof(Scalar) == 8) {
-                           uint64_t bits;
-                           std::memcpy(&bits, &elem, sizeof(Scalar));
-                           bits = std::byteswap(bits);
-                           std::memcpy(&elem, &bits, sizeof(Scalar));
-                        }
-                        dest[i] = elem;
-                        it += sizeof(Scalar);
                      }
                   }
                   else {
-                     // Native endianness or single-byte: bulk read
-                     if (byte_len > 0) {
-                        std::memcpy(value.data(), it, byte_len);
-                        it += byte_len;
+                     // No contiguous storage to bulk read into, so the interleaved [real, imag] pairs
+                     // are reassembled one element at a time.
+                     const bool swap_each = need_swap && sizeof(Scalar) > 1;
+                     const auto next_element = [&] {
+                        Scalar parts[2];
+                        std::memcpy(parts, it, sizeof(V));
+                        if (swap_each) {
+                           cbor_detail::byteswap_element(parts[0]);
+                           cbor_detail::byteswap_element(parts[1]);
+                        }
+                        it += sizeof(V);
+                        return V{parts[0], parts[1]};
+                     };
+
+                     if constexpr (set_like) {
+                        for (size_t i = 0; i < count; ++i) {
+                           value.emplace(next_element());
+                        }
+                     }
+                     else {
+                        auto dest = value.begin();
+                        for (size_t i = 0; i < count; ++i, ++dest) {
+                           *dest = next_element();
+                        }
                      }
                   }
                   return; // Done with complex array
@@ -1067,9 +1130,17 @@ namespace glz
          }
 
          if (additional_info == info::indefinite) {
-            // Indefinite-length array
-            if constexpr (resizable<T>) {
+            // Indefinite-length array. The resizable-only path below grows with resize() from index
+            // zero, which drops any prior contents on its own, so it needs no clear() of its own.
+            if constexpr (emplace_backable<T> || set_like) {
                value.clear();
+            }
+            // A target that cannot grow is filled in place, and it is walked with an iterator rather
+            // than a subscript because a non-resizable range need not be indexable. The growing cases
+            // leave this default constructed: insertion would invalidate it.
+            [[maybe_unused]] decltype(value.begin()) dest{};
+            if constexpr (not growable) {
+               dest = value.begin();
             }
             size_t i = 0;
             while (true) {
@@ -1086,18 +1157,48 @@ namespace glz
                   break;
                }
 
-               if constexpr (resizable<T>) {
-                  value.emplace_back();
-                  parse<CBOR>::op<Opts>(value.back(), ctx, it, end);
+               // A break code rather than a count ends this array, so the caller's element limit is
+               // enforced as the array grows instead of up front.
+               if constexpr (check_max_array_size(Opts) > 0) {
+                  if (i >= check_max_array_size(Opts)) [[unlikely]] {
+                     ctx.error = error_code::invalid_length;
+                     return;
+                  }
+               }
+               if constexpr (has_runtime_max_array_size<std::decay_t<decltype(ctx)>>) {
+                  if (ctx.max_array_size > 0 && i >= ctx.max_array_size) [[unlikely]] {
+                     ctx.error = error_code::invalid_length;
+                     return;
+                  }
+               }
+
+               if constexpr (emplace_backable<T>) {
+                  parse<CBOR>::op<Opts>(value.emplace_back(), ctx, it, end);
+               }
+               else if constexpr (set_like) {
+                  V element{};
+                  parse<CBOR>::op<Opts>(element, ctx, it, end);
+                  if (bool(ctx.error)) [[unlikely]]
+                     return;
+                  value.emplace(std::move(element));
+               }
+               else if constexpr (resizable<T>) {
+                  // Resizable but append-only through resize: grow by one and re-derive the write
+                  // position, since growing may invalidate any iterator held across it.
+                  value.resize(i + 1);
+                  auto slot = value.begin();
+                  std::advance(slot, i);
+                  parse<CBOR>::op<Opts>(*slot, ctx, it, end);
                }
                else {
                   if (i >= value.size()) [[unlikely]] {
                      ctx.error = error_code::exceeded_static_array_size;
                      return;
                   }
-                  parse<CBOR>::op<Opts>(value[i], ctx, it, end);
-                  ++i;
+                  parse<CBOR>::op<Opts>(*dest, ctx, it, end);
+                  ++dest;
                }
+               ++i;
 
                if (bool(ctx.error)) [[unlikely]]
                   return;
@@ -1129,24 +1230,47 @@ namespace glz
                }
             }
 
-            if constexpr (resizable<T>) {
-               value.resize(static_cast<size_t>(count));
-
-               if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
-                  value.shrink_to_fit();
+            if constexpr (set_like) {
+               value.clear();
+               for (size_t i = 0; i < count; ++i) {
+                  V element{};
+                  parse<CBOR>::op<Opts>(element, ctx, it, end);
+                  if (bool(ctx.error)) [[unlikely]]
+                     return;
+                  value.emplace(std::move(element));
+               }
+            }
+            else if constexpr (emplace_backable<T> && !resizable<T>) {
+               // Append-only: there is no way to size the target up front even though the count is known.
+               value.clear();
+               for (size_t i = 0; i < count; ++i) {
+                  parse<CBOR>::op<Opts>(value.emplace_back(), ctx, it, end);
+                  if (bool(ctx.error)) [[unlikely]]
+                     return;
                }
             }
             else {
-               if (count > value.size()) [[unlikely]] {
-                  ctx.error = error_code::exceeded_static_array_size;
-                  return;
-               }
-            }
+               if constexpr (resizable<T>) {
+                  value.resize(static_cast<size_t>(count));
 
-            for (size_t i = 0; i < count; ++i) {
-               parse<CBOR>::op<Opts>(value[i], ctx, it, end);
-               if (bool(ctx.error)) [[unlikely]]
-                  return;
+                  if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
+                     value.shrink_to_fit();
+                  }
+               }
+               else {
+                  if (count > value.size()) [[unlikely]] {
+                     ctx.error = error_code::exceeded_static_array_size;
+                     return;
+                  }
+               }
+
+               // Iteration rather than subscripting: std::list resizes but does not index.
+               auto dest = value.begin();
+               for (size_t i = 0; i < count; ++i, ++dest) {
+                  parse<CBOR>::op<Opts>(*dest, ctx, it, end);
+                  if (bool(ctx.error)) [[unlikely]]
+                     return;
+               }
             }
          }
       }

--- a/include/glaze/cbor/write.hpp
+++ b/include/glaze/cbor/write.hpp
@@ -912,26 +912,27 @@ namespace glz
       template <auto Opts>
       static void op(auto&& value, is_context auto&& ctx, auto&& b, auto& ix)
       {
-         using Variant = std::decay_t<decltype(value)>;
+         // The active alternative is taken from the variant itself rather than recovered by matching
+         // the visited type against the alternative list: the index is what the reader consumes, and a
+         // type match is ambiguous for a variant that repeats an alternative type.
+         const size_t index = value.index();
 
-         std::visit(
-            [&](auto&& v) {
-               using V = std::decay_t<decltype(v)>;
+         // A valueless variant has no alternative to name, and variant_npos is not an index any
+         // reader could resolve. Reject it here rather than emitting an unreadable array.
+         if (index >= std::variant_size_v<std::remove_cvref_t<decltype(value)>>) [[unlikely]] {
+            ctx.error = error_code::no_matching_variant_type;
+            return;
+         }
 
-               static constexpr uint64_t index = []<size_t... I>(std::index_sequence<I...>) {
-                  return ((std::is_same_v<V, std::variant_alternative_t<I, Variant>> * I) + ...);
-               }(std::make_index_sequence<std::variant_size_v<Variant>>{});
+         // Encode variant as array [index, value]
+         if (!cbor_detail::encode_arg_cx<2>(ctx, cbor::major::array, b, ix)) [[unlikely]] {
+            return;
+         }
+         if (!cbor_detail::encode_arg(ctx, cbor::major::uint, index, b, ix)) [[unlikely]] {
+            return;
+         }
 
-               // Encode variant as array [index, value]
-               if (!cbor_detail::encode_arg_cx<2>(ctx, cbor::major::array, b, ix)) [[unlikely]] {
-                  return;
-               }
-               if (!cbor_detail::encode_arg(ctx, cbor::major::uint, index, b, ix)) [[unlikely]] {
-                  return;
-               }
-               serialize<CBOR>::op<Opts>(v, ctx, b, ix);
-            },
-            value);
+         std::visit([&](auto&& v) { serialize<CBOR>::op<Opts>(v, ctx, b, ix); }, value);
       }
    };
 

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -9,10 +9,13 @@
 #include <complex>
 #include <deque>
 #include <expected>
+#include <list>
 #include <map>
 #include <random>
+#include <set>
 #include <span>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "glaze/base64/base64.hpp"
@@ -3626,13 +3629,300 @@ suite cbor_byte_uint8_unify_tests = [] {
    };
 };
 
+struct cbor_stl_members
+{
+   std::set<int> items{};
+   std::list<std::string> names{};
+};
+
+// Containers that grow by back-insertion or by emplacement rather than by subscript. The reader used
+// to index its target unconditionally, so these were a hard compile error rather than a bad read.
+suite cbor_non_indexable_container_tests = [] {
+   "list roundtrip"_test = [] {
+      const std::list<int> src{1, 2, 3};
+      std::string buffer{};
+      expect(not glz::write_cbor(src, buffer));
+
+      std::list<int> dst{9, 9, 9, 9, 9};
+      expect(not glz::read_cbor(dst, buffer));
+      expect(dst == src);
+   };
+
+   "list of strings roundtrip"_test = [] {
+      const std::list<std::string> src{"a", "bb", "ccc"};
+      std::string buffer{};
+      expect(not glz::write_cbor(src, buffer));
+
+      std::list<std::string> dst{};
+      expect(not glz::read_cbor(dst, buffer));
+      expect(dst == src);
+   };
+
+   "set roundtrip"_test = [] {
+      const std::set<int> src{3, 1, 2};
+      std::string buffer{};
+      expect(not glz::write_cbor(src, buffer));
+
+      std::set<int> dst{99};
+      expect(not glz::read_cbor(dst, buffer));
+      expect(dst == src);
+   };
+
+   "unordered_set roundtrip"_test = [] {
+      const std::unordered_set<std::string> src{"x", "y", "z"};
+      std::string buffer{};
+      expect(not glz::write_cbor(src, buffer));
+
+      std::unordered_set<std::string> dst{"stale"};
+      expect(not glz::read_cbor(dst, buffer));
+      expect(dst == src);
+   };
+
+   // 0x9F starts an indefinite-length array, terminated by the 0xFF break code.
+   "indefinite length array"_test = [] {
+      const std::string buffer{"\x9F\x01\x02\x03\xFF", 5};
+
+      std::list<int> lst{};
+      expect(not glz::read_cbor(lst, buffer));
+      expect(lst == std::list<int>{1, 2, 3});
+
+      std::set<int> st{9};
+      expect(not glz::read_cbor(st, buffer));
+      expect(st == std::set<int>{1, 2, 3});
+   };
+
+   // A vector of numbers is written as an RFC 8746 typed array, which these containers cannot bulk
+   // read into, so the reader decodes it one element at a time.
+   "typed array into non-contiguous containers"_test = [] {
+      const std::vector<int32_t> src{1, 2, 3};
+      std::string buffer{};
+      expect(not glz::write_cbor(src, buffer));
+
+      std::list<int32_t> lst{};
+      expect(not glz::read_cbor(lst, buffer));
+      expect(lst == std::list<int32_t>{1, 2, 3});
+
+      std::set<int32_t> st{99};
+      expect(not glz::read_cbor(st, buffer));
+      expect(st == std::set<int32_t>{1, 2, 3});
+
+      std::deque<int32_t> deq{};
+      expect(not glz::read_cbor(deq, buffer));
+      expect(deq == std::deque<int32_t>{1, 2, 3});
+   };
+
+   // Tag 66 is a big-endian uint32 typed array, so every element needs a byteswap on a little-endian
+   // platform. The swap is per-element here rather than over one contiguous block.
+   "byteswapped typed array into non-contiguous containers"_test = [] {
+      std::string buffer{};
+      buffer.push_back(char(0xD8)); // tag, one byte follows
+      buffer.push_back(char(66)); // uint32, big endian
+      buffer.push_back(char(0x48)); // byte string of 8
+      const unsigned char payload[] = {0, 0, 0, 1, 0, 0, 0, 2};
+      buffer.append(reinterpret_cast<const char*>(payload), sizeof(payload));
+
+      std::list<uint32_t> lst{};
+      expect(not glz::read_cbor(lst, buffer));
+      expect(lst == std::list<uint32_t>{1, 2});
+
+      std::set<uint32_t> st{};
+      expect(not glz::read_cbor(st, buffer));
+      expect(st == std::set<uint32_t>{1, 2});
+
+      std::vector<uint32_t> vec{};
+      expect(not glz::read_cbor(vec, buffer));
+      expect(vec == std::vector<uint32_t>{1, 2});
+   };
+
+   "struct member containers"_test = [] {
+      cbor_stl_members src{};
+      src.items = {1, 2, 3};
+      src.names = {"a", "b"};
+      std::string buffer{};
+      expect(not glz::write_cbor(src, buffer));
+
+      cbor_stl_members dst{};
+      expect(not glz::read_cbor(dst, buffer));
+      expect(dst.items == src.items);
+      expect(dst.names == src.names);
+   };
+
+   // A vector of std::complex is written under tag 43001 as an interleaved [real, imag] typed array,
+   // which these containers cannot bulk read into either.
+   "complex array into non-contiguous containers"_test = [] {
+      const std::vector<std::complex<double>> src{{1.0, 2.0}, {3.0, 4.0}};
+      std::string buffer{};
+      expect(not glz::write_cbor(src, buffer));
+
+      std::list<std::complex<double>> lst{};
+      expect(not glz::read_cbor(lst, buffer));
+      expect(lst == std::list<std::complex<double>>{{1.0, 2.0}, {3.0, 4.0}});
+
+      std::deque<std::complex<double>> deq{};
+      expect(not glz::read_cbor(deq, buffer));
+      expect(deq == std::deque<std::complex<double>>{{1.0, 2.0}, {3.0, 4.0}});
+   };
+};
+
+// Resizable but without back-insertion, and back-insertable but without resize. No standard container
+// is either, yet both reach the array reader, and the definite- and indefinite-length branches take
+// different routes for them: this pins the two framings to the same result.
+struct cbor_resize_only
+{
+   using value_type = int;
+   std::vector<int> data{};
+
+   auto begin() { return data.begin(); }
+   auto end() { return data.end(); }
+   auto begin() const { return data.begin(); }
+   auto end() const { return data.end(); }
+   size_t size() const { return data.size(); }
+   void resize(size_t n) { data.resize(n); }
+};
+
+struct cbor_append_only
+{
+   using value_type = int;
+   using reference = int&;
+   std::vector<int> data{};
+
+   auto begin() { return data.begin(); }
+   auto end() { return data.end(); }
+   auto begin() const { return data.begin(); }
+   auto end() const { return data.end(); }
+   size_t size() const { return data.size(); }
+   void clear() { data.clear(); }
+   int& emplace_back() { return data.emplace_back(); }
+};
+
+suite cbor_array_framing_agreement_tests = [] {
+   "definite and indefinite agree"_test = [] {
+      const std::string definite{"\x83\x01\x02\x03", 4};
+      const std::string indefinite{"\x9F\x01\x02\x03\xFF", 5};
+      const std::vector<int> expected{1, 2, 3};
+
+      cbor_resize_only a{};
+      expect(not glz::read_cbor(a, definite));
+      expect(a.data == expected);
+
+      cbor_resize_only b{};
+      expect(not glz::read_cbor(b, indefinite));
+      expect(b.data == expected);
+
+      cbor_append_only c{};
+      expect(not glz::read_cbor(c, definite));
+      expect(c.data == expected);
+
+      cbor_append_only d{};
+      expect(not glz::read_cbor(d, indefinite));
+      expect(d.data == expected);
+   };
+
+   // A prior read must not leave elements behind when the next one is shorter.
+   "growable targets are reset"_test = [] {
+      const std::string three{"\x83\x01\x02\x03", 4};
+      const std::string one{"\x9F\x07\xFF", 3};
+
+      cbor_resize_only a{};
+      expect(not glz::read_cbor(a, three));
+      expect(not glz::read_cbor(a, one));
+      expect(a.data == std::vector<int>{7});
+
+      cbor_append_only b{};
+      expect(not glz::read_cbor(b, three));
+      expect(not glz::read_cbor(b, one));
+      expect(b.data == std::vector<int>{7});
+   };
+};
+
+// An indefinite-length array is ended by a break code rather than a count, so the caller's limit has
+// to be enforced as it grows. It used to be checked only on the definite-length form, which left the
+// limit trivially bypassable by reframing the same array.
+suite cbor_indefinite_array_limit_tests = [] {
+   struct limited_opts : glz::opts
+   {
+      uint32_t format = glz::CBOR;
+      size_t max_array_size = 2;
+   };
+
+   "indefinite arrays honor max_array_size"_test = [] {
+      const std::string oversized{"\x9F\x01\x02\x03\x04\x05\xFF", 7};
+
+      std::vector<int> vec{};
+      expect(glz::read<limited_opts{}>(vec, oversized).ec == glz::error_code::invalid_length);
+
+      std::list<int> lst{};
+      expect(glz::read<limited_opts{}>(lst, oversized).ec == glz::error_code::invalid_length);
+
+      std::set<int> st{};
+      expect(glz::read<limited_opts{}>(st, oversized).ec == glz::error_code::invalid_length);
+   };
+
+   "indefinite arrays within max_array_size are accepted"_test = [] {
+      const std::string within{"\x9F\x01\x02\xFF", 4};
+
+      std::vector<int> vec{};
+      expect(not glz::read<limited_opts{}>(vec, within));
+      expect(vec == std::vector<int>{1, 2});
+   };
+};
+
+#if __cpp_exceptions
+// Assigning from this leaves the variant valueless, which has no alternative index to write. The
+// user-declared constructors make it a non-aggregate, so it needs a meta to be serializable at all.
+struct cbor_throws_on_copy
+{
+   int x{};
+   cbor_throws_on_copy() = default;
+   cbor_throws_on_copy(const cbor_throws_on_copy&) { throw std::runtime_error("copy"); }
+   cbor_throws_on_copy& operator=(const cbor_throws_on_copy&) { throw std::runtime_error("assign"); }
+};
+
+template <>
+struct glz::meta<cbor_throws_on_copy>
+{
+   using T = cbor_throws_on_copy;
+   static constexpr auto value = object(&T::x);
+};
+#endif
+
+// A variant that repeats an alternative type: the written index must be the active one, not the first
+// alternative that happens to match by type.
+suite cbor_variant_index_tests = [] {
+   "duplicate alternative types"_test = [] {
+      std::variant<int, int, double> src{std::in_place_index<1>, 7};
+      std::string buffer{};
+      expect(not glz::write_cbor(src, buffer));
+
+      std::variant<int, int, double> dst{};
+      expect(not glz::read_cbor(dst, buffer));
+      expect(dst.index() == 1);
+      expect(std::get<1>(dst) == 7);
+   };
+
+#if __cpp_exceptions
+   "valueless variant is rejected"_test = [] {
+      std::variant<int, cbor_throws_on_copy> v{};
+      try {
+         const cbor_throws_on_copy thrower{};
+         v = thrower;
+      }
+      catch (const std::runtime_error&) {
+      }
+      expect(v.valueless_by_exception());
+
+      std::string buffer{};
+      expect(glz::write_cbor(v, buffer).ec == glz::error_code::no_matching_variant_type);
+   };
+#endif
+};
+
 struct cbor_shrink_opts : glz::opts
 {
    bool shrink_to_fit = true;
 };
 
 // Resizable but deliberately without a shrink_to_fit member, like std::list.
-// std::list itself can't be used here: CBOR's array reader subscripts its target.
 // String elements keep this on the generic array path rather than the typed-array path.
 struct no_shrink_strings
 {


### PR DESCRIPTION
Closes #2788.

Two unrelated CBOR failures reported together, plus the gaps found while verifying the fixes.

## `std::variant` write failed to compile on MSVC

The writer recovered the alternative index inside `std::visit` by folding `std::is_same_v` over `std::variant_alternative_t`, naming a `Variant` alias from the enclosing scope inside a nested generic lambda. MSVC cannot resolve that alias there.

The fold was also wrong independent of the compiler: for a variant that repeats an alternative type, `((std::is_same_v<V, alternative_t<I>> * I) + ...)` *sums* every matching index, so `std::variant<int, int>` holding index 0 wrote index 1. It now uses `value.index()`, which is what the reader consumes.

A valueless variant has no alternative to name, and `variant_npos` is not an index any reader can resolve, so it is now rejected with `no_matching_variant_type` instead of emitting an unreadable array. BEVE and MessagePack already reject it, via their `index() >= ids.size()` check.

## Reads into `std::list` / `std::set` / `std::unordered_set` failed to compile

The array reader wrote elements through `value[i]`, so `std::list` (resizable, not indexable) and the set types (neither resizable nor back-insertable) were hard compile errors. Both the definite- and indefinite-length branches now share one classification of the target — set-like, back-insertable, resizable, or fixed — and fill it accordingly, walking an iterator instead of subscripting.

The two branches previously disagreed on which containers can grow (definite decided with `resizable`, indefinite with `emplace_backable`). No standard container satisfies only one, and before this change such a type failed to compile either way, so the divergence was unobservable — but it would have let a user container silently accept one framing of an array and reject the other. The shared classification pins them together, and a test covers both framings.

## Typed arrays could not be read into the containers this adds

Numeric arrays are written as RFC 8746 typed arrays (tags 64–87) and `std::complex` arrays under tag 43001. Both decode paths were gated on `contiguous<T>`, so `read_cbor(std::list<int>&, buf)` returned `syntax_error` on data Glaze itself produces for the equivalent `std::vector<int>` — and any RFC 8746 producer's output was unreadable into these containers.

Non-contiguous targets now decode typed arrays one element at a time, including the per-element byteswap for a tag whose endianness differs from the platform's, and the interleaved `[real, imag]` reassembly for complex arrays. Contiguous targets keep the bulk `memcpy`. The byteswap, previously copy-pasted at each site, is now `cbor_detail::byteswap_element`.

## `max_array_size` was bypassable by reframing an array

An indefinite-length array is ended by a break code rather than a count, and the limit was only checked against a count, so with `max_array_size = 2` the definite `0x85 …` was rejected while the identical `0x9F … 0xFF` read five elements. It is now enforced as the array grows. This matters more here because set-like targets allocate per element rather than in one block.

## Tests

New suites in `tests/cbor_test/cbor_test.cpp` cover round-trips for list/set/unordered_set (scalars, strings, struct members), indefinite-length input, typed and complex arrays into non-contiguous targets, a hand-built big-endian tag-66 array exercising the per-element swap, definite/indefinite agreement for containers with only one growth capability, the indefinite-array size limit, and both the duplicate-alternative and valueless variant cases.

`cbor_test` passes 264/264 with exceptions disabled and 269/269 with them enabled (the valueless-variant test is inherently exceptions-only, and the suite builds `-fno-exceptions` by default). Full local suite is 100/100.

## Not addressed here

Pre-existing issues found while verifying, each with a confirmed repro, left for separate changes:

- `glz::inplace_vector` throws `std::bad_alloc` out of the error-code API on oversized CBOR input, and aborts with exceptions disabled. The JSON reader handles this via a `try_emplace_back` special case the CBOR reader never had.
- Typed-array tags are matched by element size only, ignoring `is_float` / `is_signed`: a tag-71 uint64 payload read into `std::vector<double>` yields `4.94e-324` with no error. Relatedly, `byteswap_element` has no 16-byte case, so a big-endian float128 array is accepted unswapped.
- `std::vector<bool>` is a hard compile error on read (`_Bit_reference` prvalue); `std::list<bool>` and `std::deque<bool>` are fine.
- `std::vector<uint8_t>` writes a byte string that `std::list<uint8_t>` / `std::set<uint8_t>` cannot read; `std::vector<long double>` reads but cannot be written.
