### PR TITLE
bound dynamic eigen matrix reads to the matrix storage

### DIFF
--- a/include/glaze/ext/eigen.hpp
+++ b/include/glaze/ext/eigen.hpp
@@ -24,6 +24,44 @@ static_assert(false, "Eigen must be included to use glaze/ext/eigen.hpp");
 
 namespace glz
 {
+   namespace eigen_detail
+   {
+      // Validates the [rows, cols] header of a dynamic matrix against what the matrix can
+      // actually store, before it is handed to resize().
+      //
+      // A negative extent is not a dimension, and Eigen's resize() has no defined behavior for
+      // one. Worse, two negatives multiply back to a positive size(), so a header like [-2, -3]
+      // would otherwise produce a 6-element data span over a matrix that holds nothing.
+      //
+      // A dynamic matrix with a fixed maximum (Matrix<T, -1, -1, 0, MaxRows, MaxCols>) carries
+      // MaxRows * MaxCols scalars of inline storage, and its resize() only records the new
+      // extents in that fixed buffer -- it cannot grow. size() therefore reports the wire
+      // product rather than the capacity, so nothing downstream would catch a header that
+      // exceeds the buffer. Reject it here, mirroring the fixed-extent check in from<CBOR, T>.
+      template <class T>
+      [[nodiscard]] GLZ_ALWAYS_INLINE bool invalid_extents(const std::array<Eigen::Index, 2>& extents,
+                                                           is_context auto& ctx) noexcept
+      {
+         if (extents[0] < 0 || extents[1] < 0) [[unlikely]] {
+            ctx.error = error_code::syntax_error;
+            return true;
+         }
+         if constexpr (T::MaxRowsAtCompileTime >= 0) {
+            if (extents[0] > T::MaxRowsAtCompileTime) [[unlikely]] {
+               ctx.error = error_code::exceeded_static_array_size;
+               return true;
+            }
+         }
+         if constexpr (T::MaxColsAtCompileTime >= 0) {
+            if (extents[1] > T::MaxColsAtCompileTime) [[unlikely]] {
+               ctx.error = error_code::exceeded_static_array_size;
+               return true;
+            }
+         }
+         return false;
+      }
+   }
+
    template <matrix_t T>
       requires(T::RowsAtCompileTime >= 0 && T::ColsAtCompileTime >= 0)
    struct from<BEVE, T>
@@ -73,10 +111,13 @@ namespace glz
          if (bool(ctx.error)) [[unlikely]] {
             return;
          }
+         if (eigen_detail::invalid_extents<T>(extents, ctx)) [[unlikely]] {
+            return;
+         }
 
          value.resize(extents[0], extents[1]);
-         // Size the data span from the matrix's own storage, not the wire
-         // dimensions, matching from<CBOR, T>.
+         // The extents were validated against the matrix's storage above, so size the data
+         // span from size() rather than the wire product, matching from<CBOR, T>.
          std::span<typename T::Scalar> view(value.data(), static_cast<size_t>(value.size()));
          parse<BEVE>::op<Opts>(view, ctx, it, end);
       }
@@ -334,6 +375,9 @@ namespace glz
          if (bool(ctx.error)) [[unlikely]] {
             return;
          }
+         if (eigen_detail::invalid_extents<T>(extents, ctx)) [[unlikely]] {
+            return;
+         }
          value.resize(extents[0], extents[1]);
          if constexpr (not Opts.null_terminated) {
             if (it == end) [[unlikely]] {
@@ -350,8 +394,8 @@ namespace glz
                   return;
                }
             }
-            // Size the data span from the matrix's own storage, not the wire
-            // dimensions, matching from<CBOR, T>.
+            // The extents were validated against the matrix's storage above, so size the data
+            // span from size() rather than the wire product, matching from<CBOR, T>.
             std::span<typename T::Scalar> view(value.data(), static_cast<size_t>(value.size()));
             parse<JSON>::op<Opts>(view, ctx, it, end);
             if (bool(ctx.error)) [[unlikely]] {

--- a/include/glaze/ext/eigen.hpp
+++ b/include/glaze/ext/eigen.hpp
@@ -68,11 +68,16 @@ namespace glz
             return;
          }
          ++it;
