### PR TITLE
write std::pair as a nested block mapping in YAML

### DIFF
--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -2529,7 +2529,9 @@ namespace glz
       constexpr bool receives_block_mapping_column()
       {
          using V = std::remove_cvref_t<T>;
-         if constexpr (glaze_object_t<V> || reflectable<V>) {
+         // A pair is a single-entry mapping and reads the pushed indent as its own key column,
+         // exactly like a struct -- see from<YAML, pair_t>.
+         if constexpr (glaze_object_t<V> || reflectable<V> || pair_t<V>) {
             return true;
          }
          else if constexpr (glaze_value_t<V>) {
@@ -4410,8 +4412,34 @@ namespace glz
             ++it;
             yaml::skip_inline_ws(it, end);
 
-            // Parse value
-            from<YAML, second_type>::template op<Opts>(value.second, ctx, it, end);
+            // Parse value. A pair is a single-entry mapping, so its value half follows the same
+            // same-line / next-line layout rules as a map entry (see parse_map_value in the map
+            // reader). Without the next-line arm a nested value -- a container, object, or another
+            // pair, all of which the writer indents onto the following line -- fails to parse.
+            // Like a struct, a pair reads the pushed indent as its own key column
+            // (receives_block_mapping_column), so every dispatcher agrees on what was pushed.
+            const int32_t line_indent = (ctx.current_indent() < 0) ? 0 : ctx.current_indent();
+
+            if (it != end && !yaml::line_end_or_comment_table[static_cast<uint8_t>(*it)]) {
+               if (!ctx.push_indent(line_indent + 1)) [[unlikely]]
+                  return;
+               from<YAML, second_type>::template op<Opts>(value.second, ctx, it, end);
+               ctx.pop_indent();
+            }
+            else {
+               const int32_t nested_indent = yaml::detect_nested_value_indent(ctx, it, end, line_indent);
+               if (nested_indent >= 0) {
+                  yaml::skip_to_content(it, end);
+                  // A struct value reads the pushed indent as its own key column;
+                  // every other value type reads it as the enclosing baseline.
+                  const int32_t value_indent =
+                     yaml::receives_block_mapping_column<second_type>() ? nested_indent : nested_indent - 1;
+                  if (!ctx.push_indent(value_indent)) [[unlikely]]
+                     return;
+                  from<YAML, second_type>::template op<Opts>(value.second, ctx, it, end);
+                  ctx.pop_indent();
+               }
+            }
          }
       }
    };

--- a/include/glaze/yaml/write.hpp
+++ b/include/glaze/yaml/write.hpp
@@ -467,6 +467,12 @@ namespace glz
       inline void write_block_mapping(T&& value, is_context auto&& ctx, B&& b, auto& ix, int32_t indent_level,
                                       bool skip_first_indent = false);
 
+      // Forward declaration for pairs written as single-entry block mappings
+      // (definition needs write_block_mapping_value).
+      template <auto Opts, class T, class B>
+      inline void write_block_pair(T&& value, is_context auto&& ctx, B&& b, auto& ix, int32_t indent_level,
+                                   bool skip_first_indent = false);
+
       // Forward declaration for tagged-variant block output (definition needs write_block_mapping).
       template <auto Opts, class Variant, class T, class B>
       inline void write_tagged_block_object(T&& inner, size_t index, is_context auto&& ctx, B&& b, auto& ix,
@@ -733,6 +739,11 @@ namespace glz
                dump(' ', b, ix);
                write_block_mapping<Opts>(element, ctx, b, ix, indent_level + 1, true);
             }
