### PR TITLE
Count file include keys toward error_on_missing_keys

### DIFF
--- a/docs/json-include.md
+++ b/docs/json-include.md
@@ -24,6 +24,10 @@ This will read the `./obj.json` file into the `obj` as it is parsed. Since glaze
 
 > Paths are always relative to the location of the previously loaded file. For nested includes this means the user only needs to consider the relative path to the file in which the include is written.
 
+## Missing Keys
+
+An included file is a fragment of the object that names it: some of the object's keys come from the include and the rest come from the including document. With `error_on_missing_keys` the check is therefore made by the including object over the union of both documents, so the example above reads without error even though neither document lists every key on its own. Keys that appear in neither document are still reported, as are missing keys of objects nested inside an included file.
+
 ## Hostname Include
 
 Similar to `glz::file_include`, glaze provides `glz::hostname_include`. This is used for host-specific configuration files.

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -163,6 +163,56 @@ namespace glz
    template <class T>
    concept is_includer = requires(T t) { requires T::glaze_includer == true; };
 
+   // Identity of the type an object's key bits belong to (see context::include_key_type). The
+   // address of each instantiation is unique, so comparing addresses compares types.
+   template <class T>
+   inline constexpr char include_key_tag{};
+
+   // Publishes an object's missing-key bits on the context while it is parsed, so that an includer
+   // member can hand them to the read of its file, and restores the previous value on the way out.
+   template <class Ctx>
+   struct key_bits_scope final
+   {
+      Ctx& ctx;
+      void* previous;
+
+      key_bits_scope(Ctx& ctx, void* bits) noexcept : ctx(ctx), previous(ctx.key_bits) { ctx.key_bits = bits; }
+      key_bits_scope(const key_bits_scope&) = delete;
+      key_bits_scope& operator=(const key_bits_scope&) = delete;
+      ~key_bits_scope() noexcept { ctx.key_bits = previous; }
+   };
+
+   // Stands in for key_bits_scope in objects that cannot include a file, so they do not touch the
+   // context at all.
+   struct inert_key_bits_scope final
+   {
+      constexpr inert_key_bits_scope(auto&&, void*) noexcept {}
+   };
+
+   // Hands the including object's key bits to the read of an included file, and clears them
+   // afterwards in case that read never claimed them (an included document whose top level is not
+   // the including object, or one that failed before reaching its closing brace).
+   template <class Ctx>
+   struct include_key_scope final
+   {
+      Ctx& ctx;
+
+      include_key_scope(Ctx& ctx, const void* type_tag) noexcept : ctx(ctx)
+      {
+         if (ctx.key_bits) {
+            ctx.include_key_bits = ctx.key_bits;
+            ctx.include_key_type = type_tag;
+         }
+      }
+      include_key_scope(const include_key_scope&) = delete;
+      include_key_scope& operator=(const include_key_scope&) = delete;
+      ~include_key_scope() noexcept
+      {
+         ctx.include_key_bits = nullptr;
+         ctx.include_key_type = nullptr;
+      }
+   };
+
    template <class T>
    concept is_member_function_pointer = std::is_member_function_pointer_v<T>;
 

--- a/include/glaze/core/context.hpp
+++ b/include/glaze/core/context.hpp
@@ -147,6 +147,18 @@ namespace glz
       // NOTE: The default constructor is valid for std::string_view, so we use this rather than {}
       // because debuggers like jumping to std::string_view initialization calls
       std::string scratch{}; // Reusable scratch buffer for intermediate parsing (key lookup, etc.)