-         std::array<Eigen::Index, 2> extents;
+         std::array<Eigen::Index, 2> extents{};
          parse<BEVE>::op<Opts>(extents, ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
 
          value.resize(extents[0], extents[1]);
-         std::span<typename T::Scalar> view(value.data(), extents[0] * extents[1]);
+         // Size the data span from the matrix's own storage, not the wire
+         // dimensions, matching from<CBOR, T>.
+         std::span<typename T::Scalar> view(value.data(), static_cast<size_t>(value.size()));
          parse<BEVE>::op<Opts>(view, ctx, it, end);
       }
    };
@@ -324,9 +329,18 @@ namespace glz
          if (match_invalid_end<'[', Opts>(ctx, it, end)) {
             return;
          }
-         std::array<Eigen::Index, 2> extents; // NOLINT
+         std::array<Eigen::Index, 2> extents{};
          parse<JSON>::op<Opts>(extents, ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
          value.resize(extents[0], extents[1]);
+         if constexpr (not Opts.null_terminated) {
+            if (it == end) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+         }
          if (*it == ',') {
             // we have data
             ++it;
@@ -336,8 +350,19 @@ namespace glz
                   return;
                }
             }
-            std::span<typename T::Scalar> view(value.data(), extents[0] * extents[1]);
+            // Size the data span from the matrix's own storage, not the wire
+            // dimensions, matching from<CBOR, T>.
+            std::span<typename T::Scalar> view(value.data(), static_cast<size_t>(value.size()));
             parse<JSON>::op<Opts>(view, ctx, it, end);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+            if constexpr (not Opts.null_terminated) {
+               if (it == end) [[unlikely]] {
+                  ctx.error = error_code::unexpected_end;
+                  return;
+               }
+            }
          }
          match<']'>(ctx, it);
       }

--- a/tests/eigen_test/eigen_test.cpp
+++ b/tests/eigen_test/eigen_test.cpp
@@ -661,4 +661,40 @@ int main()
       expect(bool(glz::read_cbor(e, b)));
       expect(e == (Eigen::Matrix<double, 2, 2>::Zero()));
    };
+
+   // A dynamic matrix read from JSON that ends right after the [rows,cols] header
+   // used to read one byte past a non-null-terminated buffer while probing for the
+   // ',' that introduces the data. Over an exact-size view it must error, not read
+   // past the end.
+   "json dynamic matrix truncated after dimensions"_test = [] {
+      std::vector<char> storage{'[', '[', '2', ',', '3', ']'};
+      std::string_view src{storage.data(), storage.size()};
+      Eigen::MatrixXd m;
+      const auto ec = glz::read<glz::opts{.format = glz::JSON, .null_terminated = false}>(m, src);
+      expect(bool(ec));
+   };
+
+   "json dynamic matrix non null terminated roundtrip"_test = [] {
+      std::vector<char> storage{'[', '[', '1', ',', '1', ']', ',', '[', '7', ']', ']'};
+      std::string_view src{storage.data(), storage.size()};
+      Eigen::MatrixXd m;
+      expect(not glz::read<glz::opts{.format = glz::JSON, .null_terminated = false}>(m, src));
+      expect(m.rows() == 1);
+      expect(m.cols() == 1);
+      expect(m(0, 0) == 7);
+   };
+
+   // A dynamic matrix read from BEVE whose dimension header is truncated left the
+   // extents uninitialized and resized the matrix to those bytes. It must error.
+   "beve dynamic matrix truncated header"_test = [] {
+      Eigen::MatrixXd m(2, 2);
+      m << 1, 2, 3, 4;
+      std::string b;
+      expect(not glz::write_beve(m, b));
+
+      std::vector<char> storage{b.begin(), b.begin() + 2};
+      std::string_view src{storage.data(), storage.size()};
+      Eigen::MatrixXd e;
+      expect(bool(glz::read<glz::opts{.format = glz::BEVE, .null_terminated = false}>(e, src)));
+   };
 }

