### PR TITLE
escape control characters in beve, cbor, bson, and eetf converters

### DIFF
--- a/docs/EETF/erlang-external-term-format.md
+++ b/docs/EETF/erlang-external-term-format.md
@@ -19,7 +19,7 @@ std::string json{};
 auto ec = glz::eetf_to_json(term, json);
 ```
 
-An Erlang binary holds arbitrary bytes by definition, and `binary_as_base64` is off by default, so a binary is emitted as a JSON string. A control character (0x00 to 0x1F) among those bytes has no two-character JSON escape, so the conversion fails with `error_code::invalid_control_character` rather than produce output that will not re-parse.
+`binary_as_base64` is off by default, so an Erlang binary is written as a JSON string. Binaries hold arbitrary bytes, and a control character (0x00–1F) among them has no short JSON escape, so the conversion fails with `error_code::invalid_control_character`.
 
 Two ways across:
 
@@ -36,6 +36,6 @@ struct escaping : glz::eetf::eetf_opts {
 glz::eetf_to_json<escaping{}>(term, json);
 ```
 
-See [Untrusted Strings](../binary.md#untrusted-strings) for what that trade buys and costs.
+See [String Escaping](../binary.md#string-escaping).
 
-Only strings, atoms, and binaries are accepted as object keys, since a JSON key must be a string. The atoms `true` and `false` emit as bare JSON literals in value position, and stay quoted in key position.
+Only strings, atoms, and binaries work as object keys, since a JSON key must be a string. The atoms `true` and `false` are written as bare JSON literals, except as a key, where they stay quoted.

--- a/docs/EETF/erlang-external-term-format.md
+++ b/docs/EETF/erlang-external-term-format.md
@@ -10,3 +10,32 @@ If you are not using CMake the macro `GLZ_ENABLE_EETF` must be added to utilize 
 
 ## [See Unit Tests](https://github.com/stephenberry/glaze/blob/main/tests/eetf_test/eetf_test.cpp)
 
+## EETF to JSON Conversion
+
+`glz::eetf_to_json` converts a buffer of Erlang terms directly to a buffer of JSON.
+
+```c++
+std::string json{};
+auto ec = glz::eetf_to_json(term, json);
+```
+
+An Erlang binary holds arbitrary bytes by definition, and `binary_as_base64` is off by default, so a binary is emitted as a JSON string. A control character (0x00 to 0x1F) among those bytes has no two-character JSON escape, so the conversion fails with `error_code::invalid_control_character` rather than produce output that will not re-parse.
+
+Two ways across:
+
+```c++
+// binary_as_base64 is a member of eetf_opts, so set it inline.
+// Usually the right answer for a binary: no raw bytes end up in a JSON string.
+glz::eetf_to_json<glz::eetf::eetf_opts{.binary_as_base64 = true}>(term, json);
+
+// escape_control_characters is inheritable, so add it to a custom opts struct.
+// Keeps the bytes as JSON string content, escaped.
+struct escaping : glz::eetf::eetf_opts {
+   bool escape_control_characters = true;
+};
+glz::eetf_to_json<escaping{}>(term, json);
+```
+
+See [Untrusted Strings](../binary.md#untrusted-strings) for what that trade buys and costs.
+
+Only strings, atoms, and binaries are accepted as object keys, since a JSON key must be a string. The atoms `true` and `false` emit as bare JSON literals in value position, and stay quoted in key position.

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -480,32 +480,42 @@ Writing is Version 2 only. Version 2 output is not decodable as a variant by a G
 
 `glaze/binary/beve_to_json.hpp` provides `glz::beve_to_json`, which directly converts a buffer of BEVE data to a buffer of JSON data.
 
-### Untrusted Strings
+### String Escaping
 
-A converter turns a document you received into JSON text. Two of its string options are pinned, because inheriting them would let a caller produce output that is not JSON at all: `raw_string` (emit the payload unescaped) and `unquoted` (drop the quotes). This applies to `glz::cbor_to_json`, `glz::bson_to_json`, and `glz::eetf_to_json` as well.
-
-**Control characters are refused by default.** A BEVE string may hold any byte, including a control character (0x00–0x1F). Most have a two-character JSON escape — `\n`, `\t`, `\b`, `\f`, `\r` — and those pass through normally. The rest cannot be written without `\uXXXX`, so rather than emit bytes that will not re-parse, the conversion fails with `error_code::invalid_control_character`.
+A BEVE string can hold any byte, including control characters (0x00–1F). JSON cannot. `\n`, `\t`, `\b`, `\f` and `\r` are escaped normally, but the rest have no short escape, and by default the conversion fails rather than write something that will not parse:
 
 ```c++
 // a BEVE string holding a 0x01 byte
-auto ec = glz::beve_to_json(beve, json);   // ec == invalid_control_character
+std::string json{};
+auto ec = glz::beve_to_json(beve, json);
+// ec.ec == glz::error_code::invalid_control_character
 ```
 
-**`escape_control_characters` opts into carrying them across.** The byte is written as `\uXXXX`, the document round-trips, and a value that legitimately contains control bytes survives:
+To keep those bytes, turn on `escape_control_characters`. They are written as `\uXXXX` and the document round-trips:
 
 ```c++
 struct escaping : glz::opts {
    bool escape_control_characters = true;
 };
 
+std::string json{};
 auto ec = glz::beve_to_json<escaping{}>(beve, json);   // {"k":"a\u0001b"}
 ```
 
-Worth knowing what that buys and costs. A control character is legal inside a length-prefixed BEVE, CBOR, or BSON string, so `std::string("a\0b", 3)` round-trips through `write_beve`/`read_beve`, and escaping is the only way the JSON form can represent it. But escaping also means a NUL in the source becomes a NUL in whatever reads the JSON back, where an embedded null can truncate a C API or split a log line. The default refuses so the choice is yours to make explicitly.
+Which to pick:
 
-For Erlang binaries, which hold arbitrary bytes by definition, `binary_as_base64` is usually the better answer than escaping: it carries any payload across without putting raw bytes in a JSON string at all.
+- **Your data legitimately contains control bytes.** Use `escape_control_characters`. A `std::string` holding a `\0` round-trips through BEVE, and escaping is the only way JSON can carry it.
+- **The bytes are arbitrary,** as in an Erlang binary. Use `binary_as_base64` instead, so no raw bytes end up in a JSON string at all.
+- **You want to know when they appear.** Keep the default and check for `invalid_control_character`.
 
-**UTF-8 is not checked.** That is the reader's job, it is on by default there via `validate_utf8`, and unlike the escaping decision it costs a real pass over every string. `glz::jsonb_to_json` is the exception on both counts: it validates UTF-8 and escapes control characters by default, because a JSONB blob is the storage form of a JSON document that could itself have carried `\uXXXX`.
+One thing to weigh when escaping: `\u0000` is valid JSON that every parser accepts, so a NUL in your data reaches whatever reads the JSON back. Embedded nulls can truncate C strings and split log lines.
+
+The same applies to `glz::cbor_to_json`, `glz::bson_to_json`, and `glz::eetf_to_json`. `glz::jsonb_to_json` always escapes, because a JSONB blob stores a JSON document that may have contained `\uXXXX` to begin with.
+
+**Other notes**
+
+- `raw_string` and `unquoted` are ignored by these converters. Both would produce output that is not JSON.
+- UTF-8 is not checked, except by `glz::jsonb_to_json`. Reading the JSON checks it, and `validate_utf8` is on by default there.
 
 ### Function Pointers
 

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -480,6 +480,10 @@ Writing is Version 2 only. Version 2 output is not decodable as a variant by a G
 
 `glaze/binary/beve_to_json.hpp` provides `glz::beve_to_json`, which directly converts a buffer of BEVE data to a buffer of JSON data.
 
+### String Escaping
+
+A BEVE string may hold any byte, including a control character (0x00–0x1F), which JSON may not. The converter escapes those as `\uXXXX` so its output re-parses, and it does so regardless of the options you pass: `escape_control_characters`, `raw_string`, and `unquoted` are inheritable, so honoring them here would hand you a switch that turns the converter's output into something Glaze's own JSON reader rejects. `glz::cbor_to_json`, `glz::bson_to_json`, `glz::eetf_to_json`, and `glz::jsonb_to_json` behave the same way.
+
 ### Function Pointers
 
 Objects that expose function pointers (both member and non-member) through `glz::meta` are skipped by the BEVE writer by default. This mirrors JSON/TOML behaviour and avoids emitting unusable callable placeholders in binary payloads.

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -480,9 +480,22 @@ Writing is Version 2 only. Version 2 output is not decodable as a variant by a G
 
 `glaze/binary/beve_to_json.hpp` provides `glz::beve_to_json`, which directly converts a buffer of BEVE data to a buffer of JSON data.
 
-### String Escaping
+### Untrusted Strings
 
-A BEVE string may hold any byte, including a control character (0x00–0x1F), which JSON may not. The converter escapes those as `\uXXXX` so its output re-parses, and it does so regardless of the options you pass: `escape_control_characters`, `raw_string`, and `unquoted` are inheritable, so honoring them here would hand you a switch that turns the converter's output into something Glaze's own JSON reader rejects. `glz::cbor_to_json`, `glz::bson_to_json`, `glz::eetf_to_json`, and `glz::jsonb_to_json` behave the same way.
+A converter transforms a document you received, not data your program owns, so its string handling follows the reader's defaults rather than the writer's. This applies to `glz::cbor_to_json`, `glz::bson_to_json`, `glz::eetf_to_json`, and `glz::jsonb_to_json` as well.
+
+**Control characters are always escaped.** A BEVE string may hold any byte, including a control character (0x00–0x1F), which JSON may not. Those are escaped as `\uXXXX` so the output re-parses, regardless of the options you pass: `escape_control_characters`, `raw_string`, and `unquoted` are inheritable, so honoring them here would hand you a switch that turns the converter's output into something Glaze's own JSON reader rejects. There is no opt-out. Escaping itself is not what costs anything — the same scan runs either way — so this is not a performance trade you are making silently.
+
+**UTF-8 is validated where the source format promises it.** RFC 8259 requires JSON text to be UTF-8, so payloads a format states are text get the same check `glz::read_json` gives its own input, failing with `error_code::invalid_utf8`. This honors `validate_utf8`, which is on by default and compiles the check away when off.
+
+Payloads whose format defines them as *bytes* are exempt, because they never claimed to be UTF-8 and checking them would reject data their producer encoded correctly:
+
+| Payload | Checked |
+|---|---|
+| BEVE strings, CBOR text strings, BSON strings, `ERL_ATOM_UTF8_EXT` | yes |
+| `ERL_ATOM_EXT` (latin1 by spec), `ERL_STRING_EXT` (byte list), `ERL_BINARY_EXT` | no |
+
+An exempt payload can still carry bytes that are not JSON text. For Erlang binaries, `binary_as_base64` is how those cross intact.
 
 ### Function Pointers
 

--- a/docs/binary.md
+++ b/docs/binary.md
@@ -482,20 +482,30 @@ Writing is Version 2 only. Version 2 output is not decodable as a variant by a G
 
 ### Untrusted Strings
 
-A converter transforms a document you received, not data your program owns, so its string handling follows the reader's defaults rather than the writer's. This applies to `glz::cbor_to_json`, `glz::bson_to_json`, `glz::eetf_to_json`, and `glz::jsonb_to_json` as well.
+A converter turns a document you received into JSON text. Two of its string options are pinned, because inheriting them would let a caller produce output that is not JSON at all: `raw_string` (emit the payload unescaped) and `unquoted` (drop the quotes). This applies to `glz::cbor_to_json`, `glz::bson_to_json`, and `glz::eetf_to_json` as well.
 
-**Control characters are always escaped.** A BEVE string may hold any byte, including a control character (0x00–0x1F), which JSON may not. Those are escaped as `\uXXXX` so the output re-parses, regardless of the options you pass: `escape_control_characters`, `raw_string`, and `unquoted` are inheritable, so honoring them here would hand you a switch that turns the converter's output into something Glaze's own JSON reader rejects. There is no opt-out. Escaping itself is not what costs anything — the same scan runs either way — so this is not a performance trade you are making silently.
+**Control characters are refused by default.** A BEVE string may hold any byte, including a control character (0x00–0x1F). Most have a two-character JSON escape — `\n`, `\t`, `\b`, `\f`, `\r` — and those pass through normally. The rest cannot be written without `\uXXXX`, so rather than emit bytes that will not re-parse, the conversion fails with `error_code::invalid_control_character`.
 
-**UTF-8 is validated where the source format promises it.** RFC 8259 requires JSON text to be UTF-8, so payloads a format states are text get the same check `glz::read_json` gives its own input, failing with `error_code::invalid_utf8`. This honors `validate_utf8`, which is on by default and compiles the check away when off.
+```c++
+// a BEVE string holding a 0x01 byte
+auto ec = glz::beve_to_json(beve, json);   // ec == invalid_control_character
+```
 
-Payloads whose format defines them as *bytes* are exempt, because they never claimed to be UTF-8 and checking them would reject data their producer encoded correctly:
+**`escape_control_characters` opts into carrying them across.** The byte is written as `\uXXXX`, the document round-trips, and a value that legitimately contains control bytes survives:
 
-| Payload | Checked |
-|---|---|
-| BEVE strings, CBOR text strings, BSON strings, `ERL_ATOM_UTF8_EXT` | yes |
-| `ERL_ATOM_EXT` (latin1 by spec), `ERL_STRING_EXT` (byte list), `ERL_BINARY_EXT` | no |
+```c++
+struct escaping : glz::opts {
+   bool escape_control_characters = true;
+};
 
-An exempt payload can still carry bytes that are not JSON text. For Erlang binaries, `binary_as_base64` is how those cross intact.
+auto ec = glz::beve_to_json<escaping{}>(beve, json);   // {"k":"a\u0001b"}
+```
+
+Worth knowing what that buys and costs. A control character is legal inside a length-prefixed BEVE, CBOR, or BSON string, so `std::string("a\0b", 3)` round-trips through `write_beve`/`read_beve`, and escaping is the only way the JSON form can represent it. But escaping also means a NUL in the source becomes a NUL in whatever reads the JSON back, where an embedded null can truncate a C API or split a log line. The default refuses so the choice is yours to make explicitly.
+
+For Erlang binaries, which hold arbitrary bytes by definition, `binary_as_base64` is usually the better answer than escaping: it carries any payload across without putting raw bytes in a JSON string at all.
+
+**UTF-8 is not checked.** That is the reader's job, it is on by default there via `validate_utf8`, and unlike the escaping decision it costs a real pass over every string. `glz::jsonb_to_json` is the exception on both counts: it validates UTF-8 and escapes control characters by default, because a JSONB blob is the storage form of a JSON document that could itself have carried `\uXXXX`.
 
 ### Function Pointers
 

--- a/docs/bson.md
+++ b/docs/bson.md
@@ -308,6 +308,17 @@ auto encoded = glz::write_bson(h);
 // *encoded equals the 22 bytes above, byte-for-byte.
 ```
 
+## BSON to JSON Conversion
+
+`glz::bson_to_json` converts a buffer of BSON directly to a buffer of JSON.
+
+```c++
+std::string json{};
+auto ec = glz::bson_to_json(bson, json);
+```
+
+A BSON string may hold a control character (0x00 to 0x1F), which JSON may not. Those without a two-character escape make the conversion fail with `error_code::invalid_control_character` rather than produce output that will not re-parse; set `escape_control_characters` to carry them across instead. See [Untrusted Strings](binary.md#untrusted-strings) for what that trade buys and costs.
+
 ## Unsupported / Future Work
 
 - **MongoDB Extended JSON** (canonical / relaxed modes) — follow-up; this documentation covers the binary wire format only.

--- a/docs/bson.md
+++ b/docs/bson.md
@@ -317,7 +317,7 @@ std::string json{};
 auto ec = glz::bson_to_json(bson, json);
 ```
 
-A BSON string may hold a control character (0x00 to 0x1F), which JSON may not. Those without a two-character escape make the conversion fail with `error_code::invalid_control_character` rather than produce output that will not re-parse; set `escape_control_characters` to carry them across instead. See [Untrusted Strings](binary.md#untrusted-strings) for what that trade buys and costs.
+A BSON string can hold control characters (0x00–1F), which JSON cannot. Those without a short escape make the conversion fail with `error_code::invalid_control_character`. To keep them, turn on `escape_control_characters`. See [String Escaping](binary.md#string-escaping).
 
 ## Unsupported / Future Work
 

--- a/docs/cbor.md
+++ b/docs/cbor.md
@@ -61,6 +61,17 @@ Glaze CBOR implements the following standards:
 | [RFC 8746](https://www.rfc-editor.org/rfc/rfc8746.html) | Typed arrays and multi-dimensional arrays |
 | [IANA CBOR Tags](https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml) | Registered semantic tags |
 
+## CBOR to JSON Conversion
+
+`glz::cbor_to_json` converts a buffer of CBOR directly to a buffer of JSON.
+
+```c++
+std::string json{};
+auto ec = glz::cbor_to_json(cbor, json);
+```
+
+A CBOR text string may hold a control character (0x00 to 0x1F), which JSON may not. Those without a two-character escape make the conversion fail with `error_code::invalid_control_character` rather than produce output that will not re-parse; set `escape_control_characters` to carry them across instead. See [Untrusted Strings](binary.md#untrusted-strings) for what that trade buys and costs.
+
 ## Typed Arrays (RFC 8746)
 
 Glaze automatically uses RFC 8746 typed arrays for contiguous numeric containers, enabling bulk memory operations for maximum performance.

--- a/docs/cbor.md
+++ b/docs/cbor.md
@@ -70,7 +70,7 @@ std::string json{};
 auto ec = glz::cbor_to_json(cbor, json);
 ```
 
-A CBOR text string may hold a control character (0x00 to 0x1F), which JSON may not. Those without a two-character escape make the conversion fail with `error_code::invalid_control_character` rather than produce output that will not re-parse; set `escape_control_characters` to carry them across instead. See [Untrusted Strings](binary.md#untrusted-strings) for what that trade buys and costs.
+A CBOR text string can hold control characters (0x00–1F), which JSON cannot. Those without a short escape make the conversion fail with `error_code::invalid_control_character`. To keep them, turn on `escape_control_characters`. See [String Escaping](binary.md#string-escaping).
 
 ## Typed Arrays (RFC 8746)
 

--- a/docs/jsonb.md
+++ b/docs/jsonb.md
@@ -213,4 +213,6 @@ The following `glz::opts` fields influence JSONB read/write:
 
 Options marked *(custom)* are not part of the base `glz::opts` struct — define a custom opts struct inheriting from `glz::opts` and add the field.
 
-Options that apply only to text formats (`prettify`, `minified`, `comments`, `null_terminated`, `indentation_char`, `escape_control_characters`) have no effect on JSONB.
+Options that apply only to text formats (`prettify`, `minified`, `comments`, `null_terminated`, `indentation_char`, `escape_control_characters`) have no effect on reading or writing JSONB itself.
+
+`jsonb_to_json` produces JSON text, so text options do apply to it, with two exceptions. It always escapes control characters, because a JSONB blob is the storage form of a JSON document that could itself have carried an escape, and it validates UTF-8 unless `validate_utf8` is off. The other binary-to-JSON converters do neither by default; see [Untrusted Strings](binary.md#untrusted-strings).

--- a/docs/jsonb.md
+++ b/docs/jsonb.md
@@ -215,4 +215,4 @@ Options marked *(custom)* are not part of the base `glz::opts` struct — define
 
 Options that apply only to text formats (`prettify`, `minified`, `comments`, `null_terminated`, `indentation_char`, `escape_control_characters`) have no effect on reading or writing JSONB itself.
 
-`jsonb_to_json` produces JSON text, so text options do apply to it, with two exceptions. It always escapes control characters, because a JSONB blob is the storage form of a JSON document that could itself have carried an escape, and it validates UTF-8 unless `validate_utf8` is off. The other binary-to-JSON converters do neither by default; see [Untrusted Strings](binary.md#untrusted-strings).
+`jsonb_to_json` produces JSON text, so text options do apply to it. Two are fixed: it always escapes control characters, since a JSONB blob stores a JSON document that may have contained `\uXXXX` to begin with, and it validates UTF-8 unless `validate_utf8` is off. The other binary-to-JSON converters do neither by default; see [String Escaping](binary.md#string-escaping).

--- a/docs/options.md
+++ b/docs/options.md
@@ -49,6 +49,7 @@ These options are **not** in `glz::opts` by default. Add them to a custom option
 | `bool error_on_const_read` | `false` | Error when attempting to read into a const value |
 | `bool hide_non_invocable` | `true` | Hide non-invocable members from `cli_menu` |
 | `bool escape_control_characters` | `false` | Escape control characters as unicode sequences |
+| `bool reject_control_characters` | `false` | Error rather than write a control character that has no two-character escape |
 | `char indentation_char` | `' '` | Prettified JSON indentation character |
 | `uint8_t indentation_width` | `3` | Prettified JSON indentation size |
 | `bool new_lines_in_arrays` | `true` | Whether prettified arrays have new lines per element |
@@ -175,7 +176,7 @@ Performs full JSON validation on values that are skipped (unknown keys). Without
 Validates that content after the parsed value contains only valid whitespace.
 
 #### `validate_utf8`
-On by default, because RFC 8259 section 8.1 requires JSON text to be UTF-8. Every string the reader materializes is checked, including map keys, unknown keys, and values that are skipped; malformed input fails with `error_code::invalid_utf8`. The binary-to-JSON converters honor it too, for the payloads their source format states are text; see [Untrusted Strings](binary.md#untrusted-strings).
+On by default, because RFC 8259 section 8.1 requires JSON text to be UTF-8. Every string the reader materializes is checked, including map keys, unknown keys, and values that are skipped; malformed input fails with `error_code::invalid_utf8`. Of the binary-to-JSON converters, only `jsonb_to_json` checks UTF-8; see [Untrusted Strings](binary.md#untrusted-strings).
 
 ```cpp
 struct unchecked_opts : glz::opts {
@@ -285,7 +286,10 @@ Control string quoting and escape sequence handling. Useful for embedding pre-fo
 #### `escape_control_characters`
 When `true`, control characters (0x00-0x1F) are escaped as `\uXXXX` sequences. The default (`false`) does not escape these characters for performance and safety (embedding nulls can cause issues, especially with C APIs). Glaze will error when parsing non-escaped control characters per the JSON spec—this option allows writing them as escaped unicode to avoid such errors on re-read.
 
-The binary-to-JSON converters (`beve_to_json`, `cbor_to_json`, `bson_to_json`, `eetf_to_json`, `jsonb_to_json`) always escape control characters and ignore this option, along with `raw_string` and `unquoted`. Their input is a foreign document rather than the program's own strings, so inheriting these would let a caller turn the converter's output into invalid JSON. They do honor `validate_utf8`. See [Untrusted Strings](binary.md#untrusted-strings).
+The binary-to-JSON converters honor this option, and it is how you opt into carrying control characters across. Without it they fail with `error_code::invalid_control_character` rather than writing bytes that will not re-parse. `raw_string` and `unquoted` stay pinned off there regardless. See [Untrusted Strings](binary.md#untrusted-strings).
+
+#### `reject_control_characters`
+Off by default. When on, writing a control character that has no two-character JSON escape fails with `error_code::invalid_control_character` instead of emitting bytes that do not re-parse. Only consulted when `escape_control_characters` is off, since that option makes every control character writable. The binary-to-JSON converters pin it on; it costs a predictable branch on a path only reached when such a byte is present.
 
 ### Performance Options
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -176,7 +176,7 @@ Performs full JSON validation on values that are skipped (unknown keys). Without
 Validates that content after the parsed value contains only valid whitespace.
 
 #### `validate_utf8`
-On by default, because RFC 8259 section 8.1 requires JSON text to be UTF-8. Every string the reader materializes is checked, including map keys, unknown keys, and values that are skipped; malformed input fails with `error_code::invalid_utf8`. Of the binary-to-JSON converters, only `jsonb_to_json` checks UTF-8; see [Untrusted Strings](binary.md#untrusted-strings).
+On by default, because RFC 8259 section 8.1 requires JSON text to be UTF-8. Every string the reader materializes is checked, including map keys, unknown keys, and values that are skipped; malformed input fails with `error_code::invalid_utf8`. Of the binary-to-JSON converters, only `jsonb_to_json` checks UTF-8; see [String Escaping](binary.md#string-escaping).
 
 ```cpp
 struct unchecked_opts : glz::opts {
@@ -286,10 +286,10 @@ Control string quoting and escape sequence handling. Useful for embedding pre-fo
 #### `escape_control_characters`
 When `true`, control characters (0x00-0x1F) are escaped as `\uXXXX` sequences. The default (`false`) does not escape these characters for performance and safety (embedding nulls can cause issues, especially with C APIs). Glaze will error when parsing non-escaped control characters per the JSON spec—this option allows writing them as escaped unicode to avoid such errors on re-read.
 
-The binary-to-JSON converters honor this option, and it is how you opt into carrying control characters across. Without it they fail with `error_code::invalid_control_character` rather than writing bytes that will not re-parse. `raw_string` and `unquoted` stay pinned off there regardless. See [Untrusted Strings](binary.md#untrusted-strings).
+The binary-to-JSON converters use this option to decide what to do with control characters in a converted value. Off, they fail with `error_code::invalid_control_character`. On, the bytes are escaped. They ignore `raw_string` and `unquoted` either way. See [String Escaping](binary.md#string-escaping).
 
 #### `reject_control_characters`
-Off by default. When on, writing a control character that has no two-character JSON escape fails with `error_code::invalid_control_character` instead of emitting bytes that do not re-parse. Only consulted when `escape_control_characters` is off, since that option makes every control character writable. The binary-to-JSON converters pin it on; it costs a predictable branch on a path only reached when such a byte is present.
+Off by default. When on, writing a control character with no short JSON escape fails with `error_code::invalid_control_character` instead of emitting bytes that will not parse. Only applies when `escape_control_characters` is off, since that option makes every control character writable. The binary-to-JSON converters turn it on.
 
 ### Performance Options
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -175,7 +175,7 @@ Performs full JSON validation on values that are skipped (unknown keys). Without
 Validates that content after the parsed value contains only valid whitespace.
 
 #### `validate_utf8`
-On by default, because RFC 8259 section 8.1 requires JSON text to be UTF-8. Every string the reader materializes is checked, including map keys, unknown keys, and values that are skipped; malformed input fails with `error_code::invalid_utf8`.
+On by default, because RFC 8259 section 8.1 requires JSON text to be UTF-8. Every string the reader materializes is checked, including map keys, unknown keys, and values that are skipped; malformed input fails with `error_code::invalid_utf8`. The binary-to-JSON converters honor it too, for the payloads their source format states are text; see [Untrusted Strings](binary.md#untrusted-strings).
 
 ```cpp
 struct unchecked_opts : glz::opts {
@@ -285,7 +285,7 @@ Control string quoting and escape sequence handling. Useful for embedding pre-fo
 #### `escape_control_characters`
 When `true`, control characters (0x00-0x1F) are escaped as `\uXXXX` sequences. The default (`false`) does not escape these characters for performance and safety (embedding nulls can cause issues, especially with C APIs). Glaze will error when parsing non-escaped control characters per the JSON spec—this option allows writing them as escaped unicode to avoid such errors on re-read.
 
-The binary-to-JSON converters (`beve_to_json`, `cbor_to_json`, `bson_to_json`, `eetf_to_json`, `jsonb_to_json`) always escape control characters and ignore this option, along with `raw_string` and `unquoted`. Their input is a foreign blob rather than the program's own strings, so inheriting these would let a caller turn the converter's output into invalid JSON.
+The binary-to-JSON converters (`beve_to_json`, `cbor_to_json`, `bson_to_json`, `eetf_to_json`, `jsonb_to_json`) always escape control characters and ignore this option, along with `raw_string` and `unquoted`. Their input is a foreign document rather than the program's own strings, so inheriting these would let a caller turn the converter's output into invalid JSON. They do honor `validate_utf8`. See [Untrusted Strings](binary.md#untrusted-strings).
 
 ### Performance Options
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -49,7 +49,6 @@ These options are **not** in `glz::opts` by default. Add them to a custom option
 | `bool error_on_const_read` | `false` | Error when attempting to read into a const value |
 | `bool hide_non_invocable` | `true` | Hide non-invocable members from `cli_menu` |
 | `bool escape_control_characters` | `false` | Escape control characters as unicode sequences |
-| `bool reject_control_characters` | `false` | Error rather than write a control character that has no two-character escape |
 | `char indentation_char` | `' '` | Prettified JSON indentation character |
 | `uint8_t indentation_width` | `3` | Prettified JSON indentation size |
 | `bool new_lines_in_arrays` | `true` | Whether prettified arrays have new lines per element |
@@ -288,8 +287,6 @@ When `true`, control characters (0x00-0x1F) are escaped as `\uXXXX` sequences. T
 
 The binary-to-JSON converters use this option to decide what to do with control characters in a converted value. Off, they fail with `error_code::invalid_control_character`. On, the bytes are escaped. They ignore `raw_string` and `unquoted` either way. See [String Escaping](binary.md#string-escaping).
 
-#### `reject_control_characters`
-Off by default. When on, writing a control character with no short JSON escape fails with `error_code::invalid_control_character` instead of emitting bytes that will not parse. Only applies when `escape_control_characters` is off, since that option makes every control character writable. The binary-to-JSON converters turn it on.
 
 ### Performance Options
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -285,6 +285,8 @@ Control string quoting and escape sequence handling. Useful for embedding pre-fo
 #### `escape_control_characters`
 When `true`, control characters (0x00-0x1F) are escaped as `\uXXXX` sequences. The default (`false`) does not escape these characters for performance and safety (embedding nulls can cause issues, especially with C APIs). Glaze will error when parsing non-escaped control characters per the JSON spec—this option allows writing them as escaped unicode to avoid such errors on re-read.
 
+The binary-to-JSON converters (`beve_to_json`, `cbor_to_json`, `bson_to_json`, `eetf_to_json`, `jsonb_to_json`) always escape control characters and ignore this option, along with `raw_string` and `unquoted`. Their input is a foreign blob rather than the program's own strings, so inheriting these would let a caller turn the converter's output into invalid JSON.
+
 ### Performance Options
 
 #### `partial_read`

--- a/docs/security.md
+++ b/docs/security.md
@@ -230,6 +230,27 @@ This allows building unified deserializers that scale security based on the trus
 > [!WARNING]
 > When enabling `allocate_raw_pointers`, your application is responsible for tracking and freeing all allocated memory. Consider using smart pointers (`std::unique_ptr`, `std::shared_ptr`) instead, which Glaze handles automatically and safely.
 
+## Converting Untrusted Binary to JSON
+
+`glz::beve_to_json`, `glz::cbor_to_json`, `glz::bson_to_json`, `glz::eetf_to_json`, and `glz::jsonb_to_json` turn a document you received into JSON text. Their input is someone else's bytes, so a few of the writer's defaults do not apply.
+
+Every one of these formats allows a control character (0x00 to 0x1F) inside a string, and JSON does not. Most have a two-character escape and pass through normally, but the rest cannot be written without a Unicode escape. Rather than emit bytes that will not re-parse, the conversion fails with `error_code::invalid_control_character`.
+
+```cpp
+// a BEVE string holding a 0x01 byte
+std::string json{};
+auto ec = glz::beve_to_json(beve, json);
+// ec.ec == glz::error_code::invalid_control_character
+```
+
+Set `escape_control_characters` to carry such bytes across instead. This is worth an explicit decision rather than a default: escaping produces valid JSON that every parser accepts, so a NUL in the source becomes a NUL in whatever reads the result, where an embedded null can truncate a C API or split a log line. Refusing gives the operator a signal; escaping gives fidelity for values that legitimately hold control bytes.
+
+For Erlang binaries, which hold arbitrary bytes by definition, `binary_as_base64` is usually the better answer than escaping. It carries any payload without putting raw bytes in a JSON string at all.
+
+`raw_string` and `unquoted` are ignored by these converters. Both would produce output that is not JSON regardless of what the caller asks for.
+
+UTF-8 is **not** checked by the beve, cbor, bson, or eetf converters — that is the reader's job, and `validate_utf8` is on by default there. `glz::jsonb_to_json` is the exception and validates on convert.
+
 ## JSON Format Security
 
 ### Safe Parsing Defaults

--- a/docs/security.md
+++ b/docs/security.md
@@ -232,9 +232,17 @@ This allows building unified deserializers that scale security based on the trus
 
 ## Converting Untrusted Binary to JSON
 
-`glz::beve_to_json`, `glz::cbor_to_json`, `glz::bson_to_json`, `glz::eetf_to_json`, and `glz::jsonb_to_json` turn a document you received into JSON text. Their input is someone else's bytes, so a few of the writer's defaults do not apply.
+`glz::beve_to_json`, `glz::cbor_to_json`, `glz::bson_to_json`, `glz::eetf_to_json`, and `glz::jsonb_to_json` convert a document you received into JSON text.
 
-Every one of these formats allows a control character (0x00 to 0x1F) inside a string, and JSON does not. Most have a two-character escape and pass through normally, but the rest cannot be written without a Unicode escape. Rather than emit bytes that will not re-parse, the conversion fails with `error_code::invalid_control_character`.
+### Control Characters in Decoded Strings
+
+BEVE, CBOR, BSON, and EETF all allow control characters (0x00–1F) inside a string. JSON does not. A hostile or corrupt payload can therefore contain bytes that have no JSON representation, and writing them anyway produces a document that strict parsers reject.
+
+Escaping them as `\uXXXX` is valid JSON, but it has a consequence worth knowing: every parser then accepts the result, so a NUL in the payload reaches whatever consumes the JSON. Embedded nulls can truncate C strings, split log lines, and cause two systems to disagree about where a value ends.
+
+#### How Glaze Protects Against This
+
+The conversion fails instead. Control characters with no short escape produce `error_code::invalid_control_character`, so you get a signal rather than a document that is malformed or that quietly carries nulls onward.
 
 ```cpp
 // a BEVE string holding a 0x01 byte
@@ -243,13 +251,12 @@ auto ec = glz::beve_to_json(beve, json);
 // ec.ec == glz::error_code::invalid_control_character
 ```
 
-Set `escape_control_characters` to carry such bytes across instead. This is worth an explicit decision rather than a default: escaping produces valid JSON that every parser accepts, so a NUL in the source becomes a NUL in whatever reads the result, where an embedded null can truncate a C API or split a log line. Refusing gives the operator a signal; escaping gives fidelity for values that legitimately hold control bytes.
+If the payload legitimately contains control bytes, opt in with `escape_control_characters`. For Erlang binaries, prefer `binary_as_base64`, which keeps raw bytes out of the JSON string entirely. See [String Escaping](binary.md#string-escaping).
 
-For Erlang binaries, which hold arbitrary bytes by definition, `binary_as_base64` is usually the better answer than escaping. It carries any payload without putting raw bytes in a JSON string at all.
+### Other Converter Defaults
 
-`raw_string` and `unquoted` are ignored by these converters. Both would produce output that is not JSON regardless of what the caller asks for.
-
-UTF-8 is **not** checked by the beve, cbor, bson, or eetf converters — that is the reader's job, and `validate_utf8` is on by default there. `glz::jsonb_to_json` is the exception and validates on convert.
+- `raw_string` and `unquoted` are ignored. Both would produce output that is not JSON.
+- UTF-8 is not checked during conversion, except by `glz::jsonb_to_json`. Reading the JSON checks it, and `validate_utf8` is on by default there.
 
 ## JSON Format Security
 

--- a/include/glaze/beve/beve_to_json.hpp
+++ b/include/glaze/beve/beve_to_json.hpp
@@ -157,7 +157,7 @@ namespace glz
                return;
             }
             const sv value{reinterpret_cast<const char*>(it), n};
-            to<JSON, sv>::template op<detail::untrusted_string_emit_opts<Opts>>(value, ctx, out, ix);
+            detail::emit_untrusted_string<Opts>(ctx, value, out, ix);
             it += n;
             break;
          }
@@ -193,7 +193,7 @@ namespace glz
                      return;
                   }
                   const sv key{reinterpret_cast<const char*>(it), n};
-                  to<JSON, sv>::template op<detail::untrusted_string_emit_opts<Opts>>(key, ctx, out, ix);
+                  detail::emit_untrusted_string<Opts>(ctx, key, out, ix);
                   if constexpr (Opts.prettify) {
                      dump(": ", out, ix);
                   }
@@ -517,7 +517,7 @@ namespace glz
                         return;
                      }
                      const sv value{reinterpret_cast<const char*>(it), n};
-                     to<JSON, sv>::template op<detail::untrusted_string_emit_opts<Opts>>(value, ctx, out, ix);
+                     detail::emit_untrusted_string<Opts>(ctx, value, out, ix);
                      it += n;
                      if (i != n_strings - 1) {
                         dump(',', out, ix);

--- a/include/glaze/beve/beve_to_json.hpp
+++ b/include/glaze/beve/beve_to_json.hpp
@@ -157,7 +157,7 @@ namespace glz
                return;
             }
             const sv value{reinterpret_cast<const char*>(it), n};
-            to<JSON, sv>::template op<Opts>(value, ctx, out, ix);
+            to<JSON, sv>::template op<raw_string_emit_opts<Opts>>(value, ctx, out, ix);
             it += n;
             break;
          }
@@ -193,7 +193,7 @@ namespace glz
                      return;
                   }
                   const sv key{reinterpret_cast<const char*>(it), n};
-                  to<JSON, sv>::template op<Opts>(key, ctx, out, ix);
+                  to<JSON, sv>::template op<raw_string_emit_opts<Opts>>(key, ctx, out, ix);
                   if constexpr (Opts.prettify) {
                      dump(": ", out, ix);
                   }
@@ -517,7 +517,7 @@ namespace glz
                         return;
                      }
                      const sv value{reinterpret_cast<const char*>(it), n};
-                     to<JSON, sv>::template op<Opts>(value, ctx, out, ix);
+                     to<JSON, sv>::template op<raw_string_emit_opts<Opts>>(value, ctx, out, ix);
                      it += n;
                      if (i != n_strings - 1) {
                         dump(',', out, ix);

--- a/include/glaze/beve/beve_to_json.hpp
+++ b/include/glaze/beve/beve_to_json.hpp
@@ -157,7 +157,7 @@ namespace glz
                return;
             }
             const sv value{reinterpret_cast<const char*>(it), n};
-            to<JSON, sv>::template op<raw_string_emit_opts<Opts>>(value, ctx, out, ix);
+            to<JSON, sv>::template op<detail::untrusted_string_emit_opts<Opts>>(value, ctx, out, ix);
             it += n;
             break;
          }
@@ -193,7 +193,7 @@ namespace glz
                      return;
                   }
                   const sv key{reinterpret_cast<const char*>(it), n};
-                  to<JSON, sv>::template op<raw_string_emit_opts<Opts>>(key, ctx, out, ix);
+                  to<JSON, sv>::template op<detail::untrusted_string_emit_opts<Opts>>(key, ctx, out, ix);
                   if constexpr (Opts.prettify) {
                      dump(": ", out, ix);
                   }
@@ -517,7 +517,7 @@ namespace glz
                         return;
                      }
                      const sv value{reinterpret_cast<const char*>(it), n};
-                     to<JSON, sv>::template op<raw_string_emit_opts<Opts>>(value, ctx, out, ix);
+                     to<JSON, sv>::template op<detail::untrusted_string_emit_opts<Opts>>(value, ctx, out, ix);
                      it += n;
                      if (i != n_strings - 1) {
                         dump(',', out, ix);

--- a/include/glaze/bson/bson_to_json.hpp
+++ b/include/glaze/bson/bson_to_json.hpp
@@ -70,7 +70,7 @@ namespace glz
       template <auto Opts, class B>
       GLZ_ALWAYS_INLINE void emit_json_string(is_context auto& ctx, std::string_view s, B& out, size_t& ix) noexcept
       {
-         to<JSON, std::string_view>::template op<detail::untrusted_string_emit_opts<Opts>>(s, ctx, out, ix);
+         detail::emit_untrusted_string<Opts>(ctx, s, out, ix);
       }
 
       // Emit `n` payload bytes as a lowercase hex literal (no quotes, no prefix).

--- a/include/glaze/bson/bson_to_json.hpp
+++ b/include/glaze/bson/bson_to_json.hpp
@@ -70,7 +70,7 @@ namespace glz
       template <auto Opts, class B>
       GLZ_ALWAYS_INLINE void emit_json_string(is_context auto& ctx, std::string_view s, B& out, size_t& ix) noexcept
       {
-         to<JSON, std::string_view>::template op<detail::raw_string_emit_opts<Opts>>(s, ctx, out, ix);
+         to<JSON, std::string_view>::template op<detail::untrusted_string_emit_opts<Opts>>(s, ctx, out, ix);
       }
 
       // Emit `n` payload bytes as a lowercase hex literal (no quotes, no prefix).

--- a/include/glaze/bson/bson_to_json.hpp
+++ b/include/glaze/bson/bson_to_json.hpp
@@ -70,7 +70,7 @@ namespace glz
       template <auto Opts, class B>
       GLZ_ALWAYS_INLINE void emit_json_string(is_context auto& ctx, std::string_view s, B& out, size_t& ix) noexcept
       {
-         to<JSON, std::string_view>::template op<Opts>(s, ctx, out, ix);
+         to<JSON, std::string_view>::template op<detail::raw_string_emit_opts<Opts>>(s, ctx, out, ix);
       }
 
       // Emit `n` payload bytes as a lowercase hex literal (no quotes, no prefix).

--- a/include/glaze/cbor/cbor_to_json.hpp
+++ b/include/glaze/cbor/cbor_to_json.hpp
@@ -242,7 +242,7 @@ namespace glz
                   str.append(reinterpret_cast<const char*>(it), chunk_len);
                   it += chunk_len;
                }
-               to<JSON, std::string_view>::template op<raw_string_emit_opts<Opts>>(str, ctx, out, ix);
+               to<JSON, std::string_view>::template op<detail::untrusted_string_emit_opts<Opts>>(str, ctx, out, ix);
             }
             else {
                const uint64_t length = cbor_to_json_decode_arg(ctx, it, end, additional_info);
@@ -255,7 +255,7 @@ namespace glz
                }
 
                const sv value{reinterpret_cast<const char*>(it), static_cast<size_t>(length)};
-               to<JSON, sv>::template op<raw_string_emit_opts<Opts>>(value, ctx, out, ix);
+               to<JSON, sv>::template op<detail::untrusted_string_emit_opts<Opts>>(value, ctx, out, ix);
                it += length;
             }
             break;

--- a/include/glaze/cbor/cbor_to_json.hpp
+++ b/include/glaze/cbor/cbor_to_json.hpp
@@ -242,7 +242,7 @@ namespace glz
                   str.append(reinterpret_cast<const char*>(it), chunk_len);
                   it += chunk_len;
                }
-               to<JSON, std::string_view>::template op<Opts>(str, ctx, out, ix);
+               to<JSON, std::string_view>::template op<raw_string_emit_opts<Opts>>(str, ctx, out, ix);
             }
             else {
                const uint64_t length = cbor_to_json_decode_arg(ctx, it, end, additional_info);
@@ -255,7 +255,7 @@ namespace glz
                }
 
                const sv value{reinterpret_cast<const char*>(it), static_cast<size_t>(length)};
-               to<JSON, sv>::template op<Opts>(value, ctx, out, ix);
+               to<JSON, sv>::template op<raw_string_emit_opts<Opts>>(value, ctx, out, ix);
                it += length;
             }
             break;

--- a/include/glaze/cbor/cbor_to_json.hpp
+++ b/include/glaze/cbor/cbor_to_json.hpp
@@ -242,7 +242,7 @@ namespace glz
                   str.append(reinterpret_cast<const char*>(it), chunk_len);
                   it += chunk_len;
                }
