### PR TITLE
Stop the p2996 job depending on gitlab, and retry the cmake download

### DIFF
--- a/.github/workflows/p2996-reflection.yml
+++ b/.github/workflows/p2996-reflection.yml
@@ -20,6 +20,8 @@ env:
   P2996_LIB_PATH: /opt/p2996/clang/lib/x86_64-unknown-linux-gnu
   # The image is Ubuntu 24.04, whose apt cmake is 3.28 — older than the 3.31 that
   # ut requires since v1.2.0. Install an official Kitware build instead of apt's.
+  # Downloaded to a file rather than piped into tar: a retry restarts the transfer
+  # from the first byte, which would corrupt a stream tar is already reading.
   CMAKE_TARBALL: https://github.com/Kitware/CMake/releases/download/v4.4.2/cmake-4.4.2-linux-x86_64.tar.gz
 
 concurrency:
@@ -58,6 +60,10 @@ jobs:
             /tmp/p2996_test
           "
 
+    # libeigen3-dev is Eigen 3.4.0 on Ubuntu 24.04 and ships a CMake config, so
+    # tests/eigen_test takes its find_package branch. Without it that test falls back
+    # to cloning gitlab.com, which is a second forge to depend on and the one that
+    # refuses unauthenticated clones from CI address ranges.
     - name: Build and run tests with CMake
       run: |
         docker run --rm \
@@ -65,8 +71,9 @@ jobs:
           -w /glaze \
           ${{ env.P2996_IMAGE }} \
           /bin/sh -c "
-            apt-get update && apt-get install -y curl &&
-            curl -fsSL ${{ env.CMAKE_TARBALL }} | tar xz --strip-components=1 -C /usr/local &&
+            apt-get update && apt-get install -y curl libeigen3-dev &&
+            curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors -o /tmp/cmake.tar.gz ${{ env.CMAKE_TARBALL }} &&
+            tar xzf /tmp/cmake.tar.gz --strip-components=1 -C /usr/local &&
             cmake --version &&
             cmake -B build \
               -DCMAKE_CXX_COMPILER=clang++ \


### PR DESCRIPTION
## What happened

Two consecutive attempts of the same p2996 run failed on the network, against two different hosts:

```
attempt 1:  curl: (22) The requested URL returned error: 504     ← github.com release CDN, CMake tarball
attempt 2:  Had to git clone more than once: 3 times.
                'https://gitlab.com/libeigen/eigen.git'          ← HTTP 403 ×3
```

Neither reached a compiler. The job itself is healthy — 53 of the last 60 runs succeeded, and the only other failure in that window was a genuine compile error — so this is not a chronically broken workflow. But the exposure behind it is real and worth closing.

Everything this job fetches happens unauthenticated inside the container, and no workflow in the repo caches dependencies, so every run re-fetches over the wire: the CMake tarball and `openalgz/ut` from github.com, and Eigen from gitlab.com.

## The change

**Drop gitlab.com.** `tests/eigen_test/CMakeLists.txt` only clones GitLab when `find_package(Eigen3 3.4)` misses. Ubuntu 24.04 packages Eigen 3.4.0 with a full CMake config, so installing `libeigen3-dev` alongside the `curl` this step already installs makes that `find_package` succeed and removes gitlab.com from the job entirely. One less forge to depend on, and it is the one that refuses unauthenticated clones from CI address ranges.

**Retry the CMake download.** `--retry 5 --retry-delay 2 --retry-all-errors` covers the 504 class. The download now lands in a file instead of piping straight into `tar`: a retry restarts the transfer from the first byte, which would corrupt a stream `tar` is already reading.

## Verification

Run in `ubuntu:24.04` on `linux/amd64`, which is what the p2996 image is built on:

```
cmake version 4.4.2
eigen config:
/usr/share/eigen3/cmake/Eigen3Config.cmake
```

and the `find_package` path that `eigen_test` actually takes:

```
Version: 3.4.0-4build0.1
Eigen3Config.cmake  Eigen3ConfigVersion.cmake  Eigen3Targets.cmake  UseEigen3.cmake
-- RESULT: Eigen3_FOUND=TRUE version=3.4.0
-- RESULT: target Eigen3::Eigen exists
```

The workflow YAML parses and the step still resolves as expected.

## Not addressed here

The `git clone` of `openalgz/ut` in the reflection step is still a single unauthenticated GitHub clone with no retry, and FetchContent pulls `ut` again during the CMake build. Both remain exposed to the same class of transient refusal; `git` has no retry flag, so covering them means a shell retry loop or dependency caching. Left out to keep this focused on the two failures actually observed.