--- a/tests/eigen_test/eigen_test.cpp
+++ b/tests/eigen_test/eigen_test.cpp
@@ -697,4 +697,58 @@ int main()
       Eigen::MatrixXd e;
       expect(bool(glz::read<glz::opts{.format = glz::BEVE, .null_terminated = false}>(e, src)));
    };
+
+   // The data array can be well formed and the buffer still end before the ']' that closes
+   // the matrix. Matching it used to dereference the end of a non-null-terminated buffer.
+   "json dynamic matrix truncated after data"_test = [] {
+      std::vector<char> storage{'[', '[', '1', ',', '1', ']', ',', '[', '7', ']'};
+      std::string_view src{storage.data(), storage.size()};
+      Eigen::MatrixXd m;
+      const auto ec = glz::read<glz::opts{.format = glz::JSON, .null_terminated = false}>(m, src);
+      expect(bool(ec));
+   };
+
+   // A dynamic matrix with a fixed maximum holds MaxRows * MaxCols scalars inline, and its
+   // resize() only records the new extents in that fixed buffer rather than growing it. So
+   // size() reports the wire product rather than the capacity, and wire dimensions beyond the
+   // maximum have to be rejected before the resize or the data read runs past the storage.
+   // Eigen only asserts on the oversized resize when EIGEN_NO_DEBUG is off, so a release build
+   // would otherwise take the overflow silently.
+   "dynamic matrix exceeding fixed maximum storage"_test = [] {
+      using bounded_t = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, 2, 2>;
+
+      bounded_t m;
+      expect(glz::read_json(m, R"([[4,4],[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]])").ec ==
+             glz::error_code::exceeded_static_array_size);
+
+      // The same header over BEVE, produced by writing a matrix too large to fit.
+      Eigen::MatrixXd oversized(4, 4);
+      oversized.setZero();
+      std::string b;
+      expect(not glz::write_beve(oversized, b));
+      bounded_t from_beve;
+      expect(glz::read_beve(from_beve, b).ec == glz::error_code::exceeded_static_array_size);
+
+      // Dimensions within the maximum still read normally.
+      bounded_t ok;
+      expect(not glz::read_json(ok, R"([[2,2],[1,2,3,4]])"));
+      expect(ok.rows() == 2);
+      expect(ok.cols() == 2);
+      expect(ok(1, 1) == 4);
+
+      Eigen::MatrixXd fits(2, 2);
+      fits << 1, 2, 3, 4;
+      std::string fits_beve;
+      expect(not glz::write_beve(fits, fits_beve));
+      bounded_t ok_beve;
+      expect(not glz::read_beve(ok_beve, fits_beve));
+      expect(ok_beve == fits);
+   };
+
+   // Two negative extents multiply back to a positive size(), so a negative header would
+   // otherwise produce a data span over a matrix that holds nothing.
+   "json dynamic matrix negative dimensions"_test = [] {
+      Eigen::MatrixXd m;
+      expect(glz::read_json(m, R"([[-2,-3],[1,2,3,4,5,6]])").ec == glz::error_code::syntax_error);
+   };
 }


### PR DESCRIPTION
The dynamic Eigen matrix readers for JSON and BEVE take the [rows,cols] header off the wire and never check it against the buffer or the matrix's own storage. The JSON reader parses the extents array and then reads `*it` to look for the ',' that precedes the data without confirming it is still inside the buffer, so a non-null-terminated input that ends right after the header (for example the six bytes `[[2,3]` read with null_terminated off) reads one byte past the end. Both readers also size the data span from `extents[0] * extents[1]` instead of the count the matrix actually holds, which is equal only for a plain dynamic matrix and diverges for a fixed-max-storage one.

Fix checks the parse error before resizing, guards the post-header dereference against the end on non-null-terminated reads, and sizes the span from `value.size()`, the shape `from<CBOR, T>` already uses one specialization over. Well-formed input behaves the same, since `value.size()` equals the wire product after a successful resize; the tradeoff is a couple of branches on the read path that were previously skipped. Confirmed under AddressSanitizer (heap-buffer-overflow at eigen.hpp:330 before, clean after) with a regression test added to eigen_test.