-               to<JSON, std::string_view>::template op<detail::untrusted_string_emit_opts<Opts>>(str, ctx, out, ix);
+               detail::emit_untrusted_string<Opts>(ctx, str, out, ix);
             }
             else {
                const uint64_t length = cbor_to_json_decode_arg(ctx, it, end, additional_info);
@@ -255,7 +255,7 @@ namespace glz
                }
 
                const sv value{reinterpret_cast<const char*>(it), static_cast<size_t>(length)};
-               to<JSON, sv>::template op<detail::untrusted_string_emit_opts<Opts>>(value, ctx, out, ix);
+               detail::emit_untrusted_string<Opts>(ctx, value, out, ix);
                it += length;
             }
             break;

--- a/include/glaze/core/context.hpp
+++ b/include/glaze/core/context.hpp
@@ -108,6 +108,10 @@ namespace glz
       invalid_length, // Length exceeds allowed limit (buffer size or user-configured max)
       // Encoding errors
       invalid_utf8, // Malformed UTF-8 in a string; checked on read unless validate_utf8 is disabled
+      invalid_control_character, // A string carries a control character with no two-character JSON
+                                 // escape, and escape_control_characters is off so it cannot be
+                                 // written. Raised by the binary-to-JSON converters, which refuse
+                                 // to emit a byte they would have to corrupt or hide.
       // Streaming errors
       streaming_unsupported, // Document outruns the buffer window and this format's reader cannot refill
       // Expansion errors

