### PR TITLE
Fix quadratic YAML scans on long lines and silent trailing-content loss

### DIFF
--- a/include/glaze/yaml/common.hpp
+++ b/include/glaze/yaml/common.hpp
@@ -60,6 +60,33 @@ namespace glz::yaml
    // stays far above what real documents nest.
    inline constexpr size_t max_yaml_recursive_depth = 64;
 
+   // How far ahead a probe may look while deciding whether the text at a position is an implicit
+   // mapping key, that is, whether a ':' separator follows it. YAML 1.2.2 bounds this for exactly
+   // the same reason these probes need it bounded: "To limit the amount of lookahead required, the
+   // ':' indicator must appear at most 1024 Unicode characters beyond the start of the key"
+   // (7.4.2, 8.2.2). Unbounded, each probe is O(line), and the block reader runs one per entry per
+   // nesting level, so a document written as one very long line parses in quadratic time -- 220 KB
+   // on a single line spent 300 million bytes of scanning inside one of these probes alone.
+   //
+   // Counted in bytes rather than characters so the scan needs no UTF-8 decoding. A conforming
+   // 1024-character key is at most 4096 bytes wide, which puts its ':' at offset 4096, so the
+   // budget has to reach that byte -- hence the + 1, and hence nothing the spec permits is cut
+   // short. Beyond it a ':' no longer reads as a mapping separator, so a document that puts one
+   // there, which the spec does not allow, reads as the plain scalar the line now is.
+   inline constexpr size_t max_implicit_key_lookahead = 4 * 1024 + 1;
+
+   // End position for an implicit-key probe: `end`, or `max_implicit_key_lookahead` bytes past
+   // `it`, whichever comes first. Returned as an iterator of `it`'s own type so a scan can swap it
+   // in for `end` in its loop conditions unchanged. A scan must still test the real `end` where it
+   // asks "is there a character after this one" -- the returned position is only a scan bound, and
+   // dereferencing it is safe whenever it differs from `end`.
+   template <class It, class End>
+   inline It implicit_key_scan_end(It it, End end)
+   {
+      const size_t remaining = size_t(end - it);
+      return it + (remaining < max_implicit_key_lookahead ? remaining : max_implicit_key_lookahead);
+   }
+
    // YAML-specific context extending the base context
    // Adds indent tracking needed for block-style parsing
    struct yaml_context : context
@@ -203,6 +230,104 @@ namespace glz::yaml
       // Start of the YAML buffer, set by top-level parse entry.
       const char* stream_begin = nullptr;
 
