### PR TITLE
ci: cut MSVC Release build time and supersede stale runs

### DIFF
--- a/.github/workflows/armv7.yml
+++ b/.github/workflows/armv7.yml
@@ -16,6 +16,13 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build-armv7:
     runs-on: ubuntu-24.04

--- a/.github/workflows/autobahn.yml
+++ b/.github/workflows/autobahn.yml
@@ -16,6 +16,13 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,6 +9,13 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   skip_ws_benchmark:
     runs-on: ubuntu-24.04

--- a/.github/workflows/big-endian.yml
+++ b/.github/workflows/big-endian.yml
@@ -16,6 +16,13 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build-s390x:
     runs-on: ubuntu-24.04

--- a/.github/workflows/boost-asio.yml
+++ b/.github/workflows/boost-asio.yml
@@ -16,6 +16,13 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -20,6 +20,13 @@ env:
   CTEST_OUTPUT_ON_FAILURE: 1
   BUILD_TYPE: Debug
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     runs-on: windows-2025-vs2026

--- a/.github/workflows/clang-linux-erlang.yml
+++ b/.github/workflows/clang-linux-erlang.yml
@@ -16,6 +16,13 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/clang-linux-latest.yml
+++ b/.github/workflows/clang-linux-latest.yml
@@ -19,6 +19,13 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/clang-linux.yml
+++ b/.github/workflows/clang-linux.yml
@@ -16,6 +16,13 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -6,6 +6,13 @@ on:
   push:
     branches: [ main ]
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   clang-tidy-include-cleaner:
     runs-on: ubuntu-latest

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -19,6 +19,13 @@ on:
 env:
   BUILD_TYPE: Debug
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     runs-on: macos-latest

--- a/.github/workflows/disable-always-inline.yml
+++ b/.github/workflows/disable-always-inline.yml
@@ -16,6 +16,13 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   gcc15:
     runs-on: ubuntu-24.04

--- a/.github/workflows/exhaustive_float.yml
+++ b/.github/workflows/exhaustive_float.yml
@@ -16,6 +16,13 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/exhaustive_int.yml
+++ b/.github/workflows/exhaustive_int.yml
@@ -16,6 +16,13 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/gcc-erlang.yml
+++ b/.github/workflows/gcc-erlang.yml
@@ -16,6 +16,13 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/gcc-old-abi.yml
+++ b/.github/workflows/gcc-old-abi.yml
@@ -16,6 +16,13 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/gcc-x86.yml
+++ b/.github/workflows/gcc-x86.yml
@@ -16,6 +16,13 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
    build:
       runs-on: ubuntu-24.04

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -16,6 +16,13 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -16,6 +16,13 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     runs-on: windows-2025-vs2026

--- a/.github/workflows/p2996-reflection.yml
+++ b/.github/workflows/p2996-reflection.yml
@@ -22,6 +22,13 @@ env:
   # ut requires since v1.2.0. Install an official Kitware build instead of apt's.
   CMAKE_TARBALL: https://github.com/Kitware/CMake/releases/download/v4.4.2/cmake-4.4.2-linux-x86_64.tar.gz
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   test-p2996:
     runs-on: ubuntu-latest

--- a/.github/workflows/quickfuzz.yml
+++ b/.github/workflows/quickfuzz.yml
@@ -16,6 +16,13 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -16,6 +16,13 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   asan:
     runs-on: ubuntu-24.04

--- a/.github/workflows/simd-backends.yml
+++ b/.github/workflows/simd-backends.yml
@@ -32,6 +32,13 @@ env:
   # Suites that exercise UTF-8 validation. Kept narrow so the emulated job stays quick.
   UTF8_TESTS: "^(utf8_validation_test|json_conformance|json_test)$"
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   x86-backends:
     runs-on: ubuntu-24.04

--- a/.github/workflows/simple_float.yml
+++ b/.github/workflows/simple_float.yml
@@ -16,6 +16,13 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   clang:
     runs-on: ubuntu-24.04

--- a/.github/workflows/standalone-asio.yml
+++ b/.github/workflows/standalone-asio.yml
@@ -16,6 +16,13 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     name: Standalone ASIO 1.36 + SSL

