### PR TITLE
Refactor FindErlang CMake module

### DIFF
--- a/cmake/FindErlang.cmake
+++ b/cmake/FindErlang.cmake
@@ -1,162 +1,257 @@
 #[=======================================================================[.rst:
 FindErlang
--------
+----------
 
-CMake Find module that locates the Erlang/OTP runtime and erlang_interface (EI) library for building NIFs
-and EI-based projects.
+Finds the Erlang/OTP runtime and the ``erl_interface`` (EI) library, for
+building NIFs and EI-based programs.
 
-Input Variables (Hints)
-^^^^^^^^^^^^^^^^^^^^^^^
-┌───────────────────┬─────────────────────────────────────────────────────────────────────────┐
-│Variable           │Description                                                              │
-├───────────────────┼─────────────────────────────────────────────────────────────────────────┤
-│ERLANG_ROOT        │Root path of Erlang installation. If set, overrides erl auto-detection.  │
-├───────────────────┼─────────────────────────────────────────────────────────────────────────┤
-│ERLANG_EI_LIB      │Direct path to libei.a (erlang_interface library).                       │
-├───────────────────┼─────────────────────────────────────────────────────────────────────────┤
-│ERLANG_EI_INCLUDE  │Direct path to erlang_interface include directory.                       │
-├───────────────────┼─────────────────────────────────────────────────────────────────────────┤
-│$ENV{ERLANG_HOME}  │Environment variable for Erlang install root.                            │
-└───────────────────┴─────────────────────────────────────────────────────────────────────────┘
+Two discovery modes are supported:
 
-If ERLANG_EI_LIB and ERLANG_EI_INCLUDE are both provided, auto-detection via erl is skipped entirely.
-Otherwise, the module searches for the erl executable and queries it for paths.
+* **Auto-detection** (default): locate the ``erl`` executable and query it for
+  the OTP layout. Requires an ``erl`` that can run on the build host.
+* **Explicit paths**: supply ``ERLANG_EI_LIB`` and ``ERLANG_EI_INCLUDE`` and
+  ``erl`` is never invoked. This is the supported path for cross-compiling to
+  an embedded target, where the target's ``erl`` cannot run on the host.
 
-Search Paths for erl
-^^^^^^^^^^^^^^^^^^^^
-$ENV{ERLANG_HOME}/bin, ${ERLANG_ROOT}/bin, /opt/bin, /sw/bin, /usr/bin, /usr/local/bin, /opt/local/bin
+Hint Variables
+^^^^^^^^^^^^^^
 
+``Erlang_ROOT``
+  Root of the Erlang installation. Honored automatically by CMake's ``find_``
+  commands (policy ``CMP0074``); this is the preferred spelling.
+``ERLANG_ROOT``
+  Legacy spelling of the above. Adds ``<root>/bin`` to the search path for
+  ``erl``.
+``ERLANG_EI_LIB``
+  The EI library itself (e.g. ``.../lib/libei.a``) or the directory containing
+  it. Both spellings are accepted.
+``ERLANG_EI_INCLUDE``
+  Directory containing ``ei.h``.
+``ERLANG_INCLUDE``
+  Directory containing ``erl_nif.h``. Only needed when the NIF headers do not
+  sit at ``<otp-root>/usr/include``, which is where OTP installs them.
+``ENV{ERLANG_HOME}``
+  Environment variable naming the Erlang install root.
 
-Output Variables
+Search Paths for ``erl``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+``$ENV{ERLANG_HOME}/bin``, ``${ERLANG_ROOT}/bin``, ``/opt/bin``, ``/sw/bin``,
+``/usr/bin``, ``/usr/local/bin``, ``/opt/local/bin``, plus CMake's default
+program search paths (which include ``${Erlang_ROOT}``).
+
+Result Variables
 ^^^^^^^^^^^^^^^^
