### PR TITLE
Read a tagged variant's discriminator as a transient view

### DIFF
--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -135,7 +135,7 @@ Read into the owning equivalent (`std::string`, `glz::raw_json`, `glz::text`) wh
 
 The check is on the readers that point into the buffer rather than on the shape of the destination, so it applies equally to a view reached through a container, a `std::tuple`, a map key, or a `glz::custom` setter. A `std::span` over your own storage is not affected — only `std::span<const T>` is ever aimed at the input.
 
-What the check is aimed at is a view the *caller* keeps. A reader that borrows a view of the string it just parsed and turns it into a value before returning — how `std::chrono::system_clock::time_point`, `std::chrono::year_month_day`, and `glz::date_format` fields are read — holds it across nothing that refills, so those types stream normally.
+What the check is aimed at is a view the *caller* keeps. A reader that borrows a view of the string it just parsed and turns it into a value before returning — how `std::chrono::system_clock::time_point`, `std::chrono::year_month_day`, and `glz::date_format` fields are read, and how a tagged variant turns its discriminator into an alternative index — holds it across nothing that refills, so those types stream normally.
 
 Buffered reads are unaffected. A buffer holds the whole document for the duration of the call, so views into it stay valid and remain a supported zero-copy idiom.
 

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -3968,7 +3968,9 @@ namespace glz
                       from<JSON, id_type>::template op<ws_handled<Opts>()>(type_id, ctx, it, end);
                    }
                    else {
-                      from<JSON, sv>::template op<ws_handled<Opts>()>(type_id, ctx, it, end);
+                      // The id is turned into an index below and never leaves this reader, so the
+                      // view of the window it borrows cannot outlive that window.
+                      parse_transient_string_view<ws_handled<Opts>()>(type_id, ctx, it, end);
                    }
                    if (bool(ctx.error)) [[unlikely]] {
                       return false;
@@ -4180,7 +4182,9 @@ namespace glz
                                  from<JSON, id_type>::template op<ws_handled<Opts>()>(type_id, ctx, it, end);
                               }
                               else {
-                                 from<JSON, sv>::template op<ws_handled<Opts>()>(type_id, ctx, it, end);
+                                 // The id is turned into an index below and never leaves this
+                                 // reader, so the view of the window it borrows cannot outlive it.
+                                 parse_transient_string_view<ws_handled<Opts>()>(type_id, ctx, it, end);
                               }
                               if (bool(ctx.error)) [[unlikely]]
                                  return;
@@ -4410,8 +4414,10 @@ namespace glz
                               return;
                            }
 
+                           // The id is turned into an index below and never leaves this reader,
+                           // so the view of the window it borrows cannot outlive that window.
                            std::string_view type_id{};
-                           parse<JSON>::op<ws_handled<Opts>()>(type_id, ctx, it, end);
+                           parse_transient_string_view<ws_handled<Opts>()>(type_id, ctx, it, end);
                            if (bool(ctx.error)) [[unlikely]]
                               return;
                            if (skip_ws<Opts>(ctx, it, end)) {

--- a/tests/istream_buffer_test/istream_buffer_test.cpp
+++ b/tests/istream_buffer_test/istream_buffer_test.cpp
@@ -4791,4 +4791,218 @@ suite streaming_view_rejection_tests = [] {
    };
 };
 
