### PR TITLE
bounds-check output writes in the binary-to-JSON converters

### DIFF
--- a/docs/binary.md
+++ b/docs/binary.md
@@ -480,6 +480,10 @@ Writing is Version 2 only. Version 2 output is not decodable as a variant by a G
 
 `glaze/binary/beve_to_json.hpp` provides `glz::beve_to_json`, which directly converts a buffer of BEVE data to a buffer of JSON data.
 
+An empty buffer holds no value, which is not a document, and fails with `error_code::unexpected_end` rather than converting to empty output. On success the returned `error_ctx::count` is the number of bytes written, which is how a fixed-size output buffer learns how much of it holds JSON.
+
+A buffer holding several values converts to one JSON document per line. See [Delimiter Format](#delimiter-format).
+
 ### String Escaping
 
 A BEVE string can hold any byte, including control characters (0x00–1F). JSON cannot. `\n`, `\t`, `\b`, `\f` and `\r` are escaped normally, but the rest have no short escape, and by default the conversion fails rather than write something that will not parse:
@@ -737,6 +741,8 @@ auto ec = glz::read_beve_delimited(messages, buffer);
 ### Delimiter Format
 
 The BEVE delimiter is a single byte: `0x06` (extensions type 6 with subtype 0). When converting delimited BEVE to JSON via `glz::beve_to_json`, each delimiter is converted to a newline character (`\n`), producing NDJSON-compatible output.
+
+Values concatenated without delimiters, which `glz::read_beve_delimited` also accepts, get the same newline between them. Two JSON documents never run together into text that is no longer JSON.
 
 ## Lazy BEVE Parsing
 

--- a/docs/cbor.md
+++ b/docs/cbor.md
@@ -72,6 +72,26 @@ auto ec = glz::cbor_to_json(cbor, json);
 
 A CBOR text string can hold control characters (0x00–1F), which JSON cannot. Those without a short escape make the conversion fail with `error_code::invalid_control_character`. To keep them, turn on `escape_control_characters`. See [String Escaping](binary.md#string-escaping).
 
+On success the returned `error_ctx::count` is the number of bytes written. A resizable buffer is resized to fit, but a fixed-size one (`std::array`, `std::span`) has no other way to learn how much of it now holds JSON. The same applies to `glz::beve_to_json`, `glz::bson_to_json`, `glz::jsonb_to_json`, and `glz::eetf_to_json`.
+
+The buffer must hold exactly one CBOR data item, which is what a CBOR document is. An empty buffer fails with `error_code::unexpected_end`, and bytes left over after the first item (a CBOR sequence, RFC 8742) fail with `error_code::syntax_error` rather than running the items together into text no JSON parser accepts.
+
+### What CBOR Types Become
+
+CBOR says more than JSON can, so a few types are mapped rather than translated:
+
+| CBOR | JSON | Note |
+|------|------|------|
+| Byte string | String of hex digit pairs | Two lowercase hex digits per byte. Applies to byte-string keys too. |
+| `undefined` | `null` | JSON has one empty value where CBOR has two, so `undefined` and `null` become the same thing. |
+| Integer key | Quoted decimal string | A JSON object key must be a string. RFC 8949 section 6.1 allows a converter to pick a string form. |
+| Tag | The tagged value | The tag number is dropped, except for typed arrays (RFC 8746), which become JSON arrays. |
+| Simple value | Its number | Values other than `false`, `true`, `null`, and `undefined` have no JSON form. |
+
+A typed array of IEEE binary128 elements (tags 83 and 87) fails with `error_code::feature_not_supported`; no C++ floating point type Glaze reads or writes represents it. Half precision elements (tags 80 and 84) widen to double.
+
+A key that has no JSON string form at all, such as an array, a map, or a float, fails with `error_code::syntax_error`.
+
 ## Typed Arrays (RFC 8746)
 
 Glaze automatically uses RFC 8746 typed arrays for contiguous numeric containers, enabling bulk memory operations for maximum performance.

--- a/include/glaze/beve/beve_to_json.hpp
+++ b/include/glaze/beve/beve_to_json.hpp
@@ -17,7 +17,7 @@ namespace glz
          const uint8_t byte_count = byte_count_lookup[tag >> 5];
 
          auto write_number = [&]<class T>(T&& value) {
-            if ((it + sizeof(T)) > end) [[unlikely]] {
+            if (size_t(end - it) < sizeof(T)) [[unlikely]] {
                ctx.error = error_code::syntax_error;
                return;
             }
@@ -128,14 +128,14 @@ namespace glz
          case tag::null: {
             if (tag & tag::boolean) {
                if (tag >> 4) {
-                  dump("true", out, ix);
+                  if (!emit_literal<"true">(ctx, out, ix)) return;
                }
                else {
-                  dump("false", out, ix);
+                  if (!emit_literal<"false">(ctx, out, ix)) return;
                }
             }
             else {
-               dump("null", out, ix);
+               if (!emit_literal<"null">(ctx, out, ix)) return;
             }
             ++it;
             break;
@@ -158,114 +158,112 @@ namespace glz
             }
             const sv value{reinterpret_cast<const char*>(it), n};
             detail::emit_untrusted_string<Opts>(ctx, value, out, ix);
+            if (bool(ctx.error)) [[unlikely]]
+               return;
             it += n;
             break;
          }
          case tag::object: {
             ++it;
 
-            dump('{', out, ix);
-            if constexpr (Opts.prettify) {
-               ctx.depth += check_indentation_width(Opts);
-               dump('\n', out, ix);
-               dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
-            }
-            else {
-               ++ctx.depth;
-            }
+            if (!emit_char(ctx, '{', out, ix)) return;
+            {
+               // The indentation this object adds belongs to it, so every way out -- including an
+               // error return from a nested value -- puts the depth back.
+               const indent_guard indent{ctx, Opts.prettify ? check_indentation_width(Opts) : 1};
 
-            const auto key_type = (tag & 0b000'11'000) >> 3;
-            switch (key_type) {
-            case 0: {
-               // string key
-               const auto n_fields = int_from_compressed(ctx, it, end);
-               if (bool(ctx.error)) {
-                  return;
+               if constexpr (Opts.prettify) {
+                  if (!emit_newline_indent<Opts>(ctx, out, ix)) return;
                }
-               for (size_t i = 0; i < n_fields; ++i) {
-                  // convert the key
-                  const auto n = int_from_compressed(ctx, it, end);
-                  if (bool(ctx.error)) [[unlikely]] {
+
+               const auto key_type = (tag & 0b000'11'000) >> 3;
+               switch (key_type) {
+               case 0: {
+                  // string key
+                  const auto n_fields = int_from_compressed(ctx, it, end);
+                  if (bool(ctx.error)) {
                      return;
                   }
-                  if (uint64_t(end - it) < n) [[unlikely]] {
-                     ctx.error = error_code::unexpected_end;
-                     return;
-                  }
-                  const sv key{reinterpret_cast<const char*>(it), n};
-                  detail::emit_untrusted_string<Opts>(ctx, key, out, ix);
-                  if constexpr (Opts.prettify) {
-                     dump(": ", out, ix);
-                  }
-                  else {
-                     dump(':', out, ix);
-                  }
-                  it += n;
-                  beve_to_json_value<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
-                  if (bool(ctx.error)) [[unlikely]] {
-                     return;
-                  }
-                  if (i != n_fields - 1) {
-                     dump(',', out, ix);
+                  for (size_t i = 0; i < n_fields; ++i) {
+                     // convert the key
+                     const auto n = int_from_compressed(ctx, it, end);
+                     if (bool(ctx.error)) [[unlikely]] {
+                        return;
+                     }
+                     if (uint64_t(end - it) < n) [[unlikely]] {
+                        ctx.error = error_code::unexpected_end;
+                        return;
+                     }
+                     const sv key{reinterpret_cast<const char*>(it), n};
+                     detail::emit_untrusted_string<Opts>(ctx, key, out, ix);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
                      if constexpr (Opts.prettify) {
-                        dump('\n', out, ix);
-                        dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
+                        if (!emit_literal<": ">(ctx, out, ix)) return;
+                     }
+                     else {
+                        if (!emit_char(ctx, ':', out, ix)) return;
+                     }
+                     it += n;
+                     beve_to_json_value<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
+                     if (bool(ctx.error)) [[unlikely]] {
+                        return;
+                     }
+                     if (i != n_fields - 1) {
+                        if (!emit_char(ctx, ',', out, ix)) return;
+                        if constexpr (Opts.prettify) {
+                           if (!emit_newline_indent<Opts>(ctx, out, ix)) return;
+                        }
                      }
                   }
+                  break;
                }
-               break;
-            }
-            case 1:
-               [[fallthrough]]; // signed integer key
-            case 2: {
-               // unsigned integer key
-               const auto n_fields = int_from_compressed(ctx, it, end);
-               if (bool(ctx.error)) {
-                  return;
-               }
-               for (size_t i = 0; i < n_fields; ++i) {
-                  // convert the key
-                  dump('"', out, ix);
-                  beve_to_json_number<Opts>(tag, ctx, it, end, out, ix);
-                  if (bool(ctx.error)) [[unlikely]] {
+               case 1:
+                  [[fallthrough]]; // signed integer key
+               case 2: {
+                  // unsigned integer key
+                  const auto n_fields = int_from_compressed(ctx, it, end);
+                  if (bool(ctx.error)) {
                      return;
                   }
-                  dump('"', out, ix);
-                  if constexpr (Opts.prettify) {
-                     dump(": ", out, ix);
-                  }
-                  else {
-                     dump(':', out, ix);
-                  }
-                  beve_to_json_value<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
-                  if (bool(ctx.error)) [[unlikely]] {
-                     return;
-                  }
-                  if (i != n_fields - 1) {
-                     dump(',', out, ix);
+                  for (size_t i = 0; i < n_fields; ++i) {
+                     // convert the key
+                     if (!emit_char(ctx, '"', out, ix)) return;
+                     beve_to_json_number<Opts>(tag, ctx, it, end, out, ix);
+                     if (bool(ctx.error)) [[unlikely]] {
+                        return;
+                     }
+                     if (!emit_char(ctx, '"', out, ix)) return;
                      if constexpr (Opts.prettify) {
-                        dump('\n', out, ix);
-                        dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
+                        if (!emit_literal<": ">(ctx, out, ix)) return;
+                     }
+                     else {
+                        if (!emit_char(ctx, ':', out, ix)) return;
+                     }
+                     beve_to_json_value<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
+                     if (bool(ctx.error)) [[unlikely]] {
+                        return;
+                     }
+                     if (i != n_fields - 1) {
+                        if (!emit_char(ctx, ',', out, ix)) return;
+                        if constexpr (Opts.prettify) {
+                           if (!emit_newline_indent<Opts>(ctx, out, ix)) return;
+                        }
                      }
                   }
+                  break;
                }
-               break;
-            }
-            default: {
-               ctx.error = error_code::syntax_error;
-               return;
-            }
+               default: {
+                  ctx.error = error_code::syntax_error;
+                  return;
+               }
+               }
             }
 
             if constexpr (Opts.prettify) {
-               ctx.depth -= check_indentation_width(Opts);
-               dump('\n', out, ix);
-               dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
+               if (!emit_newline_indent<Opts>(ctx, out, ix)) return;
             }
-            else {
-               --ctx.depth;
-            }
-            dump('}', out, ix);
+            if (!emit_char(ctx, '}', out, ix)) return;
             break;
          }
          case tag::typed_array: {
@@ -306,11 +304,11 @@ namespace glz
                it += padding;
 
                // Now decode as a normal numeric typed array
-               dump('[', out, ix);
+               if (!emit_char(ctx, '[', out, ix)) return;
 
                auto write_aligned_array = [&]<class T>(T&& value) {
                   for (size_t i = 0; i < n; ++i) {
-                     if ((it + sizeof(T)) > end) [[unlikely]] {
+                     if (size_t(end - it) < sizeof(T)) [[unlikely]] {
                         ctx.error = error_code::unexpected_end;
                         return;
                      }
@@ -322,7 +320,7 @@ namespace glz
                      to<JSON, T>::template op<Opts>(value, ctx, out, ix);
                      it += sizeof(T);
                      if (i != n - 1) {
-                        dump(',', out, ix);
+                        if (!emit_char(ctx, ',', out, ix)) return;
                      }
                   }
                };
@@ -387,7 +385,7 @@ namespace glz
                   return;
                }
 
-               dump(']', out, ix);
+               if (!emit_char(ctx, ']', out, ix)) return;
                break;
             }
 
@@ -401,7 +399,7 @@ namespace glz
                   return;
                }
                for (size_t i = 0; i < n; ++i) {
-                  if ((it + sizeof(T)) > end) [[unlikely]] {
+                  if (size_t(end - it) < sizeof(T)) [[unlikely]] {
                      ctx.error = error_code::unexpected_end;
                      return;
                   }
@@ -413,12 +411,12 @@ namespace glz
                   to<JSON, T>::template op<Opts>(value, ctx, out, ix);
                   it += sizeof(T);
                   if (i != n - 1) {
-                     dump(',', out, ix);
+                     if (!emit_char(ctx, ',', out, ix)) return;
                   }
                }
             };
 
-            dump('[', out, ix);
+            if (!emit_char(ctx, '[', out, ix)) return;
 
             switch (value_type) {
             case 0: {
@@ -518,9 +516,11 @@ namespace glz
                      }
                      const sv value{reinterpret_cast<const char*>(it), n};
                      detail::emit_untrusted_string<Opts>(ctx, value, out, ix);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
                      it += n;
                      if (i != n_strings - 1) {
-                        dump(',', out, ix);
+                        if (!emit_char(ctx, ',', out, ix)) return;
                      }
                   }
                   break;
@@ -538,7 +538,7 @@ namespace glz
             }
             }
 
-            dump(']', out, ix);
+            if (!emit_char(ctx, ']', out, ix)) return;
 
             break;
          }
@@ -548,17 +548,17 @@ namespace glz
             if (bool(ctx.error)) [[unlikely]] {
                return;
             }
-            dump('[', out, ix);
+            if (!emit_char(ctx, '[', out, ix)) return;
             for (size_t i = 0; i < n; ++i) {
                beve_to_json_value<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
                if (bool(ctx.error)) [[unlikely]] {
                   return;
                }
                if (i != n - 1) {
-                  dump(',', out, ix);
+                  if (!emit_char(ctx, ',', out, ix)) return;
                }
             }
-            dump(']', out, ix);
+            if (!emit_char(ctx, ']', out, ix)) return;
             break;
          }
          case tag::extensions: {
@@ -567,7 +567,7 @@ namespace glz
             case 0: {
                // delimiter
                ++it;
-               dump('\n', out, ix);
+               if (!emit_char(ctx, '\n', out, ix)) return;
                break;
             }
             case 1: {
@@ -594,71 +594,70 @@ namespace glz
                const auto matrix_header = uint8_t(*it);
                ++it;
 
-               dump('{', out, ix);
-               if constexpr (Opts.prettify) {
-                  ctx.depth += check_indentation_width(Opts);
-                  dump('\n', out, ix);
-                  dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
-               }
-               else {
-                  ++ctx.depth;
+               if (!emit_char(ctx, '{', out, ix)) return;
+               {
+                  // The indentation this matrix adds belongs to it, so every way out -- including an
+                  // error return from a nested value -- puts the depth back.
+                  const indent_guard indent{ctx, Opts.prettify ? check_indentation_width(Opts) : 1};
+
+                  if constexpr (Opts.prettify) {
+                     if (!emit_newline_indent<Opts>(ctx, out, ix)) return;
+                  }
+
+                  if constexpr (Opts.prettify) {
+                     if (!emit_literal<R"("layout": )">(ctx, out, ix)) return;
+                  }
+                  else {
+                     if (!emit_literal<R"("layout":)">(ctx, out, ix)) return;
+                  }
+
+                  const auto layout = matrix_header & 0b0000000'1;
+                  if (layout) {
+                     if (!emit_literal<R"("layout_right")">(ctx, out, ix)) return;
+                  }
+                  else {
+                     if (!emit_literal<R"("layout_left")">(ctx, out, ix)) return;
+                  }
+
+                  if (!emit_char(ctx, ',', out, ix)) return;
+                  if constexpr (Opts.prettify) {
+                     if (!emit_newline_indent<Opts>(ctx, out, ix)) return;
+                  }
+
+                  if constexpr (Opts.prettify) {
+                     if (!emit_literal<R"("extents": )">(ctx, out, ix)) return;
+                  }
+                  else {
+                     if (!emit_literal<R"("extents":)">(ctx, out, ix)) return;
+                  }
+
+                  beve_to_json_value<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
+                  if (bool(ctx.error)) [[unlikely]] {
+                     return;
+                  }
+
+                  if (!emit_char(ctx, ',', out, ix)) return;
+                  if constexpr (Opts.prettify) {
+                     if (!emit_newline_indent<Opts>(ctx, out, ix)) return;
+                  }
+
+                  if constexpr (Opts.prettify) {
+                     if (!emit_literal<R"("value": )">(ctx, out, ix)) return;
+                  }
+                  else {
+                     if (!emit_literal<R"("value":)">(ctx, out, ix)) return;
+                  }
+
+                  beve_to_json_value<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
+                  if (bool(ctx.error)) [[unlikely]] {
+                     return;
+                  }
                }
 
                if constexpr (Opts.prettify) {
-                  dump<R"("layout": )">(out, ix);
+                  if (!emit_newline_indent<Opts>(ctx, out, ix)) return;
                }
-               else {
-                  dump<R"("layout":)">(out, ix);
-               }
-
-               const auto layout = matrix_header & 0b0000000'1;
-               layout ? dump<R"("layout_right")">(out, ix) : dump<R"("layout_left")">(out, ix);
-
-               dump(',', out, ix);
-               if constexpr (Opts.prettify) {
-                  dump('\n', out, ix);
-                  dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
-               }
-
-               if constexpr (Opts.prettify) {
-                  dump<R"("extents": )">(out, ix);
-               }
-               else {
-                  dump<R"("extents":)">(out, ix);
-               }
-
-               beve_to_json_value<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
-               if (bool(ctx.error)) [[unlikely]] {
-                  return;
-               }
-
-               dump(',', out, ix);
-               if constexpr (Opts.prettify) {
-                  dump('\n', out, ix);
-                  dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
-               }
-
-               if constexpr (Opts.prettify) {
-                  dump<R"("value": )">(out, ix);
-               }
-               else {
-                  dump<R"("value":)">(out, ix);
-               }
-
-               beve_to_json_value<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
-               if (bool(ctx.error)) [[unlikely]] {
-                  return;
-               }
-
-               if constexpr (Opts.prettify) {
-                  ctx.depth -= check_indentation_width(Opts);
-                  dump('\n', out, ix);
-                  dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
-               }
-               else {
-                  --ctx.depth;
-               }
-               dump('}', out, ix);
+               if (!emit_char(ctx, '}', out, ix)) return;
                break;
             }
             case 3: {
@@ -679,39 +678,39 @@ namespace glz
                   if (bool(ctx.error)) [[unlikely]] {
                      return;
                   }
-                  dump('[', out, ix);
+                  if (!emit_char(ctx, '[', out, ix)) return;
                   for (size_t i = 0; i < n; ++i) {
-                     dump('[', out, ix);
+                     if (!emit_char(ctx, '[', out, ix)) return;
                      beve_to_json_number<Opts>(number_tag, ctx, it, end, out, ix);
                      if (bool(ctx.error)) [[unlikely]] {
                         return;
                      }
-                     dump(',', out, ix);
+                     if (!emit_char(ctx, ',', out, ix)) return;
                      beve_to_json_number<Opts>(number_tag, ctx, it, end, out, ix);
                      if (bool(ctx.error)) [[unlikely]] {
                         return;
                      }
-                     dump(']', out, ix);
+                     if (!emit_char(ctx, ']', out, ix)) return;
                      if (i != n - 1) {
-                        dump(',', out, ix);
+                        if (!emit_char(ctx, ',', out, ix)) return;
                      }
                   }
-                  dump(']', out, ix);
+                  if (!emit_char(ctx, ']', out, ix)) return;
                }
                else {
                   // complex number
                   const auto number_tag = complex_header & 0b111'00000;
-                  dump('[', out, ix);
+                  if (!emit_char(ctx, '[', out, ix)) return;
                   beve_to_json_number<Opts>(number_tag, ctx, it, end, out, ix);
                   if (bool(ctx.error)) [[unlikely]] {
                      return;
                   }
-                  dump(',', out, ix);
+                  if (!emit_char(ctx, ',', out, ix)) return;
                   beve_to_json_number<Opts>(number_tag, ctx, it, end, out, ix);
                   if (bool(ctx.error)) [[unlikely]] {
                      return;
                   }
-                  dump(']', out, ix);
+                  if (!emit_char(ctx, ']', out, ix)) return;
                }
 
                break;
@@ -731,6 +730,15 @@ namespace glz
       }
    }
 
+   // Convert a BEVE buffer directly to JSON without intermediate C++ types
+   //
+   // An empty buffer holds no value, which is not a document, and is reported rather than
+   // converted into empty output.
+   //
+   // A buffer holding several values converts to one JSON document per line, the way NDJSON
+   // separates its documents. A delimiter tag writes that newline itself. Where a stream was
+   // concatenated without delimiters -- which read_beve_delimited also accepts -- the newline is
+   // written here instead, so two values never run together into text that is no longer JSON.
    template <auto Opts = glz::opts{}, class BEVEBuffer, class JSONBuffer>
    [[nodiscard]] inline error_ctx beve_to_json(const BEVEBuffer& beve, JSONBuffer& out)
    {
@@ -741,10 +749,25 @@ namespace glz
 
       context ctx{};
 
+      if (it >= end) {
+         return {0, error_code::unexpected_end};
+      }
+
+      bool needs_separator = false;
+
       while (it < end) {
+         const bool is_delimiter = uint8_t(*it) == tag::delimiter;
+
+         if (needs_separator && !is_delimiter) {
+            if (!detail::emit_char(ctx, '\n', out, ix)) {
+               return {ix, ctx.error};
+            }
+         }
+         needs_separator = !is_delimiter;
+
          detail::beve_to_json_value<Opts>(ctx, it, end, out, ix, 0);
          if (bool(ctx.error)) {
-            return {0, ctx.error};
+            return {ix, ctx.error};
          }
       }
 
@@ -752,6 +775,8 @@ namespace glz
          out.resize(ix);
       }
 
-      return {};
+      // count is the number of bytes written. A resizable buffer carries its own size, but a
+      // fixed-size one has no other way to learn how much of it now holds JSON.
+      return {ix};
    }
 }

--- a/include/glaze/beve/header.hpp
+++ b/include/glaze/beve/header.hpp
@@ -240,7 +240,7 @@ namespace glz
       std::memcpy(&header, it, 1);
       const uint8_t config = header & 0b000000'11;
 
-      if ((it + byte_count_lookup[config]) > end) [[unlikely]] {
+      if (size_t(end - it) < byte_count_lookup[config]) [[unlikely]] {
          ctx.error = error_code::unexpected_end;
          return 0;
       }
@@ -307,7 +307,7 @@ namespace glz
       std::memcpy(&header, it, 1);
       const uint8_t config = header & 0b000000'11;
 
-      if ((it + byte_count_lookup[config]) > end) [[unlikely]] {
+      if (size_t(end - it) < byte_count_lookup[config]) [[unlikely]] {
          ctx.error = error_code::unexpected_end;
          return;
       }

--- a/include/glaze/beve/read.hpp
+++ b/include/glaze/beve/read.hpp
@@ -181,7 +181,7 @@ namespace glz
          constexpr auto Length = byte_length<T>();
          uint8_t data[Length];
 
-         if ((it + Length) > end) [[unlikely]] {
+         if (size_t(end - it) < Length) [[unlikely]] {
             ctx.error = error_code::unexpected_end;
             return;
          }
@@ -223,7 +223,7 @@ namespace glz
                   }
 
                   auto decode = [&](auto&& i) {
-                     if ((it + sizeof(i)) > end) [[unlikely]] {
+                     if (size_t(end - it) < sizeof(i)) [[unlikely]] {
                         ctx.error = error_code::unexpected_end;
                         return;
                      }
@@ -306,7 +306,7 @@ namespace glz
             }
          }
 
-         if ((it + sizeof(V)) > end) [[unlikely]] {
+         if (size_t(end - it) < sizeof(V)) [[unlikely]] {
             ctx.error = error_code::unexpected_end;
             return;
          }
@@ -366,7 +366,7 @@ namespace glz
          using V = std::underlying_type_t<std::decay_t<T>>;
 
          if constexpr (check_no_header(Opts)) {
-            if ((it + sizeof(V)) > end) [[unlikely]] {
+            if (size_t(end - it) < sizeof(V)) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return;
             }
@@ -396,7 +396,7 @@ namespace glz
             }
 
             ++it;
-            if ((it + sizeof(V)) > end) [[unlikely]] {
+            if (size_t(end - it) < sizeof(V)) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return;
             }
@@ -424,7 +424,7 @@ namespace glz
       {
          if constexpr (check_no_header(Opts)) {
             using V = std::decay_t<T>;
-            if ((it + sizeof(V)) > end) [[unlikely]] {
+            if (size_t(end - it) < sizeof(V)) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return;
             }
@@ -473,7 +473,7 @@ namespace glz
             }
             ++it;
 
-            if ((it + 2 * sizeof(V)) > end) [[unlikely]] {
+            if (size_t(end - it) < 2 * sizeof(V)) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return;
             }
@@ -1564,7 +1564,7 @@ namespace glz
             value.clear();
 
             for (size_t i = 0; i < n; ++i) {
-               if ((it + sizeof(V)) > end) [[unlikely]] {
+               if (size_t(end - it) < sizeof(V)) [[unlikely]] {
                   ctx.error = error_code::unexpected_end;
                   return;
                }
@@ -2048,7 +2048,7 @@ namespace glz
 
                if constexpr (is_volatile) {
                   for (size_t i = 0; i < n; ++i) {
-                     if ((it + sizeof(V)) > end) [[unlikely]] {
+                     if (size_t(end - it) < sizeof(V)) [[unlikely]] {
                         ctx.error = error_code::unexpected_end;
                         return;
                      }
@@ -2086,7 +2086,7 @@ namespace glz
             }
             else {
                for (auto&& x : value) {
-                  if ((it + sizeof(V)) > end) [[unlikely]] {
+                  if (size_t(end - it) < sizeof(V)) [[unlikely]] {
                      ctx.error = error_code::unexpected_end;
                      return;
                   }

--- a/include/glaze/beve/skip.hpp
+++ b/include/glaze/beve/skip.hpp
@@ -38,7 +38,7 @@ namespace glz
       const auto tag = uint8_t(*it);
       const uint8_t byte_count = byte_count_lookup[tag >> 5];
       ++it;
-      if ((it + byte_count) > end) [[unlikely]] {
+      if (size_t(end - it) < byte_count) [[unlikely]] {
          ctx.error = error_code::unexpected_end;
          return;
       }

--- a/include/glaze/bson/bson_to_json.hpp
+++ b/include/glaze/bson/bson_to_json.hpp
@@ -48,43 +48,16 @@ namespace glz
 {
    namespace bson_detail
    {
-      // --- small emit helpers ------------------------------------------------
-
-      template <class B, size_t N>
-      GLZ_ALWAYS_INLINE void emit_literal(is_context auto& ctx, B& out, size_t& ix, const char (&lit)[N]) noexcept
-      {
-         constexpr size_t n = N - 1; // exclude the trailing NUL
-         if (!ensure_space(ctx, out, ix + n + write_padding_bytes)) return;
-         std::memcpy(&out[ix], lit, n);
-         ix += n;
-      }
-
-      template <class B>
-      GLZ_ALWAYS_INLINE void emit_char(is_context auto& ctx, B& out, size_t& ix, char c) noexcept
-      {
-         using V = typename std::decay_t<B>::value_type;
-         if (!ensure_space(ctx, out, ix + 1 + write_padding_bytes)) return;
-         out[ix++] = static_cast<V>(c);
-      }
+      // Structural writes go through the shared converter emits in glz::detail, which reserve
+      // exactly what they write and report whether a fixed-size buffer had room.
+      using detail::emit_char;
+      using detail::emit_hex_bytes;
+      using detail::emit_literal;
 
       template <auto Opts, class B>
       GLZ_ALWAYS_INLINE void emit_json_string(is_context auto& ctx, std::string_view s, B& out, size_t& ix) noexcept
       {
          detail::emit_untrusted_string<Opts>(ctx, s, out, ix);
-      }
-
-      // Emit `n` payload bytes as a lowercase hex literal (no quotes, no prefix).
-      template <class B>
-      inline void emit_hex_bytes(is_context auto& ctx, const uint8_t* bytes, size_t n, B& out, size_t& ix) noexcept
-      {
-         using V = typename std::decay_t<B>::value_type;
-         static constexpr char digits[] = "0123456789abcdef";
-         if (!ensure_space(ctx, out, ix + 2 * n + write_padding_bytes)) return;
-         for (size_t i = 0; i < n; ++i) {
-            const uint8_t b = bytes[i];
-            out[ix++] = static_cast<V>(digits[b >> 4]);
-            out[ix++] = static_cast<V>(digits[b & 0x0F]);
-         }
       }
 
       // --- value / document / array dispatchers ------------------------------
@@ -98,27 +71,24 @@ namespace glz
          depth_guard guard{ctx};
          if (!guard) return;
 
-         emit_char(ctx, out, ix, '{');
-         if (bool(ctx.error)) return;
+         if (!emit_char(ctx, '{', out, ix)) return;
 
          bool first = true;
          read_document_elements(ctx, it, stop, [&](uint8_t element_tag, std::string_view key) {
             if (!first) {
-               emit_char(ctx, out, ix, ',');
-               if (bool(ctx.error)) return;
+               if (!emit_char(ctx, ',', out, ix)) return;
             }
             first = false;
 
             emit_json_string<Opts>(ctx, key, out, ix);
             if (bool(ctx.error)) return;
-            emit_char(ctx, out, ix, ':');
-            if (bool(ctx.error)) return;
+            if (!emit_char(ctx, ':', out, ix)) return;
 
             bson_to_json_value<Opts>(element_tag, ctx, it, stop, out, ix);
          });
          if (bool(ctx.error)) return;
 
-         emit_char(ctx, out, ix, '}');
+         if (!emit_char(ctx, '}', out, ix)) return;
       }
 
       template <auto Opts, class It, class B>
@@ -127,21 +97,19 @@ namespace glz
          depth_guard guard{ctx};
          if (!guard) return;
 
-         emit_char(ctx, out, ix, '[');
-         if (bool(ctx.error)) return;
+         if (!emit_char(ctx, '[', out, ix)) return;
 
          bool first = true;
          read_document_elements(ctx, it, stop, [&](uint8_t element_tag, std::string_view /*key*/) {
             if (!first) {
-               emit_char(ctx, out, ix, ',');
-               if (bool(ctx.error)) return;
+               if (!emit_char(ctx, ',', out, ix)) return;
             }
             first = false;
             bson_to_json_value<Opts>(element_tag, ctx, it, stop, out, ix);
          });
          if (bool(ctx.error)) return;
 
-         emit_char(ctx, out, ix, ']');
+         if (!emit_char(ctx, ']', out, ix)) return;
       }
 
       template <auto Opts, class It, class End, class B>
@@ -217,19 +185,16 @@ namespace glz
             const uint8_t* payload = reinterpret_cast<const uint8_t*>(&*it);
             it += payload_len;
 
-            emit_literal(ctx, out, ix, R"({"$binary":{"base64":")");
-            if (bool(ctx.error)) return;
+            if (!emit_literal<R"({"$binary":{"base64":")">(ctx, out, ix)) return;
             write_base64_to(ctx, payload, static_cast<size_t>(payload_len), out, ix);
             if (bool(ctx.error)) return;
-            emit_literal(ctx, out, ix, R"(","subType":")");
-            if (bool(ctx.error)) return;
-            emit_hex_bytes(ctx, &subtype, 1, out, ix);
-            if (bool(ctx.error)) return;
-            emit_literal(ctx, out, ix, R"("}})");
+            if (!emit_literal<R"(","subType":")">(ctx, out, ix)) return;
+            if (!emit_hex_bytes(ctx, &subtype, 1, out, ix)) return;
+            if (!emit_literal<R"("}})">(ctx, out, ix)) return;
             return;
          }
          case type::undefined:
-            emit_literal(ctx, out, ix, R"({"$undefined":true})");
+            if (!emit_literal<R"({"$undefined":true})">(ctx, out, ix)) return;
             return;
          case type::object_id: {
             if (static_cast<int64_t>(end - it) < 12) [[unlikely]] {
@@ -237,11 +202,9 @@ namespace glz
                return;
             }
             const uint8_t* payload = reinterpret_cast<const uint8_t*>(&*it);
-            emit_literal(ctx, out, ix, R"({"$oid":")");
-            if (bool(ctx.error)) return;
-            emit_hex_bytes(ctx, payload, 12, out, ix);
-            if (bool(ctx.error)) return;
-            emit_literal(ctx, out, ix, R"("})");
+            if (!emit_literal<R"({"$oid":")">(ctx, out, ix)) return;
+            if (!emit_hex_bytes(ctx, payload, 12, out, ix)) return;
+            if (!emit_literal<R"("})">(ctx, out, ix)) return;
             it += 12;
             return;
          }
@@ -252,10 +215,10 @@ namespace glz
             }
             const uint8_t b = static_cast<uint8_t>(*it++);
             if (b == 0) {
-               emit_literal(ctx, out, ix, "false");
+               if (!emit_literal<"false">(ctx, out, ix)) return;
             }
             else {
-               emit_literal(ctx, out, ix, "true");
+               if (!emit_literal<"true">(ctx, out, ix)) return;
             }
             return;
          }
@@ -265,30 +228,27 @@ namespace glz
             // Canonical Extended JSON v2: always wrap in {"$numberLong":"..."}
             // (Relaxed uses ISO-8601 for in-range values, which Glaze has no
             // formatter for; canonical form is valid in both modes.)
-            emit_literal(ctx, out, ix, R"({"$date":{"$numberLong":")");
-            if (bool(ctx.error)) return;
+            if (!emit_literal<R"({"$date":{"$numberLong":")">(ctx, out, ix)) return;
             to<JSON, int64_t>::template op<Opts>(ms, ctx, out, ix);
             if (bool(ctx.error)) return;
-            emit_literal(ctx, out, ix, R"("}})");
+            if (!emit_literal<R"("}})">(ctx, out, ix)) return;
             return;
          }
          case type::null:
-            emit_literal(ctx, out, ix, "null");
+            if (!emit_literal<"null">(ctx, out, ix)) return;
             return;
          case type::regex: {
             std::string_view pattern{};
             if (!read_cstring(ctx, it, end, pattern)) return;
             std::string_view options{};
             if (!read_cstring(ctx, it, end, options)) return;
-            emit_literal(ctx, out, ix, R"({"$regularExpression":{"pattern":)");
-            if (bool(ctx.error)) return;
+            if (!emit_literal<R"({"$regularExpression":{"pattern":)">(ctx, out, ix)) return;
             emit_json_string<Opts>(ctx, pattern, out, ix);
             if (bool(ctx.error)) return;
-            emit_literal(ctx, out, ix, R"(,"options":)");
-            if (bool(ctx.error)) return;
+            if (!emit_literal<R"(,"options":)">(ctx, out, ix)) return;
             emit_json_string<Opts>(ctx, options, out, ix);
             if (bool(ctx.error)) return;
-            emit_literal(ctx, out, ix, "}}");
+            if (!emit_literal<"}}">(ctx, out, ix)) return;
             return;
          }
          case type::javascript: {
@@ -304,11 +264,10 @@ namespace glz
             }
             const auto n = static_cast<size_t>(len) - 1;
             std::string_view s{reinterpret_cast<const char*>(&*it), n};
-            emit_literal(ctx, out, ix, R"({"$code":)");
-            if (bool(ctx.error)) return;
+            if (!emit_literal<R"({"$code":)">(ctx, out, ix)) return;
             emit_json_string<Opts>(ctx, s, out, ix);
             if (bool(ctx.error)) return;
-            emit_char(ctx, out, ix, '}');
+            if (!emit_char(ctx, '}', out, ix)) return;
             it += len;
             return;
          }
@@ -325,11 +284,10 @@ namespace glz
             }
             const auto n = static_cast<size_t>(len) - 1;
             std::string_view s{reinterpret_cast<const char*>(&*it), n};
