### PR TITLE
quote non-bare map keys in the toml writer

### DIFF
--- a/include/glaze/toml/write.hpp
+++ b/include/glaze/toml/write.hpp
@@ -35,6 +35,58 @@ namespace glz
    constexpr bool skip_toml_field =
       always_skipped<T> || (!check_write_function_pointers(Options) && is_member_function_pointer<T>);
 
+   // TOML bare keys admit only [A-Za-z0-9_-]. A runtime map key holding any other
+   // byte (a dot, whitespace, '=', a quote, a line break, an empty key) is not a
+   // bare key: written verbatim it splices into the document, turning one entry
+   // into a different structure or several forged entries. Detect the bare case so
+   // ordinary keys stay byte-identical.
+   GLZ_ALWAYS_INLINE constexpr bool toml_key_is_bare(const sv key) noexcept
+   {
+      if (key.empty()) return false;
+      for (const char c : key) {
+         const auto u = uint8_t(c);
+         const bool ok =
+            (u >= 'A' && u <= 'Z') || (u >= 'a' && u <= 'z') || (u >= '0' && u <= '9') || u == '_' || u == '-';
+         if (!ok) return false;
+      }
+      return true;
+   }
+
+   // Write a TOML map key. A bare key is written unquoted (output unchanged);
+   // anything else becomes a quoted basic string with the same escaping the string
+   // value writer uses, so the key round-trips instead of altering the surrounding
+   // structure.
+   template <class B>
+   GLZ_ALWAYS_INLINE void write_toml_key(const sv key, is_context auto&& ctx, B&& b, auto& ix) noexcept
+   {
+      if (toml_key_is_bare(key)) {
+         if (!ensure_space(ctx, b, ix + key.size() + write_padding_bytes)) [[unlikely]] {
+            return;
+         }
+         std::memcpy(&b[ix], key.data(), key.size());
+         ix += key.size();
+         return;
+      }
+      // Quoted basic string. Worst case each byte escapes to two characters.
+      if (!ensure_space(ctx, b, ix + 2 * key.size() + 2 + write_padding_bytes)) [[unlikely]] {
+         return;
+      }
+      std::memcpy(&b[ix], "\"", 1);
+      ++ix;
+      for (const char c : key) {
+         if (const auto escaped = char_escape_table[uint8_t(c)]; escaped) {
+            std::memcpy(&b[ix], &escaped, 2);
+            ix += 2;
+         }
+         else {
+            std::memcpy(&b[ix], &c, 1);
+            ++ix;
+         }
+      }
+      std::memcpy(&b[ix], "\"", 1);
+      ++ix;
+   }
+
    template <>
    struct serialize<TOML>
    {
@@ -801,19 +853,23 @@ namespace glz
             return;
          }
 
-         if (!ensure_space(ctx, b, ix + key.size() + 5 + write_padding_bytes)) [[unlikely]] {
-            return;
-         }
-
          if (!first) {
+            if (!ensure_space(ctx, b, ix + 2 + write_padding_bytes)) [[unlikely]] {
+               return;
+            }
             dump(", ", b, ix);
          }
          else {
             first = false;
          }
 
-         std::memcpy(&b[ix], key.data(), key.size());
-         ix += key.size();
+         write_toml_key(key, ctx, b, ix);
+         if (bool(ctx.error)) [[unlikely]] {
+            return;
+         }
+         if (!ensure_space(ctx, b, ix + 3 + write_padding_bytes)) [[unlikely]] {
+            return;
+         }
          dump(" = ", b, ix);
 
          write_inline_value<Options>(val, ctx, b, ix);
@@ -1348,12 +1404,14 @@ namespace glz
             else {
                first = false;
             }