+      // A file include (glz::file_include, glz::hostname_include) merges an external document into
+      // the object that names it, which makes that document a fragment: some of the object's keys
+      // come from it and the rest come from the including document. With error_on_missing_keys the
+      // check therefore belongs to the including object, over the union of both. These carry the
+      // including object's key bits across the nested read: an object publishes its bits in
+      // key_bits while it parses, an includer member hands them to the read of its file in
+      // include_key_bits, and that file's top level merges its own keys into them instead of
+      // running a check of its own. include_key_type identifies the type the bits belong to so an
+      // included document of some other type never reinterprets them. See glz::include_key_scope.
+      void* key_bits{};
+      void* include_key_bits{};
+      const void* include_key_type{};
    };
 
    // Concept for any context type (base or streaming)

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -805,6 +805,24 @@ namespace glz
       return custom_getter_is_null(custom_val, ctx);
    }
 
+   // Whether any member of T performs a file include. Only these objects pay for the key-bit
+   // bookkeeping that lets an included document satisfy the including object's missing-key check.
+   template <class T>
+   constexpr bool has_includer_member = []() constexpr {
+      if constexpr (glaze_object_t<T> || reflectable<T>) {
+         bool found = false;
+         for_each<reflect<T>::size>([&]<auto I>() constexpr {
+            if constexpr (is_includer<std::decay_t<refl_t<T, I>>>) {
+               found = true;
+            }
+         });
+         return found;
+      }
+      else {
+         return false;
+      }
+   }();
+
    template <class T, auto Opts>
    constexpr auto required_fields()
    {

--- a/include/glaze/file/hostname_include.hpp
+++ b/include/glaze/file/hostname_include.hpp
@@ -115,6 +115,9 @@ namespace glz
 
          std::string nested_buffer = buffer;
          static constexpr auto NestedOpts = opt_true<disable_padding_on<Opts>(), &opts::null_terminated>;
+         // As with glz::file_include: the included file is a fragment of the object we belong to,
+         // so its keys count toward that object's missing key check.
+         const include_key_scope include_keys{ctx, &include_key_tag<std::remove_cvref_t<decltype(value.value)>>};
          const auto ecode = glz::read<NestedOpts>(value.value, nested_buffer, ctx);
          if (bool(ctx.error)) [[unlikely]] {
             ctx.error = error_code::includer_error;

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2921,6 +2921,9 @@ namespace glz
          // We need to allocate a new buffer here because we could call another includer that uses the buffer
          std::string nested_buffer = buffer;
          static constexpr auto NestedOpts = opt_true<disable_padding_on<Opts>(), &opts::null_terminated>;
+         // The included file fills in part of the object we belong to, so its keys count toward
+         // that object's missing key check rather than being required all over again here.
+         const include_key_scope include_keys{ctx, &include_key_tag<std::remove_cvref_t<decltype(value.value)>>};
          const auto ecode = glz::read<NestedOpts>(value.value, nested_buffer, ctx);
          if (bool(ctx.error)) [[unlikely]] {
             ctx.error = error_code::includer_error;
@@ -3155,6 +3158,41 @@ namespace glz
                }
             }();
 
+            // A file include merges an external document into this object, so with
+            // error_on_missing_keys the keys have to be counted across both documents (see
+            // context::key_bits). While this object parses, its bits are published for its
+            // includer members to hand down; and if this parse is itself an included document,
+            // it claims the bits of the object that included us and merges into them at the
+            // closing brace instead of running a check of its own.
+            static constexpr bool tracks_include_keys = [] {
+               // Nested so that reflecting over the members is only asked for when it can matter
+               if constexpr ((glaze_object_t<T> || reflectable<T>) && Opts.error_on_missing_keys) {
+                  return has_includer_member<T>;
+               }
+               else {
+                  return false;
+               }
+            }();
+            [[maybe_unused]] bit_array<num_members>* include_bits{};
+            if constexpr (tracks_include_keys) {
+               if (ctx.include_key_type == &include_key_tag<T>) {
+                  include_bits = static_cast<bit_array<num_members>*>(ctx.include_key_bits);
+                  ctx.include_key_bits = nullptr;
+                  ctx.include_key_type = nullptr;
+               }
+            }
+            [[maybe_unused]] const std::conditional_t<tracks_include_keys,
+                                                      key_bits_scope<std::remove_reference_t<decltype(ctx)>>,
+                                                      inert_key_bits_scope> published_bits{
+               ctx, [&]() -> void* {
+                  if constexpr (tracks_include_keys) {
+                     return &fields;
+                  }
+                  else {
+                     return nullptr;
+                  }
+               }()};
+
             size_t read_count{}; // for partial_read
 
             bool first = true;
@@ -3198,8 +3236,19 @@ namespace glz
                if (*it == '}') {
                   --ctx.depth;
                   if constexpr ((glaze_object_t<T> || reflectable<T>) && Opts.error_on_missing_keys) {
+                     const bool defer_to_includer = [&] {
+                        if constexpr (tracks_include_keys) {
+                           if (include_bits) {
+                              // An included document is a fragment: hand the keys it supplied to
+                              // the object that included it, which checks the union of both.
+                              *include_bits |= fields;
+                              return true;
+                           }
+                        }
+                        return false;
+                     }();
                      constexpr auto req_fields = required_fields<T, Opts>();
-                     if ((req_fields & fields) != req_fields) {
+                     if (not defer_to_includer && (req_fields & fields) != req_fields) {
                         for (size_t i = 0; i < num_members; ++i) {
                            if (not fields[i] && req_fields[i]) {
                               ctx.custom_error_message = reflect<T>::keys[i];

--- a/include/glaze/util/bit_array.hpp
+++ b/include/glaze/util/bit_array.hpp
@@ -135,6 +135,20 @@ namespace glz
          return ret &= rhs;
       }
 
+      constexpr bit_array& operator|=(const bit_array& rhs) noexcept
+      {
+         for (size_t i{}; i < n_chunks; ++i) {
+            data[i] |= rhs.data[i];
+         }
+         return *this;
+      }
+
+      constexpr bit_array operator|(const bit_array& rhs) const noexcept
+      {
+         auto ret = *this;
+         return ret |= rhs;
+      }
+
       constexpr bool operator==(const bit_array& rhs) const noexcept { return data == rhs.data; }
    };
 }

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <list>
 #include <map>
+#include <memory>
 #include <numbers>
 #include <random>
 #include <ranges>
@@ -4678,6 +4679,96 @@ suite file_include_test_auto = [] {
       expect(!glz::read_file_json(obj, "./auto.json", std::string{}));
       expect(obj.str == "Hello") << obj.str;
       expect(obj.i == 55) << obj.i;
+   };
+};
+
+struct missing_keys_sub
+{
+   int a{};
+   int b{};
+};
+
+struct missing_keys_includer
+{
+   glz::file_include include{};
+   std::string str{};
+   int i{};
+   missing_keys_sub sub{};
+};
+
+struct recursive_includer
+{
+   glz::file_include include{};
+   std::string str{};
+   std::unique_ptr<recursive_includer> child{};
+};
+
+// An included file fills in part of the object that names it, so with error_on_missing_keys the
+// check belongs to the including object, over the union of both documents.
+suite file_include_missing_keys_test = [] {
+   static constexpr glz::opts strict{.error_on_missing_keys = true};
+
+   "include supplies a missing key"_test = [] {
+      expect(glz::buffer_to_file(std::string{R"({"str":"Hello","sub":{"a":1,"b":2}})"}, "./include_fragment.json") ==
+             glz::error_code::none);
+
+      missing_keys_includer obj{};
+      std::string s = R"({"include": "./include_fragment.json", "i": 100})";
+      const auto ec = glz::read<strict>(obj, s);
+      expect(!ec) << glz::format_error(ec, s);
+      expect(obj.str == "Hello") << obj.str;
+      expect(obj.i == 100) << obj.i;
+      expect(obj.sub.b == 2);
+   };
+
+   "keys absent from both documents still error"_test = [] {
+      expect(glz::buffer_to_file(std::string{R"({"str":"Hello","sub":{"a":1,"b":2}})"}, "./include_fragment.json") ==
+             glz::error_code::none);
+
+      missing_keys_includer obj{};
+      std::string s = R"({"include": "./include_fragment.json"})"; // "i" is in neither document
+      expect(glz::read<strict>(obj, s) == glz::error_code::missing_key);
+   };
+
+   "objects nested within an include are still checked"_test = [] {
+      expect(glz::buffer_to_file(std::string{R"({"str":"Hello","sub":{"a":1}})"}, "./include_partial_sub.json") ==
+             glz::error_code::none);
+
+      missing_keys_includer obj{};
+      std::string s = R"({"include": "./include_partial_sub.json", "i": 100})";
+      expect(glz::read<strict>(obj, s) == glz::error_code::includer_error);
+   };
+
+   "unknown keys within an include are still checked"_test = [] {
+      expect(glz::buffer_to_file(std::string{R"({"str":"Hello","sub":{"a":1,"b":2},"nope":1})"},
+                                 "./include_unknown_key.json") == glz::error_code::none);
+
+      missing_keys_includer obj{};
+      std::string s = R"({"include": "./include_unknown_key.json", "i": 100})";
+      expect(glz::read<strict>(obj, s) == glz::error_code::includer_error);
+   };
+
+   "keys accumulate across nested includes"_test = [] {
+      expect(glz::buffer_to_file(std::string{R"({"sub":{"a":1,"b":2}})"}, "./include_inner.json") ==
+             glz::error_code::none);
+      expect(glz::buffer_to_file(std::string{R"({"include":"./include_inner.json","str":"Hello"})"},
+                                 "./include_outer.json") == glz::error_code::none);
+
+      missing_keys_includer obj{};
+      std::string s = R"({"include": "./include_outer.json", "i": 100})";
+      const auto ec = glz::read<strict>(obj, s);
+      expect(!ec) << glz::format_error(ec, s);
+      expect(obj.str == "Hello") << obj.str;
+      expect(obj.sub.b == 2);
+   };
+
+   "a nested value of the same type is checked on its own"_test = [] {
+      recursive_includer obj{};
+      std::string s = R"({"str": "a", "child": {}})";
+      expect(glz::read<strict>(obj, s) == glz::error_code::missing_key);
+
+      std::string t = R"({"child": {"str": "b"}})"; // the child's keys do not satisfy the parent
+      expect(glz::read<strict>(obj, t) == glz::error_code::missing_key);
    };
 };
 


### PR DESCRIPTION
Resolves #2810.

## The problem

A `glz::file_include` reads its file into the object that names it, through a nested `glz::read` that inherits the parse options. With `error_on_missing_keys` that made the included file responsible for every key of the object on its own, while the keys it *did* supply never counted toward the including document. Neither document could pass:

```c++
struct includer_struct {
  glz::file_include include{};
  std::string str;
  int32_t i;
};

// obj.json is {"str": "Hello"}
std::string s = R"({"include": "./obj.json", "i": 100})";
auto ec = glz::read<glz::opts{.error_on_missing_keys = true}>(obj, s);
// error: includer_error 3:1: missing_key
//    }
//    ^ i
```

## The fix

An included file is a fragment of the object that names it, so the check now belongs to the including object over the union of both documents. An object publishes its key bits on the context while it parses, an includer member hands them to the read of its file, and that file's top level merges its own keys into them instead of running a check of its own. A type tag guards the hand-off so an included document of some other type never claims bits that are not its own, and keys accumulate transitively across nested includes.

Everything else stays strict:

- keys absent from both documents are still reported
- unknown keys within an included file are still reported
- missing keys of objects nested within an included file are still reported
- a nested value of the same type as its parent is still checked on its own

`glz::hostname_include` gets the same treatment. Objects that cannot include a file do not touch the context at all, so the bookkeeping compiles out everywhere else.

## Testing

Six cases added to `json_test` covering each of the behaviors above. Full build is clean and the suite passes 118/118 locally.