### PR TITLE
Anchor the position a variant re-reads an object from

### DIFF
--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -162,6 +162,15 @@ glz::basic_istream_buffer<std::ifstream, 1 << 20> buffer(file);  // 1 MB window
 
 Leading whitespace is also read without refilling, so whitespace wider than the window stops a read before it reaches the value behind it.
 
+A `std::variant` of objects adds one more case. When the alternative is decided by the shape of the object, or by a tag that is not the first key, the reader scans the object once to work out which alternative it is and then reads it again from the opening brace. Adjacent tagging (`tag` plus `content`) always reads it twice, whatever the key order.
+
+That second pass needs the opening brace to still be in the window. A refill releases whatever the parse has stepped over, so the object has to fit in the room the window has left *at the point it starts* — not in the window's full capacity, since the reader tops the window up between elements rather than at every byte. Where it does not fit, the read stops with `error_code::streaming_unsupported` rather than re-reading relocated bytes. Give the window several times the size of the largest such object, or put an internal tag first, which skips the second pass entirely and streams at any size:
+
+```jsonc
+{"type":"circle","points":[ ... a megabyte of them ... ]}  // streams in a 64 KB window
+{"points":[ ... a megabyte of them ... ],"type":"circle"}  // needs room for the whole object
+```
+
 ## See Also
 
 - [Writing](writing.md) - Writing to buffers and error handling

--- a/include/glaze/core/context.hpp
+++ b/include/glaze/core/context.hpp
@@ -113,7 +113,10 @@ namespace glz
       // written. Raised by the binary-to-JSON converters, which refuse
       // to emit a byte they would have to corrupt or hide.
       // Streaming errors
-      streaming_unsupported, // Document outruns the buffer window and this format's reader cannot refill
+      // The buffer window is too small for what the read needs: either the format's reader has no
+      // refill points and the document outruns one window, or a value has to be re-read from its
+      // start and is longer than the window. custom_error_message says which.
+      streaming_unsupported,
       // Expansion errors
       // A YAML read produced more text than its budgets allow. Both budgets bound the same thing
       // -- text a small document can multiply into an unbounded amount -- and both call for the

--- a/include/glaze/core/streaming_state.hpp
+++ b/include/glaze/core/streaming_state.hpp
@@ -36,6 +36,7 @@ namespace glz
       bool (*refill)(void*) = nullptr;
       bool (*eof)(void*) = nullptr;
       bool (*source_eof)(void*) = nullptr;
+      size_t (*consumed)(void*) = nullptr;
 
       // Check if streaming is enabled
       bool enabled() const noexcept { return buffer_ptr != nullptr; }
@@ -45,6 +46,11 @@ namespace glz
 
       // Get current available size
       size_t size() const noexcept { return get_size(buffer_ptr); }
+
+      // How many bytes the stream has released, which is also the stream offset the window starts
+      // at. A refill moves the window without changing this, so it is what turns a pointer into a
+      // position that survives one. See rewind_anchor.
+      size_t bytes_consumed() const noexcept { return consumed(buffer_ptr); }
 
       // Consume n bytes from buffer
       void consume_bytes(size_t n) const noexcept { consume(buffer_ptr, n); }
@@ -84,6 +90,7 @@ namespace glz
       state.consume = [](void* p, size_t n) { static_cast<Buffer*>(p)->consume(n); };
       state.refill = [](void* p) -> bool { return static_cast<Buffer*>(p)->refill(); };
       state.eof = [](void* p) -> bool { return static_cast<Buffer*>(p)->eof(); };
+      state.consumed = [](void* p) -> size_t { return static_cast<Buffer*>(p)->bytes_consumed(); };
       if constexpr (requires(Buffer& b) {
                        { b.source_exhausted() } -> std::convertible_to<bool>;
                     }) {
@@ -157,6 +164,66 @@ namespace glz
             end = new_end;
          }
       }