-            emit_literal(ctx, out, ix, R"({"$symbol":)");
-            if (bool(ctx.error)) return;
+            if (!emit_literal<R"({"$symbol":)">(ctx, out, ix)) return;
             emit_json_string<Opts>(ctx, s, out, ix);
             if (bool(ctx.error)) return;
-            emit_char(ctx, out, ix, '}');
+            if (!emit_char(ctx, '}', out, ix)) return;
             it += len;
             return;
          }
@@ -344,15 +302,13 @@ namespace glz
             uint32_t seconds{};
             if (!read_le<uint32_t>(ctx, it, end, increment)) return;
             if (!read_le<uint32_t>(ctx, it, end, seconds)) return;
-            emit_literal(ctx, out, ix, R"({"$timestamp":{"t":)");
-            if (bool(ctx.error)) return;
+            if (!emit_literal<R"({"$timestamp":{"t":)">(ctx, out, ix)) return;
             to<JSON, uint32_t>::template op<Opts>(seconds, ctx, out, ix);
             if (bool(ctx.error)) return;
-            emit_literal(ctx, out, ix, R"(,"i":)");
-            if (bool(ctx.error)) return;
+            if (!emit_literal<R"(,"i":)">(ctx, out, ix)) return;
             to<JSON, uint32_t>::template op<Opts>(increment, ctx, out, ix);
             if (bool(ctx.error)) return;