-┌───────────────────────────────────────┬─────────────────────────────────────────────────────┐
-│Variable                               │Description                                          │
-├───────────────────────────────────────┼─────────────────────────────────────────────────────┤
-│Erlang_FOUND                           │TRUE if all components found                         │
-├───────────────────────────────────────┼─────────────────────────────────────────────────────┤
-│Erlang_RUNTIME                         │Path to erl executable                               │
-├───────────────────────────────────────┼─────────────────────────────────────────────────────┤
-│Erlang_OTP_ROOT_DIR                    │Root of the OTP installation                         │
-├───────────────────────────────────────┼─────────────────────────────────────────────────────┤
-│Erlang_EI_INCLUDE_DIRS                 │Include path for ei.h                                │
-├───────────────────────────────────────┼─────────────────────────────────────────────────────┤
-│Erlang_EI_LIBRARY_PATH                 │Directory containing libei.a                         │
-├───────────────────────────────────────┼─────────────────────────────────────────────────────┤
-│Erlang_OTP_VERSION                     │OTP release version string (e.g., 26)                │
-└───────────────────────────────────────┴─────────────────────────────────────────────────────┘
+
+``Erlang_FOUND``
+  True if the EI library and its headers were located.
+``Erlang_RUNTIME``
+  Path to the ``erl`` executable. Unset when explicit paths are supplied.
+``Erlang_OTP_ROOT_DIR``
+  Root of the OTP installation. Unset when explicit paths are supplied and
+  ``ERLANG_ROOT`` is not given.
+``Erlang_EI_INCLUDE_DIRS``
+  Directory containing ``ei.h``.
+``Erlang_EI_LIBRARY_PATH``
+  Directory containing the EI library.
+``Erlang_EI_LIBRARY``
+  Full path to the EI library.
+``Erlang_INCLUDE_DIRS``
+  Directory containing ``erl_nif.h``, when found.
+``Erlang_OTP_VERSION``
+  OTP release string (e.g. ``26``). Unset when explicit paths are supplied.
 
 Imported Targets
 ^^^^^^^^^^^^^^^^
-┌─────────────────┬────────────────────┬──────────────────────────────────────────────────────┐
-│Target           │Type                │Description                                           │
-├─────────────────┼────────────────────┼──────────────────────────────────────────────────────┤
-│Erlang::Erlang   │INTERFACE IMPORTED  │Base headers for NIF development (erl_nif.h)          │
-├─────────────────┼────────────────────┼──────────────────────────────────────────────────────┤
-│Erlang::EI       │INTERFACE IMPORTED  │erlang_interface library and headers (ei.h, libei.a)  │
-└─────────────────┴────────────────────┴──────────────────────────────────────────────────────┘
+
+``Erlang::Erlang``
+  Interface target carrying the NIF headers (``erl_nif.h``). Carries no include
+  directory if those headers could not be located, so that EI-only builds still
+  link cleanly.
+``Erlang::EI``
+  The ``erl_interface`` library and its headers (``ei.h``).
 
 Usage
 ^^^^^
-find_package(Erlang REQUIRED)
-target_link_libraries(my_nif PRIVATE Erlang::Erlang)
-target_link_libraries(my_ei_client PRIVATE Erlang::EI)
+
+.. code-block:: cmake
+
+  find_package(Erlang REQUIRED)
+  target_link_libraries(my_nif PRIVATE Erlang::Erlang)
+  target_link_libraries(my_ei_client PRIVATE Erlang::EI)
+
+Cross-compiling, with no runnable ``erl`` on the host::
+
+  cmake -B build \
+    -DERLANG_EI_INCLUDE=<sysroot>/lib/erlang/lib/erl_interface-5.5/include \
+    -DERLANG_EI_LIB=<sysroot>/lib/erlang/lib/erl_interface-5.5/lib
+
+Removed in this revision
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``Erlang::ERTS`` target and the ``Erlang_COMPILE``, ``Erlang_EI_PATH``,
+``Erlang_ERTS_PATH``, ``Erlang_ERTS_INCLUDE_DIRS`` and
+``Erlang_ERTS_LIBRARY_PATH`` variables are gone. ``liberts.a`` is not shipped by
+OTP as a linkable library, so ``Erlang::ERTS`` never resolved on a stock
+install, and the ERTS include directory duplicates what OTP already installs
+into ``<otp-root>/usr/include``.
 
 #]=======================================================================]
 
 include(FindPackageHandleStandardArgs)
 include(CMakePrintHelpers)
 
-function(execute_erlang IN_ERL_EXECUTABLE OUT_ERLROOT_DIR OUT_INCLUDE_DIR OUT_LIBRARY_DIR OUT_OTP_VERSION)
+# Evaluate one Erlang expression. OUT_RESULT is left empty when erl exits
+# non-zero or prints nothing, so callers can detect an unusable runtime instead
+# of building paths out of garbage.
+function(_erlang_eval IN_ERL IN_EXPRESSION OUT_RESULT)
   execute_process(
-    COMMAND ${IN_ERL_EXECUTABLE} -noshell -eval "io:format(\"~s\", [code:root_dir()])" -s erlang halt
-    OUTPUT_VARIABLE Erlang_OTP_ROOT_DIR
+    COMMAND ${IN_ERL} -noshell -eval "io:format(\"~s\", [${IN_EXPRESSION}])" -s erlang halt
+    RESULT_VARIABLE status
+    OUTPUT_VARIABLE output
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE
   )
+  if(NOT status EQUAL 0)
+    set(output "")
+  endif()
+  set(${OUT_RESULT} "${output}" PARENT_SCOPE)
+endfunction()
 
