### PR TITLE
drop the always-true is_inline_table parameter

### DIFF
--- a/include/glaze/toml/read.hpp
+++ b/include/glaze/toml/read.hpp
@@ -1665,7 +1665,7 @@ namespace glz
       void check_missing_keys_at(T&& value, const missing_key_record& node, Ctx& ctx);
 
       template <auto Opts, class T, class It, class End, class Ctx>
-      inline void parse_toml_object_members(T&& value, It&& it, End end, Ctx&& ctx, bool is_inline_table)
+      inline void parse_inline_table_members(T&& value, It&& it, End end, Ctx&& ctx)
       {
          using U = std::remove_cvref_t<T>;
          static constexpr auto N = reflect<U>::size;
@@ -1674,7 +1674,6 @@ namespace glz
          // adding to it from anywhere else in the document -- so its required keys are settled here
          // rather than deferred to the whole-document walk.
          [[maybe_unused]] bit_array<N> fields{};
-         // TODO: Think if we should make inline table a constexpr to reduce runtime checks
          // TODO: Think if it's feasible to write a function to find out the deepest nested structure
          // and use it instead of vector
 
@@ -1682,40 +1681,23 @@ namespace glz
             skip_ws_and_comments(it, end);
 
             if (it == end) {
-               if (is_inline_table) ctx.error = error_code::unexpected_end; // Inline table must end with '}'
-               break;
+               break; // Truncated; settled below the loop
             }
 
-            if (is_inline_table && (*it == '\n' || *it == '\r')) {
+            if (*it == '\n' || *it == '\r') {
                skip_to_next_line(ctx, it, end);
                continue;
             }
 
-            if (is_inline_table && *it == '}') {
+            if (*it == '}') {
                ++it; // Consume '}'
                check_required_fields<Opts, U>(fields, ctx);
                return; // End of inline table
             }
 
-            // Skip empty lines (only if not in an inline table, inline tables don't have newlines)
-            if (!is_inline_table && (*it == '\n' || *it == '\r')) {
-               skip_to_next_line(ctx, it, end);
-               continue;
-            }
-
             std::string key_str;
             // std::vector<std::string> key_str; // TODO: std::string is used temporarily, we may swap it to view later
             // on or as said before completely switch to array
-
-            // Handle section headers [section] (only if not in an inline table)
-            if (!is_inline_table && *it == '[') {
-               // For now, skip section headers - we'll implement nested object support later
-               // Or, this could be where we handle table arrays or nested tables.
-               // For the current task, we are focusing on inline tables.
-               // This part might need to be more sophisticated for full TOML table support.
-               skip_to_next_line(ctx, it, end);
-               continue;
-            }
 
             if (!parse_toml_key(key_str, ctx, it, end)) {
                return;
@@ -1787,40 +1769,32 @@ namespace glz
 
             skip_ws_and_comments(it, end);
             if (it == end) {
-               if (is_inline_table) ctx.error = error_code::unexpected_end; // Inline table must end with '}'
-               break;
+               break; // Truncated; settled below the loop
             }
 
-            if (is_inline_table) {
-               if (*it == '}') {
-                  // Handled at the start of the loop
-                  continue;
-               }
-               else if (*it == ',') {
-                  ++it; // Consume comma
-                  skip_ws_and_comments(it, end);
-                  if (it != end && *it == '}') { // Trailing comma case like { key = "val", }
-                     // This is allowed by TOML v1.0.0 for inline tables
-                     // The '}' will be consumed at the start of the next iteration.
-                  }
-               }
-               else {
-                  ctx.error = error_code::syntax_error; // Expected comma or '}'
-                  return;
+            if (*it == '}') {
+               // Handled at the start of the loop
+               continue;
+            }
+            else if (*it == ',') {
+               ++it; // Consume comma
+               skip_ws_and_comments(it, end);
+               if (it != end && *it == '}') { // Trailing comma case like { key = "val", }
+                  // This is allowed by TOML v1.0.0 for inline tables
+                  // The '}' will be consumed at the start of the next iteration.
                }
             }
             else {
-               // For top-level or standard tables, expect newline or EOF
-               if (it != end && (*it == '\n' || *it == '\r')) {
-                  skip_to_next_line(ctx, it, end);
-               }
-               else if (it != end && *it != '#') { // If not a comment, it's an error unless it's EOF
-                  // Could be an issue if there's no newline before EOF for the last key-value
-               }
+               ctx.error = error_code::syntax_error; // Expected comma or '}'
+               return;
             }
          }
 
-         check_required_fields<Opts, U>(fields, ctx);
+         // A well-formed inline table returns at its '}' above, so falling out of the loop means
+         // the document ended inside it.
+         if (not bool(ctx.error)) {
+            ctx.error = error_code::unexpected_end;
+         }
       }
    }
 
@@ -2597,7 +2571,7 @@ namespace glz
 
             // TODO: We probably should reorder that so that we dont check against less used inline table more often
             if (*it == '{') { // Check if it's an inline table
-               // parse_toml_object_members settles required keys itself, so keep the document walk
+               // parse_inline_table_members settles required keys itself, so keep the document walk
                // off this node rather than reporting every member of it as missing.
                if constexpr (check_error_on_missing_keys(Opts)) {
                   if (node) {
@@ -2612,8 +2586,8 @@ namespace glz
                   return;
                }
                // TODO: Rewrite logic here, for now it works just fine so we leave it.
-               detail::parse_toml_object_members<Opts>(value, it, end, ctx, true); // true for is_inline_table
-               // parse_toml_object_members consumes the final '}'. The inline table is the
+               detail::parse_inline_table_members<Opts>(value, it, end, ctx);
+               // parse_inline_table_members consumes the final '}'. The inline table is the
                // entire value for this struct, so return rather than looping; otherwise an
                // enclosing inline table's ',' or '}' would be misparsed as the start of a key.
                return;

--- a/tests/toml_reader_test/toml_reader_test.cpp
+++ b/tests/toml_reader_test/toml_reader_test.cpp
@@ -677,4 +677,60 @@ suite variant_alternative_budget_tests = [] {
    };
 };
 
+// An inline table's body is parsed by a loop that returns at '}'. Falling out of it any other way
+// means the document ended mid-table, which used to be silently accepted.
+namespace truncated_inline
+{
+   struct point
+   {
+      int x{};
+      int y{};
+   };
+
+   struct holder
+   {
+      point v{};
+   };
+}
+
+suite truncated_inline_table_tests = [] {
+   using namespace truncated_inline;
+
+   "an inline table with no closing brace is an error"_test = [] {
+      for (const std::string toml : {"v = {", "v = {\n", "v = { x = 1", "v = { x = 1,", "v = { x = 1, y = 2"}) {
+         holder value{};
+         const auto ec = glz::read_toml(value, toml);
+         expect(ec.ec == glz::error_code::unexpected_end) << toml;
+      }
+   };
+
+   "truncation is reported as truncation, not as a missing key"_test = [] {
+      // The required-key check belongs to the '}' path; reaching the end of the document instead
+      // is a malformed document, and saying "missing key" of it would send the caller looking for
+      // a key they did in fact write.
+      static constexpr glz::opts strict{.format = glz::TOML, .error_on_missing_keys = true};
+      const std::string toml = "v = { x = 1";
+      holder value{};
+      const auto ec = glz::read<strict>(value, toml);
+      expect(ec.ec == glz::error_code::unexpected_end) << glz::format_error(ec, toml);
+   };
+
+   "a complete inline table still reads"_test = [] {
+      const std::string toml = "v = { x = 1, y = 2 }\n";
+      holder value{};
+      const auto ec = glz::read_toml(value, toml);
+      expect(!ec) << glz::format_error(ec, toml);
+      expect(value.v.x == 1);
+      expect(value.v.y == 2);
+   };
+
+   "a trailing comma before the brace is still accepted"_test = [] {
+      const std::string toml = "v = { x = 1, y = 2, }\n";
+      holder value{};
+      const auto ec = glz::read_toml(value, toml);
+      expect(!ec) << glz::format_error(ec, toml);
+      expect(value.v.y == 2);
+   };
+};
+
 int main() { return 0; }


### PR DESCRIPTION
Follow-up to #2835, and based on it — `parse_toml_object_members` sits inside that PR's hunks, so this does not apply to `main` on its own.

`parse_toml_object_members` took a `bool is_inline_table`, had exactly one call site, and that call site passed `true`. The `!is_inline_table` branches — skipping blank lines, skipping `[section]` headers, accepting a newline instead of a `,` — were unreachable. They also made the function read like a general table-body parser, which is misleading: normal table bodies go through `op_tracked`.

Renamed to `parse_inline_table_members` and dropped the parameter.

## The bug this exposed

With the dead branches gone, the loop has one well-formed exit: the `return` at `}`. Every other way out means the document ended inside the table. That path set no error, so a truncated inline table was accepted:

```cpp
struct point { int x{}; int y{}; };
struct holder { point v{}; };

holder value{};
glz::read_toml(value, "v = {");   // returned success
```

`v = {`, `v = {\n`, `v = { x = 1,` all parsed clean and left the struct default-initialized. Falling out of the loop now yields `unexpected_end`.

This is pre-existing and independent of #2835 — `main` accepts these with `error_on_missing_keys` either on or off. #2835 partly masked it: with the option on, the trailing required-key check turned the silent success into `missing_key`, which named a key the caller had in fact written.

## Tests

4 tests in `toml_reader_test`: truncation at each position, truncation reported as truncation rather than `missing_key` under `error_on_missing_keys`, and the complete and trailing-comma forms still reading. Verified they fail without the change.

`toml_reader_test` (42), `toml_test` (389) passing. clang-format clean.
