### PR TITLE
fix: report exceeded_static_array_size instead of throwing from fixed-capacity targets

### DIFF
--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -1414,6 +1414,9 @@ namespace glz
             }
          }
          else {
+            if (exceeds_capacity(value, n, ctx)) [[unlikely]] {
+               return;
+            }
             value.resize(n);
             std::memcpy(value.data(), it, n);
          }
@@ -1820,6 +1823,9 @@ namespace glz
             }
 
             if constexpr (resizable<T>) {
+               if (exceeds_capacity(value, n, ctx)) [[unlikely]] {
+                  return;
+               }
                value.resize(n);
 
                if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
@@ -1866,6 +1872,9 @@ namespace glz
                }
 
                if constexpr (resizable<T>) {
+                  if (exceeds_capacity(value, n, ctx)) [[unlikely]] {
+                     return false;
+                  }
                   value.resize(n);
 
                   if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
@@ -2131,6 +2140,9 @@ namespace glz
             }
 
             if constexpr (resizable<T>) {
+               if (exceeds_capacity(value, n, ctx)) [[unlikely]] {
+                  return;
+               }
                value.resize(n);
 
                if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
@@ -2215,6 +2227,9 @@ namespace glz
             }
 
             if constexpr (resizable<T>) {
+               if (exceeds_capacity(value, n, ctx)) [[unlikely]] {
+                  return;
+               }
                value.resize(n);
 
                if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
@@ -2303,6 +2318,9 @@ namespace glz
             }
 
             if constexpr (resizable<T>) {
+               if (exceeds_capacity(value, n, ctx)) [[unlikely]] {
+                  return;
+               }
                value.resize(n);
 
                if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
@@ -2384,6 +2402,9 @@ namespace glz
 
          constexpr uint8_t key_tag = beve_key_traits<Key>::key_tag;
          for (size_t i = 0; i < n; ++i) {
+            if (exceeds_capacity(value, i + 1, ctx)) [[unlikely]] {
+               return;
+            }
             auto& item = value.emplace_back();
             parse<BEVE>::op<no_header_on<Opts>()>(item.first, key_tag, ctx, it, end);
             if (bool(ctx.error)) [[unlikely]] {
@@ -3295,6 +3316,9 @@ namespace glz
          }
 
          if constexpr (emplace_backable<Container>) {
+            if (exceeds_capacity(values, index + 1, ctx)) [[unlikely]] {
+               break;
+            }
             auto& value = values.emplace_back();
             parse<BEVE>::template op<set_beve<Opts>()>(value, ctx, it, end);
          }

--- a/include/glaze/cbor/read.hpp
+++ b/include/glaze/cbor/read.hpp
@@ -721,6 +721,9 @@ namespace glz
 
                if constexpr (resizable<T>) {
                   const size_t old_size = value.size();
+                  if (exceeds_capacity(value, old_size + static_cast<size_t>(chunk_len), ctx)) [[unlikely]] {
+                     return;
+                  }
                   value.resize(old_size + static_cast<size_t>(chunk_len));
                   std::memcpy(value.data() + old_size, it, chunk_len);
                }
@@ -767,6 +770,9 @@ namespace glz
             }
 
             if constexpr (resizable<T>) {
+               if (exceeds_capacity(value, static_cast<size_t>(length), ctx)) [[unlikely]] {
+                  return;
+               }
                value.resize(static_cast<size_t>(length));
                std::memcpy(value.data(), it, length);
             }
@@ -881,6 +887,9 @@ namespace glz
                      value.clear();
                   }
                   else if constexpr (resizable<T>) {
+                     if (exceeds_capacity(value, count, ctx)) [[unlikely]] {
+                        return;
+                     }
                      value.resize(count);
                      if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
                         value.shrink_to_fit();
@@ -1042,6 +1051,9 @@ namespace glz
                      value.clear();
                   }
                   else if constexpr (resizable<T>) {
+                     if (exceeds_capacity(value, count, ctx)) [[unlikely]] {
+                        return;
+                     }
                      value.resize(count);
                      if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
                         value.shrink_to_fit();
@@ -1172,6 +1184,10 @@ namespace glz
                   }
                }
 
+               if (exceeds_capacity(value, i + 1, ctx)) [[unlikely]] {
+                  return;
+               }
+
                if constexpr (emplace_backable<T>) {
                   parse<CBOR>::op<Opts>(value.emplace_back(), ctx, it, end);
                }
