### PR TITLE
Fix count_members for non-default constructible fields

### DIFF
--- a/include/glaze/reflection/to_tuple.hpp
+++ b/include/glaze/reflection/to_tuple.hpp
@@ -92,19 +92,92 @@ namespace glz
          [[maybe_unused]] constexpr operator std::string_view() const { return {}; }
       };
 
-      template <class T, class... Args>
-         requires(std::is_aggregate_v<std::remove_cvref_t<T>>)
-      inline constexpr auto count_members = [] {
-         using V = std::remove_cvref_t<T>;
-         if constexpr (requires { V{Args{}..., any_t{}}; }) {
-            return count_members<V, Args..., any_t>;
-         }
-         else {
-            return sizeof...(Args);
-         }
-      }();
+      // can V be brace-initialized from exactly N any_t values?
+      template <class V, size_t N>
+      inline constexpr bool initializable_with_n = []<size_t... I>(std::index_sequence<I...>) {
+       return requires { V{(void(I), any_t{})...}; };
+      }(std::make_index_sequence<N>{});
 
       inline constexpr size_t max_pure_reflection_count = 128;
+
+      // Lowest n for which initializable_with_n is true
+      template<class V, size_t K, size_t Max>
+      consteval size_t count_low()
+      {
+       if constexpr (K > Max) {
+           return Max;
+       }
+       else if constexpr (initializable_with_n<V, K>)
+       {
+           return K;
+       }
+       else
+       {
+           return count_low<V, K+1, Max>();
+       }
+      }
+
+      // Double from a knonw-true low until initializable_with_n is false: an exclusive upper bound
+      template<class V, size_t Low, size_t Max>
+      consteval size_t count_high()
+      {
+          if constexpr (Low * 2 > Max)
+          {
+              return Max;
+          }
+          else if constexpr (initializable_with_n<V, Low * 2>)
+          {
+              return count_high<V, Low * 2, Max>();
+          }
+          else
+          {
+              return Low * 2;
+          }
+      }
+
+      // Largest true in [Low, High): Low known true, High known false
+      template<class V, size_t Low, size_t High>
+      consteval size_t count_between()
+      {
+          if constexpr (High <= Low + 1)
+          {
+              return Low;
+          }
+          else
+          {
+              constexpr size_t Mid = Low + (High - Low) / 2;
+              if constexpr (initializable_with_n<V, Mid>)
+              {
+                  return count_between<V, Mid, High>();
+              }
+              else
+              {
+                  return count_between<V, Low, Mid>();
+              }
+          }
+      }
+
+      template <class V>
+      consteval size_t count_members_impl()
+      {
+       constexpr size_t low = count_low<V, 0, max_pure_reflection_count>();
+       if constexpr (low == 0)
+       {
+           // Every member is default-constructible. If false for n=1 that means the struct has no members.
+           if constexpr (!initializable_with_n<V, 1>) return 0;
+           constexpr size_t high = count_high<V, 1, max_pure_reflection_count>();
+           return count_between<V, 1, high>();
+       }
+       else
+       {
+           constexpr size_t high = count_high<V, low, max_pure_reflection_count>();
+           return count_between<V, low, high>();
+       }
+      }
+
+      template <class T>
+        requires(std::is_aggregate_v<std::remove_cvref_t<T>>)
+       inline constexpr auto count_members = count_members_impl<std::remove_cvref_t<T>>();
 #endif
    }
 

