### PR TITLE
fix(cbor): match typed array tags on element kind, not just element width

### DIFF
--- a/include/glaze/cbor/header.hpp
+++ b/include/glaze/cbor/header.hpp
@@ -371,6 +371,33 @@ namespace glz::cbor
          return info;
       }
 
+      // Whether a typed array tag describes exactly the element type T.
+      //
+      // RFC 8746 encodes the element kind in the tag, not just its width, and a typed array is read
+      // by copying its payload straight into the target. Matching on width alone therefore
+      // reinterprets the bytes of a differently-typed array rather than converting them: a uint64
+      // array read into double yields 4.94e-324 rather than 1.
+      //
+      // Reading a CBOR value of one kind into a target of another is already an error everywhere
+      // else in this reader -- a uint does not read into a double, nor a float into an int -- so the
+      // typed-array fast path was the one place a kind mismatch was accepted, and it accepted it by
+      // reinterpreting the bytes. A mismatch is a syntax error here too.
+      template <class T>
+      [[nodiscard]] constexpr bool matches(const typed_array_info info) noexcept
+      {
+         if (!info.valid || info.element_size != sizeof(T)) {
+            return false;
+         }
+         if constexpr (std::floating_point<T>) {
+            // Tags 83 and 87 are IEEE binary128, which is not the 80-bit extended long double that
+            // shares its 16-byte storage on x86-64, so no float Glaze can write or read matches them.
+            return info.is_float && info.element_size <= 8;
+         }
+         else {
+            return !info.is_float && info.is_signed == std::is_signed_v<T>;
+         }
+      }
+
       // Check if we need to byteswap when reading a typed array
       [[nodiscard]] constexpr bool needs_byteswap(uint64_t tag) noexcept
       {

--- a/include/glaze/cbor/read.hpp
+++ b/include/glaze/cbor/read.hpp
@@ -92,6 +92,10 @@ namespace glz
       // Byteswap one typed-array element in place. An RFC 8746 tag names the producer's endianness,
       // so an element whose tag disagrees with this platform is swapped through its bit pattern:
       // V may be a floating point type, which has no byteswap of its own.
+      //
+      // Only the widths RFC 8746 defines below binary128 are handled. A one-byte element has no
+      // endianness, and a wider one reaches here only if typed_array::matches accepted its tag, which
+      // it does not do for binary128 -- so the widths left unhandled are the widths never passed in.
       template <class V>
       GLZ_ALWAYS_INLINE void byteswap_element(V& elem) noexcept
       {
@@ -835,9 +839,8 @@ namespace glz
                if (bool(ctx.error)) [[unlikely]]
                   return;
 
-               // Verify it's a valid typed array tag for our element type
-               const auto ta_info = typed_array::get_info(tag_num);
-               if (ta_info.valid && ta_info.element_size == sizeof(V)) {
+               // Verify the tag describes exactly this element type, not merely one of its width
+               if (typed_array::matches<V>(typed_array::get_info(tag_num))) {
                   // Read the byte string
                   if (it >= end) [[unlikely]] {
                      ctx.error = error_code::unexpected_end;
@@ -993,9 +996,8 @@ namespace glz
                   if (bool(ctx.error)) [[unlikely]]
                      return;
 
-                  // Verify it's a valid typed array tag for the scalar type
-                  const auto ta_info = typed_array::get_info(scalar_tag);
-                  if (!ta_info.valid || ta_info.element_size != sizeof(Scalar)) [[unlikely]] {
+                  // Verify the tag describes exactly this scalar type, not merely one of its width
+                  if (!typed_array::matches<Scalar>(typed_array::get_info(scalar_tag))) [[unlikely]] {
                      ctx.error = error_code::syntax_error;
                      return;
                   }

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -2132,14 +2132,16 @@ inline std::string cbor_typed_array(uint8_t tag, const void* payload, size_t byt
 // one kind into a target of another is an error everywhere else in this reader, and is here too.
 void typed_array_kind_tests()
 {
-   constexpr uint8_t uint64_le = 71;
-   constexpr uint8_t sint64_le = 79;
-   constexpr uint8_t float64_le = 86;
-   constexpr uint8_t float128_le = 87;
+   // The payloads below are copied in this platform's byte order, so the tags have to say so: 71/79/86
+   // on a little-endian host, 67/75/82 on a big-endian one. Naming a fixed byte order here instead
+   // would tell the reader to byteswap a payload that was never swapped.
+   constexpr uint8_t uint64_native = glz::cbor::typed_array::native_tag<uint64_t>();
+   constexpr uint8_t sint64_native = glz::cbor::typed_array::native_tag<int64_t>();
+   constexpr uint8_t float64_native = glz::cbor::typed_array::native_tag<double>();
 
    "typed array kind must match the target"_test = [] {
       const uint64_t payload[]{1, 2};
-      const auto buffer = cbor_typed_array(uint64_le, payload, sizeof(payload));
+      const auto buffer = cbor_typed_array(uint64_native, payload, sizeof(payload));
 
       std::vector<uint64_t> matching{};
       expect(not glz::read_cbor(matching, buffer));
@@ -2155,7 +2157,7 @@ void typed_array_kind_tests()
 
    "float typed array does not read into an integer target"_test = [] {
       const double payload[]{1.5, 2.5};
-      const auto buffer = cbor_typed_array(float64_le, payload, sizeof(payload));
+      const auto buffer = cbor_typed_array(float64_native, payload, sizeof(payload));
 
       std::vector<double> matching{};
       expect(not glz::read_cbor(matching, buffer));
@@ -2170,7 +2172,7 @@ void typed_array_kind_tests()
 
    "integer typed array does not read into a float target"_test = [] {
       const int64_t payload[]{-1, 2};
-      const auto buffer = cbor_typed_array(sint64_le, payload, sizeof(payload));
+      const auto buffer = cbor_typed_array(sint64_native, payload, sizeof(payload));
 
       std::vector<int64_t> matching{};
       expect(not glz::read_cbor(matching, buffer));
@@ -2183,19 +2185,22 @@ void typed_array_kind_tests()
    // Tags 83 and 87 are IEEE binary128. Where long double is the 80-bit x86 type it shares that
    // 16-byte width without sharing the format, so width alone used to accept it -- and there is no
    // 16-byte byteswap either, so a big-endian binary128 array was read through unswapped.
+   // Neither byte order is a match, so both are named rather than just the host's.
    "binary128 typed array is rejected"_test = [] {
       const unsigned char payload[32]{};
-      const auto buffer = cbor_typed_array(float128_le, payload, sizeof(payload));
+      for (const uint8_t tag : {uint8_t(83), uint8_t(87)}) {
+         const auto buffer = cbor_typed_array(tag, payload, sizeof(payload));
 
-      std::vector<long double> as_long_double{};
-      expect(glz::read_cbor(as_long_double, buffer).ec == glz::error_code::syntax_error);
+         std::vector<long double> as_long_double{};
+         expect(glz::read_cbor(as_long_double, buffer).ec == glz::error_code::syntax_error);
+      }
    };
 
    // Non-contiguous targets take the element-wise decode rather than the bulk copy, and validate the
    // same way.
    "kind is checked for non-contiguous targets too"_test = [] {
       const uint64_t payload[]{1, 2};
-      const auto buffer = cbor_typed_array(uint64_le, payload, sizeof(payload));
+      const auto buffer = cbor_typed_array(uint64_native, payload, sizeof(payload));
 
       std::list<uint64_t> matching{};
       expect(not glz::read_cbor(matching, buffer));

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -2114,6 +2114,138 @@ void rfc8949_appendix_a_tests()
 }
 
 // Typed array tests (RFC 8746)
+// tag(n) then a byte string holding the payload, which is what an RFC 8746 typed array looks like on
+// the wire. The payload is written in this platform's byte order, so pick a tag that says so.
+inline std::string cbor_typed_array(uint8_t tag, const void* payload, size_t bytes)
+{
+   std::string buffer{};
+   buffer.push_back(char(0xD8)); // tag, one byte follows
+   buffer.push_back(char(tag));
+   buffer.push_back(char(0x58)); // byte string, one-byte length
+   buffer.push_back(char(bytes));
+   buffer.append(static_cast<const char*>(payload), bytes);
+   return buffer;
+}
+
+// A typed array is copied straight into its target, so a tag matched on element width alone
+// reinterprets the payload of a differently-typed array instead of converting it. Reading a value of
+// one kind into a target of another is an error everywhere else in this reader, and is here too.
+void typed_array_kind_tests()
+{
+   constexpr uint8_t uint64_le = 71;
+   constexpr uint8_t sint64_le = 79;
+   constexpr uint8_t float64_le = 86;
+   constexpr uint8_t float128_le = 87;
+
+   "typed array kind must match the target"_test = [] {
+      const uint64_t payload[]{1, 2};
+      const auto buffer = cbor_typed_array(uint64_le, payload, sizeof(payload));
+
+      std::vector<uint64_t> matching{};
+      expect(not glz::read_cbor(matching, buffer));
+      expect(matching == std::vector<uint64_t>{1, 2});
+
+      // Same width, different kind: reinterpreting these bytes would read 1 as 4.94e-324.
+      std::vector<double> as_double{};
+      expect(glz::read_cbor(as_double, buffer).ec == glz::error_code::syntax_error);
+
+      std::vector<int64_t> as_signed{};
+      expect(glz::read_cbor(as_signed, buffer).ec == glz::error_code::syntax_error);
+   };
+
+   "float typed array does not read into an integer target"_test = [] {
+      const double payload[]{1.5, 2.5};
+      const auto buffer = cbor_typed_array(float64_le, payload, sizeof(payload));
+
+      std::vector<double> matching{};
+      expect(not glz::read_cbor(matching, buffer));
+      expect(matching == std::vector<double>{1.5, 2.5});
+
+      std::vector<int64_t> as_signed{};
+      expect(glz::read_cbor(as_signed, buffer).ec == glz::error_code::syntax_error);
+
+      std::vector<uint64_t> as_unsigned{};
+      expect(glz::read_cbor(as_unsigned, buffer).ec == glz::error_code::syntax_error);
+   };
+
+   "integer typed array does not read into a float target"_test = [] {
+      const int64_t payload[]{-1, 2};
+      const auto buffer = cbor_typed_array(sint64_le, payload, sizeof(payload));
+
+      std::vector<int64_t> matching{};
+      expect(not glz::read_cbor(matching, buffer));
+      expect(matching == std::vector<int64_t>{-1, 2});
+
+      std::vector<double> as_double{};
+      expect(glz::read_cbor(as_double, buffer).ec == glz::error_code::syntax_error);
+   };
+
+   // Tags 83 and 87 are IEEE binary128. Where long double is the 80-bit x86 type it shares that
+   // 16-byte width without sharing the format, so width alone used to accept it -- and there is no
+   // 16-byte byteswap either, so a big-endian binary128 array was read through unswapped.
+   "binary128 typed array is rejected"_test = [] {
+      const unsigned char payload[32]{};
+      const auto buffer = cbor_typed_array(float128_le, payload, sizeof(payload));
+
+      std::vector<long double> as_long_double{};
+      expect(glz::read_cbor(as_long_double, buffer).ec == glz::error_code::syntax_error);
+   };
+
+   // Non-contiguous targets take the element-wise decode rather than the bulk copy, and validate the
+   // same way.
+   "kind is checked for non-contiguous targets too"_test = [] {
+      const uint64_t payload[]{1, 2};
+      const auto buffer = cbor_typed_array(uint64_le, payload, sizeof(payload));
+
+      std::list<uint64_t> matching{};
+      expect(not glz::read_cbor(matching, buffer));
+      expect(matching == std::list<uint64_t>{1, 2});
+
+      std::list<double> as_double{};
+      expect(glz::read_cbor(as_double, buffer).ec == glz::error_code::syntax_error);
+
+      std::set<double> as_set{};
+      expect(glz::read_cbor(as_set, buffer).ec == glz::error_code::syntax_error);
+   };
+
+   "every numeric round-trip still matches its own tag"_test = [] {
+      const auto round_trip = [](auto source) {
+         std::string buffer{};
+         expect(not glz::write_cbor(source, buffer));
+         decltype(source) result{};
+         expect(not glz::read_cbor(result, buffer));
+         expect(result == source);
+      };
+
+      round_trip(std::vector<uint8_t>{1, 2});
+      round_trip(std::vector<uint16_t>{1, 2});
+      round_trip(std::vector<uint32_t>{1, 2});
+      round_trip(std::vector<uint64_t>{1, 2});
+      round_trip(std::vector<int8_t>{-1, 2});
+      round_trip(std::vector<int16_t>{-1, 2});
+      round_trip(std::vector<int32_t>{-1, 2});
+      round_trip(std::vector<int64_t>{-1, 2});
+      round_trip(std::vector<float>{1.5f, -2.5f});
+      round_trip(std::vector<double>{1.5, -2.5});
+      round_trip(std::vector<std::complex<float>>{{1.0f, 2.0f}});
+      round_trip(std::vector<std::complex<double>>{{1.0, 2.0}, {3.0, 4.0}});
+   };
+
+   // The nested scalar tag of a complex array (tag 43001) is validated the same way.
+   "complex array scalar kind must match"_test = [] {
+      const std::vector<std::complex<double>> source{{1.0, 2.0}};
+      std::string buffer{};
+      expect(not glz::write_cbor(source, buffer));
+
+      std::vector<std::complex<double>> matching{};
+      expect(not glz::read_cbor(matching, buffer));
+      expect(matching == source);
+
+      std::vector<std::complex<float>> as_float{};
+      expect(glz::read_cbor(as_float, buffer).ec == glz::error_code::syntax_error);
+   };
+}
+
 void typed_array_tests()
 {
    "typed_array_uint8"_test = [] {
@@ -4051,6 +4183,7 @@ int main()
    large_data_tests();
    rfc8949_appendix_a_tests();
    typed_array_tests();
+   typed_array_kind_tests();
    cbor_to_json_tests();
    past_fuzzing_issues();
    error_tests();


### PR DESCRIPTION
Stacked on #2792. Base retargets as the stack merges.

## The defect

RFC 8746 encodes the element kind in the tag, and a typed array is read by copying its payload straight into the target. Accepting a tag on width alone therefore reinterpreted the bytes of a differently-typed array rather than converting them:

```cpp
// tag 71 = uint64, little endian; payload is {1, 2}
std::vector<double> v{};
glz::read_cbor(v, buffer);   // no error; v == {4.94066e-324, 9.88131e-324}
```

Signedness was ignored the same way, so a `uint64` array read into `std::vector<int64_t>` silently reinterpreted every element.

This is not how the rest of the reader behaves. A CBOR uint does not read into a `double`, nor a float into an `int` — those are syntax errors at the scalar level. The typed-array fast path was the one place a kind mismatch was accepted, and it accepted it silently.

## The fix

`typed_array::matches<T>` requires the tag's kind and width to describe exactly `T`, and is used for both the numeric typed array and the nested scalar tag of a complex array (tag 43001). A mismatch is a syntax error, consistent with the element-wise path.

Tags 83 and 87 are IEEE binary128, which is *not* the 80-bit extended `long double` that shares its 16-byte width on x86-64, so they no longer match any type. That also retires the one width `byteswap_element` has no case for — a big-endian binary128 array used to be accepted and read through unswapped.

## Compatibility

Anything Glaze writes, Glaze still reads: every typed array is written with `native_tag<V>()`, which is exactly the tag `matches<V>` accepts. What stops working is reading a typed array of one kind into a target of another, which never produced the right values anyway.

## Tests

New `typed_array_kind_tests` covers cross-kind rejection in both directions, signedness, binary128, non-contiguous targets (which take the element-wise decode rather than the bulk copy), the nested scalar tag of a complex array, and a round-trip of every numeric type that has a tag.

Full local suite is 100/100.
