### PR TITLE
run the MSVC Release build only on merges to main

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -34,7 +34,11 @@ jobs:
     strategy:
       matrix:
         cpp_version: [23]
-        build_type: [Debug, Release]
+        # A Release build here runs well past 30 minutes, which is too long to spend on every
+        # push and pull request. It runs on merges to main, where a slow and complete check is
+        # worth having on the record, and on a manual dispatch when a branch wants one before
+        # merging. Everywhere else Debug stands guard on its own.
+        build_type: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && fromJSON('["Debug", "Release"]') || fromJSON('["Debug"]') }}
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
The Release half of the MSVC matrix runs well past 30 minutes, too long to spend on every push and pull request.

The matrix now resolves per event rather than being fixed:

| event | jobs |
|---|---|
| pull request, `feature/*` push | `build (23, Debug)` |
| merge to `main` | `build (23, Debug)`, `build (23, Release)` |
| `workflow_dispatch` | `build (23, Debug)`, `build (23, Release)` |

`&&` binds tighter than `||` in Actions expressions, so `(cond) && fromJSON('["Debug", "Release"]') || fromJSON('["Debug"]')` reads as `((cond && both) || debugOnly)`; a non-empty array is truthy, so a true condition yields both and a false one falls through to Debug alone.

`main` has no required status checks and no rulesets, so a `build (23, Release)` check that no longer reports on pull requests cannot block a merge.

## Tradeoff

Pull requests lose MSVC Release coverage: optimizer-dependent breakage, and warnings that only fire under `/O2`, now surface after merge rather than before. `workflow_dispatch` is the escape hatch for a branch that wants one first, but it is opt-in, so in practice most pull requests will not have one. If that is too loose, the middle ground is keeping Release on pull requests with a trimmed set of targets rather than dropping it.

Open pull requests pick this up on their next run once it is on `main`, since `pull_request` runs use the workflow from the merge ref.
