### PR TITLE
Support arrays of class elements in volatile structs (experimental)

### DIFF
--- a/docs/volatile-support.md
+++ b/docs/volatile-support.md
@@ -39,3 +39,53 @@ expect(obj.d == 9.9);
 expect(obj.e == 12);
 ```
 
+
+## Arrays of class elements
+
+The array elements may themselves be class types, which is the usual shape of a register block built from N identical sub-blocks:
+
+```c++
+struct channel_t
+{
+   uint32_t control{};
+   uint32_t status{};
+};
+
+struct block_t
+{
+   uint32_t enable{};
+   glz::volatile_array<channel_t, 4> channels{};
+};
+```
+
+```c++
+volatile block_t block{};
+block.enable = 1;
+block.channels[0].control = 7;
+
+std::string s{};
+glz::write_json(block, s);
+// {"enable":1,"channels":[{"control":7,"status":0}, ...]}
+
+expect(!glz::read_json(block, s));
+expect(glz::get<volatile uint32_t>(block, "/channels/0/control") == uint32_t(7));
+```
+
+These arrays are traversed by index rather than by iterator: `volatile_array<T, N>::begin()` returns a `volatile T*`, which is not a `std::input_iterator` when `T` is a class type, because `std::indirectly_readable` requires `T` be constructible from `volatile T&` and an implicit copy constructor takes `const T&`. Scalar elements copy through a built-in conversion instead, so they keep taking the ordinary iterable path and their encoding is unchanged.
+
+A plain C array of class type inside a `volatile` struct works the same way:
+
+```c++
+struct block_t
+{
+   channel_t channels[4]{};
+};
+
+template <>
+struct glz::meta<block_t>
+{
+   static constexpr auto value = object(&block_t::channels);
+};
+```
+
+Note the explicit `glz::meta`: pure reflection cannot handle an aggregate containing a C array, with or without `volatile`, because the member-count probe counts the array's elements individually. Use `glz::volatile_array` (or `std::array`) to keep reflection working.

--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -1772,6 +1772,71 @@ namespace glz
       }
    };
 
+   // Reads a BEVE array by indexing rather than by iterating.
+   //
+   // The counterpart of `write_beve_indexed_array`: the elements are reached through `volatile`,
+   // so `value.begin()` is not an iterator (see `volatile_indexed_array`) and `std::span` cannot
+   // be formed over the storage. Like the fixed-extent branch of the iterator-based reader, the
+   // encoded count is validated but the extent `N` is what gets parsed.
+   template <auto Opts, size_t N>
+   void read_beve_indexed_array(auto&& value, is_context auto&& ctx, auto&& it, auto end)
+   {
+      if (invalid_end(ctx, it, end)) {
+         return;
+      }
+      if ((uint8_t(*it) & 0b00000'111) != tag::generic_array) [[unlikely]] {
+         ctx.error = error_code::syntax_error;
+         return;
+      }
+
+      depth_guard guard{ctx};
+      if (!guard) [[unlikely]] {
+         return;
+      }
+
+      ++it;
+      const size_t n = int_from_compressed(ctx, it, end);
+      if (bool(ctx.error)) [[unlikely]] {
+         return;
+      }
+
+      // Each element needs at least 1 byte for its tag
+      if (uint64_t(end - it) < n) [[unlikely]] {
+         ctx.error = error_code::invalid_length;
+         return;
+      }
+      if constexpr (check_max_array_size(Opts) > 0) {
+         if (n > check_max_array_size(Opts)) [[unlikely]] {
+            ctx.error = error_code::invalid_length;
+            return;
+         }
+      }
+      if constexpr (has_runtime_max_array_size<std::decay_t<decltype(ctx)>>) {
+         if (ctx.max_array_size > 0 && n > ctx.max_array_size) [[unlikely]] {
+            ctx.error = error_code::invalid_length;
+            return;
+         }
+      }
+
+      using val_t = std::remove_cvref_t<decltype(value[0])>;
+      for (size_t i = 0; i < N; ++i) {
+         from<BEVE, val_t>::template op<Opts>(value[i], ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+      }
+   }
+
+   template <readable_volatile_array_t T>
+   struct from<BEVE, T> final
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto end)
+      {
+         read_beve_indexed_array<Opts, std::remove_cvref_t<T>::length>(value, ctx, it, end);
+      }
+   };
+
    template <readable_array_t T>
    struct from<BEVE, T> final
    {
@@ -2689,7 +2754,14 @@ namespace glz
       template <auto Opts, class V, size_t N>
       GLZ_ALWAYS_INLINE static void op(V (&value)[N], is_context auto&& ctx, auto&& it, auto end) noexcept
       {
-         parse<BEVE>::op<Opts>(std::span{value, N}, ctx, it, end);
+         if constexpr (requires { std::span{value, N}; }) {
+            parse<BEVE>::op<Opts>(std::span{value, N}, ctx, it, end);
+         }
+         else {
+            // A class-type element reached through `volatile` gives a pointer that is neither a
+            // contiguous_iterator nor spannable, so index the array directly instead.
+            read_beve_indexed_array<Opts, N>(value, ctx, it, end);
+         }
       }
    };
 

--- a/include/glaze/beve/write.hpp
+++ b/include/glaze/beve/write.hpp
@@ -882,6 +882,47 @@ namespace glz
       }
    };
 
+   // Writes a BEVE array by indexing rather than by iterating.
+   //
+   // Needed wherever the elements are reached through `volatile`: `volatile T*` is not an
+   // iterator for a class-type `T` (see `volatile_indexed_array`), and `std::span` cannot be
+   // formed over volatile storage either. Only class-type elements reach this path -- a volatile
+   // pointer to a scalar is still an iterator, so those arrays keep taking the typed-array
+   // encodings of the `writable_array_t` writer below -- which makes the generic array tag always
+   // the right one here, matching what an equivalent std::array of the same element type produces.
+   template <auto Opts, size_t N, class B>
+   void write_beve_indexed_array(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
+   {
+      dump_type(ctx, uint8_t(tag::generic_array), b, ix);
+      if (bool(ctx.error)) [[unlikely]] {
+         return;
+      }
+      dump_compressed_int(ctx, N, b, ix);
+      if (bool(ctx.error)) [[unlikely]] {
+         return;
+      }
+
+      for (size_t i = 0; i < N; ++i) {
+         serialize<BEVE>::op<Opts>(value[i], ctx, b, ix);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+         if constexpr (is_output_streaming<std::remove_cvref_t<B>>) {
+            flush_buffer(b, ix);
+         }
+      }
+   }
+
+   template <writable_volatile_array_t T>
+   struct to<BEVE, T> final
+   {
+      template <auto Opts, class B>
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
+      {
+         write_beve_indexed_array<Opts, std::remove_cvref_t<T>::length>(value, ctx, b, ix);
+      }
+   };
+
    template <writable_array_t T>
    struct to<BEVE, T> final
    {
@@ -1284,7 +1325,14 @@ namespace glz
       template <auto Opts, class V, size_t N, class... Args>
       GLZ_ALWAYS_INLINE static void op(const V (&value)[N], is_context auto&& ctx, Args&&... args)
       {
-         serialize<BEVE>::op<Opts>(std::span{value, N}, ctx, std::forward<Args>(args)...);
+         if constexpr (requires { std::span{value, N}; }) {
+            serialize<BEVE>::op<Opts>(std::span{value, N}, ctx, std::forward<Args>(args)...);
+         }
+         else {
+            // A class-type element reached through `volatile` gives a pointer that is neither a
+            // contiguous_iterator nor spannable, so index the array directly instead.
+            write_beve_indexed_array<Opts, N>(value, ctx, std::forward<Args>(args)...);
+         }
       }
    };
 

--- a/include/glaze/concepts/container_concepts.hpp
+++ b/include/glaze/concepts/container_concepts.hpp
@@ -253,6 +253,12 @@ namespace glz
       requires std::input_iterator<decltype(t.begin())>;
    };
 
+   // Marks a container that stores its elements in volatile memory, such as glz::volatile_array.
+   // Defined here rather than alongside glz::volatile_array so that the serialization concepts can
+   // see it without pulling in the hardware headers.
+   template <class T>
+   concept is_volatile_array = requires { std::decay_t<T>::glaze_volatile_array; };
+
    // Concept for a matrix type (not a vector, which is a range)
    template <class T>
    concept matrix_t = requires(T matrix) {

--- a/include/glaze/core/common.hpp
+++ b/include/glaze/core/common.hpp
@@ -348,6 +348,24 @@ namespace glz
    concept writable_array_t = (range<T> && !custom_write<T> && !meta_value_t<T> && !str_t<T> && !writable_map_t<T> &&
                                !filesystem_path<T> && !has_value_method<T>);
 
+   // Static-extent arrays whose elements are reached through `volatile`, such as
+   // glz::volatile_array<some_class, N>.
+   //
+   // `volatile T*` is not a `std::input_iterator` when `T` is a class type:
+   // `std::indirectly_readable` requires `T` be constructible from `volatile T&`, and an
+   // implicit copy constructor takes `const T&`, to which no volatile lvalue binds. Scalar
+   // elements copy through a built-in conversion instead, so those arrays remain iterable and
+   // keep taking the ordinary `range` paths. Only the class-element case lands here, and it
+   // must be traversed by index rather than by iterator.
+   template <class T>
+   concept volatile_indexed_array = is_volatile_array<T> && !range<T> && !meta_value_t<T>;
+
+   template <class T>
+   concept readable_volatile_array_t = volatile_indexed_array<T> && !custom_read<T>;
+
+   template <class T>
+   concept writable_volatile_array_t = volatile_indexed_array<T> && !custom_write<T>;
+
    template <class T>
    concept fixed_array_value_t =
       array_t<std::decay_t<decltype(std::declval<T>()[0])>> && !resizable<std::decay_t<decltype(std::declval<T>()[0])>>;

--- a/include/glaze/core/seek.hpp
+++ b/include/glaze/core/seek.hpp
@@ -144,6 +144,32 @@ namespace glz
       }
    };
 
+   // Specialization for arrays whose elements are reached through `volatile`.
+   // These are not `array_t` because they are not iterable (see `volatile_indexed_array`),
+   // so the element is reached with `operator[]` instead of `std::next(begin(), index)`.
+   template <class T>
+      requires volatile_indexed_array<T>
+   struct seek_op<T>
+   {
+      template <class F>
+      static bool op(F&& func, auto&& value, sv json_ptr)
+      {
+         if (json_ptr.empty()) {
+            func(value);
+            return true;
+         }
+         if (json_ptr[0] != '/' || json_ptr.size() < 2) return false;
+
+         size_t index{};
+         auto [p, ec] = std::from_chars(&json_ptr[1], json_ptr.data() + json_ptr.size(), index);
+         if (ec != std::errc{}) return false;
+         json_ptr = json_ptr.substr(p - json_ptr.data());
+
+         if (index >= T::length) return false;
+         return seek(std::forward<F>(func), value[index], json_ptr);
+      }
+   };
+
    // Specialization for nullable types
    template <class T>
       requires nullable_t<T>

--- a/include/glaze/hardware/volatile_array.hpp
+++ b/include/glaze/hardware/volatile_array.hpp
@@ -9,11 +9,10 @@
 #include <initializer_list>
 #include <type_traits>
 
+#include "glaze/concepts/container_concepts.hpp" // for is_volatile_array
+
 namespace glz
 {
-   template <class T>
-   concept is_volatile_array = requires { std::decay_t<T>::glaze_volatile_array; };
-
    template <typename T, std::size_t N>
    class volatile_array
    {

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -2298,6 +2298,98 @@ namespace glz
       }
    };
 
+   // Reads a JSON array by indexing rather than by iterating.
+   //
+   // The counterpart of `write_json_indexed_array`: the elements are reached through `volatile`,
+   // so `value.begin()` is not an iterator (see `volatile_indexed_array`) and `std::span` cannot
+   // be formed over the storage. `N` is the compile-time extent, and the fixed-extent semantics
+   // match those of `std::array`: a short array leaves the trailing elements untouched, and more
+   // input elements than `N` is `exceeded_static_array_size`.
+   template <auto Options, size_t N>
+   void read_json_indexed_array(auto&& value, is_context auto&& ctx, auto&& it, auto end)
+   {
+      constexpr auto Opts = ws_handled_off<Options>();
+      if constexpr (!check_ws_handled(Options)) {
+         if (skip_ws<Opts>(ctx, it, end)) {
+            return;
+         }
+      }
+
+      if (match_invalid_end<'[', Opts>(ctx, it, end)) {
+         return;
+      }
+      // one nesting level (see enter_depth), released at each syntactic close below
+      if (enter_depth(ctx)) [[unlikely]] {
+         return;
+      }
+
+      const auto ws_start = it;
+      if (skip_ws<Opts>(ctx, it, end)) {
+         return;
+      }
+
+      if (*it == ']') {
+         --ctx.depth;
+         ++it;
+         return;
+      }
+
+      const size_t ws_size = size_t(it - ws_start);
+
+      using val_t = std::remove_cvref_t<decltype(value[0])>;
+
+      for (size_t i = 0; i < N; ++i) {
+         from<JSON, val_t>::template op<ws_handled<Opts>()>(value[i], ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+         if (skip_ws<Opts>(ctx, it, end)) {
+            return;
+         }
+         if (*it == ',') {
+            ++it;
+
+            if constexpr (!Opts.minified && !Opts.comments) {
+               if (ws_size && ws_size < size_t(end - it)) {
+                  skip_matching_ws(ws_start, it, ws_size);
+               }
+            }
+
+            if (skip_ws<Opts>(ctx, it, end)) {
+               return;
+            }
+         }
+         else if (*it == ']') {
+            --ctx.depth;
+            ++it;
+            return;
+         }
+         else [[unlikely]] {
+            ctx.error = error_code::expected_bracket;
+            return;
+         }
+      }
+
+      if constexpr (check_partial_read(Opts)) {
+         // partial_read stops early on a success path, so give the level back like the
+         // syntactic-close paths do; otherwise it accumulates across reads sharing a context.
+         --ctx.depth;
+      }
+      else {
+         ctx.error = error_code::exceeded_static_array_size;
+      }
+   }
+
+   template <readable_volatile_array_t T>
+   struct from<JSON, T>
+   {
+      template <auto Opts>
+      static void op(auto&& value, is_context auto&& ctx, auto&& it, auto end)
+      {
+         read_json_indexed_array<Opts, std::remove_cvref_t<T>::length>(value, ctx, it, end);
+      }
+   };
+
    // for types like std::vector, std::array, std::deque, etc.
    template <class T>
       requires(readable_array_t<T> && (emplace_backable<T> || is_inplace_vector<T> || !resizable<T>) && !emplaceable<T>)
@@ -5042,7 +5134,14 @@ namespace glz
       template <auto Opts, class V, size_t N>
       GLZ_ALWAYS_INLINE static void op(V (&value)[N], is_context auto&& ctx, auto&& it, auto end) noexcept
       {
-         parse<JSON>::op<Opts>(std::span{value, N}, ctx, it, end);
+         if constexpr (requires { std::span{value, N}; }) {
+            parse<JSON>::op<Opts>(std::span{value, N}, ctx, it, end);
+         }
+         else {
+            // A class-type element reached through `volatile` gives a pointer that is neither a
+            // contiguous_iterator nor spannable, so index the array directly instead.
+            read_json_indexed_array<Opts, N>(value, ctx, it, end);
+         }
       }
    };
 

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1216,6 +1216,55 @@ namespace glz
       to<JSON, V>::template op<opening_and_closing_handled_off<Opts>()>(value, ctx, b, ix);
    }
 
+   // Writes a JSON array by indexing rather than by iterating.
+   //
+   // Needed wherever the elements are reached through `volatile`: `volatile T*` is not an
+   // iterator for a class-type `T` (see `volatile_indexed_array`), and `std::span` cannot be
+   // formed over volatile storage either. `N` is the compile-time extent; elements are visited
+   // with `value[i]`, which keeps every access volatile-qualified.
+   template <auto Opts, size_t N, class... Args>
+   void write_json_indexed_array(auto&& value, is_context auto&& ctx, Args&&... args)
+   {
+      if constexpr (N == 0) {
+         dump("[]", args...);
+      }
+      else {
+         using val_t = std::remove_cvref_t<decltype(value[0])>;
+
+         dump('[', args...);
+         if constexpr (Opts.prettify && check_new_lines_in_arrays(Opts)) {
+            ctx.depth += check_indentation_width(Opts);
+            dump_newline_indent(check_indentation_char(Opts), ctx.depth, args...);
+         }
+
+         for (size_t i = 0; i < N; ++i) {
+            if (i) {
+               write_array_entry_separator<Opts>(ctx, args...);
+            }
+            to<JSON, val_t>::template op<Opts>(value[i], ctx, args...);
+            if (bool(ctx.error)) [[unlikely]] {
+               return;
+            }
+         }
+
+         if constexpr (Opts.prettify && check_new_lines_in_arrays(Opts)) {
+            ctx.depth -= check_indentation_width(Opts);
+            dump_newline_indent(check_indentation_char(Opts), ctx.depth, args...);
+         }
+         dump(']', args...);
+      }
+   }
+
+   template <writable_volatile_array_t T>
+   struct to<JSON, T>
+   {
+      template <auto Opts, class... Args>
+      static void op(auto&& value, is_context auto&& ctx, Args&&... args)
+      {
+         write_json_indexed_array<Opts, std::remove_cvref_t<T>::length>(value, ctx, std::forward<Args>(args)...);
+      }
+   };
+
    template <class T>
    concept array_padding_known = requires { typename T::value_type; } &&
                                  (required_padding<typename T::value_type>() > 0 ||
@@ -1589,7 +1638,14 @@ namespace glz
       template <auto Opts, class V, size_t N, class... Args>
       GLZ_ALWAYS_INLINE static void op(const V (&value)[N], is_context auto&& ctx, Args&&... args)
       {
-         serialize<JSON>::op<Opts>(std::span{value, N}, ctx, std::forward<Args>(args)...);
+         if constexpr (requires { std::span{value, N}; }) {
+            serialize<JSON>::op<Opts>(std::span{value, N}, ctx, std::forward<Args>(args)...);
+         }
+         else {
+            // A class-type element reached through `volatile` gives a pointer that is neither a
+            // contiguous_iterator nor spannable, so index the array directly instead.
+            write_json_indexed_array<Opts, N>(value, ctx, std::forward<Args>(args)...);
+         }
       }
    };
 

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -3401,6 +3401,167 @@ suite volatile_tests = [] {
    };
 };
 
+// A register block made of identical sub-blocks: the array elements are class types, so they are
+// reached by index rather than by iterator (a volatile T* is not an iterator for a class type).
+struct volatile_channel
+{
+   uint32_t control{};
+   uint32_t status{};
+};
+
+struct volatile_channel_block
+{
+   uint32_t enable{};
+   glz::volatile_array<volatile_channel, 4> channels{};
+};
+
+// The non-volatile mirror of volatile_channel_block, used to pin the encoding.
+struct plain_channel_block
+{
+   uint32_t enable{};
+   std::array<volatile_channel, 4> channels{};
+};
+
+struct volatile_bank
+{
+   glz::volatile_array<uint16_t, 2> regs{};
+};
+
+struct volatile_two_level
+{
+   glz::volatile_array<volatile_bank, 2> banks{};
+};
+
+struct volatile_c_array_block
+{
+   volatile_channel channels[3]{};
+   uint32_t scalars[2]{};
+};
+
+template <>
+struct glz::meta<volatile_c_array_block>
+{
+   using T = volatile_c_array_block;
+   static constexpr auto value = object(&T::channels, &T::scalars);
+};
+
+suite volatile_class_element_array_tests = [] {
+   "volatile_array of class elements"_test = [] {
+      volatile volatile_channel_block obj{};
+      obj.enable = 1;
+      for (size_t i = 0; i < 4; ++i) {
+         obj.channels[i].control = uint32_t(i);
+         obj.channels[i].status = uint32_t(100 + i);
+      }
+
+      std::string s{};
+      expect(not glz::write_beve(obj, s));
+
+      volatile volatile_channel_block obj2{};
+      expect(!glz::read_beve(obj2, s));
+      expect(obj2.enable == 1u);
+      for (size_t i = 0; i < 4; ++i) {
+         expect(obj2.channels[i].control == uint32_t(i));
+         expect(obj2.channels[i].status == uint32_t(100 + i));
+      }
+   };
+
+   // Volatile storage must not change the wire format: the bytes have to match what the same
+   // layout produces through the ordinary iterator-based array path.
+   "volatile_array of class elements matches the std::array encoding"_test = [] {
+      volatile volatile_channel_block obj{};
+      plain_channel_block mirror{};
+      obj.enable = 1;
+      mirror.enable = 1;
+      for (size_t i = 0; i < 4; ++i) {
+         obj.channels[i].control = uint32_t(i);
+         obj.channels[i].status = uint32_t(100 + i);
+         mirror.channels[i] = {uint32_t(i), uint32_t(100 + i)};
+      }
+
+      std::string s{};
+      expect(not glz::write_beve(obj, s));
+      std::string expected{};
+      expect(not glz::write_beve(mirror, expected));
+      expect(s == expected);
+   };
+
+   // Scalar elements keep taking the iterator-based path, which encodes them as a typed array
+   // rather than a generic one. Pin that: indexing them instead would silently change the wire
+   // format.
+   "volatile_array of scalar elements still encodes as a typed array"_test = [] {
+      volatile glz::volatile_array<uint16_t, 4> obj{{1, 2, 3, 4}};
+      std::string s{};
+      expect(not glz::write_beve(obj, s));
+
+      std::array<uint16_t, 4> mirror{1, 2, 3, 4};
+      std::string expected{};
+      expect(not glz::write_beve(mirror, expected));
+      expect(s == expected);
+   };
+
+   // The failure was never volatile-specific: volatile_array::begin() is unconditionally
+   // volatile-qualified, so a non-volatile object of the same type could not serialize either.
+   "non-volatile object holding a volatile_array of class elements"_test = [] {
+      volatile_channel_block obj{};
+      obj.enable = 2;
+      obj.channels[1].status = 9;
+
+      std::string s{};
+      expect(not glz::write_beve(obj, s));
+
+      volatile_channel_block obj2{};
+      expect(!glz::read_beve(obj2, s));
+      expect(obj2.enable == 2u);
+      expect(obj2.channels[1].status == 9u);
+   };
+
+   "nested volatile_array of class elements"_test = [] {
+      volatile volatile_two_level obj{};
+      obj.banks[0].regs[0] = 1;
+      obj.banks[0].regs[1] = 2;
+      obj.banks[1].regs[0] = 3;
+      obj.banks[1].regs[1] = 4;
+
+      std::string s{};
+      expect(not glz::write_beve(obj, s));
+
+      volatile volatile_two_level obj2{};
+      expect(!glz::read_beve(obj2, s));
+      expect(obj2.banks[0].regs == glz::volatile_array<uint16_t, 2>{1, 2});
+      expect(obj2.banks[1].regs == glz::volatile_array<uint16_t, 2>{3, 4});
+   };
+
+   "C array of class elements in a volatile struct"_test = [] {
+      volatile volatile_c_array_block obj{};
+      for (size_t i = 0; i < 3; ++i) {
+         obj.channels[i].control = uint32_t(i);
+         obj.channels[i].status = uint32_t(i * 10);
+      }
+      obj.scalars[0] = 7;
+      obj.scalars[1] = 8;
+
+      std::string s{};
+      expect(not glz::write_beve(obj, s));
+
+      volatile volatile_c_array_block obj2{};
+      expect(!glz::read_beve(obj2, s));
+      for (size_t i = 0; i < 3; ++i) {
+         expect(obj2.channels[i].control == uint32_t(i));
+         expect(obj2.channels[i].status == uint32_t(i * 10));
+      }
+      expect(obj2.scalars[0] == 7u);
+      expect(obj2.scalars[1] == 8u);
+   };
+
+   "volatile_array of class elements rejects a non-array"_test = [] {
+      volatile volatile_channel_block obj{};
+      std::string s{};
+      expect(not glz::write_beve(uint32_t(5), s));
+      expect(glz::read_beve(obj.channels, s) == glz::error_code::syntax_error);
+   };
+};
+
 suite generic_tests = [] {
    "generic"_test = [] {
       glz::generic json("Hello World");

--- a/tests/json_test/json_test.cpp
+++ b/tests/json_test/json_test.cpp
@@ -12167,6 +12167,170 @@ suite volatile_tests = [] {
    };
 };
 
+// A register block made of identical sub-blocks: the array elements are class types, so they are
+// reached by index rather than by iterator (a volatile T* is not an iterator for a class type).
+struct volatile_channel
+{
+   uint32_t control{};
+   uint32_t status{};
+};
+
+struct volatile_channel_block
+{
+   uint32_t enable{};
+   glz::volatile_array<volatile_channel, 4> channels{};
+};
+
+struct volatile_bank
+{
+   glz::volatile_array<uint16_t, 2> regs{};
+};
+
+struct volatile_two_level
+{
+   glz::volatile_array<volatile_bank, 2> banks{};
+};
+
+struct volatile_c_array_block
+{
+   volatile_channel channels[3]{};
+   uint32_t scalars[2]{};
+};
+
+template <>
+struct glz::meta<volatile_c_array_block>
+{
+   using T = volatile_c_array_block;
+   static constexpr auto value = object(&T::channels, &T::scalars);
+};
+
+suite volatile_class_element_array_tests = [] {
+   "volatile_array of class elements"_test = [] {
+      volatile volatile_channel_block obj{};
+      obj.enable = 1;
+      for (size_t i = 0; i < 4; ++i) {
+         obj.channels[i].control = uint32_t(i);
+         obj.channels[i].status = uint32_t(100 + i);
+      }
+
+      std::string s{};
+      expect(not glz::write_json(obj, s));
+      expect(
+         s ==
+         R"({"enable":1,"channels":[{"control":0,"status":100},{"control":1,"status":101},{"control":2,"status":102},{"control":3,"status":103}]})")
+         << s;
+
+      volatile volatile_channel_block obj2{};
+      expect(!glz::read_json(obj2, s));
+      std::string s2{};
+      expect(not glz::write_json(obj2, s2));
+      expect(s2 == s) << s2;
+   };
+
+   "volatile_array of class elements prettified"_test = [] {
+      volatile volatile_channel_block obj{};
+      obj.enable = 1;
+      obj.channels[0].control = 7;
+
+      std::string pretty{};
+      expect(not glz::write<glz::opts{.prettify = true}>(obj, pretty));
+
+      volatile volatile_channel_block obj2{};
+      expect(!glz::read_json(obj2, pretty));
+      expect(obj2.channels[0].control == 7u);
+      expect(obj2.enable == 1u);
+   };
+
+   // The failure was never volatile-specific: volatile_array::begin() is unconditionally
+   // volatile-qualified, so a non-volatile object of the same type could not serialize either.
+   "non-volatile object holding a volatile_array of class elements"_test = [] {
+      volatile_channel_block obj{};
+      obj.enable = 2;
+      obj.channels[1].status = 9;
+
+      std::string s{};
+      expect(not glz::write_json(obj, s));
+
+      volatile_channel_block obj2{};
+      expect(!glz::read_json(obj2, s));
+      expect(obj2.enable == 2u);
+      expect(obj2.channels[1].status == 9u);
+   };
+
+   "nested volatile_array of class elements"_test = [] {
+      volatile volatile_two_level obj{};
+      obj.banks[0].regs[0] = 1;
+      obj.banks[0].regs[1] = 2;
+      obj.banks[1].regs[0] = 3;
+      obj.banks[1].regs[1] = 4;
+
+      std::string s{};
+      expect(not glz::write_json(obj, s));
+      expect(s == R"({"banks":[{"regs":[1,2]},{"regs":[3,4]}]})") << s;
+
+      volatile volatile_two_level obj2{};
+      expect(!glz::read_json(obj2, s));
+      std::string s2{};
+      expect(not glz::write_json(obj2, s2));
+      expect(s2 == s) << s2;
+   };
+
+   "C array of class elements in a volatile struct"_test = [] {
+      volatile volatile_c_array_block obj{};
+      for (size_t i = 0; i < 3; ++i) {
+         obj.channels[i].control = uint32_t(i);
+         obj.channels[i].status = uint32_t(i * 10);
+      }
+      obj.scalars[0] = 7;
+      obj.scalars[1] = 8;
+
+      std::string s{};
+      expect(not glz::write_json(obj, s));
+      expect(
+         s ==
+         R"({"channels":[{"control":0,"status":0},{"control":1,"status":10},{"control":2,"status":20}],"scalars":[7,8]})")
+         << s;
+
+      volatile volatile_c_array_block obj2{};
+      expect(!glz::read_json(obj2, s));
+      std::string s2{};
+      expect(not glz::write_json(obj2, s2));
+      expect(s2 == s) << s2;
+   };
+
+   // Fixed-extent semantics match std::array: a short array leaves the tail alone, and a long one
+   // is rejected rather than writing past the end.
+   "volatile_array of class elements sizing"_test = [] {
+      volatile volatile_channel_block obj{};
+      obj.channels[3].status = 77;
+      expect(!glz::read_json(obj, R"({"channels":[{"control":1,"status":2}]})"));
+      expect(obj.channels[0].control == 1u);
+      expect(obj.channels[3].status == 77u);
+
+      volatile volatile_channel_block obj2{};
+      expect(glz::read_json(obj2, R"({"channels":[{},{},{},{},{}]})") == glz::error_code::exceeded_static_array_size);
+
+      volatile volatile_channel_block obj3{};
+      obj3.channels[0].control = 5;
+      expect(!glz::read_json(obj3, R"({"channels":[]})"));
+      expect(obj3.channels[0].control == 5u);
+   };
+
+   "json pointer into volatile class array elements"_test = [] {
+      volatile volatile_channel_block obj{};
+      obj.channels[2].control = 21;
+      obj.channels[3].status = 33;
+
+      expect(glz::get<volatile uint32_t>(obj, "/channels/2/control") == uint32_t(21));
+      expect(glz::get<volatile uint32_t>(obj, "/channels/3/status") == uint32_t(33));
+      expect(not glz::get<volatile uint32_t>(obj, "/channels/9/status").has_value());
+
+      volatile volatile_two_level nested{};
+      nested.banks[1].regs[0] = 3;
+      expect(glz::get<volatile uint16_t>(nested, "/banks/1/regs/0") == uint16_t(3));
+   };
+};
+
 struct path_test_struct
 {
    uint32_t i{0};


### PR DESCRIPTION
> **Experimental — not necessarily intended for merge.** Opening this for review and discussion; I'm not yet sure this belongs in Glaze.

## The problem

`volatile T*` is not a `std::input_iterator` when `T` is a class type. `std::indirectly_readable` requires `T` be constructible from `volatile T&`, and an implicit copy constructor takes `const T&`, to which no volatile lvalue binds.

That means `glz::volatile_array<some_class, N>` (and a C array of class type inside a `volatile` struct) fails every `range`-based serialization path, and `std::span` cannot be formed over the storage either. This is the natural shape of a register block built from N identical sub-blocks:

```c++
struct channel_t
{
   uint32_t control{};
   uint32_t status{};
};

