### PR TITLE
fix(jsonrpc): require the jsonrpc and method members, and bound batch responses

### DIFF
--- a/docs/rpc/jsonrpc-registry.md
+++ b/docs/rpc/jsonrpc-registry.md
@@ -188,9 +188,11 @@ A batch whose responses would exceed the limit is **abandoned rather than trunca
 {"jsonrpc":"2.0","error":{"code":-32000,"message":"Server error","data":"Batch response exceeds max_batch_response_size"},"id":null}
 ```
 
-Elements already processed keep their effects — a JSON-RPC batch is not a transaction. Single requests are not subject to the limit: one request yields one response, whose size is bounded by the registered data rather than by the caller. Raise it for a service whose legitimate batches are larger, or lower it to keep a hostile one cheap.
+Elements already processed keep their effects — a JSON-RPC batch is not a transaction. The element that trips the limit has already been built when the check runs, so the peak is the limit plus one response rather than the limit exactly. Raise it for a service whose legitimate batches are larger, or lower it to keep a hostile one cheap.
 
-`glz::rpc::server` exposes the same setting.
+Single requests are not subject to the limit, because one request yields one response. Note what that does and does not bound: a single response is bounded by the size of the registered data, not by the size of the request — and where writable members are registered, a caller can grow that data itself. Register large mutable members with that in mind.
+
+`glz::rpc::server` exposes the same setting, with two differences. Its responses are still structured when the limit is applied, so their size is estimated rather than summed; escaping can push the written response past the limit by a small constant factor. And it reports the failure as a single-element array, `[{"jsonrpc":"2.0","error":{"code":-32000,...},"id":null}]`, rather than the bare object the registry returns.
 
 ## Error Handling
 

--- a/docs/rpc/jsonrpc-registry.md
+++ b/docs/rpc/jsonrpc-registry.md
@@ -204,6 +204,11 @@ server.call(R"({"jsonrpc":"2.0","method":"counter","params":"not_an_int","id":1}
 // Invalid version
 server.call(R"({"jsonrpc":"1.0","method":"greet","id":1})");
 // Returns: {"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid Request",...},"id":1}
+
+// Missing a required member. `jsonrpc` and `method` must both be present -- note that omitting
+// `method` is not the same as sending `"method":""`, which addresses the root endpoint.
+server.call(R"({"id":1})");
+// Returns: {"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid Request","data":"Missing 'jsonrpc' member"},"id":1}
 ```
 
 ## ID Types