--- a/include/glaze/core/error_category.hpp
+++ b/include/glaze/core/error_category.hpp
@@ -81,6 +81,7 @@ struct glz::meta<glz::error_code>
                                     "buffer_overflow",
                                     "invalid_length",
                                     "invalid_utf8",
+                                    "invalid_control_character",
                                     "streaming_unsupported",
                                     "exceeded_max_expansion"};
    static constexpr std::array value{none, //
@@ -162,6 +163,7 @@ struct glz::meta<glz::error_code>
                                      invalid_length, //
                                      // Encoding errors
                                      invalid_utf8, //
+                                     invalid_control_character, //
                                      // Streaming errors
                                      streaming_unsupported, //
                                      // Expansion errors

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -49,7 +49,11 @@ namespace glz
          1 << 4, // whether to turn off writing unknown fields for a glz::meta specialized for unknown writing
       is_padded = 1 << 5, // whether or not the read buffer is padded
       disable_padding = 1 << 6, // to explicitly disable padding for contexts like includers
-      write_unchecked = 1 << 7 // the write buffer has sufficient space and does not need to be checked
+      write_unchecked = 1 << 7, // the write buffer has sufficient space and does not need to be checked
+      // Error rather than write a control character that has no two-character JSON escape. Set by
+      // the binary-to-JSON converters, which are emitting someone else's bytes and would rather
+      // refuse one than mangle it. Only consulted when escape_control_characters is off.
+      reject_control_characters = 1 << 8
    };
 
    // NOTE TO USER:
@@ -318,9 +322,6 @@ namespace glz
    struct escape_control_characters_opt_tag
    {};
 
-   struct reject_control_characters_opt_tag
-   {};
-
    struct quoted_num_opt_tag
    {};
 
@@ -354,10 +355,6 @@ namespace glz
    template <auto member_ptr>
    concept is_escape_control_characters_tag =
       std::same_as<std::decay_t<decltype(member_ptr)>, escape_control_characters_opt_tag>;
-
-   template <auto member_ptr>
-   concept is_reject_control_characters_tag =
-      std::same_as<std::decay_t<decltype(member_ptr)>, reject_control_characters_opt_tag>;
 
    template <auto member_ptr>
    concept is_quoted_num_tag = std::same_as<std::decay_t<decltype(member_ptr)>, quoted_num_opt_tag>;
