### PR TITLE
Declare stream_request_params_v2 callbacks in the order callers use them

### DIFF
--- a/docs/networking/http-client.md
+++ b/docs/networking/http-client.md
@@ -254,10 +254,10 @@ struct stream_request_params_v2 {
     size_t max_buffer_size{1024 * 1024};
     std::string body;
     glz::http_headers headers;
-    http_connect_handler on_connect;
-    http_disconnect_handler on_disconnect;
     http_data_handler on_data;
     http_error_handler on_error;
+    http_connect_handler on_connect;
+    http_disconnect_handler on_disconnect;
     std::function<bool(int)> status_is_error{[](int status){ return status >= 400; }};
 };
 ```
@@ -269,10 +269,10 @@ struct stream_request_params_v2 {
 -   `max_buffer_size`: Larger buffer can decrease dropouts and increase throughput at cost of memory usage. (default is 1 MiB)
 -   `body`: The HTTP Body to send.
 -   `headers`: The HTTP headers to send.
--   `on_connect`: A callback that's called when the connection is established and the headers are received.
--   `on_disconnect`: A callback that's called when the connection is closed.
 -   `on_data`: A callback that's called when data is received.
 -   `on_error`: A callback that's called when an error occurs.
+-   `on_connect`: A callback that's called when the connection is established and the headers are received.
+-   `on_disconnect`: A callback that's called when the connection is closed.
 -   `status_is_error`: Optional predicate to decide whether a status code should trigger `on_error` (defaults to checking for codes ≥ 400).
 
 To override the default behaviour you can supply a predicate:

--- a/include/glaze/net/http_client.hpp
+++ b/include/glaze/net/http_client.hpp
@@ -979,10 +979,14 @@ namespace glz
       size_t max_buffer_size{1024 * 1024};
       std::string body;
       glz::http_headers headers;
-      http_connect_handler on_connect;
-      http_disconnect_handler on_disconnect;
+      // Declared in the order callers reach for them. Designators must appear in
+      // declaration order (gcc and MSVC enforce this; clang accepts any order as an
+      // extension), so the spelling that comes naturally - on_data and on_error first,
+      // the optional on_connect and on_disconnect after - has to be the declared one.
       http_data_handler on_data;
       http_error_handler on_error;
+      http_connect_handler on_connect;
+      http_disconnect_handler on_disconnect;
       std::function<bool(int)> status_is_error{[](int status) { return status >= 400; }};
    };
 

--- a/tests/networking_tests/http_chunked_test/http_chunked_test.cpp
+++ b/tests/networking_tests/http_chunked_test/http_chunked_test.cpp
@@ -1153,8 +1153,6 @@ suite chunked_streaming_tests = [] {
          .url = server.base_url() + "/single-chunk",
          .body = {},
          .headers = {},
-         .on_connect = {},
-         .on_disconnect = [&] { done_promise.set_value(); },
          .on_data =
             [&](std::string_view data) {
                std::lock_guard lock(data_mutex);
@@ -1162,6 +1160,8 @@ suite chunked_streaming_tests = [] {
                ++chunk_count;
             },
          .on_error = [](std::error_code) {},
+         .on_connect = {},
+         .on_disconnect = [&] { done_promise.set_value(); },
       });
 
       auto status = done_future.wait_for(std::chrono::seconds(5));
@@ -1189,8 +1189,6 @@ suite chunked_streaming_tests = [] {
          .url = server.base_url() + "/multi-chunk",
          .body = {},
          .headers = {},
-         .on_connect = {},
-         .on_disconnect = [&] { done_promise.set_value(); },
          .on_data =
             [&](std::string_view data) {
                std::lock_guard lock(data_mutex);
@@ -1198,6 +1196,8 @@ suite chunked_streaming_tests = [] {
                ++chunk_count;
             },
          .on_error = [](std::error_code) {},
+         .on_connect = {},
+         .on_disconnect = [&] { done_promise.set_value(); },
       });
 
       auto status = done_future.wait_for(std::chrono::seconds(5));
@@ -1224,14 +1224,14 @@ suite chunked_streaming_tests = [] {
          .url = server.base_url() + "/large-chunked",
          .body = {},
          .headers = {},
-         .on_connect = {},
-         .on_disconnect = [&] { done_promise.set_value(); },
          .on_data =
             [&](std::string_view data) {
                std::lock_guard lock(data_mutex);
                received_data.append(data);
             },
          .on_error = [](std::error_code) {},
+         .on_connect = {},
+         .on_disconnect = [&] { done_promise.set_value(); },
       });
 
       auto status = done_future.wait_for(std::chrono::seconds(10));
@@ -1258,14 +1258,14 @@ suite chunked_streaming_tests = [] {
          .url = server.base_url() + "/empty-chunked",
          .body = {},
          .headers = {},
-         .on_connect = {},
-         .on_disconnect = [&] { done_promise.set_value(); },
          .on_data =
             [&](std::string_view data) {
                std::lock_guard lock(data_mutex);
                received_data.append(data);
             },
          .on_error = [](std::error_code) {},
+         .on_connect = {},
+         .on_disconnect = [&] { done_promise.set_value(); },
       });
 
       auto status = done_future.wait_for(std::chrono::seconds(5));
@@ -1652,8 +1652,6 @@ suite chunked_raw_socket_tests = [] {
          .url = "http://127.0.0.1:" + std::to_string(port) + "/test",
          .body = {},
          .headers = {},
-         .on_connect = {},
-         .on_disconnect = [&] { finish(); },
          .on_data =
             [&](std::string_view data) {
                // Record only the claimed size; reading the bytes of an oversized view is
@@ -1663,6 +1661,8 @@ suite chunked_raw_socket_tests = [] {
                }
             },
          .on_error = [&](std::error_code) { error_fired = true; },
+         .on_connect = {},
+         .on_disconnect = [&] { finish(); },
       });
 
       done_future.wait_for(std::chrono::seconds(5));

--- a/tests/networking_tests/http_content_length_test/http_content_length_test.cpp
+++ b/tests/networking_tests/http_content_length_test/http_content_length_test.cpp
@@ -576,11 +576,10 @@ suite content_length_connection_reuse = [] {
       std::promise<void> stream_done;
       auto stream_finished = stream_done.get_future();
       std::string streamed;
-      // Designator order has to match declaration order; gcc and MSVC reject it otherwise.
       auto conn = client.stream_request_v2({.url = base,
-                                            .on_disconnect = [&] { stream_done.set_value(); },
                                             .on_data = [&](std::string_view data) { streamed.append(data); },
-                                            .on_error = [](std::error_code) {}});
+                                            .on_error = [](std::error_code) {},
+                                            .on_disconnect = [&] { stream_done.set_value(); }});
       expect(conn != nullptr) << "stream request should start";
       expect(stream_finished.wait_for(std::chrono::seconds(5)) == std::future_status::ready)
          << "stream should reach its end";
@@ -683,9 +682,9 @@ suite content_length_connection_reuse = [] {
       auto stream_finished = stream_done.get_future();
       std::string streamed;
       auto conn = client.stream_request_v2({.url = base,
-                                            .on_disconnect = [&] { stream_done.set_value(); },
                                             .on_data = [&](std::string_view data) { streamed.append(data); },
-                                            .on_error = [](std::error_code) {}});
+                                            .on_error = [](std::error_code) {},
+                                            .on_disconnect = [&] { stream_done.set_value(); }});
       expect(conn != nullptr) << "stream request should start";
       expect(stream_finished.wait_for(std::chrono::seconds(5)) == std::future_status::ready)
          << "stream should reach its end";


### PR DESCRIPTION
## The problem

`stream_request_params_v2` declares its four callbacks as `on_connect`, `on_disconnect`, `on_data`, `on_error`. That is not the order a caller reaches for them: `on_data` and `on_error` are the two every streaming call supplies, and `on_connect`/`on_disconnect` are the optional extras.

Designators have to appear in declaration order. gcc and MSVC enforce the ISO rule as a hard error; clang accepts any order as an extension and stays silent. So the spelling that comes naturally,

```cpp
client.stream_request_v2({.url = url, .on_data = f, .on_error = g, .on_disconnect = h});
```

compiles locally on clang and then fails the build on gcc and MSVC. Because it is an error rather than a warning, the mistake reaches CI instead of the editor. #2782 hit exactly this: one designator out of order took out twelve jobs — every gcc, MSVC and sanitizer build — while every clang job stayed green.

## The fix

Declare the callbacks as `on_data`, `on_error`, `on_connect`, `on_disconnect`, so the obvious spelling is the correct one. The non-callback fields keep their positions.

This also lines the struct back up with two things it had drifted from:

- `perform_stream_request` has always taken the handlers in that order, and both `stream_request` and `stream_request_v2` forward them that way.
- The deprecated `stream_request_params` put `on_data` and `on_error` immediately after `url`. The v2 struct is what moved them behind the optional pair.

## Compatibility

This is a source break for designated initializers that named `on_connect` or `on_disconnect` before `on_data` or `on_error`. It breaks loudly, at compile time, and only on the compilers that enforce the rule; the fix is to reorder the designators. Field types, names, defaults and semantics are all unchanged, so clang builds are unaffected in either direction, and positional aggregate initialization of a twelve-field struct with four distinct `std::function` signatures does not silently change meaning.

The five call sites in `http_chunked_test` and the field list in `docs/networking/http-client.md` are updated. The remaining designated-initializer call sites in `http_client_test` use the deprecated v1 `stream_request_params`, which is untouched.

## Testing

`http_chunked_test` 59/59, `http_client_test` 39/39, `http_content_length_test` 24/24, `http_client_pool_test` 14/14. Every TU in the repo that includes `http_client.hpp` syntax-checks clean under `-Werror=reorder-init-list` (clang's spelling of the rule gcc and MSVC enforce), with the SSL test checked under `-DGLZ_ENABLE_SSL`. A scratch check confirms the natural order now compiles under that flag and the previous order is what it rejects.

## Note on #2782

#2782 adds a `stream_request_v2` call site written in the current declaration order. Whichever of the two merges second needs its designators reordered — a four-line change in one test.
