### PR TITLE
fix(cbor): read the array form of a byte sequence into non-indexable targets

### DIFF
--- a/include/glaze/cbor/read.hpp
+++ b/include/glaze/cbor/read.hpp
@@ -726,7 +726,11 @@ namespace glz
                if (!make_room(count)) [[unlikely]] {
                   return;
                }
-               parse<CBOR>::op<Opts>(value[count], ctx, it, end);
+               // Reached through data() rather than a subscript: contiguous storage is what this
+               // reader relies on, and a contiguous range need not also be indexable. Re-read on
+               // every pass, since make_room grows a resizable target one element at a time and any
+               // pointer taken before that is stale.
+               parse<CBOR>::op<Opts>(value.data()[count], ctx, it, end);
                if (bool(ctx.error)) [[unlikely]]
                   return;
                ++count;
@@ -768,8 +772,11 @@ namespace glz
                }
             }
 
+            // As above, through data() rather than a subscript. The target reached its full size
+            // before the loop, so one pointer serves the whole of it.
+            auto* dest = value.data();
             for (; count < n; ++count) {
-               parse<CBOR>::op<Opts>(value[count], ctx, it, end);
+               parse<CBOR>::op<Opts>(dest[count], ctx, it, end);
                if (bool(ctx.error)) [[unlikely]]
                   return;
             }

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -3772,6 +3772,39 @@ struct cbor_stl_members
    std::list<std::string> names{};
 };
 
+// Contiguous byte ranges that are deliberately not indexable. A contiguous range owes the reader
+// size() and data(); nothing obliges it to carry a subscript operator as well, and the array form of
+// the byte sequence reader used to reach its elements through one.
+struct cbor_resizable_byte_range_no_subscript
+{
+   using value_type = uint8_t;
+   std::vector<uint8_t> storage{};
+   auto begin() { return storage.begin(); }
+   auto end() { return storage.end(); }
+   auto begin() const { return storage.begin(); }
+   auto end() const { return storage.end(); }
+   size_t size() const { return storage.size(); }
+   uint8_t* data() { return storage.data(); }
+   const uint8_t* data() const { return storage.data(); }
+   void resize(size_t n) { storage.resize(n); }
+   void clear() { storage.clear(); }
+   bool operator==(const cbor_resizable_byte_range_no_subscript&) const = default;
+};
+
+struct cbor_fixed_byte_range_no_subscript
+{
+   using value_type = uint8_t;
+   std::array<uint8_t, 5> storage{};
+   auto begin() { return storage.begin(); }
+   auto end() { return storage.end(); }
+   auto begin() const { return storage.begin(); }
+   auto end() const { return storage.end(); }
+   size_t size() const { return storage.size(); }
+   uint8_t* data() { return storage.data(); }
+   const uint8_t* data() const { return storage.data(); }
+   bool operator==(const cbor_fixed_byte_range_no_subscript&) const = default;
+};
+
 // A sequence of bytes has two legitimate CBOR encodings: a byte string (major type 2), which the
 // contiguous byte ranges write, and a plain array of small unsigned integers (major type 4), which
 // the others write. Each reader used to accept only its own, so Glaze could not read back its own
@@ -3843,6 +3876,31 @@ suite cbor_byte_sequence_encoding_tests = [] {
       std::array<uint8_t, 4> arr{9, 9, 9, 9};
       expect(not glz::read_cbor(arr, indefinite_array));
       expect(arr == std::array<uint8_t, 4>{1, 2, 3, 0});
+   };
+
+   // The array form fills its target one element at a time, which is where a subscript used to be
+   // assumed. Both framings and both kinds of target are covered because they take different paths:
+   // the definite one sizes the target once up front, the indefinite one grows it per element.
+   "array reads into contiguous byte ranges that are not indexable"_test = [] {
+      const std::string definite_array{"\x83\x01\x02\x03", 4};
+      const std::string indefinite_array{"\x9F\x01\x02\x03\xFF", 5};
+
+      for (const auto& buffer : {definite_array, indefinite_array}) {
+         cbor_resizable_byte_range_no_subscript resizable{{9, 9}};
+         expect(not glz::read_cbor(resizable, buffer));
+         expect(resizable.storage == std::vector<uint8_t>{1, 2, 3});
+
+         // A fixed-size target zero-fills its tail rather than growing.
+         cbor_fixed_byte_range_no_subscript fixed{{9, 9, 9, 9, 9}};
+         expect(not glz::read_cbor(fixed, buffer));
+         expect(fixed.storage == std::array<uint8_t, 5>{1, 2, 3, 0, 0});
+      }
+
+      // A byte string reaches the same targets through the bulk copy, which never indexed.
+      const std::string byte_string{"\x43\x01\x02\x03", 4};
+      cbor_resizable_byte_range_no_subscript resizable{};
+      expect(not glz::read_cbor(resizable, byte_string));
+      expect(resizable.storage == std::vector<uint8_t>{1, 2, 3});
    };
 
    "every byte container still round-trips"_test = [] {


### PR DESCRIPTION
Follow-up to #2796, which fixed this same fault in the typed array reader. Independent of that stack and based on `main`.

## A contiguous byte range had to be indexable to be read

A sequence of bytes has two legitimate CBOR encodings, and #2795 taught the byte string reader to accept both. The array form (major type 4) fills its target one element at a time, and it reached each element through a subscript:

```cpp
parse<CBOR>::op<Opts>(value[count], ctx, it, end);
```

`contiguous_byte_range` is built on `contiguous`, which is `has_size && has_data`. A contiguous range owes this reader `size()` and `data()`; nothing obliges it to carry `operator[]` as well. So a contiguous byte range without a subscript operator failed to compile:

```
include/glaze/cbor/read.hpp:729:38: error: type 'byte_range_no_subscript'
                                     does not provide a subscript operator
```

This is a compile-time failure reached only from user code, not silent misbehaviour, and the standard containers all satisfy the subscript by accident. It matters because it is the reader contradicting its own concept: the constraint promises that `size()` and `data()` are enough, and the body then requires more.

The byte string path was never affected. It copies in bulk through `data()` already.

## Both fill loops now go through data()

The two loops need different handling, which is the only subtle part of the change:

- The **definite** form sizes its target once before the loop, so one hoisted pointer serves the whole of it.
- The **indefinite** form calls `make_room` per element, which `resize`s a resizable target one element at a time. A hoisted pointer would dangle after the first grow, so this one re-reads `value.data()` on every pass.

Nothing about what is written changes, and no behaviour changes for any container that already worked.

## Tests

Two contiguous byte ranges that deliberately omit `operator[]`, one resizable and one fixed-size, read from the definite array form, the indefinite array form, and a byte string. The fixed-size target also confirms its tail still zero-fills.

The tests were checked against the bug rather than merely alongside the fix:

- reverting the whole header change fails to compile at line 729 for both new types
- reverting **only** the definite-path fix fails at line 778 for both new types

The second check was worth doing. The first revert reports only line 729, since clang suppresses the cascading error, which would leave the impression that the definite-path site was unreachable and its fix unnecessary. Isolating it shows both sites were independently broken.

`cbor_test` is 288/288 (1204 asserts). Full local suite is 117/117.