-  execute_process(
-    COMMAND ${IN_ERL_EXECUTABLE} -noshell -eval "io:format(\"~s\", [code:lib_dir()])" -s erlang halt
-    OUTPUT_VARIABLE Erlang_OTP_LIB_DIR
-  )
+# Query a runnable erl for the OTP layout. Leaves the OUT_* variables untouched
+# if erl cannot be run or answers unexpectedly -- a find module must report
+# "not found", never abort the caller's configure.
+function(_erlang_query IN_ERL OUT_OTP_ROOT OUT_EI_INCLUDE OUT_EI_LIBRARY_DIR OUT_OTP_VERSION)
+  _erlang_eval("${IN_ERL}" "code:root_dir()" root_dir)
+  _erlang_eval("${IN_ERL}" "code:lib_dir()" lib_dir)
+  _erlang_eval("${IN_ERL}" "filename:basename(code:lib_dir('erl_interface'))" ei_dir)
+  _erlang_eval("${IN_ERL}" "erlang:system_info(otp_release)" otp_version)
 
-  execute_process(
-    COMMAND ${IN_ERL_EXECUTABLE} -noshell -eval "io:format(\"~s\",[filename:basename(code:lib_dir('erl_interface'))])" -s erlang halt
-    OUTPUT_VARIABLE Erlang_EI_DIR
-  )
+  # A missing answer means we cannot trust any of the paths, so give up on the
+  # whole query rather than synthesize half a layout.
+  if("${root_dir}" STREQUAL "" OR "${lib_dir}" STREQUAL "" OR "${ei_dir}" STREQUAL "")
+    return()
+  endif()
 
-  execute_process(
-    COMMAND ${IN_ERL_EXECUTABLE} -noshell -eval "io:format(\"~s\", [erlang:system_info(otp_release)])" -s erlang halt
-    OUTPUT_VARIABLE Erlang_OTP_VERSION
-  )
-
-  set(${OUT_ERLROOT_DIR} ${Erlang_OTP_ROOT_DIR} PARENT_SCOPE)
-  set(${OUT_INCLUDE_DIR} ${Erlang_OTP_LIB_DIR}/${Erlang_EI_DIR}/include PARENT_SCOPE)
-  set(${OUT_LIBRARY_DIR} ${Erlang_OTP_LIB_DIR}/${Erlang_EI_DIR}/lib PARENT_SCOPE)
-  set(${OUT_OTP_VERSION} ${Erlang_OTP_VERSION} PARENT_SCOPE)
-endfunction(execute_erlang)
+  set(${OUT_OTP_ROOT} "${root_dir}" PARENT_SCOPE)
+  set(${OUT_EI_INCLUDE} "${lib_dir}/${ei_dir}/include" PARENT_SCOPE)
+  set(${OUT_EI_LIBRARY_DIR} "${lib_dir}/${ei_dir}/lib" PARENT_SCOPE)
+  set(${OUT_OTP_VERSION} "${otp_version}" PARENT_SCOPE)
+endfunction()
 
 if(CMAKE_VERBOSE_MAKEFILE)
-  cmake_print_variables(ERLANG_ROOT ERLANG_EI_LIB ERLANG_EI_INCLUDE)
+  cmake_print_variables(Erlang_ROOT ERLANG_ROOT ERLANG_EI_LIB ERLANG_EI_INCLUDE ERLANG_INCLUDE)
 endif()
 
-if (ERLANG_EI_LIB AND ERLANG_EI_INCLUDE)
-  get_filename_component(Erlang_OTP_ROOT_DIR "${ERLANG_EI_INCLUDE}/../.." ABSOLUTE)
-  set(Erlang_EI_LIBRARY_PATH ${ERLANG_EI_LIB})
-  set(Erlang_EI_INCLUDE_DIRS ${ERLANG_EI_INCLUDE})
-  set(Erlang_OTP_VERSION "User Provided")
+# Candidate directories, either handed to us or discovered via erl.
+set(_erlang_ei_include_hint "")
+set(_erlang_ei_library_hint "")
+set(_erlang_nif_include_hint "${ERLANG_INCLUDE}")
+
+if(ERLANG_EI_LIB AND ERLANG_EI_INCLUDE)
+  set(_erlang_ei_include_hint "${ERLANG_EI_INCLUDE}")
+  # Accept either the library file or the directory holding it.
+  if(IS_DIRECTORY "${ERLANG_EI_LIB}")
+    set(_erlang_ei_library_hint "${ERLANG_EI_LIB}")
+  else()
+    get_filename_component(_erlang_ei_library_hint "${ERLANG_EI_LIB}" DIRECTORY)
+  endif()
+  # The OTP root cannot be derived reliably from a hand-assembled sysroot
+  # layout, so only trust it when it was given explicitly.
+  if(ERLANG_ROOT)
+    set(Erlang_OTP_ROOT_DIR "${ERLANG_ROOT}")
+  elseif(Erlang_ROOT)
+    set(Erlang_OTP_ROOT_DIR "${Erlang_ROOT}")
+  endif()
 else()