+            else if constexpr (pair_t<element_t>) {
+               // A pair is a single-entry mapping - compact form, entry inline after dash
+               dump(' ', b, ix);
+               write_block_pair<Opts>(element, ctx, b, ix, indent_level + 1, true);
+            }
             else if constexpr (has_custom_meta_v<element_t>) {
                // Types with top-level custom serialization produce scalar output -
                // write inline after dash
@@ -747,7 +758,7 @@ namespace glz
                write_block_mapping_nested<Opts>(element, ctx, b, ix, indent_level + 1);
             }
             else {
-               // Other types (pairs, tuples, etc.) - write inline after dash
+               // Other types (tuples, custom scalars, etc.) - write inline after dash
                dump(' ', b, ix);
                serialize<YAML>::op<Opts>(element, ctx, b, ix);
                dump('\n', b, ix);
@@ -919,13 +930,11 @@ namespace glz
       template <auto Opts, class B>
       static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
       {
-         const auto& [key, val] = value;
-
-         using first_type = typename std::remove_cvref_t<T>::first_type;
-         using second_type = typename std::remove_cvref_t<T>::second_type;
-
          if constexpr (yaml::check_flow_style(Opts) || yaml::check_flow_context(Opts)) {
             // Flow style: {key: value}
+            using first_type = typename std::remove_cvref_t<T>::first_type;
+            const auto& [key, val] = value;
+
             if (!ensure_space(ctx, b, ix + 8)) [[unlikely]] {
                return;
             }
@@ -947,41 +956,12 @@ namespace glz
             dump('}', b, ix);
          }
          else {
-            // Block style: key: value
-            constexpr uint8_t indent_width = yaml::check_indent_width(yaml::yaml_opts{});
+            // Block style: a pair is a single-entry mapping
             int32_t indent_level = 0;
             if constexpr (requires { ctx.indent_level; }) {
                indent_level = ctx.indent_level;
             }
-
-            // Write indentation
-            const int32_t spaces = indent_level * indent_width;
-            if (!ensure_space(ctx, b, ix + spaces + 64)) [[unlikely]] {
-               return;
-            }
-            for (int32_t i = 0; i < spaces; ++i) {
-               b[ix++] = ' ';
-            }
-
-            // Write key
-            if constexpr (str_t<first_type>) {
-               yaml::write_yaml_string<Opts>(str_view<first_type>(key), ctx, b, ix);
-            }
-            else {
-               serialize<YAML>::op<Opts>(key, ctx, b, ix);
-            }
-
-            dump(':', b, ix);
-
-            if constexpr (yaml::is_simple_type<second_type>()) {
-               dump(' ', b, ix);
-               serialize<YAML>::op<Opts>(val, ctx, b, ix);
-               dump('\n', b, ix);
-            }
-            else {
-               dump('\n', b, ix);
-               serialize<YAML>::op<Opts>(val, ctx, b, ix);
-            }
+            yaml::write_block_pair<Opts>(value, ctx, b, ix, indent_level);
          }
       }
    };