+// A variant's discriminator is read as a view of the window and immediately turned into an
+// alternative index -- it never leaves the reader that parsed it, so it cannot outlive the window
+// the way a view handed back to the caller would. Reading it through the guarded string_view reader
+// nonetheless failed to compile for every tagged variant under a streaming context (issue #2823),
+// including a plain buffered read that merely passed a glz::streaming_context.
+struct put_action_t
+{
+   std::map<std::string, int> data{};
+};
+
+struct delete_action_t
+{
+   std::string data{};
+};
+
+using tagged_action_t = std::variant<put_action_t, delete_action_t>;
+
+template <>
+struct glz::meta<tagged_action_t>
+{
+   static constexpr std::string_view tag = "action";
+   static constexpr auto ids = std::array{"PUT", "DELETE"};
+};
+
+struct numbered_a_t
+{
+   int x{};
+};
+
+struct numbered_b_t
+{
+   int x{};
+};
+
+using numbered_variant_t = std::variant<numbered_a_t, numbered_b_t>;
+
+template <>
+struct glz::meta<numbered_variant_t>
+{
+   static constexpr std::string_view tag = "t";
+   static constexpr auto ids = std::array{1, 2};
+};
+
+struct adjacent_a_t
+{
+   int x{};
+};
+
+struct adjacent_b_t
+{
+   std::string y{};
+};
+
+using adjacent_variant_t = std::variant<adjacent_a_t, adjacent_b_t>;
+
+template <>
+struct glz::meta<adjacent_variant_t>
+{
+   static constexpr std::string_view tag = "kind";
+   static constexpr std::string_view content = "value";
+   static constexpr auto ids = std::array{"a", "b"};
+};
+
+struct unit_alternative_t
+{};
+
+struct valued_alternative_t
+{
+   int x{};
+};
+
+using unit_variant_t = std::variant<unit_alternative_t, valued_alternative_t>;
+
+template <>
+struct glz::meta<unit_variant_t>
+{
+   static constexpr std::string_view tag = "t";
+   static constexpr auto ids = std::array{"unit", "valued"};
+};
+
+// The tag name is also a field on each alternative, which sends the reader down the re-parse path
+// so the discriminator lands in the struct as well as selecting the alternative.
+struct tag_as_field_a_t
+{
+   std::string t{};
+   int x{};
+};
+
+struct tag_as_field_b_t
+{
+   std::string t{};
+   double y{};
+};
+
+using tag_as_field_variant_t = std::variant<tag_as_field_a_t, tag_as_field_b_t>;
+
+template <>
+struct glz::meta<tag_as_field_variant_t>
+{
+   static constexpr std::string_view tag = "t";
+   static constexpr auto ids = std::array{"a", "b"};
+};
+
+suite tagged_variant_streaming_tests = [] {
+   // The shape reported in issue #2823: an ordinary buffered read that happens to be handed a
+   // streaming_context. Nothing streams here -- ctx.stream is not enabled -- but the guard keys off
+   // the context type, so this has to compile as much as it has to produce the right answer.
+   "a buffered read with a streaming_context reads a tagged variant"_test = [] {
+      const std::string doc = R"([{"action":"DELETE","data":"x"},{"action":"PUT","data":{"k":1}}])";
+      std::vector<tagged_action_t> values{};
+      glz::streaming_context ctx{};
+      expect(!glz::read<glz::opts{}>(values, doc, ctx));
+      expect(values.size() == 2u);
+      expect(std::holds_alternative<delete_action_t>(values[0]));
+      expect(std::get<delete_action_t>(values[0]).data == "x");
+      expect(std::holds_alternative<put_action_t>(values[1]));
+      expect(std::get<put_action_t>(values[1]).data.at("k") == 1);
+   };
+
+   "a tagged variant streams"_test = [] {
+      std::istringstream in{R"({"action":"DELETE","data":"the_internet"})"};
+      glz::basic_istream_buffer<std::istringstream, 512> buffer{in};
+      tagged_action_t value{};
+      expect(!glz::read_json(value, buffer));
+      expect(std::holds_alternative<delete_action_t>(value));
+      expect(std::get<delete_action_t>(value).data == "the_internet");
+   };
+
+   "an integral discriminator streams"_test = [] {
+      std::istringstream in{R"({"t":2,"x":5})"};
+      glz::basic_istream_buffer<std::istringstream, 512> buffer{in};
+      numbered_variant_t value{};
+      expect(!glz::read_json(value, buffer));
+      expect(std::holds_alternative<numbered_b_t>(value));
+      expect(std::get<numbered_b_t>(value).x == 5);
+   };
+
+   "an adjacently tagged variant streams"_test = [] {
+      std::istringstream in{R"({"kind":"b","value":{"y":"hello"}})"};
+      glz::basic_istream_buffer<std::istringstream, 512> buffer{in};
+      adjacent_variant_t value{};
+      expect(!glz::read_json(value, buffer));
+      expect(std::holds_alternative<adjacent_b_t>(value));
+      expect(std::get<adjacent_b_t>(value).y == "hello");
+   };
+
+   "a unit alternative streams"_test = [] {
+      std::istringstream in{R"({"t":"unit"})"};
+      glz::basic_istream_buffer<std::istringstream, 512> buffer{in};
+      unit_variant_t value{valued_alternative_t{}};
+      expect(!glz::read_json(value, buffer));
+      expect(std::holds_alternative<unit_alternative_t>(value));
+   };
+
+   "a tag that is also a field streams"_test = [] {
+      std::istringstream in{R"({"t":"b","y":1.5})"};
+      glz::basic_istream_buffer<std::istringstream, 512> buffer{in};
+      tag_as_field_variant_t value{};
+      expect(!glz::read_json(value, buffer));
+      expect(std::holds_alternative<tag_as_field_b_t>(value));
+      expect(std::get<tag_as_field_b_t>(value).t == "b");
+      expect(std::get<tag_as_field_b_t>(value).y == 1.5);
+   };
+
+   // The discriminator is a view of the window, so the case that would catch it outliving that
+   // window is one where the window moves between alternatives. A 512 byte buffer holds only a few
+   // of these records, so the read refills repeatedly and a stale view would surface as a wrong
+   // alternative rather than as a crash.
+   "discriminators stay correct across refills"_test = [] {
+      std::string doc = "[";
+      for (int i = 0; i < 24; ++i) {
+         if (i) {
+            doc += ',';
+         }
+         if (i % 2) {
+            doc += R"({"action":"DELETE","data":")" + std::string(48, 'd') + std::to_string(i) + R"("})";
+         }
+         else {
+            doc += R"({"action":"PUT","data":{"n)" + std::to_string(i) + R"(":)" + std::to_string(i) + R"(}})";
+         }
+      }
+      doc += ']';
+
+      std::istringstream in{doc};
+      glz::basic_istream_buffer<std::istringstream, 512> buffer{in};
+      std::vector<tagged_action_t> values{};
+      expect(!glz::read_json(values, buffer));
+      expect(values.size() == 24u) << values.size();
+      for (size_t i = 0; i < values.size(); ++i) {
+         if (i % 2) {
+            expect(std::holds_alternative<delete_action_t>(values[i])) << i;
+            expect(std::get<delete_action_t>(values[i]).data == std::string(48, 'd') + std::to_string(i)) << i;
+         }
+         else {
+            expect(std::holds_alternative<put_action_t>(values[i])) << i;
+            expect(std::get<put_action_t>(values[i]).data.at("n" + std::to_string(i)) == int(i)) << i;
+         }
+      }
+   };
+
+   // json_stream_reader drives the same readers through its own streaming context.
+   "a stream reader yields tagged variants"_test = [] {
+      std::istringstream in{"{\"action\":\"DELETE\",\"data\":\"a\"}\n{\"action\":\"PUT\",\"data\":{\"k\":2}}\n"};
+      glz::json_stream_reader<tagged_action_t, std::istringstream, 512> reader{in};
+      tagged_action_t value{};
+      expect(!reader.read_next(value));
+      expect(std::holds_alternative<delete_action_t>(value));
+      expect(std::get<delete_action_t>(value).data == "a");
+      expect(!reader.read_next(value));
+      expect(std::holds_alternative<put_action_t>(value));
+      expect(std::get<put_action_t>(value).data.at("k") == 2);
+   };
+};
+
 int main() { return 0; }