-  set(Erlang_BIN_PATHS
-    $ENV{ERLANG_HOME}/bin
-    ${ERLANG_ROOT}/bin
-    /opt/bin
-    /sw/bin
-    /usr/bin
-    /usr/local/bin
-    /opt/local/bin
-  )
   find_program(Erlang_RUNTIME
     NAMES erl
-    PATHS ${Erlang_BIN_PATHS}
+    PATHS
+      $ENV{ERLANG_HOME}/bin
+      ${ERLANG_ROOT}/bin
+      /opt/bin
+      /sw/bin
+      /usr/bin
+      /usr/local/bin
+      /opt/local/bin
   )
-  if(NOT Erlang_RUNTIME)
-    message(FATAL_ERROR "erl executable not found! Please install Erlang or provide actual location")
+  mark_as_advanced(Erlang_RUNTIME)
+  if(Erlang_RUNTIME)
+    _erlang_query("${Erlang_RUNTIME}"
+      Erlang_OTP_ROOT_DIR
+      _erlang_ei_include_hint
+      _erlang_ei_library_hint
+      Erlang_OTP_VERSION
+    )
   endif()
-  execute_erlang(${Erlang_RUNTIME} Erlang_OTP_ROOT_DIR Erlang_EI_INCLUDE_DIRS Erlang_EI_LIBRARY_PATH Erlang_OTP_VERSION)
 endif()
 
