### PR TITLE
reject CBOR integers and enum ordinals that overflow the target type

### DIFF
--- a/include/glaze/cbor/read.hpp
+++ b/include/glaze/cbor/read.hpp
@@ -2338,6 +2338,14 @@ namespace glz
          from<CBOR, U>::template op<Opts>(u, ctx, it, end);
          if (bool(ctx.error)) [[unlikely]]
             return;
+         if constexpr (std::same_as<underlying, bool>) {
+            // The uint8_t bound is wider than bool's domain, so anything above 1 has to be
+            // rejected here: casting it into a bool-backed enum would be undefined behavior.
+            if (u > 1) [[unlikely]] {
+               ctx.error = error_code::parse_number_failure;
+               return;
+            }
+         }
          value = static_cast<std::decay_t<T>>(u);
       }
    };

--- a/include/glaze/cbor/read.hpp
+++ b/include/glaze/cbor/read.hpp
@@ -2329,7 +2329,10 @@ namespace glz
       {
          // Read the ordinal through the range-checked integer reader so an out-of-range wire
          // value is rejected instead of being silently truncated into the underlying type.
-         using U = std::underlying_type_t<std::decay_t<T>>;
+         // bool is a legal fixed underlying type, and the writer emits such an enum as a CBOR
+         // integer, so route it through the uint8_t reader rather than the boolean reader.
+         using underlying = std::underlying_type_t<std::decay_t<T>>;
+         using U = std::conditional_t<std::same_as<underlying, bool>, uint8_t, underlying>;
          U u{};
          from<CBOR, U>::template op<Opts>(u, ctx, it, end);
          if (bool(ctx.error)) [[unlikely]]
@@ -2348,7 +2351,10 @@ namespace glz
       {
          // Read the ordinal through the range-checked integer reader so an out-of-range wire
          // value is rejected instead of being silently truncated into the underlying type.
-         using U = std::underlying_type_t<std::decay_t<T>>;
+         // bool is a legal fixed underlying type, and the writer emits such an enum as a CBOR
+         // integer, so route it through the uint8_t reader rather than the boolean reader.
+         using underlying = std::underlying_type_t<std::decay_t<T>>;
+         using U = std::conditional_t<std::same_as<underlying, bool>, uint8_t, underlying>;
          U u{};
          from<CBOR, U>::template op<Opts>(u, ctx, it, end);
          if (bool(ctx.error)) [[unlikely]]

--- a/include/glaze/cbor/read.hpp
+++ b/include/glaze/cbor/read.hpp
@@ -366,6 +366,14 @@ namespace glz
          if (bool(ctx.error)) [[unlikely]]
             return;
 
+         // Reject a value that does not fit in T, matching the signed reader below and the
+         // JSON/MessagePack integer readers. Without this a uint16/uint32/uint64 argument is
+         // silently truncated into a narrower target (e.g. 300 -> uint8_t 44) with success.
+         if (result > static_cast<uint64_t>((std::numeric_limits<T>::max)())) [[unlikely]] {
+            ctx.error = error_code::parse_number_failure;
+            return;
+         }
+
          value = static_cast<T>(result);
       }
    };
@@ -2319,35 +2327,14 @@ namespace glz
       template <auto Opts>
       GLZ_ALWAYS_INLINE static void op(auto& value, is_context auto& ctx, auto& it, auto end) noexcept
       {
-         using namespace cbor;
-
-         if (it >= end) [[unlikely]] {
-            ctx.error = error_code::unexpected_end;
+         // Read the ordinal through the range-checked integer reader so an out-of-range wire
+         // value is rejected instead of being silently truncated into the underlying type.
+         using U = std::underlying_type_t<std::decay_t<T>>;
+         U u{};
+         from<CBOR, U>::template op<Opts>(u, ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]]
             return;
-         }
-
-         uint8_t initial;
-         std::memcpy(&initial, it, 1);
-         ++it;
-
-         const uint8_t major_type = get_major_type(initial);
-         const uint8_t additional_info = get_additional_info(initial);
-
-         if (major_type == major::uint) {
-            uint64_t n = cbor_detail::decode_arg(ctx, it, end, additional_info);
-            if (bool(ctx.error)) [[unlikely]]
-               return;
-            value = static_cast<std::decay_t<T>>(n);
-         }
-         else if (major_type == major::nint) {
-            uint64_t n = cbor_detail::decode_arg(ctx, it, end, additional_info);
-            if (bool(ctx.error)) [[unlikely]]
-               return;
-            value = static_cast<std::decay_t<T>>(~n);
-         }
-         else [[unlikely]] {
-            ctx.error = error_code::syntax_error;
-         }
+         value = static_cast<std::decay_t<T>>(u);
       }
    };
 
