### PR TITLE
reject indefinite marker in cbor skip_argument

### DIFF
--- a/include/glaze/cbor/cbor_to_json.hpp
+++ b/include/glaze/cbor/cbor_to_json.hpp
@@ -321,9 +321,12 @@ namespace glz
                ctx.depth += check_indentation_width(Opts);
             }
 
+            // A prettified map only breaks the line before its '}' when it holds at least one
+            // pair, so an empty map stays "{}" whether its length was definite or indefinite.
+            bool wrote_pair = false;
+
             if (additional_info == info::indefinite) {
                // Indefinite-length map
-               bool first = true;
                while (true) {
                   if (it >= end) [[unlikely]] {
                      ctx.error = error_code::unexpected_end;
@@ -337,14 +340,14 @@ namespace glz
                      break;
                   }
 
-                  if (!first) {
+                  if (wrote_pair) {
                      dump(',', out, ix);
                   }
                   if constexpr (Opts.prettify) {
                      dump('\n', out, ix);
                      dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
                   }
-                  first = false;
+                  wrote_pair = true;
 
                   // Key (must be string for JSON compatibility)
                   cbor_to_json_key<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
@@ -368,6 +371,8 @@ namespace glz
                const uint64_t count = cbor_to_json_decode_arg(ctx, it, end, additional_info);
                if (bool(ctx.error)) [[unlikely]]
                   return;
+
+               wrote_pair = count > 0;
 
                for (uint64_t i = 0; i < count; ++i) {
                   if (i > 0) {
@@ -399,7 +404,7 @@ namespace glz
 
             if constexpr (Opts.prettify) {
                ctx.depth -= check_indentation_width(Opts);
-               if (additional_info != 0 || additional_info == info::indefinite) {
+               if (wrote_pair) {
                   dump('\n', out, ix);
                   dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
                }

--- a/include/glaze/cbor/skip.hpp
+++ b/include/glaze/cbor/skip.hpp
@@ -74,7 +74,11 @@ namespace glz
             return val;
          }
          case info::indefinite:
-            return 0; // Caller handles indefinite specially
+            // Indefinite length is only well-formed for byte/text strings, arrays, and maps,
+            // and those callers intercept additional_info == 31 before reaching here. Any other
+            // major type (uint, nint, tag) carrying it is not well-formed per RFC 8949 Appendix C.
+            ctx.error = error_code::syntax_error;
+            return 0;
          default:
             ctx.error = error_code::syntax_error; // Reserved (28-30)
             return 0;

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -3570,6 +3570,58 @@ void cbor_skip_marker_tests_run()
    };
 }
 
+namespace cbor_skip_wellformed_tests
+{
+   struct one_member
+   {
+      int a{};
+   };
+
+   inline constexpr glz::opts skip_opts{.format = glz::CBOR, .error_on_unknown_keys = false};
+
+   // A one-pair map whose key "zz" is not a member, so its value goes through skip_value<CBOR>.
+   template <class... Bytes>
+   std::vector<uint8_t> unknown_value(Bytes... value_bytes)
+   {
+      return {0xA1, 0x62, 'z', 'z', static_cast<uint8_t>(value_bytes)...};
+   }
+}
+
+suite cbor_skip_wellformed = [] {
+   using namespace cbor_skip_wellformed_tests;
+
+   // additional_info 31 marks indefinite length, which is only well-formed for byte/text
+   // strings, arrays, and maps. On major type 0 (uint), 1 (nint), or 6 (tag) it is not
+   // well-formed (RFC 8949 Appendix C). The reader's decode_arg already rejects it; the
+   // skip path must agree instead of consuming the item and reporting success.
+   "skip rejects indefinite marker on uint"_test = [] {
+      one_member v{};
+      expect(glz::read<skip_opts>(v, unknown_value(0x1F)).ec == glz::error_code::syntax_error);
+   };
+
+   "skip rejects indefinite marker on nint"_test = [] {
+      one_member v{};
+      expect(glz::read<skip_opts>(v, unknown_value(0x3F)).ec == glz::error_code::syntax_error);
+   };
+
+   "skip rejects indefinite marker on tag"_test = [] {
+      one_member v{};
+      // Tag (0xDF) followed by a well-formed uint so the failure is the marker, not a short read.
+      expect(glz::read<skip_opts>(v, unknown_value(0xDF, 0x05)).ec == glz::error_code::syntax_error);
+   };
+
+   "skip accepts well-formed unknown values"_test = [] {
+      one_member a{};
+      expect(not glz::read<skip_opts>(a, unknown_value(0x05))); // uint 5
+      one_member b{};
+      expect(not glz::read<skip_opts>(b, unknown_value(0x19, 0x01, 0x2C))); // uint 300
+      one_member c{};
+      expect(not glz::read<skip_opts>(c, unknown_value(0x7F, 0x61, 'a', 0x61, 'b', 0xFF))); // indefinite text
+      one_member d{};
+      expect(not glz::read<skip_opts>(d, unknown_value(0x9F, 0x01, 0x02, 0xFF))); // indefinite array
+   };
+};
+
 // A std::variant whose own meta opts into custom_read/custom_write (with full from/to
 // specializations) must not be ambiguous with the built-in CBOR variant handlers.
 // Parity with the JSON fix in #2591.

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -2464,6 +2464,36 @@ void cbor_to_json_tests()
       expect(not glz::cbor_to_json(cbor_buffer, json));
       expect(json == "[100,200,300]");
    };
+
+   // Prettified output breaks the line before '}' only when the map holds pairs. The emptiness of
+   // a map is not decided by its additional info: an indefinite map ends at the break code, and a
+   // definite one may carry a zero count in a following byte.
+   "cbor_to_json_prettify_empty_map"_test = [] {
+      constexpr glz::opts pretty{.prettify = true};
+
+      const std::array<uint8_t, 1> definite{0xa0}; // map(0)
+      expect(glz::cbor_to_json<pretty>(definite).value() == "{}");
+
+      const std::array<uint8_t, 2> indefinite{0xbf, 0xff}; // map(*) with an immediate break
+      expect(glz::cbor_to_json<pretty>(indefinite).value() == "{}");
+
+      const std::array<uint8_t, 2> definite_wide{0xb8, 0x00}; // map(0) with a 1-byte count
+      expect(glz::cbor_to_json<pretty>(definite_wide).value() == "{}");
+   };
+
+   "cbor_to_json_prettify_non_empty_map"_test = [] {
+      constexpr glz::opts pretty{.prettify = true};
+
+      const std::array<uint8_t, 4> definite{0xa1, 0x61, 'a', 0x01}; // map(1){ "a": 1 }
+      expect(glz::cbor_to_json<pretty>(definite).value() == "{\n   \"a\": 1\n}");
+
+      const std::array<uint8_t, 5> indefinite{0xbf, 0x61, 'a', 0x01, 0xff}; // map(*){ "a": 1 }
+      expect(glz::cbor_to_json<pretty>(indefinite).value() == "{\n   \"a\": 1\n}");
+
+      // An empty nested map must not disturb the indentation of the map holding it.
+      const std::array<uint8_t, 5> nested{0xa1, 0x61, 'a', 0xbf, 0xff}; // map(1){ "a": map(*){} }
+      expect(glz::cbor_to_json<pretty>(nested).value() == "{\n   \"a\": {}\n}");
+   };
 }
 
 void past_fuzzing_issues()

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -3618,7 +3618,9 @@ suite cbor_skip_wellformed = [] {
       one_member c{};
       expect(not glz::read<skip_opts>(c, unknown_value(0x7F, 0x61, 'a', 0x61, 'b', 0xFF))); // indefinite text
       one_member d{};
-      expect(not glz::read<skip_opts>(d, unknown_value(0x9F, 0x01, 0x02, 0xFF))); // indefinite array
+      expect(not glz::read<skip_opts>(d, unknown_value(0x5F, 0x41, 0x01, 0x41, 0x02, 0xFF))); // indefinite bytes
+      one_member e{};
+      expect(not glz::read<skip_opts>(e, unknown_value(0x9F, 0x01, 0x02, 0xFF))); // indefinite array
    };
 };
 


### PR DESCRIPTION
`skip_value<CBOR>::skip_argument` reads the argument for the uint, nint, and tag major types by switching on the 5-bit additional info. It has a `case info::indefinite` (additional info 31) that returns 0 without an error, on the assumption the caller intercepts it. Only the byte/text-string, array, and map skippers do that intercept, so on major type 0, 1, or 6 the marker reaches `skip_argument` and is accepted. A skipped map value of the single byte `0x1F` (uint with additional info 31), reachable through `read<CBOR>` with `error_on_unknown_keys = false`, and at default options through a `glz::skip{}` member (`from<CBOR, glz::skip>`) or a const member when `error_on_const_read = false`, therefore reports success on input that is not well-formed per RFC 8949 Appendix C.

Before, the skip path accepted these items while the reader's own `decode_arg` already rejected the identical bytes with `syntax_error`, so whether a value was well-formed depended on whether its key happened to be a struct member. After, `skip_argument` returns `syntax_error` for additional info 31, matching `decode_arg`. The tradeoff is that the indefinite marker on a non-container type now fails instead of being consumed as a no-op; genuine indefinite-length strings, arrays, and maps are untouched, since their skippers never route additional info 31 through `skip_argument`.