--- a/include/glaze/reflection/to_tuple.hpp
+++ b/include/glaze/reflection/to_tuple.hpp
@@ -173,6 +173,9 @@ namespace glz
       template <class V>
       consteval size_t count_members_impl()
       {
+       static_assert(!initializable_with_n<V, max_pure_reflection_count + 1>,
+                     "glaze: this type has more members than pure reflection supports "
+                     "(max_pure_reflection_count); provide a glz::meta<T> specialization.");
        constexpr size_t low = count_low<V, 0, max_pure_reflection_count>();
        if constexpr (low == 0)
        {

--- a/include/glaze/reflection/to_tuple.hpp
+++ b/include/glaze/reflection/to_tuple.hpp
@@ -173,6 +173,8 @@ namespace glz
       template <class V>
       consteval size_t count_members_impl()
       {
+       // Note: this assertion will not catch every violation.
+       // Example: struct with max_pure_reflection_count + 2 fields with the last one non-default constructible
        static_assert(!initializable_with_n<V, max_pure_reflection_count + 1>,
                      "glaze: this type has more members than pure reflection supports "
                      "(max_pure_reflection_count); provide a glz::meta<T> specialization.");

--- a/include/glaze/reflection/to_tuple.hpp
+++ b/include/glaze/reflection/to_tuple.hpp
@@ -99,6 +99,7 @@ namespace glz
       }(std::make_index_sequence<N>{});
 
       inline constexpr size_t max_pure_reflection_count = 128;
+      inline constexpr size_t no_proven_upper_bound = max_pure_reflection_count + 1;
 
       // Lowest n for which initializable_with_n is true
       template<class V, size_t K, size_t Max>
@@ -123,7 +124,7 @@ namespace glz
       {
           if constexpr (Low * 2 > Max)
           {
-              return Max;
+              return no_proven_upper_bound;
           }
           else if constexpr (initializable_with_n<V, Low * 2>)
           {
@@ -157,6 +158,18 @@ namespace glz
           }
       }
 
+      // Largest true value in [Low, Max], given Low is true.
+      template<class V, size_t Low, size_t High, size_t Max>
+      consteval size_t resolve_count()
+      {
+          if constexpr (High > Max && initializable_with_n<V, Max>) {
+              return Max;
+          }
+          else {
+              return count_between<V, Low, High>();
+          }
+      }
+
       template <class V>
       consteval size_t count_members_impl()
       {
@@ -166,12 +179,12 @@ namespace glz
            // Every member is default-constructible. If false for n=1 that means the struct has no members.
            if constexpr (!initializable_with_n<V, 1>) return 0;
            constexpr size_t high = count_high<V, 1, max_pure_reflection_count>();
-           return count_between<V, 1, high>();
+           return resolve_count<V, 1, high, max_pure_reflection_count>();
        }
        else
        {
            constexpr size_t high = count_high<V, low, max_pure_reflection_count>();
-           return count_between<V, low, high>();
+           return resolve_count<V, low, high, max_pure_reflection_count>();
        }
       }
 

--- a/tests/json_reflection_test/json_reflection_test.cpp
+++ b/tests/json_reflection_test/json_reflection_test.cpp
@@ -1382,4 +1382,51 @@ suite rename_tests = [] {
    };
 };
 
+struct ctor_only_member
+{
+   ctor_only_member(int v) : v{v} {}
+   int v;
+};
+
+template <>
+struct glz::meta<ctor_only_member>
+{
+   static constexpr auto value = glz::object(&ctor_only_member::v);
+};
+
+struct non_default_constructible_second
+{
+   double a;
+   ctor_only_member b;
+};
+static_assert(glz::detail::count_members<non_default_constructible_second> == 2,
+              "a non-default-constructible member at position >=2 must not zero the count");
+
+// An unbraced sub-object can absorb extra initializers
+struct elision_inner
+{
+   int a, b;
+};
+
+struct elision_outer
+{
+   elision_inner i;
+   int c;
+};
+static_assert(glz::detail::count_members<elision_outer> == 2,
+              "brace elision must not overcount");
+
+suite non_default_constructible_member_tests = [] {
+   "non-default-constructible member at position 2"_test = [] {
+      std::string buffer{};
+      expect(not glz::write_json(non_default_constructible_second{2.0, ctor_only_member{1}}, buffer));
+      expect(buffer == R"({"a":2,"b":{"v":1}})") << buffer;
+
+      non_default_constructible_second obj{0.0, ctor_only_member{0}};
+      expect(not glz::read_json(obj, buffer));
+      expect(obj.a == 2.0);
+      expect(obj.b.v == 1);
+   };
+};
+
 int main() { return 0; }

--- a/tests/json_reflection_test/json_reflection_test.cpp
+++ b/tests/json_reflection_test/json_reflection_test.cpp
@@ -1416,18 +1416,28 @@ struct elision_outer
 static_assert(glz::detail::count_members<elision_outer> == 2,
               "brace elision must not overcount");
 
+#define MEMBERS_8(p) int p##0, p##1, p##2, p##3, p##4, p##5, p##6, p##7;
+#define MEMBERS_64(p) MEMBERS_8(p##a) MEMBERS_8(p##b) MEMBERS_8(p##c) MEMBERS_8(p##d) MEMBERS_8(p##e) MEMBERS_8(p##f) MEMBERS_8(p##g) MEMBERS_8(p##h)
+
 struct max_members_t
 {
-   #define FIELDS_8(p) int p##0, p##1, p##2, p##3, p##4, p##5, p##6, p##7;
-   #define FIELDS_64(p) FIELDS_8(p##a) FIELDS_8(p##b) FIELDS_8(p##c) FIELDS_8(p##d) FIELDS_8(p##e) FIELDS_8(p##f) FIELDS_8(p##g) FIELDS_8(p##h)
-
-   FIELDS_64(x) FIELDS_64(y)
-
-   #undef FIELDS_64
-   #undef FIELD_8
+   MEMBERS_64(x) MEMBERS_64(y)
 };
 static_assert(glz::detail::count_members<max_members_t> == glz::detail::max_pure_reflection_count,
               "a struct with exactly max_pure_reflection_count members must not count one short");