@@ -2359,35 +2346,14 @@ namespace glz
       template <auto Opts>
       GLZ_ALWAYS_INLINE static void op(auto& value, is_context auto& ctx, auto& it, auto end) noexcept
       {
-         using namespace cbor;
-
-         if (it >= end) [[unlikely]] {
-            ctx.error = error_code::unexpected_end;
+         // Read the ordinal through the range-checked integer reader so an out-of-range wire
+         // value is rejected instead of being silently truncated into the underlying type.
+         using U = std::underlying_type_t<std::decay_t<T>>;
+         U u{};
+         from<CBOR, U>::template op<Opts>(u, ctx, it, end);
+         if (bool(ctx.error)) [[unlikely]]
             return;
-         }
-
-         uint8_t initial;
-         std::memcpy(&initial, it, 1);
-         ++it;
-
-         const uint8_t major_type = get_major_type(initial);
-         const uint8_t additional_info = get_additional_info(initial);
-
-         if (major_type == major::uint) {
-            uint64_t n = cbor_detail::decode_arg(ctx, it, end, additional_info);
-            if (bool(ctx.error)) [[unlikely]]
-               return;
-            value = static_cast<std::decay_t<T>>(n);
-         }
-         else if (major_type == major::nint) {
-            uint64_t n = cbor_detail::decode_arg(ctx, it, end, additional_info);
-            if (bool(ctx.error)) [[unlikely]]
-               return;
-            value = static_cast<std::decay_t<T>>(~n);
-         }
-         else [[unlikely]] {
-            ctx.error = error_code::syntax_error;
-         }
+         value = static_cast<std::decay_t<T>>(u);
       }
    };
 

--- a/include/glaze/cbor/read.hpp
+++ b/include/glaze/cbor/read.hpp
@@ -2320,30 +2320,9 @@ namespace glz
       }
    };
 
-   // Enums with glaze reflection
-   template <glaze_enum_t T>
-   struct from<CBOR, T>
-   {
-      template <auto Opts>
-      GLZ_ALWAYS_INLINE static void op(auto& value, is_context auto& ctx, auto& it, auto end) noexcept
-      {
-         // Read the ordinal through the range-checked integer reader so an out-of-range wire
-         // value is rejected instead of being silently truncated into the underlying type.
-         // bool is a legal fixed underlying type, and the writer emits such an enum as a CBOR
-         // integer, so route it through the uint8_t reader rather than the boolean reader.
-         using underlying = std::underlying_type_t<std::decay_t<T>>;
-         using U = std::conditional_t<std::same_as<underlying, bool>, uint8_t, underlying>;
-         U u{};
-         from<CBOR, U>::template op<Opts>(u, ctx, it, end);
-         if (bool(ctx.error)) [[unlikely]]
-            return;
-         value = static_cast<std::decay_t<T>>(u);
-      }
-   };
-
-   // Plain enums
+   // Enums, reflected or plain: both are read as the ordinal, so one reader covers them
    template <class T>
-      requires(std::is_enum_v<T> && !glaze_enum_t<T>)
+      requires(std::is_enum_v<T>)
    struct from<CBOR, T>
    {
       template <auto Opts>

--- a/include/glaze/cbor/write.hpp
+++ b/include/glaze/cbor/write.hpp
@@ -952,32 +952,9 @@ namespace glz
       }
    };
 
-   // Enums with glaze reflection
-   template <glaze_enum_t T>
-   struct to<CBOR, T> final
-   {
-      template <auto Opts>
-      GLZ_ALWAYS_INLINE static void op(auto&& value, is_context auto&& ctx, auto&& b, auto& ix)
-      {
-         using V = std::underlying_type_t<std::decay_t<T>>;
-         if constexpr (std::is_signed_v<V>) {
-            const auto v = static_cast<V>(value);
-            if (v >= 0) {
-               cbor_detail::encode_arg(ctx, cbor::major::uint, static_cast<uint64_t>(v), b, ix);
-            }
-            else {
-               cbor_detail::encode_arg(ctx, cbor::major::nint, static_cast<uint64_t>(~v), b, ix);
-            }
-         }
-         else {
-            cbor_detail::encode_arg(ctx, cbor::major::uint, static_cast<uint64_t>(value), b, ix);
-         }
-      }
-   };
-
-   // Plain enums (non-glaze)
+   // Enums, reflected or plain: both are written as the ordinal, so one writer covers them
    template <class T>
-      requires(std::is_enum_v<T> && !glaze_enum_t<T>)
+      requires(std::is_enum_v<T>)
    struct to<CBOR, T> final
    {
       template <auto Opts>

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -498,6 +498,35 @@ void integer_tests()
       expect(not glz::read_cbor(result, buffer));
       expect(result == v);
    };