-            // Write the key as a bare key
-            if (!ensure_space(ctx, b, ix + key.size() + 4 + write_padding_bytes)) [[unlikely]] {
+            // Write the key, quoting it when it is not a valid TOML bare key.
+            write_toml_key(key, ctx, b, ix);
+            if (bool(ctx.error)) [[unlikely]] {
                return;
             }
-            std::memcpy(&b[ix], key.data(), key.size());
-            ix += key.size();
+            if (!ensure_space(ctx, b, ix + 3 + write_padding_bytes)) [[unlikely]] {
+               return;
+            }
             std::memcpy(&b[ix], " = ", 3);
             ix += 3;
 

--- a/include/glaze/toml/write.hpp
+++ b/include/glaze/toml/write.hpp
@@ -53,9 +53,9 @@ namespace glz
    }
 
    // Write a TOML map key. A bare key is written unquoted (output unchanged);
-   // anything else becomes a quoted basic string with the same escaping the string
-   // value writer uses, so the key round-trips instead of altering the surrounding
-   // structure.
+   // anything else becomes a quoted basic string. Characters with a short escape use
+   // it, control bytes without one go out as \u00XX, so the key round-trips instead
+   // of altering the surrounding structure or reparsing as invalid TOML.
    template <class B>
    GLZ_ALWAYS_INLINE void write_toml_key(const sv key, is_context auto&& ctx, B&& b, auto& ix) noexcept
    {
@@ -67,8 +67,9 @@ namespace glz
          ix += key.size();
          return;
       }
-      // Quoted basic string. Worst case each byte escapes to two characters.
-      if (!ensure_space(ctx, b, ix + 2 * key.size() + 2 + write_padding_bytes)) [[unlikely]] {
+      // Quoted basic string. Worst case a control byte with no short escape
+      // expands to a six-character \u00XX sequence.
+      if (!ensure_space(ctx, b, ix + 6 * key.size() + 2 + write_padding_bytes)) [[unlikely]] {
          return;
       }
       std::memcpy(&b[ix], "\"", 1);
@@ -77,6 +78,16 @@ namespace glz
          if (const auto escaped = char_escape_table[uint8_t(c)]; escaped) {
             std::memcpy(&b[ix], &escaped, 2);
             ix += 2;
+         }
+         else if (uint8_t(c) < 0x20) {
+            // A control byte with no two-character escape must go out as \u00XX,
+            // otherwise it would sit raw in the basic string and reparse as invalid TOML.
+            char unicode_escape[6] = {'\\', 'u', '0', '0', '0', '0'};
+            constexpr char hex_digits[] = "0123456789ABCDEF";
+            unicode_escape[4] = hex_digits[(uint8_t(c) >> 4) & 0xF];
+            unicode_escape[5] = hex_digits[uint8_t(c) & 0xF];
+            std::memcpy(&b[ix], unicode_escape, 6);
+            ix += 6;
          }
          else {
             std::memcpy(&b[ix], &c, 1);

--- a/tests/toml_test/toml_test.cpp
+++ b/tests/toml_test/toml_test.cpp
@@ -5838,4 +5838,73 @@ suite recursion_depth_tests = [] {
    };
 };
 
+suite toml_map_key_quoting_tests = [] {
+   // A runtime map key that is not a valid TOML bare key must be quoted, or it
+   // splices into the document: a dotted key becomes a nested table and a key
+   // holding '=' / a line break forges extra entries.
+   "dotted key is quoted"_test = [] {
+      std::map<std::string, int> m{{"a.b", 1}};
+      std::string buffer{};
+      expect(not glz::write_toml(m, buffer));
+      expect(buffer == R"("a.b" = 1)") << buffer;
+      std::map<std::string, int> back{};
+      expect(not glz::read_toml(back, buffer)) << buffer;
+      expect(back == m);
+   };
+
+   "key with '=' and newline does not inject"_test = [] {
+      std::map<std::string, int> m{{"x = 1\ninjected", 2}};
+      std::string buffer{};
+      expect(not glz::write_toml(m, buffer));
+      expect(buffer == R"("x = 1\ninjected" = 2)") << buffer;
+      std::map<std::string, int> back{};
+      expect(not glz::read_toml(back, buffer)) << buffer;
+      expect(back.size() == 1);
+      expect(back == m);
+   };
+
+   "key with space and quote is quoted"_test = [] {
+      std::map<std::string, int> m{{"a b\"c", 3}};
+      std::string buffer{};
+      expect(not glz::write_toml(m, buffer));
+      expect(buffer == R"("a b\"c" = 3)") << buffer;
+      std::map<std::string, int> back{};
+      expect(not glz::read_toml(back, buffer)) << buffer;
+      expect(back == m);
+   };
+
+   "empty key is quoted"_test = [] {
+      std::map<std::string, int> m{{"", 4}};
+      std::string buffer{};
+      expect(not glz::write_toml(m, buffer));
+      expect(buffer == R"("" = 4)") << buffer;
+      std::map<std::string, int> back{};
+      expect(not glz::read_toml(back, buffer)) << buffer;
+      expect(back == m);
+   };
+
+   "bare keys stay unquoted"_test = [] {
+      std::map<std::string, int> m{{"normal_key-1", 5}, {"a", 6}};
+      std::string buffer{};
+      expect(not glz::write_toml(m, buffer));
+      expect(buffer == R"(a = 6
+normal_key-1 = 5)")
+         << buffer;
+      std::map<std::string, int> back{};
+      expect(not glz::read_toml(back, buffer)) << buffer;
+      expect(back == m);
+   };
+
+   // The inline-table map writer (a map nested as a value) shares the same key path.
+   "inline map key is quoted"_test = [] {
+      std::map<std::string, std::map<std::string, int>> m{{"outer", {{"in.ner", 7}}}};
+      std::string buffer{};
+      expect(not glz::write_toml(m, buffer));
+      expect(buffer == R"(outer = {"in.ner" = 7})") << buffer;
+      std::map<std::string, std::map<std::string, int>> back{};
+      expect(not glz::read_toml(back, buffer)) << buffer;
+      expect(back == m);
+   };
+};
+
 int main() { return 0; }

--- a/tests/toml_test/toml_test.cpp
+++ b/tests/toml_test/toml_test.cpp
@@ -5895,6 +5895,18 @@ normal_key-1 = 5)")
       expect(back == m);
    };
 