@@ -1095,8 +1075,9 @@ namespace glz
             }
          }
          else if constexpr (writable_map_t<val_t> || writable_array_t<val_t> || glaze_object_t<val_t> ||
-                            reflectable<val_t>) {
-            // Complex types go on next line with increased indent
+                            reflectable<val_t> || pair_t<val_t>) {
+            // Complex types go on next line with increased indent. A pair is a single-entry
+            // mapping, so it nests like a map rather than sharing the key's line (issue #2829).
             dump('\n', b, ix);
 
             // Create a modified context with incremented indent level
@@ -1115,6 +1096,64 @@ namespace glz
             dump(' ', b, ix);
             serialize<YAML>::op<Opts>(member, ctx, b, ix);
             dump('\n', b, ix);
+         }
+      }
+
+      // Write a pair as a single-entry block mapping: `key: value`. Layout of the value half is
+      // shared with object members and map entries, so a pair whose second type is a container or
+      // object nests on the following line instead of running onto the key's line (issue #2829).
+      // `skip_first_indent` suppresses the leading indentation for the compact `- key: value` form.
+      template <auto Opts, class T, class B>
+      inline void write_block_pair(T&& value, is_context auto&& ctx, B&& b, auto& ix, int32_t indent_level,
+                                   bool skip_first_indent)
+      {
+         using V = std::remove_cvref_t<T>;
+         using first_type = typename V::first_type;
+         using second_type = std::remove_cvref_t<typename V::second_type>;
+         constexpr uint8_t indent_width = check_indent_width(yaml_opts{});
+
+         if (bool(ctx.error)) [[unlikely]]
+            return;
+
+         const auto& [key, val] = value;
+
+         const int32_t spaces = skip_first_indent ? 0 : indent_level * indent_width;
+         if (!ensure_space(ctx, b, ix + spaces + 8)) [[unlikely]] {
+            return;
+         }
+         for (int32_t i = 0; i < spaces; ++i) {
+            b[ix++] = ' ';
+         }
+
+         // Write key
+         if constexpr (str_t<first_type>) {
+            write_yaml_string<Opts>(str_view<first_type>(key), ctx, b, ix);
+         }
+         else {
+            serialize<YAML>::op<Opts>(key, ctx, b, ix);
+         }
+
+         // write_block_mapping reserves `key.size() + 8` up front because its keys are known at
+         // compile time. A pair's key is a runtime value whose writer reserves only what the key
+         // itself needs (as little as 8 bytes total for a bool/char/null key), so the slack the
+         // ':' and the unguarded leading dumps in write_block_mapping_value rely on has to be
+         // re-established here.
+         if (!ensure_space(ctx, b, ix + 8)) [[unlikely]] {
+            return;
+         }
+
+         dump(':', b, ix);
+
+         // A value exposed through a transparent write wrapper is laid out by the type it resolves
+         // to, matching write_block_mapping's handling of such members (issue #2595).
+         if constexpr (transparent_write_wrapper<second_type> && !is_or_wraps_variant<second_type>()) {
+            unwrap_write_value(val, ctx, [&]<class Inner>(Inner&& inner) {
+               write_block_mapping_value<Opts, std::remove_cvref_t<Inner>>(std::forward<Inner>(inner), ctx, b, ix,
+                                                                           indent_level);
+            });
+         }
+         else {
+            write_block_mapping_value<Opts, second_type>(val, ctx, b, ix, indent_level);
          }
       }
 
@@ -1245,6 +1284,9 @@ namespace glz
          }
          else if constexpr (writable_array_t<V>) {
             write_block_sequence<Opts>(value, ctx, b, ix, indent_level);
+         }
+         else if constexpr (pair_t<V>) {
+            write_block_pair<Opts>(value, ctx, b, ix, indent_level);
          }
          else if constexpr (writable_map_t<V>) {
             // Map handling

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -11683,4 +11683,346 @@ suite yaml_under_indented_block_value_tests = [] {
    };
 };
 
