### PR TITLE
feat(eigen): meta::name for Transform and Array (#2765)

### DIFF
--- a/include/glaze/ext/eigen.hpp
+++ b/include/glaze/ext/eigen.hpp
@@ -378,10 +378,32 @@ struct glz::meta<Eigen::Matrix<Scalar, Rows, Cols>>
                                                    chars<">">>;
 };
 
+template <class Scalar, int Rows, int Cols>
+struct glz::meta<Eigen::Array<Scalar, Rows, Cols>>
+{
+   static constexpr std::string_view name = join_v<chars<"Eigen::Array<">, name_v<Scalar>, chars<",">, //
+                                                   chars<num_to_string<Rows>::value>, chars<",">, //
+                                                   chars<num_to_string<Cols>::value>, chars<",">, //
+                                                   chars<">">>;
+};
+
+template <class Scalar, int Dim, int Mode>
+struct glz::meta<Eigen::Transform<Scalar, Dim, Mode>>
+{
+   static constexpr std::string_view name = join_v<chars<"Eigen::Transform<">, name_v<Scalar>, chars<",">, //
+                                                   chars<num_to_string<Dim>::value>, chars<",">, //
+                                                   chars<num_to_string<Mode>::value>, chars<",">, //
+                                                   chars<">">>;
+};
+
 // Register Eigen types as having specified Glaze serialization
 // This prevents P2996 automatic reflection from creating ambiguous specializations
 template <typename Scalar, int Rows, int Cols, int Options, int MaxRows, int MaxCols>
 struct glz::specified<Eigen::Matrix<Scalar, Rows, Cols, Options, MaxRows, MaxCols>> : std::true_type
+{};
+
+template <typename Scalar, int Rows, int Cols, int Options, int MaxRows, int MaxCols>
+struct glz::specified<Eigen::Array<Scalar, Rows, Cols, Options, MaxRows, MaxCols>> : std::true_type
 {};
 
 template <typename Scalar, int Dim, int Mode>

--- a/tests/eigen_test/eigen_test.cpp
+++ b/tests/eigen_test/eigen_test.cpp
@@ -420,6 +420,14 @@ int main()
       expect(c1.matrix() == c2.matrix());
    };
 
+   "Eigen meta names"_test = [] {
+      static_assert(glz::name_v<Eigen::Matrix3d>.starts_with("Eigen::Matrix<"));
+      static_assert(glz::name_v<Eigen::Array<float, 2, 3>>.starts_with("Eigen::Array<"));
+      static_assert(glz::name_v<Eigen::Isometry3d>.starts_with("Eigen::Transform<"));
+      static_assert(glz::name_v<Eigen::AffineCompact2d>.starts_with("Eigen::Transform<"));
+      expect(glz::name_v<Eigen::Isometry3d> != glz::name_v<Eigen::AffineCompact2d>);
+   };
+
    "const Matrix4d JSON"_test = [] {
       const Eigen::Matrix4d m = Eigen::Matrix4d::Identity();
       std::string json;


### PR DESCRIPTION
## Summary
Adds `glz::meta::name` (and related naming) for `Eigen::Transform` / `Eigen::Array` so schema/reflection can name these types (#2765).

## Test plan
- [ ] eigen_test covers Transform/Array name meta
- [ ] Existing Eigen glaze tests still pass

Closes #2765