struct block_t
{
   uint32_t enable{};
   glz::volatile_array<channel_t, 4> channels{};
};
```

Scalar elements are unaffected: they copy through a built-in conversion, so those arrays stay iterable.

## The change

- `is_volatile_array` moves from `hardware/volatile_array.hpp` to `concepts/container_concepts.hpp` so the serialization concepts can see it without pulling in the hardware headers.
- New `volatile_indexed_array` concept (`is_volatile_array && !range && !meta_value_t`) selects only the class-element case.
- Index-based array readers/writers for JSON and BEVE: `read/write_json_indexed_array` and `read/write_beve_indexed_array`. Elements are visited with `value[i]`, keeping every access volatile-qualified.
- The `V (&value)[N]` C-array specializations gain an `if constexpr (requires { std::span{value, N}; })` fallback to the same index-based path.
- A `seek_op` specialization so JSON pointers (`glz::get`, `/channels/0/control`) reach into these arrays.
- Docs section in `docs/volatile-support.md`.

Fixed-extent semantics match `std::array`: a short JSON array leaves trailing elements untouched, and more input elements than `N` is `exceeded_static_array_size`.

## Tests

New suites in `beve_test` and `json_test` covering class elements, two-level nesting, C arrays of class type (with explicit `glz::meta`), JSON-pointer access, prettify, and the short/overlong array cases.

Two encoding tests pin the wire format:
- A `volatile_array<class, N>` produces byte-identical output to the equivalent `std::array<class, N>`.
- A `volatile_array<scalar, N>` still encodes as a BEVE *typed* array, not a generic one. Routing scalars through the index path would have silently changed the format.

## Open questions

- Is this worth the added surface area in the hot serialization headers, given how narrow the use case is?
- Pure reflection still cannot handle an aggregate containing a C array (the member-count probe counts the array's elements individually), so those need an explicit `glz::meta`. Documented rather than fixed here.

Local: `beve_test` 456/456 and `json_test` 729/729 pass.