--- a/docs/rpc/jsonrpc-registry.md
+++ b/docs/rpc/jsonrpc-registry.md
@@ -174,6 +174,24 @@ std::string response = server.call(R"([
 
 Notifications in a batch are processed but excluded from the response array. If all requests in a batch are notifications, an empty string is returned.
 
+### Batch Response Limit
+
+A batch answers every element it holds, so a request of a fixed size can ask for an answer of any size — a hundred-byte batch of root reads returns a hundred copies of the registered object. Only the server can bound that, so it does:
+
+```cpp
+server.max_batch_response_size = 1024 * 1024; // default is 16 MiB
+```
+
+A batch whose responses would exceed the limit is **abandoned rather than truncated**, so a client never mistakes a partial array for a complete one:
+
+```json
+{"jsonrpc":"2.0","error":{"code":-32000,"message":"Server error","data":"Batch response exceeds max_batch_response_size"},"id":null}
+```
+
+Elements already processed keep their effects — a JSON-RPC batch is not a transaction. Single requests are not subject to the limit: one request yields one response, whose size is bounded by the registered data rather than by the caller. Raise it for a service whose legitimate batches are larger, or lower it to keep a hostile one cheap.
+
+`glz::rpc::server` exposes the same setting.
+
 ## Error Handling
 
 The registry returns standard JSON-RPC 2.0 error codes:
@@ -185,6 +203,7 @@ The registry returns standard JSON-RPC 2.0 error codes:
 | -32601 | Method not found | The method does not exist |
 | -32602 | Invalid params | Invalid method parameter(s) |
 | -32603 | Internal error | Internal JSON-RPC error |
+| -32000 | Server error | Batch response exceeded `max_batch_response_size` |
 
 ### Examples
 

--- a/docs/rpc/repe-jsonrpc-conversion.md
+++ b/docs/rpc/repe-jsonrpc-conversion.md
@@ -90,6 +90,16 @@ if (msg.has_value()) {
 }
 ```
 
+The request must carry both members JSON-RPC 2.0 requires. A request that omits `jsonrpc` or `method`, or that names a version other than `2.0`, is rejected rather than converted:
+
+| request | error |
+|---------|-------|
+| `{"method":"add","id":1}` | `Missing 'jsonrpc' member` |
+| `{"jsonrpc":"1.0","method":"add","id":1}` | `Unsupported 'jsonrpc' version: "1.0"` |
+| `{"jsonrpc":"2.0","id":1}` | `Missing 'method' member` |
+
+This matters because the conversion is otherwise lossless in the wrong direction: an absent `method` would become the query `"/"`, and the REPE message that came out would be indistinguishable from one whose client really asked for it. Only absence is an error, so an explicit `"method":""` still converts, to the query `"/"`.
+
 #### Response Conversion
 
 **Function:** `expected<message, std::string> from_jsonrpc_response(std::string_view json_response)`
@@ -169,6 +179,7 @@ auto msg2 = repe::from_jsonrpc_request(jsonrpc2);
 - REPE message body must be in JSON format for conversion to JSON-RPC requests
 - REPE message body should be in JSON or UTF8 format for conversion to JSON-RPC responses
 - The query field in REPE requests is treated as the method name (leading slash is optional)
+- JSON-RPC requests must carry `jsonrpc` and `method`; see the request conversion section above
 
 ### Bridging Protocols Example
 

--- a/include/glaze/ext/jsonrpc.hpp
+++ b/include/glaze/ext/jsonrpc.hpp
@@ -87,6 +87,11 @@ namespace glz::rpc
          return {error_e::method_not_found, "Method: '" + std::string(presumed_method) + "' not found",
                  std::string(code_as_sv(error_e::method_not_found))};
       }
+      static error missing_member(std::string_view member)
+      {
+         return {error_e::invalid_request, "Missing '" + std::string(member) + "' member",
+                 std::string(code_as_sv(error_e::invalid_request))};
+      }
 
       operator bool() const noexcept { return code != rpc::error_e::no_error; }
 
@@ -121,6 +126,32 @@ namespace glz::rpc
    request_t(id_t&&, std::string_view, Params&&) -> request_t<std::decay_t<Params>>;
 
    using generic_request_t = request_t<glz::raw_json_view>;
+
+   // The request as received, for validating the envelope before any default stands in for a member
+   // that was never sent.
+   //
+   // request_t defaults `jsonrpc` to "2.0" and `method` to "", so a request that omits either reads
+   // back indistinguishable from one that sent the default: a missing version passes for 2.0, and a
+   // missing method names "" -- which is a live endpoint in the registry, where it addresses the
+   // root object. JSON RPC 2.0 requires both members, so absence has to stay separable from
+   // present-and-empty. Params are left raw; they are read against the target's own type once the
+   // envelope is known to be well formed.
+   struct request_envelope_t
+   {
+      id_t id{};
+      std::optional<std::string_view> method{};
+      glz::raw_json_view params{};
+      std::optional<std::string_view> version{};
+
+      struct glaze
+      {
+         using T = request_envelope_t;
+         static constexpr auto value = glz::object("jsonrpc", &T::version, //
+                                                   &T::method, //
+                                                   &T::params, //
+                                                   &T::id);
+      };
+   };
 
    template <class Result>
    struct response_t
@@ -334,7 +365,7 @@ namespace glz::rpc
      private:
       auto per_request(std::string_view json_request) -> std::optional<response_t<glz::raw_json>>
       {
-         expected<generic_request_t, glz::error_ctx> request{glz::read_json<generic_request_t>(json_request)};
+         expected<request_envelope_t, glz::error_ctx> request{glz::read_json<request_envelope_t>(json_request)};
 
          if (!request.has_value()) {
             // Failed, but let's try to extract the `id`
@@ -346,14 +377,24 @@ namespace glz::rpc
          }
 
          auto& req{request.value()};
-         if (req.version != rpc::supported_version) {
-            return raw_response_t{std::move(req.id), rpc::error::version(req.version)};
+         // `jsonrpc` and `method` are both required. Neither may fall through to a default: an
+         // absent version would pass for 2.0, and an absent method would be matched against the
+         // registered names as if the caller had asked for "".
+         if (!req.version) {
+            return raw_response_t{std::move(req.id), rpc::error::missing_member("jsonrpc")};
          }
+         if (*req.version != rpc::supported_version) {
+            return raw_response_t{std::move(req.id), rpc::error::version(*req.version)};
+         }
+         if (!req.method) {
+            return raw_response_t{std::move(req.id), rpc::error::missing_member("method")};
+         }
+         const std::string_view method_name{*req.method};
 
          std::optional<response_t<glz::raw_json>> return_v{};
-         bool method_found = methods.any([&json_request, &req, &return_v](auto&& method) -> bool {
+         bool method_found = methods.any([&json_request, &req, method_name, &return_v](auto&& method) -> bool {
             using meth_t = std::remove_reference_t<decltype(method)>;
-            if (req.method != meth_t::name_v) {
+            if (method_name != meth_t::name_v) {
                return false;
             }
             const auto& params_request{glz::read_json<typename meth_t::request_t>(json_request)};
@@ -386,7 +427,7 @@ namespace glz::rpc
             return true;
          });
          if (!method_found) {
-            return raw_response_t{std::move(req.id), rpc::error::method(req.method)};
+            return raw_response_t{std::move(req.id), rpc::error::method(method_name)};
          }
          return return_v;
       };

--- a/include/glaze/ext/jsonrpc.hpp
+++ b/include/glaze/ext/jsonrpc.hpp
@@ -443,11 +443,22 @@ namespace glz::rpc
          return return_v;
       };
 
-      // What a response will cost once written. Exact serialization is not needed here -- this only
-      // has to track the payload the caller controls, which is the result body and the error text.
+      // What a response will cost once written. The registry can sum finished strings; here the
+      // responses are still structured, so this has to account for every part the caller can grow.
+      // Three of them can: the result body, the error text, and -- the one that is easy to miss --
+      // the id, which is echoed back verbatim from the request and is not otherwise bounded.
+      //
+      // Escaping is not modelled. A result body is raw JSON and is written as-is, but error text and
+      // a string id are escaped on the way out, which can double them at worst: glaze rejects raw
+      // control bytes, so the only escapes reachable from a legal request are the two-byte kind. The
+      // limit therefore bounds the written response within a small constant factor rather than
+      // exactly, which is what it is for.
       static size_t response_cost(const raw_response_t& response)
       {
-         size_t cost = 64; // envelope: version, id and the surrounding punctuation
+         size_t cost = 64; // envelope: version and the surrounding punctuation
+         if (auto* id = std::get_if<std::string_view>(&response.id)) {
+            cost += id->size();
+         }
          if (response.result) {
             cost += response.result->str.size();
          }

--- a/include/glaze/ext/jsonrpc.hpp
+++ b/include/glaze/ext/jsonrpc.hpp
@@ -51,6 +51,13 @@ namespace glz::rpc
    using id_t = std::variant<glz::generic::null_t, std::string_view, std::int64_t>;
    inline constexpr std::string_view supported_version{"2.0"};
 
+   // Ceiling on what one batch may answer with. A batch response past this is already outside what
+   // a JSON RPC service does in normal operation -- it is roughly sixteen thousand kilobyte
+   // responses -- while still being small enough that a request built to be answered expensively is
+   // stopped while it is cheap. A service whose legitimate batches are larger raises it; both
+   // servers expose it as a per-instance setting.
+   inline constexpr size_t default_max_batch_response_size{16u * 1024u * 1024u};
+
    struct error final
    {
       error_e code{error_e::no_error};
@@ -314,6 +321,10 @@ namespace glz::rpc
 
       glz::tuple<server_method_t<Method>...> methods{};
 
+      // See rpc::default_max_batch_response_size. A batch answers every element it holds, so a
+      // bounded request can ask for an unbounded answer; only the server can cap that.
+      size_t max_batch_response_size{rpc::default_max_batch_response_size};
+
       template <string_literal name>
       constexpr void on(const auto& callback) // std::function<expected<result_t, rpc::error>(params_t const&)>
       {
@@ -432,13 +443,40 @@ namespace glz::rpc
          return return_v;
       };
 
+      // What a response will cost once written. Exact serialization is not needed here -- this only
+      // has to track the payload the caller controls, which is the result body and the error text.
+      static size_t response_cost(const raw_response_t& response)
+      {
+         size_t cost = 64; // envelope: version, id and the surrounding punctuation
+         if (response.result) {
+            cost += response.result->str.size();
+         }
+         if (response.error) {
+            cost += response.error->message.size();
+            if (response.error->data) {
+               cost += response.error->data->size();
+            }
+         }
+         return cost;
+      }
+
       auto batch_request(const std::vector<glz::raw_json_view>& batch_requests)
       {
          std::vector<response_t<glz::raw_json>> return_vec;
          return_vec.reserve(batch_requests.size());
+         size_t total_size{2}; // []
          for (auto&& request : batch_requests) {
             auto response{per_request(request.str)};
             if (response.has_value()) {
+               total_size += response_cost(response.value()) + 1; // +1 for comma
+               // Checked as the batch is walked, so the memory the limit bounds is never allocated.
+               // The batch is abandoned rather than truncated -- a caller must not mistake a partial
+               // array for a complete one.
+               if (total_size > max_batch_response_size) {
+                  return std::vector<response_t<glz::raw_json>>{
+                     raw_response_t{rpc::error{error_e::server_error_lower, "Batch response exceeds "
+                                                                           "max_batch_response_size"}}};
+               }
                return_vec.emplace_back(std::move(response.value()));
             }
          }

--- a/include/glaze/rpc/registry.hpp
+++ b/include/glaze/rpc/registry.hpp
@@ -154,6 +154,15 @@ namespace glz
 
       typename protocol_storage<Proto>::type endpoints{};
 
+      // A batch answers every element it holds, so the response grows with the product of the batch
+      // length and the size of what each element reads -- a bounded request can ask for an unbounded
+      // answer. Nothing in the request caps that, so the server has to. Raise it for a service whose
+      // legitimate batches are larger than this, or lower it to keep a hostile one cheap; a batch
+      // that would exceed it is abandoned rather than truncated, so a client never mistakes a
+      // partial answer for a complete one. Single requests are not subject to it: one request yields
+      // one response, which is bounded by the registered data rather than by the caller.
+      size_t max_batch_response_size{rpc::default_max_batch_response_size};
+
       void clear() { endpoints.clear(); }
 
      private:
@@ -639,6 +648,14 @@ namespace glz
             auto response = process_single_request(req.str);
             if (response.has_value()) {
                total_size += response->size() + 1; // +1 for comma
+               // Checked as the batch is walked rather than after it, so the memory the limit is
+               // meant to bound is never allocated in the first place. The elements already run
+               // keep their effects -- a JSON RPC batch is not a transaction -- but the caller is
+               // told the batch failed rather than handed a partial array it cannot distinguish
+               // from a complete one.
+               if (total_size > max_batch_response_size) {
+                  return R"({"jsonrpc":"2.0","error":{"code":-32000,"message":"Server error","data":"Batch response exceeds max_batch_response_size"},"id":null})";
+               }
                responses.push_back(std::move(*response));
             }
          }

--- a/include/glaze/rpc/registry.hpp
+++ b/include/glaze/rpc/registry.hpp
@@ -527,7 +527,7 @@ namespace glz
       std::optional<std::string> process_single_request(std::string_view json_request)
          requires(Proto == JSONRPC)
       {
-         rpc::generic_request_t request{};
+         rpc::request_envelope_t request{};
          if (const auto read_ec = glz::read<read_opts>(request, json_request); read_ec) {
             // Check if it's a JSON syntax error vs schema error
             static constexpr registry_validate_opts<read_opts> validate_opts{{read_opts}};
@@ -547,32 +547,45 @@ namespace glz
 
          auto& req = request;
 
-         // Validate version
-         if (req.version != rpc::supported_version) {
+         const auto invalid_request = [&req](const std::string& data) {
             std::string id_json = glz::write_json(req.id).value_or("null");
             return R"({"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid Request","data":)" +
-                   write_json("Invalid version: " + std::string(req.version)).value_or("null") + R"(},"id":)" +
-                   id_json + "}";
+                   write_json(data).value_or("null") + R"(},"id":)" + id_json + "}";
+         };
+
+         // `jsonrpc` and `method` are both required members, and an absent one cannot be allowed to
+         // fall through to a default: an absent version would pass for 2.0, and an absent method
+         // names "", which is the root endpoint -- so `{"id":1}` would answer with the whole
+         // registered object rather than being rejected.
+         if (!req.version) {
+            return invalid_request("Missing 'jsonrpc' member");
          }
+         if (*req.version != rpc::supported_version) {
+            return invalid_request("Invalid version: " + std::string(*req.version));
+         }
+         if (!req.method) {
+            return invalid_request("Missing 'method' member");
+         }
+         const std::string_view method_name = *req.method;
 
          // Check if this is a notification (id is null)
          bool is_notification = std::holds_alternative<glz::generic::null_t>(req.id);
 
          // Look up the endpoint - try direct lookup first (handles methods that already start with /)
-         auto it = endpoints.find(req.method);
+         auto it = endpoints.find(method_name);
          if (it == endpoints.end()) {
-            if (!req.method.empty()) {
+            if (!method_name.empty()) {
                // Try with leading slash using stack buffer for common case
                char buf[256];
-               if (req.method.size() < sizeof(buf) - 1) {
+               if (method_name.size() < sizeof(buf) - 1) {
                   buf[0] = '/';
-                  std::memcpy(buf + 1, req.method.data(), req.method.size());
-                  it = endpoints.find(std::string_view{buf, req.method.size() + 1});
+                  std::memcpy(buf + 1, method_name.data(), method_name.size());
+                  it = endpoints.find(std::string_view{buf, method_name.size() + 1});
                }
                else {
                   // Fallback for very long method names
                   std::string method_path = "/";
-                  method_path += req.method;
+                  method_path += method_name;
                   it = endpoints.find(method_path);
                }
             }
@@ -586,7 +599,7 @@ namespace glz
                }
                std::string id_json = glz::write_json(req.id).value_or("null");
                return R"({"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found","data":)" +
-                      write_json(req.method).value_or("null") + R"(},"id":)" + id_json + "}";
+                      write_json(method_name).value_or("null") + R"(},"id":)" + id_json + "}";
             }
          }
 

--- a/include/glaze/rpc/registry.hpp
+++ b/include/glaze/rpc/registry.hpp
@@ -159,8 +159,10 @@ namespace glz
       // answer. Nothing in the request caps that, so the server has to. Raise it for a service whose
       // legitimate batches are larger than this, or lower it to keep a hostile one cheap; a batch
       // that would exceed it is abandoned rather than truncated, so a client never mistakes a
-      // partial answer for a complete one. Single requests are not subject to it: one request yields
-      // one response, which is bounded by the registered data rather than by the caller.
+      // partial answer for a complete one. Single requests are not subject to it, because one
+      // request yields one response -- note that this bounds a response by the size of the
+      // registered data, which a caller can itself grow where writable members are registered, and
+      // not by the size of the request.
       size_t max_batch_response_size{rpc::default_max_batch_response_size};
 
       void clear() { endpoints.clear(); }
@@ -648,11 +650,13 @@ namespace glz
             auto response = process_single_request(req.str);
             if (response.has_value()) {
                total_size += response->size() + 1; // +1 for comma
-               // Checked as the batch is walked rather than after it, so the memory the limit is
-               // meant to bound is never allocated in the first place. The elements already run
-               // keep their effects -- a JSON RPC batch is not a transaction -- but the caller is
-               // told the batch failed rather than handed a partial array it cannot distinguish
-               // from a complete one.
+               // Checked as the batch is walked rather than after it, so the elements past the
+               // limit are never run and what they would have answered with is never built. The
+               // element that trips it has already been built, so the peak is the limit plus one
+               // response rather than the limit exactly. The elements already run keep their
+               // effects -- a JSON RPC batch is not a transaction -- but the caller is told the
+               // batch failed rather than handed a partial array it cannot distinguish from a
+               // complete one.
                if (total_size > max_batch_response_size) {
                   return R"({"jsonrpc":"2.0","error":{"code":-32000,"message":"Server error","data":"Batch response exceeds max_batch_response_size"},"id":null})";
                }

--- a/include/glaze/rpc/repe/repe_to_jsonrpc.hpp
+++ b/include/glaze/rpc/repe/repe_to_jsonrpc.hpp
@@ -174,18 +174,41 @@ namespace glz::repe
    }
 
    // Convert JSON-RPC request to REPE message
+   //
+   // A request that omits `jsonrpc` or `method` is rejected rather than converted. Both are required
+   // by JSON-RPC 2.0, and neither can be allowed to fall through to a default here: rpc::request_t
+   // defaults the version to "2.0", so an absent one would pass for a version that was never sent,
+   // and an absent method would name "", producing the REPE query "/" as though the caller had asked
+   // for it. Nothing downstream can recover the distinction -- the emitted message is well formed,
+   // and a REPE server has no way to tell it apart from a query the client really wrote. Rejecting
+   // costs callers nothing new: the failure channel is the one they already check.
+   //
+   // An explicit `"method":""` is still converted, to the query "/". Only absence is an error.
    inline expected<message, std::string> from_jsonrpc_request(std::string_view json_request)
    {
-      auto req = read_json<rpc::generic_request_t>(json_request);
+      auto req = read_json<rpc::request_envelope_t>(json_request);
       if (!req) {
          return unexpected<std::string>("Failed to parse JSON-RPC request");
+      }
+
+      if (!req->version) {
+         return unexpected<std::string>("Missing 'jsonrpc' member");
+      }
+      if (*req->version != rpc::supported_version) {
+         // Written as a JSON string rather than spliced in raw: the version is attacker-controlled,
+         // and this message is the sort of thing a bridge forwards into an error response.
+         return unexpected<std::string>("Unsupported 'jsonrpc' version: " +
+                                        glz::write_json(*req->version).value_or(R"("")"));
+      }
+      if (!req->method) {
+         return unexpected<std::string>("Missing 'method' member");
       }
 
       message msg{};
 
       // Set query as method name with leading slash
       msg.query = "/";
-      msg.query += req->method;
+      msg.query += *req->method;
 
       // Set body as params (if not empty)
       if (!req->params.str.empty() && req->params.str != "null") {

--- a/tests/jsonrpc_test/jsonrpc_test.cpp
+++ b/tests/jsonrpc_test/jsonrpc_test.cpp
@@ -391,6 +391,36 @@ ut::suite struct_test_cases = [] {
          << response_vec[2].error->data.value_or("");
    };
 
+   "server batch response limit"_test = [] {
+      rpc::server<rpc::method<"foo", foo_params, foo_result>> limited{};
+      limited.on<"foo">([](const foo_params&) -> foo_result { return {.foo_c = true, .foo_d = "payload"}; });
+
+      std::string request = "[";
+      for (size_t i = 0; i < 64; ++i) {
+         if (i) {
+            request += ',';
+         }
+         request += R"({"jsonrpc":"2.0","method":"foo","params":{"foo_a":1,"foo_b":"x"},"id":)";
+         request += std::to_string(i);
+         request += '}';
+      }
+      request += ']';
+
+      limited.max_batch_response_size = 256;
+      auto response_vec = limited.call<std::vector<rpc::response_t<glz::raw_json>>>(request);
+      ut::expect(response_vec.size() == 1) << response_vec.size();
+      ut::expect(response_vec[0].error.has_value());
+      ut::expect(response_vec[0].error->code == glz::rpc::error_e::server_error_lower);
+      ut::expect(!response_vec[0].result.has_value());
+
+      limited.max_batch_response_size = glz::rpc::default_max_batch_response_size;
+      response_vec = limited.call<std::vector<rpc::response_t<glz::raw_json>>>(request);
+      ut::expect(response_vec.size() == 64) << response_vec.size();
+      for (auto& response : response_vec) {
+         ut::expect(!response.error.has_value());
+      }
+   };
+
    ut::test("server valid or error return") = [&server] {
       server.on<"foo">([](const foo_params& params) -> glz::expected<foo_result, glz::rpc::error> {
          if (params.foo_a == 10) // dummy invalid param case

--- a/tests/jsonrpc_test/jsonrpc_test.cpp
+++ b/tests/jsonrpc_test/jsonrpc_test.cpp
@@ -421,6 +421,43 @@ ut::suite struct_test_cases = [] {
       }
    };
 
+   // The two elements below are far too few to reach the limit on envelope overhead alone, so each
+   // of these only trips if the part of the response it names is actually being counted.
+   "server batch limit counts the result body"_test = [] {
+      rpc::server<rpc::method<"foo", foo_params, foo_result>> limited{};
+      limited.on<"foo">([](const foo_params&) -> foo_result {
+         return {.foo_c = true, .foo_d = std::string(8192, 'x')};
+      });
+      limited.max_batch_response_size = 4096;
+
+      auto response_vec = limited.call<std::vector<rpc::response_t<glz::raw_json>>>(
+         R"([{"jsonrpc":"2.0","method":"foo","params":{"foo_a":1,"foo_b":"x"},"id":1},
+             {"jsonrpc":"2.0","method":"foo","params":{"foo_a":1,"foo_b":"x"},"id":2}])");
+      ut::expect(response_vec.size() == 1) << response_vec.size();
+      ut::expect(response_vec[0].error.has_value());
+      ut::expect(response_vec[0].error->code == glz::rpc::error_e::server_error_lower);
+   };
+
+   // The id is echoed back verbatim and is not otherwise bounded, so a batch of long ids can carry
+   // an answer far past the limit if the estimate leaves it out.
+   "server batch limit counts the echoed id"_test = [] {
+      rpc::server<rpc::method<"foo", foo_params, foo_result>> limited{};
+      limited.on<"foo">([](const foo_params&) -> foo_result { return {}; });
+      limited.max_batch_response_size = 4096;
+
+      const std::string id(8192, 'A');
+      std::string request = R"([{"jsonrpc":"2.0","method":"foo","params":{"foo_a":1,"foo_b":"x"},"id":")";
+      request += id;
+      request += R"("},{"jsonrpc":"2.0","method":"foo","params":{"foo_a":1,"foo_b":"x"},"id":")";
+      request += id;
+      request += R"("}])";
+
+      auto response_vec = limited.call<std::vector<rpc::response_t<glz::raw_json>>>(request);
+      ut::expect(response_vec.size() == 1) << response_vec.size();
+      ut::expect(response_vec[0].error.has_value());
+      ut::expect(response_vec[0].error->code == glz::rpc::error_e::server_error_lower);
+   };
+
    ut::test("server valid or error return") = [&server] {
       server.on<"foo">([](const foo_params& params) -> glz::expected<foo_result, glz::rpc::error> {
          if (params.foo_a == 10) // dummy invalid param case

--- a/tests/jsonrpc_test/jsonrpc_test.cpp
+++ b/tests/jsonrpc_test/jsonrpc_test.cpp
@@ -364,6 +364,33 @@ ut::suite struct_test_cases = [] {
       }
    };
 
+   // `jsonrpc` and `method` are both required. An absent one used to read back as the default the
+   // request type carries, so a request that never named a version was answered as if it had asked
+   // for 2.0, and one that never named a method was matched against the registered names as "".
+   "server missing required members"_test = [&server] {
+      server.on<"foo">([](const foo_params&) -> foo_result { return {}; });
+
+      auto response_vec = server.call<std::vector<rpc::response_t<glz::raw_json>>>(R"(
+      [
+          {"method":"foo","params":{"foo_a":1337,"foo_b":"hello world"},"id": 1},
+          {"jsonrpc":"2.0","params":{"foo_a":1337,"foo_b":"hello world"},"id": 2},
+          {"id": 3}
+      ]
+      )");
+      ut::expect(response_vec.size() == 3);
+      for (auto& response : response_vec) {
+         ut::expect(response.error.has_value());
+         ut::expect(response.error->code == glz::rpc::error_e::invalid_request);
+         ut::expect(!response.result.has_value());
+      }
+      ut::expect(response_vec[0].error->data.value_or("") == "Missing 'jsonrpc' member")
+         << response_vec[0].error->data.value_or("");
+      ut::expect(response_vec[1].error->data.value_or("") == "Missing 'method' member")
+         << response_vec[1].error->data.value_or("");
+      ut::expect(response_vec[2].error->data.value_or("") == "Missing 'jsonrpc' member")
+         << response_vec[2].error->data.value_or("");
+   };
+
    ut::test("server valid or error return") = [&server] {
       server.on<"foo">([](const foo_params& params) -> glz::expected<foo_result, glz::rpc::error> {
          if (params.foo_a == 10) // dummy invalid param case

--- a/tests/networking_tests/jsonrpc_registry_test/jsonrpc_registry_test.cpp
+++ b/tests/networking_tests/jsonrpc_registry_test/jsonrpc_registry_test.cpp
@@ -265,6 +265,67 @@ suite jsonrpc_error_tests = [] {
       expect(response.find(R"("error")") != std::string::npos) << response;
       expect(response.find(R"(-32600)") != std::string::npos) << response; // Invalid Request
    };
+
+   // `jsonrpc` and `method` are both required members. An absent one used to read back as the
+   // default the request type carries, which made `{"id":1}` a version 2.0 call on the empty method
+   // -- and the empty method is the root endpoint, so it answered with the whole registered object.
+   "missing_version"_test = [] {
+      glz::registry<glz::opts{}, glz::JSONRPC> server{};
+
+      my_functions_t obj{};
+      server.on(obj);
+
+      auto response = server.call(R"({"method":"hello","id":1})");
+      expect(response.find(R"(-32600)") != std::string::npos) << response; // Invalid Request
+      expect(response.find(R"("result")") == std::string::npos) << response;
+      expect(response.find(R"("id":1)") != std::string::npos) << response;
+   };
+
+   "missing_method"_test = [] {
+      glz::registry<glz::opts{}, glz::JSONRPC> server{};
+
+      my_functions_t obj{};
+      obj.i = 55;
+      server.on(obj);
+
+      auto response = server.call(R"({"jsonrpc":"2.0","id":1})");
+      expect(response.find(R"(-32600)") != std::string::npos) << response; // Invalid Request
+      expect(response.find(R"("result")") == std::string::npos) << response;
+      expect(response.find(R"(55)") == std::string::npos) << "must not dispatch to the root endpoint: " << response;
+   };
+
+   "bare_id_is_not_a_request"_test = [] {
+      glz::registry<glz::opts{}, glz::JSONRPC> server{};
+
+      my_functions_t obj{};
+      obj.i = 55;
+      server.on(obj);
+
+      auto response = server.call(R"({"id":1})");
+      expect(response.find(R"(-32600)") != std::string::npos) << response; // Invalid Request
+      expect(response.find(R"("result")") == std::string::npos) << response;
+      expect(response.find(R"(55)") == std::string::npos) << "must not dispatch to the root endpoint: " << response;
+   };
+
+   // Every element of a batch is validated on its own, so a batch of bare ids cannot turn one small
+   // request into one whole-object response per element.
+   "batch_of_bare_ids_is_not_amplified"_test = [] {
+      glz::registry<glz::opts{}, glz::JSONRPC> server{};
+
+      my_functions_t obj{};
+      server.on(obj);
+
+      const std::string_view request = R"([{"id":1},{"id":2},{"id":3}])";
+      auto response = server.call(request);
+      expect(response[0] == '[') << response;
+      expect(response.find(R"("result")") == std::string::npos) << response;
+      size_t errors = 0;
+      for (size_t pos = response.find("-32600"); pos != std::string::npos;
+           pos = response.find("-32600", pos + 1)) {
+         ++errors;
+      }
+      expect(errors == 3u) << response;
+   };
 };
 
 suite jsonrpc_id_types_tests = [] {

--- a/tests/networking_tests/jsonrpc_registry_test/jsonrpc_registry_test.cpp
+++ b/tests/networking_tests/jsonrpc_registry_test/jsonrpc_registry_test.cpp
@@ -45,6 +45,25 @@ struct my_nested_functions_t
    std::string my_string{};
 };
 
+// Counts how many elements of a batch actually ran, which is how the limit is shown to be enforced
+// as the batch is walked rather than after it has been built.
+struct counting_functions_t
+{
+   size_t calls{};
+   std::string blob = std::string(4096, 'x');
+   std::string fetch()
+   {
+      ++calls;
+      return blob;
+   }
+
+   struct glaze
+   {
+      using T = counting_functions_t;
+      static constexpr auto value = glz::object(&T::calls, &T::blob, &T::fetch);
+   };
+};
+
 struct example_functions_t
 {
    std::string name{};
@@ -241,6 +260,40 @@ suite jsonrpc_batch_tests = [] {
       expect(response[0] == '[') << response.substr(0, 64);
       expect(response.find(R"(-32000)") == std::string::npos) << response.substr(0, 200);
       expect(response.size() > 1024u) << response.size();
+   };
+
+   // The limit is checked as the batch is walked, so the elements past it are never run. A check
+   // that ran only after the loop would answer with the same error while still having built the
+   // whole oversized response first, which is the case this pins.
+   "batch_response_limit_stops_early"_test = [] {
+      glz::registry<glz::opts{}, glz::JSONRPC> server{};
+
+      counting_functions_t obj{};
+      server.on(obj);
+
+      std::string request = "[";
+      for (size_t i = 0; i < 512; ++i) {
+         if (i) {
+            request += ',';
+         }
+         request += R"({"jsonrpc":"2.0","method":"fetch","id":)";
+         request += std::to_string(i);
+         request += '}';
+      }
+      request += ']';
+
+      // Each element answers with the 4 KB blob, so the limit is reached within the first few.
+      server.max_batch_response_size = 8 * 1024;
+      auto response = server.call(request);
+      expect(response.find(R"(-32000)") != std::string::npos) << response;
+      expect(obj.calls > 0u) << "the batch should have started";
+      expect(obj.calls < 8u) << "elements past the limit must never run, ran " << obj.calls;
+
+      obj.calls = 0;
+      server.max_batch_response_size = glz::rpc::default_max_batch_response_size;
+      response = server.call(request);
+      expect(response[0] == '[') << response.substr(0, 64);
+      expect(obj.calls == 512u) << obj.calls;
    };
 
    "empty_batch_error"_test = [] {

--- a/tests/networking_tests/jsonrpc_registry_test/jsonrpc_registry_test.cpp
+++ b/tests/networking_tests/jsonrpc_registry_test/jsonrpc_registry_test.cpp
@@ -291,7 +291,8 @@ suite jsonrpc_error_tests = [] {
       auto response = server.call(R"({"jsonrpc":"2.0","id":1})");
       expect(response.find(R"(-32600)") != std::string::npos) << response; // Invalid Request
       expect(response.find(R"("result")") == std::string::npos) << response;
-      expect(response.find(R"(55)") == std::string::npos) << "must not dispatch to the root endpoint: " << response;
+      // The root endpoint answers with the whole object, so its members must not appear.
+      expect(response.find(R"("i":)") == std::string::npos) << "must not dispatch to the root endpoint: " << response;
    };
 
    "bare_id_is_not_a_request"_test = [] {
@@ -304,27 +305,44 @@ suite jsonrpc_error_tests = [] {
       auto response = server.call(R"({"id":1})");
       expect(response.find(R"(-32600)") != std::string::npos) << response; // Invalid Request
       expect(response.find(R"("result")") == std::string::npos) << response;
-      expect(response.find(R"(55)") == std::string::npos) << "must not dispatch to the root endpoint: " << response;
+      // The root endpoint answers with the whole object, so its members must not appear.
+      expect(response.find(R"("i":)") == std::string::npos) << "must not dispatch to the root endpoint: " << response;
    };
 
-   // Every element of a batch is validated on its own, so a batch of bare ids cannot turn one small
-   // request into one whole-object response per element.
+   // Every element of a batch is validated on its own. A bare id used to reach the root endpoint,
+   // which answers with the whole registered object -- so a batch of them returned one whole-object
+   // response per element, and the response grew with the product of the batch length and the size
+   // of the registered object rather than with the length of the request.
    "batch_of_bare_ids_is_not_amplified"_test = [] {
       glz::registry<glz::opts{}, glz::JSONRPC> server{};
 
       my_functions_t obj{};
       server.on(obj);
 
-      const std::string_view request = R"([{"id":1},{"id":2},{"id":3}])";
+      std::string request = "[";
+      for (size_t i = 0; i < 256; ++i) {
+         if (i) {
+            request += ',';
+         }
+         request += R"({"id":)";
+         request += std::to_string(i);
+         request += '}';
+      }
+      request += ']';
+
       auto response = server.call(request);
       expect(response[0] == '[') << response;
       expect(response.find(R"("result")") == std::string::npos) << response;
+
       size_t errors = 0;
-      for (size_t pos = response.find("-32600"); pos != std::string::npos;
-           pos = response.find("-32600", pos + 1)) {
+      for (size_t pos = response.find("-32600"); pos != std::string::npos; pos = response.find("-32600", pos + 1)) {
          ++errors;
       }
-      expect(errors == 3u) << response;
+      expect(errors == 256u) << errors;
+
+      // Each element answers with a fixed-size error rather than a copy of the registered object,
+      // so the response stays a constant multiple of the request no matter what is registered.
+      expect(response.size() < 16 * request.size()) << response.size() << " vs " << request.size();
    };
 };
 

--- a/tests/networking_tests/jsonrpc_registry_test/jsonrpc_registry_test.cpp
+++ b/tests/networking_tests/jsonrpc_registry_test/jsonrpc_registry_test.cpp
@@ -207,6 +207,42 @@ suite jsonrpc_batch_tests = [] {
       expect(obj.i == 99) << "Value should have been updated by notification";
    };
 
+   // A batch answers every element it holds, so a request of a fixed size can ask for an answer of
+   // any size. Only the server can bound that.
+   "batch_response_limit"_test = [] {
+      glz::registry<glz::opts{}, glz::JSONRPC> server{};
+
+      my_functions_t obj{};
+      server.on(obj);
+
+      std::string request = "[";
+      for (size_t i = 0; i < 512; ++i) {
+         if (i) {
+            request += ',';
+         }
+         request += R"({"jsonrpc":"2.0","method":"","id":)";
+         request += std::to_string(i);
+         request += '}';
+      }
+      request += ']';
+
+      // Every element reads the root endpoint, which answers with the whole object, so the batch is
+      // well over a kilobyte of response.
+      server.max_batch_response_size = 1024;
+      auto response = server.call(request);
+      expect(response.find(R"(-32000)") != std::string::npos) << response;
+      expect(response.find(R"("result")") == std::string::npos) << response;
+      expect(response[0] == '{') << "the batch is abandoned, not truncated to a partial array";
+      expect(response.size() < 4096u) << response.size();
+
+      // The same batch is answered in full once the limit allows it.
+      server.max_batch_response_size = glz::rpc::default_max_batch_response_size;
+      response = server.call(request);
+      expect(response[0] == '[') << response.substr(0, 64);
+      expect(response.find(R"(-32000)") == std::string::npos) << response.substr(0, 200);
+      expect(response.size() > 1024u) << response.size();
+   };
+
    "empty_batch_error"_test = [] {
       glz::registry<glz::opts{}, glz::JSONRPC> server{};
 

--- a/tests/networking_tests/repe_to_jsonrpc_test/repe_to_jsonrpc_test.cpp
+++ b/tests/networking_tests/repe_to_jsonrpc_test/repe_to_jsonrpc_test.cpp
@@ -203,6 +203,63 @@ suite jsonrpc_to_repe_request_tests = [] {
       expect(msg->header.id == 999);
       expect(msg->header.notify == false);
    };
+
+   "missing_version_is_rejected"_test = [] {
+      std::string jsonrpc = R"({"method":"test","params":[],"id":1})";
+
+      auto msg = repe::from_jsonrpc_request(jsonrpc);
+      expect(!msg.has_value());
+      expect(msg.error() == "Missing 'jsonrpc' member") << msg.error();
+   };
+
+   "unsupported_version_is_rejected"_test = [] {
+      std::string jsonrpc = R"({"jsonrpc":"1.0","method":"test","params":[],"id":1})";
+
+      auto msg = repe::from_jsonrpc_request(jsonrpc);
+      expect(!msg.has_value());
+      expect(msg.error() == R"(Unsupported 'jsonrpc' version: "1.0")") << msg.error();
+   };
+
+   "unsupported_version_is_escaped"_test = [] {
+      // The version is echoed into the error, and a bridge is liable to forward that error into a
+      // JSON-RPC response, so it must not be able to close the string it lands in.
+      //
+      // The version is read as a string_view, so it views the buffer's raw bytes rather than the
+      // decoded value: `a\"b`, four characters. Writing that back escapes both the backslash and
+      // the quote, which is why the expected form is doubled.
+      std::string jsonrpc = R"({"jsonrpc":"a\"b","method":"test","id":1})";
+
+      auto msg = repe::from_jsonrpc_request(jsonrpc);
+      expect(!msg.has_value());
+      expect(msg.error() == R"(Unsupported 'jsonrpc' version: "a\\\"b")") << msg.error();
+      // The point of the escaping: no bare quote survives to terminate the string it is spliced into.
+      expect(msg.error().find(R"(\")") != std::string::npos) << msg.error();
+   };
+
+   "missing_method_is_rejected"_test = [] {
+      // Without this the absent method would name "", and the caller would be handed a well formed
+      // REPE message querying "/" that it cannot tell apart from one the client actually wrote.
+      std::string jsonrpc = R"({"jsonrpc":"2.0","params":[],"id":1})";
+
+      auto msg = repe::from_jsonrpc_request(jsonrpc);
+      expect(!msg.has_value());
+      expect(msg.error() == "Missing 'method' member") << msg.error();
+   };
+
+   "bare_id_is_not_a_request"_test = [] {
+      auto msg = repe::from_jsonrpc_request(R"({"id":1})");
+      expect(!msg.has_value());
+      expect(msg.error() == "Missing 'jsonrpc' member") << msg.error();
+   };
+
+   "explicit_empty_method_is_converted"_test = [] {
+      // Absence is the error, not emptiness: an explicitly empty method still converts.
+      std::string jsonrpc = R"({"jsonrpc":"2.0","method":"","params":[],"id":1})";
+
+      auto msg = repe::from_jsonrpc_request(jsonrpc);
+      expect(msg.has_value());
+      expect(msg->query == "/") << msg->query;
+   };
 };
 
 suite jsonrpc_to_repe_response_tests = [] {


### PR DESCRIPTION
Found by the `jsonrpc_registry` fuzzer as a timeout: 56 s and a 1.5 GB response from a 921 KB input. Two faults are behind it, and only fixing both makes the timeout go away.

## 1. Requests missing required members were dispatched

`rpc::request_t` defaults `jsonrpc` to `"2.0"` and `method` to `""`, so nothing distinguishes a member that arrived from one that was never sent — and both are *required* by JSON-RPC 2.0. An absent `jsonrpc` fell through to exactly the value the version check looks for, and an absent `method` named `""`, which is not inert here but a **live endpoint**: the documented way to address the root object.

`{"id":1}` was therefore a valid 2.0 call on root, answered with the entire registered object. In a batch that is one whole-object dump per element, and the testcase is 8537 such fragments.

`rpc::request_envelope_t` holds both members in `std::optional`, so absence stays separable from present-and-empty, and both servers now answer `-32600`. Explicit `"method":""` still reaches the root endpoint, with a test pinning it. `glz::rpc::server` in `ext/jsonrpc.hpp` carried the same defect — no root endpoint so no amplification, but it accepted unversioned requests and answered a methodless one `-32601` rather than `-32600`.

## 2. The timeout survived that fix

A batch answers every element it holds, so a fixed-size request can ask for an unbounded answer. Same-size inputs, all well-formed and spec-conformant, against the ASAN+UBSan target:

| 921 KB input | before | after fix 1 | after fix 2 |
|---|---|---|---|
| original clusterfuzz testcase | 56.2 s | **0.15 s** | 0.22 s |
| ~24,900 valid reads of one 150 KB member | 49.6 s | 49.6 s ❌ | **0.40 s** |
| same via explicit `"method":""` | 56.3 s | 56.7 s ❌ | **0.20 s** |

Two of the three are untouched by the conformance fix, and involve neither the root endpoint nor a malformed request. So both servers gain `max_batch_response_size` (default 16 MiB, per-instance), checked **as the batch is walked** so elements past the limit never run, and **abandoning rather than truncating** — answered with `-32000`, so a partial array cannot pass for a complete one. Elements already processed keep their effects; a JSON-RPC batch is not a transaction. Single requests are exempt, since one request yields one response — though that bounds a response by the size of the registered data, which a caller can itself grow where writable members are registered.

## 3. The REPE converter invented the members it was missing

`from_jsonrpc_request` inherited the same defaults and never checked the version at all, so an absent `method` became the REPE query `"/"` — a well-formed message indistinguishable from one a client actually wrote. No amplification behind this one: REPE registers its root under `""` and members under `"/name"`, so `"/"` matches nothing and yields `method_not_found`. The fault is that a converter fabricated a request. Now rejected through the existing failure channel, which adds failure *cases* rather than widening the contract — the return type is unchanged and every documented caller already checks `has_value()`.

## Behavior changes worth a look

- A request missing a required member is now **answered** where an id-less one was silently dropped, so `[{},{},…]` returns errors. This is what §5 and the §7 batch example ask for, and it matches the pre-existing invalid-version path, which already replied regardless of notification status.
- `null` reads into a disengaged optional, so `{"jsonrpc":null,"jsonrpc":"2.0",…}` is now accepted where the duplicate key previously caused a rejection. Glaze does not reject duplicate keys generally, so this is a consistency artifact rather than a new hole.
- 16 MiB will reject batches that some deployment considers legitimate.

## Verification

The limit's two weak points were found by deliberately breaking the new code rather than by reading it. `rpc::server` estimates rather than sums, because its responses are still structured when the limit applies, and the estimate omitted the echoed `id` — 400 elements carrying a 256 KB id each returned **100 MB against a 1 MiB limit**, with the undercount growing without ceiling. Separately, moving the check after the loop built the whole oversized response first and still passed every assertion. Both are now covered; a zeroed envelope constant and `>` vs `>=` remain uncaught, both by design. Escaping is not modelled, so the limit bounds the written response within a small constant factor rather than exactly.

The new tests were checked against the bug rather than merely alongside the fix: compiled *unmodified against `main`'s headers*, they fail 4 registry tests, 1 ext-server test, and all 5 converter rejection tests (30 asserts). Every new assertion that can run against the old code does fail there, including the one bounding **response size against request size**.

`jsonrpc_registry_test` 31/31 (100 asserts), `jsonrpc_test` 30/30 (188 asserts), `repe_to_jsonrpc_test` 42/42 (127 asserts). Full suite 117/117. Beyond it, 6,447 generated inputs — adversarial envelopes, truncations at every byte of both optionals, 253/254/255/300-byte method names, escaped and control-character methods and ids, duplicate keys, and mutations of the testcase — run clean through the ASAN+UBSan driver. Apple clang ships no libFuzzer runtime, so a real campaign has to come from OSS-Fuzz.