@@ -541,20 +538,6 @@ namespace glz
    {
       if constexpr (requires { Opts.escape_control_characters; }) {
          return Opts.escape_control_characters;
-      }
-      else {
-         return false;
-      }
-   }
-
-   // Error instead of writing a control character that has no two-character JSON escape. Only
-   // consulted when escape_control_characters is off, which is the case where the writer would
-   // otherwise emit bytes that do not re-parse. The binary-to-JSON converters pin it on: a
-   // decoded value is someone else's bytes, and silently mangling one is worse than refusing it.
-   consteval bool check_reject_control_characters(auto&& Opts)
-   {
-      if constexpr (requires { Opts.reject_control_characters; }) {
-         return Opts.reject_control_characters;
       }
       else {
          return false;
@@ -942,6 +925,19 @@ namespace glz
 
    consteval bool check_write_unchecked(auto&& o) { return o.internal & uint32_t(opts_internal::write_unchecked); }
 
+   consteval bool check_reject_control_characters(auto&& o)
+   {
+      return o.internal & uint32_t(opts_internal::reject_control_characters);
+   }
+
+   template <auto Opts>
+   constexpr auto reject_control_characters()
+   {
+      auto ret = Opts;
+      ret.internal |= uint32_t(opts_internal::reject_control_characters);
+      return ret;
+   }
+
    template <auto Opts>
    constexpr auto opening_handled()
    {
@@ -1105,20 +1101,6 @@ namespace glz
             return opts_escape_control_characters{{Opts}, static_cast<bool>(value)};
          }
       }
-      else if constexpr (is_reject_control_characters_tag<member_ptr>) {
-         if constexpr (requires { Opts.reject_control_characters; }) {
-            auto ret = Opts;
-            ret.reject_control_characters = static_cast<bool>(value);
-            return ret;
-         }
-         else {
-            struct opts_reject_control_characters : std::decay_t<decltype(Opts)>
-            {
-               bool reject_control_characters{};
-            };
-            return opts_reject_control_characters{{Opts}, static_cast<bool>(value)};
-         }
-      }
       else if constexpr (is_quoted_num_tag<member_ptr>) {
          if constexpr (requires { Opts.quoted_num; }) {
             auto ret = Opts;
@@ -1259,20 +1241,6 @@ namespace glz
                bool escape_control_characters = true;
             };
             return opts_escape_control_characters{{Opts}};
-         }
-      }
-      else if constexpr (is_reject_control_characters_tag<member_ptr>) {
-         if constexpr (requires { Opts.reject_control_characters; }) {
-            auto ret = Opts;
-            ret.reject_control_characters = true;
-            return ret;
-         }
-         else {
-            struct opts_reject_control_characters : std::decay_t<decltype(Opts)>
-            {
-               bool reject_control_characters = true;
-            };
-            return opts_reject_control_characters{{Opts}};
          }
       }
       else if constexpr (is_quoted_num_tag<member_ptr>) {
@@ -1416,16 +1384,6 @@ namespace glz
          if constexpr (requires { Opts.escape_control_characters; }) {
             auto ret = Opts;
             ret.escape_control_characters = false;
-            return ret;
-         }
-         else {
-            return Opts;
-         }
-      }
-      else if constexpr (is_reject_control_characters_tag<member_ptr>) {
-         if constexpr (requires { Opts.reject_control_characters; }) {
-            auto ret = Opts;
-            ret.reject_control_characters = false;
             return ret;
          }
          else {

--- a/include/glaze/core/opts.hpp
+++ b/include/glaze/core/opts.hpp
@@ -318,6 +318,9 @@ namespace glz
    struct escape_control_characters_opt_tag
    {};
 
+   struct reject_control_characters_opt_tag
+   {};
+
    struct quoted_num_opt_tag
    {};
 
@@ -351,6 +354,10 @@ namespace glz
    template <auto member_ptr>
    concept is_escape_control_characters_tag =
       std::same_as<std::decay_t<decltype(member_ptr)>, escape_control_characters_opt_tag>;
+
+   template <auto member_ptr>
+   concept is_reject_control_characters_tag =
+      std::same_as<std::decay_t<decltype(member_ptr)>, reject_control_characters_opt_tag>;
 
    template <auto member_ptr>
    concept is_quoted_num_tag = std::same_as<std::decay_t<decltype(member_ptr)>, quoted_num_opt_tag>;
@@ -534,6 +541,20 @@ namespace glz
    {
       if constexpr (requires { Opts.escape_control_characters; }) {
          return Opts.escape_control_characters;
+      }
+      else {
+         return false;
+      }
+   }
+
+   // Error instead of writing a control character that has no two-character JSON escape. Only
+   // consulted when escape_control_characters is off, which is the case where the writer would
+   // otherwise emit bytes that do not re-parse. The binary-to-JSON converters pin it on: a
+   // decoded value is someone else's bytes, and silently mangling one is worse than refusing it.
+   consteval bool check_reject_control_characters(auto&& Opts)
+   {
+      if constexpr (requires { Opts.reject_control_characters; }) {
+         return Opts.reject_control_characters;
       }
       else {
          return false;
@@ -1084,6 +1105,20 @@ namespace glz
             return opts_escape_control_characters{{Opts}, static_cast<bool>(value)};
          }
       }
+      else if constexpr (is_reject_control_characters_tag<member_ptr>) {
+         if constexpr (requires { Opts.reject_control_characters; }) {
+            auto ret = Opts;
+            ret.reject_control_characters = static_cast<bool>(value);
+            return ret;
+         }
+         else {
+            struct opts_reject_control_characters : std::decay_t<decltype(Opts)>
+            {
+               bool reject_control_characters{};
+            };
+            return opts_reject_control_characters{{Opts}, static_cast<bool>(value)};
+         }
+      }
       else if constexpr (is_quoted_num_tag<member_ptr>) {
          if constexpr (requires { Opts.quoted_num; }) {
             auto ret = Opts;
@@ -1224,6 +1259,20 @@ namespace glz
                bool escape_control_characters = true;
             };
             return opts_escape_control_characters{{Opts}};
+         }
+      }
+      else if constexpr (is_reject_control_characters_tag<member_ptr>) {
+         if constexpr (requires { Opts.reject_control_characters; }) {
+            auto ret = Opts;
+            ret.reject_control_characters = true;
+            return ret;
+         }
+         else {
+            struct opts_reject_control_characters : std::decay_t<decltype(Opts)>
+            {
+               bool reject_control_characters = true;
+            };
+            return opts_reject_control_characters{{Opts}};
          }
       }
       else if constexpr (is_quoted_num_tag<member_ptr>) {
@@ -1367,6 +1416,16 @@ namespace glz
          if constexpr (requires { Opts.escape_control_characters; }) {
             auto ret = Opts;
             ret.escape_control_characters = false;
+            return ret;
+         }
+         else {
+            return Opts;
+         }
+      }
+      else if constexpr (is_reject_control_characters_tag<member_ptr>) {
+         if constexpr (requires { Opts.reject_control_characters; }) {
+            auto ret = Opts;
+            ret.reject_control_characters = false;
             return ret;
          }
          else {

--- a/include/glaze/eetf/eetf_to_json.hpp
+++ b/include/glaze/eetf/eetf_to_json.hpp
@@ -147,7 +147,7 @@ namespace glz
             if (bool(ctx.error)) return;
             if (check_invalid_offset(ctx, it, end, len)) return;
             const sv value{reinterpret_cast<const char*>(it), len};
-            to<JSON, sv>::template op<raw_string_emit_opts<Opts>>(value, ctx, out, ix);
+            to<JSON, sv>::template op<detail::untrusted_string_emit_opts<Opts>>(value, ctx, out, ix);
             std::advance(it, len);
             break;
          }
@@ -166,7 +166,7 @@ namespace glz
                dump("false", out, ix);
             }
             else {
-               to<JSON, sv>::template op<raw_string_emit_opts<Opts>>(value, ctx, out, ix);
+               to<JSON, sv>::template op<detail::untrusted_string_emit_opts<Opts>>(value, ctx, out, ix);
             }
             std::advance(it, len);
             break;
@@ -296,7 +296,7 @@ namespace glz
             }
             else {
                const sv value{reinterpret_cast<const char*>(it), len};
-               to<JSON, sv>::template op<raw_string_emit_opts<Opts>>(value, ctx, out, ix);
+               to<JSON, sv>::template op<detail::untrusted_string_emit_opts<Opts>>(value, ctx, out, ix);
             }
             std::advance(it, len);
             break;

--- a/include/glaze/eetf/eetf_to_json.hpp
+++ b/include/glaze/eetf/eetf_to_json.hpp
@@ -147,7 +147,7 @@ namespace glz
             if (bool(ctx.error)) return;
             if (check_invalid_offset(ctx, it, end, len)) return;
             const sv value{reinterpret_cast<const char*>(it), len};
-            to<JSON, sv>::template op<Opts>(value, ctx, out, ix);
+            to<JSON, sv>::template op<raw_string_emit_opts<Opts>>(value, ctx, out, ix);
             std::advance(it, len);
             break;
          }
@@ -166,7 +166,7 @@ namespace glz
                dump("false", out, ix);
             }
             else {
-               to<JSON, sv>::template op<Opts>(value, ctx, out, ix);
+               to<JSON, sv>::template op<raw_string_emit_opts<Opts>>(value, ctx, out, ix);
             }
             std::advance(it, len);
             break;

--- a/include/glaze/eetf/eetf_to_json.hpp
+++ b/include/glaze/eetf/eetf_to_json.hpp
@@ -73,7 +73,9 @@ namespace glz
          }
       }
 
-      template <auto Opts, class Buffer>
+      // Key marks the term as an object key rather than a value. JSON keys must be strings, so
+      // the atoms that would otherwise emit as bare `true` / `false` stay quoted there.
+      template <auto Opts, bool Key = false, class Buffer>
       void term_to_json_value(auto&& ctx, auto&& it, auto&& end, Buffer& out, auto&& ix, uint32_t recursive_depth)
       {
          // Check recursion depth limit
@@ -147,7 +149,14 @@ namespace glz
             if (bool(ctx.error)) return;
             if (check_invalid_offset(ctx, it, end, len)) return;
             const sv value{reinterpret_cast<const char*>(it), len};
-            to<JSON, sv>::template op<detail::untrusted_string_emit_opts<Opts>>(value, ctx, out, ix);
+            // Only the UTF8 tag states its payload is UTF-8. ERL_ATOM_EXT is latin1 by spec and
+            // ERL_STRING_EXT is a list of bytes, so neither is held to a claim it never made.
+            if (type == ERL_ATOM_UTF8_EXT) {
+               detail::emit_untrusted_string<Opts>(ctx, value, out, ix);
+            }
+            else {
+               detail::emit_untrusted_bytes<Opts>(ctx, value, out, ix);
+            }
             std::advance(it, len);
             break;
          }
@@ -159,14 +168,20 @@ namespace glz
             if (bool(ctx.error)) return;
             if (check_invalid_offset(ctx, it, end, len)) return;
             const sv value{reinterpret_cast<const char*>(it), len};
-            if (len == 4 && std::memcmp(it, "true", 4) == 0) {
+            // A JSON object key must be a string, so an atom in key position stays quoted.
+            // Dumping the bare literal there produced `{true:1}`, which reports success and
+            // then fails to re-parse.
+            if (not Key && value == "true") {
                dump("true", out, ix);
             }
-            else if (len == 5 && std::memcmp(it, "false", 5) == 0) {
+            else if (not Key && value == "false") {
                dump("false", out, ix);
             }
+            else if (type == ERL_SMALL_ATOM_UTF8_EXT) {
+               detail::emit_untrusted_string<Opts>(ctx, value, out, ix);
+            }
             else {
-               to<JSON, sv>::template op<detail::untrusted_string_emit_opts<Opts>>(value, ctx, out, ix);
+               detail::emit_untrusted_bytes<Opts>(ctx, value, out, ix); // latin1 by spec
             }
             std::advance(it, len);
             break;
@@ -251,7 +266,7 @@ namespace glz
                   ctx.custom_error_message = "unsupported key type";
                   return;
                }
-               term_to_json_value<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
+               term_to_json_value<Opts, true>(ctx, it, end, out, ix, recursive_depth + 1);
                if (bool(ctx.error)) return;
                if constexpr (Opts.prettify) {
                   dump(": ", out, ix);
@@ -295,8 +310,10 @@ namespace glz
                dump('"', out, ix);
             }
             else {
+               // A binary holds arbitrary bytes by definition, so it is never claiming UTF-8.
+               // binary_as_base64 is how a payload that is not JSON text crosses intact.
                const sv value{reinterpret_cast<const char*>(it), len};
-               to<JSON, sv>::template op<detail::untrusted_string_emit_opts<Opts>>(value, ctx, out, ix);
+               detail::emit_untrusted_bytes<Opts>(ctx, value, out, ix);
             }
             std::advance(it, len);
             break;

--- a/include/glaze/eetf/eetf_to_json.hpp
+++ b/include/glaze/eetf/eetf_to_json.hpp
@@ -296,7 +296,7 @@ namespace glz
             }
             else {
                const sv value{reinterpret_cast<const char*>(it), len};
-               to<JSON, sv>::template op<Opts>(value, ctx, out, ix);
+               to<JSON, sv>::template op<raw_string_emit_opts<Opts>>(value, ctx, out, ix);
             }
             std::advance(it, len);
             break;

--- a/include/glaze/eetf/eetf_to_json.hpp
+++ b/include/glaze/eetf/eetf_to_json.hpp
@@ -149,14 +149,7 @@ namespace glz
             if (bool(ctx.error)) return;
             if (check_invalid_offset(ctx, it, end, len)) return;
             const sv value{reinterpret_cast<const char*>(it), len};
-            // Only the UTF8 tag states its payload is UTF-8. ERL_ATOM_EXT is latin1 by spec and
-            // ERL_STRING_EXT is a list of bytes, so neither is held to a claim it never made.
-            if (type == ERL_ATOM_UTF8_EXT) {
-               detail::emit_untrusted_string<Opts>(ctx, value, out, ix);
-            }
-            else {
-               detail::emit_untrusted_bytes<Opts>(ctx, value, out, ix);
-            }
+            detail::emit_untrusted_string<Opts>(ctx, value, out, ix);
             std::advance(it, len);
             break;
          }
@@ -177,11 +170,8 @@ namespace glz
             else if (not Key && value == "false") {
                dump("false", out, ix);
             }
-            else if (type == ERL_SMALL_ATOM_UTF8_EXT) {
-               detail::emit_untrusted_string<Opts>(ctx, value, out, ix);
-            }
             else {
-               detail::emit_untrusted_bytes<Opts>(ctx, value, out, ix); // latin1 by spec
+               detail::emit_untrusted_string<Opts>(ctx, value, out, ix);
             }
             std::advance(it, len);
             break;
@@ -310,10 +300,11 @@ namespace glz
                dump('"', out, ix);
             }
             else {
-               // A binary holds arbitrary bytes by definition, so it is never claiming UTF-8.
-               // binary_as_base64 is how a payload that is not JSON text crosses intact.
+               // A binary holds arbitrary bytes by definition, so a control character among them
+               // is expected rather than exceptional. binary_as_base64 carries such a payload
+               // across without involving the escaping decision at all.
                const sv value{reinterpret_cast<const char*>(it), len};
-               detail::emit_untrusted_bytes<Opts>(ctx, value, out, ix);
+               detail::emit_untrusted_string<Opts>(ctx, value, out, ix);
             }
             std::advance(it, len);
             break;

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -45,7 +45,7 @@ namespace glz
       //   * unquoted drops the surrounding quotes as well.
       // Each default is reasonable for a program serializing its own string; none is
       // reasonable for a foreign blob. Pinning all three keeps the converter's output strict