+      // What lies between a position and the start of its line: how far along the line it sits,
+      // whether a tab precedes it (never legal in indentation), and whether anything other than
+      // indentation does (which makes it a mid-line position rather than the start of content).
+      struct line_prefix
+      {
+         int32_t column{};
+         bool has_tab{};
+         bool has_content{};
+      };
+
+      // Memo over one line of the buffer: `memo_line_begin` is a known line start, no line break
+      // lies in [memo_line_begin, memo_verified_end), and the last two pointers hold where that
+      // span's first tab and first non-indentation character were found (null for neither).
+      // Positions rather than flags, so a query covering less of the line than an earlier one
+      // still gets its own answer. All four are derived purely from the buffer, so they are safe
+      // to copy into a speculative context and safe to discard with one.
+      mutable const char* memo_line_begin = nullptr;
+      mutable const char* memo_verified_end = nullptr;
+      mutable const char* memo_first_tab = nullptr;
+      mutable const char* memo_first_content = nullptr;
+
+      // Bring the memo up to `p`, which must point into the buffer beginning at `stream_begin`.
+      //
+      // Block parsing needs to know where a position sits on its line often -- to judge a key's
+      // visual indent, to place a sequence dash, to tell content from indentation, to reject a tab
+      // used as one -- and each of those walks back to the preceding line break. That walk is
+      // O(line length), paid once per entry per nesting level, so a document written as one very
+      // long line costs quadratic time before any of it is parsed. Memoizing turns a query that has
+      // moved forward into a walk over only the bytes parsing advanced past since the last one,
+      // which makes the total linear; a query that moves backward off the memo falls back to the
+      // plain walk and re-seeds it. The walk collects the tab and the content position on its way,
+      // since it reads exactly the bytes they are found in.
+      void memoize_line(const char* p) const noexcept
+      {
+         if (memo_line_begin && p >= memo_line_begin && p <= memo_verified_end) {
+            return;
+         }
+         // A query past the memoized span only has to walk the new bytes; one before it (or with
+         // no memo yet) walks all the way back.
+         const bool extends = memo_line_begin && p > memo_verified_end;
+         const char* const floor = extends ? memo_verified_end : stream_begin;
+         const char* first_tab = nullptr;
+         const char* first_content = nullptr;
+         const char* q = p;
+         while (q > floor) {
+            const char c = *(q - 1);
+            if (c == '\n' || c == '\r') break;
+            --q;
+            // Walking backward, the last one seen is the earliest one on the line.
+            if (c == '\t')
+               first_tab = q;
+            else if (c != ' ')
+               first_content = q;
+         }
+         if (extends && q == floor) {
+            // The new bytes continue the memoized line, so anything it already found is earlier.
+            if (memo_first_tab) first_tab = memo_first_tab;
+            if (memo_first_content) first_content = memo_first_content;
+         }
+         else {
+            memo_line_begin = q;
+         }
+         memo_verified_end = p;
+         memo_first_tab = first_tab;
+         memo_first_content = first_content;
+      }
+
+      // Start of the line containing `p` (`p` itself when there is no buffer to walk).
+      const char* line_begin_of(const char* p) const noexcept
+      {
+         if (!stream_begin || p < stream_begin) {
+            return p;
+         }
+         memoize_line(p);
+         return memo_line_begin;
+      }
+
+      line_prefix line_prefix_before(const char* p) const noexcept
+      {
+         const char* const begin = line_begin_of(p);
+         if (begin >= p) {
+            return {};
+         }
+         return {int32_t(p - begin), memo_first_tab && memo_first_tab < p,
+                 memo_first_content && memo_first_content < p};
+      }
+
+      // Drop the memo. Every pointer in it addresses the buffer of the read that filled it, so a
+      // context reused for a second document must not carry it into one; the outermost parse calls
+      // this as it takes ownership of a new buffer.
+      void reset_line_memo() const noexcept
+      {
+         memo_line_begin = nullptr;
+         memo_verified_end = nullptr;
+         memo_first_tab = nullptr;
+         memo_first_content = nullptr;
+      }
+
       // Set when `%TAG !! ...` remaps the secondary handle away from the core schema.
       // In that case `!!foo` must not be treated as built-in core tags.
       bool secondary_tag_handle_overridden = false;
@@ -227,6 +352,11 @@ namespace glz::yaml
          c.explicit_mapping_key_context = explicit_mapping_key_context;
          c.allow_indentless_sequence = allow_indentless_sequence;
          c.stream_begin = stream_begin;
+         // The line memo only records what the buffer says, so a probe may keep using it.
+         c.memo_line_begin = memo_line_begin;
+         c.memo_verified_end = memo_verified_end;
+         c.memo_first_tab = memo_first_tab;
+         c.memo_first_content = memo_first_content;
          c.secondary_tag_handle_overridden = secondary_tag_handle_overridden;
          // Carry the recursion depth so a speculative type-probe shares the parent's budget
          // and can't reset the stack-overflow guard partway down a deeply nested value.
@@ -798,14 +928,16 @@ namespace glz::yaml
    }
 
    // Quick check if current line contains a colon that could indicate a block mapping key.
