### PR TITLE
Give every workflow an explicit token scope

### DIFF
--- a/.github/workflows/armv7.yml
+++ b/.github/workflows/armv7.yml
@@ -16,6 +16,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main

--- a/.github/workflows/autobahn.yml
+++ b/.github/workflows/autobahn.yml
@@ -16,6 +16,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,6 +9,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main

--- a/.github/workflows/big-endian.yml
+++ b/.github/workflows/big-endian.yml
@@ -16,6 +16,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main

--- a/.github/workflows/boost-asio.yml
+++ b/.github/workflows/boost-asio.yml
@@ -16,6 +16,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main

--- a/.github/workflows/clang-cl.yml
+++ b/.github/workflows/clang-cl.yml
@@ -16,6 +16,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
   BUILD_TYPE: Debug

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -9,6 +9,10 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  # Commits the clang-format fixes back to the branch.
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/clang-linux-erlang.yml
+++ b/.github/workflows/clang-linux-erlang.yml
@@ -16,6 +16,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main

--- a/.github/workflows/clang-linux-latest.yml
+++ b/.github/workflows/clang-linux-latest.yml
@@ -19,6 +19,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main

--- a/.github/workflows/clang-linux.yml
+++ b/.github/workflows/clang-linux.yml
@@ -16,6 +16,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  # Commits the include-cleaner fixes back to the branch.
+  contents: write
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -16,6 +16,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   BUILD_TYPE: Debug
 

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -3,6 +3,9 @@ name: code_coverage
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   BUILD_TYPE: Debug
 

--- a/.github/workflows/disable-always-inline.yml
+++ b/.github/workflows/disable-always-inline.yml
@@ -16,6 +16,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main

--- a/.github/workflows/exhaustive_float.yml
+++ b/.github/workflows/exhaustive_float.yml
@@ -16,6 +16,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main

--- a/.github/workflows/exhaustive_int.yml
+++ b/.github/workflows/exhaustive_int.yml
@@ -16,6 +16,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main

--- a/.github/workflows/gcc-erlang.yml
+++ b/.github/workflows/gcc-erlang.yml
@@ -16,6 +16,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main

--- a/.github/workflows/gcc-old-abi.yml
+++ b/.github/workflows/gcc-old-abi.yml
@@ -16,6 +16,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main

--- a/.github/workflows/gcc-x86.yml
+++ b/.github/workflows/gcc-x86.yml
@@ -16,6 +16,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -16,6 +16,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -16,6 +16,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -10,6 +10,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   BUILD_TYPE: Release
   CMAKE_GENERATOR: Ninja

--- a/.github/workflows/p2996-reflection.yml
+++ b/.github/workflows/p2996-reflection.yml
@@ -11,6 +11,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   BUILD_TYPE: Release
   # Public Docker image with Bloomberg clang-p2996

--- a/.github/workflows/quickfuzz.yml
+++ b/.github/workflows/quickfuzz.yml
@@ -16,6 +16,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -16,6 +16,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main

--- a/.github/workflows/simd-backends.yml
+++ b/.github/workflows/simd-backends.yml
@@ -28,6 +28,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 env:
   # Suites that exercise UTF-8 validation. Kept narrow so the emulated job stays quick.
   UTF8_TESTS: "^(utf8_validation_test|json_conformance|json_test)$"

--- a/.github/workflows/simple_float.yml
+++ b/.github/workflows/simple_float.yml
@@ -16,6 +16,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main

--- a/.github/workflows/standalone-asio.yml
+++ b/.github/workflows/standalone-asio.yml
@@ -16,6 +16,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main

--- a/.github/workflows/windows-header-compatibility.yml
+++ b/.github/workflows/windows-header-compatibility.yml
@@ -34,6 +34,9 @@ on:
       - '.github/workflows/windows-header-compatibility.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main

--- a/.github/workflows/yaml-conformance-data-gcc.yml
+++ b/.github/workflows/yaml-conformance-data-gcc.yml
@@ -16,6 +16,9 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   # Supersede an in-flight run when a branch is pushed again, so a fixup commit
   # does not leave the previous run competing for the same runners. Pushes to main


### PR DESCRIPTION
Step one of restricting what a CI job can do with its `GITHUB_TOKEN`.

The repository default is currently **read-write**, and only `docs.yml` declared a scope of its own. So all 30 other workflows were handing their jobs a token that can push to `main` — including jobs that run third-party actions, and including jobs triggered by pushes to `main` and `feature/*`, where the token is not downgraded the way it is for fork pull requests.

Exactly two workflows need to write anything:

| Workflow | Scope | Why |
|---|---|---|
| `clang-format.yml` | `contents: write` | commits formatting fixes back to the branch |
| `clang-tidy.yml` | `contents: write` | commits include-cleaner fixes back to the branch |
| `docs.yml` | unchanged | already declared `pages: write` + `id-token: write` |
| everything else (28) | `contents: read` | only reads the checkout |

`upload-artifact` needs no extra scope — it authenticates against the artifact backend with the runtime token, not `GITHUB_TOKEN`.

### Why per-workflow rather than just the repository setting

Flipping the repository default alone would achieve the same runtime effect in fewer keystrokes, but it puts the security posture in a settings page instead of the repository. Declaring it in each file means the workflow says what it is allowed to do, it shows up in review when a workflow is added or changed, and it survives someone flipping the setting back.

### Ordering

**This PR is a no-op by itself** — the default is still read-write, so nothing loses access. It has to land first, so that flipping the repository default to read-only afterwards doesn't break the two workflows that commit.

Once this merges: Settings → Actions → General → Workflow permissions → **Read repository contents and packages permissions**. Worth unchecking "Allow GitHub Actions to create and approve pull requests" at the same time; nothing here uses it.

CI on this PR exercises the change directly, since editing `.github/workflows/**` triggers the full suite.
