### PR TITLE
Gate glaze::glaze's MSVC-only interface flags per consumer

### DIFF
--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -49,3 +49,26 @@ jobs:
     - name: Test
       working-directory: build
       run: ctest --build-config ${{env.BUILD_TYPE}} --timeout 300
+
+  build-direct-clang-cl:
+    runs-on: windows-2025-vs2026
+    timeout-minutes: 25
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - uses: seanmiddleditch/gha-setup-ninja@v6
+
+    - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: x64
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build-direct-clang-cl -G Ninja -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_STANDARD=23
+
+    - name: Build
+      run: cmake --build build-direct-clang-cl --parallel
+
+    - name: Test
+      working-directory: build-direct-clang-cl
+      run: ctest --build-config ${{env.BUILD_TYPE}} --timeout 300

--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -57,18 +57,19 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - uses: seanmiddleditch/gha-setup-ninja@v6
-
-    - uses: ilammy/msvc-dev-cmd@v1
-      with:
-        arch: x64
-
-    - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build-direct-clang-cl -G Ninja -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_STANDARD=23
-
-    - name: Build
-      run: cmake --build build-direct-clang-cl --parallel
-
-    - name: Test
-      working-directory: build-direct-clang-cl
-      run: ctest --build-config ${{env.BUILD_TYPE}} --timeout 300
+    # Ninja and vswhere are both preinstalled on this runner image, and vcvarsall is
+    # what hands clang-cl the MSVC headers, libraries and linker, so nothing here has
+    # to be fetched from outside the image. That keeps the job's supply chain to the
+    # runner itself rather than a third-party action fetching a toolchain at run time.
+    # The developer environment only lives as long as the step that calls vcvarsall,
+    # so configure, build and test all run inside this one step.
+    - name: Configure, build and test with clang-cl
+      shell: cmd
+      run: |
+        "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath > "%RUNNER_TEMP%\vsinstall.txt" || exit /b 1
+        set /p VSINSTALL=<"%RUNNER_TEMP%\vsinstall.txt"
+        if not defined VSINSTALL (echo No Visual Studio installation with the C++ toolset was found & exit /b 1)
+        call "%VSINSTALL%\VC\Auxiliary\Build\vcvarsall.bat" x64 || exit /b 1
+        cmake -B build-direct-clang-cl -G Ninja -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DCMAKE_CXX_STANDARD=23 || exit /b 1
+        cmake --build build-direct-clang-cl --parallel || exit /b 1
+        ctest --test-dir build-direct-clang-cl --build-config %BUILD_TYPE% --timeout 300 || exit /b 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,9 +31,13 @@ if (MSVC)
   # consumer only gets these flags if *it* is actually compiling with real MSVC. (Note
   # $<CXX_COMPILER_FRONTEND_VARIANT:MSVC> would not work here: it evaluates to true for
   # clang-cl too, since matching MSVC's driver interface is the entire premise of clang-cl.)
+  # The compile options narrow further to CXX, for the same reason the else() branch below
+  # guards on COMPILE_LANGUAGE: a consumer that compiles C, ISPC or CUDA alongside its C++
+  # should not have /Zc:lambda handed to those compilers. Link options have no per-language
+  # form, so they stay on CXX_COMPILER_ID alone.
   target_compile_options(glaze_glaze INTERFACE
     # for a C++ standards compliant preprocessor, not needed for clang-cl
-    $<$<CXX_COMPILER_ID:MSVC>:/Zc:preprocessor /permissive- /Zc:lambda>)
+    $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/Zc:preprocessor /permissive- /Zc:lambda>)
 
   # Whole-program optimization changes codegen quality, never correctness, and the
   # top-level build is glaze's own test suite -- correctness checks that gain nothing
@@ -46,8 +50,8 @@ if (MSVC)
   option(glaze_ENABLE_LTCG "Build with MSVC whole-program optimization (/GL /LTCG)" OFF)
   if(PROJECT_IS_TOP_LEVEL AND glaze_ENABLE_LTCG)
     target_compile_options(glaze_glaze INTERFACE
-      $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:Release>>:/GL>
-      $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:MinSizeRel>>:/GL>)
+      $<$<AND:$<COMPILE_LANG_AND_ID:CXX,MSVC>,$<CONFIG:Release>>:/GL>
+      $<$<AND:$<COMPILE_LANG_AND_ID:CXX,MSVC>,$<CONFIG:MinSizeRel>>:/GL>)
     target_link_options(glaze_glaze INTERFACE
       $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:Release>>:/LTCG /INCREMENTAL:NO>
       $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:MinSizeRel>>:/LTCG /INCREMENTAL:NO>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,9 @@ if (MSVC)
   # form, so they stay on CXX_COMPILER_ID alone.
   target_compile_options(glaze_glaze INTERFACE
     # for a C++ standards compliant preprocessor, not needed for clang-cl
-    $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/Zc:preprocessor /permissive- /Zc:lambda>)
+    $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/Zc:preprocessor>
+    $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/permissive->
+    $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/Zc:lambda>)
 
   # Whole-program optimization changes codegen quality, never correctness, and the
   # top-level build is glaze's own test suite -- correctness checks that gain nothing