+
+struct over_max_members_t
+{
+   int extra_member;
+   MEMBERS_64(x) MEMBERS_64(y)
+};
+static_assert(glz::detail::initializable_with_n<over_max_members_t, glz::detail::max_pure_reflection_count + 1>,
+              "a type over the limit must be detectable one past the limit");
+static_assert(not glz::detail::initializable_with_n<max_members_t, glz::detail::max_pure_reflection_count + 1>,
+              "a type exactly at the limit must not be mistaken for one over it");
+
+#undef MEMBERS_64
+#undef MEMBERS_8
 
 suite non_default_constructible_member_tests = [] {
    "non-default-constructible member at position 2"_test = [] {

--- a/tests/json_reflection_test/json_reflection_test.cpp
+++ b/tests/json_reflection_test/json_reflection_test.cpp
@@ -1416,6 +1416,19 @@ struct elision_outer
 static_assert(glz::detail::count_members<elision_outer> == 2,
               "brace elision must not overcount");
 
+struct max_members_t
+{
+   #define FIELDS_8(p) int p##0, p##1, p##2, p##3, p##4, p##5, p##6, p##7;
+   #define FIELDS_64(p) FIELDS_8(p##a) FIELDS_8(p##b) FIELDS_8(p##c) FIELDS_8(p##d) FIELDS_8(p##e) FIELDS_8(p##f) FIELDS_8(p##g) FIELDS_8(p##h)
+
+   FIELDS_64(x) FIELDS_64(y)
+
+   #undef FIELDS_64
+   #undef FIELD_8
+}
+static_assert(glz::detail::count_members<max_members_t> == glz::detail::max_pure_reflection_count,
+              "a struct with exactly max_pure_reflection_count members must not count one short");
+
 suite non_default_constructible_member_tests = [] {
    "non-default-constructible member at position 2"_test = [] {
       std::string buffer{};

--- a/tests/json_reflection_test/json_reflection_test.cpp
+++ b/tests/json_reflection_test/json_reflection_test.cpp
@@ -1425,7 +1425,7 @@ struct max_members_t
 
    #undef FIELDS_64
    #undef FIELD_8
-}
+};
 static_assert(glz::detail::count_members<max_members_t> == glz::detail::max_pure_reflection_count,
               "a struct with exactly max_pure_reflection_count members must not count one short");
 

--- a/tests/json_reflection_test/json_reflection_test.cpp
+++ b/tests/json_reflection_test/json_reflection_test.cpp
@@ -1450,6 +1450,12 @@ suite non_default_constructible_member_tests = [] {
       expect(obj.a == 2.0);
       expect(obj.b.v == 1);
    };
+
+    "non-default-constructible member at position 2 writes correctly"_test = [] {
+        std::string buffer{};
+        expect(not glz::write_json(non_default_constructible_second{2.0, ctor_only_member{1}}, buffer));
+        expect(buffer == R"({"a":2,"b":{"v":1}})") << buffer;
+    };
 };
 
 int main() { return 0; }


### PR DESCRIPTION
Hey `glaze` folks, thanks for all your work on this software!

I've been experimenting with `glaze` and noticed that the C++23 (i.e., non P2996 reflection) `count_members` makes some assumptions about the fields in the aggregate and can return incorrect results.

## Example

Using this minimal example:
```cpp
struct ctor_only_member
{
   ctor_only_member(int v) : v{v} {}
   int v;
};

template <>
struct glz::meta<ctor_only_member>
{
   static constexpr auto value = glz::object(&ctor_only_member::v);
};

struct non_default_constructible_second
{
   double a;
   ctor_only_member b;
};
```

### Before Fix
`glz::detail::count_members<non_default_constructible_second>` evaluates to 0.

### After Fix
`glz::detail::count_members<non_default_constructible_second>` evaluates to 2.

## Summary

The pro for making this change is resolving this unexpected behavior. The con is that we need to do some search which could increase compile times.

This PR first adds a test that fails, and then implements a fix. The approach I used was to do a galloping search up to the `max_pure_reflection_count` to find an upper bound and then do a binary search to find the number of members.

I'd definitely appreciate a maintainers' opinion on whether this is a good solution or not. It made sense to me, but if there's a better way in C++23, then great!