-find_package_handle_standard_args(
-  Erlang
-  DEFAULT_MSG
-  Erlang_OTP_ROOT_DIR
-  Erlang_EI_LIBRARY_PATH
-  Erlang_EI_INCLUDE_DIRS
+# OTP installs erl_nif.h under <root>/usr/include (see OTP's
+# erts/emulator/Makefile.in RELEASE_INCLUDES); there is no <root>/include.
+if(NOT _erlang_nif_include_hint AND Erlang_OTP_ROOT_DIR)
+  set(_erlang_nif_include_hint "${Erlang_OTP_ROOT_DIR}/usr/include")
+endif()
+
+# Confirm the hints actually hold what we expect instead of assuming a layout.
+find_path(Erlang_EI_INCLUDE_DIRS
+  NAMES ei.h
+  HINTS ${_erlang_ei_include_hint}
+  NO_DEFAULT_PATH
 )
 
-if(NOT EXISTS "${Erlang_EI_LIBRARY_PATH}/libei.a")
-  message(FATAL_ERROR "libei.a not found at ${Erlang_EI_LIBRARY_PATH}")
+find_library(Erlang_EI_LIBRARY
+  NAMES ei
+  HINTS ${_erlang_ei_library_hint}
+  NO_DEFAULT_PATH
+)
+
+# NIF headers are optional: an EI-only consumer never includes erl_nif.h.
+find_path(Erlang_INCLUDE_DIRS
+  NAMES erl_nif.h
+  HINTS ${_erlang_nif_include_hint}
+  NO_DEFAULT_PATH
+)
+
+mark_as_advanced(Erlang_EI_INCLUDE_DIRS Erlang_EI_LIBRARY Erlang_INCLUDE_DIRS)
+
+if(Erlang_EI_LIBRARY)
+  get_filename_component(Erlang_EI_LIBRARY_PATH "${Erlang_EI_LIBRARY}" DIRECTORY)
 endif()
 
+find_package_handle_standard_args(Erlang
+  REQUIRED_VARS Erlang_EI_LIBRARY Erlang_EI_INCLUDE_DIRS
+  VERSION_VAR Erlang_OTP_VERSION
+)
+
 if(Erlang_FOUND)
-  cmake_print_variables(Erlang_OTP_VERSION Erlang_EI_INCLUDE_DIRS Erlang_EI_LIBRARY_PATH)
+  if(CMAKE_VERBOSE_MAKEFILE)
+    cmake_print_variables(Erlang_OTP_VERSION Erlang_OTP_ROOT_DIR Erlang_EI_INCLUDE_DIRS
+                          Erlang_EI_LIBRARY Erlang_INCLUDE_DIRS)
+  endif()
 
   if(NOT TARGET Erlang::Erlang)
     add_library(Erlang::Erlang INTERFACE IMPORTED)
-    set_target_properties(Erlang::Erlang
-      PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES ${Erlang_OTP_ROOT_DIR}/include
-    )
+    # Only publish the include directory when it really exists: CMake rejects an
+    # imported target whose INTERFACE_INCLUDE_DIRECTORIES names a missing path.
+    if(Erlang_INCLUDE_DIRS)
+      set_property(TARGET Erlang::Erlang PROPERTY
+        INTERFACE_INCLUDE_DIRECTORIES "${Erlang_INCLUDE_DIRS}"
+      )
+    endif()
   endif()
 
   if(NOT TARGET Erlang::EI)
-    add_library(erlang_ei STATIC IMPORTED)
-    set_property(TARGET erlang_ei PROPERTY
-      IMPORTED_LOCATION ${Erlang_EI_LIBRARY_PATH}/libei.a
-    )
-
-    add_library(Erlang::EI INTERFACE IMPORTED)
-    set_property(TARGET Erlang::EI PROPERTY
-      INTERFACE_INCLUDE_DIRECTORIES ${Erlang_EI_INCLUDE_DIRS}
-    )
-    set_property(TARGET Erlang::EI PROPERTY
-      INTERFACE_LINK_LIBRARIES erlang_ei
+    # UNKNOWN rather than STATIC so a shared libei works too, and so no extra
+    # non-namespaced target leaks into the consumer's global target namespace.
+    add_library(Erlang::EI UNKNOWN IMPORTED)
+    set_target_properties(Erlang::EI
+      PROPERTIES
+      IMPORTED_LOCATION "${Erlang_EI_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${Erlang_EI_INCLUDE_DIRS}"
     )
   endif()
 endif()
+
+unset(_erlang_ei_include_hint)
+unset(_erlang_ei_library_hint)
+unset(_erlang_nif_include_hint)

--- a/cmake/FindErlang.cmake
+++ b/cmake/FindErlang.cmake
@@ -1,171 +1,162 @@
-# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
-# file Copyright.txt or https://cmake.org/licensing for details.
-
 #[=======================================================================[.rst:
 FindErlang
 -------
 
-Finds Erlang libraries.
+CMake Find module that locates the Erlang/OTP runtime and erlang_interface (EI) library for building NIFs
+and EI-based projects.
+
+Input Variables (Hints)
+^^^^^^^^^^^^^^^^^^^^^^^
+┌───────────────────┬─────────────────────────────────────────────────────────────────────────┐
+│Variable           │Description                                                              │
+├───────────────────┼─────────────────────────────────────────────────────────────────────────┤
+│ERLANG_ROOT        │Root path of Erlang installation. If set, overrides erl auto-detection.  │
+├───────────────────┼─────────────────────────────────────────────────────────────────────────┤
+│ERLANG_EI_LIB      │Direct path to libei.a (erlang_interface library).                       │
+├───────────────────┼─────────────────────────────────────────────────────────────────────────┤
+│ERLANG_EI_INCLUDE  │Direct path to erlang_interface include directory.                       │
+├───────────────────┼─────────────────────────────────────────────────────────────────────────┤
+│$ENV{ERLANG_HOME}  │Environment variable for Erlang install root.                            │
+└───────────────────┴─────────────────────────────────────────────────────────────────────────┘
+
+If ERLANG_EI_LIB and ERLANG_EI_INCLUDE are both provided, auto-detection via erl is skipped entirely.
+Otherwise, the module searches for the erl executable and queries it for paths.
+
+Search Paths for erl
+^^^^^^^^^^^^^^^^^^^^
+$ENV{ERLANG_HOME}/bin, ${ERLANG_ROOT}/bin, /opt/bin, /sw/bin, /usr/bin, /usr/local/bin, /opt/local/bin
+
+
+Output Variables
+^^^^^^^^^^^^^^^^
+┌───────────────────────────────────────┬─────────────────────────────────────────────────────┐
+│Variable                               │Description                                          │
+├───────────────────────────────────────┼─────────────────────────────────────────────────────┤
+│Erlang_FOUND                           │TRUE if all components found                         │
+├───────────────────────────────────────┼─────────────────────────────────────────────────────┤
+│Erlang_RUNTIME                         │Path to erl executable                               │
+├───────────────────────────────────────┼─────────────────────────────────────────────────────┤
+│Erlang_OTP_ROOT_DIR                    │Root of the OTP installation                         │
+├───────────────────────────────────────┼─────────────────────────────────────────────────────┤
+│Erlang_EI_INCLUDE_DIRS                 │Include path for ei.h                                │
+├───────────────────────────────────────┼─────────────────────────────────────────────────────┤
+│Erlang_EI_LIBRARY_PATH                 │Directory containing libei.a                         │
+├───────────────────────────────────────┼─────────────────────────────────────────────────────┤
+│Erlang_OTP_VERSION                     │OTP release version string (e.g., 26)                │
+└───────────────────────────────────────┴─────────────────────────────────────────────────────┘
 
 Imported Targets
 ^^^^^^^^^^^^^^^^
+┌─────────────────┬────────────────────┬──────────────────────────────────────────────────────┐
+│Target           │Type                │Description                                           │
+├─────────────────┼────────────────────┼──────────────────────────────────────────────────────┤
+│Erlang::Erlang   │INTERFACE IMPORTED  │Base headers for NIF development (erl_nif.h)          │
+├─────────────────┼────────────────────┼──────────────────────────────────────────────────────┤
+│Erlang::EI       │INTERFACE IMPORTED  │erlang_interface library and headers (ei.h, libei.a)  │
+└─────────────────┴────────────────────┴──────────────────────────────────────────────────────┘
 
-This module provides the following imported targets, if found:
-
-``Erlang::Erlang``
-  Header only interface library suitible for compiling NIFs.
-
-``Erlang::EI``
-  Erlang interface library.
-
-``Erlang::ERTS``
-  Erlang runtime system library.
-
-Result Variables
-^^^^^^^^^^^^^^^^
-
-This will define the following variables:
-
-``Erlang_FOUND``
-  True if the system has the Erlang library.
-``Erlang_RUNTIME``
-  The path to the Erlang runtime.
-``Erlang_COMPILE``
-  The path to the Erlang compiler.
-``Erlang_EI_PATH``
-  The path to the Erlang erl_interface path.
-``Erlang_ERTS_PATH``
-  The path to the Erlang erts path.
-``Erlang_EI_INCLUDE_DIRS``
-  /include appended to Erlang_EI_PATH.
-``Erlang_EI_LIBRARY_PATH``
-  /lib appended to Erlang_EI_PATH.
-``Erlang_ERTS_INCLUDE_DIRS``
-  /include appended to Erlang_ERTS_PATH.
-``Erlang_ERTS_LIBRARY_PATH``
-  /lib appended to Erlang_ERTS_PATH.
-``Erlang_OTP_VERSION``
-  Current Erlang OTP version
+Usage
+^^^^^
+find_package(Erlang REQUIRED)
+target_link_libraries(my_nif PRIVATE Erlang::Erlang)
+target_link_libraries(my_ei_client PRIVATE Erlang::EI)
 
 #]=======================================================================]
+
 include(FindPackageHandleStandardArgs)
+include(CMakePrintHelpers)
 
-SET(Erlang_BIN_PATH
-  $ENV{ERLANG_HOME}/bin
-  /opt/bin
-  /sw/bin
-  /usr/bin
-  /usr/local/bin
-  /opt/local/bin
+function(execute_erlang IN_ERL_EXECUTABLE OUT_ERLROOT_DIR OUT_INCLUDE_DIR OUT_LIBRARY_DIR OUT_OTP_VERSION)
+  execute_process(
+    COMMAND ${IN_ERL_EXECUTABLE} -noshell -eval "io:format(\"~s\", [code:root_dir()])" -s erlang halt
+    OUTPUT_VARIABLE Erlang_OTP_ROOT_DIR
   )
 
-FIND_PROGRAM(Erlang_RUNTIME
-  NAMES erl
-  PATHS ${Erlang_BIN_PATH}
+  execute_process(
+    COMMAND ${IN_ERL_EXECUTABLE} -noshell -eval "io:format(\"~s\", [code:lib_dir()])" -s erlang halt
+    OUTPUT_VARIABLE Erlang_OTP_LIB_DIR
   )
 
-FIND_PROGRAM(Erlang_COMPILE
-  NAMES erlc
-  PATHS ${Erlang_BIN_PATH}
+  execute_process(
+    COMMAND ${IN_ERL_EXECUTABLE} -noshell -eval "io:format(\"~s\",[filename:basename(code:lib_dir('erl_interface'))])" -s erlang halt
+    OUTPUT_VARIABLE Erlang_EI_DIR
   )
 
-EXECUTE_PROCESS(
-  COMMAND         erl -noshell -eval "io:format(\"~s\", [code:lib_dir()])" -s erlang halt
-  OUTPUT_VARIABLE Erlang_OTP_LIB_DIR
+  execute_process(
+    COMMAND ${IN_ERL_EXECUTABLE} -noshell -eval "io:format(\"~s\", [erlang:system_info(otp_release)])" -s erlang halt
+    OUTPUT_VARIABLE Erlang_OTP_VERSION
   )
 
-EXECUTE_PROCESS(
-  COMMAND         erl -noshell -eval "io:format(\"~s\", [code:root_dir()])" -s erlang halt
-  OUTPUT_VARIABLE Erlang_OTP_ROOT_DIR
+  set(${OUT_ERLROOT_DIR} ${Erlang_OTP_ROOT_DIR} PARENT_SCOPE)
+  set(${OUT_INCLUDE_DIR} ${Erlang_OTP_LIB_DIR}/${Erlang_EI_DIR}/include PARENT_SCOPE)
+  set(${OUT_LIBRARY_DIR} ${Erlang_OTP_LIB_DIR}/${Erlang_EI_DIR}/lib PARENT_SCOPE)
+  set(${OUT_OTP_VERSION} ${Erlang_OTP_VERSION} PARENT_SCOPE)
+endfunction(execute_erlang)
+
+if(CMAKE_VERBOSE_MAKEFILE)
+  cmake_print_variables(ERLANG_ROOT ERLANG_EI_LIB ERLANG_EI_INCLUDE)
+endif()
+
+if (ERLANG_EI_LIB AND ERLANG_EI_INCLUDE)
+  get_filename_component(Erlang_OTP_ROOT_DIR "${ERLANG_EI_INCLUDE}/../.." ABSOLUTE)
+  set(Erlang_EI_LIBRARY_PATH ${ERLANG_EI_LIB})
+  set(Erlang_EI_INCLUDE_DIRS ${ERLANG_EI_INCLUDE})
+  set(Erlang_OTP_VERSION "User Provided")
+else()
+  set(Erlang_BIN_PATHS
+    $ENV{ERLANG_HOME}/bin
+    ${ERLANG_ROOT}/bin
+    /opt/bin
+    /sw/bin
+    /usr/bin
+    /usr/local/bin
+    /opt/local/bin
   )
-
-EXECUTE_PROCESS(
-  COMMAND         erl -noshell -eval "io:format(\"~s\",[filename:basename(code:lib_dir('erl_interface'))])" -s erlang halt
-  OUTPUT_VARIABLE Erlang_EI_DIR
+  find_program(Erlang_RUNTIME
+    NAMES erl
+    PATHS ${Erlang_BIN_PATHS}
   )
+  if(NOT Erlang_RUNTIME)
+    message(FATAL_ERROR "erl executable not found! Please install Erlang or provide actual location")
+  endif()
+  execute_erlang(${Erlang_RUNTIME} Erlang_OTP_ROOT_DIR Erlang_EI_INCLUDE_DIRS Erlang_EI_LIBRARY_PATH Erlang_OTP_VERSION)
+endif()
 
-EXECUTE_PROCESS(
-  COMMAND         erl -noshell -eval "io:format(\"~s\",[filename:basename(code:lib_dir('erts'))])" -s erlang halt
-  OUTPUT_VARIABLE Erlang_ERTS_DIR
-  )
-
-EXECUTE_PROCESS(
-  COMMAND         erl -noshell -eval "io:format(\"~s\", [erlang:system_info(otp_release)])" -s erlang halt
-  OUTPUT_VARIABLE Erlang_OTP_VERSION
-  )
-
-SET(Erlang_EI_PATH           ${Erlang_OTP_LIB_DIR}/${Erlang_EI_DIR})
-SET(Erlang_EI_INCLUDE_DIRS   ${Erlang_OTP_LIB_DIR}/${Erlang_EI_DIR}/include)
-SET(Erlang_EI_LIBRARY_PATH   ${Erlang_OTP_LIB_DIR}/${Erlang_EI_DIR}/lib)
-
-SET(Erlang_ERTS_PATH         ${Erlang_OTP_ROOT_DIR}/${Erlang_ERTS_DIR})
-SET(Erlang_ERTS_INCLUDE_DIRS ${Erlang_OTP_ROOT_DIR}/${Erlang_ERTS_DIR}/include)
-SET(Erlang_ERTS_LIBRARY_PATH ${Erlang_OTP_ROOT_DIR}/${Erlang_ERTS_DIR}/lib)
-
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(
+find_package_handle_standard_args(
   Erlang
   DEFAULT_MSG
-  Erlang_RUNTIME
-  Erlang_COMPILE
-  Erlang_OTP_LIB_DIR
   Erlang_OTP_ROOT_DIR
-  Erlang_EI_DIR
-  Erlang_ERTS_DIR
-  Erlang_OTP_VERSION
-  )
+  Erlang_EI_LIBRARY_PATH
+  Erlang_EI_INCLUDE_DIRS
+)
+
+if(NOT EXISTS "${Erlang_EI_LIBRARY_PATH}/libei.a")
+  message(FATAL_ERROR "libei.a not found at ${Erlang_EI_LIBRARY_PATH}")
+endif()
 
 if(Erlang_FOUND)
+  cmake_print_variables(Erlang_OTP_VERSION Erlang_EI_INCLUDE_DIRS Erlang_EI_LIBRARY_PATH)
+
   if(NOT TARGET Erlang::Erlang)
     add_library(Erlang::Erlang INTERFACE IMPORTED)
     set_target_properties(Erlang::Erlang
       PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES ${Erlang_OTP_ROOT_DIR}/usr/include
-      )
-  endif()
-
-  if(NOT TARGET Erlang::ERTS)
-    add_library(Erlang::ERTS STATIC IMPORTED)
-    set_target_properties(Erlang::ERTS
-      PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES ${Erlang_ERTS_INCLUDE_DIRS}
-      IMPORTED_LOCATION             ${Erlang_ERTS_LIBRARY_PATH}/liberts.a
-      )
+      INTERFACE_INCLUDE_DIRECTORIES ${Erlang_OTP_ROOT_DIR}/include
+    )
   endif()
 
   if(NOT TARGET Erlang::EI)
     add_library(erlang_ei STATIC IMPORTED)
     set_property(TARGET erlang_ei PROPERTY
       IMPORTED_LOCATION ${Erlang_EI_LIBRARY_PATH}/libei.a
-      )
+    )
+
     add_library(Erlang::EI INTERFACE IMPORTED)
     set_property(TARGET Erlang::EI PROPERTY
       INTERFACE_INCLUDE_DIRECTORIES ${Erlang_EI_INCLUDE_DIRS}
-      )
+    )
     set_property(TARGET Erlang::EI PROPERTY
       INTERFACE_LINK_LIBRARIES erlang_ei
-      )
+    )
   endif()
-endif(Erlang_FOUND)
-
-
-
-#[[
-https://gist.github.com/JayKickliter/dd0016bd5545de466e7ca158d4b19417
-How I compile Erlang from source on macOS
-
-CFLAGS="-Og -ggdb3 -fno-omit-frame-pointer" \
-CXXFLAGS="-Og -ggdb3 -fno-omit-frame-pointer" \
-./configure \
-      --prefix=$HOME/.local \
-      --disable-silent-rules \
-      --enable-dynamic-ssl-lib \
-      --with-ssl=/usr/local/opt/openssl \
-      --disable-hipe \
-      --enable-sctp \
-      --enable-shared-zlib \
-      --enable-smp-support \
-      --enable-threads \
-      --enable-wx \
-      --without-javac \
-      --enable-darwin-64bit
-]]
+endif()

--- a/cmake/FindErlang.cmake
+++ b/cmake/FindErlang.cmake
@@ -218,10 +218,16 @@ if(Erlang_EI_LIBRARY)
   get_filename_component(Erlang_EI_LIBRARY_PATH "${Erlang_EI_LIBRARY}" DIRECTORY)
 endif()
 
+# glaze embeds this module verbatim into glazeConfig.cmake rather than
+# installing it as a file (see install-rules.cmake), so the call below can run
+# while CMAKE_FIND_PACKAGE_NAME is "glaze". FPHSA flags that as a likely typo
+# and warns every consumer at configure time; the mismatch is deliberate here.
+set(FPHSA_NAME_MISMATCHED TRUE)
 find_package_handle_standard_args(Erlang
   REQUIRED_VARS Erlang_EI_LIBRARY Erlang_EI_INCLUDE_DIRS
   VERSION_VAR Erlang_OTP_VERSION
 )
+unset(FPHSA_NAME_MISMATCHED)
 
 if(Erlang_FOUND)
   if(CMAKE_VERBOSE_MAKEFILE)

--- a/cmake/install-config.cmake.in
+++ b/cmake/install-config.cmake.in
@@ -7,6 +7,21 @@ include(CMakeFindDependencyMacro)
 set(_glaze_EETF_FORMAT "@glaze_EETF_FORMAT@")
 if(_glaze_EETF_FORMAT)
 @glaze_FIND_ERLANG_SCRIPT@
+    # glaze::glaze links Erlang::EI unconditionally once built with EETF, so a
+    # consumer that cannot resolve Erlang cannot use this package at all. Report
+    # it as a failed find_package, which REQUIRED turns into a clear error and a
+    # plain find_package can test with glaze_FOUND. Without this the missing
+    # Erlang::EI target only surfaces from glazeTargets.cmake at generate time,
+    # after configure has already reported success.
+    if(NOT Erlang_FOUND)
+        set(glaze_FOUND FALSE)
+        set(glaze_NOT_FOUND_MESSAGE
+            "glaze was built with glaze_EETF_FORMAT=ON but Erlang/OTP's erl_interface \
+library was not found. Install Erlang/OTP, or point the build at it with \
+ERLANG_EI_LIB and ERLANG_EI_INCLUDE.")
+        unset(_glaze_EETF_FORMAT)
+        return()
+    endif()
 endif()
 unset(_glaze_EETF_FORMAT)
 


### PR DESCRIPTION
Refactor FindErlang CMake module

Remove some issues, more clearer behavior and result. Add inplace documentation for developers.

**The reason for this PR**: During real-world use of this module in embedded systems, several issues were identified. These issues led to a redesign of the module into its current form, which provides a more flexible and predictable build process for both conventional systems and embedded systems using cross-compilation.