+   }
+
+   // A position in the input that a reader means to come back to after reading past it -- how a
+   // variant re-reads an object once it knows which alternative it holds.
+   //
+   // A buffered read just keeps the pointer. A streaming read cannot, for the reason spelled out at
+   // the bottom of this file: a refill relocates the window and releases what the parse has stepped
+   // over, and the stale pointer stays inside the buffer's allocation, so the re-read quietly lands
+   // on something else and reports success.
+   //
+   // The position is held as a stream offset instead, which a refill does not change, and returned
+   // to only while those bytes are still in the window. When they are not, the document asked for
+   // more lookback than the window can hold; rewind() says so rather than guessing.
+   //
+   // For a context with no streaming state -- every buffered read -- this is the pointer that would
+   // have been kept anyway, and every branch below folds away.
+   template <class It>
+   struct rewind_anchor
+   {
+      It pos{};
+      size_t offset{}; // stream offset of `pos`; meaningful only under a streaming read
+
+      // Return `it`, and the window edge that goes with it, to the anchored position. False means
+      // the bytes are gone, with ctx.error set to say why.
+      template <class Ctx, class End>
+      [[nodiscard]] GLZ_ALWAYS_INLINE bool rewind(Ctx& ctx, It& it, End& end) const noexcept
+      {
+         if constexpr (has_streaming_state<Ctx>) {
+            if (ctx.stream.enabled()) {
+               // Where the offset sits in the window now. The window holds stream offsets
+               // [bytes_consumed(), bytes_consumed() + size()]; anything earlier has been released.
+               const size_t base = ctx.stream.bytes_consumed();
+               if (offset < base || (offset - base) > ctx.stream.size()) [[unlikely]] {
+                  ctx.error = error_code::streaming_unsupported;
+                  ctx.custom_error_message =
+                     "this value has to be re-read from its start, and the window has moved past it";
+                  return false;
+               }
+               it = ctx.stream.data() + (offset - base);
+               end = ctx.stream.data() + ctx.stream.size();
+               return true;
+            }
+         }
+         it = pos;
+         return true;
+      }
+   };
+
+   // Anchor where `it` is now. Under a streaming read the position is recorded as a stream offset,
+   // which is what lets it survive the refills that happen before the reader comes back to it.
+   template <class Ctx, class It>
+   [[nodiscard]] GLZ_ALWAYS_INLINE rewind_anchor<std::decay_t<It>> make_rewind_anchor(Ctx& ctx, It it) noexcept
+   {
+      rewind_anchor<std::decay_t<It>> anchor{it, 0};
+      if constexpr (has_streaming_state<Ctx>) {
+         if (ctx.stream.enabled()) {
+            anchor.offset = ctx.stream.bytes_consumed() + size_t(it - ctx.stream.data());
+         }
+      }
+      return anchor;
    }
 }
 

--- a/include/glaze/json/read.hpp
+++ b/include/glaze/json/read.hpp
@@ -3298,6 +3298,7 @@ namespace glz
                            skip_value<JSON>::op<Opts>(ctx, it, end);
                            if (bool(ctx.error)) [[unlikely]]
                               return;
+                           resync_window_end(ctx, end); // a streaming skip refills
                            if (skip_ws<Opts>(ctx, it, end)) {
                               return;
                            }
@@ -3906,18 +3907,24 @@ namespace glz
          }
          ++ctx.depth;
 