--- a/tests/streaming_view_rejection/CMakeLists.txt
+++ b/tests/streaming_view_rejection/CMakeLists.txt
@@ -9,6 +9,7 @@ set(glz_rejection_cases
     DIRECT_VIEW
     BEHIND_TUPLE
     TEXT_VIEW
+    TAGGED_VARIANT_VIEW
     PAST_ANY_DEPTH
     CUSTOM_SETTER
     NDJSON

--- a/tests/streaming_view_rejection/rejection_cases.cpp
+++ b/tests/streaming_view_rejection/rejection_cases.cpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <string_view>
 #include <tuple>
+#include <variant>
 #include <vector>
 
 #include "glaze/glaze.hpp"
@@ -62,6 +63,25 @@ struct holds_text_view_t
    glz::text_view tv{};
 };
 
+// A tagged variant's discriminator is exempt from the guard: it is turned into an alternative index
+// inside the reader that parsed it and never reaches the caller (issue #2823). That exemption is the
+// discriminator's alone -- an alternative that really does hold a view must still be rejected.
+struct view_alternative_t
+{
+   std::string_view v{};
+};
+struct plain_alternative_t
+{
+   int n{};
+};
+using tagged_view_variant_t = std::variant<view_alternative_t, plain_alternative_t>;
+template <>
+struct glz::meta<tagged_view_variant_t>
+{
+   static constexpr std::string_view tag = "t";
+   static constexpr auto ids = std::array{"view", "plain"};
+};
+
 template <class T>
 void stream_into()
 {
@@ -81,6 +101,9 @@ int main()
 #endif
 #ifdef GLZ_REJECT_CASE_TEXT_VIEW
    stream_into<holds_text_view_t>();
+#endif
+#ifdef GLZ_REJECT_CASE_TAGGED_VARIANT_VIEW
+   stream_into<tagged_view_variant_t>();
 #endif
 #ifdef GLZ_REJECT_CASE_PAST_ANY_DEPTH
    stream_into<deeply_nested_view_t>();


### PR DESCRIPTION
Fixes #2823.

## The problem

`GLZ_ASSERT_OWNS_ITS_BYTES` keys off the *type* of the context, not on whether streaming is actually enabled. The JSON variant reader parses a string discriminator through `from<JSON, std::string_view>`, so every tagged variant failed to compile under a `streaming_context` — including the reported case, which is an ordinary buffered read that merely passes one (`ctx.stream` is never enabled there).

```cpp
using tagged_variant = std::variant<put_action, delete_action>;
template <> struct glz::meta<tagged_variant> {
   static constexpr std::string_view tag = "action";
   static constexpr auto ids = std::array{"PUT", "DELETE"};
};

glz::streaming_context ctx{};
glz::read<glz::opts{}>(var, s, ctx);  // static assertion failed: ... fills a non-owning view
```

## The fix

The discriminator is not the kind of view the guard is aimed at. It is turned into an alternative index a few lines after it is read and never reaches the caller, and nothing refills in between — only `skip_ws` runs, which has no refill point. That is exactly what `parse_transient_string_view` already says for the chrono readers.

All three sites that read a string id now use it: adjacent tagging, and the deduced object path with and without deduction keys.

## Scope of the exemption

It is the discriminator's alone. An alternative that really holds a `std::string_view` is still rejected, and `tests/streaming_view_rejection` gains a `TAGGED_VARIANT_VIEW` case that pins that — a future change widening the exemption to the whole variant reader turns into a failing test rather than into silently wrong data.

## Tests

A new suite in `tests/istream_buffer_test` covers:

- the reported shape (buffered read + `streaming_context`)
- real streaming reads of internal string ids, integral ids, adjacent tagging, a unit alternative, and a tag that is also a struct field
- `json_stream_reader` over tagged variants
- 24 tagged records through a 512-byte window, so the window moves repeatedly between alternatives and a discriminator that outlived it would surface as a wrong alternative

All 119 ctest targets pass, including the nine compile-rejection cases. Verified locally on Apple clang only.

## Merge order

This unblocks streaming for **adjacently tagged** variants, and `read_adjacent` still re-reads the object from a raw pointer, which a refill invalidates — in a 512-byte window that returns a silently wrong value for a document no reader should accept. #2825 fixes it. Please merge both, or #2825 first; this one alone widens a pre-existing hole.

## Known limitation, not addressed here

A deduced variant re-parses the object from its start (`it = start`), but under streaming a `skip_value` refill releases those bytes first. This predates this PR and reproduces identically on `main` with no tagged variant involved, so it is left for a follow-up.