+
+   "uint8_out_of_range"_test = [] {
+      // 300 (0x19 0x01 0x2C) does not fit in a uint8_t; the reader must reject it rather
+      // than truncate to 44, matching the signed reader and the JSON/MessagePack readers.
+      const std::string buffer = {char(0x19), char(0x01), char(0x2C)};
+      uint8_t result = 7;
+      expect(bool(glz::read_cbor(result, buffer)));
+   };
+
+   "uint16_out_of_range"_test = [] {
+      const std::string buffer = {char(0x1A), char(0x00), char(0x01), char(0x00), char(0x00)}; // 65536
+      uint16_t result = 7;
+      expect(bool(glz::read_cbor(result, buffer)));
+   };
+
+   "uint8_max_in_range"_test = [] {
+      const std::string buffer = {char(0x18), char(0xFF)}; // 255
+      uint8_t result{};
+      expect(not glz::read_cbor(result, buffer));
+      expect(result == 255u);
+   };
+
+   "uint64_max_in_range"_test = [] {
+      const std::string buffer = {char(0x1B), char(0xFF), char(0xFF), char(0xFF), char(0xFF),
+                                  char(0xFF), char(0xFF), char(0xFF), char(0xFF)};
+      uint64_t result{};
+      expect(not glz::read_cbor(result, buffer));
+      expect(result == (std::numeric_limits<uint64_t>::max)());
+   };
 }
 
 void float_tests()
@@ -1001,6 +1030,21 @@ void enum_tests()
       obj = {};
       expect(not glz::read_cbor(obj, buffer));
       expect(obj.b == sub::END);
+   };
+
+   "enum_out_of_range"_test = [] {
+      // sub has a uint8_t underlying type; 300 does not fit and must be rejected rather than
+      // truncated into the enum, the way the JSON and MessagePack enum readers reject it.
+      const std::string buffer = {char(0x19), char(0x01), char(0x2C)}; // 300
+      sub result = sub::START;
+      expect(bool(glz::read_cbor(result, buffer)));
+   };
+
+   "enum_negative_into_unsigned"_test = [] {
+      // A negative ordinal (0x20 = -1) cannot be represented by a uint8_t-backed enum.
+      const std::string buffer = {char(0x20)};
+      sub result = sub::START;
+      expect(bool(glz::read_cbor(result, buffer)));
    };
 }
 

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -1060,6 +1060,14 @@ void enum_tests()
       expect(not glz::read_cbor(result, buffer));
       expect(result == bool_enum::on);
    };
+
+   "bool_underlying_enum_out_of_range"_test = [] {
+      // The ordinal is read through the uint8_t reader, whose bound is wider than bool's domain,
+      // so 2 has to be rejected here rather than cast into a bool-backed enum.
+      const std::string buffer = {char(0x02)};
+      bool_enum result{};
+      expect(bool(glz::read_cbor(result, buffer)));
+   };
 }
 
 void variant_tests()

--- a/tests/cbor_test/cbor_test.cpp
+++ b/tests/cbor_test/cbor_test.cpp
@@ -310,6 +310,9 @@ struct signal_t
 // Enum with underlying type
 enum class sub : uint8_t { START, END, UPDATE_ITEM, UPDATE_PRICE };
 
+// bool is a legal fixed underlying type
+enum class bool_enum : bool { off, on };
+
 struct enum_struct
 {
    sub b;
@@ -1045,6 +1048,17 @@ void enum_tests()
       const std::string buffer = {char(0x20)};
       sub result = sub::START;
       expect(bool(glz::read_cbor(result, buffer)));
+   };
+
+   "bool_underlying_enum"_test = [] {
+      // The writer emits a bool-backed enum as a CBOR integer, so the reader must not route it
+      // through the boolean reader, which only accepts the simple true/false values.
+      std::string buffer{};
+      expect(not glz::write_cbor(bool_enum::on, buffer));
+
+      bool_enum result{};
+      expect(not glz::read_cbor(result, buffer));
+      expect(result == bool_enum::on);
    };
 }
 


### PR DESCRIPTION
The CBOR unsigned integer reader casts `decode_arg`'s 64-bit result straight into the target type with no range check, so an argument that does not fit is silently truncated: `read_cbor` of 300 (`19 01 2C`) into a `uint8_t` returns success with the value 44. The two enum readers do the same into the enum's underlying type. The signed integer reader right below already rejects an out-of-range argument, and the JSON and MessagePack integer readers reject the same input, so CBOR is the outlier.

Before: an out-of-range CBOR integer or enum ordinal narrows to a wrong value with a success code. After: it is a `parse_number_failure`, matching the signed reader and the other formats. The unsigned reader now range-checks against the target's max like its signed sibling, and each enum ordinal is read through that checked integer reader for its underlying type, so one bound covers both. Keeping the check in the reader is the only layer that sees the decoded 64-bit value before it narrows. Tradeoff: in-range values, including a full-width `uint64`, are byte-for-byte unchanged; only values that previously truncated now error.