-            emit_literal(ctx, out, ix, "}}");
+            if (!emit_literal<"}}">(ctx, out, ix)) return;
             return;
          }
          case type::int64: {
@@ -370,19 +326,17 @@ namespace glz
             // Extended JSON v2 $numberDecimal requires a decimal string, which
             // Glaze has no decimal128 formatter for. Emit under a non-`$`
             // wrapper so this doesn't masquerade as real $numberDecimal.
-            emit_literal(ctx, out, ix, R"({"decimal128Hex":")");
-            if (bool(ctx.error)) return;
-            emit_hex_bytes(ctx, payload, 16, out, ix);
-            if (bool(ctx.error)) return;
-            emit_literal(ctx, out, ix, R"("})");
+            if (!emit_literal<R"({"decimal128Hex":")">(ctx, out, ix)) return;
+            if (!emit_hex_bytes(ctx, payload, 16, out, ix)) return;
+            if (!emit_literal<R"("})">(ctx, out, ix)) return;
             it += 16;
             return;
          }
          case type::min_key:
-            emit_literal(ctx, out, ix, R"({"$minKey":1})");
+            if (!emit_literal<R"({"$minKey":1})">(ctx, out, ix)) return;
             return;
          case type::max_key:
-            emit_literal(ctx, out, ix, R"({"$maxKey":1})");
+            if (!emit_literal<R"({"$maxKey":1})">(ctx, out, ix)) return;
             return;
          case type::db_pointer:
          case type::code_w_scope:
@@ -429,7 +383,9 @@ namespace glz
       if constexpr (resizable<JSONBuffer>) {
          out.resize(ix);
       }
-      return {};
+      // count is the number of bytes written. A resizable buffer carries its own size, but a
+      // fixed-size one has no other way to learn how much of it now holds JSON.
+      return {ix};
    }
 
    template <auto Opts = glz::opts{}, class BSONBuffer>

--- a/include/glaze/cbor/cbor_to_json.hpp
+++ b/include/glaze/cbor/cbor_to_json.hpp
@@ -33,7 +33,7 @@ namespace glz
             return val;
          }
          case info::uint16_follows: {
-            if ((it + 2) > end) [[unlikely]] {
+            if ((end - it) < 2) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return 0;
             }
@@ -46,7 +46,7 @@ namespace glz
             return val;
          }
          case info::uint32_follows: {
-            if ((it + 4) > end) [[unlikely]] {
+            if ((end - it) < 4) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return 0;
             }
@@ -59,7 +59,7 @@ namespace glz
             return val;
          }
          case info::uint64_follows: {
-            if ((it + 8) > end) [[unlikely]] {
+            if ((end - it) < 8) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return 0;
             }
@@ -126,10 +126,12 @@ namespace glz
          }
 
          case major::bstr: {
-            // Byte string - encode as base64 in JSON
+            // Byte string - written as a JSON string of hex digit pairs (see emit_hex_bytes)
+            if (!emit_char(ctx, '"', out, ix)) return;
+
             if (additional_info == info::indefinite) {
-               // Indefinite-length byte string - collect chunks first
-               std::vector<uint8_t> bytes;
+               // Indefinite-length byte string - each chunk is hex encoded as it is read, so a long
+               // byte string never has to be assembled in memory first
                while (true) {
                   if (it >= end) [[unlikely]] {
                      ctx.error = error_code::unexpected_end;
@@ -161,22 +163,9 @@ namespace glz
                      return;
                   }
 
-                  if (chunk_len > 0) {
-                     const size_t old_size = bytes.size();
-                     bytes.resize(old_size + chunk_len);
-                     std::memcpy(bytes.data() + old_size, it, chunk_len);
-                     it += chunk_len;
-                  }
+                  if (!emit_hex_bytes(ctx, it, chunk_len, out, ix)) return;
+                  it += chunk_len;
                }
-               // Write as base64-encoded string
-               dump('"', out, ix);
-               // Simple hex encoding for now (TODO: proper base64)
-               for (uint8_t b : bytes) {
-                  static constexpr char hex[] = "0123456789abcdef";
-                  dump(hex[(b >> 4) & 0xf], out, ix);
-                  dump(hex[b & 0xf], out, ix);
-               }
-               dump('"', out, ix);
             }
             else {
                const uint64_t length = cbor_to_json_decode_arg(ctx, it, end, additional_info);
@@ -188,18 +177,11 @@ namespace glz
                   return;
                }
 
-               // Write as hex-encoded string
-               dump('"', out, ix);
-               for (uint64_t i = 0; i < length; ++i) {
-                  static constexpr char hex[] = "0123456789abcdef";
-                  uint8_t b;
-                  std::memcpy(&b, it + i, 1);
-                  dump(hex[(b >> 4) & 0xf], out, ix);
-                  dump(hex[b & 0xf], out, ix);
-               }
-               dump('"', out, ix);
+               if (!emit_hex_bytes(ctx, it, length, out, ix)) return;
                it += length;
             }
+
+            if (!emit_char(ctx, '"', out, ix)) return;
             break;
          }
 
@@ -262,7 +244,20 @@ namespace glz
          }
 
          case major::array: {
-            dump('[', out, ix);
+            // The elements of an array stay on one line, so a separator is ',' or ", "
+            const auto convert_element = [&](const bool needs_comma) {
+               if (needs_comma) {
+                  if constexpr (Opts.prettify) {
+                     if (!emit_literal<", ">(ctx, out, ix)) return;
+                  }
+                  else {
+                     if (!emit_char(ctx, ',', out, ix)) return;
+                  }
+               }
+               cbor_to_json_value<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
+            };
+
+            if (!emit_char(ctx, '[', out, ix)) return;
 
             if (additional_info == info::indefinite) {
                // Indefinite-length array
@@ -280,17 +275,10 @@ namespace glz
                      break;
                   }
 
-                  if (!first) {
-                     dump(',', out, ix);
-                     if constexpr (Opts.prettify) {
-                        dump(' ', out, ix);
-                     }
-                  }
-                  first = false;
-
-                  cbor_to_json_value<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
+                  convert_element(!first);
                   if (bool(ctx.error)) [[unlikely]]
                      return;
+                  first = false;
                }
             }
             else {
@@ -299,117 +287,96 @@ namespace glz
                   return;
 
                for (uint64_t i = 0; i < count; ++i) {
-                  if (i > 0) {
-                     dump(',', out, ix);
-                     if constexpr (Opts.prettify) {
-                        dump(' ', out, ix);
-                     }
-                  }
-                  cbor_to_json_value<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
+                  convert_element(i > 0);
                   if (bool(ctx.error)) [[unlikely]]
                      return;
                }
             }
 
