### PR TITLE
fix(net): write exactly one Host and Connection in client requests

### DIFF
--- a/include/glaze/net/http_client.hpp
+++ b/include/glaze/net/http_client.hpp
@@ -205,23 +205,65 @@ namespace glz
       {
          const bool is_default_port = (!use_https && url.port == 80) || (use_https && url.port == 443);
 
+         // This builder owns the single Host and Connection field on the wire, the
+         // same way it owns the body framing below. A caller's value replaces the
+         // writer's default instead of riding alongside it, and only the first
+         // usable one is kept: RFC 9112 3.2 admits exactly one Host, and a second
+         // one lets an intermediary and the origin resolve the same request to
+         // different authorities (request smuggling) - glaze's own server answers a
+         // repeat with 400. Connection is likewise reduced to one field, since a
+         // "close" and a "keep-alive" on the same message leave each hop to pick a
+         // different connection lifetime. glz::http_headers keeps repeats, so a
+         // single lookup would not have caught the second one.
+         //
+         // A field carrying CR or LF is not usable, because the loop below drops it
+         // rather than write a split message. Taking one here would suppress the
+         // writer's default and send an HTTP/1.1 request with no Host at all.
+         const std::string* caller_host = nullptr;
+         const std::string* caller_connection = nullptr;
+         for (const auto& [name, value] : headers) {
+            if (header_field_has_crlf(name, value)) [[unlikely]] {
+               continue;
+            }
+            if (glz::striequal(name, "host")) {
+               if (!caller_host) {
+                  caller_host = &value;
+               }
+            }
+            else if (glz::striequal(name, "connection")) {
+               if (!caller_connection) {
+                  caller_connection = &value;
+               }
+            }
+         }
+
          std::string request_str;
          request_str.reserve(512 + body.size());
          request_str.append(method);
          request_str.append(" ");
          request_str.append(url.path);
          request_str.append(" HTTP/1.1\r\n");
+         // RFC 9112 5: a user agent SHOULD generate Host as the first field after
+         // the request-line, so a caller's value is written in this slot rather
+         // than wherever it happened to sit among their headers.
          request_str.append("Host: ");
-         request_str.append(url.host);
-         if (!is_default_port) {
-            char
-               port_buf[8]; // a uint16_t port is at most 5 digits; pad so the sizing does not depend on itoa internals
-            auto* end = glz::to_chars(port_buf, url.port);
-            request_str.push_back(':');
-            request_str.append(port_buf, static_cast<size_t>(end - port_buf));
+         if (caller_host) {
+            request_str.append(*caller_host);
+         }
+         else {
+            request_str.append(url.host);
+            if (!is_default_port) {
+               // A uint16_t port is at most 5 digits; pad so the sizing does not depend on itoa internals
+               char port_buf[8];
+               auto* end = glz::to_chars(port_buf, url.port);
+               request_str.push_back(':');
+               request_str.append(port_buf, static_cast<size_t>(end - port_buf));
+            }
          }
          request_str.append("\r\n");
-         request_str.append("Connection: keep-alive\r\n");
+         request_str.append("Connection: ");
+         request_str.append(caller_connection ? std::string_view{*caller_connection} : "keep-alive");
+         request_str.append("\r\n");
          // RFC 9110 8.6: a user agent SHOULD send Content-Length when the method
          // anticipates content, even for an empty body - origin servers and proxies
          // commonly answer a bodyless POST with 411 Length Required. Since a caller's
@@ -249,6 +291,12 @@ namespace glz
             // (RFC 9112 6.3, request smuggling). glz::http_headers keeps
             // repeats, so a single lookup would not have caught the second one.
             if (header_field_frames_body(name)) [[unlikely]] {
+               continue;
+            }
+            // Host and Connection were resolved above and written once; whatever
+            // the caller supplied is already on the wire (or was rejected there),
+            // so every field of either name is skipped here.
+            if (glz::striequal(name, "host") || glz::striequal(name, "connection")) {
                continue;
             }
             request_str.append(name);

--- a/tests/networking_tests/http_response_splitting_test/http_response_splitting_test.cpp
+++ b/tests/networking_tests/http_response_splitting_test/http_response_splitting_test.cpp
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <future>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <ut/ut.hpp>
 
@@ -75,6 +76,29 @@ namespace
          return f.get();
       }
       return "TIMEOUT";
+   }
+
+   // Counts whole field lines rather than substrings: a plain find("Host:") would
+   // also count an "X-Forwarded-Host:" that a later test happens to add.
+   size_t count_header_fields(std::string_view message, std::string_view name)
+   {
+      const std::string field_start = "\r\n" + std::string{name} + ": ";
+      size_t count = 0;
+      for (size_t at = message.find(field_start); at != std::string_view::npos;
+           at = message.find(field_start, at + 1)) {
+         ++count;
+      }
+      return count;
+   }
+
+   glz::url_parts test_url()
+   {
+      glz::url_parts url;
+      url.protocol = "http";
+      url.host = "example.com";
+      url.port = 80;
+      url.path = "/";
+      return url;
    }
 
 } // namespace
