### PR TITLE
fix(cbor): read typed arrays into append-only containers

### DIFF
--- a/include/glaze/cbor/read.hpp
+++ b/include/glaze/cbor/read.hpp
@@ -1185,6 +1185,18 @@ namespace glz
                         value.shrink_to_fit();
                      }
                   }
+                  else if constexpr (emplace_backable<T>) {
+                     // Append-only: the count is known, but the only way to reach it is one element at
+                     // a time. Growing to count here rather than while filling leaves both fill paths
+                     // below writing into storage that already exists.
+                     if (exceeds_capacity(value, count, ctx)) [[unlikely]] {
+                        return;
+                     }
+                     value.clear();
+                     for (size_t i = 0; i < count; ++i) {
+                        value.emplace_back();
+                     }
+                  }
                   else {
                      if (count != value.size()) [[unlikely]] {
                         ctx.error = error_code::exceeded_static_array_size;
@@ -1197,12 +1209,15 @@ namespace glz
 
                   if constexpr (contiguous<T>) {
                      if (need_swap && sizeof(V) > 1) {
-                        // Need to byteswap each element
+                        // Need to byteswap each element. Written through data() rather than a
+                        // subscript: contiguous storage is what this branch relies on, and a
+                        // contiguous range need not also be indexable.
+                        auto* dest = value.data();
                         for (size_t i = 0; i < count; ++i) {
                            V elem;
                            std::memcpy(&elem, it, sizeof(V));
                            cbor_detail::byteswap_element(elem);
-                           value[i] = elem;
+                           dest[i] = elem;
                            it += sizeof(V);
                         }
                      }
@@ -1346,6 +1361,17 @@ namespace glz
                      value.resize(count);
                      if constexpr (check_shrink_to_fit(Opts) && has_shrink_to_fit<T>) {
                         value.shrink_to_fit();
+                     }
+                  }
+                  else if constexpr (emplace_backable<T>) {
+                     // Append-only, as above: grow to the known count so the fill paths below only
+                     // have to write into elements that already exist.
+                     if (exceeds_capacity(value, count, ctx)) [[unlikely]] {
+                        return;
+                     }
+                     value.clear();
+                     for (size_t i = 0; i < count; ++i) {
+                        value.emplace_back();
                      }
                   }
                   else {

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -4167,6 +4167,40 @@ struct cbor_append_only
    int& emplace_back() { return data.emplace_back(); }
 };
 
+// Append-only and contiguous: the typed-array reader sizes it through emplace_back but fills it in
+// bulk through data(), so the elements have to exist before the fill.
+struct cbor_append_only_contiguous
+{
+   using value_type = int32_t;
+   using reference = int32_t&;
+   std::vector<int32_t> storage{};
+
+   auto begin() { return storage.begin(); }
+   auto end() { return storage.end(); }
+   auto begin() const { return storage.begin(); }
+   auto end() const { return storage.end(); }
+   size_t size() const { return storage.size(); }
+   int32_t* data() { return storage.data(); }
+   const int32_t* data() const { return storage.data(); }
+   void clear() { storage.clear(); }
+   int32_t& emplace_back() { return storage.emplace_back(); }
+};
+
+struct cbor_append_only_complex
+{
+   using value_type = std::complex<double>;
+   using reference = std::complex<double>&;
+   std::vector<std::complex<double>> data{};
+
+   auto begin() { return data.begin(); }
+   auto end() { return data.end(); }
+   auto begin() const { return data.begin(); }
+   auto end() const { return data.end(); }
+   size_t size() const { return data.size(); }
+   void clear() { data.clear(); }
+   std::complex<double>& emplace_back() { return data.emplace_back(); }
+};
+
 suite cbor_array_framing_agreement_tests = [] {
    "definite and indefinite agree"_test = [] {
       const std::string definite{"\x83\x01\x02\x03", 4};
@@ -4204,6 +4238,55 @@ suite cbor_array_framing_agreement_tests = [] {
       expect(not glz::read_cbor(b, three));
       expect(not glz::read_cbor(b, one));
       expect(b.data == std::vector<int>{7});
+   };
+
+   // The third framing: a numeric array is written as an RFC 8746 typed array, so this is the shape
+   // Glaze itself produces for the equivalent vector. It has to agree with the two generic framings.
+   "typed array framing agrees"_test = [] {
+      std::string typed{};
+      expect(not glz::write_cbor(std::vector<int32_t>{1, 2, 3}, typed));
+      const std::vector<int> expected{1, 2, 3};
+
+      cbor_append_only a{};
+      expect(not glz::read_cbor(a, typed));
+      expect(a.data == expected);
+
+      cbor_resize_only b{};
+      expect(not glz::read_cbor(b, typed));
+      expect(b.data == expected);
+
+      cbor_append_only_contiguous c{};
+      expect(not glz::read_cbor(c, typed));
+      expect(c.storage == std::vector<int32_t>{1, 2, 3});
+   };
+
+   // Complex arrays travel under tag 43001 as interleaved [real, imag] pairs, on the same path.
+   "complex typed array framing agrees"_test = [] {
+      const std::vector<std::complex<double>> src{{1.0, 2.0}, {3.0, 4.0}};
+      std::string typed{};
+      expect(not glz::write_cbor(src, typed));
+
+      cbor_append_only_complex a{};
+      expect(not glz::read_cbor(a, typed));
+      expect(a.data == src);
+   };
+
+   // A shorter typed array must not leave the previous read's elements behind either.
+   "typed arrays reset append-only targets"_test = [] {
+      std::string three{};
+      expect(not glz::write_cbor(std::vector<int32_t>{1, 2, 3}, three));
+      std::string one{};
+      expect(not glz::write_cbor(std::vector<int32_t>{7}, one));
+
+      cbor_append_only a{};
+      expect(not glz::read_cbor(a, three));
+      expect(not glz::read_cbor(a, one));
+      expect(a.data == std::vector<int>{7});
+
+      cbor_append_only_contiguous b{};
+      expect(not glz::read_cbor(b, three));
+      expect(not glz::read_cbor(b, one));
+      expect(b.storage == std::vector<int32_t>{7});
    };
 };
 


### PR DESCRIPTION
Stacked on #2795. Completes the target classification #2791 introduced.

## The gap

The array reader classifies its target four ways -- set-like, resizable, back-insertable, or fixed -- but only the generic-array branches ever consulted the back-insertable case. The typed-array and complex-array branches went set-like, resizable, else fixed-size.

So a container that grows only through `emplace_back` read one framing of an array and rejected the other:

```
append_only <- definite generic array: ok, size 3
append_only <- typed array:            exceeded_static_array_size
```

The second is the encoding Glaze itself writes for the equivalent `std::vector<int32_t>`, so such a container could not read back its own round trip. This is the same divergence `cbor_append_only` was added to pin down in #2791, just never carried into the typed-array paths. #2795 hit the same question for byte strings and answered it correctly there, which leaves two decode paths in one file disagreeing about the same target.

No standard container is affected: `inplace_vector` has both `resize` and `emplace_back`, so it takes the resizable path, as do `vector`, `list` and `deque`. Only user containers reach it.

## Sizing up front rather than while filling

Both branches now grow an append-only target to the known count during classification, not during the fill:

```cpp
else if constexpr (emplace_backable<T>) {
   if (exceeds_capacity(value, count, ctx)) [[unlikely]] { return; }
   value.clear();
   for (size_t i = 0; i < count; ++i) { value.emplace_back(); }
}
```

The branch sits after `resizable<T>`, so anything that can be sized in one call still is. Doing it here rather than in the fill loop matters for correctness, not just tidiness: a target that is contiguous *and* append-only is filled by the bulk `memcpy` through `data()`, which would have written into a cleared container. Sizing during classification leaves both fill paths writing into elements that already exist, so neither has to know how its target grew. It also picks up the `exceeds_capacity` check from #2792 for free.

## A subscript that was never required

The byteswap fill wrote `value[i]`, but that branch is guarded on `contiguous`, which is `has_size && has_data`. It does not imply `operator[]`, so a contiguous target that isn't indexable was a hard compile error:

```
error: type 'cbor_append_only_contiguous' does not provide a subscript operator
```

It now writes through `data()`, matching the bulk read three lines below. This is the same assumption #2791 removed from the generic array path, left behind here; it is present on `main` independently of this stack, but the test that exposes it lives on this branch, so it is fixed here.

## Tests

Three cases added to `cbor_array_framing_agreement_tests`, with `cbor_append_only_contiguous` and `cbor_append_only_complex` joining the existing `cbor_append_only` and `cbor_resize_only`: the typed-array framing agreeing with both generic framings, the tag-43001 complex path, and a shorter typed array not leaving the previous read's elements behind.

`cbor_test` is 287/287, up from 284. Full local suite is 117/117.

Both fixes were checked to be load-bearing: with `read.hpp` reverted the suite fails to compile on the subscript, and with only the `data()` change applied all three new tests fail across 12 assertions. The `cbor_resize_only` assertions pass either way, which confirms the new tests isolate the append-only path.