-      // JSON. Mirrors jsonb_to_json's raw_string_emit_opts.
+      // JSON.
       template <auto Opts>
       inline constexpr auto raw_string_emit_opts =
          opt_false<opt_false<opt_true<Opts, escape_control_characters_opt_tag{}>, raw_string_opt_tag{}>,

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -34,6 +34,24 @@
 
 namespace glz
 {
+   namespace detail
+   {
+      // Options for emitting an untrusted byte payload as a JSON string literal through
+      // to<JSON, string_view>. A binary-to-JSON converter turns someone else's blob into
+      // JSON text, so it cannot inherit the three writer options that each let payload bytes
+      // reach the document unescaped:
+      //   * escape_control_characters (off by default) leaves raw 0x00-0x1F bytes in place,
+      //   * raw_string emits the payload without escaping it at all,
+      //   * unquoted drops the surrounding quotes as well.
+      // Each default is reasonable for a program serializing its own string; none is
+      // reasonable for a foreign blob. Pinning all three keeps the converter's output strict
+      // JSON. Mirrors jsonb_to_json's raw_string_emit_opts.
+      template <auto Opts>
+      inline constexpr auto raw_string_emit_opts =
+         opt_false<opt_false<opt_true<Opts, escape_control_characters_opt_tag{}>, raw_string_opt_tag{}>,
+                   unquoted_opt_tag{}>;
+   }
+
    // This serialize<JSON> indirection only exists to call std::remove_cvref_t on the type
    // so that type matching doesn't depend on qualifiers.
    // It is recommended to directly call to<JSON, std::remove_cvref_t<T>> to reduce compilation overhead.

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -37,27 +37,27 @@ namespace glz
    namespace detail
    {
       // Options for emitting an untrusted byte payload as a JSON string literal through
-      // to<JSON, string_view>. A binary-to-JSON converter turns someone else's blob into
-      // JSON text, so it cannot inherit the three writer options that each let payload bytes
-      // reach the document unescaped:
-      //   * escape_control_characters (off by default) leaves raw 0x00-0x1F bytes in place,
-      //   * raw_string emits the payload without escaping it at all,
-      //   * unquoted drops the surrounding quotes as well.
-      // Each default is reasonable for a program serializing its own string; none is
-      // reasonable for a foreign blob. Pinning all three keeps the converter's output strict
-      // JSON, and pins it for the caller too: these are inheritable options, so a converter
-      // that read them from the caller's opts would hand the caller a switch that turns the
-      // converter's output into something its own JSON reader rejects. There is deliberately
-      // no opt-out.
+      // to<JSON, string_view>. A binary-to-JSON converter turns someone else's blob into JSON
+      // text, so two writer options that would let payload bytes reach the document unescaped
+      // are pinned off: raw_string emits the payload without escaping it at all, and unquoted
+      // drops the surrounding quotes as well. Neither default is reasonable for a foreign blob.
       //
-      // Every binary-to-JSON converter (beve, cbor, bson, eetf, jsonb) routes its string
-      // emits through this, so a new converter should too. Prefer the two functions below,
-      // which apply it; reach for the options directly only to emit through something other
-      // than to<JSON, string_view>.
+      // Control characters are the caller's decision, so escape_control_characters is inherited
+      // rather than pinned, and reject_control_characters is pinned on to give the default a
+      // defined meaning:
+      //   * off (default) -- a decoded value carrying a control character with no two-character
+      //     escape fails with error_code::invalid_control_character. Nothing is written that
+      //     would not re-parse, and nothing is quietly reshaped.
+      //   * on -- the byte is escaped as \uXXXX and the output round-trips. This is the opt-in
+      //     for payloads that legitimately carry control characters, and it does mean a NUL in
+      //     a decoded value becomes a NUL in whatever reads the JSON back.
+      //
+      // Every binary-to-JSON converter (beve, cbor, bson, eetf, jsonb) routes its string emits
+      // through emit_untrusted_string below, so a new converter should too.
       template <auto Opts>
       inline constexpr auto untrusted_string_emit_opts =
-         opt_false<opt_false<opt_true<Opts, escape_control_characters_opt_tag{}>, raw_string_opt_tag{}>,
-                   unquoted_opt_tag{}>;
+         opt_true<opt_false<opt_false<Opts, raw_string_opt_tag{}>, unquoted_opt_tag{}>,
+                  reject_control_characters_opt_tag{}>;
 
       // Bytes the JSON string writer emits for `str` under escape_control_characters, excluding
       // the surrounding quotes. Only a buffer that cannot grow has any use for this; see the
@@ -896,6 +896,11 @@ namespace glz
                   }
                }
                else {
+                  if constexpr (check_reject_control_characters(Opts)) {
+                     if (uint8_t(value) < 0x20) [[unlikely]] {
+                        ctx.error = error_code::invalid_control_character;
+                     }
+                  }
                   std::memcpy(&b[ix], &value, 1);
                   ++ix;
                }
@@ -1023,6 +1028,16 @@ namespace glz
                         }
                      }
                      else {
+                        if constexpr (check_reject_control_characters(Opts)) {
+                           // A control character with no two-character escape cannot be written
+                           // without \uXXXX. The table entry is zero, so the memcpy below would
+                           // put two NULs where one byte was. Flag it and let the loop finish:
+                           // returning early here would leave c un-advanced and the SIMD scan
+                           // would find the same byte forever. The output is abandoned anyway.
+                           if (char_escape_table[uint8_t(*c)] == 0) [[unlikely]] {
+                              ctx.error = error_code::invalid_control_character;
+                           }
+                        }
                         std::memcpy(data, &char_escape_table[uint8_t(*c)], 2);
                         data += 2;
                      }
@@ -1093,6 +1108,11 @@ namespace glz
                         }
                      }
                      else {
+                        if constexpr (check_reject_control_characters(Opts)) {
+                           if (uint8_t(*c) < 0x20) [[unlikely]] {
+                              ctx.error = error_code::invalid_control_character;
+                           }
+                        }
                         std::memcpy(data, c, 1);
                         ++data;
                      }
@@ -1110,27 +1130,14 @@ namespace glz
 
    namespace detail
    {
-      // Emit an untrusted payload that the source format defines as bytes rather than as text.
-      // An Erlang binary or a latin1 ERL_ATOM_EXT never claimed to be UTF-8, so checking it as
-      // UTF-8 would reject data its producer encoded correctly. Such a payload can still hold
-      // bytes that are not JSON text at all; eetf's binary_as_base64 is how those cross intact.
-      template <auto Opts, class B>
-      GLZ_ALWAYS_INLINE void emit_untrusted_bytes(is_context auto& ctx, const std::string_view s, B& out, size_t& ix)
-      {
-         to<JSON, std::string_view>::template op<untrusted_string_emit_opts<Opts>>(s, ctx, out, ix);
-      }
-
-      // Emit an untrusted payload that the source format states is UTF-8 text, checking that
-      // claim first. RFC 8259 section 8.1 requires JSON text to be UTF-8, and these bytes came
-      // out of a blob rather than out of the program, so they get the check the JSON reader
-      // gives its own input. Honors validate_utf8, which compiles the check away.
+      // Emit an untrusted byte payload as a JSON string literal. See untrusted_string_emit_opts
+      // for what is pinned and why. UTF-8 is deliberately not checked here: that is the reader's
+      // job, it is on by default there, and unlike the escaping decision it costs a real pass
+      // over every string.
       template <auto Opts, class B>
       GLZ_ALWAYS_INLINE void emit_untrusted_string(is_context auto& ctx, const std::string_view s, B& out, size_t& ix)
       {
-         if (validate_utf8_span<Opts>(ctx, s.data(), s.data() + s.size())) [[unlikely]] {
-            return;
-         }
-         emit_untrusted_bytes<Opts>(ctx, s, out, ix);
+         to<JSON, std::string_view>::template op<untrusted_string_emit_opts<Opts>>(s, ctx, out, ix);
       }
    }
 

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -51,7 +51,9 @@ namespace glz
       // no opt-out.
       //
       // Every binary-to-JSON converter (beve, cbor, bson, eetf, jsonb) routes its string
-      // emits through this, so a new converter should too.
+      // emits through this, so a new converter should too. Prefer the two functions below,
+      // which apply it; reach for the options directly only to emit through something other
+      // than to<JSON, string_view>.
       template <auto Opts>
       inline constexpr auto untrusted_string_emit_opts =
          opt_false<opt_false<opt_true<Opts, escape_control_characters_opt_tag{}>, raw_string_opt_tag{}>,
@@ -1105,6 +1107,32 @@ namespace glz
          }
       }
    };
+
+   namespace detail
+   {
+      // Emit an untrusted payload that the source format defines as bytes rather than as text.
+      // An Erlang binary or a latin1 ERL_ATOM_EXT never claimed to be UTF-8, so checking it as
+      // UTF-8 would reject data its producer encoded correctly. Such a payload can still hold
+      // bytes that are not JSON text at all; eetf's binary_as_base64 is how those cross intact.
+      template <auto Opts, class B>
+      GLZ_ALWAYS_INLINE void emit_untrusted_bytes(is_context auto& ctx, const std::string_view s, B& out, size_t& ix)
+      {
+         to<JSON, std::string_view>::template op<untrusted_string_emit_opts<Opts>>(s, ctx, out, ix);
+      }
+
+      // Emit an untrusted payload that the source format states is UTF-8 text, checking that
+      // claim first. RFC 8259 section 8.1 requires JSON text to be UTF-8, and these bytes came
+      // out of a blob rather than out of the program, so they get the check the JSON reader
+      // gives its own input. Honors validate_utf8, which compiles the check away.
+      template <auto Opts, class B>
+      GLZ_ALWAYS_INLINE void emit_untrusted_string(is_context auto& ctx, const std::string_view s, B& out, size_t& ix)
+      {
+         if (validate_utf8_span<Opts>(ctx, s.data(), s.data() + s.size())) [[unlikely]] {
+            return;
+         }
+         emit_untrusted_bytes<Opts>(ctx, s, out, ix);
+      }
+   }
 
    template <class T>
       requires((glaze_enum_t<T> || (meta_keys<T> && std::is_enum_v<std::decay_t<T>>)) && not custom_write<T>)

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -56,6 +56,56 @@ namespace glz
       inline constexpr auto untrusted_string_emit_opts =
          opt_false<opt_false<opt_true<Opts, escape_control_characters_opt_tag{}>, raw_string_opt_tag{}>,
                    unquoted_opt_tag{}>;
+
+      // Bytes the JSON string writer emits for `str` under escape_control_characters, excluding
+      // the surrounding quotes. Only a buffer that cannot grow has any use for this; see the
+      // reservation in to<JSON, str_t>::op. A byte-at-a-time count costs about as much as the
+      // escaping write it is sizing, so this reuses the writer's own 8-byte scan: a block with
+      // nothing to escape adds nothing to the size and is skipped whole.
+      inline size_t escaped_string_size(const std::string_view str) noexcept
+      {
+         const size_t n = str.size();
+         size_t size = n;
+         const char* c = str.data();
+         const char* const e = c + n;
+
+         if (n > 7) {
+            for (const char* const end_m7 = e - 7; c < end_m7;) {
+               uint64_t swar;
+               std::memcpy(&swar, c, 8);
+               if constexpr (std::endian::native == std::endian::big) {
+                  swar = std::byteswap(swar);
+               }
+
+               constexpr uint64_t lo7_mask = repeat_byte8(0b01111111);
+               const uint64_t lo7 = swar & lo7_mask;
+               const uint64_t quote = (lo7 ^ repeat_byte8('"')) + lo7_mask;
+               const uint64_t backslash = (lo7 ^ repeat_byte8('\\')) + lo7_mask;
+               const uint64_t less_32 = (swar & repeat_byte8(0b01100000)) + lo7_mask;
+               uint64_t next = ~((quote & backslash & less_32) | swar);
+
+               next &= repeat_byte8(0b10000000);
+               if (next == 0) {
+                  c += 8;
+                  continue;
+               }
+
+               c += (countr_zero(next) >> 3);
+               size += char_escape_table[uint8_t(*c)] ? 1 : 5; // two-character escape, or \u00XX
+               ++c;
+            }
+         }
+
+         for (; c < e; ++c) {
+            if (char_escape_table[uint8_t(*c)]) {
+               size += 1;
+            }
+            else if (uint8_t(*c) < 0x20) {
+               size += 5;
+            }
+         }
+         return size;
+      }
    }
 
    // This serialize<JSON> indirection only exists to call std::remove_cvref_t on the type
@@ -901,8 +951,28 @@ namespace glz
                // For each individual character we need room for two characters to handle escapes.
                // When using Unicode escapes, we might need up to 6 characters (\uXXXX) per character
                if constexpr (check_escape_control_characters(Opts)) {
+                  if constexpr (has_bounded_capacity<B>) {
+                     // 6 bytes per character is a ceiling only a string of nothing but control
+                     // characters reaches. A resizable buffer merely over-allocates against it,
+                     // but a fixed buffer has nowhere to grow, so the ceiling would reject output
+                     // that fits. Measuring the string answers exactly, at the cost of a pass over
+                     // it, so bracket the measurement between two O(1) bounds and only pay it when
+                     // the answer is still in doubt: the ceiling fitting means yes, and the floor
+                     // of one byte per character not fitting means no.
+                     const size_t capacity = buffer_traits<std::remove_cvref_t<B>>::capacity(b);
+                     size_t required = ix + 10 + 6 * n;
+                     if (required > capacity) [[unlikely]] {
+                        required = ix + 10 + n;
+                        if (required <= capacity) {
+                           required = ix + 10 + detail::escaped_string_size(str);
+                        }
+                     }
+                     if (!ensure_space(ctx, b, required)) [[unlikely]] {
+                        return;
+                     }
+                  }
                   // We need 2 + 6 * n characters in the worst case (all control chars)
-                  if (!ensure_space(ctx, b, ix + 10 + 6 * n)) [[unlikely]] {
+                  else if (!ensure_space(ctx, b, ix + 10 + 6 * n)) [[unlikely]] {
                      return;
                   }
                }

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -45,9 +45,15 @@ namespace glz
       //   * unquoted drops the surrounding quotes as well.
       // Each default is reasonable for a program serializing its own string; none is
       // reasonable for a foreign blob. Pinning all three keeps the converter's output strict
-      // JSON.
+      // JSON, and pins it for the caller too: these are inheritable options, so a converter
+      // that read them from the caller's opts would hand the caller a switch that turns the
+      // converter's output into something its own JSON reader rejects. There is deliberately
+      // no opt-out.
+      //
+      // Every binary-to-JSON converter (beve, cbor, bson, eetf, jsonb) routes its string
+      // emits through this, so a new converter should too.
       template <auto Opts>
-      inline constexpr auto raw_string_emit_opts =
+      inline constexpr auto untrusted_string_emit_opts =
          opt_false<opt_false<opt_true<Opts, escape_control_characters_opt_tag{}>, raw_string_opt_tag{}>,
                    unquoted_opt_tag{}>;
    }

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -43,8 +43,10 @@ namespace glz
       // drops the surrounding quotes as well. Neither default is reasonable for a foreign blob.
       //
       // Control characters are the caller's decision, so escape_control_characters is inherited
-      // rather than pinned, and reject_control_characters is pinned on to give the default a
-      // defined meaning:
+      // rather than pinned. The opts_internal::reject_control_characters flag is set alongside it
+      // to give the default a defined meaning. It is internal because no user sets it: the knob
+      // they reach for is escape_control_characters, and this only says which way its absence
+      // should be read at a converter emit site.
       //   * off (default) -- a decoded value carrying a control character with no two-character
       //     escape fails with error_code::invalid_control_character. Nothing is written that
       //     would not re-parse, and nothing is quietly reshaped.
@@ -56,8 +58,7 @@ namespace glz
       // through emit_untrusted_string below, so a new converter should too.
       template <auto Opts>
       inline constexpr auto untrusted_string_emit_opts =
-         opt_true<opt_false<opt_false<Opts, raw_string_opt_tag{}>, unquoted_opt_tag{}>,
-                  reject_control_characters_opt_tag{}>;
+         glz::reject_control_characters<opt_false<opt_false<Opts, raw_string_opt_tag{}>, unquoted_opt_tag{}>>();
 
       // Bytes the JSON string writer emits for `str` under escape_control_characters, excluding
       // the surrounding quotes. Only a buffer that cannot grow has any use for this; see the