@@ -212,6 +236,150 @@ suite client_request_serializer_crlf = [] {
          expect(request.find("Content-Length") == std::string::npos)
             << method << " with no body must not carry a Content-Length";
       }
+   };
+
+   // The writer owns one Host and one Connection field. A caller who supplies
+   // either replaces the writer's default rather than adding a second field to
+   // the wire.
+   "build_http_request_bytes prefers caller Host and Connection"_test = [] {
+      const glz::url_parts url = test_url();
+
+      const glz::http_headers headers{
+         {"Host", "custom.example"},
+         {"Connection", "close"},
+         {"X-Safe", "kept"},
+      };
+
+      const std::string request = glz::detail::build_http_request_bytes("GET", url, false, "", headers);
+
+      expect(count_header_fields(request, "Host") == 1) << "Exactly one Host must reach the wire";
+      expect(count_header_fields(request, "Connection") == 1) << "Exactly one Connection must reach the wire";
+      expect(request.find("Host: custom.example\r\n") != std::string::npos) << "The caller's Host must be written";
+      expect(request.find("example.com") == std::string::npos) << "The derived Host must not also be written";
+      expect(request.find("Connection: close\r\n") != std::string::npos) << "The caller's Connection must be written";
+      expect(request.find("keep-alive") == std::string::npos) << "The default Connection must not also be written";
+      expect(request.find("X-Safe: kept") != std::string::npos) << "Unrelated headers must still be written";
+   };
+
+   // Field names are case-insensitive (RFC 9110 5.1), so a lowercase caller field
+   // has to suppress the default just as an exactly-cased one does.
+   "build_http_request_bytes matches caller Host and Connection case-insensitively"_test = [] {
+      const glz::url_parts url = test_url();
+
+      const glz::http_headers headers{
+         {"host", "custom.example"},
+         {"CONNECTION", "close"},
+      };
+
+      const std::string request = glz::detail::build_http_request_bytes("GET", url, false, "", headers);
+
+      expect(count_header_fields(request, "Host") == 1);
+      expect(count_header_fields(request, "Connection") == 1);
+      expect(request.find("example.com") == std::string::npos) << "The derived Host must be suppressed";
+      expect(request.find("keep-alive") == std::string::npos) << "The default Connection must be suppressed";
+   };
+
+   // RFC 9112 3.2 admits exactly one Host. glz::http_headers keeps repeats, so a
+   // caller can express two - and two authorities on one request let an
+   // intermediary and the origin resolve it differently (request smuggling).
+   // glaze's own server answers a repeated Host with 400, so the writer must not
+   // be able to generate one.
+   "build_http_request_bytes writes one Host when the caller repeats it"_test = [] {
+      const glz::url_parts url = test_url();
+
+      const glz::http_headers headers{
+         {"Host", "first.example"},
+         {"Host", "second.example"},
+      };
+
+      const std::string request = glz::detail::build_http_request_bytes("GET", url, false, "", headers);
+
+      expect(count_header_fields(request, "Host") == 1) << "A repeated caller Host must not reach the wire twice";
+      expect(request.find("Host: first.example\r\n") != std::string::npos) << "The first caller Host is the one kept";
+      expect(request.find("second.example") == std::string::npos) << "The repeat must be dropped";
+   };
+
+   // A "close" and a "keep-alive" on one message leave each hop free to pick a
+   // different connection lifetime, so Connection is reduced to a single field
+   // the same way Host is.
+   "build_http_request_bytes writes one Connection when the caller repeats it"_test = [] {
+      const glz::url_parts url = test_url();
+
+      const glz::http_headers headers{
+         {"Connection", "close"},
+         {"Connection", "keep-alive"},
+      };
+
+      const std::string request = glz::detail::build_http_request_bytes("GET", url, false, "", headers);
+
+      expect(count_header_fields(request, "Connection") == 1)
+         << "A repeated caller Connection must not reach the wire twice";
+      expect(request.find("Connection: close\r\n") != std::string::npos)
+         << "The first caller Connection is the one kept";
+      expect(request.find("keep-alive") == std::string::npos) << "The contradicting repeat must be dropped";
+   };
+
+   // The CRLF guard drops a caller field carrying CR or LF, so such a field must
+   // not count as having supplied a Host either: suppressing the derived one
+   // would put an HTTP/1.1 request with no Host at all on the wire (RFC 9112 3.2),
+   // which glaze's own server answers with 400.
+   "build_http_request_bytes keeps its Host when the caller's carries CRLF"_test = [] {
+      const glz::url_parts url = test_url();
+
+      const glz::http_headers headers{
+         {"Host", "evil.example\r\nX-Injected: 1"},
+         {"Connection", "close\r\nX-Injected: 2"},
+      };
+
+      const std::string request = glz::detail::build_http_request_bytes("GET", url, false, "", headers);
+
+      expect(request.find("X-Injected") == std::string::npos) << "A CRLF-bearing field must be dropped";
+      expect(count_header_fields(request, "Host") == 1) << "The request must still carry exactly one Host";
+      expect(request.find("Host: example.com\r\n") != std::string::npos) << "The derived Host must survive";
+      expect(count_header_fields(request, "Connection") == 1) << "The request must still carry one Connection";
+      expect(request.find("Connection: keep-alive\r\n") != std::string::npos)
+         << "The default Connection must survive";
+   };
+
+   // RFC 9112 5: a user agent SHOULD generate Host as the first field after the
+   // request-line. That holds whether the value is derived or caller-supplied,
+   // so a caller's Host is written in the Host slot rather than wherever it sat
+   // among their headers.
+   "build_http_request_bytes writes Host first"_test = [] {
+      const glz::url_parts url = test_url();
+
+      const glz::http_headers headers{
+         {"X-First", "1"},
+         {"Host", "custom.example"},
+      };
+
+      const std::string derived = glz::detail::build_http_request_bytes("GET", url, false, "", {});
+      expect(derived.starts_with("GET / HTTP/1.1\r\nHost: example.com\r\n")) << "A derived Host leads the field block";
+
+      const std::string overridden = glz::detail::build_http_request_bytes("POST", url, false, "B", headers);
+      expect(overridden.starts_with("POST / HTTP/1.1\r\nHost: custom.example\r\n"))
+         << "A caller Host leads the field block too";
+      expect(overridden.find("X-First: 1") != std::string::npos) << "The caller's other headers must still be written";
+   };
+
+   // The derived Host still carries the port whenever it is not the scheme
+   // default, and only then.
+   "build_http_request_bytes derives Host from the url when the caller supplies none"_test = [] {
+      glz::url_parts url = test_url();
+      url.port = 8080;
+
+      const std::string request = glz::detail::build_http_request_bytes("GET", url, false, "", {});
+      expect(request.find("Host: example.com:8080\r\n") != std::string::npos)
+         << "A non-default port belongs in the Host";
+
+      url.port = 80;
+      const std::string default_port = glz::detail::build_http_request_bytes("GET", url, false, "", {});
+      expect(default_port.find("Host: example.com\r\n") != std::string::npos)
+         << "The scheme's default port is omitted";
+
+      url.port = 443;
+      const std::string https = glz::detail::build_http_request_bytes("GET", url, true, "", {});
+      expect(https.find("Host: example.com\r\n") != std::string::npos) << "443 is the default port for https";
    };
 };
 


