### PR TITLE
Write an empty YAML mapping as {} (#2827)

### DIFF
--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -199,6 +199,17 @@ person:
 person: {name: John, age: 30}
 ```
 
+### Empty Collections
+
+An empty mapping or sequence has no block form, so it is written with the flow token. A bare `key:` is null, not an empty collection:
+
+```yaml
+mapping: {}
+sequence: []
+```
+
+An object writes `{}` too when nothing is left to emit for it, which includes a struct whose every member was dropped by `skip_null_members` or `meta::skip_if`.
+
 ## Document Markers
 
 Glaze supports YAML document markers:

--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -3807,10 +3807,19 @@ namespace glz
 
             // Process this mapping entry (key + colon + value)
             int32_t effective_line_indent = line_indent;
-            if (discover_indent && established_mapping_indent_this_line && discovered_first_key_mid_line &&
-                parent_indent >= 0 && discovered_first_key_visual_indent > effective_line_indent) {
-               // First discovered key may begin mid-line (e.g. sequence entry "- key: value");
-               // pass visual key indent so same-line values compute block-scalar indentation correctly.
+            if (discover_indent && established_mapping_indent_this_line &&
+                discovered_first_key_visual_indent > effective_line_indent &&
+                !(discovered_first_key_mid_line && parent_indent < 0)) {
+               // The first discovered key has no indentation of its own left to measure: it may
+               // begin mid-line (a sequence entry's "- key: value"), or the caller may have already
+               // consumed the line's indentation before handing the mapping over. Pass its visual
+               // column so the entry judges its value against the key's real indent -- otherwise a
+               // key with an empty value takes the following sibling line for nested content
+               // (issue #2827) and same-line block scalars compute the wrong indentation.
+               // The exception is a ROOT mapping whose first key begins mid-line, which means node
+               // properties sit ahead of it (`!!str &a1 "foo":`): those belong to the document node
+               // rather than to the key's column, so the measured indent stands. Conformance tests
+               // 7FWL and HMQ5 pin that case.
                effective_line_indent = discovered_first_key_visual_indent;
             }
 

--- a/include/glaze/yaml/write.hpp
+++ b/include/glaze/yaml/write.hpp
@@ -463,9 +463,12 @@ namespace glz
       template <auto Opts, class T, class B>
       inline void write_block_mapping_nested(T&& value, is_context auto&& ctx, B&& b, auto& ix, int32_t indent_level);
 
+      // `entry_already_written` marks that the mapping this call contributes to already has an
+      // entry on the buffer (a tagged variant's discriminator), so an empty member set must not
+      // emit the `{}` fallback on top of it.
       template <auto Opts, class T, class B>
       inline void write_block_mapping(T&& value, is_context auto&& ctx, B&& b, auto& ix, int32_t indent_level,
-                                      bool skip_first_indent = false);
+                                      bool skip_first_indent = false, bool entry_already_written = false);
 
       // Forward declaration for pairs written as single-entry block mappings
       // (definition needs write_block_mapping_value).
@@ -529,6 +532,142 @@ namespace glz
          }
       }
 
+      // Write a flow token (`{}` / `[]`) as a line of its own: indentation, the token, and a
+      // newline unless the token IS the document. This is what an empty mapping or sequence
+      // renders as when the caller could not place it on the key's line.
+      template <class B>
+      inline void write_empty_block_line(const sv token, is_context auto&& ctx, B&& b, auto& ix, int32_t indent_level,
+                                         bool skip_first_indent = false)
+      {
+         constexpr uint8_t indent_width = check_indent_width(yaml_opts{});
+         const int32_t spaces = skip_first_indent ? 0 : indent_level * indent_width;
+         if (!ensure_space(ctx, b, ix + spaces + 8)) [[unlikely]] {
+            return;
+         }
+         for (int32_t i = 0; i < spaces; ++i) {
+            b[ix++] = ' ';
+         }
+         dump(token, b, ix);
+         if (indent_level > 0) {
+            dump('\n', b, ix);
+         }
+      }
+
+      // An empty mapping and an empty sequence have no block representation: a bare `key:` (or a
+      // lone `-`) reads back as null rather than as an empty container, so such values must be
+      // written with the flow tokens `{}` / `[]` on the key's line (issue #2827). Emptiness is
+      // resolved at runtime because dynamic types (glz::generic and other variants) only reveal
+      // what they hold at runtime.
+      enum struct block_emptiness : uint8_t { non_empty, mapping, sequence };
+
+      template <class T>
+      inline block_emptiness block_empty_kind(const T& value)
+      {
+         using V = std::remove_cvref_t<T>;
+         // A custom writer decides its own representation, including when it is empty. This is
+         // checked before the unwrapping below because a type can be both `glaze_value_t` (or a
+         // variant) and `custom_write` -- the float_format_t pattern -- and every other dispatch
+         // in the library guards those two on `!custom_write` for exactly this reason.
+         if constexpr (custom_write<V> || has_custom_meta_v<V>) {
+            return block_emptiness::non_empty;
+         }
+         else if constexpr (is_variant<V>) {
+            return std::visit([](const auto& inner) { return block_empty_kind(inner); }, value);
+         }
+         else if constexpr (glaze_value_t<V>) {
+            // Unwrap glaze_value types (like glz::generic) to inspect what they hold
+            return block_empty_kind(get_member(value, meta_wrapper_v<V>));
+         }
+         else if constexpr (nullable_like<V>) {
+            return value ? block_empty_kind(*value) : block_emptiness::non_empty;
+         }
+         else if constexpr (is_simple_type<V>()) {
+            return block_emptiness::non_empty;
+         }
+         else if constexpr (writable_map_t<V> && has_empty<V>) {
+            return value.empty() ? block_emptiness::mapping : block_emptiness::non_empty;
+         }
+         else if constexpr (writable_array_t<V>) {
+            // Mirrors how write_block_sequence itself decides a sequence is empty, so a range that
+            // reports emptiness only through its iterators is classified the same way.
+            if constexpr (has_empty<V>) {
+               return value.empty() ? block_emptiness::sequence : block_emptiness::non_empty;
+            }
+            else if constexpr (requires {
+                                  value.begin();
+                                  value.end();
+                               }) {
+               return (value.begin() == value.end()) ? block_emptiness::sequence : block_emptiness::non_empty;
+            }
+            else {
+               return block_emptiness::non_empty;
+            }
+         }
+         else {
+            return block_emptiness::non_empty;
+         }
+      }
+
+      // Emit `{}` / `[]` inline after an already-written `key:` or `-`. Returns true when the
+      // value was written, in which case the caller must not open a nested block for it.
+      template <class T, class B>
+      inline bool write_empty_block_inline(const T& value, B&& b, auto& ix)
+      {
+         switch (block_empty_kind(value)) {
+         case block_emptiness::mapping:
+            dump(" {}\n", b, ix);
+            return true;
+         case block_emptiness::sequence:
+            dump(" []\n", b, ix);
+            return true;
+         default:
+            return false;
+         }
+      }
+
+      // Write `value` as the nested block of an already-written `key:` or `-`, at `indent_level`.
+      //
+      // A mapping that turns out to have no entries -- every member skipped by skip_null_members or
+      // meta::skip_if, or a type with no members at all -- renders as a lone `{}` line. Whether that
+      // happens cannot be known before writing it: `serialize<YAML>::op` returns void, so the buffer
+      // is the only channel back from a nested write. So the block is written, and a `{}` line is
+      // then pulled up onto the key's line to match how an empty container is written. Rewinding the
+      // buffer this way follows the JSON writer's trailing-comma rewinds (json/write.hpp:2089).
+      template <auto Opts, class T, class B>
+      inline void write_nested_block(T&& value, is_context auto&& ctx, B&& b, auto& ix, int32_t indent_level)
+      {
+         dump('\n', b, ix);
+         const auto start = ix;
+
+         if constexpr (requires { ctx.indent_level; }) {
+            // A context that threads its own indentation routes through serialize<YAML> so the
+            // value's own writer sees the deeper indent.
+            auto nested_ctx = ctx;
+            nested_ctx.indent_level = indent_level;
+            serialize<YAML>::op<Opts>(value, nested_ctx, b, ix);
+         }
+         else {
+            write_block_mapping_nested<Opts>(value, ctx, b, ix, indent_level);
+         }
+
+         if (ix - start >= 3 && b[ix - 1] == '\n' && b[ix - 2] == '}' && b[ix - 3] == '{') {
+            for (auto i = start; i + 3 < ix; ++i) {
+               if (b[i] != ' ') {
+                  return; // the `{}` belongs to something else on the line
+               }
+            }
+            const auto block_end = ix;
+            ix = start - 1; // drop the newline that opened the block
+            dump(" {}\n", b, ix);
+            // A fixed-size buffer is never truncated to `ix` (buffer_traits::finalize is a no-op for
+            // std::array/std::span/char*), so the bytes the rewind abandoned would otherwise stay
+            // visible past the end of the document.
+            for (auto i = ix; i < block_end; ++i) {
+               b[i] = '\0';
+            }
+         }
+      }
+
       // Write a variant's held value in block context, ensuring strings get correct indent_level.
       template <auto Opts, class T, class B>
       inline void write_variant_value(T&& value, is_context auto&& ctx, B&& b, auto& ix, int32_t indent_level)
@@ -577,17 +716,7 @@ namespace glz
          }
 
          if (is_empty) {
-            const int32_t spaces = indent_level * indent_width;
-            if (!ensure_space(ctx, b, ix + spaces + 8)) [[unlikely]] {
-               return;
-            }
-            for (int32_t i = 0; i < spaces; ++i) {
-               b[ix++] = ' ';
-            }
-            dump("[]", b, ix);
-            if (indent_level > 0) {
-               dump('\n', b, ix);
-            }
+            write_empty_block_line("[]", ctx, b, ix, indent_level);
             return;
          }
 
@@ -641,30 +770,14 @@ namespace glz
                   dump('\n', b, ix);
                }
                else {
-                  // Complex inner type - check for empty containers first
-                  bool wrote_empty = false;
-                  if constexpr (writable_map_t<inner_t>) {
-                     if (element->empty()) {
-                        dump(" {}\n", b, ix);
-                        wrote_empty = true;
-                     }
-                  }
-                  else if constexpr (writable_array_t<inner_t>) {
-                     if constexpr (requires { element->empty(); }) {
-                        if (element->empty()) {
-                           dump(" []\n", b, ix);
-                           wrote_empty = true;
-                        }
-                     }
-                  }
-                  if (!wrote_empty) {
+                  // Complex inner type - an empty container has no block form
+                  if (!write_empty_block_inline(*element, b, ix)) {
                      if constexpr (glaze_object_t<inner_t> || reflectable<inner_t>) {
                         dump(' ', b, ix);
                         write_block_mapping<Opts>(*element, ctx, b, ix, indent_level + 1, true);
                      }
                      else {
-                        dump('\n', b, ix);
-                        write_block_mapping_nested<Opts>(*element, ctx, b, ix, indent_level + 1);
+                        write_nested_block<Opts>(*element, ctx, b, ix, indent_level + 1);
                      }
                   }
                }
@@ -675,6 +788,9 @@ namespace glz
                   dump(' ', b, ix);
                   write_variant_value<Opts>(element, ctx, b, ix, indent_level);
                   dump('\n', b, ix);
+               }
+               else if (write_empty_block_inline(element, b, ix)) {
+                  // An empty mapping/sequence alternative has no block form
                }
                else {
                   // Complex variant content (maps/arrays/objects) - write in block style
@@ -705,22 +821,8 @@ namespace glz
                                                                          true);
                            }
                            else {
-                              if constexpr (writable_map_t<inner_t>) {
-                                 if (inner.empty()) {
-                                    dump(" {}\n", b, ix);
-                                    return;
-                                 }
-                              }
-                              else if constexpr (writable_array_t<inner_t>) {
-                                 if constexpr (requires { inner.empty(); }) {
-                                    if (inner.empty()) {
-                                       dump(" []\n", b, ix);
-                                       return;
-                                    }
-                                 }
-                              }
-                              dump('\n', b, ix);
-                              write_block_mapping_nested<Opts>(inner, ctx, b, ix, indent_level + 1);
+                              // Emptiness was already handled inline by the caller
+                              write_nested_block<Opts>(inner, ctx, b, ix, indent_level + 1);
                            }
                         },
                         element);
@@ -729,8 +831,7 @@ namespace glz
                      // glaze_value_t wrapping a variant — simple types were already
                      // handled by variant_holds_simple_type above, so the held value
                      // is guaranteed to be a complex type (map/array/object).
-                     dump('\n', b, ix);
-                     write_block_mapping_nested<Opts>(element, ctx, b, ix, indent_level + 1);
+                     write_nested_block<Opts>(element, ctx, b, ix, indent_level + 1);
                   }
                }
             }
@@ -752,10 +853,11 @@ namespace glz
                dump('\n', b, ix);
             }
             else if constexpr (writable_map_t<element_t> || writable_array_t<element_t> || glaze_value_t<element_t>) {
-               // Containers and glaze_value_t (which may wrap containers) -
-               // write on next line with increased indent
-               dump('\n', b, ix);
-               write_block_mapping_nested<Opts>(element, ctx, b, ix, indent_level + 1);
+               // Containers and glaze_value_t (which may wrap containers) - write on next line
+               // with increased indent, unless empty, which has no block form
+               if (!write_empty_block_inline(element, b, ix)) {
+                  write_nested_block<Opts>(element, ctx, b, ix, indent_level + 1);
+               }
             }
             else {
                // Other types (tuples, custom scalars, etc.) - write inline after dash
@@ -981,15 +1083,10 @@ namespace glz
       inline void write_block_mapping_value(Member&& member, is_context auto&& ctx, B&& b, auto& ix,
                                             int32_t indent_level)
       {
-         // Handle empty containers inline (before type dispatch)
-         if constexpr (range<val_t> && !str_t<val_t> && !is_simple_type<val_t>() && has_empty<val_t>) {
-            if (member.empty()) {
-               if constexpr (writable_map_t<val_t>) {
-                  dump(" {}\n", b, ix);
-               }
-               else {
-                  dump(" []\n", b, ix);
-               }
+         // An empty mapping or sequence has no block form and is written inline (issue #2827).
+         // Covers dynamic values (glz::generic) and optionals as well as plain containers.
+         if constexpr (!is_simple_type<val_t>()) {
+            if (write_empty_block_inline(member, b, ix)) {
                return;
             }
          }
@@ -1025,34 +1122,9 @@ namespace glz
                dump('\n', b, ix);
             }
             else {
-               // Complex inner type - check for empty containers first
-               bool wrote_empty = false;
-               if constexpr (writable_map_t<inner_t>) {
-                  if (member->empty()) {
-                     dump(" {}\n", b, ix);
-                     wrote_empty = true;
-                  }
-               }
-               else if constexpr (writable_array_t<inner_t>) {
-                  if constexpr (requires { member->empty(); }) {
-                     if (member->empty()) {
-                        dump(" []\n", b, ix);
-                        wrote_empty = true;
-                     }
-                  }
-               }
-               if (!wrote_empty) {
-                  // Non-empty complex inner type - next line with increased indent
-                  dump('\n', b, ix);
-                  if constexpr (requires { ctx.indent_level; }) {
-                     auto nested_ctx = ctx;
-                     nested_ctx.indent_level = indent_level + 1;
-                     serialize<YAML>::op<Opts>(*member, nested_ctx, b, ix);
-                  }
-                  else {
-                     write_block_mapping_nested<Opts>(*member, ctx, b, ix, indent_level + 1);
-                  }
-               }
+               // Non-empty complex inner type (emptiness was handled above) - next line with
+               // increased indent
+               yaml::write_nested_block<Opts>(*member, ctx, b, ix, indent_level + 1);
             }
          }
          else if constexpr (is_or_wraps_variant<val_t>()) {
@@ -1063,32 +1135,14 @@ namespace glz
                dump('\n', b, ix);
             }
             else {
-               dump('\n', b, ix);
-               if constexpr (requires { ctx.indent_level; }) {
-                  auto nested_ctx = ctx;
-                  nested_ctx.indent_level = indent_level + 1;
-                  serialize<YAML>::op<Opts>(member, nested_ctx, b, ix);
-               }
-               else {
-                  write_block_mapping_nested<Opts>(member, ctx, b, ix, indent_level + 1);
-               }
+               yaml::write_nested_block<Opts>(member, ctx, b, ix, indent_level + 1);
             }
          }
          else if constexpr (writable_map_t<val_t> || writable_array_t<val_t> || glaze_object_t<val_t> ||
                             reflectable<val_t> || pair_t<val_t>) {
             // Complex types go on next line with increased indent. A pair is a single-entry
             // mapping, so it nests like a map rather than sharing the key's line (issue #2829).
-            dump('\n', b, ix);
-
-            // Create a modified context with incremented indent level
-            if constexpr (requires { ctx.indent_level; }) {
-               auto nested_ctx = ctx;
-               nested_ctx.indent_level = indent_level + 1;
-               serialize<YAML>::op<Opts>(member, nested_ctx, b, ix);
-            }
-            else {
-               write_block_mapping_nested<Opts>(member, ctx, b, ix, indent_level + 1);
-            }
+            yaml::write_nested_block<Opts>(member, ctx, b, ix, indent_level + 1);
          }
          else {
             // All other types (custom_t, types with custom to/from<YAML>, etc.)
@@ -1160,11 +1214,13 @@ namespace glz
       // Write block-style mapping
       template <auto Opts, class T, class B>
       inline void write_block_mapping(T&& value, is_context auto&& ctx, B&& b, auto& ix, int32_t indent_level,
-                                      bool skip_first_indent)
+                                      bool skip_first_indent, bool entry_already_written)
       {
          using V = std::remove_cvref_t<T>;
          constexpr auto N = reflect<V>::size;
          constexpr uint8_t indent_width = check_indent_width(yaml_opts{});
+
+         bool wrote_member = false;
 
          for_each<N>([&]<size_t I>() {
             if (bool(ctx.error)) [[unlikely]]
@@ -1208,6 +1264,8 @@ namespace glz
                   if (is_default_value(member)) return;
                }
 
+               wrote_member = true;
+
                // Write indentation (skip for first field when in compact sequence context)
                if (skip_first_indent) {
                   skip_first_indent = false;
@@ -1245,6 +1303,12 @@ namespace glz
                }
             }
          });
+
+         if (!wrote_member && !entry_already_written && !bool(ctx.error)) {
+            // Every member was skipped, or the object has none: writing nothing would read back
+            // as null (or as an empty document at the root), so emit `{}` (issue #2827).
+            write_empty_block_line("{}", ctx, b, ix, indent_level, skip_first_indent);
+         }
       }
 
       // Helper for nested objects
@@ -1292,6 +1356,16 @@ namespace glz
             // Map handling
             constexpr uint8_t indent_width = check_indent_width(yaml_opts{});
 
+            if constexpr (has_empty<V>) {
+               if (value.empty()) {
+                  // A mapping with no entries has no block form: writing nothing would read back
+                  // as null (or as an empty document at the root), so emit `{}` (issue #2827).
+                  // Callers that can place the token on the key's line do so before getting here.
+                  write_empty_block_line("{}", ctx, b, ix, indent_level);
+                  return;
+               }
+            }
+
             for (auto&& [k, v] : value) {
                if (bool(ctx.error)) [[unlikely]]
                   return;
@@ -1316,6 +1390,14 @@ namespace glz
                dump(':', b, ix);
 
                using val_t = std::remove_cvref_t<decltype(v)>;
+
+               // An empty mapping or sequence has no block form and is written inline (issue #2827)
+               if constexpr (!is_simple_type<val_t>()) {
+                  if (write_empty_block_inline(v, b, ix)) {
+                     continue;
+                  }
+               }
+
                if constexpr (str_t<val_t>) {
                   dump(' ', b, ix);
                   write_yaml_string<Opts>(str_view<val_t>(v), ctx, b, ix, indent_level);
@@ -1344,26 +1426,8 @@ namespace glz
                      dump('\n', b, ix);
                   }
                   else {
-                     // Complex inner type - check for empty containers first
-                     bool wrote_empty = false;
-                     if constexpr (writable_map_t<inner_t>) {
-                        if (v->empty()) {
-                           dump(" {}\n", b, ix);
-                           wrote_empty = true;
-                        }
-                     }
-                     else if constexpr (writable_array_t<inner_t>) {
-                        if constexpr (requires { v->empty(); }) {
-                           if (v->empty()) {
-                              dump(" []\n", b, ix);
-                              wrote_empty = true;
-                           }
-                        }
-                     }
-                     if (!wrote_empty) {
-                        dump('\n', b, ix);
-                        write_block_mapping_nested<Opts>(*v, ctx, b, ix, indent_level + 1);
-                     }
+                     // Complex inner type (emptiness was handled above)
+                     write_nested_block<Opts>(*v, ctx, b, ix, indent_level + 1);
                   }
                }
                else if constexpr (is_or_wraps_variant<val_t>()) {
@@ -1375,13 +1439,11 @@ namespace glz
                      dump('\n', b, ix);
                   }
                   else {
-                     dump('\n', b, ix);
-                     write_block_mapping_nested<Opts>(v, ctx, b, ix, indent_level + 1);
+                     write_nested_block<Opts>(v, ctx, b, ix, indent_level + 1);
                   }
                }
                else {
-                  dump('\n', b, ix);
-                  write_block_mapping_nested<Opts>(v, ctx, b, ix, indent_level + 1);
+                  write_nested_block<Opts>(v, ctx, b, ix, indent_level + 1);
                }
             }
          }
@@ -1513,7 +1575,8 @@ namespace glz
          dump('\n', b, ix);
 
          // Remaining members are emitted at the mapping's indent (the tag occupied the first line).
-         write_block_mapping<Opts>(inner, ctx, b, ix, indent_level, false);
+         constexpr bool tag_entry_already_written = true;
+         write_block_mapping<Opts>(inner, ctx, b, ix, indent_level, false, tag_entry_already_written);
       }
 
       // Write a tagged variant alternative that holds an object as a flow mapping
@@ -1572,6 +1635,12 @@ namespace glz
 
          const int32_t spaces = indent_level * indent_width;
          const std::string_view body_sv{body.data(), body_ix};
+         // An empty mapping body renders as `{}` (write_block_mapping_nested is total for mappings,
+         // see issue #2827); the tag entry alone is then the whole mapping, so appending the token
+         // would leave a stray flow node under the tag line.
+         if (body_sv == "{}" || body_sv == "{}\n") {
+            return;
+         }
          size_t line_start = 0;
          while (line_start < body_sv.size()) {
             const size_t nl = body_sv.find('\n', line_start);

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -12057,4 +12057,351 @@ suite issue_2829_pair_block_layout = [] {
    };
 };
 
+namespace i2827
+{
+   struct member_t
+   {
+      std::optional<int> chance{};
+      bool operator==(const member_t&) const = default;
+   };
+
+   struct slot_t
+   {
+      std::map<std::string, member_t> members{};
+      bool operator==(const slot_t&) const = default;
+   };
+
+   struct slots_t
+   {
+      std::optional<std::vector<slot_t>> slots{};
+      bool operator==(const slots_t&) const = default;
+   };
+
+   struct containers_t
+   {
+      std::map<std::string, int> mapping{};
+      std::vector<int> sequence{};
+      std::optional<std::map<std::string, int>> optional_mapping{};
+      bool operator==(const containers_t&) const = default;
+   };
+
+   struct all_optional_t
+   {
+      std::optional<int> a{};
+      bool operator==(const all_optional_t&) const = default;
+   };
+
+   struct holds_all_optional_t
+   {
+      all_optional_t inner{};
+      int after{};
+      bool operator==(const holds_all_optional_t&) const = default;
+   };
+
+   // The collapsed mapping is the LAST thing written, so nothing overwrites what the rewind
+   // abandoned -- the shape that exposes stale bytes in a buffer that is never truncated.
+   struct trailing_all_optional_t
+   {
+      int before{};
+      all_optional_t inner{};
+      bool operator==(const trailing_all_optional_t&) const = default;
+   };
+
+   // A tagged variant alternative whose members are all skipped: the discriminator entry is the
+   // whole mapping, so the writer must NOT also emit `{}` under it.
+   struct empty_alt_t
+   {
+      std::optional<int> unset{};
+      bool operator==(const empty_alt_t&) const = default;
+   };
+   struct filled_alt_t
+   {
+      int a{};
+      bool operator==(const filled_alt_t&) const = default;
+   };
+   using tagged_t = std::variant<empty_alt_t, filled_alt_t>;
+
+   // Both glaze_value_t and custom_write (the float_format_t pattern): the custom writer owns the
+   // representation, including when the wrapped container is empty.
+   struct custom_joined_t
+   {
+      std::vector<int> data{};
+   };
+
+   struct holds_custom_t
+   {
+      custom_joined_t joined{};
+      int after{};
+   };
+}
+
+template <>
+struct glz::meta<i2827::empty_alt_t>
+{
+   using T = i2827::empty_alt_t;
+   static constexpr auto value = object("unset", &T::unset);
+};
+template <>
+struct glz::meta<i2827::filled_alt_t>
+{
+   using T = i2827::filled_alt_t;
+   static constexpr auto value = object("a", &T::a);
+};
+template <>
+struct glz::meta<i2827::tagged_t>
+{
+   static constexpr std::string_view tag = "kind";
+   static constexpr auto ids = std::array{"EMPTY", "FILLED"};
+};
+template <>
+struct glz::meta<i2827::custom_joined_t>
+{
+   static constexpr auto value = &i2827::custom_joined_t::data;
+   static constexpr bool custom_write = true;
+};
+
+namespace glz
+{
+   template <uint32_t Format>
+   struct to<Format, i2827::custom_joined_t>
+   {
+      template <auto Opts, class B>
+      static void op(auto&& value, is_context auto&& ctx, B&& b, auto& ix)
+      {
+         std::string joined{};
+         for (size_t i = 0; i < value.data.size(); ++i) {
+            if (i) joined += ',';
+            joined += std::to_string(value.data[i]);
+         }
+         serialize<Format>::template op<Opts>(joined, ctx, b, ix);
+      }
+   };
+}
+
+// An empty mapping has no block form: a bare `key:` reads back as null, not as an empty
+// mapping, so the writer emits the flow token `{}` (as it already did for `[]`).
+suite issue_2827_empty_mapping_round_trip = [] {
+   using namespace i2827;
+
+   "generic empty mapping round trips"_test = [] {
+      glz::generic_u64 document{};
+      expect(!glz::read_yaml(document, std::string{"a: {}\n"}));
+      expect(document["a"].is_object());
+
+      const auto written = glz::write_yaml(document);
+      expect(written.has_value());
+      expect(written.value() == "a: {}\n") << written.value();
+
+      glz::generic_u64 reread{};
+      expect(!glz::read_yaml(reread, written.value()));
+      expect(reread["a"].is_object());
+      expect(!reread["a"].is_null());
+   };
+
+   "generic empty sequence round trips"_test = [] {
+      glz::generic_u64 document{};
+      expect(!glz::read_yaml(document, std::string{"a: []\n"}));
+
+      const auto written = glz::write_yaml(document);
+      expect(written.has_value());
+      expect(written.value() == "a: []\n") << written.value();
+
+      glz::generic_u64 reread{};
+      expect(!glz::read_yaml(reread, written.value()));
+      expect(reread["a"].is_array());
+   };
+
+   "empty containers as map values"_test = [] {
+      const std::map<std::string, std::map<std::string, int>> nested{{"a", {}}, {"z", {{"k", 1}}}};
+      const auto written = glz::write_yaml(nested);
+      expect(written.has_value());
+      expect(written.value() == "a: {}\nz:\n  k: 1\n") << written.value();
+
+      std::map<std::string, std::map<std::string, int>> parsed{};
+      const auto ec = glz::read_yaml(parsed, written.value());
+      expect(!ec) << glz::format_error(ec, written.value());
+      expect(parsed == nested);
+   };
+
+   "empty containers as object members"_test = [] {
+      const containers_t original{};
+      const auto written = glz::write_yaml(original);
+      expect(written.has_value());
+      expect(written.value() == "mapping: {}\nsequence: []\n") << written.value();
+
+      // Reading a mapping MERGES (like JSON and BEVE), so a pre-existing key the document does
+      // not mention survives; a sequence is replaced outright.
+      containers_t parsed{.mapping = {{"stale", 1}}, .sequence = {9}};
+      const auto ec = glz::read_yaml(parsed, written.value());
+      expect(!ec) << glz::format_error(ec, written.value());
+      expect(parsed.mapping.size() == 1);
+      expect(parsed.mapping.contains("stale"));
+      expect(parsed.sequence.empty());
+   };
+
+   "empty container behind an optional"_test = [] {
+      const containers_t original{.optional_mapping = std::map<std::string, int>{}};
+      const auto written = glz::write_yaml(original);
+      expect(written.has_value());
+      expect(written.value() == "mapping: {}\nsequence: []\noptional_mapping: {}\n") << written.value();
+
+      containers_t parsed{};
+      const auto ec = glz::read_yaml(parsed, written.value());
+      expect(!ec) << glz::format_error(ec, written.value());
+      expect(parsed.optional_mapping.has_value());
+      expect(parsed.optional_mapping->empty());
+   };
+
+   "empty mapping as a sequence element"_test = [] {
+      const std::vector<std::map<std::string, int>> sequence{{}, {{"k", 1}}};
+      const auto written = glz::write_yaml(sequence);
+      expect(written.has_value());
+      expect(written.value() == "- {}\n-\n  k: 1\n") << written.value();
+
+      std::vector<std::map<std::string, int>> parsed{};
+      const auto ec = glz::read_yaml(parsed, written.value());
+      expect(!ec) << glz::format_error(ec, written.value());
+      expect(parsed == sequence);
+   };
+
+   "an object whose members are all skipped is an empty mapping"_test = [] {
+      const holds_all_optional_t original{.inner = {}, .after = 5};
+      const auto written = glz::write_yaml(original);
+      expect(written.has_value());
+      expect(written.value() == "inner: {}\nafter: 5\n") << written.value();
+
+      holds_all_optional_t parsed{};
+      const auto ec = glz::read_yaml(parsed, written.value());
+      expect(!ec) << glz::format_error(ec, written.value());
+      expect(parsed == original);
+   };
+
+   "empty documents"_test = [] {
+      expect(glz::write_yaml(std::map<std::string, int>{}).value() == "{}");
+      expect(glz::write_yaml(all_optional_t{}).value() == "{}");
+      expect(glz::write_yaml(std::vector<int>{}).value() == "[]");
+   };
+
+   "nested struct target round trips"_test = [] {
+      const std::string source{"slots:\n  - members:\n      '17186822': {}\n      '17186837': {}\n"};
+
+      glz::generic_u64 document{};
+      expect(!glz::read_yaml(document, source));
+
+      const auto written = glz::write_yaml(document);
+      expect(written.has_value());
+
+      slots_t parsed{};
+      const auto ec = glz::read_yaml(parsed, written.value());
+      expect(!ec) << glz::format_error(ec, written.value());
+      expect(parsed.slots.has_value());
+      if (parsed.slots.has_value() && parsed.slots->size() == 1) {
+         expect(parsed.slots->front().members.size() == 2);
+      }
+      else {
+         expect(false) << written.value();
+      }
+   };
+
+   // The first key of a nested mapping has no indentation left to measure (the enclosing reader
+   // consumed it), so its column has to be recovered; otherwise an entry with an empty value
+   // swallows the sibling line that follows it.
+   "an empty value does not consume the next sibling"_test = [] {
+      const std::string source{"members:\n  '1':\n  '2':\n"};
+
+      slot_t parsed{};
+      const auto ec = glz::read_yaml(parsed, source);
+      expect(!ec) << glz::format_error(ec, source);
+      expect(parsed.members.size() == 2);
+      expect(parsed.members.contains("1"));
+      expect(parsed.members.contains("2"));
+   };
+
+   "an empty value does not consume the next sibling in a nested map"_test = [] {
+      const std::string source{"outer:\n  a:\n  b:\n"};
+
+      std::map<std::string, std::map<std::string, int>> parsed{};
+      const auto ec = glz::read_yaml(parsed, source);
+      expect(!ec) << glz::format_error(ec, source);
+      expect(parsed.size() == 1);
+      expect(parsed["outer"].size() == 2) << glz::write_json(parsed).value_or("");
+   };
+
+   // The empty-mapping collapse rewinds the write buffer, so it must leave nothing behind in a
+   // buffer that is never truncated to the written length (finalize is a no-op for std::array).
+   "the collapse leaves no stale bytes in a fixed buffer"_test = [] {
+      std::array<char, 512> buffer{};
+      const auto ec = glz::write<glz::yaml::yaml_opts{}>(trailing_all_optional_t{.before = 5}, buffer);
+      expect(!ec);
+      expect(std::string_view{buffer.data(), ec.count} == "before: 5\ninner: {}\n");
+      // The repo reads fixed buffers through data(); stale bytes past the length show up here.
+      expect(std::string_view{buffer.data()} == "before: 5\ninner: {}\n") << std::string_view{buffer.data()};
+   };
+
+   "an all-skipped object nests in every position"_test = [] {
+      const std::map<std::string, all_optional_t> as_map_value{{"k", {}}};
+      expect(glz::write_yaml(as_map_value).value() == "k: {}\n") << glz::write_yaml(as_map_value).value();
+
+      const std::vector<all_optional_t> as_sequence_element{{}, {}};
+      expect(glz::write_yaml(as_sequence_element).value() == "- {}\n- {}\n")
+         << glz::write_yaml(as_sequence_element).value();
+
+      const std::optional<all_optional_t> behind_optional{all_optional_t{}};
+      const std::map<std::string, std::optional<all_optional_t>> optional_value{{"k", behind_optional}};
+      expect(glz::write_yaml(optional_value).value() == "k: {}\n") << glz::write_yaml(optional_value).value();
+
+      // Each form must read back as the same (default) object.
+      std::map<std::string, all_optional_t> parsed{};
+      const auto ec = glz::read_yaml(parsed, std::string{"k: {}\n"});
+      expect(!ec);
+      expect(parsed.size() == 1);
+   };
+
+   // A discriminator entry IS the mapping's content, so an alternative with nothing left to write
+   // must not get a `{}` appended under it -- that document does not read back.
+   "a tagged alternative with no members written keeps just its discriminator"_test = [] {
+      const tagged_t root{empty_alt_t{}};
+      const auto written = glz::write_yaml(root);
+      expect(written.has_value());
+      expect(written.value() == "kind: EMPTY\n") << written.value();
+
+      tagged_t reread{filled_alt_t{}};
+      const auto ec = glz::read_yaml(reread, written.value());
+      expect(!ec) << glz::format_error(ec, written.value());
+      expect(std::holds_alternative<empty_alt_t>(reread));
+
+      const std::map<std::string, tagged_t> as_value{{"entry", empty_alt_t{}}};
+      const auto nested = glz::write_yaml(as_value);
+      expect(nested.has_value());
+      expect(nested.value() == "entry:\n  kind: EMPTY\n") << nested.value();
+
+      std::map<std::string, tagged_t> nested_reread{};
+      const auto nested_ec = glz::read_yaml(nested_reread, nested.value());
+      expect(!nested_ec) << glz::format_error(nested_ec, nested.value());
+      expect(std::holds_alternative<empty_alt_t>(nested_reread.at("entry")));
+   };
+
+   // A type that is both glaze_value_t and custom_write writes itself, empty payload included:
+   // classifying it by the container it wraps would bypass its writer.
+   "a custom writer keeps its representation when empty"_test = [] {
+      const auto written = glz::write_yaml(holds_custom_t{});
+      expect(written.has_value());
+      expect(written.value() == "joined: ''\nafter: 0\n") << written.value();
+
+      const auto filled = glz::write_yaml(holds_custom_t{{{1, 2, 3}}, 7});
+      expect(filled.has_value());
+      expect(filled.value() == "joined: '1,2,3'\nafter: 7\n") << filled.value();
+   };
+
+   "an indented document keeps its top-level keys as siblings"_test = [] {
+      const std::string source{"  a:\n  b: 1\n"};
+
+      glz::generic_u64 document{};
+      const auto ec = glz::read_yaml(document, source);
+      expect(!ec) << glz::format_error(ec, source);
+      expect(document["a"].is_null());
+      expect(document["b"].as<int>() == 1);
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
Closes #2827.

An empty mapping was written as a bare `key:`, which reads back as null, so `generic -> write_yaml -> generic` lost the value. Empty sequences already wrote `[]`.

### Writer

`{}` is now emitted wherever a mapping has nothing to write: as a map value, a struct member, a sequence element (`- {}`), and as the whole document. The check runs at runtime, so it also covers values whose type is only known then — `glz::generic` and other variants, and containers behind an optional. An object whose members were all dropped by `skip_null_members` or `meta::skip_if` writes `{}` as well; that one cannot be predicted before writing it, so the block is written and a lone `{}` line is pulled up onto the key's line.

A type that is both `glaze_value_t` and `custom_write` keeps its own representation when empty, and a tagged variant's discriminator line never gets a `{}` appended under it.

### Reader

The first key of a nested block mapping has no indentation left to measure — the enclosing reader consumed it — so it was judged at column 0, and an entry with an empty value took the following sibling line as nested content:

```yaml
members:
  '17186822':    # consumed '17186837' as its own child
  '17186837':
```

That reported `unknown_key` against a struct target, or silently nested the sibling against a map target. The key's real column is now used. A root mapping whose first key carries node properties keeps the measured indent (conformance tests 7FWL, HMQ5).

### Verification

- yaml_test 791, yaml_conformance 402, yaml_conformance_struct 105, chrono_test, embedded_null_test — all pass.
- Against an 18,721-document corpus: round-trip mismatches drop from 160 to 97 with no new read-back failures. 38 documents parse differently; PyYAML agrees with the new behavior in 22 of them and with the old in none.