### PR TITLE
fix(net): avoid duplicate Host/Connection when caller supplies them (#2777)

### DIFF
--- a/include/glaze/net/http_client.hpp
+++ b/include/glaze/net/http_client.hpp
@@ -268,23 +268,43 @@ namespace glz
       {
          const bool is_default_port = (!use_https && url.port == 80) || (use_https && url.port == 443);
 
+         // Prefer a single Host / Connection on the wire. If the caller already
+         // supplied either, skip our defaults so we do not emit duplicates (#2777).
+         bool caller_has_host = false;
+         bool caller_has_connection = false;
+         for (const auto& [name, value] : headers) {
+            if (header_field_has_crlf(name, value)) [[unlikely]] {
+               continue;
+            }
+            if (glz::striequal(name, "host")) {
+               caller_has_host = true;
+            }
+            else if (glz::striequal(name, "connection")) {
+               caller_has_connection = true;
+            }
+         }
+
          std::string request_str;
          request_str.reserve(512 + body.size());
          request_str.append(method);
          request_str.append(" ");
          request_str.append(url.path);
          request_str.append(" HTTP/1.1\r\n");
-         request_str.append("Host: ");
-         request_str.append(url.host);
-         if (!is_default_port) {
-            char
-               port_buf[8]; // a uint16_t port is at most 5 digits; pad so the sizing does not depend on itoa internals
-            auto* end = glz::to_chars(port_buf, url.port);
-            request_str.push_back(':');
-            request_str.append(port_buf, static_cast<size_t>(end - port_buf));
+         if (!caller_has_host) {
+            request_str.append("Host: ");
+            request_str.append(url.host);
+            if (!is_default_port) {
+               char
+                  port_buf[8]; // a uint16_t port is at most 5 digits; pad so the sizing does not depend on itoa internals
+               auto* end = glz::to_chars(port_buf, url.port);
+               request_str.push_back(':');
+               request_str.append(port_buf, static_cast<size_t>(end - port_buf));
+            }
+            request_str.append("\r\n");
          }
-         request_str.append("\r\n");
-         request_str.append("Connection: keep-alive\r\n");
+         if (!caller_has_connection) {
+            request_str.append("Connection: keep-alive\r\n");
+         }
          // RFC 9110 8.6: a user agent SHOULD send Content-Length when the method
          // anticipates content, even for an empty body - origin servers and proxies
          // commonly answer a bodyless POST with 411 Length Required. Since a caller's

--- a/tests/networking_tests/http_response_splitting_test/http_response_splitting_test.cpp
+++ b/tests/networking_tests/http_response_splitting_test/http_response_splitting_test.cpp
@@ -213,6 +213,44 @@ suite client_request_serializer_crlf = [] {
             << method << " with no body must not carry a Content-Length";
       }
    };
+
+   // Caller-supplied Host / Connection must replace the writer's defaults (#2777),
+   // not ride alongside them as a second field on the wire.
+   "build_http_request_bytes prefers caller Host and Connection"_test = [] {
+      glz::url_parts url;
+      url.protocol = "http";
+      url.host = "example.com";
+      url.port = 80;
+      url.path = "/";
+
+      const glz::http_headers headers{
+         {"Host", "custom.example"},
+         {"Connection", "close"},
+         {"X-Safe", "kept"},
+      };
+
+      const std::string request = glz::detail::build_http_request_bytes("GET", url, false, "", headers);
+
+      expect(request.find("Host: custom.example\r\n") != std::string::npos) << "Caller Host must be written";
+      expect(request.find("Host: example.com") == std::string::npos) << "Default Host must not also be written";
+      expect(request.find("Connection: close\r\n") != std::string::npos) << "Caller Connection must be written";
+      expect(request.find("Connection: keep-alive") == std::string::npos)
+         << "Default Connection must not also be written";
+      expect(request.find("X-Safe: kept") != std::string::npos);
+
+      size_t host_count = 0;
+      for (size_t at = request.find("Host:"); at != std::string::npos; at = request.find("Host:", at + 1)) {
+         ++host_count;
+      }
+      expect(host_count == 1) << "Exactly one Host must be written, found " << host_count;
+
+      size_t conn_count = 0;
+      for (size_t at = request.find("Connection:"); at != std::string::npos;
+           at = request.find("Connection:", at + 1)) {
+         ++conn_count;
+      }
+      expect(conn_count == 1) << "Exactly one Connection must be written, found " << conn_count;
+   };
 };
 
 suite http_response_splitting_suite = [] {


### PR DESCRIPTION
﻿## Summary
Avoids duplicate `Host` and `Connection` headers when the caller supplies them (#2777).

`build_http_request_bytes` previously always wrote default `Host` / `Connection: keep-alive`, then appended caller headers. Callers that set either field ended up with two on the wire.

## Change
- Detect caller `Host` / `Connection` (case-insensitive, ignoring CRLF-rejected fields)
- Emit writer defaults only when absent
- Caller values are written once in the header loop (body framing still owned by the writer)

## Test
Adds `build_http_request_bytes prefers caller Host and Connection` to `http_response_splitting_test`.

Closes #2777
