### PR TITLE
fix(cbor): read booleans that live in a std::vector<bool>

### DIFF
--- a/include/glaze/cbor/read.hpp
+++ b/include/glaze/cbor/read.hpp
@@ -306,8 +306,11 @@ namespace glz
    template <boolean_like T>
    struct from<CBOR, T>
    {
+      // A forwarding reference, not auto&: an element of std::vector<bool> is reached through a proxy
+      // that its container hands back by value, so binding the target as an lvalue reference would
+      // reject every bool that lives in one. The other formats' boolean readers take it the same way.
       template <auto Opts>
-      GLZ_ALWAYS_INLINE static void op(auto& value, is_context auto& ctx, auto& it, auto end) noexcept
+      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto& ctx, auto& it, auto end) noexcept
       {
          using namespace cbor;
 

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -3772,6 +3772,85 @@ struct cbor_stl_members
    std::list<std::string> names{};
 };
 
+struct cbor_flags_holder
+{
+   std::vector<bool> flags{};
+   int count{};
+};
+
+// std::vector<bool> packs its elements, so one is reached only through a proxy the container returns
+// by value. The reader used to bind its target as an lvalue reference, which no proxy can satisfy, so
+// reading one was a compile error while std::deque<bool> and std::list<bool> read fine.
+suite cbor_vector_bool_tests = [] {
+   "roundtrip"_test = [] {
+      const std::vector<bool> src{true, false, true, true, false};
+      std::string buffer{};
+      expect(not glz::write_cbor(src, buffer));
+
+      std::vector<bool> dst{};
+      expect(not glz::read_cbor(dst, buffer));
+      expect(dst == src);
+
+      // A longer prior value must be replaced, not merely overwritten in part.
+      std::vector<bool> stale(20, true);
+      expect(not glz::read_cbor(stale, buffer));
+      expect(stale == src);
+   };
+
+   "indefinite length"_test = [] {
+      const std::string buffer{"\x9F\xF5\xF4\xF5\xFF", 5};
+
+      std::vector<bool> dst{};
+      expect(not glz::read_cbor(dst, buffer));
+      expect(dst == std::vector<bool>{true, false, true});
+   };
+
+   "struct member and nesting"_test = [] {
+      const cbor_flags_holder src{{true, false}, 7};
+      std::string buffer{};
+      expect(not glz::write_cbor(src, buffer));
+
+      cbor_flags_holder dst{};
+      expect(not glz::read_cbor(dst, buffer));
+      expect(dst.flags == src.flags);
+      expect(dst.count == 7);
+
+      const std::vector<std::vector<bool>> nested{{true}, {false, true}};
+      buffer.clear();
+      expect(not glz::write_cbor(nested, buffer));
+
+      std::vector<std::vector<bool>> nested_dst{};
+      expect(not glz::read_cbor(nested_dst, buffer));
+      expect(nested_dst == nested);
+   };
+
+   "other bool containers still read"_test = [] {
+      const std::vector<bool> src{true, false, true};
+      std::string buffer{};
+      expect(not glz::write_cbor(src, buffer));
+
+      std::deque<bool> deq{};
+      expect(not glz::read_cbor(deq, buffer));
+      expect(deq == std::deque<bool>{true, false, true});
+
+      std::list<bool> lst{};
+      expect(not glz::read_cbor(lst, buffer));
+      expect(lst == std::list<bool>{true, false, true});
+
+      std::array<bool, 3> arr{};
+      expect(not glz::read_cbor(arr, buffer));
+      expect(arr == std::array<bool, 3>{true, false, true});
+   };
+
+   // Accepting the proxy must not also start accepting non-boolean input.
+   "non-boolean element is still an error"_test = [] {
+      const std::string buffer{"\x82\xF5\x01", 3};
+
+      std::vector<bool> dst{};
+      expect(glz::read_cbor(dst, buffer).ec == glz::error_code::syntax_error);
+   };
+};
+
 // Containers that grow by back-insertion or by emplacement rather than by subscript. The reader used
 // to index its target unconditionally, so these were a hard compile error rather than a bad read.
 suite cbor_non_indexable_container_tests = [] {


### PR DESCRIPTION
Stacked on #2793. Base retargets as the stack merges.

`std::vector<bool>` packs its elements, so one is reached only through a proxy the container returns by value. The CBOR boolean reader bound its target as `auto&`, which no proxy prvalue can satisfy, so this was a hard compile error:

```cpp
std::vector<bool> flags{};
glz::read_cbor(flags, buffer);   // error: no matching function for call to 'op'
```

Writing was never affected, and `std::deque<bool>` and `std::list<bool>` — whose elements are real `bool`s — read fine. So a `std::vector<bool>` member made a whole struct unreadable in CBOR while remaining writable.

The fix is to take the target by forwarding reference, as the JSON, BEVE and MessagePack boolean readers already do. One line.

## Tests

New `cbor_vector_bool_tests` covers the round-trip, replacing a longer prior value, indefinite-length input, a struct member, nesting, the other bool containers still reading, and that a non-boolean element is still a syntax error — accepting the proxy should not also start accepting non-boolean input.

Full local suite is 100/100.