@@ -1242,6 +1258,9 @@ namespace glz
             }
             else if constexpr (emplace_backable<T> && !resizable<T>) {
                // Append-only: there is no way to size the target up front even though the count is known.
+               if (exceeds_capacity(value, static_cast<size_t>(count), ctx)) [[unlikely]] {
+                  return;
+               }
                value.clear();
                for (size_t i = 0; i < count; ++i) {
                   parse<CBOR>::op<Opts>(value.emplace_back(), ctx, it, end);
@@ -1251,6 +1270,9 @@ namespace glz
             }
             else {
                if constexpr (resizable<T>) {
+                  if (exceeds_capacity(value, static_cast<size_t>(count), ctx)) [[unlikely]] {
+                     return;
+                  }
                   value.resize(static_cast<size_t>(count));
 
                   if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {

--- a/include/glaze/core/read.hpp
+++ b/include/glaze/core/read.hpp
@@ -13,6 +13,28 @@
 
 namespace glz
 {
+   // A container whose capacity is fixed at compile time -- glz::inplace_vector, std::inplace_vector --
+   // reports being full only through try_emplace_back. Its resize(), reserve() and emplace_back()
+   // throw std::bad_alloc past capacity, and abort outright when exceptions are disabled.
+   template <class T>
+   concept fixed_capacity_container = has_try_emplace_back<std::remove_cvref_t<T>> && requires(T& t) {
+      { t.max_size() } -> std::convertible_to<size_t>;
+   };
+
+   // Reject an element count a fixed-capacity target cannot hold, before it is grown to that count.
+   // Untrusted input decides these counts, so without this the container's own bad_alloc escapes the
+   // error-code API -- and terminates the process outright in a reader marked noexcept.
+   [[nodiscard]] GLZ_ALWAYS_INLINE bool exceeds_capacity(auto& value, const size_t n, is_context auto& ctx) noexcept
+   {
+      if constexpr (fixed_capacity_container<decltype(value)>) {
+         if (n > value.max_size()) [[unlikely]] {
+            ctx.error = error_code::exceeded_static_array_size;
+            return true;
+         }
+      }
+      return false;
+   }
+
    template <auto Opts, bool Padded = false>
    auto read_iterators(contiguous auto&& buffer) noexcept
    {

--- a/include/glaze/msgpack/read.hpp
+++ b/include/glaze/msgpack/read.hpp
@@ -856,6 +856,9 @@ namespace glz
                   }
                   const size_t len = payload.size();
                   if constexpr (resizable<std::remove_cvref_t<Range>>) {
+                     if (exceeds_capacity(value, len, ctx)) [[unlikely]] {
+                        return;
+                     }
                      value.clear();
                      if constexpr (has_reserve<std::remove_cvref_t<Range>>) {
                         value.reserve(len);
@@ -893,6 +896,9 @@ namespace glz
          }
 
          if constexpr (emplace_backable<std::decay_t<Value>>) {
+            if (exceeds_capacity(value, len, ctx)) [[unlikely]] {
+               return;
+            }
             value.clear();
             if constexpr (has_reserve<std::decay_t<Value>>) {
                // Each element occupies at least one byte on the wire, so a valid len can never
@@ -939,6 +945,9 @@ namespace glz
             return;
          }
          value.type = type;
+         if (exceeds_capacity(value.data, len, ctx)) [[unlikely]] {
+            return;
+         }
          value.data.resize(len);
          if (len > 0) {
             std::memcpy(value.data.data(), it, len);

--- a/tests/inplace_vector/inplace_vector_test.cpp
+++ b/tests/inplace_vector/inplace_vector_test.cpp
@@ -3,7 +3,10 @@
 #include <compare>
 #include <numeric>
 
+#include "glaze/beve.hpp"
+#include "glaze/cbor.hpp"
 #include "glaze/glaze.hpp"
+#include "glaze/msgpack.hpp"
 #include "ut/ut.hpp"
 
 using namespace ut;
@@ -127,6 +130,74 @@ suite json_test = [] {
    "pair_vec"_test = [] {
       test_pair_vec<inplace_vector<std::pair<int, int>, 2>>();
       test_pair_vec<freestanding_iv<std::pair<int, int>, 2>>();
+   };
+};
+
+// An inplace_vector reports being full only through try_emplace_back. Its resize(), reserve() and
+// emplace_back() throw std::bad_alloc past capacity -- and abort() with exceptions disabled, which is
+// how this file's second build runs -- so a reader that sizes one from a wire count has to check the
+// capacity first. Untrusted input picks these counts, so the failure has to stay inside the error
+// code. MessagePack's reader is additionally marked noexcept, where a throw terminates outright.
+template <class IV, class Src>
+constexpr auto test_binary_overflow = [](auto write, auto read) {
+   const Src oversized(100, typename Src::value_type{});
+   std::string buffer{};
+   expect(not write(oversized, buffer));
+
+   IV vec{};
+   expect(read(vec, buffer) == glz::error_code::exceeded_static_array_size);
+
+   // The same value within capacity still round-trips.
+   const Src fits(3, typename Src::value_type{});
+   buffer.clear();
+   expect(not write(fits, buffer));
+   expect(not read(vec, buffer));
+   expect(vec.size() == 3);
+};
+
+suite binary_format_overflow_tests = [] {
+   "cbor"_test = [] {
+      const auto write = [](auto& v, auto& b) { return glz::write_cbor(v, b); };
+      const auto read = [](auto& v, auto& b) { return glz::read_cbor(v, b); };
+      // Numbers take the RFC 8746 typed-array path, strings the generic one, bytes the byte string.
+      test_binary_overflow<inplace_vector<int, 4>, std::vector<int>>(write, read);
+      test_binary_overflow<inplace_vector<std::string, 4>, std::vector<std::string>>(write, read);
+      test_binary_overflow<inplace_vector<std::byte, 4>, std::vector<std::byte>>(write, read);
+   };
+
+   "cbor indefinite length"_test = [] {
+      std::string array{"\x9F", 1};
+      for (int i = 0; i < 100; ++i) array.push_back('\x01');
+      array.push_back('\xFF');
+
+      inplace_vector<int, 4> vec{};
+      expect(glz::read_cbor(vec, array) == glz::error_code::exceeded_static_array_size);
+
+      std::string byte_string{"\x5F", 1};
+      for (int i = 0; i < 10; ++i) {
+         byte_string.push_back('\x4A');
+         byte_string.append(10, 'z');
+      }
+      byte_string.push_back('\xFF');
+
+      inplace_vector<std::byte, 4> bytes{};
+      expect(glz::read_cbor(bytes, byte_string) == glz::error_code::exceeded_static_array_size);
+   };
+
+   "beve"_test = [] {
+      const auto write = [](auto& v, auto& b) { return glz::write_beve(v, b); };
+      const auto read = [](auto& v, auto& b) { return glz::read_beve(v, b); };
+      test_binary_overflow<inplace_vector<int, 4>, std::vector<int>>(write, read);
+      test_binary_overflow<inplace_vector<std::string, 4>, std::vector<std::string>>(write, read);
+      test_binary_overflow<inplace_vector<std::byte, 4>, std::vector<std::byte>>(write, read);
+   };
+
+   "msgpack"_test = [] {
+      const auto write = [](auto& v, auto& b) { return glz::write_msgpack(v, b); };
+      const auto read = [](auto& v, auto& b) { return glz::read_msgpack(v, b); };
+      test_binary_overflow<inplace_vector<int, 4>, std::vector<int>>(write, read);
+      test_binary_overflow<inplace_vector<std::string, 4>, std::vector<std::string>>(write, read);
+      test_binary_overflow<inplace_vector<std::byte, 4>, std::vector<std::byte>>(write, read);
    };
 };
 


### PR DESCRIPTION
Follow-up to #2791, and stacked on it. Base retargets to `main` once #2791 merges.

## The defect

A fixed-capacity container — `glz::inplace_vector`, `std::inplace_vector` — reports being full only through `try_emplace_back`. Its `resize()`, `reserve()` and `emplace_back()` throw `std::bad_alloc` past capacity, and `abort()` when exceptions are disabled.

The binary readers size their target from a count on the wire, so untrusted input drove those calls directly and the container's `bad_alloc` escaped the error-code API. The JSON reader already handled this by growing through `try_emplace_back`.

Reading a 100-element array into a `glz::inplace_vector<int, 4>`, before this change:

| format | array | byte string |
|---|---|---|
| JSON | `exceeded_static_array_size` | — |
| CBOR | throws `std::bad_alloc` | throws `std::bad_alloc` |
| BEVE | throws `std::bad_alloc` | throws `std::bad_alloc` |
| MessagePack | **terminates** | **terminates** |

MessagePack is worse than the rest: its reader is marked `noexcept`, so the throw is a `std::terminate`, not something a caller can catch. With exceptions disabled — how half of this repo's tests build — every one of these is an `abort()`.

The report that prompted this was CBOR-only. BEVE and MessagePack turned out to have the identical defect, so all three are fixed here rather than leaving two formats crashing on the same input.

## The fix

`glz::exceeds_capacity` reports `exceeded_static_array_size` when a count will not fit, and is checked at every site where a reader grows an array or byte-range target from the input:

- **CBOR** — typed, complex, generic and indefinite arrays; definite and indefinite byte strings
- **BEVE** — number, string, complex and generic arrays; byte ranges; pair arrays; `read_beve_delimited`
- **MessagePack** — arrays, binary ranges, ext payloads

It compiles to nothing for a container that can allocate, so nothing changes for `std::vector` and friends.

## Tests

The new cases live in the `inplace_vector` suite, which is built twice — once with exceptions and once without. A regression fails loudly either way: an uncaught throw in one build, an abort in the other.

Full local suite is 100/100.