--- a/include/glaze/jsonb/jsonb_to_json.hpp
+++ b/include/glaze/jsonb/jsonb_to_json.hpp
@@ -21,22 +21,14 @@ namespace glz
 {
    namespace jsonb_detail
    {
-      // Emit a JSON string literal from a raw UTF-8 byte payload. Uses the JSON writer so all
-      // control characters and structural JSON chars are correctly escaped. The option pinning
-      // that keeps a caller's opts from reopening that hole lives in detail::untrusted_string_emit_opts,
-      // which every binary-to-JSON converter shares.
+      // Emit a JSON string literal from a raw UTF-8 byte payload. The UTF-8 check and the option
+      // pinning that keeps a caller's opts from reopening the escaping hole both live in
+      // detail::emit_untrusted_string, which every binary-to-JSON converter shares. No
+      // accumulator is passed: nothing has scanned this payload yet.
       template <auto Opts, class B>
       inline void emit_raw_string_as_json(is_context auto& ctx, const char* data, size_t size, B& out, size_t& ix)
       {
-         // RFC 8259 section 8.1 requires JSON text to be UTF-8, and these bytes came out of a
-         // blob rather than out of the program, so they get the same treatment the JSON reader
-         // gives its input. Honors the `validate_utf8` option, which compiles the check away.
-         // No accumulator is available here: nothing has scanned this payload yet.
-         if (validate_utf8_span<Opts>(ctx, data, data + size)) [[unlikely]] {
-            return;
-         }
-         const sv s{data, size};
-         to<JSON, sv>::template op<detail::untrusted_string_emit_opts<Opts>>(s, ctx, out, ix);
+         detail::emit_untrusted_string<Opts>(ctx, sv{data, size}, out, ix);
       }
 
       // The spec marks several payloads as "already valid JSON text" so that a converter can

--- a/include/glaze/jsonb/jsonb_to_json.hpp
+++ b/include/glaze/jsonb/jsonb_to_json.hpp
@@ -21,14 +21,26 @@ namespace glz
 {
    namespace jsonb_detail
    {
-      // Emit a JSON string literal from a raw UTF-8 byte payload. The UTF-8 check and the option
-      // pinning that keeps a caller's opts from reopening the escaping hole both live in
-      // detail::emit_untrusted_string, which every binary-to-JSON converter shares. No
-      // accumulator is passed: nothing has scanned this payload yet.
+      // Emit a JSON string literal from a raw UTF-8 byte payload, sharing the option pinning in
+      // detail::emit_untrusted_string with every other binary-to-JSON converter.
+      //
+      // JSONB differs from those converters in one respect: a control character in a payload is
+      // expected rather than anomalous, because a JSONB blob is the storage form of a JSON
+      // document that could itself have carried \uXXXX. Escaping is pinned on here so the
+      // converter keeps round-tripping such a document instead of refusing it, which is also the
+      // behavior this converter shipped with.
       template <auto Opts, class B>
       inline void emit_raw_string_as_json(is_context auto& ctx, const char* data, size_t size, B& out, size_t& ix)
       {
-         detail::emit_untrusted_string<Opts>(ctx, sv{data, size}, out, ix);
+         // RFC 8259 section 8.1 requires JSON text to be UTF-8, and these bytes came out of a
+         // blob rather than out of the program, so they get the same treatment the JSON reader
+         // gives its input. Honors the `validate_utf8` option, which compiles the check away.
+         // No accumulator is available here: nothing has scanned this payload yet.
+         if (validate_utf8_span<Opts>(ctx, data, data + size)) [[unlikely]] {
+            return;
+         }
+         detail::emit_untrusted_string<opt_true<Opts, escape_control_characters_opt_tag{}>>(ctx, sv{data, size}, out,
+                                                                                            ix);
       }
 
       // The spec marks several payloads as "already valid JSON text" so that a converter can

--- a/include/glaze/jsonb/jsonb_to_json.hpp
+++ b/include/glaze/jsonb/jsonb_to_json.hpp
@@ -22,22 +22,9 @@ namespace glz
    namespace jsonb_detail
    {
       // Emit a JSON string literal from a raw UTF-8 byte payload. Uses the JSON writer so all
-      // control characters and structural JSON chars are correctly escaped.
-      //
-      // Three writer options would each let payload bytes reach the output document unescaped,
-      // and all three are inheritable, so a caller's opts would otherwise silently reopen the
-      // hole this converter exists to close:
-      //   * escape_control_characters (off by default) leaves raw control bytes in place,
-      //   * raw_string emits the payload without escaping it at all,
-      //   * unquoted drops the surrounding quotes as well.
-      // Each default is reasonable for a C++ string being serialized, because that is the
-      // program's own data. None of them is reasonable for a blob, which is someone else's.
-      // The converter promises strict JSON, so it pins all three rather than inheriting them.
-      template <auto Opts>
-      inline constexpr auto raw_string_emit_opts =
-         opt_false<opt_false<opt_true<Opts, escape_control_characters_opt_tag{}>, raw_string_opt_tag{}>,
-                   unquoted_opt_tag{}>;
-
+      // control characters and structural JSON chars are correctly escaped. The option pinning
+      // that keeps a caller's opts from reopening that hole lives in detail::raw_string_emit_opts,
+      // which every binary-to-JSON converter shares.
       template <auto Opts, class B>
       inline void emit_raw_string_as_json(is_context auto& ctx, const char* data, size_t size, B& out, size_t& ix)
       {
@@ -49,7 +36,7 @@ namespace glz
             return;
          }
          const sv s{data, size};
-         to<JSON, sv>::template op<raw_string_emit_opts<Opts>>(s, ctx, out, ix);
+         to<JSON, sv>::template op<detail::raw_string_emit_opts<Opts>>(s, ctx, out, ix);
       }
 
       // The spec marks several payloads as "already valid JSON text" so that a converter can

--- a/include/glaze/jsonb/jsonb_to_json.hpp
+++ b/include/glaze/jsonb/jsonb_to_json.hpp
@@ -23,7 +23,7 @@ namespace glz
    {
       // Emit a JSON string literal from a raw UTF-8 byte payload. Uses the JSON writer so all
       // control characters and structural JSON chars are correctly escaped. The option pinning
-      // that keeps a caller's opts from reopening that hole lives in detail::raw_string_emit_opts,
+      // that keeps a caller's opts from reopening that hole lives in detail::untrusted_string_emit_opts,
       // which every binary-to-JSON converter shares.
       template <auto Opts, class B>
       inline void emit_raw_string_as_json(is_context auto& ctx, const char* data, size_t size, B& out, size_t& ix)
@@ -36,7 +36,7 @@ namespace glz
             return;
          }
          const sv s{data, size};
-         to<JSON, sv>::template op<detail::raw_string_emit_opts<Opts>>(s, ctx, out, ix);
+         to<JSON, sv>::template op<detail::untrusted_string_emit_opts<Opts>>(s, ctx, out, ix);
       }
 
       // The spec marks several payloads as "already valid JSON text" so that a converter can

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -2868,6 +2868,28 @@ suite beve_to_json_tests = [] {
       expect(round_trip == v);
    };
 
+   "beve_to_json passes through control characters that have a short escape"_test = [] {
+      // The default refuses only control characters with no two-character JSON escape. Backspace,
+      // tab, newline, form feed and carriage return have one, so they keep converting normally.
+      // The reject sits in the else of the escape table lookup and cannot see them. The long
+      // value puts the run past the scalar tail and into the writer's block scan, which rejects
+      // at a separate site.
+      const std::string shorts = "\b\t\n\f\r";
+      std::map<std::string, std::string> v = {{"k" + shorts, shorts},
+                                              {"long", std::string(64, 'a') + shorts + std::string(64, 'b')}};
+      std::string buffer{};
+      expect(not glz::write_beve(v, buffer));
+
+      std::string json{};
+      expect(!glz::beve_to_json(buffer, json)) << json;
+      expect(json.find("\\b\\t\\n\\f\\r") != std::string::npos) << json;
+      expect(json.find_first_of(shorts) == std::string::npos) << json;
+
+      std::map<std::string, std::string> round_trip{};
+      expect(!glz::read_json(round_trip, json)) << json;
+      expect(round_trip == v);
+   };
+
    "beve_to_json std::map"_test = [] {
       std::map<std::string, int> v = {{"first", 1}, {"second", 2}, {"third", 3}};
       std::string buffer{};

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -2803,9 +2803,9 @@ suite beve_custom_key_tests = [] {
    "vector pair CastModuleID"_test = [] { verify_vector_pair_roundtrip<CastModuleID>(); };
 };
 
-struct beve_no_utf8_opts : glz::opts
+struct beve_escape_opts : glz::opts
 {
-   bool validate_utf8 = false;
+   bool escape_control_characters = true;
 };
 
 suite beve_to_json_tests = [] {
@@ -2842,34 +2842,30 @@ suite beve_to_json_tests = [] {
       expect(json == R"("Hello World")") << json;
    };
 
-   "beve_to_json escapes control characters"_test = [] {
-      // A control byte is legal in a BEVE string but must be escaped so the JSON output
-      // re-parses. Covers both a value and a map key.
+   "beve_to_json rejects control characters by default"_test = [] {
+      // A control byte is legal in a BEVE string but cannot be written as JSON without \uXXXX.
+      // The default refuses it rather than emitting bytes that will not re-parse, so the caller
+      // gets a signal instead of a malformed document.
       std::map<std::string, std::string> v = {{std::string("k\001"), std::string("a\001b")}};
       std::string buffer{};
       expect(not glz::write_beve(v, buffer));
 
       std::string json{};
-      expect(!glz::beve_to_json(buffer, json));
-      expect(json == "{\"k\\u0001\":\"a\\u0001b\"}") << json;
-      std::map<std::string, std::string> round_trip{};
-      expect(!glz::read_json(round_trip, json)) << json;
-      expect(round_trip == v);
+      expect(glz::beve_to_json(buffer, json).ec == glz::error_code::invalid_control_character);
    };
 
-   "beve_to_json validates UTF-8"_test = [] {
-      // A BEVE string is UTF-8 by spec, and RFC 8259 requires JSON text to be UTF-8, so the
-      // converter checks the claim rather than copying a lone continuation byte into the output.
-      // Honors validate_utf8 like the reader does, so it can still be turned off.
-      std::map<std::string, std::string> v{{"k", std::string("a\x80z")}};
+   "beve_to_json escapes control characters when asked"_test = [] {
+      // escape_control_characters opts into carrying them across. Covers a value and a map key.
+      std::map<std::string, std::string> v = {{std::string("k\001"), std::string("a\001b")}};
       std::string buffer{};
       expect(not glz::write_beve(v, buffer));
 
       std::string json{};
-      expect(glz::beve_to_json(buffer, json).ec == glz::error_code::invalid_utf8);
-
-      std::string unchecked{};
-      expect(not glz::beve_to_json<beve_no_utf8_opts{}>(buffer, unchecked));
+      expect(!glz::beve_to_json<beve_escape_opts{}>(buffer, json));
+      expect(json == "{\"k\\u0001\":\"a\\u0001b\"}") << json;
+      std::map<std::string, std::string> round_trip{};
+      expect(!glz::read_json(round_trip, json)) << json;
+      expect(round_trip == v);
    };
 
    "beve_to_json std::map"_test = [] {
@@ -6230,23 +6226,23 @@ suite beve_bounded_buffer_overflow_tests = [] {
    };
 
    "beve_to_json into a bounded buffer reserves what the strings escape to"_test = [] {
-      // The converter always escapes control characters, whose worst-case reservation is
-      // 6 bytes per character. A fixed buffer cannot grow, so it is sized by what the string
-      // actually escapes to and a payload that fits is not rejected.
+      // Under escape_control_characters the worst-case reservation is 6 bytes per character.
+      // A fixed buffer cannot grow, so it is sized by what the string actually escapes to and
+      // a payload that fits is not rejected.
       std::map<std::string, std::string> v{{"k", std::string("a\001b") + std::string(200, 'c')}};
       std::string beve{};
       expect(not glz::write_beve(v, beve));
 
       std::string reference{};
-      expect(not glz::beve_to_json(beve, reference));
+      expect(not glz::beve_to_json<beve_escape_opts{}>(beve, reference));
       expect(reference.size() == 216) << reference.size(); // 1222 of worst case
 
       std::array<char, 512> buffer{};
-      expect(not glz::beve_to_json(beve, buffer)) << "216 bytes of output should fit in 512";
+      expect(not glz::beve_to_json<beve_escape_opts{}>(beve, buffer)) << "216 bytes should fit in 512";
       expect(std::string_view(buffer.data(), reference.size()) == reference);
 
       std::array<char, 16> tiny{};
-      expect(glz::beve_to_json(beve, tiny).ec == glz::error_code::buffer_overflow);
+      expect(glz::beve_to_json<beve_escape_opts{}>(beve, tiny).ec == glz::error_code::buffer_overflow);
    };
 };
 

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -2837,6 +2837,21 @@ suite beve_to_json_tests = [] {
       expect(json == R"("Hello World")") << json;
    };
 
+   "beve_to_json escapes control characters"_test = [] {
+      // A control byte is legal in a BEVE string but must be escaped so the JSON output
+      // re-parses. Covers both a value and a map key.
+      std::map<std::string, std::string> v = {{std::string("k\001"), std::string("a\001b")}};
+      std::string buffer{};
+      expect(not glz::write_beve(v, buffer));
+
+      std::string json{};
+      expect(!glz::beve_to_json(buffer, json));
+      expect(json == "{\"k\\u0001\":\"a\\u0001b\"}") << json;
+      std::map<std::string, std::string> round_trip{};
+      expect(!glz::read_json(round_trip, json)) << json;
+      expect(round_trip == v);
+   };
+
    "beve_to_json std::map"_test = [] {
       std::map<std::string, int> v = {{"first", 1}, {"second", 2}, {"third", 3}};
       std::string buffer{};

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -2803,6 +2803,11 @@ suite beve_custom_key_tests = [] {
    "vector pair CastModuleID"_test = [] { verify_vector_pair_roundtrip<CastModuleID>(); };
 };
 
+struct beve_no_utf8_opts : glz::opts
+{
+   bool validate_utf8 = false;
+};
+
 suite beve_to_json_tests = [] {
    "beve_to_json bool"_test = [] {
       bool b = true;
@@ -2850,6 +2855,21 @@ suite beve_to_json_tests = [] {
       std::map<std::string, std::string> round_trip{};
       expect(!glz::read_json(round_trip, json)) << json;
       expect(round_trip == v);
+   };
+
+   "beve_to_json validates UTF-8"_test = [] {
+      // A BEVE string is UTF-8 by spec, and RFC 8259 requires JSON text to be UTF-8, so the
+      // converter checks the claim rather than copying a lone continuation byte into the output.
+      // Honors validate_utf8 like the reader does, so it can still be turned off.
+      std::map<std::string, std::string> v{{"k", std::string("a\x80z")}};
+      std::string buffer{};
+      expect(not glz::write_beve(v, buffer));
+
+      std::string json{};
+      expect(glz::beve_to_json(buffer, json).ec == glz::error_code::invalid_utf8);
+
+      std::string unchecked{};
+      expect(not glz::beve_to_json<beve_no_utf8_opts{}>(buffer, unchecked));
    };
 
    "beve_to_json std::map"_test = [] {

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -6208,6 +6208,26 @@ suite beve_bounded_buffer_overflow_tests = [] {
       expect(!ec) << "read should succeed";
       expect(decoded == obj) << "decoded map should match";
    };
+
+   "beve_to_json into a bounded buffer reserves what the strings escape to"_test = [] {
+      // The converter always escapes control characters, whose worst-case reservation is
+      // 6 bytes per character. A fixed buffer cannot grow, so it is sized by what the string
+      // actually escapes to and a payload that fits is not rejected.
+      std::map<std::string, std::string> v{{"k", std::string("a\001b") + std::string(200, 'c')}};
+      std::string beve{};
+      expect(not glz::write_beve(v, beve));
+
+      std::string reference{};
+      expect(not glz::beve_to_json(beve, reference));
+      expect(reference.size() == 216) << reference.size(); // 1222 of worst case
+
+      std::array<char, 512> buffer{};
+      expect(not glz::beve_to_json(beve, buffer)) << "216 bytes of output should fit in 512";
+      expect(std::string_view(buffer.data(), reference.size()) == reference);
+
+      std::array<char, 16> tiny{};
+      expect(glz::beve_to_json(beve, tiny).ec == glz::error_code::buffer_overflow);
+   };
 };
 
 // Structs for DoS prevention tests

--- a/tests/bson_test/bson_test.cpp
+++ b/tests/bson_test/bson_test.cpp
@@ -1447,6 +1447,20 @@ namespace
          expect(json.value() == R"({"a":1,"b":9000000000,"c":1.5,"d":true,"e":"hi"})");
       };
 
+      "convert-escapes-control-characters"_test = [] {
+         // A control byte is legal in a BSON string value but must be escaped so the
+         // converter output re-parses as JSON.
+         std::map<std::string, std::string> v{{"k", std::string("a\001b")}};
+         auto bson = glz::write_bson(v);
+         expect(bson.has_value());
+         auto json = glz::bson_to_json(bson.value());
+         expect(json.has_value());
+         expect(json.value() == "{\"k\":\"a\\u0001b\"}") << json.value();
+         std::map<std::string, std::string> round_trip{};
+         expect(!glz::read_json(round_trip, json.value())) << json.value();
+         expect(round_trip == v);
+      };
+
       "convert-nested-document"_test = [] {
          outer_s v{inner_s{42}};
          auto bson = glz::write_bson(v);

--- a/tests/bson_test/bson_test.cpp
+++ b/tests/bson_test/bson_test.cpp
@@ -387,6 +387,11 @@ using namespace bson_test;
 
 namespace
 {
+   struct bson_no_utf8_opts : glz::opts
+   {
+      bool validate_utf8 = false;
+   };
+
    suite bson_interop_tests = [] {
       "spec-canonical-hello-world"_test = [] {
          // {"hello": "world"} — the canonical example from bsonspec.org.
@@ -1459,6 +1464,16 @@ namespace
          std::map<std::string, std::string> round_trip{};
          expect(!glz::read_json(round_trip, json.value())) << json.value();
          expect(round_trip == v);
+      };
+
+      "convert-validates-utf8"_test = [] {
+         // A BSON string is UTF-8 by spec, so the converter holds it to that rather than
+         // copying a lone continuation byte into JSON text.
+         std::map<std::string, std::string> v{{"k", std::string("a\x80z")}};
+         auto bson = glz::write_bson(v);
+         expect(bson.has_value());
+         expect(not glz::bson_to_json(bson.value()).has_value());
+         expect(glz::bson_to_json<bson_no_utf8_opts{}>(bson.value()).has_value());
       };
 
       "convert-nested-document"_test = [] {

--- a/tests/bson_test/bson_test.cpp
+++ b/tests/bson_test/bson_test.cpp
@@ -1475,6 +1475,27 @@ namespace
          expect(round_trip == v);
       };
 
+      "convert-passes-through-short-escape-control-characters"_test = [] {
+         // The default refuses only control characters with no two-character JSON escape.
+         // Backspace, tab, newline, form feed and carriage return have one, so they keep
+         // converting normally. The reject sits in the else of the escape table lookup and
+         // cannot see them. The long value puts the run past the scalar tail and into the
+         // writer's block scan, which rejects at a separate site.
+         const std::string shorts = "\b\t\n\f\r";
+         std::map<std::string, std::string> v{{"k" + shorts, shorts},
+                                              {"long", std::string(64, 'a') + shorts + std::string(64, 'b')}};
+         auto bson = glz::write_bson(v);
+         expect(bson.has_value());
+         auto json = glz::bson_to_json(bson.value());
+         expect(json.has_value());
+         expect(json.value().find("\\b\\t\\n\\f\\r") != std::string::npos) << json.value();
+         expect(json.value().find_first_of(shorts) == std::string::npos) << json.value();
+
+         std::map<std::string, std::string> round_trip{};
+         expect(!glz::read_json(round_trip, json.value())) << json.value();
+         expect(round_trip == v);
+      };
+
       "convert-nested-document"_test = [] {
          outer_s v{inner_s{42}};
          auto bson = glz::write_bson(v);

--- a/tests/bson_test/bson_test.cpp
+++ b/tests/bson_test/bson_test.cpp
@@ -387,9 +387,9 @@ using namespace bson_test;
 
 namespace
 {
-   struct bson_no_utf8_opts : glz::opts
+   struct bson_escape_opts : glz::opts
    {
-      bool validate_utf8 = false;
+      bool escape_control_characters = true;
    };
 
    suite bson_interop_tests = [] {
@@ -1452,28 +1452,27 @@ namespace
          expect(json.value() == R"({"a":1,"b":9000000000,"c":1.5,"d":true,"e":"hi"})");
       };
 
-      "convert-escapes-control-characters"_test = [] {
-         // A control byte is legal in a BSON string value but must be escaped so the
-         // converter output re-parses as JSON.
+      "convert-rejects-control-characters-by-default"_test = [] {
+         // A control byte is legal in a BSON string but cannot be written as JSON without
+         // \uXXXX, so the default refuses it rather than emitting output that will not re-parse.
          std::map<std::string, std::string> v{{"k", std::string("a\001b")}};
          auto bson = glz::write_bson(v);
          expect(bson.has_value());
          auto json = glz::bson_to_json(bson.value());
+         expect(not json.has_value());
+         expect(json.error().ec == glz::error_code::invalid_control_character);
+      };
+
+      "convert-escapes-control-characters-when-asked"_test = [] {
+         std::map<std::string, std::string> v{{"k", std::string("a\001b")}};
+         auto bson = glz::write_bson(v);
+         expect(bson.has_value());
+         auto json = glz::bson_to_json<bson_escape_opts{}>(bson.value());
          expect(json.has_value());
          expect(json.value() == "{\"k\":\"a\\u0001b\"}") << json.value();
          std::map<std::string, std::string> round_trip{};
          expect(!glz::read_json(round_trip, json.value())) << json.value();
          expect(round_trip == v);
-      };
-
-      "convert-validates-utf8"_test = [] {
-         // A BSON string is UTF-8 by spec, so the converter holds it to that rather than
-         // copying a lone continuation byte into JSON text.
-         std::map<std::string, std::string> v{{"k", std::string("a\x80z")}};
-         auto bson = glz::write_bson(v);
-         expect(bson.has_value());
-         expect(not glz::bson_to_json(bson.value()).has_value());
-         expect(glz::bson_to_json<bson_no_utf8_opts{}>(bson.value()).has_value());
       };
 
       "convert-nested-document"_test = [] {

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -2375,6 +2375,28 @@ void cbor_to_json_tests()
       expect(round_trip == v);
    };
 
+   "cbor_to_json_passes_through_short_escape_control_characters"_test = [] {
+      // The default refuses only control characters with no two-character JSON escape. Backspace,
+      // tab, newline, form feed and carriage return have one, so they keep converting normally.
+      // The reject sits in the else of the escape table lookup and cannot see them. The long
+      // value puts the run past the scalar tail and into the writer's block scan, which rejects
+      // at a separate site.
+      const std::string shorts = "\b\t\n\f\r";
+      std::map<std::string, std::string> v{{"k" + shorts, shorts},
+                                           {"long", std::string(64, 'a') + shorts + std::string(64, 'b')}};
+      std::string cbor_buffer;
+      expect(not glz::write_cbor(v, cbor_buffer));
+
+      std::string json;
+      expect(not glz::cbor_to_json(cbor_buffer, json)) << json;
+      expect(json.find("\\b\\t\\n\\f\\r") != std::string::npos) << json;
+      expect(json.find_first_of(shorts) == std::string::npos) << json;
+
+      std::map<std::string, std::string> round_trip{};
+      expect(not glz::read_json(round_trip, json)) << json;
+      expect(round_trip == v);
+   };
+
    "cbor_to_json_array"_test = [] {
       std::vector<int> v = {1, 2, 3};
       std::string cbor_buffer;

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -2308,9 +2308,9 @@ void typed_array_tests()
 }
 
 // CBOR-to-JSON conversion tests
-struct cbor_no_utf8_opts : glz::opts
+struct cbor_escape_opts : glz::opts
 {
-   bool validate_utf8 = false;
+   bool escape_control_characters = true;
 };
 
 void cbor_to_json_tests()
@@ -2350,34 +2350,29 @@ void cbor_to_json_tests()
       expect(json == "\"hello\"");
    };
 
-   "cbor_to_json_escapes_control_characters"_test = [] {
-      // A control byte is legal in a CBOR text string but must be escaped so the JSON
-      // output re-parses. Covers both a value and a map key.
+   "cbor_to_json_rejects_control_characters_by_default"_test = [] {
+      // A control byte is legal in a CBOR text string but cannot be written as JSON without
+      // \uXXXX, so the default refuses it rather than emitting output that will not re-parse.
       std::map<std::string, std::string> v{{std::string("k\001"), std::string("a\001b")}};
       std::string cbor_buffer;
       expect(not glz::write_cbor(v, cbor_buffer));
 
       std::string json;
-      expect(not glz::cbor_to_json(cbor_buffer, json));
-      expect(json == "{\"k\\u0001\":\"a\\u0001b\"}") << json;
-      std::map<std::string, std::string> round_trip{};
-      expect(not glz::read_json(round_trip, json)) << json;
-      expect(round_trip == v);
+      expect(glz::cbor_to_json(cbor_buffer, json).ec == glz::error_code::invalid_control_character);
    };
 
-   "cbor_to_json_validates_utf8"_test = [] {
-      // A CBOR text string (major type 3) is UTF-8 by spec, so the converter holds it to that
-      // rather than copying a lone continuation byte into JSON text. Byte strings are unaffected;
-      // they already go out as hex.
-      std::map<std::string, std::string> v{{"k", std::string("a\x80z")}};
+   "cbor_to_json_escapes_control_characters_when_asked"_test = [] {
+      // escape_control_characters opts into carrying them across. Covers a value and a map key.
+      std::map<std::string, std::string> v{{std::string("k\001"), std::string("a\001b")}};
       std::string cbor_buffer;
       expect(not glz::write_cbor(v, cbor_buffer));
 
       std::string json;
-      expect(glz::cbor_to_json(cbor_buffer, json).ec == glz::error_code::invalid_utf8);
-
-      std::string unchecked;
-      expect(not glz::cbor_to_json<cbor_no_utf8_opts{}>(cbor_buffer, unchecked));
+      expect(not glz::cbor_to_json<cbor_escape_opts{}>(cbor_buffer, json));
+      expect(json == "{\"k\\u0001\":\"a\\u0001b\"}") << json;
+      std::map<std::string, std::string> round_trip{};
+      expect(not glz::read_json(round_trip, json)) << json;
+      expect(round_trip == v);
    };
 
    "cbor_to_json_array"_test = [] {

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -2308,6 +2308,11 @@ void typed_array_tests()
 }
 
 // CBOR-to-JSON conversion tests
+struct cbor_no_utf8_opts : glz::opts
+{
+   bool validate_utf8 = false;
+};
+
 void cbor_to_json_tests()
 {
    "cbor_to_json_integer"_test = [] {
@@ -2358,6 +2363,21 @@ void cbor_to_json_tests()
       std::map<std::string, std::string> round_trip{};
       expect(not glz::read_json(round_trip, json)) << json;
       expect(round_trip == v);
+   };
+
+   "cbor_to_json_validates_utf8"_test = [] {
+      // A CBOR text string (major type 3) is UTF-8 by spec, so the converter holds it to that
+      // rather than copying a lone continuation byte into JSON text. Byte strings are unaffected;
+      // they already go out as hex.
+      std::map<std::string, std::string> v{{"k", std::string("a\x80z")}};
+      std::string cbor_buffer;
+      expect(not glz::write_cbor(v, cbor_buffer));
+
+      std::string json;
+      expect(glz::cbor_to_json(cbor_buffer, json).ec == glz::error_code::invalid_utf8);
+
+      std::string unchecked;
+      expect(not glz::cbor_to_json<cbor_no_utf8_opts{}>(cbor_buffer, unchecked));
    };
 
    "cbor_to_json_array"_test = [] {

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -2345,6 +2345,21 @@ void cbor_to_json_tests()
       expect(json == "\"hello\"");
    };
 
+   "cbor_to_json_escapes_control_characters"_test = [] {
+      // A control byte is legal in a CBOR text string but must be escaped so the JSON
+      // output re-parses. Covers both a value and a map key.
+      std::map<std::string, std::string> v{{std::string("k\001"), std::string("a\001b")}};
+      std::string cbor_buffer;
+      expect(not glz::write_cbor(v, cbor_buffer));
+
+      std::string json;
+      expect(not glz::cbor_to_json(cbor_buffer, json));
+      expect(json == "{\"k\\u0001\":\"a\\u0001b\"}") << json;
+      std::map<std::string, std::string> round_trip{};
+      expect(not glz::read_json(round_trip, json)) << json;
+      expect(round_trip == v);
+   };
+
    "cbor_to_json_array"_test = [] {
       std::vector<int> v = {1, 2, 3};
       std::string cbor_buffer;

--- a/tests/eetf_test/eetf_test.cpp
+++ b/tests/eetf_test/eetf_test.cpp
@@ -774,6 +774,35 @@ suite eetf_to_json_tests = [] {
       expect(!glz::read_json(round_trip, escaped)) << escaped;
       expect(round_trip == std::string("a\001b"));
    };
+   "eetf_to_json binary passes through control characters that have a short escape"_test = [] {
+      // The default refuses only control characters with no two-character JSON escape. Backspace,
+      // tab, newline, form feed and carriage return have one, so they keep converting normally.
+      // The reject sits in the else of the escape table lookup and cannot see them.
+      constexpr std::array<std::uint8_t, 11> tail{
+         uint8_t(glz::eetf_magic_version), uint8_t(ERL_BINARY_EXT), 0, 0, 0, 5, '\b', '\t', '\n', '\f', '\r'};
+
+      std::string tail_json{};
+      expect(!glz::eetf_to_json(tail, tail_json)) << tail_json;
+      expect(tail_json == R"("\b\t\n\f\r")") << tail_json;
+
+      // Long enough that the run lands past the scalar tail, in the writer's block scan, which
+      // rejects at a separate site.
+      const std::string payload = std::string(64, 'a') + "\b\t\n\f\r" + std::string(64, 'b');
+      std::string buffer{};
+      buffer.push_back(char(glz::eetf_magic_version));
+      buffer.push_back(char(ERL_BINARY_EXT));
+      for (int shift = 24; shift >= 0; shift -= 8) {
+         buffer.push_back(char(uint8_t(payload.size() >> shift)));
+      }
+      buffer += payload;
+
+      std::string json{};
+      expect(!glz::eetf_to_json(buffer, json)) << json;
+
+      std::string round_trip{};
+      expect(!glz::read_json(round_trip, json)) << json;
+      expect(round_trip == payload);
+   };
 };
 
 int main()

--- a/tests/eetf_test/eetf_test.cpp
+++ b/tests/eetf_test/eetf_test.cpp
@@ -705,6 +705,48 @@ suite eetf_to_json_tests = [] {
       expect(json == "{\"0\":\"\\u0001\"}") << json;
    };
 
+   "eetf_to_json quotes an atom object key"_test = [] {
+      // A JSON object key must be a string. The true/false atoms emit as bare literals in value
+      // position, which is right, but as a key that produced `{true:1}` and reported success.
+      constexpr std::array<std::uint8_t, 14> buffer{uint8_t(glz::eetf_magic_version),
+                                                    ERL_MAP_EXT,
+                                                    0,
+                                                    0,
+                                                    0,
+                                                    1,
+                                                    uint8_t(ERL_SMALL_ATOM_UTF8_EXT),
+                                                    4,
+                                                    't',
+                                                    'r',
+                                                    'u',
+                                                    'e',
+                                                    uint8_t(ERL_SMALL_INTEGER_EXT),
+                                                    1};
+
+      std::string json{};
+      expect(!glz::eetf_to_json(buffer, json));
+      expect(json == R"({"true":1})") << json;
+
+      std::map<std::string, int> round_trip{};
+      expect(!glz::read_json(round_trip, json)) << json;
+      expect(round_trip == std::map<std::string, int>{{"true", 1}});
+   };
+
+   "eetf_to_json leaves byte-defined payloads unchecked"_test = [] {
+      // ERL_ATOM_EXT is latin1 by spec and a binary is arbitrary bytes by definition, so neither
+      // is claiming to be UTF-8 and neither is held to it. binary_as_base64 is how a payload that
+      // is not JSON text crosses intact.
+      constexpr std::array<std::uint8_t, 7> latin1_atom{
+         uint8_t(glz::eetf_magic_version), uint8_t(ERL_ATOM_EXT), 0, 3, 'a', 0x80, 'z'};
+      std::string atom_json{};
+      expect(!glz::eetf_to_json(latin1_atom, atom_json));
+
+      constexpr std::array<std::uint8_t, 9> binary{
+         uint8_t(glz::eetf_magic_version), uint8_t(ERL_BINARY_EXT), 0, 0, 0, 3, 'a', 0x80, 'z'};
+      std::string binary_json{};
+      expect(!glz::eetf_to_json(binary, binary_json));
+   };
+
    "eetf_to_json binary escapes control characters"_test = [] {
       // binary_as_base64 is off by default, so an ERL_BINARY_EXT payload is emitted as a JSON
       // string. Its bytes are arbitrary, so any control byte among them has to be escaped.

--- a/tests/eetf_test/eetf_test.cpp
+++ b/tests/eetf_test/eetf_test.cpp
@@ -14,6 +14,7 @@
 #include "glaze/eetf/read.hpp"
 #include "glaze/eetf/wrappers.hpp"
 #include "glaze/eetf/write.hpp"
+#include "glaze/json/read.hpp"
 #include "glaze/trace/trace.hpp"
 #include "scratch_directory.hpp"
 #include "ut/ut.hpp"
@@ -700,7 +701,23 @@ suite eetf_to_json_tests = [] {
 
       std::string json{};
       expect(!glz::eetf_to_json(buffer, json));
-      expect(json == "{\"0\":\"\001\"}") << json;
+      // A binary holds arbitrary bytes, so a control byte must be escaped for the output to be JSON.
+      expect(json == "{\"0\":\"\\u0001\"}") << json;
+   };
+
+   "eetf_to_json binary escapes control characters"_test = [] {
+      // binary_as_base64 is off by default, so an ERL_BINARY_EXT payload is emitted as a JSON
+      // string. Its bytes are arbitrary, so any control byte among them has to be escaped.
+      constexpr std::array<std::uint8_t, 9> buffer{
+         uint8_t(glz::eetf_magic_version), uint8_t(ERL_BINARY_EXT), 0, 0, 0, 3, 'a', 1, 'b'};
+
+      std::string json{};
+      expect(!glz::eetf_to_json(buffer, json));
+      expect(json == "\"a\\u0001b\"") << json;
+
+      std::string round_trip{};
+      expect(!glz::read_json(round_trip, json)) << json;
+      expect(round_trip == std::string("a\001b"));
    };
 };
 

--- a/tests/eetf_test/eetf_test.cpp
+++ b/tests/eetf_test/eetf_test.cpp
@@ -324,6 +324,11 @@ suite etf_tests = [] {
    };
 };
 
+struct eetf_escape_opts : glz::eetf::eetf_opts
+{
+   bool escape_control_characters = true;
+};
+
 suite eetf_to_json_tests = [] {
    "eetf_to_json true"_test = [] {
       bool b = true;
@@ -636,10 +641,24 @@ suite eetf_to_json_tests = [] {
    };
 
    "eetf_to_json check big-endian size"_test = [] {
+      // 0x03E8 == 1000, and the payload is 1000 zero bytes.
       constexpr std::array<std::uint8_t, 1006> buffer{
          uint8_t(glz::eetf_magic_version), uint8_t(ERL_BINARY_EXT), 0, 0, 0x03, 0xE8};
+
+      // A binary of NULs is the case the default exists for. Before, this converted "successfully"
+      // to 1995 bytes of which 1993 were NUL: not JSON, and reported as a success.
+      std::string rejected{};
+      expect(glz::eetf_to_json(buffer, rejected).ec == glz::error_code::invalid_control_character);
+
+      // The length decode is what this test is about, so escape and check the result is a
+      // well formed string of 1000 escaped NULs.
       std::string json{};
-      expect(!glz::eetf_to_json(buffer, json));
+      expect(!glz::eetf_to_json<eetf_escape_opts{}>(buffer, json));
+      expect(json.size() == 2 + 1000 * 6) << json.size();
+
+      std::string round_trip{};
+      expect(!glz::read_json(round_trip, json));
+      expect(round_trip == std::string(1000, '\0'));
    };
 
    "eetf_to_json truncated binary"_test = [] {
@@ -699,10 +718,14 @@ suite eetf_to_json_tests = [] {
                                                     1,
                                                     1};
 
+      // The subject here is the binary map key. The value byte is a control character, which the
+      // converter refuses by default, so this opts into escaping to keep exercising the key path.
       std::string json{};
-      expect(!glz::eetf_to_json(buffer, json));
-      // A binary holds arbitrary bytes, so a control byte must be escaped for the output to be JSON.
+      expect(!glz::eetf_to_json<eetf_escape_opts{}>(buffer, json));
       expect(json == "{\"0\":\"\\u0001\"}") << json;
+
+      std::string rejected{};
+      expect(glz::eetf_to_json(buffer, rejected).ec == glz::error_code::invalid_control_character);
    };
 
    "eetf_to_json quotes an atom object key"_test = [] {
@@ -732,33 +755,23 @@ suite eetf_to_json_tests = [] {
       expect(round_trip == std::map<std::string, int>{{"true", 1}});
    };
 
-   "eetf_to_json leaves byte-defined payloads unchecked"_test = [] {
-      // ERL_ATOM_EXT is latin1 by spec and a binary is arbitrary bytes by definition, so neither
-      // is claiming to be UTF-8 and neither is held to it. binary_as_base64 is how a payload that
-      // is not JSON text crosses intact.
-      constexpr std::array<std::uint8_t, 7> latin1_atom{
-         uint8_t(glz::eetf_magic_version), uint8_t(ERL_ATOM_EXT), 0, 3, 'a', 0x80, 'z'};
-      std::string atom_json{};
-      expect(!glz::eetf_to_json(latin1_atom, atom_json));
-
-      constexpr std::array<std::uint8_t, 9> binary{
-         uint8_t(glz::eetf_magic_version), uint8_t(ERL_BINARY_EXT), 0, 0, 0, 3, 'a', 0x80, 'z'};
-      std::string binary_json{};
-      expect(!glz::eetf_to_json(binary, binary_json));
-   };
-
-   "eetf_to_json binary escapes control characters"_test = [] {
+   "eetf_to_json binary rejects control characters by default"_test = [] {
       // binary_as_base64 is off by default, so an ERL_BINARY_EXT payload is emitted as a JSON
-      // string. Its bytes are arbitrary, so any control byte among them has to be escaped.
+      // string. Its bytes are arbitrary, so a control byte among them is entirely possible, and
+      // it cannot be written as JSON without \uXXXX. Refused rather than mangled.
       constexpr std::array<std::uint8_t, 9> buffer{
          uint8_t(glz::eetf_magic_version), uint8_t(ERL_BINARY_EXT), 0, 0, 0, 3, 'a', 1, 'b'};
 
       std::string json{};
-      expect(!glz::eetf_to_json(buffer, json));
-      expect(json == "\"a\\u0001b\"") << json;
+      expect(glz::eetf_to_json(buffer, json).ec == glz::error_code::invalid_control_character);
+
+      // Two ways across: escape the byte, or carry the binary as base64.
+      std::string escaped{};
+      expect(!glz::eetf_to_json<eetf_escape_opts{}>(buffer, escaped));
+      expect(escaped == "\"a\\u0001b\"") << escaped;
 
       std::string round_trip{};
-      expect(!glz::read_json(round_trip, json)) << json;
+      expect(!glz::read_json(round_trip, escaped)) << escaped;
       expect(round_trip == std::string("a\001b"));
    };
 };

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -15049,6 +15049,12 @@ namespace bounded_buffer_test_types
       std::vector<int> data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20};
       int b = 2;
    };
+
+   // escape_control_characters is an inheritable option rather than a member of glz::opts.
+   struct escape_control_opts : glz::opts
+   {
+      bool escape_control_characters = true;
+   };
 }
 
 suite bounded_buffer_overflow_tests = [] {
@@ -15073,6 +15079,59 @@ suite bounded_buffer_overflow_tests = [] {
 
       auto result = glz::write_json(obj, buffer);
       expect(result.ec == glz::error_code::buffer_overflow) << "should return buffer_overflow error";
+   };
+
+   "bounded buffer reserves what an escaped string escapes to"_test = [] {
+      // escape_control_characters reserves 6 bytes per character, a ceiling only a string of
+      // nothing but control characters reaches. A resizable buffer over-allocates against it,
+      // but a fixed one has nowhere to grow, so the ceiling would reject output that fits.
+      const std::string value = std::string(100, 'a') + '\001' + std::string(100, 'b');
+      std::array<char, 512> buffer{}; // 208 bytes of output, 1216 of worst case
+
+      auto result = glz::write<escape_control_opts{}>(value, buffer);
+      expect(not result) << "208 bytes of output should fit in a 512 byte buffer";
+      expect(std::string_view(buffer.data(), result.count) ==
+             '"' + std::string(100, 'a') + "\\u0001" + std::string(100, 'b') + '"');
+   };
+
+   "escaped_string_size matches what the writer emits"_test = [] {
+      // The bounded buffer reservation is only correct while this stays exact, and it skips
+      // whole 8-byte blocks, so cover every byte value at offsets landing in the block scan
+      // and in the scalar tail.
+      constexpr std::array lengths{size_t(1), size_t(7), size_t(8), size_t(9), size_t(16), size_t(40)};
+      size_t mismatches = 0;
+      size_t checked = 0;
+      size_t expected = 0;
+      for (int byte = 0; byte < 256; ++byte) {
+         for (size_t len : lengths) {
+            expected += len;
+            for (size_t pos = 0; pos < len; ++pos) {
+               std::string value(len, 'x');
+               value[pos] = char(byte);
+               std::string out{};
+               if (glz::write<escape_control_opts{}>(value, out)) {
+                  ++mismatches;
+                  continue;
+               }
+               ++checked;
+               if (glz::detail::escaped_string_size(value) != out.size() - 2) { // less the quotes
+                  ++mismatches;
+               }
+            }
+         }
+      }
+      expect(checked == expected) << checked << " of " << expected;
+      expect(mismatches == 0) << mismatches;
+   };
+
+   "bounded buffer still overflows when the escaped string does not fit"_test = [] {
+      // Measuring the string must not lose the overflow error for output that genuinely
+      // does not fit: every character here escapes to 6 bytes.
+      const std::string value(100, '\001');
+      std::array<char, 128> buffer{};
+
+      auto result = glz::write<escape_control_opts{}>(value, buffer);
+      expect(result.ec == glz::error_code::buffer_overflow) << "600 bytes of escapes must not fit in 128";
    };
 
    "write to std::span with sufficient space succeeds"_test = [] {


### PR DESCRIPTION
`beve_to_json`, `cbor_to_json`, `bson_to_json`, and `eetf_to_json` emit decoded strings through `to<JSON, string_view>` using the caller's inherited options. `escape_control_characters` is off by default, so a control byte (0x00 to 0x1F) in a decoded value was written without an escape, and a control byte is legal inside a binary-format string. The converter reported success and produced a document Glaze's own reader rejects.

What came out was worse than "unescaped". Strings long enough for the SWAR or SIMD path get `char_escape_table[c]` memcpy'd, and that entry is **zero** for a control character with no short escape, so one byte became two NULs and the string changed length. Short strings on the scalar tail passed the byte through raw. The two paths disagreed.

A pre-existing eetf test was pinning exactly this. `"eetf_to_json check big-endian size"` converts a 1000-byte binary of NULs and asserted success; on `main` it produces 1995 bytes of which 1993 are NUL.

## The approach

Refuse, rather than either escaping by default or continuing to emit bytes that will not re-parse.

A control character with no two-character JSON escape now fails with **`error_code::invalid_control_character`**. The ones that do have an escape (newline, tab, backspace, form feed, carriage return) are unaffected, so ordinary text never trips it.

Escaping was the obvious fix and it is the wrong default. It does not merely make the output parse, it makes it acceptable *everywhere*: a NUL that most strict parsers would have rejected becomes an escape every parser takes, and lands in whatever reads the JSON back, where an embedded null truncates C APIs and splits log lines. That is a decision for the caller, not for the converter.

Not escaping is not a policy either. It yields no error code and nothing to hook a decision onto, just malformed bytes and the hope that something strict is downstream.

So the two are separated. **Encoding** is `escape_control_characters`, inherited rather than pinned, and it is how a caller opts into carrying such bytes across:

```c++
struct escaping : glz::opts {
   bool escape_control_characters = true;
};

glz::beve_to_json<escaping{}>(beve, json);   // control bytes escaped, round-trips
```

That case is real. A control character is legal in a length-prefixed BEVE, CBOR, or BSON string; a `std::string` holding one round-trips through `write_beve`/`read_beve`, and escaping is the only way the JSON form can represent it. It is now an explicit choice.

`raw_string` and `unquoted` stay pinned off. Both produce output that is not JSON regardless of what the caller wants.

`jsonb_to_json` keeps escaping and keeps validating UTF-8. A JSONB blob is the storage form of a JSON document that could itself have carried an escape, so a control character there is expected rather than anomalous.

## Cost

The check rides a branch the writer already takes. Only a quote, a backslash, or a control character reaches the escape path at all, so nothing is added to the scan. Measured on an M-series mac, clang -O3, `beve_to_json` of a clean 1500 byte payload:

| | ns/op |
|---|---|
| `origin/main` | 121 |
| this branch, default | 122 |
| this branch, `escape_control_characters` | 147 |

The default also beats the escaping path, because it no longer pays the 6n worst-case reservation that escaping forces.

Setting the error cannot return early out of `write_escape`: the SIMD loops locate the byte and rely on the lambda advancing `c`, so an early return makes the scan find the same byte forever. It flags and lets the write finish; the output is abandoned.

## Bounded output buffers

Under `escape_control_characters` the writer reserves `10 + 6n` for a string. A resizable buffer only over-allocates against that ceiling, but `JSONBuffer` is unconstrained: for a `std::array` or `std::span`, `ensure_space` reports `buffer_overflow` instead of growing, so the ceiling rejects output that fits. 216 bytes of escaped `beve_to_json` output did not fit in a 512 byte array.

6 bytes per character is reached only by a string of nothing but control characters, so bounded buffers measure the string instead, bracketed between two O(1) bounds and paid only when the answer is in doubt: the ceiling fitting means yes, the floor of one byte per character not fitting means no. `escaped_string_size` reuses the writer's own 8-byte block scan rather than counting byte at a time, which cost about as much as the escaping write it sizes. A test pins it against the writer's actual output for every byte value at offsets landing in both the block scan and the scalar tail.

Scoped to `escape_control_characters`. Plain `write_json` keeps the reservation it has today, for resizable and bounded buffers alike.

## Atom object keys in eetf

Separate bug, no option involved. `eetf_to_json` dumped the atoms `true` and `false` as bare literals in key position, so a map keyed by the atom `true` converted to `{true:1}` and reported success. A JSON object key must be a string; `term_to_json_value` takes a `Key` flag and keeps the atom quoted there. Values are unchanged.

## UTF-8

Not checked by beve/cbor/bson/eetf. `validate_utf8` is a read-side option (every other consumer is in `read.hpp`, `parse.hpp`, or `lazy.hpp`), it is on by default there, and unlike the escaping decision it costs a real pass: ~8.5 ns per string plus ~0.015 ns/byte ASCII, ~0.1 ns/byte multibyte. `jsonb_to_json` is the exception and keeps the check it has on `main`.

## Docs

`docs/binary.md` gains an "Untrusted Strings" section covering what is pinned, what the default refuses, and the tradeoff `escape_control_characters` buys. `docs/options.md` documents the new `reject_control_characters` option and updates `escape_control_characters` and `validate_utf8`.