-         const auto obj_start = it;
+         // Adjacent tagging reads the object twice -- once to find the discriminator, once to read
+         // the content into the alternative it named -- so `walk` returns here at the start of each
+         // pass. Under a streaming read those two passes straddle refills, which is what the anchor
+         // is for; a raw pointer would address relocated bytes by the second one.
+         auto obj_start = make_rewind_anchor(ctx, it);
 
          // Walk the members, handing each key to `on_key`, which must consume that key's value.
          // Leaves `it` just past the closing brace. Returns false once an error has been set.
          const auto walk = [&](auto&& on_key) {
-            it = obj_start;
+            if (!obj_start.rewind(ctx, it, end)) {
+               return false;
+            }
             if (skip_ws<Opts>(ctx, it, end)) {
                return false;
             }
-            const auto first = it;
+            bool first_key = true;
             while (*it != '}') {
-               if (it != first) {
+               if (!first_key) {
                   if (match_invalid_end<',', Opts>(ctx, it, end)) {
                      return false;
                   }
@@ -3946,6 +3953,10 @@ namespace glz
                if (!on_key(key)) {
                   return false;
                }
+               // on_key consumed a value, and a streaming read refills inside one, which leaves the
+               // window edge this frame is holding behind.
+               resync_window_end(ctx, end);
+               first_key = false;
                if (skip_ws<Opts>(ctx, it, end)) {
                   return false;
                }
@@ -4116,7 +4127,11 @@ namespace glz
                   if (skip_ws<Opts>(ctx, it, end)) {
                      return;
                   }
-                  auto start = it;
+                  // Once the reader knows which alternative this object holds it may have to read
+                  // it again from here. Anchor the position rather than keep the pointer: the scan
+                  // below skips values, and a streaming skip refills, which moves the window out
+                  // from under a raw pointer (see rewind_anchor).
+                  auto start = make_rewind_anchor(ctx, it);
                   bool first_key = true;
                   // Parse bifurcation for tagged variants:
                   //
@@ -4132,17 +4147,20 @@ namespace glz
                   // One exception: if the tag name is also a field on the resolved struct
                   // (contains_tag), we must re-parse regardless so the value is stored in
                   // the struct field. This override is applied inside each std::visit lambda.
+                  //
+                  // Either way the rewind can fail under a streaming read: the window only holds so
+                  // much, and an object wider than it has no start left to return to.
                   auto position_after_tag = [&] {
                      if (first_key) {
                         if (*it == ',') ++it; // skip comma; handles tag-only objects where *it == '}'
+                        return true;
                      }
-                     else {
-                        it = start; // tag was not the first key, re-parse from the beginning
-                     }
+                     return start.rewind(ctx, it, end); // tag came later, re-parse from the beginning
                   };
-                  while (*it != '}') {
-                     if (it != start) {
-                        first_key = false;
+                  // `first_key` also answers "were we reset to the object start", which is what
+                  // position_after_tag does for every key but the first.
+                  for (; *it != '}'; first_key = false) {
+                     if (!first_key) {
                         if (match_invalid_end<',', Opts>(ctx, it, end)) {
                            return;
                         }
@@ -4217,7 +4235,7 @@ namespace glz
                                     return;
                                  }
 
-                                 position_after_tag();
+                                 if (!position_after_tag()) return;
                                  tag_specified_index = type_index; // Store the tag-specified type
                                  if (value.index() != type_index) emplace_runtime_variant(value, type_index);
                                  std::visit(
@@ -4236,7 +4254,8 @@ namespace glz
                                        }
                                        else if constexpr (is_object) {
                                           if constexpr (contains_tag<V, tag_literal>()) {
-                                             it = start; // tag is a struct field, must re-parse
+                                             // tag is a struct field, must re-parse
+                                             if (!start.rewind(ctx, it, end)) return;
                                           }
                                           from<JSON, V>::template op<opening_handled<Opts>(), tag_literal>(v, ctx, it,
                                                                                                            end);
@@ -4273,7 +4292,8 @@ namespace glz
                                              }
                                           }
                                           if constexpr (contains_tag<memory_type<V>, tag_literal>()) {
-                                             it = start; // tag is a struct field, must re-parse
+                                             // tag is a struct field, must re-parse
+                                             if (!start.rewind(ctx, it, end)) return;
                                           }
                                           from<JSON, memory_type<V>>::template op<opening_handled<Opts>(), tag_literal>(
                                              *v, ctx, it, end);
@@ -4284,7 +4304,7 @@ namespace glz
                                           // This only works when the tag was the first key. If it came later,
                                           // we were reset to the object start and the custom handler would
                                           // absorb the tag, so error rather than corrupt the value.
-                                          if (it == start) {
+                                          if (!first_key) {
                                              ctx.error = error_code::feature_not_supported;
                                              ctx.custom_error_message =
                                                 "the tag must be the first key for a custom variant alternative";
@@ -4305,7 +4325,7 @@ namespace glz
                                     // Use the first unlabeled type as the default
                                     const auto default_type_index = ids_size;
 
-                                    position_after_tag();
+                                    if (!position_after_tag()) return;
                                     tag_specified_index = default_type_index; // Store the default type index
                                     if (value.index() != default_type_index)
                                        emplace_runtime_variant(value, default_type_index);
@@ -4326,7 +4346,8 @@ namespace glz
                                           }
                                           else if constexpr (is_object) {
                                              if constexpr (contains_tag<V, tag_literal>()) {
-                                                it = start; // tag is a struct field, must re-parse
+                                                // tag is a struct field, must re-parse
+                                                if (!start.rewind(ctx, it, end)) return;
                                              }
                                              from<JSON, V>::template op<opening_handled<Opts>()>(v, ctx, it, end);
                                           }
@@ -4360,7 +4381,8 @@ namespace glz
                                                 }
                                              }
                                              if constexpr (contains_tag<memory_type<V>, tag_literal>()) {
-                                                it = start; // tag is a struct field, must re-parse
+                                                // tag is a struct field, must re-parse
+                                                if (!start.rewind(ctx, it, end)) return;
                                              }
                                              from<JSON, memory_type<V>>::template op<opening_handled<Opts>()>(*v, ctx,
                                                                                                               it, end);
@@ -4370,7 +4392,7 @@ namespace glz
                                              // works when the tag was the first key (see above). If it came
                                              // later we were reset to the object start, so error rather than
                                              // let the custom handler absorb the tag.
-                                             if (it == start) {
+                                             if (!first_key) {
                                                 ctx.error = error_code::feature_not_supported;
                                                 ctx.custom_error_message =
                                                    "the tag must be the first key for a custom variant alternative";
@@ -4427,7 +4449,7 @@ namespace glz
                            const auto type_index = variant_id_to_index<T>::op(
                               type_id.data(), type_id.data() + type_id.size(), type_id.size());
                            if (type_index < ids_v<T>.size()) [[likely]] {
-                              position_after_tag();
+                              if (!position_after_tag()) return;
                               tag_specified_index = type_index; // Store the tag-specified type
                               if (value.index() != type_index) emplace_runtime_variant(value, type_index);
                            }
@@ -4437,7 +4459,7 @@ namespace glz
                               constexpr auto variant_size = std::variant_size_v<T>;
                               if constexpr (ids_size < variant_size) {
                                  // Use the first unlabeled type as the default
-                                 position_after_tag();
+                                 if (!position_after_tag()) return;
                                  const auto default_index = ids_size;
                                  tag_specified_index = default_index; // Store the default type index
                                  if (value.index() != default_index) emplace_runtime_variant(value, default_index);
@@ -4459,7 +4481,7 @@ namespace glz
                                     // just consumed). If the tag came after other keys, position_after_tag()
                                     // reset us to the object start and the custom handler would absorb the tag
                                     // into its value, so error here rather than corrupt the result.
-                                    if (it == start) {
+                                    if (!first_key) {
                                        ctx.error = error_code::feature_not_supported;
                                        ctx.custom_error_message =
                                           "the tag must be the first key for a custom variant alternative";
@@ -4469,7 +4491,8 @@ namespace glz
                                  }
                                  else {
                                     if constexpr (contains_tag<V, tag_literal>()) {
-                                       it = start; // tag is a struct field, must re-parse
+                                       // tag is a struct field, must re-parse
+                                       if (!start.rewind(ctx, it, end)) return;
                                     }
                                     from<JSON, V>::template op<opening_handled<Opts>(), tag_literal>(v, ctx, it, end);
                                  }
@@ -4489,6 +4512,7 @@ namespace glz
                            skip_value<JSON>::op<Opts>(ctx, it, end);
                            if (bool(ctx.error)) [[unlikely]]
                               return;
+                           resync_window_end(ctx, end); // a streaming skip refills
                            if (skip_ws<Opts>(ctx, it, end)) {
                               return;
                            }
@@ -4508,7 +4532,7 @@ namespace glz
                      // Only short-circuit for variants without tags
                      else if constexpr (tag_v<T>.empty()) {
                         if (matching_types == 1) {
-                           it = start;
+                           if (!start.rewind(ctx, it, end)) return;
                            const auto type_index = possible_types.countr_zero();
 
                            if (value.index() != static_cast<size_t>(type_index))
@@ -4580,6 +4604,7 @@ namespace glz
                      skip_value<JSON>::op<Opts>(ctx, it, end);
                      if (bool(ctx.error)) [[unlikely]]
                         return;
+                     resync_window_end(ctx, end); // a streaming skip refills
                      if (skip_ws<Opts>(ctx, it, end)) {
                         return;
                      }
@@ -4603,7 +4628,7 @@ namespace glz
                            return;
                         }
 
-                        it = start;
+                        if (!start.rewind(ctx, it, end)) return;
                         if (value.index() != static_cast<size_t>(type_index))
                            emplace_runtime_variant(value, type_index);
                         std::visit(
@@ -4705,7 +4730,7 @@ namespace glz
                               return;
                            }
 
-                           it = start;
+                           if (!start.rewind(ctx, it, end)) return;
                            if (value.index() != chosen_index) emplace_runtime_variant(value, chosen_index);
                            std::visit(
                               [&](auto&& v) {

--- a/tests/istream_buffer_test/istream_buffer_test.cpp
+++ b/tests/istream_buffer_test/istream_buffer_test.cpp
@@ -3701,9 +3701,12 @@ suite streaming_state_unit_tests = [] {
       auto state = glz::make_streaming_state(buffer);
       size_t original_size = state.size();
 
+      expect(state.bytes_consumed() == 0u);
       state.consume_bytes(5);
 
       expect(buffer.bytes_consumed() == 5u);
+      // The window's own stream offset, which is what makes a position survive a refill.
+      expect(state.bytes_consumed() == 5u);
       // After consume, size should be reduced
       expect(state.size() == original_size - 5u);
    };
@@ -5002,6 +5005,249 @@ suite tagged_variant_streaming_tests = [] {
       expect(!reader.read_next(value));
       expect(std::holds_alternative<put_action_t>(value));
       expect(std::get<put_action_t>(value).data.at("k") == 2);
+   };
+};
+
+// A variant deduced by shape or by a tag re-reads the object from its opening brace once it knows
+// which alternative it holds. Under a streaming read the bytes it wants to go back to may already
+// have been released: the scan that found the tag skips values, and a streaming skip refills.
+//
+// The position is anchored as a stream offset rather than kept as a pointer (see glz::rewind_anchor),
+// so the re-read either lands where it meant to or reports that the window is too small. Before that
+// the reader returned to a pointer into relocated bytes, which surfaced as a syntax error naming a
+// position the document does not have.
+struct wide_alpha_t
+{
+   int a{};
+   std::vector<int> data{};
+};
+
+struct wide_beta_t
+{
+   int b{};
+   std::vector<int> data{};
+};
+
+using wide_tagged_t = std::variant<wide_alpha_t, wide_beta_t>;
+
+template <>
+struct glz::meta<wide_tagged_t>
+{
+   static constexpr std::string_view tag = "t";
+   static constexpr auto ids = std::array{"a", "b"};
+};
+
+// Distinct alternatives, not an alias of the pair above: a using-alias would name the same type and
+// pick up its glz::meta, which would quietly send these through the tagged reader instead.
+struct plain_alpha_t
+{
+   int a{};
+   std::vector<int> data{};
+};
+
+struct plain_beta_t
+{
+   int b{};
+   std::vector<int> data{};
+};
+
+using wide_untagged_t = std::variant<plain_alpha_t, plain_beta_t>; // deduced by the unique keys "a"/"b"
+static_assert(glz::tag_v<wide_untagged_t>.empty(), "this pair must reach the shape-deduction path");
+
+// The discriminator names a scalar alternative while the content is an object, so every read of
+// this shape has to fail. That makes it a probe for the re-read landing somewhere it should not:
+// a success means the second pass parsed bytes the document does not have there.
+struct nested_payload_t
+{
+   std::vector<int> data{};
+   int value{};
+};
+
+using adjacent_probe_t = std::variant<int, nested_payload_t>;
+
+template <>
+struct glz::meta<adjacent_probe_t>
+{
+   static constexpr std::string_view tag = "kind";
+   static constexpr std::string_view content = "value";
+   static constexpr auto ids = std::array{"a", "b"};
+};
+
+// Adjacent tagging reads the object twice however the keys are ordered, so both orders need the
+// object to still be in the window for the second pass. Its own alternatives again, for the same
+// reason: a variant of the pair above would be the same type as wide_untagged_t.
+struct adj_alpha_t
+{
+   int a{};
+   std::vector<int> data{};
+};
+
+struct adj_beta_t
+{
+   int b{};
+   std::vector<int> data{};
+};
+
+using wide_adjacent_t = std::variant<adj_alpha_t, adj_beta_t>;
+
+template <>
+struct glz::meta<wide_adjacent_t>
+{
+   static constexpr std::string_view tag = "kind";
+   static constexpr std::string_view content = "value";
+   static constexpr auto ids = std::array{"a", "b"};
+};
+
+// Wide enough that a 512 byte window cannot hold one, but built from values that each fit, so the
+// only thing standing in the way is the re-read.
+inline std::string wide_int_array(int n)
+{
+   std::string s = "[";
+   for (int i = 0; i < n; ++i) {
+      if (i) {
+         s += ',';
+      }
+      s += std::to_string(i % 10);
+   }
+   return s + ']';
+}
+
+suite variant_rewind_streaming_tests = [] {
+   // The re-read that can be done is still done: the object fits, so the anchor is still in the
+   // window and the tag being the last key costs nothing but a second pass.
+   "a variant that fits the window is re-read"_test = [] {
+      const std::string doc = R"({"b":7,"data":)" + wide_int_array(400) + R"(,"t":"b"})";
+      std::istringstream in{doc};
+      glz::basic_istream_buffer<std::istringstream, 65536> buffer{in};
+      wide_tagged_t value{};
+      expect(!glz::read_json(value, buffer));
+      expect(std::holds_alternative<wide_beta_t>(value));
+      expect(std::get<wide_beta_t>(value).b == 7);
+      expect(std::get<wide_beta_t>(value).data.size() == 400u);
+   };
+
+   "an object wider than the window says so"_test = [] {
+      const std::string doc = R"({"b":7,"data":)" + wide_int_array(400) + R"(,"t":"b"})";
+      expect(doc.size() > 512u);
+
+      std::istringstream in{doc};
+      glz::basic_istream_buffer<std::istringstream, 512> buffer{in};
+      wide_tagged_t value{};
+      const auto ec = glz::read_json(value, buffer);
+      expect(ec == glz::error_code::streaming_unsupported)
+         << "a syntax error would blame the document for a window that was too small";
+   };
+
+   // Shape deduction re-reads for the same reason a tag does, and has done so since long before
+   // tagged variants could be streamed at all.
+   "an untagged deduced variant reports the same limit"_test = [] {
+      const std::string doc = R"({"data":)" + wide_int_array(400) + R"(,"b":7})";
+      expect(doc.size() > 512u);
+
+      std::istringstream in{doc};
+      glz::basic_istream_buffer<std::istringstream, 512> buffer{in};
+      wide_untagged_t value{};
+      const auto ec = glz::read_json(value, buffer);
+      expect(ec == glz::error_code::streaming_unsupported)
+         << "a syntax error would blame the document for a window that was too small";
+   };
+
+   // The direction that has to keep working. A tag in front resolves the alternative without any
+   // lookback, so the object body streams through refills like any other object and its width is
+   // no longer the reader's business.
+   "a tag that comes first needs no re-read"_test = [] {
+      const std::string doc = R"({"t":"b","b":7,"data":)" + wide_int_array(400) + "}";
+      expect(doc.size() > 512u);
+
+      std::istringstream in{doc};
+      glz::basic_istream_buffer<std::istringstream, 512> buffer{in};
+      wide_tagged_t value{};
+      expect(!glz::read_json(value, buffer));
+      expect(std::holds_alternative<wide_beta_t>(value));
+      expect(std::get<wide_beta_t>(value).b == 7);
+      expect(std::get<wide_beta_t>(value).data.size() == 400u) << std::get<wide_beta_t>(value).data.size();
+   };
+
+   "an adjacently tagged object that fits is re-read"_test = [] {
+      const std::string doc = R"({"value":{"b":7,"data":)" + wide_int_array(300) + R"(},"kind":"b"})";
+      std::istringstream in{doc};
+      glz::basic_istream_buffer<std::istringstream, 65536> buffer{in};
+      wide_adjacent_t value{};
+      expect(!glz::read_json(value, buffer));
+      expect(std::holds_alternative<adj_beta_t>(value));
+      expect(std::get<adj_beta_t>(value).b == 7);
+      expect(std::get<adj_beta_t>(value).data.size() == 300u);
+   };
+
+   // Unlike an internal tag, putting the discriminator first buys nothing here -- the content is
+   // read on a second pass either way -- so both orders have to report the window rather than
+   // blame the document.
+   "an adjacently tagged object wider than the window says so"_test = [] {
+      for (const std::string& doc : {R"({"kind":"b","value":{"b":7,"data":)" + wide_int_array(300) + "}}",
+                                     R"({"value":{"b":7,"data":)" + wide_int_array(300) + R"(},"kind":"b"})"}) {
+         expect(doc.size() > 512u);
+         std::istringstream in{doc};
+         glz::basic_istream_buffer<std::istringstream, 512> buffer{in};
+         wide_adjacent_t value{};
+         const auto ec = glz::read_json(value, buffer);
+         expect(ec == glz::error_code::streaming_unsupported) << doc.substr(0, 12);
+      }
+   };
+
+   // Sweeping the size walks the object's end across the window edge. Before the second pass was
+   // anchored, one size in this range returned a plain `int` scraped out of the nested object --
+   // a successful read of a document that cannot be read at all.
+   "a re-read never succeeds where the document forbids it"_test = [] {
+      size_t succeeded = 0;
+      for (int n = 200; n <= 300; ++n) {
+         const std::string arr = wide_int_array(n);
+         for (const std::string& doc : {R"({"kind":"a","value":{"data":)" + arr + R"(,"value":7}})",
+                                        R"({"value":{"data":)" + arr + R"(,"value":7},"kind":"a"})"}) {
+            adjacent_probe_t buffered{};
+            expect(bool(glz::read_json(buffered, doc))) << "the content is not an int";
+
+            std::istringstream in{doc};
+            glz::basic_istream_buffer<std::istringstream, 512> buffer{in};
+            adjacent_probe_t streamed{};
+            if (!glz::read_json(streamed, buffer)) {
+               ++succeeded;
+            }
+         }
+      }
+      expect(succeeded == 0u) << succeeded << " streaming reads succeeded where the buffered read failed";
+   };
+
+   // Many variants in one document, each needing a re-read, with the window moving between them.
+   // The anchor is re-taken per object, so what matters is that every one of them lands on its own
+   // opening brace rather than on a stale offset from the object before it.
+   "re-read variants stay correct across refills"_test = [] {
+      std::string doc = "[";
+      for (int i = 0; i < 20; ++i) {
+         if (i) {
+            doc += ',';
+         }
+         // The discriminating key comes last, so every element takes the re-read path.
+         doc += R"({"data":)" + wide_int_array(20) + R"(,")" + (i % 2 ? "b" : "a") + R"(":)" + std::to_string(i) + "}";
+      }
+      doc += ']';
+
+      std::istringstream in{doc};
+      glz::basic_istream_buffer<std::istringstream, 512> buffer{in};
+      std::vector<wide_untagged_t> values{};
+      expect(!glz::read_json(values, buffer));
+      expect(values.size() == 20u) << values.size();
+      for (size_t i = 0; i < values.size(); ++i) {
+         if (i % 2) {
+            expect(std::holds_alternative<plain_beta_t>(values[i])) << i;
+            expect(std::get<plain_beta_t>(values[i]).b == int(i)) << i;
+            expect(std::get<plain_beta_t>(values[i]).data.size() == 20u) << i;
+         }
+         else {
+            expect(std::holds_alternative<plain_alpha_t>(values[i])) << i;
+            expect(std::get<plain_alpha_t>(values[i]).a == int(i)) << i;
+            expect(std::get<plain_alpha_t>(values[i]).data.size() == 20u) << i;
+         }
+      }
    };
 };
 


### PR DESCRIPTION
Follow-up to #2824. **Stacked on it** — base is `stream-tagged-variant-discriminator`, so review the second commit only; GitHub retargets to `main` once #2824 merges.

## The problem

A variant deduced by shape, or by a tag that is not the first key, scans the object once to work out which alternative it holds and then reads it again from the opening brace. Adjacent tagging (`tag` + `content`) reads it twice whatever the key order. Both returned there by keeping the pointer — but the scan skips values, and a streaming skip refills, which releases the bytes behind it and moves the window. The pointer stays inside the buffer's own allocation, so nothing crashes and nothing compares out of range; the re-read simply lands on whatever now occupies that address.

**For adjacent tagging that is not just a wrong error, it is a wrong value.** A discriminator naming the `int` alternative over content that is an object is a document no reader can accept. In a 512-byte window it returned success, with an `int` scraped out of the content:

```
{"kind":"a","value":{"data":[ ...247 ints... ],"value":7}}

buffered:  parse_number_failure
before:    SUCCESS, int = 7          <-- silent corruption
after:     streaming_unsupported
```

For a deduced object it showed up as a valid document rejected at a position it does not have — `1:514: expected_quote` for an 824-byte document.

Both predate #2824: untagged shape deduction and integral-id adjacent tagging reach these paths on `main` today. #2824 widens the adjacent case to the ordinary string-id spelling, which is why these should land together — **please do not merge #2824 alone.**

## The fix

`glz::rewind_anchor` holds the position as a stream offset, which a refill does not change, and returns to it only while those bytes are still in the window. When they are not, the document asked for more lookback than the window has left, and it says so rather than guessing. `rewind()` is `[[nodiscard]]`, so every site has to decide what to do when the bytes are gone.

`streaming_state` grows a `bytes_consumed()` accessor — what turns a pointer into a position that survives a refill. Every buffer that can stream already provides it; `read_streaming` calls it directly for error reporting.

Three readers also left this frame's window edge behind after a skip that refilled — both scans in `read_deduced`, the `walk` in `read_adjacent`, and the tag key an object skips on a variant's behalf — so each now resyncs it.

`read_deduced` also drops `rewind_anchor::holds()` in favour of the `first_key` flag already in scope, which it was re-deriving through three indirect calls per key.

## What does not change

- An object that fits is re-read exactly as before.
- An internal tag placed first resolves the alternative with no lookback at all, so those objects stream at any size — pinned by a test.
- For a buffered read the anchor is the pointer that was being kept anyway and every branch folds away. Same for a buffered read that merely passes a `streaming_context`.

## Scope — what this does *not* fix

- **An object that outruns the window before the discriminator is even found** still fails in the scan with a syntax error, because the key scan has no refill point. That is the general "one value has to fit in the window" limit, not specific to variants, and it means a minority of sizes still report `expected_quote` rather than `streaming_unsupported`.
- **`process_variant_alternatives`** (speculative backtracking for non-object variants, `read.hpp:3774+`) and the non-auto-deducible fallback still rewind with raw pointers. Same shape, different mechanism, pre-existing; `rewind_anchor` would apply.
- The wider audit of `skip_value` callers that do not resync `end` is left alone; only the variant-related ones are touched here.

## Tests

Eight cases in `tests/istream_buffer_test`, the sharpest being a sweep over object sizes asserting that a streaming read never succeeds where the buffered read fails — that is the case that caught the corruption above. Plus: the `bytes_consumed()` accessor, an object that fits being re-read correctly, over-wide tagged/untagged/adjacent objects all reporting `streaming_unsupported`, a tag-first object streaming past the window, and 20 re-read variants in one array through a 512-byte window.

All 119 ctest targets pass. Verified locally on Apple clang only.