### PR TITLE
honor meta::skip when reading YAML

### DIFF
--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -2917,17 +2917,26 @@ namespace glz
                   visit<N>(
                      [&]<size_t I>() {
                         if (I == index) {
-                           decltype(auto) member = [&]() -> decltype(auto) {
-                              if constexpr (reflectable<U>) {
-                                 return get<I>(to_tie(value));
-                              }
-                              else {
-                                 return get_member(value, get<I>(reflect<U>::values));
-                              }
-                           }();
+                           // A field that `meta::skip` excludes from parsing still owns its key, so
+                           // the entry is consumed and discarded rather than rejected as unknown.
+                           // The branch is `if constexpr`/`else` so the skipped field's parser is
+                           // never instantiated -- see `skipped_by_meta`.
+                           if constexpr (skipped_by_meta<U, I, operation::parse>) {
+                              skip_yaml_value<Opts>(ctx, it, end, 0, true);
+                           }
+                           else {
+                              decltype(auto) member = [&]() -> decltype(auto) {
+                                 if constexpr (reflectable<U>) {
+                                    return get<I>(to_tie(value));
+                                 }
+                                 else {
+                                    return get_member(value, get<I>(reflect<U>::values));
+                                 }
+                              }();
 
-                           using member_type = std::decay_t<decltype(member)>;
-                           from<YAML, member_type>::template op<flow_context_on<Opts>()>(member, ctx, it, end);
+                              using member_type = std::decay_t<decltype(member)>;
+                              from<YAML, member_type>::template op<flow_context_on<Opts>()>(member, ctx, it, end);
+                           }
                         }
                         return !bool(ctx.error);
                      },
@@ -3551,20 +3560,40 @@ namespace glz
          }
       }
 
-      // Skip the value of an unknown block-mapping entry, whether it is inline (on the key's line)
-      // or begins on a following, more-indented line (a nested block sequence or mapping).
-      // `key_indent` is the column of the entry's key; deeper lines belong to the value.
+      // Skip the value of a block-mapping entry the reader does not store, whether it is inline (on
+      // the key's line) or begins on a following, more-indented line (a nested block sequence or
+      // mapping). `key_indent` is the column of the entry's key; deeper lines belong to the value.
+      //
+      // An implicit "key: value" pair inside a flow collection ([a: 1, b: 2]) also reaches this
+      // through parse_block_mapping's flow arm, and there the value ends at ',', ']' or '}' rather
+      // than at a column. Skipping such a value as a block scalar would run straight through those
+      // delimiters and swallow the rest of the collection, so the flow context is passed on to the
+      // scalar skipper -- mirroring the parse path, which reads the same value in flow context.
       template <auto Opts, class Ctx, class It, class End>
       inline void skip_unknown_block_value(Ctx& ctx, It& it, End end, int32_t key_indent) noexcept
       {
+         constexpr bool in_flow = yaml::check_flow_context(Opts);
+
          if (it != end && !yaml::line_end_or_comment_table[static_cast<uint8_t>(*it)]) {
-            skip_yaml_value<Opts>(ctx, it, end, key_indent, false);
+            skip_yaml_value<Opts>(ctx, it, end, in_flow ? 0 : key_indent, in_flow);
          }
          else {
             const int32_t nested_indent = detect_nested_value_indent(ctx, it, end, key_indent);
             if (nested_indent >= 0) {
                skip_to_content(it, end);
-               skip_yaml_value<Opts>(ctx, it, end, key_indent, false);
+               // Every line of a value that begins below its key sits at nested_indent or deeper,
+               // and the first line shallower than that ends it -- so the block is judged against
+               // nested_indent - 1 rather than against the key's column. The two differ when the
+               // key began mid-line ("- key:" as a sequence entry), where the column reaching this
+               // function is the enclosing mapping's, which every line of the value is deeper than;
+               // measuring against it would swallow the entries that follow the skipped one. This
+               // mirrors the parse path, which pushes the same detected indent for the member.
+               //
+               // An indentless sequence sits at its key's own column rather than deeper, so the
+               // key's column is the floor: there the sequence's dashes and the skipped key's
+               // siblings share a column, and only the dash tells them apart.
+               const int32_t value_indent = (nested_indent - 1) > key_indent ? (nested_indent - 1) : key_indent;
+               skip_yaml_value<Opts>(ctx, it, end, in_flow ? 0 : value_indent, in_flow);
             }
          }
       }