-   // Only scans to end of line (bounded by newline), so O(line length) not O(input).
+   // Scans no further than the end of the line or `max_implicit_key_lookahead` bytes, whichever
+   // comes first, so the cost of a probe is bounded by a constant rather than by the line.
    // Returns false for obvious non-mappings to avoid expensive full parse attempts.
    template <class It, class End>
    inline bool line_could_be_block_mapping(It it, End end)
    {
+      const auto stop = implicit_key_scan_end(it, end);
       bool prev_was_whitespace = true; // Start of value acts like after whitespace
       int flow_depth = 0;
-      while (it != end) {
+      while (it != stop) {
          const char c = *it;
          if (c == '\n' || c == '\r') {
             return false;
@@ -831,10 +963,10 @@ namespace glz::yaml
          if ((c == '"' || c == '\'') && prev_was_whitespace) {
             const char quote = c;
             ++it;
-            while (it != end && *it != quote) {
+            while (it != stop && *it != quote) {
                if (*it == '\\' && quote == '"') {
                   ++it; // Skip escape character
-                  if (it != end) ++it; // Skip escaped character
+                  if (it != stop) ++it; // Skip escaped character
                }
                else if (*it == '\n' || *it == '\r') {
                   // Unterminated quote on this line
@@ -844,7 +976,7 @@ namespace glz::yaml
                   ++it;
                }
             }
-            if (it != end) ++it; // Skip closing quote
+            if (it != stop) ++it; // Skip closing quote
             prev_was_whitespace = false;
             continue;
          }

--- a/include/glaze/yaml/read.hpp
+++ b/include/glaze/yaml/read.hpp
@@ -70,6 +70,11 @@ namespace glz
          if constexpr (requires { ctx.stream_begin; }) {
             if (!ctx.stream_begin && it != end) {
                ctx.stream_begin = &*it;
+               // The line memo holds pointers into whatever buffer filled it, so a reused
+               // context must not carry a previous read's into this one.
+               if constexpr (requires { ctx.reset_line_memo(); }) {
+                  ctx.reset_line_memo();
+               }
                // Seed the alias replay budget from the document this read was handed. Done here
                // rather than in glz::read so every YAML entry point is covered, and only on the
                // outermost parse so a nested document does not hand itself a fresh budget.
@@ -145,6 +150,24 @@ namespace glz
                   }
                   return false;
                };
+
+               // The scan below reads the tail a line at a time, which only means anything if the
+               // tail starts at one. A root node can stop mid-line -- a plain scalar ends at a
+               // ':' it is not allowed to take as a separator, a flow collection ends at its
+               // bracket -- and what sits after it there is leftover content on that line, not
+               // the opening of a new one. Only inline whitespace and a comment may follow. Let
+               // the line scan see anything else and it misreads it: a leftover ':' passes as an
+               // explicit-key continuation and the remainder of the document falls on the floor.
+               if constexpr (requires { ctx.line_prefix_before(it); }) {
+                  if (it != end && ctx.line_prefix_before(it).has_content) {
+                     auto rest = it;
+                     while (rest != end && (*rest == ' ' || *rest == '\t')) ++rest;
+                     if (rest != end && *rest != '\n' && *rest != '\r' && *rest != '#') {
+                        ctx.error = error_code::syntax_error;
+                        return;
+                     }
+                  }
+               }
 
                auto tail_scan = it;
                bool seen_document_end_marker = false;
@@ -3006,26 +3029,29 @@ namespace glz
 
       // Detects a plain "key: value" mapping indicator in an inline block-map
       // value segment, while ignoring quoted strings and nested flow collections.
+      // The separator it looks for terminates an implicit key, so the scan is bounded by the
+      // longest implicit key the spec allows rather than by the length of the line.
       template <class It, class End>
       inline bool inline_value_has_plain_mapping_indicator(It pos, End end) noexcept
       {
+         const auto stop = yaml::implicit_key_scan_end(pos, end);
          int flow_depth = 0;
-         while (pos != end) {
+         while (pos != stop) {
             const char c = *pos;
             if (c == '\n' || c == '\r' || c == '#') return false;
             if (c == '"' || c == '\'') {
                const char quote = c;
                ++pos;
-               while (pos != end && *pos != quote) {
+               while (pos != stop && *pos != quote) {
                   if (*pos == '\\' && quote == '"') {
                      ++pos;
-                     if (pos != end) ++pos;
+                     if (pos != stop) ++pos;
                   }
                   else {
                      ++pos;
                   }
                }
-               if (pos != end) ++pos;
+               if (pos != stop) ++pos;
                continue;
             }
             if (c == '[' || c == '{') {
@@ -3251,12 +3277,7 @@ namespace glz
             dash_col = line_indent;
             if constexpr (std::is_pointer_v<std::decay_t<It>>) {
                if (ctx.stream_begin) {
-                  auto p = &*it;
-                  dash_col = 0;
-                  while (p > ctx.stream_begin && *(p - 1) != '\n' && *(p - 1) != '\r') {
-                     --p;
-                     ++dash_col;
-                  }
+                  dash_col = ctx.line_prefix_before(&*it).column;
                }
             }
 
@@ -3722,27 +3743,15 @@ namespace glz
                discovered_first_key_visual_indent = line_indent;
                if constexpr (std::is_pointer_v<std::decay_t<It>>) {
                   if (ctx.stream_begin && line_start > ctx.stream_begin) {
-                     auto line_begin = line_start;
-                     while (line_begin > ctx.stream_begin && *(line_begin - 1) != '\n' && *(line_begin - 1) != '\r') {
-                        --line_begin;
+                     const auto prefix = ctx.line_prefix_before(line_start);
+                     if (prefix.has_tab) {
+                        ctx.error = error_code::syntax_error;
+                        return;
                      }
 
-                     bool seen_non_whitespace = false;
-                     int32_t visual_indent = 0;
-                     for (auto p = line_begin; p != line_start; ++p) {
-                        if (*p == '\t') {
-                           ctx.error = error_code::syntax_error;
-                           return;
-                        }
-                        if (*p != ' ') {
-                           seen_non_whitespace = true;
-                        }
-                        ++visual_indent;
-                     }
-
-                     discovered_first_key_mid_line = seen_non_whitespace;
-                     if (mapping_indent == 0 && visual_indent > 0) {
-                        discovered_first_key_visual_indent = visual_indent;
+                     discovered_first_key_mid_line = prefix.has_content;
+                     if (mapping_indent == 0 && prefix.column > 0) {
+                        discovered_first_key_visual_indent = prefix.column;
                      }
                   }
                }
@@ -3870,6 +3879,18 @@ namespace glz
                skip_comment(it, end);
                if (it != end && (*it == '\n' || *it == '\r')) {
                   skip_newline(it, end);
+               }
+               else if (it != end) {
+                  // The entry stopped part way along its line with something other than
+                  // whitespace or a comment after it -- a ':' its value could not take as a
+                  // separator, say. The next pass measures indent as though this were the start
+                  // of a line, so what is left of the real one is lost; reject it instead.
+                  if constexpr (requires { ctx.line_prefix_before(it); }) {
+                     if (ctx.line_prefix_before(it).has_content) {
+                        ctx.error = error_code::syntax_error;
+                        return;
+                     }
+                  }
                }
             }
          }
@@ -4764,27 +4785,12 @@ namespace glz
                         // delimiters ({...} / [...]) or quoted.
                         if constexpr (std::is_pointer_v<std::decay_t<decltype(it)>>) {
                            if (ctx.stream_begin) {
-                              const auto begin = static_cast<std::remove_cvref_t<decltype(it)>>(ctx.stream_begin);
                               auto is_line_content_start = [&](auto pos) {
-                                 auto line = pos;
-                                 while (line != begin) {
-                                    auto prev = line - 1;
-                                    if (*prev == '\n' || *prev == '\r') break;
-                                    line = prev;
-                                 }
-                                 for (auto p = line; p != pos; ++p) {
-                                    if (*p != ' ' && *p != '\t') return false;
-                                 }
-                                 return true;
+                                 return !ctx.line_prefix_before(pos).has_content;
                               };
 
                               auto line_has_explicit_value_indicator = [&](auto pos) {
-                                 auto line = pos;
-                                 while (line != begin) {
-                                    auto prev = line - 1;
-                                    if (*prev == '\n' || *prev == '\r') break;
-                                    line = prev;
-                                 }
+                                 const char* line = ctx.line_begin_of(pos);
                                  while (line != end && (*line == ' ' || *line == '\t')) ++line;
                                  return line != end && *line == ':';
                               };
@@ -5280,15 +5286,17 @@ namespace glz
    };
 
    // Quick check for implicit single-pair flow mappings used as sequence entries
-   // (e.g. `"k":v`, `{k: v}:v`, `k: v`) up to the next top-level flow delimiter.
+   // (e.g. `"k":v`, `{k: v}:v`, `k: v`) up to the next top-level flow delimiter, and no further
+   // than the longest implicit key the spec allows.
    template <class It, class End>
    inline bool line_could_be_flow_mapping(It it, End end)
    {
+      const auto stop = yaml::implicit_key_scan_end(it, end);
       int flow_depth = 0;
       bool prev_was_whitespace = true;
       bool key_supports_adjacent_value = false;
 
-      while (it != end) {
+      while (it != stop) {
          const char c = *it;
          if (c == '\n' || c == '\r') {
             return false;
@@ -5302,10 +5310,10 @@ namespace glz
          if ((c == '"' || c == '\'') && prev_was_whitespace) {
             const char quote = c;
             ++it;
-            while (it != end && *it != quote) {
+            while (it != stop && *it != quote) {
                if (*it == '\\' && quote == '"') {
                   ++it;
-                  if (it != end) ++it;
+                  if (it != stop) ++it;
                }
                else if (*it == '\n' || *it == '\r') {
                   return false;
@@ -5314,7 +5322,7 @@ namespace glz
                   ++it;
                }
             }
-            if (it != end) ++it;
+            if (it != stop) ++it;
             key_supports_adjacent_value = true;
             prev_was_whitespace = false;
             continue;
@@ -5417,22 +5425,25 @@ namespace glz
          // In flow context, only treat plain content as an implicit "key: value"
          // when a mapping separator appears before the next top-level flow delimiter.
          auto could_be_implicit_flow_pair = [&](auto pos) {
+            // Bounded by the longest implicit key the spec allows: unbounded, this probe runs
+            // once per entry per nesting level over the whole remaining flow collection.
+            const auto stop = yaml::implicit_key_scan_end(pos, end);
             int depth = 0;
-            while (pos != end) {
+            while (pos != stop) {
                const char c = *pos;
                if (c == '"' || c == '\'') {
                   const char quote = c;
                   ++pos;
-                  while (pos != end && *pos != quote) {
+                  while (pos != stop && *pos != quote) {
                      if (*pos == '\\' && quote == '"') {
                         ++pos;
-                        if (pos != end) ++pos;
+                        if (pos != stop) ++pos;
                      }
                      else {
                         ++pos;
                      }
                   }
-                  if (pos != end) ++pos;
+                  if (pos != stop) ++pos;
                   continue;
                }
                if (c == '[' || c == '{') {
@@ -5484,16 +5495,12 @@ namespace glz
    // longer reflects the mapping's true column; recovering it from the buffer gives a single
    // context-independent value (root, struct member, sequence item all differ) that drives both the
    // tag scan and the indent under which the chosen alternative is parsed.
-   template <class It>
-   inline int32_t tagged_mapping_visual_indent(It it, const char* stream_begin, int32_t fallback) noexcept
+   template <class Ctx, class It>
+   inline int32_t tagged_mapping_visual_indent(const Ctx& ctx, It it, int32_t fallback) noexcept
    {
       if constexpr (std::is_pointer_v<std::decay_t<It>>) {
-         if (stream_begin && it >= stream_begin) {
-            auto line_begin = it;
-            while (line_begin > stream_begin && *(line_begin - 1) != '\n' && *(line_begin - 1) != '\r') {
-               --line_begin;
-            }
-            return static_cast<int32_t>(it - line_begin);
+         if (ctx.stream_begin && it >= ctx.stream_begin) {
+            return ctx.line_prefix_before(it).column;
          }
       }
       return fallback;
@@ -5667,8 +5674,7 @@ namespace glz
                // The mapping's keys sit at the column of `it`. Recover that column from the buffer:
                // the indent stack carries the parent context's indent (a struct member, a sequence
                // item, etc. each push a different offset), not this mapping's true column (see helper).
-               const int32_t mapping_column =
-                  tagged_mapping_visual_indent(it, ctx.stream_begin, ctx.current_indent() + 1);
+               const int32_t mapping_column = tagged_mapping_visual_indent(ctx, it, ctx.current_indent() + 1);
                auto tag_ctx = ctx.make_speculative();
                const size_t index = scan_variant_tag_index<V, Opts>(tag_ctx, it, end, mapping_column);
                ctx.alias_expansion_budget = tag_ctx.alias_expansion_budget; // charged even if no tag matched

--- a/tests/yaml_test/yaml_test.cpp
+++ b/tests/yaml_test/yaml_test.cpp
@@ -4513,6 +4513,76 @@ ship-to: *id001)";
       expect(p.first == "answer");
       expect(p.second == 42);
    };
+
+   "content_left_over_on_a_line_is_rejected"_test = [] {
+      // A node can stop part way along its line: a plain scalar ends at a ':' it is not allowed
+      // to take as a separator, a flow collection ends at its bracket. Both the root tail scan
+      // and the block mapping loop then read the rest of that line as though it were the start of
+      // a new one, which let a leftover ':' pass as an explicit-key continuation and dropped
+      // everything after it -- silently, with no error. `"'q' zz"` read as "q" and `"a: 1 b: 2"`
+      // as its first pair. Whatever the reader could not use has to be an error instead.
+      for (const std::string_view doc :
+           {"'q' zz", "'q' zz\n", "[1, 2] zz\n", "- 'q' zz\n", "outer:\n  'q' zz\n", "a: 1 b: 2\n"}) {
+         glz::generic parsed{};
+         expect(bool(glz::read_yaml<glz::opts{.error_on_unknown_keys = false}>(parsed, doc))) << doc;
+      }
+
+      // Only what the line may legitimately end with still passes: nothing, whitespace, or a
+      // comment -- and a following line is still a following line.
+      for (const std::string_view doc :
+           {"'q'", "'q'   \n", "'q' # c\n", "[1, 2] # c\n", "a: 1 # c\n", "a: 1\nb: 2\n", "? a : b\n",
+            "- a: 1\n  b: 2\n", "a: 1\n...\n", "a: 1\n---\nb: 2\n", "url: http://x.y/z\n"}) {
+         glz::generic parsed{};
+         expect(!glz::read_yaml<glz::opts{.error_on_unknown_keys = false}>(parsed, doc)) << doc;
+      }
+   };
+
+   "implicit_key_lookahead_is_bounded"_test = [] {
+      // What bounds those probes is the spec's own bound on how far a ':' may sit from the key it
+      // terminates: at most 1024 characters (7.4.2, 8.2.2). The widest conforming key is 1024
+      // four-byte characters, which puts its ':' at byte offset 4096, and it must still parse.
+      const auto is_mapping = [](size_t characters) {
+         std::string doc;
+         for (size_t i = 0; i < characters; ++i) doc += "\xF0\x9F\x98\x80"; // U+1F600, four bytes
+         doc += ": v";
+         glz::generic parsed{};
+         const auto ec = glz::read_yaml(parsed, doc);
+         expect(!ec) << characters << ' ' << glz::format_error(ec, doc);
+         return parsed.is_object();
+      };
+      expect(is_mapping(1024));
+
+      // One character further and that ':' is past the bound, so it no longer separates a key
+      // from a value. Nothing else on the line can, either, which leaves the line with content
+      // the document has no reading for -- so it is rejected rather than quietly reinterpreted.
+      // The spec does not allow a key this long in the first place.
+      std::string over(glz::yaml::max_implicit_key_lookahead, 'k');
+      over += ": v";
+      for (const std::string& doc : {over, over + "\nsecond: 2\n", "outer:\n  " + over + "\n", "- " + over + "\n"}) {
+         glz::generic parsed{};
+         expect(bool(glz::read_yaml<glz::opts{.error_on_unknown_keys = false}>(parsed, doc))) << doc.size();
+      }
+   };
+
+   "long_line_columns_are_measured_correctly"_test = [] {
+      // The column of a position is memoized across queries rather than recomputed by walking
+      // back to the line start. Long lines are where that memo does the work, so they are where
+      // a stale one would show: an indent misread by one changes the shape of the result.
+      const std::string key(2000, 'k');
+      const std::string value(20000, 'v');
+
+      glz::generic nested{};
+      const std::string doc = "outer:\n  " + key + ": " + value + "\n  second: 2\n";
+      const auto ec = glz::read_yaml<glz::opts{.error_on_unknown_keys = false}>(nested, doc);
+      expect(!ec) << glz::format_error(ec, doc);
+      expect(nested["outer"][key].as<std::string>() == value);
+      expect(nested["outer"]["second"].as<int>() == 2);
+
+      // A tab in the indentation of a long line is still rejected.
+      glz::generic tabbed{};
+      const std::string tab_doc = "outer:\n\t" + key + ": " + value + "\n";
+      expect(bool(glz::read_yaml<glz::opts{.error_on_unknown_keys = false}>(tabbed, tab_doc)));
+   };
 };
 
 // ============================================================


### PR DESCRIPTION
Fixes an OSS-Fuzz `yaml_generic` timeout: 220 KB of YAML punctuation with no line break in it took 18 s under the fuzz harness.

## Quadratic line scans

Two families of scans assumed lines are short, and the block reader runs both once per entry per nesting level, which is quadratic on a single-line document — 300 million bytes of scanning for 34 KB of parsing.

- **Implicit-key probes** (`line_could_be_block_mapping`, `line_could_be_flow_mapping`, `inline_value_has_plain_mapping_indicator`, `could_be_implicit_flow_pair`) scanned to the end of the line. They are now bounded by YAML 1.2.2's own rule (7.4.2, 8.2.2): the `:` must appear at most 1024 characters past the start of the key, so 4096 bytes plus the one that offset lands on. A key beyond that is not a key, which the spec does not allow anyway.
- **Column measurements** walked back to the preceding line break. `yaml_context` now memoizes the current line's start along with its first tab and first non-indentation character, collected by the walk that was already reading those bytes, so a query that has moved forward only walks the bytes parsing advanced past.

## Trailing content silently dropped

The root tail scan reads the tail a line at a time, but a node can stop part way along its line — a plain scalar ends at a `:` it may not take as a separator, a flow collection ends at its bracket. The leftover was then read as the start of a line it was not on, so a stray `:` passed as an explicit-key continuation and the rest of the document was discarded with no error: `'q' zz` read as `"q"`, `a: 1 b: 2` as its first pair. A node stopping mid-line may now be followed only by whitespace or a comment, at the document root and per block-mapping entry.

## Verification

- 192,000 generated documents diffed against `main`: 4,426 newly rejected, 55 changed error code, none newly accepted, and none where both versions accept but the value differs. Every sampled rejection is a document `main` parsed a fragment of and threw the rest away.
- Full suite green, including 507 conformance tests. Legitimate shapes that stop mid-line are unchanged: `? a : b`, compact sequence maps, multiline flow collections, merge keys, `http://x.y/z`, `12:30:00`, CRLF, `...`, and second documents.
- The reported testcase: 18.4 s → 0.08 s, no sanitizer findings.