### PR TITLE
Include unordered_map meta header in json/schema.hpp

### DIFF
--- a/include/glaze/json/schema.hpp
+++ b/include/glaze/json/schema.hpp
@@ -8,6 +8,7 @@
 #include "glaze/api/std/functional.hpp"
 #include "glaze/api/std/list.hpp"
 #include "glaze/api/std/map.hpp"
+#include "glaze/api/std/unordered_map.hpp"
 #include "glaze/api/std/optional.hpp"
 #include "glaze/api/std/shared_ptr.hpp"
 #include "glaze/api/std/string.hpp"

--- a/tests/json_test/jsonschema_test.cpp
+++ b/tests/json_test/jsonschema_test.cpp
@@ -657,6 +657,14 @@ suite value_type_variant_schema = [] {
          << schema;
    };
 
+   "unordered_map<string,string> additionalProperties inlined"_test = [] {
+      auto schema = glz::write_json_schema<std::unordered_map<std::string, std::string>>().value();
+      expect(
+         schema ==
+         R"({"type":"object","additionalProperties":{"type":"string"},"title":"std::unordered_map<std::string,std::string>"})")
+         << schema;
+   };
+
    "glaze_array_t schema"_test = [] {
       auto schema = glz::write_json_schema<point3d>().value();
       auto obj = glz::read_json<glz::schema>(schema);


### PR DESCRIPTION
Fixes #2764

`glaze/json/schema.hpp` already pulls in `glaze/api/std/map.hpp` for consistent type naming across compilers, but was missing the matching header for `std::unordered_map`.

Adds the include and a JSON Schema regression test mirroring the existing `std::map` case.