### PR DESCRIPTION
Fixes #2777. Supersedes #2778 (@annihilatorq) and #2804 (@alisonpetersonhq), both of which landed on the same core fix first; this PR builds on their approach and closes the remaining gaps. Both are credited as co-authors on the commit.

## The bug

`build_http_request_bytes` wrote its own `Host` and `Connection: keep-alive` unconditionally and then appended the caller's headers, so a caller who set either got two fields on the wire.

## The change

The writer now owns a single field of each name, the same way it already owns the body framing. It resolves the caller's first usable value up front, writes it in the `Host` slot, and skips every `Host` and `Connection` field in the header loop.

That structure closes four things at once:

| | before | after |
|---|---|---|
| caller sets `Host` | two `Host` fields | caller's value, written once |
| caller repeats `Host` | two `Host` fields | first value only |
| caller `Host` carries CRLF | field dropped, derived `Host` also written | derived `Host` kept |
| caller `Host` set | written mid-block | written first after the request-line |

Details:

- **A caller's repeat is dropped.** RFC 9112 3.2 admits exactly one `Host`, and glaze's own server answers a repeat with 400 (`http_server.hpp`). Two authorities on one request let an intermediary and the origin resolve it differently. `Connection` is reduced the same way, since a `close` and a `keep-alive` on one message let each hop pick a different connection lifetime. `glz::http_headers` keeps repeats, so both are expressible in a single call.
- **A CRLF-bearing caller field does not count as having supplied one.** The header loop drops such a field rather than write a split message, so treating it as the caller's `Host` would suppress the derived one and put an HTTP/1.1 request with *no* `Host` at all on the wire.
- **`Host` stays first** after the request-line (RFC 9112 5) whether its value is derived or caller-supplied.