+   // A control byte with no short escape must go out as \u00XX, not raw, or the
+   // key sits unescaped in the basic string and reparses as invalid TOML.
+   "control byte key is escaped as \\u00XX"_test = [] {
+      std::map<std::string, int> m{{std::string("a\x01\x1f", 3), 8}};
+      std::string buffer{};
+      expect(not glz::write_toml(m, buffer));
+      expect(buffer == R"("a\u0001\u001F" = 8)") << buffer;
+      std::map<std::string, int> back{};
+      expect(not glz::read_toml(back, buffer)) << buffer;
+      expect(back == m);
+   };
+
    // The inline-table map writer (a map nested as a value) shares the same key path.
    "inline map key is quoted"_test = [] {
       std::map<std::string, std::map<std::string, int>> m{{"outer", {{"in.ner", 7}}}};


### PR DESCRIPTION
The TOML writer emits runtime map keys verbatim as bare keys, at both key sites (write_inline_map and the top-level map writer in toml/write.hpp). TOML bare keys only admit [A-Za-z0-9_-], so a std::map key holding a dot, whitespace, `=`, a quote, or a line break splices into the document instead of naming one entry. write_toml of `{"a.b": 1}` emits `a.b = 1`, which is the nested table a -> b (and the reader then rejects it), and `{"x = 1\ninjected": 2}` emits two lines that read back as `{x: 1, injected: 2}`. write_toml returns success in both cases.

Route both key sites through a write_toml_key that emits a quoted basic string with the existing char_escape_table escaping when the key is not a valid bare key, and leaves bare keys byte-identical. Before, a non-identifier key produced a different document or forged entries; after, the key round-trips. The YAML writer already quotes runtime keys through write_yaml_string and the CSV writer through dump_csv_string, so keeping the decision inside the map writer matches the siblings and callers keep passing a plain map. Tradeoff: a quoted key adds the two quotes plus a byte per escaped character, and (like the string value writer) a control byte with no short escape still passes through, but the structural characters that break framing are all escaped.