### PR TITLE
feat(json): support std::chrono::utc_clock time points (#2657)

### DIFF
--- a/include/glaze/core/chrono.hpp
+++ b/include/glaze/core/chrono.hpp
@@ -35,6 +35,13 @@ namespace glz
    concept is_system_time_point =
       is_time_point<T> && std::is_same_v<typename std::remove_cvref_t<T>::clock, std::chrono::system_clock>;
 
+#if defined(__cpp_lib_chrono) && __cpp_lib_chrono >= 201907L
+   // Concept for utc_clock time_points (serialize as ISO 8601 string via clock_cast)
+   template <class T>
+   concept is_utc_time_point =
+      is_time_point<T> && std::is_same_v<typename std::remove_cvref_t<T>::clock, std::chrono::utc_clock>;
+#endif
+
    // Concept for steady_clock time_points (serialize as numeric count)
    template <class T>
    concept is_steady_time_point =

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -5209,6 +5209,29 @@ namespace glz
       }
    };
 
+#if defined(__cpp_lib_chrono) && __cpp_lib_chrono >= 201907L
+   // utc_clock::time_point: parse from ISO 8601 string via clock_cast from sys_time.
+   template <is_utc_time_point T>
+      requires(not custom_read<T>)
+   struct from<JSON, T>
+   {
+      template <auto Opts, class It0, class It1>
+      static void op(auto&& value, is_context auto&& ctx, It0&& it, It1 end) noexcept
+      {
+         std::string_view str;
+         parse_transient_string_view<Opts>(str, ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+
+         std::chrono::system_clock::time_point sys{};
+         chrono_detail::parse_iso8601(str, sys, ctx.error);
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+         value = std::chrono::clock_cast<std::chrono::utc_clock>(sys);
+      }
+   };
+#endif
+
    // year_month_day: parse from "YYYY-MM-DD" JSON string
    template <is_year_month_day T>
       requires(not custom_read<T>)

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -2594,6 +2594,25 @@ namespace glz
       }
    };
 
+#if defined(__cpp_lib_chrono) && __cpp_lib_chrono >= 201907L
+   // utc_clock::time_point: serialize as ISO 8601 string (UTC), same wire form as sys_time.
+   template <is_utc_time_point T>
+      requires(not custom_write<T>)
+   struct to<JSON, T>
+   {
+      template <auto Opts, class B>
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix) noexcept
+      {
+         using Period = typename std::remove_cvref_t<T>::duration::period;
+         if (!ensure_space(ctx, b, ix + chrono_detail::iso_time_point_max_size<Period>)) [[unlikely]] {
+            return;
+         }
+         const auto sys = std::chrono::clock_cast<std::chrono::system_clock>(value);
+         chrono_detail::write_iso_time_point<not check_unquoted(Opts)>(sys, ctx, b, ix);
+      }
+   };
+#endif
+
    // year_month_day: serialize as "YYYY-MM-DD" JSON string
    template <is_year_month_day T>
       requires(not custom_write<T>)

--- a/tests/chrono_test/chrono_test.cpp
+++ b/tests/chrono_test/chrono_test.cpp
@@ -1748,4 +1748,18 @@ suite date_format_tests = [] {
    };
 };
 
+#if defined(__cpp_lib_chrono) && __cpp_lib_chrono >= 201907L
+suite utc_clock_json_tests = [] {
+   "utc_time_json_roundtrip"_test = [] {
+      const std::chrono::utc_time<std::chrono::seconds> t{
+         std::chrono::floor<std::chrono::seconds>(std::chrono::utc_clock::now())};
+      const auto json = glz::write_json(t);
+      expect(bool(json));
+      std::chrono::utc_time<std::chrono::seconds> parsed{};
+      expect(!glz::read_json(parsed, json.value()));
+      expect(parsed == t);
+   };
+};
+#endif
+
 int main() { return 0; }


### PR DESCRIPTION
## Summary

Adds JSON serialization support for `std::chrono::utc_clock` time points (`utc_time`), addressing #2657.

UTC timestamps use the same ISO 8601 wire format as `system_clock` time points, converting via `std::chrono::clock_cast` on read and write.

Fixes #2657

## Test plan

- [x] `tests/chrono_test/chrono_test.cpp`: `utc_time_json_roundtrip` (C++20 `__cpp_lib_chrono`)