-            dump(']', out, ix);
+            if (!emit_char(ctx, ']', out, ix)) return;
             break;
          }
 
          case major::map: {
-            dump('{', out, ix);
-            if constexpr (Opts.prettify) {
-               ctx.depth += check_indentation_width(Opts);
-            }
+            if (!emit_char(ctx, '{', out, ix)) return;
 
             // A prettified map only breaks the line before its '}' when it holds at least one
             // pair, so an empty map stays "{}" whether its length was definite or indefinite.
             bool wrote_pair = false;
 
-            if (additional_info == info::indefinite) {
-               // Indefinite-length map
-               while (true) {
-                  if (it >= end) [[unlikely]] {
-                     ctx.error = error_code::unexpected_end;
-                     return;
-                  }
-                  uint8_t peek;
-                  std::memcpy(&peek, it, 1);
-
-                  if (peek == initial_byte(major::simple, simple::break_code)) {
-                     ++it;
-                     break;
-                  }
-
-                  if (wrote_pair) {
-                     dump(',', out, ix);
-                  }
-                  if constexpr (Opts.prettify) {
-                     dump('\n', out, ix);
-                     dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
-                  }
-                  wrote_pair = true;
-
-                  // Key (must be string for JSON compatibility)
-                  cbor_to_json_key<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
-                  if (bool(ctx.error)) [[unlikely]]
-                     return;
-
-                  if constexpr (Opts.prettify) {
-                     dump(": ", out, ix);
-                  }
-                  else {
-                     dump(':', out, ix);
-                  }
-
-                  // Value
-                  cbor_to_json_value<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
-                  if (bool(ctx.error)) [[unlikely]]
-                     return;
+            // One pair: the ',' separating it from the pair before, the line a prettified map opens
+            // for it, then the key, the colon, and the value.
+            const auto convert_pair = [&](const bool needs_comma) {
+               if (needs_comma) {
+                  if (!emit_char(ctx, ',', out, ix)) return;
                }
-            }
-            else {
-               const uint64_t count = cbor_to_json_decode_arg(ctx, it, end, additional_info);
+               if constexpr (Opts.prettify) {
+                  if (!emit_newline_indent<Opts>(ctx, out, ix)) return;
+               }
+
+               // Key (must be a string for JSON compatibility)
+               cbor_to_json_key<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
                if (bool(ctx.error)) [[unlikely]]
                   return;
 
-               wrote_pair = count > 0;
+               if constexpr (Opts.prettify) {
+                  if (!emit_literal<": ">(ctx, out, ix)) return;
+               }
+               else {
+                  if (!emit_char(ctx, ':', out, ix)) return;
+               }
 
-               for (uint64_t i = 0; i < count; ++i) {
-                  if (i > 0) {
-                     dump(',', out, ix);
-                  }
-                  if constexpr (Opts.prettify) {
-                     dump('\n', out, ix);
-                     dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
-                  }
+               cbor_to_json_value<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
+            };
 
-                  // Key
-                  cbor_to_json_key<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
+            {
+               // The indentation this map adds belongs to this map, so it is raised for the pairs
+               // and no longer: leaving it up on an error path would indent whatever the context
+               // is used for next.
+               const indent_guard indent{ctx, Opts.prettify ? check_indentation_width(Opts) : 0};
+
+               if (additional_info == info::indefinite) {
+                  // Indefinite-length map
+                  while (true) {
+                     if (it >= end) [[unlikely]] {
+                        ctx.error = error_code::unexpected_end;
+                        return;
+                     }
+                     uint8_t peek;
+                     std::memcpy(&peek, it, 1);
+
+                     if (peek == initial_byte(major::simple, simple::break_code)) {
+                        ++it;
+                        break;
+                     }
+
+                     convert_pair(wrote_pair);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                     wrote_pair = true;
+                  }
+               }
+               else {
+                  const uint64_t count = cbor_to_json_decode_arg(ctx, it, end, additional_info);
                   if (bool(ctx.error)) [[unlikely]]
                      return;
 
-                  if constexpr (Opts.prettify) {
-                     dump(": ", out, ix);
-                  }
-                  else {
-                     dump(':', out, ix);
-                  }
+                  wrote_pair = count > 0;
 
-                  // Value
-                  cbor_to_json_value<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
-                  if (bool(ctx.error)) [[unlikely]]
-                     return;
+                  for (uint64_t i = 0; i < count; ++i) {
+                     convert_pair(i > 0);
+                     if (bool(ctx.error)) [[unlikely]]
+                        return;
+                  }
                }
             }
 
             if constexpr (Opts.prettify) {
-               ctx.depth -= check_indentation_width(Opts);
                if (wrote_pair) {
-                  dump('\n', out, ix);
-                  dumpn(check_indentation_char(Opts), ctx.depth, out, ix);
+                  if (!emit_newline_indent<Opts>(ctx, out, ix)) return;
                }
             }
-            dump('}', out, ix);
+            if (!emit_char(ctx, '}', out, ix)) return;
             break;
          }
 
@@ -447,6 +414,15 @@ namespace glz
                   return;
                }
 
+               // Tags 83 and 87 hold IEEE binary128 elements, which no C++ floating point type this
+               // library writes or reads represents. Rejecting the width here, before the array is
+               // opened, keeps the element loop over widths it can decode and leaves no half
+               // written array behind.
+               if (ta_info.element_size > 8) [[unlikely]] {
+                  ctx.error = error_code::feature_not_supported;
+                  return;
+               }
+
                if (byte_len % ta_info.element_size != 0) [[unlikely]] {
                   ctx.error = error_code::syntax_error;
                   return;
@@ -455,16 +431,26 @@ namespace glz
                const size_t count = byte_len / ta_info.element_size;
                const bool need_swap = typed_array::needs_byteswap(tag_num);
 
-               dump('[', out, ix);
+               if (!emit_char(ctx, '[', out, ix)) return;
 
                for (size_t i = 0; i < count; ++i) {
                   if (i > 0) {
-                     dump(',', out, ix);
+                     if (!emit_char(ctx, ',', out, ix)) return;
                   }
 
                   // Read and optionally byteswap the element
                   if (ta_info.is_float) {
-                     if (ta_info.element_size == 4) {
+                     if (ta_info.element_size == 2) {
+                        // Half precision (tags 80 and 84) has no C++ type; it widens to double,
+                        // the same conversion decode_half performs for a bare float16 value.
+                        uint16_t half;
+                        std::memcpy(&half, it, 2);
+                        if (need_swap) {
+                           half = std::byteswap(half);
+                        }
+                        to<JSON, double>::template op<Opts>(decode_half(half), ctx, out, ix);
+                     }
+                     else if (ta_info.element_size == 4) {
                         float val;
                         std::memcpy(&val, it, 4);
                         if (need_swap) {
@@ -564,10 +550,14 @@ namespace glz
                      }
                   }
 
+                  if (bool(ctx.error)) [[unlikely]] {
+                     return;
+                  }
+
                   it += ta_info.element_size;
                }
 
-               dump(']', out, ix);
+               if (!emit_char(ctx, ']', out, ix)) return;
             }
             else {
                // Other tags - just output the tagged content
@@ -579,17 +569,20 @@ namespace glz
          case major::simple: {
             switch (additional_info) {
             case simple::false_value:
-               dump("false", out, ix);
+               if (!emit_literal<"false">(ctx, out, ix)) return;
                break;
             case simple::true_value:
-               dump("true", out, ix);
+               if (!emit_literal<"true">(ctx, out, ix)) return;
                break;
             case simple::null_value:
+            // JSON has one empty value and CBOR has two. `undefined` becomes `null` because that is
+            // the only thing JSON can say, so the distinction between "no value" and "absent value"
+            // does not survive the conversion.
             case simple::undefined:
-               dump("null", out, ix);
+               if (!emit_literal<"null">(ctx, out, ix)) return;
                break;
             case simple::float16: {
-               if ((it + 2) > end) [[unlikely]] {
+               if ((end - it) < 2) [[unlikely]] {
                   ctx.error = error_code::unexpected_end;
                   return;
                }
@@ -604,7 +597,7 @@ namespace glz
                break;
             }
             case simple::float32: {
-               if ((it + 4) > end) [[unlikely]] {
+               if ((end - it) < 4) [[unlikely]] {
                   ctx.error = error_code::unexpected_end;
                   return;
                }
@@ -620,7 +613,7 @@ namespace glz
                break;
             }
             case simple::float64: {
-               if ((it + 8) > end) [[unlikely]] {
+               if ((end - it) < 8) [[unlikely]] {
                   ctx.error = error_code::unexpected_end;
                   return;
                }
@@ -717,25 +710,27 @@ namespace glz
             cbor_to_json_key<Opts>(ctx, it, end, out, ix, recursive_depth + 1);
             return;
          }
-         case major::uint: {
-            ++it;
-            const uint64_t value = cbor_to_json_decode_arg(ctx, it, end, additional_info);
-            if (bool(ctx.error)) [[unlikely]]
-               return;
-            dump('"', out, ix);
-            to<JSON, uint64_t>::template op<Opts>(value, ctx, out, ix);
-            dump('"', out, ix);
-            return;
-         }
+         case major::uint:
          case major::nint: {
             ++it;
-            const uint64_t n = cbor_to_json_decode_arg(ctx, it, end, additional_info);
+            const uint64_t arg = cbor_to_json_decode_arg(ctx, it, end, additional_info);
             if (bool(ctx.error)) [[unlikely]]
                return;
-            const int64_t value = static_cast<int64_t>(~n);
-            dump('"', out, ix);
-            to<JSON, int64_t>::template op<Opts>(value, ctx, out, ix);
-            dump('"', out, ix);
+
+            const auto emit_quoted = [&](const auto value) {
+               if (!emit_char(ctx, '"', out, ix)) return;
+               to<JSON, decltype(value)>::template op<Opts>(value, ctx, out, ix);
+               if (bool(ctx.error)) [[unlikely]]
+                  return;
+               if (!emit_char(ctx, '"', out, ix)) return;
+            };
+
+            if (major_type == major::uint) {
+               emit_quoted(arg);
+            }
+            else {
+               emit_quoted(static_cast<int64_t>(~arg));
+            }
             return;
          }
          default:
@@ -746,6 +741,12 @@ namespace glz
    }
 
    // Convert CBOR buffer directly to JSON without intermediate C++ types
+   //
+   // The buffer holds exactly one CBOR data item, which is what a CBOR-encoded document is. An
+   // empty buffer is not one, and a buffer holding several is a CBOR sequence (RFC 8742), whose
+   // items would run together into text no JSON parser accepts. Both are reported rather than
+   // written, because a converter that answers a malformed document with a malformed one just
+   // moves the problem downstream.
    template <auto Opts = glz::opts{}, class CBORBuffer, class JSONBuffer>
    [[nodiscard]] inline error_ctx cbor_to_json(const CBORBuffer& cbor, JSONBuffer& out)
    {
@@ -756,18 +757,26 @@ namespace glz
 
       context ctx{};
 
-      while (it < end) {
-         detail::cbor_to_json_value<Opts>(ctx, it, end, out, ix, 0);
-         if (bool(ctx.error)) {
-            return {0, ctx.error};
-         }
+      if (it >= end) {
+         return {0, error_code::unexpected_end};
+      }
+
+      detail::cbor_to_json_value<Opts>(ctx, it, end, out, ix, 0);
+      if (bool(ctx.error)) {
+         return {ix, ctx.error};
+      }
+
+      if (it < end) {
+         return {ix, error_code::syntax_error};
       }
 
       if constexpr (resizable<JSONBuffer>) {
          out.resize(ix);
       }
 
-      return {};
+      // count is the number of bytes written. A resizable buffer carries its own size, but a
+      // fixed-size one has no other way to learn how much of it now holds JSON.
+      return {ix};
    }
 
    // Convenience function returning string

--- a/include/glaze/cbor/read.hpp
+++ b/include/glaze/cbor/read.hpp
@@ -45,7 +45,7 @@ namespace glz
             return val;
          }
          case info::uint16_follows: {
-            if ((it + 2) > end) [[unlikely]] {
+            if ((end - it) < 2) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return 0;
             }
@@ -58,7 +58,7 @@ namespace glz
             return val;
          }
          case info::uint32_follows: {
-            if ((it + 4) > end) [[unlikely]] {
+            if ((end - it) < 4) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return 0;
             }
@@ -71,7 +71,7 @@ namespace glz
             return val;
          }
          case info::uint64_follows: {
-            if ((it + 8) > end) [[unlikely]] {
+            if ((end - it) < 8) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return 0;
             }
@@ -457,7 +457,7 @@ namespace glz
 
          switch (additional_info) {
          case simple::float16: {
-            if ((it + 2) > end) [[unlikely]] {
+            if ((end - it) < 2) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return;
             }
@@ -471,7 +471,7 @@ namespace glz
             break;
          }
          case simple::float32: {
-            if ((it + 4) > end) [[unlikely]] {
+            if ((end - it) < 4) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return;
             }
@@ -487,7 +487,7 @@ namespace glz
             break;
          }
          case simple::float64: {
-            if ((it + 8) > end) [[unlikely]] {
+            if ((end - it) < 8) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return;
             }

--- a/include/glaze/cbor/skip.hpp
+++ b/include/glaze/cbor/skip.hpp
@@ -35,7 +35,7 @@ namespace glz
             return val;
          }
          case info::uint16_follows: {
-            if ((it + 2) > end) [[unlikely]] {
+            if ((end - it) < 2) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return 0;
             }
@@ -48,7 +48,7 @@ namespace glz
             return val;
          }
          case info::uint32_follows: {
-            if ((it + 4) > end) [[unlikely]] {
+            if ((end - it) < 4) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return 0;
             }
@@ -61,7 +61,7 @@ namespace glz
             return val;
          }
          case info::uint64_follows: {
-            if ((it + 8) > end) [[unlikely]] {
+            if ((end - it) < 8) [[unlikely]] {
                ctx.error = error_code::unexpected_end;
                return 0;
             }
@@ -295,21 +295,21 @@ namespace glz
                ++it; // Simple value in next byte
                break;
             case simple::float16:
-               if ((it + 2) > end) [[unlikely]] {
+               if ((end - it) < 2) [[unlikely]] {
                   ctx.error = error_code::unexpected_end;
                   return;
                }
                it += 2;
                break;
             case simple::float32:
-               if ((it + 4) > end) [[unlikely]] {
+               if ((end - it) < 4) [[unlikely]] {
                   ctx.error = error_code::unexpected_end;
                   return;
                }
                it += 4;
                break;
             case simple::float64:
-               if ((it + 8) > end) [[unlikely]] {
+               if ((end - it) < 8) [[unlikely]] {
                   ctx.error = error_code::unexpected_end;
                   return;
                }

--- a/include/glaze/core/context.hpp
+++ b/include/glaze/core/context.hpp
@@ -198,6 +198,26 @@ namespace glz
       explicit operator bool() const noexcept { return entered; }
    };
 
+   // Raises the indentation depth for the lifetime of a container being written, so that every way
+   // out of it -- including an error return from a nested value -- puts the depth back. The step is
+   // the writer's indentation width, passed in because it is a formatting option the context knows
+   // nothing about.
+   template <class Ctx>
+   struct indent_guard
+   {
+      Ctx& ctx;
+      size_t step;
+
+      indent_guard(Ctx& c, const size_t indentation_step) noexcept : ctx(c), step(indentation_step)
+      {
+         ctx.depth += step;
+      }
+      ~indent_guard() { ctx.depth -= step; }
+
+      indent_guard(const indent_guard&) = delete;
+      indent_guard& operator=(const indent_guard&) = delete;
+   };
+
    // A variant read is speculative: an alternative is parsed to find out whether it fits, and a
    // rejected one is rewound and the next tried. Nest that -- a variant whose alternatives contain
    // variants -- and the re-parses multiply, so a failure at the bottom of an ambiguous nest costs

--- a/include/glaze/core/reflect.hpp
+++ b/include/glaze/core/reflect.hpp
@@ -2519,7 +2519,7 @@ namespace glz
          else {
             if constexpr (N == 2) {
                if constexpr (uindex > 0) {
-                  if ((it + uindex) >= end) [[unlikely]] {
+                  if (size_t(end - it) <= uindex) [[unlikely]] {
                      return N; // error
                   }
                }
@@ -2529,7 +2529,7 @@ namespace glz
             }
             else {
                if constexpr (uindex > 0) {
-                  if ((it + uindex) >= end) [[unlikely]] {
+                  if (size_t(end - it) <= uindex) [[unlikely]] {
                      return N; // error
                   }
                }
@@ -2548,7 +2548,7 @@ namespace glz
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto end) noexcept
       {
          if constexpr (uindex > 0) {
-            if ((it + uindex) >= end) [[unlikely]] {
+            if (size_t(end - it) <= uindex) [[unlikely]] {
                return N; // error
             }
          }
@@ -2567,7 +2567,7 @@ namespace glz
       GLZ_ALWAYS_INLINE static constexpr size_t op(auto&& it, auto end) noexcept
       {
          if constexpr (HashInfo.front_hash_bytes == 2) {
-            if ((it + 2) >= end) [[unlikely]] {
+            if (size_t(end - it) <= 2) [[unlikely]] {
                return N; // error
             }
             uint16_t h;
@@ -2586,7 +2586,7 @@ namespace glz
             return HashInfo.table[bitmix(h, HashInfo.seed) % bsize];
          }
          else if constexpr (HashInfo.front_hash_bytes == 4) {
-            if ((it + 4) >= end) [[unlikely]] {
+            if (size_t(end - it) <= 4) [[unlikely]] {
                return N;
             }
             uint32_t h;
@@ -2605,7 +2605,7 @@ namespace glz
             return HashInfo.table[bitmix(h, HashInfo.seed) % bsize];
          }
          else if constexpr (HashInfo.front_hash_bytes == 8) {
-            if ((it + 8) >= end) [[unlikely]] {
+            if (size_t(end - it) <= 8) [[unlikely]] {
                return N;
             }
             uint64_t h;
@@ -2641,7 +2641,7 @@ namespace glz
          if (c) [[likely]] {
             const auto n = uint8_t(static_cast<std::decay_t<decltype(it)>>(c) - it);
             const auto pos = per_length_info<T>.unique_index[n];
-            if ((it + pos) >= end) [[unlikely]] {
+            if (size_t(end - it) <= pos) [[unlikely]] {
                return N; // error
             }
             const auto h = bitmix(uint16_t(it[pos]) | (uint16_t(n) << 8), HashInfo.seed);
@@ -2669,7 +2669,7 @@ namespace glz
          // extra characters exist after the closing quote (e.g., standalone enum: "value")
 
          if constexpr (length_range == 0) {
-            if ((it + min_length) >= end) [[unlikely]] {
+            if (size_t(end - it) <= min_length) [[unlikely]] {
                return N;
             }
             const auto h = full_hash<HashInfo.min_length, HashInfo.max_length, HashInfo.seed>(it, min_length);
@@ -2884,7 +2884,7 @@ namespace glz
          // a gap of [min_length, max_length] would read it[255]. The wrapper's length pre-screen
          // does not catch that, so this reader keeps its own end check.
          const auto pos = per_length_info<T>.unique_index[uint8_t(n)];
-         if ((it + pos) >= end) [[unlikely]] {
+         if (size_t(end - it) <= pos) [[unlikely]] {
             return N; // error
          }
          const auto h = bitmix(uint16_t(it[pos]) | (uint16_t(n) << 8), HashInfo.seed);

--- a/include/glaze/eetf/eetf_to_json.hpp
+++ b/include/glaze/eetf/eetf_to_json.hpp
@@ -352,6 +352,8 @@ namespace glz
          out.resize(ix);
       }
 
-      return {};
+      // count is the number of bytes written. A resizable buffer carries its own size, but a
+      // fixed-size one has no other way to learn how much of it now holds JSON.
+      return {ix};
    }
 } // namespace glz

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1155,7 +1155,7 @@ namespace glz
          if (!ensure_space(ctx, out, ix + 1)) [[unlikely]] {
             return false;
          }
-         dump(c, out, ix);
+         dump<false>(c, out, ix);
          return true;
       }
 
@@ -1166,7 +1166,7 @@ namespace glz
          if (!ensure_space(ctx, out, ix + s.size())) [[unlikely]] {
             return false;
          }
-         dump(s, out, ix);
+         dump<false>(s, out, ix);
          return true;
       }
 
@@ -1177,7 +1177,8 @@ namespace glz
          if (!ensure_space(ctx, out, ix + 1 + ctx.depth)) [[unlikely]] {
             return false;
          }
-         dump_newline_indent(check_indentation_char(Opts), ctx.depth, out, ix);
+         dump<false>('\n', out, ix);
+         dumpn_unchecked(check_indentation_char(Opts), ctx.depth, out, ix);
          return true;
       }
 
@@ -1196,8 +1197,8 @@ namespace glz
          for (uint64_t i = 0; i < n; ++i) {
             uint8_t b;
             std::memcpy(&b, data + i, 1);
-            dump(digits[(b >> 4) & 0xf], out, ix);
-            dump(digits[b & 0xf], out, ix);
+            dump<false>(digits[(b >> 4) & 0xf], out, ix);
+            dump<false>(digits[b & 0xf], out, ix);
          }
          return true;
       }

--- a/include/glaze/json/write.hpp
+++ b/include/glaze/json/write.hpp
@@ -1140,6 +1140,67 @@ namespace glz
       {
          to<JSON, std::string_view>::template op<untrusted_string_emit_opts<Opts>>(s, ctx, out, ix);
       }
+
+      // Structural writes for the binary-to-JSON converters.
+      //
+      // dump() grows a resizable buffer but does not bounds check one it cannot grow, so a
+      // converter has to reserve before it writes or it walks off the end of a std::array or
+      // std::span. Each of these folds the reservation into the write, which keeps the byte count
+      // next to the bytes rather than hand-maintained at the call site. They return false, with
+      // ctx.error set to buffer_overflow, when a fixed-size buffer has no room left.
+
+      template <class B>
+      [[nodiscard]] GLZ_ALWAYS_INLINE bool emit_char(is_context auto& ctx, const char c, B& out, size_t& ix)
+      {
+         if (!ensure_space(ctx, out, ix + 1)) [[unlikely]] {
+            return false;
+         }
+         dump(c, out, ix);
+         return true;
+      }
+
+      template <string_literal str, class B>
+      [[nodiscard]] GLZ_ALWAYS_INLINE bool emit_literal(is_context auto& ctx, B& out, size_t& ix)
+      {
+         static constexpr auto s = str.sv();
+         if (!ensure_space(ctx, out, ix + s.size())) [[unlikely]] {
+            return false;
+         }
+         dump(s, out, ix);
+         return true;
+      }
+
+      // The newline and indentation that open a line of prettified output
+      template <auto Opts, class B>
+      [[nodiscard]] GLZ_ALWAYS_INLINE bool emit_newline_indent(is_context auto& ctx, B& out, size_t& ix)
+      {
+         if (!ensure_space(ctx, out, ix + 1 + ctx.depth)) [[unlikely]] {
+            return false;
+         }
+         dump_newline_indent(check_indentation_char(Opts), ctx.depth, out, ix);
+         return true;
+      }
+
+      // Byte payloads have no JSON counterpart, so they are written as a string of two lowercase
+      // hex digits per byte. The caller writes the surrounding quotes, which lets an indefinite
+      // length payload be emitted chunk by chunk rather than assembled first.
+      template <class B>
+      [[nodiscard]] inline bool emit_hex_bytes(is_context auto& ctx, auto data, const uint64_t n, B& out, size_t& ix)
+      {
+         static constexpr char digits[] = "0123456789abcdef";
+
+         if (!ensure_space(ctx, out, ix + 2 * n)) [[unlikely]] {
+            return false;
+         }
+
+         for (uint64_t i = 0; i < n; ++i) {
+            uint8_t b;
+            std::memcpy(&b, data + i, 1);
+            dump(digits[(b >> 4) & 0xf], out, ix);
+            dump(digits[b & 0xf], out, ix);
+         }
+         return true;
+      }
    }
 
    template <class T>

--- a/include/glaze/jsonb/jsonb_to_json.hpp
+++ b/include/glaze/jsonb/jsonb_to_json.hpp
@@ -484,16 +484,18 @@ namespace glz
 
       jsonb_detail::jsonb_to_json_value<Opts>(ctx, it, end, out, ix, 0);
       if (bool(ctx.error)) {
-         return {0, ctx.error};
+         return {ix, ctx.error};
       }
       if (it != end) {
-         return {0, error_code::syntax_error};
+         return {ix, error_code::syntax_error};
       }
 
       if constexpr (resizable<JSONBuffer>) {
          out.resize(ix);
       }
-      return {};
+      // count is the number of bytes written. A resizable buffer carries its own size, but a
+      // fixed-size one has no other way to learn how much of it now holds JSON.
+      return {ix};
    }
 
    template <auto Opts = glz::opts{}, class JSONBBuffer>

--- a/include/glaze/msgpack/common.hpp
+++ b/include/glaze/msgpack/common.hpp
@@ -150,7 +150,7 @@ namespace glz::msgpack
    template <class It>
    GLZ_ALWAYS_INLINE bool read_uint16(is_context auto& ctx, It& it, const It& end, uint16_t& out) noexcept
    {
-      if ((it + 2) > end) [[unlikely]] {
+      if ((end - it) < 2) [[unlikely]] {
          ctx.error = error_code::unexpected_end;
          return false;
       }
@@ -164,7 +164,7 @@ namespace glz::msgpack
    template <class It>
    GLZ_ALWAYS_INLINE bool read_uint32(is_context auto& ctx, It& it, const It& end, uint32_t& out) noexcept
    {
-      if ((it + 4) > end) [[unlikely]] {
+      if ((end - it) < 4) [[unlikely]] {
          ctx.error = error_code::unexpected_end;
          return false;
       }
@@ -181,7 +181,7 @@ namespace glz::msgpack
    template <class It>
    GLZ_ALWAYS_INLINE bool read_uint64(is_context auto& ctx, It& it, const It& end, uint64_t& out) noexcept
    {
-      if ((it + 8) > end) [[unlikely]] {
+      if ((end - it) < 8) [[unlikely]] {
          ctx.error = error_code::unexpected_end;
          return false;
       }

--- a/include/glaze/toml/skip.hpp
+++ b/include/glaze/toml/skip.hpp
@@ -22,17 +22,17 @@ namespace glz::toml
          return;
       }
 
-      if ((it + 2) < end && *it == '"' && *(it + 1) == '"' && *(it + 2) == '"') {
+      if (size_t(end - it) > 2 && *it == '"' && *(it + 1) == '"' && *(it + 2) == '"') {
          it += 3;
          if (it != end && *it == '\n') {
             ++it;
          }
-         else if ((it + 1) < end && *it == '\r' && *(it + 1) == '\n') {
+         else if (size_t(end - it) > 1 && *it == '\r' && *(it + 1) == '\n') {
             it += 2;
          }
 
          while (true) {
-            if ((it + 2) >= end) [[unlikely]] {
+            if (size_t(end - it) <= 2) [[unlikely]] {
                ctx.error = error_code::syntax_error;
                return;
             }
@@ -84,17 +84,17 @@ namespace glz::toml
          return;
       }
 
-      if ((it + 2) < end && *it == '\'' && *(it + 1) == '\'' && *(it + 2) == '\'') {
+      if (size_t(end - it) > 2 && *it == '\'' && *(it + 1) == '\'' && *(it + 2) == '\'') {
          it += 3;
          if (it != end && *it == '\n') {
             ++it;
          }
-         else if ((it + 1) < end && *it == '\r' && *(it + 1) == '\n') {
+         else if (size_t(end - it) > 1 && *it == '\r' && *(it + 1) == '\n') {
             it += 2;
          }
 
          while (true) {
-            if ((it + 2) >= end) [[unlikely]] {
+            if (size_t(end - it) <= 2) [[unlikely]] {
                ctx.error = error_code::syntax_error;
                return;
             }

--- a/include/glaze/util/dump.hpp
+++ b/include/glaze/util/dump.hpp
@@ -135,6 +135,10 @@ namespace glz
       ix += n;
    }
 
+   // A memset of zero bytes touches no memory, but forming &b[ix] with ix == b.size() is already
+   // out of range for a bounded buffer, and an indentation of zero reaches exactly that. The
+   // address is therefore only formed when there is something to write.
+
    template <auto c, class B>
    [[deprecated("use dumpn(c, n, b, ix) instead of dumpn<c>(n, b, ix) to reduce template instantiations")]]
    GLZ_ALWAYS_INLINE void dumpn(size_t n, B& b, size_t& ix) noexcept(not vector_like<B>)
@@ -145,8 +149,10 @@ namespace glz
             b.resize(2 * k);
          }
       }
-      std::memset(&b[ix], c, n);
-      ix += n;
+      if (n) {
+         std::memset(&b[ix], c, n);
+         ix += n;
+      }
    }
 
    template <class B>
@@ -158,8 +164,10 @@ namespace glz
             b.resize(2 * k);
          }
       }
-      std::memset(&b[ix], c, n);
-      ix += n;
+      if (n) {
+         std::memset(&b[ix], c, n);
+         ix += n;
+      }
    }
 
    template <auto c, class B>
@@ -167,15 +175,19 @@ namespace glz
       "use dumpn_unchecked(c, n, b, ix) instead of dumpn_unchecked<c>(n, b, ix) to reduce template instantiations")]]
    GLZ_ALWAYS_INLINE void dumpn_unchecked(size_t n, B& b, size_t& ix) noexcept
    {
-      std::memset(&b[ix], c, n);
-      ix += n;
+      if (n) {
+         std::memset(&b[ix], c, n);
+         ix += n;
+      }
    }
 
    template <class B>
    GLZ_ALWAYS_INLINE void dumpn_unchecked(const byte_sized auto c, size_t n, B& b, size_t& ix) noexcept
    {
-      std::memset(&b[ix], c, n);
-      ix += n;
+      if (n) {
+         std::memset(&b[ix], c, n);
+         ix += n;
+      }
    }
 
    template <char IndentChar, class B>
@@ -192,8 +204,10 @@ namespace glz
 
       assign_maybe_cast<'\n'>(b, ix);
       ++ix;
-      std::memset(&b[ix], IndentChar, n);
-      ix += n;
+      if (n) {
+         std::memset(&b[ix], IndentChar, n);
+         ix += n;
+      }
    }
 
    template <class B>
@@ -208,8 +222,10 @@ namespace glz
 
       assign_maybe_cast('\n', b, ix);
       ++ix;
-      std::memset(&b[ix], c, n);
-      ix += n;
+      if (n) {
+         std::memset(&b[ix], c, n);
+         ix += n;
+      }
    }
 
    template <const sv& str, bool Checked = true, class B>

--- a/include/glaze/util/dump.hpp
+++ b/include/glaze/util/dump.hpp
@@ -63,6 +63,22 @@ namespace glz
       }
    }
 
+   // The address of the write position, formed without subscripting so that a full buffer
+   // (ix == size()) yields a one-past-the-end pointer instead of an out of range access. A memset or
+   // memcpy of zero bytes through that pointer is well defined, so a length of zero needs no branch.
+   template <class B>
+   GLZ_ALWAYS_INLINE auto data_at(B& b, const size_t ix) noexcept
+   {
+      if constexpr (std::is_pointer_v<std::remove_cvref_t<B>>) {
+         return b + ix;
+      }
+      else {
+         static_assert(has_data<std::remove_cvref_t<B>>,
+                       "an output buffer must be contiguous: dump writes through memset and memcpy");
+         return b.data() + ix;
+      }
+   }
+
    // Low-level buffer write primitives (dump functions)
    // ================================================
    // These functions write directly to the buffer WITHOUT bounds checking for bounded buffers.
@@ -135,10 +151,6 @@ namespace glz
       ix += n;
    }
 
-   // A memset of zero bytes touches no memory, but forming &b[ix] with ix == b.size() is already
-   // out of range for a bounded buffer, and an indentation of zero reaches exactly that. The
-   // address is therefore only formed when there is something to write.
-
    template <auto c, class B>
    [[deprecated("use dumpn(c, n, b, ix) instead of dumpn<c>(n, b, ix) to reduce template instantiations")]]
    GLZ_ALWAYS_INLINE void dumpn(size_t n, B& b, size_t& ix) noexcept(not vector_like<B>)
@@ -149,10 +161,8 @@ namespace glz
             b.resize(2 * k);
          }
       }
-      if (n) {
-         std::memset(&b[ix], c, n);
-         ix += n;
-      }
+      std::memset(data_at(b, ix), c, n);
+      ix += n;
    }
 
    template <class B>
@@ -164,10 +174,8 @@ namespace glz
             b.resize(2 * k);
          }
       }
-      if (n) {
-         std::memset(&b[ix], c, n);
-         ix += n;
-      }
+      std::memset(data_at(b, ix), c, n);
+      ix += n;
    }
 
    template <auto c, class B>
@@ -175,19 +183,15 @@ namespace glz
       "use dumpn_unchecked(c, n, b, ix) instead of dumpn_unchecked<c>(n, b, ix) to reduce template instantiations")]]
    GLZ_ALWAYS_INLINE void dumpn_unchecked(size_t n, B& b, size_t& ix) noexcept
    {
-      if (n) {
-         std::memset(&b[ix], c, n);
-         ix += n;
-      }
+      std::memset(data_at(b, ix), c, n);
+      ix += n;
    }
 
    template <class B>
    GLZ_ALWAYS_INLINE void dumpn_unchecked(const byte_sized auto c, size_t n, B& b, size_t& ix) noexcept
    {
-      if (n) {
-         std::memset(&b[ix], c, n);
-         ix += n;
-      }
+      std::memset(data_at(b, ix), c, n);
+      ix += n;
    }
 
    template <char IndentChar, class B>
@@ -204,10 +208,8 @@ namespace glz
 
       assign_maybe_cast<'\n'>(b, ix);
       ++ix;
-      if (n) {
-         std::memset(&b[ix], IndentChar, n);
-         ix += n;
-      }
+      std::memset(data_at(b, ix), IndentChar, n);
+      ix += n;
    }
 
    template <class B>
@@ -222,10 +224,8 @@ namespace glz
 
       assign_maybe_cast('\n', b, ix);
       ++ix;
-      if (n) {
-         std::memset(&b[ix], c, n);
-         ix += n;
-      }
+      std::memset(data_at(b, ix), c, n);
+      ix += n;
    }
 
    template <const sv& str, bool Checked = true, class B>

--- a/tests/beve_test/beve_test.cpp
+++ b/tests/beve_test/beve_test.cpp
@@ -2948,6 +2948,51 @@ suite beve_to_json_tests = [] {
       expect(json == R"([99,"spiders"])") << json;
    };
 
+   // An empty buffer holds no value, and no value is not a JSON document. The conversion used to
+   // report success while producing nothing.
+   "beve_to_json requires a value"_test = [] {
+      std::string json{};
+      expect(glz::beve_to_json(std::string_view{}, json).ec == glz::error_code::unexpected_end);
+   };
+
+   // Several values in one buffer convert to one JSON document per line. A delimiter tag writes
+   // that newline; without one the converter writes it, rather than running the two documents
+   // together into text that is no longer JSON.
+   "beve_to_json separates several values"_test = [] {
+      std::string delimited{};
+      expect(not glz::write_beve_append(1, delimited));
+      expect(not glz::write_beve_append_with_delimiter(2, delimited));
+
+      std::string json{};
+      expect(not glz::beve_to_json(delimited, json));
+      expect(json == "1\n2") << json;
+
+      std::string concatenated{};
+      expect(not glz::write_beve_append(1, concatenated));
+      expect(not glz::write_beve_append(2, concatenated));
+
+      expect(not glz::beve_to_json(concatenated, json));
+      expect(json == "1\n2") << json;
+   };
+
+   // dump() does not bounds check a buffer it cannot grow, so the converter reserves every write.
+   "beve_to_json fixed buffer"_test = [] {
+      std::vector<std::vector<int>> v{{}, {}};
+      std::string buffer{};
+      expect(not glz::write_beve(v, buffer));
+
+      std::array<char, 64> room{};
+      const auto ec = glz::beve_to_json(buffer, room);
+      expect(not ec);
+      // count carries the written length, which a fixed-size buffer has no other way to learn
+      expect(std::string_view{room.data(), ec.count} == "[[],[]]");
+
+      // Nested arrays write nothing but structural characters, the writes that used to go
+      // unchecked, so they overflow a small buffer without ever reaching a value writer.
+      std::array<char, 2> cramped{};
+      expect(glz::beve_to_json(buffer, cramped).ec == glz::error_code::buffer_overflow);
+   };
+
    "beve_to_json std::variant<int, std::string>"_test = [] {
       std::variant<int, std::string> v = 99;
       std::string buffer{};

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -2533,6 +2533,80 @@ void cbor_to_json_tests()
       expect(glz::cbor_to_json<pretty>(definite_wide).value() == "{}");
    };
 
+   // A CBOR document is one data item. Neither an empty buffer nor a CBOR sequence (RFC 8742) is
+   // one, and converting either used to report success while producing text no JSON parser accepts.
+   "cbor_to_json_requires_exactly_one_item"_test = [] {
+      std::string json;
+      expect(glz::cbor_to_json(std::string_view{}, json).ec == glz::error_code::unexpected_end);
+
+      const std::array<uint8_t, 2> two_items{0x01, 0x02};
+      expect(glz::cbor_to_json(two_items, json).ec == glz::error_code::syntax_error);
+
+      // Trailing bytes after a complete item are trailing bytes even when they are not a full item
+      const std::array<uint8_t, 2> trailing{0x01, 0x19};
+      expect(glz::cbor_to_json(trailing, json).ec == glz::error_code::syntax_error);
+   };
+
+   // dump() does not bounds check a buffer it cannot grow, so the converter reserves every write.
+   "cbor_to_json_fixed_buffer"_test = [] {
+      const std::array<uint8_t, 4> input{0x83, 0x01, 0x02, 0x03}; // [1,2,3]
+
+      std::array<char, 64> room{};
+      const auto ec = glz::cbor_to_json(input, room);
+      expect(not ec);
+      // count carries the written length, which a fixed-size buffer has no other way to learn
+      expect(std::string_view{room.data(), ec.count} == "[1,2,3]");
+
+      // Nested arrays write nothing but structural characters, the writes that used to go
+      // unchecked, so they overflow a small buffer without ever reaching a value writer.
+      const std::array<uint8_t, 3> nested{0x81, 0x81, 0x80}; // [[[]]]
+      std::array<char, 2> cramped{};
+      expect(glz::cbor_to_json(nested, cramped).ec == glz::error_code::buffer_overflow);
+   };
+
+   // A byte string has no JSON counterpart and becomes a string of hex digit pairs, whether its
+   // length is known up front or it arrives in chunks.
+   "cbor_to_json_byte_string_hex"_test = [] {
+      const std::array<uint8_t, 4> definite{0x43, 0x01, 0xab, 0xff}; // bytes(3)
+      expect(glz::cbor_to_json(definite).value() == "\"01abff\"");
+
+      // indefinite: two chunks then break
+      const std::array<uint8_t, 7> indefinite{0x5f, 0x42, 0x01, 0xab, 0x41, 0xff, 0xff};
+      expect(glz::cbor_to_json(indefinite).value() == "\"01abff\"");
+
+      const std::array<uint8_t, 2> empty_chunks{0x5f, 0xff};
+      expect(glz::cbor_to_json(empty_chunks).value() == "\"\"");
+   };
+
+   // RFC 8746 tags 80 and 84 hold half precision elements, which widen to double on the way out.
+   // Tags 83 and 87 hold binary128, which has no C++ representation here and is refused before
+   // any part of the array is written.
+   "cbor_to_json_typed_array_float_widths"_test = [] {
+      const std::array<uint8_t, 7> half{0xd8, 0x50, 0x44, 0x3c, 0x00, 0xc0, 0x00}; // tag(80) bytes(4)
+      expect(glz::cbor_to_json(half).value() == "[1,-2]");
+
+      const std::array<uint8_t, 3> binary128{0xd8, 0x53, 0x40}; // tag(83) bytes(0)
+      expect(glz::cbor_to_json(binary128).error().ec == glz::error_code::feature_not_supported);
+   };
+
+   // At depth zero a prettified line break writes '\n' and nothing else, which used to leave the
+   // write index one past the end of a buffer that cannot grow and form &out[size] to memset zero
+   // bytes through. The address is out of range whether or not the memset touches it.
+   "cbor_to_json_prettify_exact_fit_fixed_buffer"_test = [] {
+      constexpr glz::opts pretty{.prettify = true};
+
+      const std::array<uint8_t, 3> input{0xa1, 0x40, 0xa0}; // map(1){ bytes(0): map(0) }
+      constexpr std::string_view expected = "{\n   \"\": {}\n}";
+
+      std::array<char, expected.size()> exact{};
+      const auto ec = glz::cbor_to_json<pretty>(input, exact);
+      expect(not ec);
+      expect(std::string_view{exact.data(), ec.count} == expected);
+
+      std::array<char, expected.size() - 1> short_by_one{};
+      expect(glz::cbor_to_json<pretty>(input, short_by_one).ec == glz::error_code::buffer_overflow);
+   };
+
    "cbor_to_json_prettify_non_empty_map"_test = [] {
       constexpr glz::opts pretty{.prettify = true};
 


### PR DESCRIPTION
Fixes #2842.

`dump()` grows a resizable buffer but does not bounds check one it cannot grow, so the binary-to-JSON converters wrote past the end of a `std::array` or `std::span` output buffer. Under ASan, `[[[]]]` converted into a 2-byte array is a stack-buffer-overflow.

All five converters now reserve before every write through shared `emit_char` / `emit_literal` / `emit_newline_indent` / `emit_hex_bytes` helpers in `glz::detail`, and report bytes written in `error_ctx::count` — a fixed-size output buffer previously had no way to learn how much of it held JSON.

### Also

- `(it + n) > end` bounds checks rewritten as `(end - it) < n`, which is the same test without the out-of-range pointer arithmetic. 40 sites across cbor, beve, msgpack, `core/reflect.hpp`, and `toml/skip.hpp`.
- `dumpn` no longer forms `&b[ix]` when there is nothing to write. A zero-width indent left `ix == size()`, out of range for a bounded buffer even though the `memset` never touched it.
- `ctx.depth` is restored on error paths, via an `indent_guard` beside the existing `depth_guard`.
- `cbor_to_json` requires exactly one CBOR data item. An empty buffer and a CBOR sequence both used to report success while producing text no JSON parser accepts.
- `beve_to_json` requires at least one value, and writes the NDJSON separator between values that were concatenated without a delimiter tag.
- float16 typed arrays (RFC 8746 tags 80/84) now convert; binary128 (83/87) is rejected before the array is opened rather than partway through it.
- `bson_to_json` moved onto the shared helpers, dropping its per-token 256-byte reservation. A 15-byte document needed a 271-byte fixed buffer and now needs 28.

### Tests

cbor 307, beve 456, bson 124, jsonb 163 under ASan/UBSan and libc++ hardening; eetf 43, json 725, yaml 796, toml 389, msgpack 70.
