### PR TITLE
fix out-of-bounds write in csv double numeric writer

### DIFF
--- a/include/glaze/csv/write.hpp
+++ b/include/glaze/csv/write.hpp
@@ -51,7 +51,9 @@ namespace glz
                      return size_t{64};
                   }
                   else if constexpr (sizeof(T) > 4) {
-                     return size_t{32};
+                     // glz::to_chars may use up to zmij::double_buffer_size bytes of the
+                     // buffer as scratch; 32 was two short. Matches required_padding<double>().
+                     return size_t{zmij::double_buffer_size + 4};
                   }
                   else {
                      return size_t{24};

--- a/tests/csv_test/csv_bounded_buffer_test.cpp
+++ b/tests/csv_test/csv_bounded_buffer_test.cpp
@@ -105,6 +105,31 @@ suite csv_bounded_buffer_overflow_tests = [] {
       auto result = glz::write_csv(obj, buffer);
       expect(not result) << "write should succeed";
    };
+
+   // A leading double is written relying only on the numeric capacity guard. glz::to_chars
+   // may use up to zmij::double_buffer_size (34) bytes of scratch, so a 32/33-byte buffer must
+   // report buffer_overflow rather than write past the end.
+   "csv leading double into undersized buffer returns buffer_overflow"_test = [] {
+      std::vector<double> v{-2000000000000000.0};
+      for (size_t n : {size_t{32}, size_t{33}, size_t{34}, size_t{37}}) {
+         std::vector<char> storage(n);
+         std::span<char> buffer(storage.data(), storage.size());
+         auto result = glz::write_csv(v, buffer);
+         expect(result.ec == glz::error_code::buffer_overflow) << "size " << n << " should overflow cleanly";
+      }
+   };
+
+   "csv leading double into sufficient bounded buffer succeeds"_test = [] {
+      std::vector<double> v{-2000000000000000.0};
+      std::array<char, 64> buffer{};
+
+      auto result = glz::write_csv(v, buffer);
+      expect(not result) << "write should succeed";
+      expect(result.count > 0) << "count should be non-zero";
+
+      std::string_view csv(buffer.data(), result.count);
+      expect(csv.find("-2000000000000000") != std::string_view::npos) << "value should round-trip";
+   };
 };
 
 int main() { return 0; }


### PR DESCRIPTION
`to<CSV, num_t>::op` guards a bounded buffer by reserving `max_numeric_chars` before it hands off to `write_chars`, but the double case reserves 32 bytes while `glz::to_chars` documents that it may use up to `zmij::double_buffer_size` (34) bytes of the buffer as scratch. When a double is written with 32 or 33 bytes of headroom in a `std::array`/`std::span`, for example a leading double in `write_csv(std::vector<double>{-2000000000000000.0}, span)` where the value lands at ix 0, `ensure_space` reports success and zmij's fixed-point shuffle writes up to 2 bytes past the buffer.

Before: the guard passes and the write silently runs off the end of the buffer instead of returning `buffer_overflow`, which is an ASAN heap-buffer-overflow on the bounded-buffer path. After: the double case reserves `zmij::double_buffer_size + 4`, the same value the JSON writer's `required_padding<double>()` already uses, so an undersized buffer reports `buffer_overflow` and any buffer that fits produces byte-identical output. The tradeoff is 6 more reserved bytes per double on the bounded path; float, integer, and resizable-string writes are unchanged.