### PR TITLE
fix(cbor): read either encoding of a byte sequence, and write extended-precision floats

### DIFF
--- a/include/glaze/cbor/header.hpp
+++ b/include/glaze/cbor/header.hpp
@@ -237,6 +237,21 @@ namespace glz::cbor
    // RFC 8746 Typed Array helpers
    namespace typed_array
    {
+      // Whether RFC 8746 has a tag for T at all. The tags cover the fixed-width integers and IEEE
+      // binary32/binary64; a numeric type outside that set -- long double, where it is the 80-bit
+      // x86 type or any other extended format -- has no typed array representation and is written
+      // as a plain CBOR array of numbers instead.
+      template <class T>
+      concept taggable =
+         std::same_as<T, uint8_t> || std::same_as<T, uint16_t> || std::same_as<T, uint32_t> ||
+         std::same_as<T, uint64_t> || std::same_as<T, int8_t> || std::same_as<T, int16_t> || std::same_as<T, int32_t> ||
+         std::same_as<T, int64_t> || std::same_as<T, float> || std::same_as<T, double>;
+
+      // The same question for a std::complex, whose interleaved form is tagged by its scalar. The
+      // nested requires-clause guards the substitution, so this is valid to ask of any type.
+      template <class T>
+      concept taggable_scalar = requires { typename T::value_type; } && taggable<typename T::value_type>;
+
       // Select the appropriate tag for a type based on native endianness
       template <class T>
       [[nodiscard]] consteval uint64_t native_tag() noexcept

--- a/include/glaze/cbor/read.hpp
+++ b/include/glaze/cbor/read.hpp
@@ -662,6 +662,127 @@ namespace glz
       requires(contiguous_byte_range<std::remove_cvref_t<T>> && !str_t<T>)
    struct from<CBOR, T>
    {
+      // The same bytes are also legitimately carried as a plain array of small unsigned integers
+      // (major type 4). That is what a non-contiguous byte range such as std::list<uint8_t> writes,
+      // and what CBOR producers that treat a byte sequence as an array of numbers emit, so read
+      // either encoding into the same target. The initial byte has already been consumed.
+      template <auto Opts>
+      static void read_as_array(auto& value, is_context auto& ctx, auto& it, auto end, const uint8_t additional_info)
+      {
+         using namespace cbor;
+
+         depth_guard guard{ctx};
+         if (!guard) [[unlikely]] {
+            return;
+         }
+
+         // Grow to i + 1 elements, or bounds-check a fixed-size target. Returns false on failure.
+         const auto make_room = [&](const size_t i) {
+            if constexpr (resizable<T>) {
+               if (exceeds_capacity(value, i + 1, ctx)) [[unlikely]] {
+                  return false;
+               }
+               value.resize(i + 1);
+            }
+            else {
+               if (i >= value.size()) [[unlikely]] {
+                  ctx.error = error_code::exceeded_static_array_size;
+                  return false;
+               }
+            }
+            return true;
+         };
+
+         size_t count = 0;
+         if (additional_info == info::indefinite) {
+            if constexpr (resizable<T>) {
+               value.clear();
+            }
+            while (true) {
+               if (it >= end) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
+
+               uint8_t peek;
+               std::memcpy(&peek, it, 1);
+               if (peek == initial_byte(major::simple, simple::break_code)) {
+                  ++it;
+                  break;
+               }
+
+               if constexpr (check_max_array_size(Opts) > 0) {
+                  if (count >= check_max_array_size(Opts)) [[unlikely]] {
+                     ctx.error = error_code::invalid_length;
+                     return;
+                  }
+               }
+               if constexpr (has_runtime_max_array_size<std::decay_t<decltype(ctx)>>) {
+                  if (ctx.max_array_size > 0 && count >= ctx.max_array_size) [[unlikely]] {
+                     ctx.error = error_code::invalid_length;
+                     return;
+                  }
+               }
+               if (!make_room(count)) [[unlikely]] {
+                  return;
+               }
+               parse<CBOR>::op<Opts>(value[count], ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
+               ++count;
+            }
+         }
+         else {
+            const uint64_t n = cbor_detail::decode_arg(ctx, it, end, additional_info);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
+
+            // Every element occupies at least one byte, so a valid count cannot exceed the input.
+            if (n > static_cast<uint64_t>(end - it)) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+            if constexpr (check_max_array_size(Opts) > 0) {
+               if (n > check_max_array_size(Opts)) [[unlikely]] {
+                  ctx.error = error_code::invalid_length;
+                  return;
+               }
+            }
+            if constexpr (has_runtime_max_array_size<std::decay_t<decltype(ctx)>>) {
+               if (ctx.max_array_size > 0 && n > ctx.max_array_size) [[unlikely]] {
+                  ctx.error = error_code::invalid_length;
+                  return;
+               }
+            }
+
+            if constexpr (resizable<T>) {
+               if (exceeds_capacity(value, static_cast<size_t>(n), ctx)) [[unlikely]] {
+                  return;
+               }
+               value.resize(static_cast<size_t>(n));
+            }
+            else {
+               if (n > value.size()) [[unlikely]] {
+                  ctx.error = error_code::exceeded_static_array_size;
+                  return;
+               }
+            }
+
+            for (; count < n; ++count) {
+               parse<CBOR>::op<Opts>(value[count], ctx, it, end);
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
+            }
+         }
+
+         if constexpr (!resizable<T>) {
+            // Zero-fill any unused tail, as the byte string path does.
+            if (count < value.size()) {
+               std::memset(value.data() + count, 0, value.size() - count);
+            }
+         }
+      }
+
       template <auto Opts>
       static void op(auto& value, is_context auto& ctx, auto& it, auto end)
       {
@@ -679,6 +800,11 @@ namespace glz
          const uint8_t major_type = get_major_type(initial);
          const uint8_t additional_info = get_additional_info(initial);
 
+         if (major_type == major::array) {
+            read_as_array<Opts>(value, ctx, it, end, additional_info);
+            return;
+         }
+
          if (major_type != major::bstr) [[unlikely]] {
             ctx.error = error_code::syntax_error;
             return;
@@ -690,6 +816,7 @@ namespace glz
                value.clear();
             }
             size_t offset = 0; // fill position for fixed-size targets
+            uint64_t total = 0; // bytes accumulated so far, across chunks
             while (true) {
                if (it >= end) [[unlikely]] {
                   ctx.error = error_code::unexpected_end;
@@ -724,6 +851,22 @@ namespace glz
                if (static_cast<uint64_t>(end - it) < chunk_len) [[unlikely]] {
                   ctx.error = error_code::unexpected_end;
                   return;
+               }
+
+               // A break code rather than a length ends this byte string, so the caller's limit is
+               // enforced against the running total instead of a single header.
+               total += chunk_len;
+               if constexpr (check_max_array_size(Opts) > 0) {
+                  if (total > check_max_array_size(Opts)) [[unlikely]] {
+                     ctx.error = error_code::invalid_length;
+                     return;
+                  }
+               }
+               if constexpr (has_runtime_max_array_size<std::decay_t<decltype(ctx)>>) {
+                  if (ctx.max_array_size > 0 && total > ctx.max_array_size) [[unlikely]] {
+                     ctx.error = error_code::invalid_length;
+                     return;
+                  }
                }
 
                if constexpr (resizable<T>) {
@@ -807,6 +950,86 @@ namespace glz
       requires(!eigen_t<T> && !contiguous_byte_range<std::remove_cvref_t<T>>)
    struct from<CBOR, T> final
    {
+      // A sequence of bytes is also legitimately carried as a CBOR byte string (major type 2). That
+      // is what a contiguous byte range such as std::vector<uint8_t> writes, so a byte-like range
+      // reads either encoding. `append` takes one decoded byte and returns false once the target is
+      // full; the initial byte has already been consumed.
+      template <auto Opts>
+      static void read_byte_string(is_context auto& ctx, auto& it, auto end, const uint8_t additional_info,
+                                   auto&& append)
+      {
+         using namespace cbor;
+
+         // An indefinite-length byte string is ended by a break code rather than a length, so the
+         // caller's limit is enforced against the running total rather than a single header.
+         uint64_t total = 0;
+
+         // Copy `length` bytes out of the input, having checked they are all present.
+         const auto take = [&](const uint64_t length) {
+            if (static_cast<uint64_t>(end - it) < length) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return false;
+            }
+            total += length;
+            if constexpr (check_max_array_size(Opts) > 0) {
+               if (total > check_max_array_size(Opts)) [[unlikely]] {
+                  ctx.error = error_code::invalid_length;
+                  return false;
+               }
+            }
+            if constexpr (has_runtime_max_array_size<std::decay_t<decltype(ctx)>>) {
+               if (ctx.max_array_size > 0 && total > ctx.max_array_size) [[unlikely]] {
+                  ctx.error = error_code::invalid_length;
+                  return false;
+               }
+            }
+            for (uint64_t i = 0; i < length; ++i, ++it) {
+               uint8_t byte;
+               std::memcpy(&byte, it, 1);
+               if (!append(byte)) [[unlikely]] {
+                  return false;
+               }
+            }
+            return true;
+         };
+
+         if (additional_info == info::indefinite) {
+            while (true) {
+               if (it >= end) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
+
+               uint8_t chunk_initial;
+               std::memcpy(&chunk_initial, it, 1);
+               if (chunk_initial == initial_byte(major::simple, simple::break_code)) {
+                  ++it;
+                  return;
+               }
+
+               // Chunks of an indefinite-length byte string are themselves definite byte strings.
+               if (get_major_type(chunk_initial) != major::bstr ||
+                   get_additional_info(chunk_initial) == info::indefinite) [[unlikely]] {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
+               ++it;
+
+               const uint64_t chunk_len = cbor_detail::decode_arg(ctx, it, end, get_additional_info(chunk_initial));
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
+               if (!take(chunk_len)) [[unlikely]]
+                  return;
+            }
+         }
+
+         const uint64_t length = cbor_detail::decode_arg(ctx, it, end, additional_info);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+
+         (void)take(length);
+      }
+
       template <auto Opts>
       static void op(auto& value, is_context auto& ctx, auto& it, auto end)
       {
@@ -831,6 +1054,67 @@ namespace glz
 
          const uint8_t major_type = get_major_type(initial);
          const uint8_t additional_info = get_additional_info(initial);
+
+         // A byte-like range also accepts a CBOR byte string, which is what the contiguous byte
+         // ranges write for the same bytes.
+         if constexpr (byte_like<V>) {
+            if (major_type == major::bstr) {
+               ++it; // consume the initial byte
+
+               depth_guard guard{ctx};
+               if (!guard) [[unlikely]] {
+                  return;
+               }
+
+               if constexpr (growable) {
+                  value.clear();
+               }
+
+               size_t filled = 0;
+               // Only a target that cannot grow is filled in place; growing would invalidate this.
+               [[maybe_unused]] decltype(value.begin()) dest{};
+               if constexpr (not growable) {
+                  dest = value.begin();
+               }
+               read_byte_string<Opts>(ctx, it, end, additional_info, [&](const uint8_t byte) {
+                  if (exceeds_capacity(value, filled + 1, ctx)) [[unlikely]] {
+                     return false;
+                  }
+                  if constexpr (set_like) {
+                     value.emplace(static_cast<V>(byte));
+                  }
+                  else if constexpr (emplace_backable<T>) {
+                     value.emplace_back(static_cast<V>(byte));
+                  }
+                  else if constexpr (resizable<T>) {
+                     value.resize(filled + 1);
+                     auto slot = value.begin();
+                     std::advance(slot, filled);
+                     *slot = static_cast<V>(byte);
+                  }
+                  else {
+                     if (filled >= value.size()) [[unlikely]] {
+                        ctx.error = error_code::exceeded_static_array_size;
+                        return false;
+                     }
+                     *dest = static_cast<V>(byte);
+                     ++dest;
+                  }
+                  ++filled;
+                  return true;
+               });
+
+               if constexpr (!growable) {
+                  // Zero-fill any unused tail, as the byte string reader does for std::array.
+                  if (not bool(ctx.error)) {
+                     for (; filled < value.size(); ++filled, ++dest) {
+                        *dest = V{};
+                     }
+                  }
+               }
+               return;
+            }
+         }
 
          // Check for RFC 8746 typed array (tag + byte string)
          if constexpr (num_t<V> && !std::same_as<V, bool>) {

--- a/include/glaze/cbor/write.hpp
+++ b/include/glaze/cbor/write.hpp
@@ -411,8 +411,10 @@ namespace glz
       {
          using V = range_value_t<std::remove_cvref_t<T>>;
 
-         // Use RFC 8746 typed arrays for numeric types (bulk memcpy)
-         if constexpr (num_t<V> && !std::same_as<V, bool> && contiguous<T>) {
+         // Use RFC 8746 typed arrays for numeric types (bulk memcpy). A numeric type RFC 8746 has no
+         // tag for -- long double, where it is an extended format -- falls through to the generic
+         // array below and is written element by element.
+         if constexpr (num_t<V> && !std::same_as<V, bool> && contiguous<T> && cbor::typed_array::taggable<V>) {
             // Write the tag for this type using native endianness
             constexpr uint64_t tag = cbor::typed_array::native_tag<V>();
             if (!cbor_detail::encode_arg(ctx, cbor::major::tag, tag, b, ix)) [[unlikely]] {
@@ -436,7 +438,7 @@ namespace glz
                ix += byte_len;
             }
          }
-         else if constexpr (complex_t<V> && contiguous<T>) {
+         else if constexpr (complex_t<V> && contiguous<T> && cbor::typed_array::taggable_scalar<V>) {
             // Complex array: tag 43001 with interleaved typed array [r0, i0, r1, i1, ...]
             // std::complex<T> stores data as [real, imag] pairs contiguously
             using Scalar = typename V::value_type;

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -3772,6 +3772,162 @@ struct cbor_stl_members
    std::list<std::string> names{};
 };
 
+// A sequence of bytes has two legitimate CBOR encodings: a byte string (major type 2), which the
+// contiguous byte ranges write, and a plain array of small unsigned integers (major type 4), which
+// the others write. Each reader used to accept only its own, so Glaze could not read back its own
+// output whenever the container type differed.
+suite cbor_byte_sequence_encoding_tests = [] {
+   "byte string reads into non-contiguous byte ranges"_test = [] {
+      const std::vector<uint8_t> src{1, 2, 3};
+      std::string buffer{};
+      expect(not glz::write_cbor(src, buffer));
+      expect(buffer == std::string("\x43\x01\x02\x03", 4)) << "expected a byte string";
+
+      std::list<uint8_t> lst{9, 9, 9, 9, 9};
+      expect(not glz::read_cbor(lst, buffer));
+      expect(lst == std::list<uint8_t>{1, 2, 3});
+
+      std::deque<uint8_t> deq{};
+      expect(not glz::read_cbor(deq, buffer));
+      expect(deq == std::deque<uint8_t>{1, 2, 3});
+
+      std::set<uint8_t> st{7};
+      expect(not glz::read_cbor(st, buffer));
+      expect(st == std::set<uint8_t>{1, 2, 3});
+
+      std::list<std::byte> bytes{};
+      expect(not glz::read_cbor(bytes, buffer));
+      expect(bytes == std::list<std::byte>{std::byte{1}, std::byte{2}, std::byte{3}});
+   };
+
+   "array reads into contiguous byte ranges"_test = [] {
+      const std::list<uint8_t> src{1, 2, 3};
+      std::string buffer{};
+      expect(not glz::write_cbor(src, buffer));
+      expect(buffer == std::string("\x83\x01\x02\x03", 4)) << "expected a plain array";
+
+      std::vector<uint8_t> vec{9, 9};
+      expect(not glz::read_cbor(vec, buffer));
+      expect(vec == std::vector<uint8_t>{1, 2, 3});
+
+      std::vector<std::byte> bytes{};
+      expect(not glz::read_cbor(bytes, buffer));
+      expect(bytes == std::vector<std::byte>{std::byte{1}, std::byte{2}, std::byte{3}});
+
+      // A fixed-size target zero-fills its tail, as it does for a byte string.
+      std::array<uint8_t, 5> arr{9, 9, 9, 9, 9};
+      expect(not glz::read_cbor(arr, buffer));
+      expect(arr == std::array<uint8_t, 5>{1, 2, 3, 0, 0});
+
+      std::array<uint8_t, 2> too_small{};
+      expect(glz::read_cbor(too_small, buffer).ec == glz::error_code::exceeded_static_array_size);
+   };
+
+   "indefinite length forms of both encodings"_test = [] {
+      const std::string chunked_byte_string{"\x5F\x42\x01\x02\x41\x03\xFF", 7};
+
+      std::vector<uint8_t> vec{};
+      expect(not glz::read_cbor(vec, chunked_byte_string));
+      expect(vec == std::vector<uint8_t>{1, 2, 3});
+
+      std::list<uint8_t> lst{};
+      expect(not glz::read_cbor(lst, chunked_byte_string));
+      expect(lst == std::list<uint8_t>{1, 2, 3});
+
+      const std::string indefinite_array{"\x9F\x01\x02\x03\xFF", 5};
+
+      std::vector<uint8_t> vec2{};
+      expect(not glz::read_cbor(vec2, indefinite_array));
+      expect(vec2 == std::vector<uint8_t>{1, 2, 3});
+
+      std::array<uint8_t, 4> arr{9, 9, 9, 9};
+      expect(not glz::read_cbor(arr, indefinite_array));
+      expect(arr == std::array<uint8_t, 4>{1, 2, 3, 0});
+   };
+
+   "every byte container still round-trips"_test = [] {
+      const auto round_trip = [](auto source) {
+         std::string buffer{};
+         expect(not glz::write_cbor(source, buffer));
+         decltype(source) result{};
+         expect(not glz::read_cbor(result, buffer));
+         expect(result == source);
+      };
+
+      round_trip(std::vector<uint8_t>{1, 2, 3});
+      round_trip(std::vector<std::byte>{std::byte{1}, std::byte{2}});
+      round_trip(std::list<uint8_t>{1, 2, 3});
+      round_trip(std::deque<uint8_t>{1, 2, 3});
+      round_trip(std::set<uint8_t>{1, 2, 3});
+      round_trip(std::array<uint8_t, 3>{1, 2, 3});
+   };
+
+   "max_array_size applies to both encodings"_test = [] {
+      struct limited_opts : glz::opts
+      {
+         uint32_t format = glz::CBOR;
+         size_t max_array_size = 4;
+      };
+
+      std::string byte_string{};
+      expect(not glz::write_cbor(std::vector<uint8_t>(10, 1), byte_string));
+
+      std::vector<uint8_t> vec{};
+      expect(glz::read<limited_opts{}>(vec, byte_string).ec == glz::error_code::invalid_length);
+      std::list<uint8_t> lst{};
+      expect(glz::read<limited_opts{}>(lst, byte_string).ec == glz::error_code::invalid_length);
+
+      // Six bytes spread over three chunks: no single header exceeds the limit, the total does.
+      const std::string chunked{"\x5F\x42\x01\x02\x42\x03\x04\x42\x05\x06\xFF", 11};
+      std::vector<uint8_t> vec2{};
+      expect(glz::read<limited_opts{}>(vec2, chunked).ec == glz::error_code::invalid_length);
+      std::list<uint8_t> lst2{};
+      expect(glz::read<limited_opts{}>(lst2, chunked).ec == glz::error_code::invalid_length);
+
+      const std::string indefinite_array{"\x9F\x01\x02\x03\x04\x05\xFF", 7};
+      std::vector<uint8_t> vec3{};
+      expect(glz::read<limited_opts{}>(vec3, indefinite_array).ec == glz::error_code::invalid_length);
+   };
+
+   "truncated input is still rejected"_test = [] {
+      const std::string truncated_byte_string{"\x43\x01", 2};
+      std::vector<uint8_t> vec{};
+      expect(bool(glz::read_cbor(vec, truncated_byte_string)));
+      std::list<uint8_t> lst{};
+      expect(bool(glz::read_cbor(lst, truncated_byte_string)));
+
+      const std::string truncated_array{"\x83\x01", 2};
+      std::vector<uint8_t> vec2{};
+      expect(bool(glz::read_cbor(vec2, truncated_array)));
+   };
+
+   "non-byte element types are unaffected"_test = [] {
+      std::string buffer{};
+      expect(not glz::write_cbor(std::vector<std::string>{"a"}, buffer));
+
+      std::vector<uint8_t> vec{};
+      expect(bool(glz::read_cbor(vec, buffer)));
+   };
+};
+
+// RFC 8746 has no tag for an extended-precision float, so a container of them is written as a plain
+// array of numbers rather than failing to compile in the typed-array tag lookup.
+suite cbor_long_double_tests = [] {
+   "vector of long double round-trips"_test = [] {
+      const std::vector<long double> src{1.5L, 2.5L, -3.25L};
+      std::string buffer{};
+      expect(not glz::write_cbor(src, buffer));
+
+      std::vector<long double> dst{};
+      expect(not glz::read_cbor(dst, buffer));
+      expect(dst == src);
+
+      std::list<long double> lst{};
+      expect(not glz::read_cbor(lst, buffer));
+      expect(lst == std::list<long double>{1.5L, 2.5L, -3.25L});
+   };
+};
+
 struct cbor_flags_holder
 {
    std::vector<bool> flags{};


### PR DESCRIPTION
Stacked on #2794. Base retargets as the stack merges. Last of the follow-ups to #2791.

## Byte sequences had two encodings and each reader accepted only one

A sequence of bytes has two legitimate CBOR encodings, and Glaze writes both:

- a **byte string** (major type 2) for a contiguous byte range — `std::vector<uint8_t>` writes `43 01 02 03`
- a **plain array** of small unsigned integers (major type 4) for any other byte-like range — `std::list<uint8_t>` writes `83 01 02 03`

An array of numbers is also what CBOR producers that don't treat a byte sequence as bytes will emit.

Each reader accepted only its own encoding, so neither direction worked — Glaze could not read back its own output whenever the container type differed:

```cpp
std::string buffer{};
glz::write_cbor(std::vector<uint8_t>{1, 2, 3}, buffer);

std::list<uint8_t> lst{};
glz::read_cbor(lst, buffer);        // syntax_error  (reported)

glz::write_cbor(std::list<uint8_t>{1, 2, 3}, buffer);
std::vector<uint8_t> vec{};
glz::read_cbor(vec, buffer);        // syntax_error  (the reciprocal)
```

Both readers now accept both encodings, in definite and indefinite form, with fixed-size targets zero-filling their tail either way. **Nothing about what is written changes.**

## max_array_size was bypassable by chunking a byte string

An indefinite-length byte string is ended by a break code rather than a length, and the limit was only checked against a length header. Six bytes spread over three chunks passed a limit of four. It is now enforced against the running total across chunks, matching the definite form and the array reader.

## std::vector<long double> could be read but not written

RFC 8746 has no typed array tag for an extended-precision float, so the tag lookup was a `static_assert` rather than a fallback — `write_cbor` on a `std::vector<long double>` failed to compile, while reading one worked and writing a scalar `long double` worked. Numeric element types without a tag now fall through to the generic array writer and are written element by element, as the scalar writer already did. Same for a `std::complex` whose scalar has no tag.

## Integer spellings with no fixed-width alias could not be written either

Same root cause as the `long double` case above, and closed by the same fallback. The tag lookup matched on the exact fixed-width types, so any integer spelling that is a *distinct* type from every `intN_t` alias reached the `static_assert` rather than a fallback:

```cpp
std::string buffer{};
glz::write_cbor(std::vector<long>{1, 2, 3}, buffer);
// on main: static_assert failed, "Unsupported type for typed array"
```

Which spelling is affected follows from the platform's data model, so this is not an exotic case. Verified here on macOS, where `int64_t` is `long long` and so `std::vector<long>` and `std::vector<unsigned long>` both fail to compile on `main` and both compile on this branch, writing a generic array. MSVC is affected the same way, its `long` being 32-bit and distinct from `int32_t`. On an LP64 Linux, where `int64_t` *is* `long`, the distinct spelling is `long long` instead.

No CI job caught this because it is a compile-time failure reached only from user code: nothing in the suite instantiates those types, and this branch does not add a test for them.

## Tests

New `cbor_byte_sequence_encoding_tests` covers both encodings into every byte container (vector, list, deque, set, array, `std::byte` and `uint8_t` alike), the indefinite forms of both, tail zero-filling and overflow for fixed-size targets, `max_array_size` on all four encodings including the chunked bypass, truncated input, and that non-byte element types are unaffected. `cbor_long_double_tests` covers the write path that used to fail to compile.

Full local suite is 100/100.