## Tests

Seven cases added to `http_response_splitting_test`, where the other `build_http_request_bytes` unit tests already live: caller override, case-insensitive matching, repeated `Host`, repeated `Connection`, CRLF-bearing `Host`/`Connection`, `Host`-first ordering, and derived-`Host` port handling (non-default, 80, 443). Field counting matches whole field lines rather than substrings, so an `X-Forwarded-Host:` added later cannot silently satisfy a `Host` assertion.

Locally: all 22 networking tests pass (20 `http_*`/`url`/`cors` plus both websocket tests).

## Deliberately not in scope

- **Caller `Host` values are not checked for authority validity.** `Host: a b` is written as given. The server has `detail::is_valid_authority`, but it lives in `http_server.hpp` rather than the shared `http.hpp`, and unlike the CRLF guard this is not a framing control: the caller already owns every header value, so an invalid `Host` is a caller error with a visible 400, not a smuggling vector. Hoisting the authority predicates into `http.hpp` so both sides share one rule is a reasonable follow-up.
- **A request-side `Connection: close` does not stop the socket from being pooled.** The client decides reuse from the *response*'s `Connection` (`http_client.hpp`), so a server that honors `close` without echoing it leaves a dead socket in the pool. This PR is what first makes a caller's `close` reliably reach the server, so it is worth a follow-up, but it is a pool-lifecycle concern rather than a request-writer one.