@@ -53,8 +55,10 @@ if (MSVC)
       $<$<AND:$<COMPILE_LANG_AND_ID:CXX,MSVC>,$<CONFIG:Release>>:/GL>
       $<$<AND:$<COMPILE_LANG_AND_ID:CXX,MSVC>,$<CONFIG:MinSizeRel>>:/GL>)
     target_link_options(glaze_glaze INTERFACE
-      $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:Release>>:/LTCG /INCREMENTAL:NO>
-      $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:MinSizeRel>>:/LTCG /INCREMENTAL:NO>)
+      $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:Release>>:/LTCG>
+      $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:Release>>:/INCREMENTAL:NO>
+      $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:MinSizeRel>>:/LTCG>
+      $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:MinSizeRel>>:/INCREMENTAL:NO>)
   endif()
 else()
   # Only apply -Wno-missing-braces for C and C++ compilation to avoid breaking ISPC and other language builds

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,29 +20,38 @@ add_library(glaze::glaze ALIAS glaze_glaze)
 
 
 if (MSVC)
-  string(REGEX MATCH "\/cl(.exe)?$" matched_cl ${CMAKE_CXX_COMPILER})
-  if (matched_cl)
+  # glaze_glaze is an INTERFACE library, so these target_compile_options/target_link_options
+  # calls set properties that get applied to whatever *consumes* glaze::glaze, evaluated at
+  # each consumer's own generate time -- not to glaze's own build. A plain CMAKE_CXX_COMPILER_ID
+  # check here would instead freeze the *current* (glaze's own configure-time) compiler identity
+  # into those properties, which then leaks onto every consumer regardless of what compiler that
+  # consumer itself uses (see #2814): a consumer built with clang-cl, or with any compiler other
+  # than the one glaze happened to be configured with, would silently inherit MSVC-only flags.
+  # $<CXX_COMPILER_ID:MSVC> is a generator expression, re-evaluated per consumer, so each
+  # consumer only gets these flags if *it* is actually compiling with real MSVC. (Note
+  # $<CXX_COMPILER_FRONTEND_VARIANT:MSVC> would not work here: it evaluates to true for
+  # clang-cl too, since matching MSVC's driver interface is the entire premise of clang-cl.)
+  target_compile_options(glaze_glaze INTERFACE
     # for a C++ standards compliant preprocessor, not needed for clang-cl
-    target_compile_options(glaze_glaze INTERFACE "/Zc:preprocessor" /permissive- /Zc:lambda)
-    
-    # Whole-program optimization changes codegen quality, never correctness, and the
-    # top-level build is glaze's own test suite -- correctness checks that gain nothing
-    # from it. Because glaze is header-only, every test executable pays a full link-time
-    # code generation pass, and there are ~70 of them: /GL /LTCG more than doubled the
-    # MSVC Release CI build (32 min of compiling versus 13 min without). The benchmarks
-    # in benchmarks/ configure as their own top-level project, so they never saw these
-    # flags anyway, and published numbers are measured on GCC. Opt in when profiling
-    # glaze itself on MSVC.
-    option(glaze_ENABLE_LTCG "Build with MSVC whole-program optimization (/GL /LTCG)" OFF)
-    if(PROJECT_IS_TOP_LEVEL AND glaze_ENABLE_LTCG)
-      target_compile_options(glaze_glaze INTERFACE
-        $<$<CONFIG:Release>:/GL>
-        $<$<CONFIG:MinSizeRel>:/GL>)
-      target_link_options(glaze_glaze INTERFACE
-        $<$<CONFIG:Release>:/LTCG /INCREMENTAL:NO>
-        $<$<CONFIG:MinSizeRel>:/LTCG /INCREMENTAL:NO>)
-    endif()
-   endif()
+    $<$<CXX_COMPILER_ID:MSVC>:/Zc:preprocessor /permissive- /Zc:lambda>)
+
+  # Whole-program optimization changes codegen quality, never correctness, and the
+  # top-level build is glaze's own test suite -- correctness checks that gain nothing
+  # from it. Because glaze is header-only, every test executable pays a full link-time
+  # code generation pass, and there are ~70 of them: /GL /LTCG more than doubled the
+  # MSVC Release CI build (32 min of compiling versus 13 min without). The benchmarks
+  # in benchmarks/ configure as their own top-level project, so they never saw these
+  # flags anyway, and published numbers are measured on GCC. Opt in when profiling
+  # glaze itself on MSVC.
+  option(glaze_ENABLE_LTCG "Build with MSVC whole-program optimization (/GL /LTCG)" OFF)
+  if(PROJECT_IS_TOP_LEVEL AND glaze_ENABLE_LTCG)
+    target_compile_options(glaze_glaze INTERFACE
+      $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:Release>>:/GL>
+      $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:MinSizeRel>>:/GL>)
+    target_link_options(glaze_glaze INTERFACE
+      $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:Release>>:/LTCG /INCREMENTAL:NO>
+      $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:MinSizeRel>>:/LTCG /INCREMENTAL:NO>)
+  endif()
 else()
   # Only apply -Wno-missing-braces for C and C++ compilation to avoid breaking ISPC and other language builds
   target_compile_options(${PROJECT_NAME}_${PROJECT_NAME} INTERFACE


### PR DESCRIPTION
Closes https://github.com/stephenberry/glaze/issues/2814 

Fix detection of clang-cl in CMake and add a CI job to test direct usage of clang-cl.