### PR TITLE
Cap YAML nesting at its own depth limit so deep input cannot overflow the stack

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -270,7 +270,7 @@ If the payload legitimately contains control bytes, opt in with `escape_control_
 
 When parsing JSON from untrusted sources:
 
-1. **Recursion depth is bounded**: the readers, skippers, and format converters cap nesting at `max_recursive_depth_limit` (256 levels) and return `error_code::exceeded_max_recursive_depth`, so deeply nested input cannot overflow the stack. Every object and every array counts as a level, so a struct holding a vector of itself reaches the cap at 128 struct levels. Flatten your data structures if you legitimately need to exceed that.
+1. **Recursion depth is bounded**: the readers, skippers, and format converters cap nesting at `max_recursive_depth_limit` (256 levels) and return `error_code::exceeded_max_recursive_depth`, so deeply nested input cannot overflow the stack. Every object and every array counts as a level, so a struct holding a vector of itself reaches the cap at 128 struct levels. YAML caps lower, at `glz::yaml::max_yaml_recursive_depth` (64 levels): a YAML level routes through the variant reader's speculative mapping probe and costs several times the stack a JSON level does, so it has to stop sooner to stay inside the same stack. Flatten your data structures if you legitimately need to exceed that.
 
 2. **Limit string sizes**: Very large strings can consume excessive memory. Control this through input buffer size limits.
 

--- a/include/glaze/core/context.hpp
+++ b/include/glaze/core/context.hpp
@@ -172,15 +172,19 @@ namespace glz
    // ctx.depth as a completion counter (a value that closed cleanly ends at depth 0, which is how
    // finalize_read_context tells "the buffer ended exactly here" from "the buffer was truncated"),
    // so they count by hand and enforce the same limit inline.
+   //
+   // `limit` defaults to the shared cap but is a parameter because the cap is a stack budget, not a
+   // document property: a reader whose levels cost several times what a JSON level costs has to
+   // stop several times sooner to stay inside the same stack. See `yaml::max_yaml_recursive_depth`.
    template <class Ctx>
    struct depth_guard
    {
       Ctx& ctx;
       bool entered = false;
 
-      depth_guard(Ctx& c) noexcept : ctx(c)
+      depth_guard(Ctx& c, const size_t limit = max_recursive_depth_limit) noexcept : ctx(c)
       {
-         if (ctx.depth >= max_recursive_depth_limit) [[unlikely]] {
+         if (ctx.depth >= limit) [[unlikely]] {
             ctx.error = error_code::exceeded_max_recursive_depth;
             return;
          }

--- a/include/glaze/yaml/common.hpp
+++ b/include/glaze/yaml/common.hpp
@@ -48,6 +48,18 @@ namespace glz::yaml
    inline constexpr size_t max_key_expansion_factor = 64;
    inline constexpr size_t min_key_expansion_bytes = 8 << 20;
 
+   // How deeply a YAML document may nest. Lower than the shared `max_recursive_depth_limit`
+   // because the cap is a stack budget rather than a statement about documents, and a YAML level
+   // is not a JSON level: a generic value routes through the variant reader, which speculatively
+   // parses an alternative before committing to it, so one level of nesting is a chain of large
+   // frames (variant op -> block-mapping probe -> map op -> value) instead of a single small one.
+   // Measured on the generic reader, a block-mapping level costs ~6x what a JSON one does, which
+   // put 256 levels past an 8 MB stack in an unoptimized sanitizer build -- the depth guard
+   // reported the limit, but only after the stack was already gone. This cap keeps the deepest
+   // accepted YAML document inside roughly the same stack that the shared cap buys JSON, and it
+   // stays far above what real documents nest.
+   inline constexpr size_t max_yaml_recursive_depth = 64;
+
    // YAML-specific context extending the base context
    // Adds indent tracking needed for block-style parsing
    struct yaml_context : context
@@ -57,7 +69,7 @@ namespace glz::yaml
       // back() gives the current block indent level.
       std::vector<int16_t> indent_stack = [] {
          std::vector<int16_t> v;
-         v.reserve(max_recursive_depth_limit);
+         v.reserve(max_yaml_recursive_depth);
          return v;
       }();
 
@@ -65,7 +77,7 @@ namespace glz::yaml
 
       bool push_indent(int32_t indent) noexcept
       {
-         if (indent_stack.size() >= max_recursive_depth_limit) [[unlikely]] {
+         if (indent_stack.size() >= max_yaml_recursive_depth) [[unlikely]] {
             error = error_code::exceeded_max_recursive_depth;
             return false;
          }

--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -311,7 +311,7 @@ namespace glz
          // depth guard, so this is the only depth accounting a chain of aliases into a
          // non-variant target gets. The cycle check above stops the unbounded case; this bounds
          // a legitimate but deeply chained one.
-         depth_guard guard{ctx};
+         depth_guard guard{ctx, yaml::max_yaml_recursive_depth};
          if (!guard) [[unlikely]]
             return true;
 
@@ -5601,7 +5601,7 @@ namespace glz
          // Every nested generic/variant value routes back through this reader, so bounding
          // depth here caps flow-collection and flow-embedded mapping recursion that the
          // indent stack does not cover.
-         depth_guard guard{ctx};
+         depth_guard guard{ctx, yaml::max_yaml_recursive_depth};
          if (!guard) [[unlikely]]
             return;
 

--- a/include/glaze/yaml/skip.hpp
+++ b/include/glaze/yaml/skip.hpp
@@ -134,7 +134,7 @@ namespace glz::yaml
       // Nested flow collections with alternating delimiters ("[{[{...") recurse one frame per
       // delimiter, so bound the recursion to stop adversarial skipped input from overflowing the
       // stack. Same-delimiter nesting ("[[[[") is handled by the loop below without recursing.
-      depth_guard guard{ctx};
+      depth_guard guard{ctx, yaml::max_yaml_recursive_depth};
       if (!guard) [[unlikely]] {
          return;
       }

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -10862,8 +10862,9 @@ suite recursion_depth_tests = [] {
    "flow nesting at the depth limit boundary"_test = [] {
       // Pin the exact contract against the named constant: a generic value nested exactly to the
       // limit parses, one level deeper is rejected. The bracket-count-based deep tests above sit far
-      // from the boundary and would not catch an off-by-one in the guard.
-      constexpr size_t limit = glz::max_recursive_depth_limit;
+      // from the boundary and would not catch an off-by-one in the guard. YAML caps lower than the
+      // shared limit because a YAML level costs several times the stack a JSON one does.
+      constexpr size_t limit = glz::yaml::max_yaml_recursive_depth;
       {
          const std::string yaml = std::string(limit, '[') + std::string(limit, ']');
          glz::generic value{};
@@ -10872,6 +10873,37 @@ suite recursion_depth_tests = [] {
       }
       {
          const std::string yaml = std::string(limit + 1, '[') + std::string(limit + 1, ']');
+         glz::generic value{};
+         auto ec = glz::read_yaml(value, yaml);
+         expect(ec.ec == glz::error_code::exceeded_max_recursive_depth);
+      }
+   };
+
+   "block mapping nesting at the depth limit boundary"_test = [] {
+      // Block mappings are the expensive shape: every level runs the variant reader's speculative
+      // mapping probe, so one level is a chain of large frames rather than a single small one. This
+      // is what exhausted the stack before the limit could report itself back when YAML shared the
+      // JSON cap. The innermost scalar is a level of its own, so `limit - 1` mappings is the
+      // deepest document that fits.
+      constexpr size_t limit = glz::yaml::max_yaml_recursive_depth;
+      const auto nested = [](const size_t mappings) {
+         std::string yaml{};
+         for (size_t i = 0; i < mappings; ++i) {
+            yaml += std::string(2 * i, ' ');
+            yaml += "k:\n";
+         }
+         yaml += std::string(2 * mappings, ' ');
+         yaml += "v\n";
+         return yaml;
+      };
+      {
+         const std::string yaml = nested(limit - 1);
+         glz::generic value{};
+         auto ec = glz::read_yaml(value, yaml);
+         expect(!ec) << glz::format_error(ec, yaml);
+      }
+      {
+         const std::string yaml = nested(limit);
          glz::generic value{};
          auto ec = glz::read_yaml(value, yaml);
          expect(ec.ec == glz::error_code::exceeded_max_recursive_depth);


### PR DESCRIPTION
Fixes a stack overflow in the YAML reader found by fuzzing (`yaml_generic`).

The depth guard was working -- the parse ended with `exceeded_max_recursive_depth` -- but the stack was already exhausted by the time the limit was reached. One level of YAML nesting is not one level of JSON nesting: a generic value routes through the variant reader, which speculatively parses an alternative before committing to it, so a level is a chain of large frames (`variant op -> block-mapping probe -> map op -> value`) rather than a single small one.

Measured stack per nesting level on `glz::generic`:

| build | JSON | YAML |
|---|---|---|
| `-O2` | 373 B | 1,416 B |
| `-O0 -fsanitize=address` | 3.5 KB | 21 KB |

At the shared limit of 256, YAML needed ~5.4 MB for plain nesting and more than the 8 MB main stack for the reported input, where JSON needs ~890 KB for the same 256 levels.

The recursion cap is a stack budget rather than a statement about documents, so YAML now has its own:

- `glz::yaml::max_yaml_recursive_depth` (64), used by the YAML `depth_guard` sites, `push_indent`, and the indent stack's reserve.
- `glz::depth_guard` takes the limit as a defaulted constructor argument, leaving every other format unchanged.

Peak stack for the reported input drops from over 8 MB to 1.35 MB in an unoptimized sanitizer build, and a max-depth document costs ~90 KB in a release build, which also makes the reader safe on small thread stacks.

**Behavior change:** YAML documents nesting deeper than 64 levels now return `exceeded_max_recursive_depth`. The boundary test was pinned to the shared constant and is retargeted; a new test covers the block-mapping path specifically. `docs/security.md` records the lower YAML cap.

Verified: the testcase completes cleanly under ASAN+UBSAN, all 18,721 files in the local YAML corpus run clean, and `yaml_test`, `json_test`, `beve_test`, `cbor_test`, `msgpack_test`, and `toml_test` all pass.