@@ -3888,41 +3917,50 @@ namespace glz
                   visit<N>(
                      [&]<size_t I>() {
                         if (I == index) {
-                           decltype(auto) member = [&]() -> decltype(auto) {
-                              if constexpr (reflectable<U>) {
-                                 return get<I>(to_tie(value));
-                              }
-                              else {
-                                 return get_member(value, get<I>(reflect<U>::values));
-                              }
-                           }();
-
-                           using member_type = std::decay_t<decltype(member)>;
-
-                           // Check if value is on same line or next line
-                           if (it != end && !yaml::line_end_or_comment_table[static_cast<uint8_t>(*it)]) {
-                              if (!ctx.push_indent(line_indent + 1)) [[unlikely]]
-                                 return false;
-                              from<YAML, member_type>::template op<Opts>(member, ctx, it, end);
-                              ctx.pop_indent();
+                           // A field that `meta::skip` excludes from parsing still owns its key, so
+                           // the entry is consumed and discarded rather than rejected as unknown.
+                           // The branch is `if constexpr`/`else` so the skipped field's parser is
+                           // never instantiated -- see `skipped_by_meta`.
+                           if constexpr (skipped_by_meta<U, I, operation::parse>) {
+                              skip_unknown_block_value<Opts>(ctx, it, end, line_indent);
                            }
                            else {
-                              int32_t nested_indent = detect_nested_value_indent(ctx, it, end, line_indent);
-                              if (nested_indent >= 0) {
-                                 skip_to_content(it, end);
-                                 if constexpr (discovers_own_block_mapping_indent<member_type>()) {
-                                    if (!ctx.push_indent(nested_indent - 1)) [[unlikely]]
-                                       return false;
+                              decltype(auto) member = [&]() -> decltype(auto) {
+                                 if constexpr (reflectable<U>) {
+                                    return get<I>(to_tie(value));
                                  }
                                  else {
-                                    if (!ctx.push_indent(nested_indent)) [[unlikely]]
-                                       return false;
+                                    return get_member(value, get<I>(reflect<U>::values));
                                  }
-                                 const bool prev_allow_indentless_sequence = ctx.allow_indentless_sequence;
-                                 ctx.allow_indentless_sequence = (nested_indent <= line_indent);
+                              }();
+
+                              using member_type = std::decay_t<decltype(member)>;
+
+                              // Check if value is on same line or next line
+                              if (it != end && !yaml::line_end_or_comment_table[static_cast<uint8_t>(*it)]) {
+                                 if (!ctx.push_indent(line_indent + 1)) [[unlikely]]
+                                    return false;
                                  from<YAML, member_type>::template op<Opts>(member, ctx, it, end);
-                                 ctx.allow_indentless_sequence = prev_allow_indentless_sequence;
                                  ctx.pop_indent();
+                              }
+                              else {
+                                 int32_t nested_indent = detect_nested_value_indent(ctx, it, end, line_indent);
+                                 if (nested_indent >= 0) {
+                                    skip_to_content(it, end);
+                                    if constexpr (discovers_own_block_mapping_indent<member_type>()) {
+                                       if (!ctx.push_indent(nested_indent - 1)) [[unlikely]]
+                                          return false;
+                                    }
+                                    else {
+                                       if (!ctx.push_indent(nested_indent)) [[unlikely]]
+                                          return false;
+                                    }
+                                    const bool prev_allow_indentless_sequence = ctx.allow_indentless_sequence;
+                                    ctx.allow_indentless_sequence = (nested_indent <= line_indent);
+                                    from<YAML, member_type>::template op<Opts>(member, ctx, it, end);
+                                    ctx.allow_indentless_sequence = prev_allow_indentless_sequence;
+                                    ctx.pop_indent();
+                                 }
                               }
                            }
                         }

--- a/include/glaze/yaml/skip.hpp
+++ b/include/glaze/yaml/skip.hpp
@@ -208,6 +208,28 @@ namespace glz::yaml
       }
    }
 
+   // Whether a line reads as a mapping entry ("key: value"), i.e. it holds a ':' followed by a
+   // space or the line end. parse_plain_scalar_multiline applies this same heuristic to refuse to
+   // fold such a line into a multi-line plain scalar, so a skipper that must consume exactly what
+   // the parser would consume has to stop at it as well. `it` is expected at the line's first
+   // non-space character; the scan is deliberately raw (no quote or flow tracking) to stay in
+   // lockstep with the parser's heuristic.
+   template <class It, class End>
+   inline bool line_reads_as_mapping_entry(It it, End end) noexcept
+   {
+      while (it != end && *it != '\n' && *it != '\r') {
+         if (*it == ':') {
+            auto after_colon = it + 1;
+            if (after_colon == end || *after_colon == ' ' || *after_colon == '\t' || *after_colon == '\n' ||
+                *after_colon == '\r') {
+               return true;
+            }
+         }
+         ++it;
+      }
+      return false;
+   }
+
    // Skip a plain scalar (unquoted)
    template <class It, class End>
    inline void skip_plain_scalar(It& it, End end, bool in_flow) noexcept
@@ -217,6 +239,24 @@ namespace glz::yaml
 
          // End of plain scalar
          if (c == '\n' || c == '\r') {
+            if (in_flow) {
+               // A plain scalar in flow context folds across lines: it ends only where the next
+               // content is a flow indicator, a ':', a comment, or the input's end. This mirrors
+               // parse_plain_scalar's flow rule so that skipping a value consumes exactly what
+               // reading it would have -- stopping at the line break instead would leave the
+               // scalar's own continuation to be read as the collection's next entry.
+               auto continuation = it;
+               skip_newline(continuation, end);
+               while (continuation != end && (*continuation == ' ' || *continuation == '\t')) {
+                  ++continuation;
+               }
+               if (continuation == end || *continuation == '#' || *continuation == ',' || *continuation == ']' ||
+                   *continuation == '}' || *continuation == ':') {
+                  break;
+               }
+               it = continuation;
+               continue;
+            }
             break;
          }
 
@@ -419,6 +459,16 @@ namespace glz::yaml
             }
 
             if (line_indent <= current_indent) {
+               it = line_start;
+               break;
+            }
+
+            // A deeper line that reads as a mapping entry is a sibling of the skipped key, not a
+            // continuation of its scalar -- the parser stops there, so the skipper must too. This
+            // matters when the skipped key began mid-line ("- key: value"), where the key's true
+            // column is deeper than the indent this loop is measuring against, and every following
+            // sibling would otherwise be swallowed along with the value.
+            if (line_reads_as_mapping_entry(it, end)) {
                it = line_start;
                break;
             }

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -277,6 +277,23 @@ struct glz::meta<yaml_skip_struct>
    static constexpr bool skip(const std::string_view key, const glz::meta_context&) { return key == "secret"; }
 };
 
+// Struct whose skip fires only while parsing, so writing is left untouched
+struct yaml_skip_on_parse_struct
+{
+   std::string name{};
+   std::string computed{};
+   int version{};
+};
+
+template <>
+struct glz::meta<yaml_skip_on_parse_struct>
+{
+   static constexpr bool skip(const std::string_view key, const glz::meta_context& ctx)
+   {
+      return key == "computed" && ctx.op == glz::operation::parse;
+   }
+};
+
 // Struct with runtime skip_if for YAML
 struct yaml_skip_if_struct
 {
@@ -8935,6 +8952,200 @@ suite yaml_skip_tests = [] {
       expect(yaml.find("name: Bob") != std::string::npos);
       expect(yaml.find("age: 30") != std::string::npos);
       expect(yaml.find("city: LA") != std::string::npos);
+   };
+
+   // A field meta::skip excludes from parsing still owns its key: its entry is consumed and
+   // discarded, leaving the member at whatever value it already held.
+   "yaml_read_skip_ignores_field"_test = [] {
+      yaml_skip_struct obj{"", "untouched", 0};
+      const std::string yaml = "id: abc\nsecret: leaked\ncount: 42\n";
+      auto ec = glz::read_yaml(obj, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(obj.id == "abc");
+      expect(obj.secret == "untouched") << obj.secret;
+      expect(obj.count == 42);
+   };
+
+   "yaml_read_skip_ignores_field_in_flow_style"_test = [] {
+      yaml_skip_struct obj{"", "untouched", 0};
+      const std::string yaml = "{id: abc, secret: leaked, count: 42}";
+      auto ec = glz::read_yaml(obj, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(obj.id == "abc");
+      expect(obj.secret == "untouched") << obj.secret;
+      expect(obj.count == 42);
+   };
+
+   // The skipped entry's value may be a block that spans following lines. All of it belongs to the
+   // skipped key, and the sibling entry after it must still be parsed.
+   "yaml_read_skip_ignores_nested_block_value"_test = [] {
+      yaml_skip_struct obj{"", "untouched", 0};
+      const std::string yaml = R"(id: abc
+secret:
+  nested: value
+  items:
+    - 1
+    - 2
+count: 42
+)";
+      auto ec = glz::read_yaml(obj, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(obj.id == "abc");
+      expect(obj.secret == "untouched") << obj.secret;
+      expect(obj.count == 42);
+   };
+
+   // A skipped key is a known key, so it is accepted rather than rejected as unknown
+   "yaml_read_skip_with_error_on_unknown_keys"_test = [] {
+      yaml_skip_struct obj{"", "untouched", 0};
+      const std::string yaml = "id: abc\nsecret: leaked\ncount: 42\n";
+      expect(!glz::read<glz::yaml::yaml_opts{.error_on_unknown_keys = true}>(obj, yaml));
+      expect(obj.id == "abc");
+      expect(obj.secret == "untouched") << obj.secret;
+      expect(obj.count == 42);
+   };
+
+   // error_on_missing_keys must not require a field that parsing skips
+   "yaml_read_skip_not_required_by_error_on_missing_keys"_test = [] {
+      yaml_skip_struct obj{"", "untouched", 0};
+      const std::string yaml = "id: abc\ncount: 42\n";
+      expect(!glz::read<glz::yaml::yaml_opts{.error_on_missing_keys = true}>(obj, yaml));
+      expect(obj.id == "abc");
+      expect(obj.secret == "untouched") << obj.secret;
+      expect(obj.count == 42);
+   };
+
+   // An implicit "key: value" pair inside a flow collection is read by the block-mapping parser in
+   // flow context, where the value ends at ',' or ']' rather than at a column. A skipped value must
+   // stop at those delimiters too, or the rest of the collection goes with it.
+   "yaml_read_skip_in_implicit_flow_pair"_test = [] {
+      std::vector<yaml_skip_struct> v;
+      const std::string yaml = "[secret: leaked, id: abc]";
+      auto ec = glz::read_yaml(v, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(v.size() == 2u) << v.size();
+      if (v.size() == 2u) {
+         expect(v[0].secret == "") << v[0].secret;
+         expect(v[1].id == "abc") << v[1].id;
+      }
+   };
+
+   // A skipped key that begins mid-line ("- key: value") is measured against the enclosing
+   // mapping's column, not its own, so its value must not swallow the siblings that follow it.
+   "yaml_read_skip_first_key_of_sequence_entry"_test = [] {
+      std::vector<yaml_skip_struct> v;
+      const std::string yaml = R"(- secret: leaked
+  id: abc
+  count: 42
+- secret: also_leaked
+  id: def
+  count: 7
+)";
+      auto ec = glz::read_yaml(v, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(v.size() == 2u) << v.size();
+      if (v.size() == 2u) {
+         expect(v[0].id == "abc") << v[0].id;
+         expect(v[0].count == 42);
+         expect(v[0].secret == "") << v[0].secret;
+         expect(v[1].id == "def") << v[1].id;
+         expect(v[1].count == 7);
+      }
+   };
+
+   // Same shape, but the skipped value is a block that begins on the following lines
+   "yaml_read_skip_nested_value_in_sequence_entry"_test = [] {
+      std::vector<yaml_skip_struct> v;
+      const std::string yaml = R"(- secret:
+    nested: value
+  id: abc
+  count: 42
+)";
+      auto ec = glz::read_yaml(v, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(v.size() == 1u) << v.size();
+      if (v.size() == 1u) {
+         expect(v[0].id == "abc") << v[0].id;
+         expect(v[0].count == 42);
+      }
+   };
+
+   // A multi-line plain scalar under a skipped key folds its deeper continuation lines, then ends
+   // at the first line that reads as a sibling entry
+   "yaml_read_skip_multiline_plain_scalar"_test = [] {
+      yaml_skip_struct obj{};
+      const std::string yaml = R"(secret: first
+  continued
+id: abc
+count: 42
+)";
+      auto ec = glz::read_yaml(obj, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(obj.id == "abc") << obj.id;
+      expect(obj.count == 42);
+   };
+
+   // The skipped value's own deeper entries belong to it, including a nested block that returns to
+   // the value's column. Under error_on_unknown_keys a value cut short would surface as a spurious
+   // unknown key, so this pins the skip to consume exactly the value and no more.
+   "yaml_read_skip_nested_value_returning_to_its_column"_test = [] {
+      yaml_skip_struct obj{};
+      const std::string yaml = R"(secret:
+  first:
+    deep: 1
+  second: 2
+id: abc
+count: 42
+)";
+      expect(!glz::read<glz::yaml::yaml_opts{.error_on_unknown_keys = true}>(obj, yaml))
+         << "the skipped value's own entries must not be reported as unknown keys";
+      expect(obj.id == "abc") << obj.id;
+      expect(obj.count == 42);
+   };
+
+   // An indentless sequence sits at its key's column, where only the dash separates it from the
+   // skipped key's siblings
+   "yaml_read_skip_indentless_sequence_value"_test = [] {
+      yaml_skip_struct obj{};
+      const std::string yaml = R"(secret:
+- 1
+- 2
+id: abc
+count: 42
+)";
+      auto ec = glz::read_yaml(obj, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(obj.id == "abc") << obj.id;
+      expect(obj.count == 42);
+   };
+
+   // A plain scalar in flow context folds across lines, so a skipped one must consume its
+   // continuation rather than leave it to be read as the mapping's next entry
+   "yaml_read_skip_multiline_flow_scalar"_test = [] {
+      yaml_skip_struct obj{};
+      const std::string yaml = "{id: abc, secret: foo\n  bar, count: 42}";
+      auto ec = glz::read_yaml(obj, yaml);
+      expect(!ec) << glz::format_error(ec, yaml);
+      expect(obj.id == "abc") << obj.id;
+      expect(obj.count == 42);
+      expect(obj.secret == "") << obj.secret;
+   };
+
+   // A skip() that fires only on parse excludes nothing from serialization
+   "yaml_skip_on_parse_leaves_serialization_untouched"_test = [] {
+      yaml_skip_on_parse_struct obj{"data", "computed_value", 1};
+      std::string yaml;
+      expect(!glz::write_yaml(obj, yaml));
+      expect(yaml.find("name: data") != std::string::npos) << yaml;
+      expect(yaml.find("computed: computed_value") != std::string::npos) << yaml;
+      expect(yaml.find("version: 1") != std::string::npos) << yaml;
+
+      const std::string input = "name: new\ncomputed: ignored\nversion: 2\n";
+      auto ec = glz::read_yaml(obj, input);
+      expect(!ec) << glz::format_error(ec, input);
+      expect(obj.name == "new");
+      expect(obj.computed == "computed_value") << obj.computed;
+      expect(obj.version == 2);
    };
 };
 


### PR DESCRIPTION
Fixes #2830.

`glz::meta<T>::skip` was honored by the JSON reader and the YAML writer, but not by the YAML reader, so `read_yaml` overwrote fields that `skip` excluded from parsing. `modify = glz::object("b", glz::skip{})` worked because that changes the member's *type*, which never depended on the reader consulting `skip`.

## The fix

`skipped_by_meta<T, I, operation::parse>` was consumed in only two places: `json/read.hpp` and `required_fields()`. Both YAML struct dispatch sites -- the flow-mapping parser and `parse_block_mapping` -- now consume and discard a skipped entry instead of parsing it.

Semantics match JSON: a skipped key is still a *known* key, so it is accepted rather than rejected under `error_on_unknown_keys`, and `error_on_missing_keys` does not require it. The branch is `if constexpr`/`else` per the guidance on `skipped_by_meta`, so the skipped field's parser is never instantiated -- a field skipped *because* its type cannot be parsed still compiles.

## Four skipper divergences fixed along the way

Discarding the entry routes it through the value skipper, which diverged from the parser in four shapes -- each one silently losing data or erroring on a document that previously read. They are pre-existing bugs on the unknown-key path, so fixing them where they live repairs that path too:

| shape | was |
|---|---|
| `[secret: x, id: zzz]` | `skip_unknown_block_value` ignored the flow context and ran through `,` and `]` |
| `- secret: x` / `  id: zzz` | a mid-line first key reports the enclosing mapping's column, so the sibling looked like scalar continuation |
| `secret:` / `  n:` / `    deep: 1` / `  m: 2` | the value was cut short at `m`, surfacing as a spurious `unknown_key` under `error_on_unknown_keys` |
| `{id: abc, secret: foo\n  bar}` | flow scalars fold across lines; the skipper stopped at the line break |

The governing invariant: **a skipped value must consume exactly what parsing it would have consumed.** The key's column stays the floor when judging a nested value, so an indentless sequence still ends where its dashes do.

## Verification

- A 38-document battery run against `main` shows the unknown-key path changed in exactly 8 rows, every one a strict improvement (data recovered, or a spurious `unexpected_end` removed). All other rows byte-identical.
- A second battery asserts skipped ≡ unknown across 28 shapes: all consistent.
- `yaml_test` 760/760, `yaml_conformance` 402/402, `chrono_test` 126/126, `embedded_null_test` 3/3.
- 13 tests added; 10 of them fail on `main`.

## Known divergence, not addressed here

An anchor defined inside a skipped value is not registered, so a later alias to it errors:

```yaml
secret: &anc hello
id: *anc          # syntax_error -- undefined alias
```

Skipped and unknown keys behave identically here, and unknown keys have always behaved this way -- the skipper does not record anchor spans. Making it work means teaching the skipper to register anchors, which is a new capability affecting the unknown-key path broadly, so it is left out of this change.

Separately: `docs/skip-keys.md` still presents `skip` as a JSON feature, and BEVE/CBOR/TOML/CSV/jsonb ignore it on both sides.
