### PR TITLE
guard yaml pair flow-mapping key peek against end of input

### DIFF
--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -4282,6 +4282,11 @@ namespace glz
                return; // Empty pair
             }
 
+            if (it == end) [[unlikely]] {
+               ctx.error = error_code::unexpected_end;
+               return;
+            }
+
             // Parse key
             if constexpr (str_t<first_type>) {
                // Skip anchor on key

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -4471,6 +4471,31 @@ ship-to: *id001)";
       expect(!ec) << glz::format_error(ec, view);
       expect(glz::write_json(parsed).value_or("WRITE_ERR") == R"("x")");
    };
+
+   "pair_flow_mapping_truncated_stays_in_bounds"_test = [] {
+      static constexpr glz::opts options{.format = glz::YAML, .null_terminated = false};
+      // A flow-mapping pair whose input ends right after the opening '{' (once any inline
+      // whitespace is consumed) leaves the cursor at the end of the buffer. The key peek must
+      // stop there rather than read the byte past a non-null-terminated buffer.
+      for (const std::string_view s : {"{", "{ ", "{\t", "{  "}) {
+         std::vector<char> buf{s.begin(), s.end()};
+         const std::string_view view{buf.data(), buf.data() + buf.size()};
+         std::pair<std::string, int> p{};
+         const auto ec = glz::read<options>(p, view);
+         expect(ec.ec == glz::error_code::unexpected_end) << s;
+         expect(ec.count <= view.size()) << s;
+      }
+
+      // A complete flow-mapping pair still parses.
+      const std::string_view valid = "{answer: 42}";
+      std::vector<char> buf{valid.begin(), valid.end()};
+      const std::string_view view{buf.data(), buf.data() + buf.size()};
+      std::pair<std::string, int> p{};
+      const auto ec = glz::read<options>(p, view);
+      expect(!ec) << glz::format_error(ec, view);
+      expect(p.first == "answer");
+      expect(p.second == 42);
+   };
 };
 
 // ============================================================


### PR DESCRIPTION
The YAML std::pair reader parses the flow form {key: value}. After skipping the opening { and inline whitespace, its empty-pair check `if (it != end && *it == '}')` doesn't return when it == end, so a buffer that stops right after the { falls through and peeks *it one byte past the end. Reading a std::pair<std::string, V> from the single byte "{" over a non-null-terminated buffer (null_terminated=false, a string_view or span) is an out-of-bounds read.

Add an it == end check after the empty-pair test so the reader returns unexpected_end instead. The sibling flow-mapping and map readers already loop on while (it != end) and the pair reader's own anchor branch guards it == end after the name, so this was the one flow site missing the bound. The check belongs in the reader because that is where the cursor position is known; valid input parses the same.