+namespace i2829
+{
+   struct pair_wrapper
+   {
+      std::pair<double, double> value{};
+      bool operator==(const pair_wrapper&) const = default;
+   };
+
+   struct inner
+   {
+      int a{};
+      std::string b{};
+      bool operator==(const inner&) const = default;
+   };
+
+   struct map_wrapper
+   {
+      std::map<std::string, int> value{};
+      bool operator==(const map_wrapper&) const = default;
+   };
+
+   struct str_pair_wrapper
+   {
+      std::pair<std::string, int> value{};
+      bool operator==(const str_pair_wrapper&) const = default;
+   };
+
+   // Struct members used to reach the pair reader through the struct dispatcher, which pushes a
+   // different indent than the map dispatcher does.
+   struct pair_of_string
+   {
+      std::pair<std::string, std::string> p{};
+      bool operator==(const pair_of_string&) const = default;
+   };
+
+   struct pair_of_object
+   {
+      std::pair<std::string, inner> p{};
+      bool operator==(const pair_of_object&) const = default;
+   };
+
+   struct pair_of_map
+   {
+      std::pair<std::string, std::map<std::string, int>> p{};
+      bool operator==(const pair_of_map&) const = default;
+   };
+
+   struct pair_of_seq
+   {
+      std::pair<std::string, std::vector<int>> p{};
+      bool operator==(const pair_of_seq&) const = default;
+   };
+
+   // Transparent write wrapper over a sequence; `mimic` makes it serialize exactly as its
+   // single member, so the pair writer must lay it out by the resolved type.
+   struct mimic_seq
+   {
+      std::vector<int> v{};
+      bool operator==(const mimic_seq&) const = default;
+   };
+
+   struct nested_pairs
+   {
+      std::pair<std::string, std::vector<int>> seq{};
+      std::pair<std::string, std::map<std::string, int>> mapping{};
+      std::pair<std::string, inner> object{};
+      std::pair<std::string, std::pair<std::string, int>> nested{};
+      bool operator==(const nested_pairs&) const = default;
+   };
+}
+
+template <>
+struct glz::meta<i2829::mimic_seq>
+{
+   using mimic = std::vector<int>;
+   static constexpr auto value = &i2829::mimic_seq::v;
+};
+
+// A pair is a single-entry mapping, so in block style it nests under its key rather than
+// running onto the key's line (which produced the invalid "value: 0.5: -3.25").
+suite issue_2829_pair_block_layout = [] {
+   using namespace i2829;
+
+   "pair member nests under its key"_test = [] {
+      const pair_wrapper w{{0.5, -3.25}};
+      const auto written = glz::write_yaml(w);
+      expect(written.has_value());
+      expect(written.value() == "value:\n  0.5: -3.25\n") << written.value();
+
+      pair_wrapper parsed{};
+      const auto ec = glz::read_yaml(parsed, written.value());
+      expect(!ec) << glz::format_error(ec, written.value());
+      expect(parsed == w);
+   };
+
+   "pair member matches a single-entry map member"_test = [] {
+      const map_wrapper m{{{"answer", 42}}};
+      const str_pair_wrapper p{{"answer", 42}};
+
+      const auto ms = glz::write_yaml(m);
+      const auto ps = glz::write_yaml(p);
+      expect(ms.has_value());
+      expect(ps.has_value());
+      expect(ms.value() == ps.value()) << ps.value();
+   };
+
+   "pair values that are containers or objects nest one level deeper"_test = [] {
+      nested_pairs original{};
+      original.seq = {"nums", {1, 2, 3}};
+      original.mapping = {"m", {{"x", 1}, {"y", 2}}};
+      original.object = {"o", {7, "seven"}};
+      original.nested = {"outer", {"inner", 3}};
+
+      const auto written = glz::write_yaml(original);
+      expect(written.has_value());
+      expect(written.value() ==
+             "seq:\n"
+             "  nums:\n"
+             "    - 1\n"
+             "    - 2\n"
+             "    - 3\n"
+             "mapping:\n"
+             "  m:\n"
+             "    x: 1\n"
+             "    y: 2\n"
+             "object:\n"
+             "  o:\n"
+             "    a: 7\n"
+             "    b: seven\n"
+             "nested:\n"
+             "  outer:\n"
+             "    inner: 3\n")
+         << written.value();
+
+      nested_pairs parsed{};
+      const auto ec = glz::read_yaml(parsed, written.value());
+      expect(!ec) << glz::format_error(ec, written.value());
+      expect(parsed == original);
+   };
+
+   "block sequence of pairs uses the compact dash form"_test = [] {
+      const std::vector<std::pair<std::string, int>> original{{"a", 1}, {"b", 2}};
+      const auto written = glz::write_yaml(original);
+      expect(written.has_value());
+      expect(written.value() == "- a: 1\n- b: 2\n") << written.value();
+
+      std::vector<std::pair<std::string, int>> parsed{};
+      const auto ec = glz::read_yaml(parsed, written.value());
+      expect(!ec) << glz::format_error(ec, written.value());
+      expect(parsed == original);
+   };
+
+   "block sequence of pairs holding sequences"_test = [] {
+      const std::vector<std::pair<std::string, std::vector<int>>> original{{"a", {1, 2}}, {"b", {3}}};
+      const auto written = glz::write_yaml(original);
+      expect(written.has_value());
+      expect(written.value() ==
+             "- a:\n"
+             "    - 1\n"
+             "    - 2\n"
+             "- b:\n"
+             "    - 3\n")
+         << written.value();
+
+      std::vector<std::pair<std::string, std::vector<int>>> parsed{};
+      const auto ec = glz::read_yaml(parsed, written.value());
+      expect(!ec) << glz::format_error(ec, written.value());
+      expect(parsed == original);
+   };
+
+   "map value that is a pair nests under its key"_test = [] {
+      const std::map<std::string, std::pair<std::string, int>> original{{"x", {"a", 1}}};
+      const auto written = glz::write_yaml(original);
+      expect(written.has_value());
+      expect(written.value() == "x:\n  a: 1\n") << written.value();
+
+      std::map<std::string, std::pair<std::string, int>> parsed{};
+      const auto ec = glz::read_yaml(parsed, written.value());
+      expect(!ec) << glz::format_error(ec, written.value());
+      expect(parsed == original);
+   };
+
+   "empty container pair value stays inline"_test = [] {
+      const std::pair<std::string, std::vector<int>> original{"e", {}};
+      const auto written = glz::write_yaml(original);
+      expect(written.has_value());
+      expect(written.value() == "e: []\n") << written.value();
+
+      std::pair<std::string, std::vector<int>> parsed{"", {9}};
+      const auto ec = glz::read_yaml(parsed, written.value());
+      expect(!ec) << glz::format_error(ec, written.value());
+      expect(parsed == original);
+   };
+
+   // The struct, map, and sequence dispatchers each push an indent before handing off to the
+   // pair reader; all three must agree that what they pushed is the pair's key column, or the
+   // pair rejects layouts the equivalent map accepts.
+   "reader accepts every child column the equivalent map accepts"_test = [] {
+      {
+         pair_of_string v{};
+         const std::string yaml = "p:\n  k: foo\n   bar\n";
+         const auto ec = glz::read_yaml(v, yaml);
+         expect(!ec) << glz::format_error(ec, yaml);
+         expect(v.p.first == "k");
+         expect(v.p.second == "foo bar");
+      }
+      {
+         pair_of_string v{};
+         const std::string yaml = "p:\n  k: |\n   a\n";
+         const auto ec = glz::read_yaml(v, yaml);
+         expect(!ec) << glz::format_error(ec, yaml);
+         expect(v.p.second == "a\n");
+      }
+      {
+         pair_of_object v{};
+         const std::string yaml = "p:\n  k:\n   a: 1\n   b: x\n";
+         const auto ec = glz::read_yaml(v, yaml);
+         expect(!ec) << glz::format_error(ec, yaml);
+         expect(v.p.second == inner{1, "x"});
+      }
+      {
+         pair_of_map v{};
+         const std::string yaml = "p:\n  k:\n   x: 1\n";
+         const auto ec = glz::read_yaml(v, yaml);
+         expect(!ec) << glz::format_error(ec, yaml);
+         expect(v.p.second.at("x") == 1);
+      }
+      {
+         // An indentless sequence under a pair key. This used to "succeed" while silently
+         // dropping every element.
+         pair_of_seq v{};
+         const std::string yaml = "p:\n  k:\n  - 1\n  - 2\n";
+         const auto ec = glz::read_yaml(v, yaml);
+         expect(!ec) << glz::format_error(ec, yaml);
+         expect(v.p.second == std::vector{1, 2});
+      }
+      {
+         pair_of_seq v{};
+         const std::string yaml = "p:\n  k:\n   - 1\n   - 2\n";
+         const auto ec = glz::read_yaml(v, yaml);
+         expect(!ec) << glz::format_error(ec, yaml);
+         expect(v.p.second == std::vector{1, 2});
+      }
+   };
+
+   "pair value behind a transparent write wrapper nests by its resolved type"_test = [] {
+      {
+         // Resolves to an object.
+         const std::pair<std::string, i2595::mimic_leaf> original{"k", {{"asdf", 7}}};
+         const auto written = glz::write_yaml(original);
+         expect(written.has_value());
+         expect(written.value() == "k:\n  name: asdf\n  id: 7\n") << written.value();
+
+         std::pair<std::string, i2595::mimic_leaf> parsed{};
+         const auto ec = glz::read_yaml(parsed, written.value());
+         expect(!ec) << glz::format_error(ec, written.value());
+         expect(parsed == original);
+      }
+      {
+         // Resolves to a sequence.
+         const std::pair<std::string, mimic_seq> original{"k", {{1, 2}}};
+         const auto written = glz::write_yaml(original);
+         expect(written.has_value());
+         expect(written.value() == "k:\n  - 1\n  - 2\n") << written.value();
+
+         std::pair<std::string, mimic_seq> parsed{};
+         const auto ec = glz::read_yaml(parsed, written.value());
+         expect(!ec) << glz::format_error(ec, written.value());
+         expect(parsed == original);
+      }
+   };
+
+   // A pair's key is a runtime value, so unlike a struct's compile-time key the writer cannot
+   // fold its length into the up-front reservation. A fixed buffer must report an error rather
+   // than run past its end.
+   "bounded buffer write reports an error instead of overflowing"_test = [] {
+      constexpr glz::yaml::yaml_opts opts{};
+      {
+         const std::pair<bool, std::vector<int>> p{false, {}};
+         std::array<char, 8> buffer{};
+         const auto ec = glz::write<opts>(p, buffer);
+         expect(ec.ec == glz::error_code::buffer_overflow);
+      }
+      {
+         const std::pair<char, std::map<std::string, int>> p{'x', {}};
+         std::array<char, 8> buffer{};
+         const auto ec = glz::write<opts>(p, buffer);
+         expect(ec.ec == glz::error_code::buffer_overflow);
+      }
+      {
+         // Enough room for the whole document, so it must succeed.
+         const std::pair<bool, std::vector<int>> p{false, {}};
+         std::array<char, 32> buffer{};
+         const auto ec = glz::write<opts>(p, buffer);
+         expect(!ec);
+         expect(std::string_view{buffer.data()} == "false: []\n");
+      }
+   };
+
+   "glz::pair matches std::pair"_test = [] {
+      const glz::pair<std::string, std::vector<int>> original{"k", {1, 2}};
+      const auto written = glz::write_yaml(original);
+      expect(written.has_value());
+      expect(written.value() == glz::write_yaml(std::pair<std::string, std::vector<int>>{"k", {1, 2}}).value())
+         << written.value();
+      expect(written.value() == "k:\n  - 1\n  - 2\n") << written.value();
+   };
+
+   "non-string key with a nested value"_test = [] {
+      const std::pair<int, std::vector<int>> original{7, {1, 2}};
+      const auto written = glz::write_yaml(original);
+      expect(written.has_value());
+      expect(written.value() == "7:\n  - 1\n  - 2\n") << written.value();
+
+      std::pair<int, std::vector<int>> parsed{};
+      const auto ec = glz::read_yaml(parsed, written.value());
+      expect(!ec) << glz::format_error(ec, written.value());
+      expect(parsed == original);
+   };
+
+   "flow style is unchanged"_test = [] {
+      nested_pairs original{};
+      original.seq = {"nums", {1, 2, 3}};
+      original.mapping = {"m", {{"x", 1}}};
+      original.object = {"o", {7, "seven"}};
+      original.nested = {"outer", {"inner", 3}};
+
+      std::string buffer{};
+      constexpr glz::yaml::yaml_opts opts{.flow_style = true};
+      expect(!glz::write<opts>(original, buffer));
+      expect(buffer ==
+             "{seq: {nums: [1, 2, 3]}, mapping: {m: {x: 1}}, object: {o: {a: 7, b: seven}}, "
+             "nested: {outer: {inner: 3}}}")
+         << buffer;
+
+      nested_pairs parsed{};
+      const auto ec = glz::read_yaml(parsed, buffer);
+      expect(!ec) << glz::format_error(ec, buffer);
+      expect(parsed == original);
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
Fixes #2829.

## The bug

A `std::pair` member wrote invalid YAML:

```cpp
struct PairWrapper { std::pair<double, double> value{}; };
glz::write_yaml(PairWrapper{{0.5, -3.25}});
```

```yaml
value: 0.5: -3.25   # before
```

```yaml
value:              # after
  0.5: -3.25
```

## Root cause

A pair is a single-entry mapping, but in block style every writer path routed it into the "assume scalar, write on the same line" branch. The pair writer also read `ctx.indent_level`, a member that does not exist anywhere in the codebase, so the `requires` guard around it was always false and the pair's indentation was pinned to zero — a pair holding a container or object came out at column 0 no matter how deeply nested:

```yaml
pv: nums:
- 1
- 2
```

On the read side, the block arm of `from<YAML, pair_t>` parsed the value immediately after the colon with no next-line handling, so a correctly indented nested value could not be read back.

## Changes

**Writer.** New `yaml::write_block_pair` writes the pair as the single-entry mapping it is: indentation (suppressible for the compact `- key: value` form), key, `:`, then the value half through the existing `write_block_mapping_value` — the same layout routine used by object members and map entries, including the transparent-write-wrapper unwrap from #2595. Pairs now nest from `write_block_mapping_value`, `write_block_mapping_nested`, and `write_block_sequence`. Output matches a one-entry `std::map` exactly.

Because a pair's key is a runtime value, the writer cannot fold its length into the up-front reservation the way `write_block_mapping` folds in `key.size()`. That slack is re-established after the key is written; a `bool`, `char`, or null key otherwise leaves too little room for the `:` and the unguarded leading dumps in `write_block_mapping_value`, which overran fixed-size buffers.

**Reader.** The block arm now mirrors the map reader's same-line / next-line dispatch. `pair_t` joins `receives_block_mapping_column` so the struct, map, and sequence dispatchers agree that what they push is the pair's key column — they disagreed by one, and a pair reached through a struct member rejected child columns the equivalent map accepts and silently dropped every element of an indentless sequence.

Flow style is unchanged. The only reader behavior changes are inputs that previously errored, plus `key:` with no value now yielding a default-constructed value, which is what a map entry already did.

## Tests

New `issue_2829_pair_block_layout` suite in `tests/yaml_test/yaml_test.cpp` (13 tests): the reported case, pair-vs-map layout parity, container/object/nested-pair values, sequences of pairs, map values that are pairs, empty containers, non-string keys with nested values, `glz::pair`, transparent write wrappers, reader-only inputs at each accepted child column, bounded-buffer writes, and flow style.

Each regression test was verified to fail against the unfixed code.

Full suite passes: 119/119 ctest targets, `yaml_test` 774 tests / 2916 asserts, `yaml_conformance` 402, `yaml_conformance_struct` 105. ASAN + UBSAN clean across a sweep of fixed buffer sizes 1–64 and every scalar key type.

## Pre-existing issues found but not addressed here

Unchanged by this PR, byte-identical before and after — mentioning them in case they are worth their own issues:

- `std::tuple` as a struct member writes invalid block YAML via the `glaze_array_t` / `is_std_tuple` path (`t: - 1\n- 2`).
- A pair with a non-scalar key writes garbage (`std::pair<std::pair<int,int>,int>` → `1: 2\n: 3`).
- `std::variant` with a pair alternative cannot be read at all. The writer now produces correct YAML for it, which the reader still rejects.