--- a/.github/workflows/windows-header-compatibility.yml
+++ b/.github/workflows/windows-header-compatibility.yml
@@ -34,6 +34,13 @@ on:
       - '.github/workflows/windows-header-compatibility.yml'
   workflow_dispatch:
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/yaml-conformance-data-gcc.yml
+++ b/.github/workflows/yaml-conformance-data-gcc.yml
@@ -16,6 +16,13 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  # Supersede an in-flight run when a branch is pushed again, so a fixup commit
+  # does not leave the previous run competing for the same runners. Pushes to main
+  # are exempt: every merged commit keeps a completed CI record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,11 +25,20 @@ if (MSVC)
     # for a C++ standards compliant preprocessor, not needed for clang-cl
     target_compile_options(glaze_glaze INTERFACE "/Zc:preprocessor" /permissive- /Zc:lambda)
     
-    if(PROJECT_IS_TOP_LEVEL)
-      target_compile_options(glaze_glaze INTERFACE 
+    # Whole-program optimization changes codegen quality, never correctness, and the
+    # top-level build is glaze's own test suite -- correctness checks that gain nothing
+    # from it. Because glaze is header-only, every test executable pays a full link-time
+    # code generation pass, and there are ~70 of them: /GL /LTCG more than doubled the
+    # MSVC Release CI build (32 min of compiling versus 13 min without). The benchmarks
+    # in benchmarks/ configure as their own top-level project, so they never saw these
+    # flags anyway, and published numbers are measured on GCC. Opt in when profiling
+    # glaze itself on MSVC.
+    option(glaze_ENABLE_LTCG "Build with MSVC whole-program optimization (/GL /LTCG)" OFF)
+    if(PROJECT_IS_TOP_LEVEL AND glaze_ENABLE_LTCG)
+      target_compile_options(glaze_glaze INTERFACE
         $<$<CONFIG:Release>:/GL>
         $<$<CONFIG:MinSizeRel>:/GL>)
-      target_link_options(glaze_glaze INTERFACE 
+      target_link_options(glaze_glaze INTERFACE
         $<$<CONFIG:Release>:/LTCG /INCREMENTAL:NO>
         $<$<CONFIG:MinSizeRel>:/LTCG /INCREMENTAL:NO>)
     endif()


### PR DESCRIPTION
## Problem

The MSVC Release job is the slowest thing in CI at ~36 minutes, gating merges. Debug is ~17.

Step timings from run [31829299355](https://github.com/stephenberry/glaze/actions/runs/31829299355):

| | Debug | Release |
|---|---|---|
| Build | 12m40s | **32m09s** |
| Test | 3m43s | 3m36s |

The tests are not the cost. The entire gap is compilation, from `/GL` + `/LTCG`. The Release log contains ~70 `Generating code` / `Finished generating code` pairs spread evenly across the whole build: one whole-program link-time codegen pass per test executable.

## Why those flags were pure overhead

- Glaze is header-only, so each of the ~70 test binaries pays its own full LTCG pass.
- The flags were gated on `PROJECT_IS_TOP_LEVEL`, and the only thing built top-level is the test suite. Correctness checks gain nothing from whole-program optimization.
- `benchmarks/` configures as its own top-level project (`cmake -S benchmarks`), so it never received these flags to begin with, and `benchmark.yml` measures on Ubuntu/GCC. Nothing that reports a number depends on this.

## Changes

**`CMakeLists.txt`** puts them behind `glaze_ENABLE_LTCG`, default `OFF`, with the rationale in a comment so they don't get reinstated by reflex. `-Dglaze_ENABLE_LTCG=ON` restores the old behavior for profiling glaze on MSVC.

**27 PR-triggered workflows** get a concurrency group, so a fixup push supersedes its in-flight run rather than leaving it to compete for the same runners:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

Pushes to `main` are exempt, so every merged commit keeps a completed CI record. `docs.yml` is untouched, since it has its own `pages` group.

## Coverage

Unchanged. MSVC Release still builds and runs the full suite, which is worth keeping: `NDEBUG` compiles out asserts, and the optimizer exposes UB and lifetime bugs Debug hides.

## Expected effect

Release should land near Debug's build time, putting the job around 17-20 minutes instead of 36. That is extrapolated from the Debug baseline rather than measured, since MSVC cannot be built locally on macOS. **This PR's own CI run is the confirmation.**

After this, the critical path becomes `clang19 (Release, 23)` at ~23 min.

## Verification done locally

- CMake configures clean with the option off.
- All 31 workflows parse as valid YAML.
- Exactly one `concurrency:` key per file; both expression lines match byte-for-byte across all 27.

## Note

`msys2.yml` was left alone because it has no `pull_request` trigger, but it does run on `feature/*` pushes and so can still stack up superseded runs on the same scarce Windows runner pool. Happy to include it if wanted.